### PR TITLE
Fix #54: Question about input handling during agent runs — relates to...

### DIFF
--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -141,9 +141,20 @@ export function useAgent({
 
   const submit = useCallback(
     (message: string): void => {
-      // Block submit while a stream is active to prevent race conditions
-      // where a second run cancels the first, leaving dangling tool calls
-      if (abortRef.current) return;
+      // If a run is already active, interrupt it so the operator can inject
+      // a message mid-run (Human in the Loop).  PatchToolCallsMiddleware on
+      // the backend handles any dangling tool calls left by the interruption.
+      if (abortRef.current) {
+        const threadId = threadIdRef.current;
+        if (threadId) {
+          clientRef.current.runs
+            .cancelMany({ threadId, status: "running" })
+            .catch(() => {});
+        }
+        abortRef.current.abort();
+        abortRef.current = null;
+        addEvent({ type: "system", content: "Interrupted by operator." });
+      }
 
       addEvent({ type: "user", content: message });
 
@@ -390,8 +401,13 @@ export function useAgent({
           setError(msg);
         }
 
-        abortRef.current = null;
-        resetStreamState();
+        // Only reset if this run was not interrupted by a new submit().
+        // An interrupt sets abortController.signal.aborted and immediately
+        // starts a fresh runStream(), so we must not clobber its state.
+        if (!abortController.signal.aborted) {
+          abortRef.current = null;
+          resetStreamState();
+        }
       };
 
       runStream().catch((err) => {

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -243,7 +243,7 @@ export function REPL({ initialMessage }: REPLProps) {
           )}
 
           <Prompt
-            isDisabled={agent.isStreaming}
+            isDisabled={false}
             onSubmit={handleSubmit}
             activeAgent={agent.activeAgent}
           />


### PR DESCRIPTION
Closes #54

## Summary

Enables mid-run operator input ("Human in the Loop") by allowing `submit()` in `useAgent.ts` to interrupt an active stream rather than silently dropping the message. The `Prompt` component is also unblocked so the input field remains active while the agent is streaming.

## Changes

- **`clients/cli/src/hooks/useAgent.ts` — `submit()`**: Replaced the early-return guard with an interrupt sequence: calls `clientRef.current.runs.cancelMany({ threadId, status: "running" })` to cancel backend runs, aborts the active `AbortController`, nulls `abortRef.current`, and emits a `"Interrupted by operator."` system event before proceeding with the new message.
- **`clients/cli/src/hooks/useAgent.ts` — stream cleanup**: Added an `abortController.signal.aborted` check before `resetStreamState()` so that the finishing handler of an interrupted stream does not clobber the `abortRef` or stream state belonging to the newly started run.
- **`clients/cli/src/screens/REPL.tsx`**: Changed `<Prompt isDisabled={agent.isStreaming}>` to `isDisabled={false}`, keeping the input field enabled at all times.

## Testing

- [ ] `make lint` passes
- [ ] `make test-local` passes
- [ ] Docker build succeeds (`make build`)
- [x] Manual testing (describe below)

Started a long-running agent stream, typed a follow-up message mid-run, and confirmed: (1) the `"Interrupted by operator."` system event appears in the REPL, (2) the prior stream is cancelled, and (3) the new message is submitted and a fresh run begins without dangling tool call errors. Also verified that normal (non-interrupted) runs still clean up `abortRef` and reset stream state correctly after completion.

## Related Issues

Addresses #54 — mid-run input was silently blocked; `PatchToolCallsMiddleware` on the backend handles any tool calls left open by the interruption.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*