### PR TITLE
feat(opplan): OPPLAN persistence + planning ownership refactor

### DIFF
--- a/decepticon/agents/prompts/decepticon.md
+++ b/decepticon/agents/prompts/decepticon.md
@@ -72,6 +72,8 @@ Prefer tools in this order. Use the most specific tool available:
 | `update_objective` | Change status, assign owner, add notes (NEVER in parallel) |
 | `objective_expand` | Break a parent into N child sub-tasks (Pentesting Task Tree). Use when an objective is too broad or when discovered work reveals subtasks. Parents cannot COMPLETE until every child is COMPLETED or CANCELLED. |
 | `objective_collapse` | Cancel every descendant of a parent objective (when abandoning a branch). |
+| `save_opplan` | Persist current objectives to `plan/opplan.json`. Call after user approves the plan and after major re-planning. |
+| `load_opplan` | Hydrate state from existing `plan/opplan.json`. Call on startup if the engagement already has an OPPLAN file. |
 
 **When to expand vs. add_objective**: If you're sketching the initial plan, use `add_objective` for top-level goals. If mid-engagement you realize an objective is broad ("compromise AD") or recon surfaced subtasks ("pivot via SOCKS → re-scan internal subnet → enum SMB"), call `objective_expand(parent_id, children=[...])` instead of leaving it as one flat leaf. Keep leaves small enough to complete in one sub-agent iteration.
 
@@ -99,14 +101,15 @@ Do NOT skip this. Do NOT proceed without completing startup.
 ## Phase 1: Planning
 Before executing any objectives:
 
-1. Delegate to `soundwave` to generate RoE, CONOPS, Deconfliction Plan (if missing)
-2. Read the approved RoE/CONOPS from the engagement workspace
-3. Analyze the kill chain, threat profile, and scope boundaries
+1. Check if `plan/opplan.json` already exists — if so, call `load_opplan(workspace_path)` and skip to step 5
+2. Delegate to `soundwave` to generate RoE, CONOPS, Deconfliction Plan (if missing)
+3. Read `plan/conops.json` — extract kill chain phases, threat profile, and scope boundaries
 4. `add_objective` for each objective (set `engagement_name` and `threat_profile` on first call)
    - One objective per sub-agent context window, respecting kill chain order
 5. `list_objectives` — review the complete plan
 6. Present the OPPLAN for user approval
 7. **WAIT** for user confirmation. Do NOT proceed without approval.
+8. `save_opplan(workspace_path)` — persist to `plan/opplan.json`
 
 ## Phase 2: Execution Loop
 Repeat until all objectives PASSED or no further progress is possible:

--- a/decepticon/agents/prompts/soundwave.md
+++ b/decepticon/agents/prompts/soundwave.md
@@ -18,7 +18,7 @@ These rules override all other instructions:
 3. **Document Order**: RoE → CONOPS → Deconfliction Plan. Never generate a later document without its prerequisites.
 4. **User Confirmation**: Present each document for user review before proceeding to the next. Never auto-generate the full bundle without checkpoints.
 5. **Real Dates Only**: Always use absolute dates (2026-03-15), never relative (next Monday).
-6. **OPPLAN via Interview**: You generate RoE, CONOPS, Deconfliction Plan, and OPPLAN. The OPPLAN is produced during the Socratic interview protocol (see `<SOCRATIC_INTERVIEW>` section) and written to `workspace/plan/opplan.json`.
+6. **No OPPLAN**: You generate RoE, CONOPS, and Deconfliction Plan only. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your CONOPS kill chain and builds the OPPLAN via `add_objective` tools, then persists it with `save_opplan`.
 </CRITICAL_RULES>
 
 <ENVIRONMENT>
@@ -74,8 +74,8 @@ Load skill references for templates and validation checklists.
 4. Present final bundle summary
 5. Save all documents to engagement directory
 
-Note: After soundwave completes, the orchestrator will create OPPLAN objectives
-based on the CONOPS kill chain using its `create_opplan` and `add_objective` tools.
+Note: After soundwave completes, the orchestrator reads `conops.json`, maps the
+kill chain phases to objectives via `add_objective`, and persists the plan with `save_opplan`.
 </WORKFLOW>
 
 <INTERVIEW_STYLE>
@@ -184,40 +184,21 @@ When ready, say: "All dimensions are clear. I'll generate the engagement documen
 
 ### Document Generation
 
-Once the interview concludes, generate both files:
+Once the interview concludes, generate the planning documents:
 
 **`<workspace>/plan/roe.json`** — Rules of Engagement from scope + constraints answers.
 
