### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@
 ANTHROPIC_API_KEY=your-anthropic-key-here
 OPENAI_API_KEY=your-openai-key-here
 # GOOGLE_API_KEY=your-google-key-here
+# MINIMAX_API_KEY=your-minimax-key-here
 
 # --- LiteLLM Proxy ---
 LITELLM_MASTER_KEY=sk-decepticon-master

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -53,6 +53,19 @@ model_list:
       model: gemini/gemini-2.5-flash
       api_key: os.environ/GEMINI_API_KEY
 
+  # ── MiniMax ──────────────────────────────────────────────────────────
+  - model_name: minimax/MiniMax-M2.7
+    litellm_params:
+      model: openai/MiniMax-M2.7
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax/MiniMax-M2.7-highspeed
+    litellm_params:
+      model: openai/MiniMax-M2.7-highspeed
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
   # ── Local LLM (Ollama) ──────────────────────────────────────────────
   # Uncomment when running Ollama locally
   # - model_name: ollama/llama3.2

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -56,6 +56,8 @@ HAIKU = "anthropic/claude-haiku-4-5"
 GPT_5 = "openai/gpt-5.4"
 GPT_4 = "openai/gpt-4.1"
 GEMINI_FLASH = "gemini/gemini-2.5-flash"
+MINIMAX = "minimax/MiniMax-M2.7"
+MINIMAX_HIGHSPEED = "minimax/MiniMax-M2.7-highspeed"
 
 
 class ProxyConfig(BaseModel):

--- a/tests/unit/llm/test_minimax.py
+++ b/tests/unit/llm/test_minimax.py
@@ -1,0 +1,85 @@
+"""Unit tests for MiniMax provider support in decepticon.llm.models"""
+
+
+from decepticon.llm.factory import LLMFactory
+from decepticon.llm.models import (
+    MINIMAX,
+    MINIMAX_HIGHSPEED,
+    LLMModelMapping,
+    ModelAssignment,
+    ProxyConfig,
+)
+
+
+class TestMinimaxModelConstants:
+    def test_minimax_constant_format(self):
+        assert MINIMAX == "minimax/MiniMax-M2.7"
+
+    def test_minimax_highspeed_constant_format(self):
+        assert MINIMAX_HIGHSPEED == "minimax/MiniMax-M2.7-highspeed"
+
+    def test_minimax_uses_minimax_prefix(self):
+        assert MINIMAX.startswith("minimax/")
+        assert MINIMAX_HIGHSPEED.startswith("minimax/")
+
+
+class TestMinimaxModelAssignment:
+    def test_minimax_as_primary(self):
+        assignment = ModelAssignment(primary=MINIMAX)
+        assert assignment.primary == MINIMAX
+        assert assignment.fallback is None
+
+    def test_minimax_highspeed_as_fallback(self):
+        assignment = ModelAssignment(primary=MINIMAX, fallback=MINIMAX_HIGHSPEED)
+        assert assignment.fallback == MINIMAX_HIGHSPEED
+
+    def test_minimax_temperature_default(self):
+        assignment = ModelAssignment(primary=MINIMAX)
+        assert assignment.temperature == 0.7
+
+    def test_minimax_custom_temperature(self):
+        assignment = ModelAssignment(primary=MINIMAX, temperature=1.0)
+        assert assignment.temperature == 1.0
+
+
+class TestMinimaxInMapping:
+    def test_minimax_can_be_set_on_role(self):
+        mapping = LLMModelMapping(
+            recon=ModelAssignment(primary=MINIMAX, temperature=0.3)
+        )
+        assert mapping.get_assignment("recon").primary == MINIMAX
+
+    def test_minimax_highspeed_can_be_fallback(self):
+        mapping = LLMModelMapping(
+            recon=ModelAssignment(primary=MINIMAX, fallback=MINIMAX_HIGHSPEED)
+        )
+        assert mapping.get_assignment("recon").fallback == MINIMAX_HIGHSPEED
+
+    def test_minimax_factory_creates_model(self):
+        proxy = ProxyConfig(url="http://localhost:4000", api_key="test-key")
+        mapping = LLMModelMapping(
+            recon=ModelAssignment(primary=MINIMAX, temperature=0.3)
+        )
+        factory = LLMFactory(proxy, mapping)
+        model = factory.get_model("recon")
+        assert model is not None
+        assert model.model_name == MINIMAX
+
+    def test_minimax_highspeed_factory_creates_model(self):
+        proxy = ProxyConfig(url="http://localhost:4000", api_key="test-key")
+        mapping = LLMModelMapping(
+            recon=ModelAssignment(primary=MINIMAX_HIGHSPEED, temperature=0.3)
+        )
+        factory = LLMFactory(proxy, mapping)
+        model = factory.get_model("recon")
+        assert model.model_name == MINIMAX_HIGHSPEED
+
+    def test_minimax_fallback_model_returned(self):
+        proxy = ProxyConfig(url="http://localhost:4000", api_key="test-key")
+        mapping = LLMModelMapping(
+            recon=ModelAssignment(primary=MINIMAX, fallback=MINIMAX_HIGHSPEED)
+        )
+        factory = LLMFactory(proxy, mapping)
+        fallbacks = factory.get_fallback_models("recon")
+        assert len(fallbacks) == 1
+        assert fallbacks[0].model_name == MINIMAX_HIGHSPEED


### PR DESCRIPTION
## Summary

- Add `MINIMAX` (`minimax/MiniMax-M2.7`) and `MINIMAX_HIGHSPEED` (`minimax/MiniMax-M2.7-highspeed`) model constants to `decepticon/llm/models.py`
- Register both models in `config/litellm.yaml` using the OpenAI-compatible MiniMax API (`https://api.minimax.io/v1`)
- Add `MINIMAX_API_KEY` env var documentation in `.env.example`
- Add unit tests covering MiniMax constants, model assignments, and factory integration (`tests/unit/llm/test_minimax.py`)

## How it works

MiniMax exposes an OpenAI-compatible chat API at `https://api.minimax.io/v1`. This PR routes requests through the existing LiteLLM proxy using the `minimax/` provider prefix — no new dependencies required.

Users can enable MiniMax by setting `MINIMAX_API_KEY` and assigning `minimax/MiniMax-M2.7` (or `minimax/MiniMax-M2.7-highspeed`) to any agent role in their model mapping, for example:

```python
from decepticon.llm.models import MINIMAX, LLMModelMapping, ModelAssignment

mapping = LLMModelMapping(
    recon=ModelAssignment(primary=MINIMAX, temperature=0.3)
)
```

## API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api