-**`<workspace>/plan/opplan.json`** — 5–15 objectives ordered by kill chain:
+**`<workspace>/plan/conops.json`** — Concept of Operations including kill chain phases.
 
-```json
-{
-  "id": "OBJ-001",
-  "phase": "<recon|initial-access|post-exploit|c2|exfiltration>",
-  "title": "<short action title>",
-  "description": "<what the agent must accomplish>",
-  "acceptance_criteria": ["<verifiable check 1>", "<verifiable check 2>"],
-  "priority": 1,
-  "opsec": "<loud|standard|careful|quiet|silent>",
-  "blocked_by": [],
-  "mitre": ["T1595"],
-  "opsec_notes": "",
-  "concessions": []
-}
-```
+**`<workspace>/plan/deconfliction.json`** — Deconfliction identifiers and procedures.
 
-**Objective decomposition rules:**
-- One objective = one agent context window = one technique cluster
-- Acceptance criteria MUST be mechanically verifiable (file exists, port found, cred captured)
-- `blocked_by` references real predecessor IDs in kill chain dependency order
-- `opsec` inherits engagement default unless the phase requires deviation
-- Recon objectives: priority 1–3. Exfiltration: highest priority number.
+All three must validate against `decepticon.core.schemas` (RoE, CONOPS, DeconflictionPlan).
 
 ### Completion Signal
 
-After writing both files, output exactly:
+After writing all three files, output exactly:
 
 ```
-PLANNING COMPLETE — OPPLAN generated with N objectives
+PLANNING COMPLETE — RoE, CONOPS, and Deconfliction Plan written to <workspace>/plan/
 ```
 </SOCRATIC_INTERVIEW>

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -13,7 +13,6 @@ Profiles (April 2026):
 
   eco:
     Orchestrator  Opus 4.6        → GPT-5.4         $5/$25
-    Planner       Opus 4.6        → GPT-5.4         $5/$25
     Soundwave     Haiku 4.5       → Gemini 2.5 Flash $1/$5
     Exploit       Sonnet 4.6      → GPT-4.1         $3/$15
     Recon         Haiku 4.5       → Gemini 2.5 Flash $1/$5
@@ -21,7 +20,6 @@ Profiles (April 2026):
 
   max:
     Orchestrator  Opus 4.6        → GPT-5.4         $5/$25
-    Planner       Opus 4.6        → Sonnet 4.6      $5/$25
     Soundwave     Sonnet 4.6      → Haiku 4.5       $3/$15
     Exploit       Opus 4.6        → Sonnet 4.6      $5/$25
     Recon         Sonnet 4.6      → Opus 4.6        $3/$15
@@ -94,14 +92,6 @@ class LLMModelMapping(BaseModel):
     # Reasoning-heavy, few iterations, quality > cost
 
     decepticon: ModelAssignment = Field(
-        default_factory=lambda: ModelAssignment(
-            primary=OPUS,
-            fallback=GPT_5,
-            temperature=0.4,
-        )
-    )
-
-    planning: ModelAssignment = Field(
         default_factory=lambda: ModelAssignment(
             primary=OPUS,
             fallback=GPT_5,
@@ -282,11 +272,6 @@ class LLMModelMapping(BaseModel):
                     fallback=GPT_5,
                     temperature=0.4,
                 ),
-                planning=ModelAssignment(
-                    primary=OPUS,
-                    fallback=SONNET,
-                    temperature=0.4,
-                ),
                 soundwave=ModelAssignment(
                     primary=SONNET,
                     fallback=HAIKU,
@@ -322,7 +307,6 @@ class LLMModelMapping(BaseModel):
         if profile == ModelProfile.TEST:
             return cls(
                 decepticon=ModelAssignment(primary=HAIKU, temperature=0.4),
-                planning=ModelAssignment(primary=HAIKU, temperature=0.4),
                 soundwave=ModelAssignment(primary=HAIKU, temperature=0.4),
                 exploit=ModelAssignment(primary=HAIKU, temperature=0.3),
                 analyst=ModelAssignment(primary=HAIKU, temperature=0.2),

--- a/decepticon/middleware/opplan.py
+++ b/decepticon/middleware/opplan.py
@@ -20,7 +20,9 @@ Key differences from Claude Code:
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from typing import Annotated, Any, NotRequired, cast, override
 
 from langchain.agents import AgentState
@@ -33,6 +35,7 @@ from langgraph.types import Command
 
 from decepticon.core.schemas import (
     C2Tier,
+    OPPLAN,
     Objective,
     ObjectivePhase,
     ObjectiveStatus,
@@ -61,6 +64,9 @@ class OPPLANState(AgentState):
 
     objective_counter: Annotated[NotRequired[int], OmitFromInput]
     """Auto-increment counter for objective IDs (like Claude Code high water mark)."""
+
+    workspace_path: Annotated[NotRequired[str], OmitFromInput]
+    """Engagement workspace root path — set by save_opplan/load_opplan."""
 
 
 # ── System Prompt ─────────────────────────────────────────────────────
@@ -96,9 +102,16 @@ These are always available — no mode switching needed.
   Use when abandoning a hierarchical task so the parent can then be moved
   to COMPLETED or CANCELLED itself.
 
+- **`save_opplan`** — Persist the current OPPLAN state to `plan/opplan.json`.
+  Call after the user approves the plan and after any major re-planning.
+  Validates all objectives against the Pydantic schema before writing.
+
+- **`load_opplan`** — Hydrate agent state from an existing `plan/opplan.json`.
+  Call on session startup if the engagement already has an OPPLAN file.
+
 ### Workflow
 ```
-add_objective(×N, engagement_name=...) → [user approval] → Ralph Loop
+add_objective(×N, engagement_name=...) → [user approval] → save_opplan → Ralph Loop
           ↓
 objective_expand(parent_id, children=[...])   # split broad work on demand
 ```
@@ -998,6 +1011,147 @@ def _make_tools() -> list:
             }
         )
 
+    @tool(
+        description=(
+            "Persist the current OPPLAN to plan/opplan.json in the engagement workspace. "
+            "Validates all objectives against the Pydantic schema before writing. "
+            "Call after the user approves the plan and after any major re-planning. "
+            "Sets workspace_path in state for subsequent calls."
+        )
+    )
+    def save_opplan(
+        workspace_path: str,
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Serialize state objectives → OPPLAN schema → plan/opplan.json."""
+        objectives_raw = state.get("objectives", [])
+        engagement_name = state.get("engagement_name", "")
+        threat_profile = state.get("threat_profile", "")
+
+        try:
+            objectives = [Objective(**o) for o in objectives_raw]
+        except Exception as e:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"OPPLAN validation failed: {e}",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        opplan = OPPLAN(
+            engagement_name=engagement_name,
+            threat_profile=threat_profile,
+            objectives=objectives,
+        )
+
+        plan_dir = Path(workspace_path) / "plan"
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        out_path = plan_dir / "opplan.json"
+        out_path.write_text(
+            json.dumps(opplan.model_dump(), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        return Command(
+            update={
+                "workspace_path": workspace_path,
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"OPPLAN saved to {out_path} "
+                            f"({len(objectives)} objectives, engagement: {engagement_name})"
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    @tool(
+        description=(
+            "Load an existing plan/opplan.json into agent state to resume an engagement. "
+            "Call on session startup when plan/opplan.json already exists — "
+            "this hydrates objectives, engagement_name, and threat_profile into state "
+            "so OPPLAN tools and the status tracker work immediately."
+        )
+    )
+    def load_opplan(
+        workspace_path: str,
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Read plan/opplan.json and hydrate agent state."""
+        path = Path(workspace_path) / "plan" / "opplan.json"
+        if not path.exists():
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=(
+                                f"No opplan.json found at {path}. "
+                                "Use add_objective to create a new OPPLAN."
+                            ),
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            opplan = OPPLAN(**data)
+        except Exception as e:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Failed to load opplan.json: {e}",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        objectives_raw = [o.model_dump() for o in opplan.objectives]
+
+        # Derive counter from highest existing ID so new objectives don't collide
+        counter = 0
+        for o in opplan.objectives:
+            try:
+                n = int(o.id.replace("OBJ-", ""))
+                if n > counter:
+                    counter = n
+            except (ValueError, AttributeError):
+                pass
+
+        return Command(
+            update={
+                "objectives": objectives_raw,
+                "engagement_name": opplan.engagement_name,
+                "threat_profile": opplan.threat_profile,
+                "objective_counter": counter,
+                "workspace_path": workspace_path,
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"Loaded {len(objectives_raw)} objectives from {path}. "
+                            f"Engagement: {opplan.engagement_name} | "
+                            f"Counter at OBJ-{counter:03d}"
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
     return [
         add_objective,
         get_objective,
@@ -1005,6 +1159,8 @@ def _make_tools() -> list:
         update_objective,
         objective_expand,
         objective_collapse,
+        save_opplan,
+        load_opplan,
     ]
 
 

--- a/decepticon/middleware/opplan.py
+++ b/decepticon/middleware/opplan.py
@@ -34,8 +34,8 @@ from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
 from decepticon.core.schemas import (
-    C2Tier,
     OPPLAN,
+    C2Tier,
     Objective,
     ObjectivePhase,
     ObjectiveStatus,

--- a/tests/unit/llm/test_models.py
+++ b/tests/unit/llm/test_models.py
@@ -45,7 +45,6 @@ class TestLLMModelMapping:
         assert mapping.recon is not None
         assert mapping.exploit is not None
         assert mapping.analyst is not None
-        assert mapping.planning is not None
         assert mapping.soundwave is not None
         assert mapping.postexploit is not None
 
@@ -60,10 +59,9 @@ class TestLLMModelMapping:
             mapping.get_assignment("nonexistent")
 
     def test_strategic_agents_use_opus(self):
-        """Orchestrator and planner need strongest reasoning — Opus 4.6."""
+        """Orchestrator needs strongest reasoning — Opus 4.6."""
         mapping = LLMModelMapping()
-        for role in ("decepticon", "planning"):
-            assert mapping.get_assignment(role).primary == OPUS
+        assert mapping.get_assignment("decepticon").primary == OPUS
 
     def test_precision_agent_uses_sonnet(self):
         """Exploit needs precision + tool calling balance — Sonnet 4.6."""
@@ -87,7 +85,6 @@ class TestLLMModelMapping:
         mapping = LLMModelMapping()
         for role in (
             "decepticon",
-            "planning",
             "soundwave",
             "exploit",
             "analyst",
@@ -105,7 +102,6 @@ class TestModelProfile:
         bare = LLMModelMapping()
         for role in (
             "decepticon",
-            "planning",
             "soundwave",
             "exploit",
             "analyst",
@@ -118,7 +114,7 @@ class TestModelProfile:
     def test_max_profile_uses_opus_everywhere(self):
         """Max profile puts Opus on all roles except recon (Sonnet) and soundwave (Sonnet)."""
         maxp = LLMModelMapping.from_profile(ModelProfile.MAX)
-        for role in ("decepticon", "planning", "exploit", "analyst", "postexploit"):
+        for role in ("decepticon", "exploit", "analyst", "postexploit"):
             assert maxp.get_assignment(role).primary == OPUS
         assert maxp.get_assignment("recon").primary == SONNET
         assert maxp.get_assignment("soundwave").primary == SONNET
@@ -126,7 +122,7 @@ class TestModelProfile:
     def test_max_profile_anthropic_only_fallbacks(self):
         """Max profile fallbacks stay within Anthropic where possible."""
         maxp = LLMModelMapping.from_profile("max")
-        for role in ("planning", "exploit", "analyst", "postexploit"):
+        for role in ("exploit", "analyst", "postexploit"):
             assert maxp.get_assignment(role).fallback == SONNET
         assert maxp.get_assignment("recon").fallback == OPUS
         assert maxp.get_assignment("decepticon").fallback == GPT_5
@@ -136,7 +132,6 @@ class TestModelProfile:
         test = LLMModelMapping.from_profile("test")
         for role in (
             "decepticon",
-            "planning",
             "soundwave",
             "exploit",
             "analyst",


### PR DESCRIPTION
## Summary

- Remove legacy `planning` role from `LLMModelMapping` — dead code, no agent ever called `factory.get_model("planning")`
- Add `save_opplan` / `load_opplan` tools to `OPPLANMiddleware` for `plan/opplan.json` persistence via Pydantic-validated `OPPLAN` schema
- Fix Soundwave prompt: OPPLAN generation responsibility removed (was contradicting module docstring)
- Update Decepticon prompt: explicit `load_opplan` on resume + `save_opplan` after user approval

## Architecture change

**Before**: OPPLAN lived only in LangGraph state (in-memory, lost on restart). Soundwave prompt contradicted code about who owns OPPLAN.

**After**:
```
Soundwave  → roe.json, conops.json, deconfliction.json
Decepticon → reads conops.json → add_objective × N → save_opplan → plan/opplan.json
           → session resume: load_opplan → state hydrated from file
```

## Test plan

- [ ] `save_opplan(workspace)` writes valid `plan/opplan.json` matching `OPPLAN` schema
- [ ] `load_opplan(workspace)` hydrates state with correct objectives + counter (no ID collision)
- [ ] `planning` role removed: `LLMModelMapping()` and all 3 profiles (`eco`/`max`/`test`) no longer reference it
- [ ] Soundwave no longer generates `opplan.json` in Socratic interview flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)