### PR TITLE
feat(cli,web): proper pause/resume and message queuing for HITL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,8 @@ jobs:
       - name: Run pip-audit
         run: uv tool run pip-audit --requirement requirements.txt --ignore-vuln GHSA-xxxx-xxxx-xxxx || true
       - name: Gitleaks
-        uses: docker://zricethez/gitleaks:latest
+        uses: gitleaks/gitleaks-action@v2
         continue-on-error: true
-        with:
-          args: detect --source . -v
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/clients/cli/src/commands/help.ts
+++ b/clients/cli/src/commands/help.ts
@@ -19,8 +19,8 @@ const help: Command = {
       "",
       "Shortcuts:",
       "  ctrl+o  Expand (toggle transcript view)",
-      "  ctrl+c  Cancel stream / exit transcript / exit",
-      "  Esc     Exit transcript",
+      "  ctrl+c  Pause stream (1x) / cancel (2x) / exit (idle)",
+      "  Esc     Exit transcript / clear queue",
     ];
 
     ctx.addSystemEvent(lines.join("\n"));

--- a/clients/cli/src/commands/registry.ts
+++ b/clients/cli/src/commands/registry.ts
@@ -9,9 +9,10 @@ import type { Command } from "./types.js";
 import help from "./help.js";
 import clear from "./clear.js";
 import quit from "./quit.js";
+import resume from "./resume.js";
 
 /** All registered commands. Add new commands here. */
-const COMMANDS: Command[] = [help, clear, quit];
+const COMMANDS: Command[] = [help, clear, quit, resume];
 
 /** Get all registered commands. */
 export function getCommands(): Command[] {

--- a/clients/cli/src/commands/resume.ts
+++ b/clients/cli/src/commands/resume.ts
@@ -1,0 +1,13 @@
+import type { Command } from "./types.js";
+
+const resume: Command = {
+  name: "resume",
+  description: "Resume a paused run with optional feedback",
+  aliases: ["r"],
+  argumentHint: "[feedback]",
+  execute(args, ctx) {
+    ctx.resume(args || undefined);
+  },
+};
+
+export default resume;

--- a/clients/cli/src/commands/types.ts
+++ b/clients/cli/src/commands/types.ts
@@ -13,6 +13,8 @@ export interface CommandContext {
   clearEvents: () => void;
   /** Submit a message to the agent. */
   submit: (input: string) => void;
+  /** Resume a paused run with optional feedback. */
+  resume: (value?: string) => void;
   /** Exit the application. */
   exit: () => void;
 }

--- a/clients/cli/src/components/ActivityIndicator.tsx
+++ b/clients/cli/src/components/ActivityIndicator.tsx
@@ -2,10 +2,11 @@ import React, { useRef } from "react";
 import { Box, Text } from "ink";
 import { useSpinnerFrame } from "../hooks/useSpinnerFrame.js";
 import type { StreamStats } from "../hooks/useAgent.js";
+import type { RunState } from "../hooks/useAgent.js";
 import { GLYPH_DOT, GLYPH_SEP } from "../utils/theme.js";
 
 interface ActivityIndicatorProps {
-  isStreaming: boolean;
+  runState: RunState;
   streamStats: StreamStats | null;
 }
 
@@ -56,7 +57,7 @@ function ShimmerText({ text, tick }: { text: string; tick: number }) {
   );
 }
 
-// Pulse palette for the ● icon — smooth bright↔dim cycle synced with shimmer
+// Pulse palette for the icon — smooth bright/dim cycle synced with shimmer
 const PULSE_COLORS = [
   "#fecaca", // bright peak
   "#fca5a5",
@@ -74,19 +75,29 @@ const PULSE_COLORS = [
  *
  * Never returns null — maintains stable layout height like Claude Code's SpinnerGlyph.
  * When idle, renders an empty line to preserve layout; when streaming, shows the full
- * animated indicator. This prevents flicker from mount/unmount cycles.
+ * animated indicator. When paused, shows a static pause indicator.
  */
 export const ActivityIndicator = React.memo(function ActivityIndicator({
-  isStreaming,
+  runState,
   streamStats,
 }: ActivityIndicatorProps) {
-  const { tick } = useSpinnerFrame(isStreaming);
+  const isActive = runState === "streaming" || runState === "connecting";
+  const { tick } = useSpinnerFrame(isActive);
   const displayTokensRef = useRef(0);
 
-  // Reset token counter when idle, but keep the component mounted
-  if (!isStreaming) {
+  // Paused state — static indicator
+  if (runState === "paused") {
     displayTokensRef.current = 0;
-    // Empty placeholder — same height as active state to prevent layout shift
+    return (
+      <Box marginTop={1} height={1}>
+        <Text color="yellow">{GLYPH_DOT} Paused — /resume to continue, or type a new message</Text>
+      </Box>
+    );
+  }
+
+  // Idle — empty placeholder to prevent layout shift
+  if (!isActive) {
+    displayTokensRef.current = 0;
     return <Box marginTop={1} height={1} />;
   }
 

--- a/clients/cli/src/components/Prompt.tsx
+++ b/clients/cli/src/components/Prompt.tsx
@@ -6,12 +6,17 @@ import { useSpinnerFrame } from "../hooks/useSpinnerFrame.js";
 import { getCommands } from "../commands/registry.js";
 import { labelForAgent } from "../utils/agents.js";
 import { CLI_VERSION } from "../utils/version.js";
+import type { RunState } from "../hooks/useAgent.js";
 
 interface PromptProps {
-  isDisabled: boolean;
+  runState: RunState;
   onSubmit: (input: string) => void;
   /** Currently active agent name, e.g. "recon". null when idle. */
   activeAgent?: string | null;
+  /** Queued message waiting to be sent after stream completes. */
+  queuedMessage?: string | null;
+  /** Callback to update the queued message (for editing). */
+  onEditQueue?: (message: string) => void;
 }
 
 const DEBOUNCE_MS = 150;
@@ -44,16 +49,47 @@ const StatusLine = React.memo(function StatusLine({
   );
 });
 
+/** Context-sensitive keybinding hints. */
+function KeybindingHints({ runState, hasQueue }: { runState: RunState; hasQueue: boolean }) {
+  switch (runState) {
+    case "streaming":
+    case "connecting":
+      return (
+        <Text dimColor>
+          {"  ctrl+o: expand  ctrl+c: pause  2x: cancel"}
+        </Text>
+      );
+    case "paused":
+      return (
+        <Text dimColor>
+          {"  ctrl+o: expand  ctrl+c: cancel  /resume: continue"}
+        </Text>
+      );
+    default:
+      return (
+        <Text dimColor>
+          {hasQueue
+            ? "  ctrl+o: expand  ctrl+c: clear queue  esc: clear queue"
+            : "  ctrl+o: expand  ctrl+c: exit"}
+        </Text>
+      );
+  }
+}
+
 export const Prompt = React.memo(function Prompt({
-  isDisabled,
+  runState,
   onSubmit,
   activeAgent = null,
+  queuedMessage = null,
+  onEditQueue,
 }: PromptProps) {
   const lastSubmitRef = useRef(0);
   const { columns } = useTerminalSize();
   const [inputValue, setInputValue] = useState("");
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [inputKey, setInputKey] = useState(0);
+
+  const isActive = runState === "streaming" || runState === "connecting";
 
   // Derive autocomplete entries from command registry
   const commandEntries = useMemo(() => {
@@ -96,7 +132,14 @@ export const Prompt = React.memo(function Prompt({
 
   // Up/Down/Tab — TextInput explicitly ignores these, so they bubble here
   useInput((_input, key) => {
-    if (isDisabled || !showMenu) return;
+    // Up arrow when queued + streaming: load queued message into input for editing
+    if (key.upArrow && queuedMessage && isActive) {
+      setInputValue(queuedMessage);
+      setInputKey((prev) => prev + 1);
+      return;
+    }
+
+    if (!showMenu) return;
 
     if (key.upArrow) {
       setSelectedIdx((prev) => Math.max(0, prev - 1));
@@ -124,24 +167,38 @@ export const Prompt = React.memo(function Prompt({
       lastSubmitRef.current = now;
       setInputValue("");
       setInputKey((prev) => prev + 1);
+
+      // If streaming and not a slash command, update the queue
+      if (isActive && onEditQueue && !value.startsWith("/")) {
+        onEditQueue(value);
+        return;
+      }
+
       onSubmit(value);
     },
-    [onSubmit],
+    [onSubmit, isActive, onEditQueue],
   );
 
   const maxCmdLen = Math.max(...commandEntries.map((c) => c.cmd.length));
 
   return (
     <Box flexDirection="column" marginTop={1}>
+      {/* Queued message display */}
+      {queuedMessage && isActive && (
+        <Box marginLeft={2} marginBottom={0}>
+          <Text dimColor italic>{"  "}{queuedMessage}</Text>
+        </Box>
+      )}
+
       <Text dimColor>{"─".repeat(columns)}</Text>
       <Box flexDirection="row">
         <Text color="white">{"› "}</Text>
         <TextInput
           key={inputKey}
-          placeholder=""
+          placeholder={queuedMessage && isActive ? "Press up to edit queued message" : ""}
           defaultValue={inputValue || undefined}
           suggestions={suggestionList}
-          isDisabled={isDisabled}
+          isDisabled={false}
           onChange={handleChange}
           onSubmit={handleSubmit}
         />
@@ -168,10 +225,8 @@ export const Prompt = React.memo(function Prompt({
       {/* Compact status line — always visible */}
       <StatusLine activeAgent={activeAgent} />
 
-      {/* Keybinding hints */}
-      <Text dimColor>
-        {"  ctrl+o: expand  ctrl+c: cancel/exit"}
-      </Text>
+      {/* Context-sensitive keybinding hints */}
+      <KeybindingHints runState={runState} hasQueue={queuedMessage != null} />
     </Box>
   );
 });

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -7,6 +7,11 @@
  * Also subscribes to stream_mode="custom" for sub-agent events emitted by
  * StreamingRunnable via get_stream_writer(). This enables real-time visibility
  * into sub-agent tool calls, bash execution, and AI reasoning.
+ *
+ * Supports three run lifecycle operations:
+ * - interrupt(): Pause at checkpoint (Ctrl+C single press) — state preserved
+ * - cancel(): Hard abort (Ctrl+C double press, or from paused) — state lost
+ * - resume(): Continue from pause point with optional feedback
  */
 
 import { useState, useCallback, useRef } from "react";
@@ -55,16 +60,32 @@ export interface StreamStats {
   completionTokens: number;
 }
 
+/** Agent run lifecycle state. */
+export type RunState = "idle" | "connecting" | "streaming" | "paused";
+
 interface UseAgentReturn {
   submit: (message: string) => void;
-  /** Cancel the current streaming run. */
+  /** Pause the current run at checkpoint (Ctrl+C single). State preserved. */
+  interrupt: () => void;
+  /** Hard cancel the current run (Ctrl+C double, or from paused). State lost. */
   cancel: () => void;
+  /** Resume a paused run with optional operator feedback. */
+  resume: (value?: string) => void;
+  /** Enqueue a message to auto-submit when current run completes. */
+  enqueue: (message: string) => void;
+  /** Clear the queued message. */
+  clearQueuedMessage: () => void;
   events: AgentEvent[];
+  /** Current run lifecycle state. */
+  runState: RunState;
+  /** Derived from runState for backward compatibility. */
   isStreaming: boolean;
   pendingTool: PendingTool | null;
   streamStats: StreamStats | null;
   /** Currently active agent name (e.g. "decepticon", "recon"). */
   activeAgent: string | null;
+  /** Queued message to auto-submit on completion. */
+  queuedMessage: string | null;
   error: string | null;
   clearEvents: () => void;
   addSystemEvent: (content: string) => void;
@@ -80,13 +101,23 @@ export function useAgent({
   const eventsRef = useRef<AgentEvent[]>([]);
   const lastCountRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
+  const runIdRef = useRef<string | null>(null);
+  const queuedMessageRef = useRef<string | null>(null);
 
   const [events, setEvents] = useState<AgentEvent[]>([]);
-  const [isStreaming, setIsStreaming] = useState(false);
+  const [runState, setRunState] = useState<RunState>("idle");
   const [pendingTool, setPendingTool] = useState<PendingTool | null>(null);
   const [streamStats, setStreamStats] = useState<StreamStats | null>(null);
   const [activeAgent, setActiveAgent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [queuedMessage, setQueuedMessage] = useState<string | null>(null);
+
+  // Ref for runState to avoid stale closures in async callbacks
+  const runStateRef = useRef<RunState>(runState);
+  runStateRef.current = runState;
+
+  // Derived for backward compatibility
+  const isStreaming = runState === "streaming" || runState === "connecting";
 
   const addEvent = useCallback(
     (partial: Omit<AgentEvent, "id" | "timestamp">) => {
@@ -109,43 +140,346 @@ export function useAgent({
   );
 
   const resetStreamState = useCallback(() => {
-    setIsStreaming(false);
+    setRunState("idle");
     setPendingTool(null);
     setStreamStats(null);
     setActiveAgent(null);
   }, []);
 
-  const cancel = useCallback(() => {
-    // Cancel running runs on the server FIRST (before aborting local stream)
-    const threadId = threadIdRef.current;
-    if (threadId) {
-      clientRef.current.runs
-        .cancelMany({ threadId, status: "running" })
-        .catch(() => {});
-    }
+  // ── Enqueue / clear queue ───────────────────────────────────────
 
-    // Then abort the local stream
+  const enqueue = useCallback(
+    (message: string) => {
+      queuedMessageRef.current = message;
+      setQueuedMessage(message);
+      addEvent({ type: "system", content: `Queued: "${message}"` });
+    },
+    [addEvent],
+  );
+
+  const clearQueuedMessage = useCallback(() => {
+    queuedMessageRef.current = null;
+    setQueuedMessage(null);
+  }, []);
+
+  // ── Stream event processing (shared by submit and resume) ──────
+
+  const processStream = useCallback(
+    async (
+      stream: AsyncIterable<{ event: string; data: unknown }>,
+      abortController: AbortController,
+    ) => {
+      // Capture run_id from the first metadata event for interrupt/cancel
+      // LangGraph SDK emits: { event: "metadata", data: { run_id, thread_id } }
+      const toolCallArgs = new Map<string, Record<string, unknown>>();
+      const toolCallNames = new Map<string, string>();
+      let cumTotal = 0;
+      let cumPrompt = 0;
+      let cumCompletion = 0;
+
+      const handleCustomEvent = (data: SubagentCustomEvent) => {
+        switch (data.type) {
+          case "subagent_start":
+            setActiveAgent(data.agent);
+            addEvent({
+              type: "subagent_start",
+              content: data.prompt ?? `Starting ${data.agent}`,
+              subagent: data.agent,
+            });
+            break;
+
+          case "subagent_tool_call":
+            setPendingTool({
+              name: data.tool ?? "",
+              args: data.args ?? {},
+            });
+            break;
+
+          case "subagent_tool_result": {
+            setPendingTool(null);
+            const status: "success" | "error" =
+              data.status === "error" ? "error" : "success";
+
+            if (data.tool === "bash") {
+              addEvent({
+                type: "bash_result",
+                content: data.content ?? "",
+                toolName: "bash",
+                toolArgs: data.args ?? {},
+                status,
+                subagent: data.agent,
+              });
+            } else {
+              addEvent({
+                type: "tool_result",
+                content: data.content ?? "",
+                toolName: data.tool ?? "",
+                toolArgs: data.args ?? {},
+                status,
+                subagent: data.agent,
+              });
+            }
+            break;
+          }
+
+          case "subagent_message":
+            addEvent({
+              type: "ai_message",
+              content: data.text ?? "",
+              subagent: data.agent,
+            });
+            break;
+
+          case "subagent_end":
+            addEvent({
+              type: "subagent_end",
+              content: data.elapsed
+                ? `Completed (${Math.floor(data.elapsed / 1000)}s)`
+                : "Completed",
+              subagent: data.agent,
+              status: data.error ? "error" : "success",
+            });
+            setActiveAgent("decepticon");
+            setPendingTool(null);
+            break;
+        }
+      };
+
+      for await (const event of stream) {
+        if (abortController.signal.aborted) break;
+
+        // Capture run_id from metadata event for precise interrupt/cancel
+        if (event.event === "metadata") {
+          const meta = event.data as { run_id?: string };
+          if (meta.run_id) {
+            runIdRef.current = meta.run_id;
+          }
+          continue;
+        }
+
+        // Handle server-side errors (LLM connection failures, etc.)
+        if (event.event === "error") {
+          const errData = event.data as
+            | { message?: string; error?: string }
+            | string;
+          const errMsg =
+            typeof errData === "string"
+              ? errData
+              : errData?.message ?? errData?.error ?? "Server error";
+          setError(errMsg);
+          continue;
+        }
+
+        // Handle custom events (sub-agent streaming from StreamingRunnable)
+        if (event.event === "custom") {
+          const data = event.data as SubagentCustomEvent;
+          if (data && typeof data === "object" && "type" in data) {
+            handleCustomEvent(data);
+          }
+          continue;
+        }
+
+        if (event.event !== "values") continue;
+
+        const data = event.data as {
+          messages?: LangChainMessage[];
+        };
+        const messages = data.messages ?? [];
+        const newMessages = messages.slice(lastCountRef.current);
+        lastCountRef.current = messages.length;
+
+        for (const msg of newMessages) {
+          if (msg.type === "human") continue;
+
+          if (msg.type === "ai") {
+            // Extract token usage
+            const usage = msg.response_metadata?.token_usage;
+            if (usage) {
+              cumTotal += usage.total_tokens ?? 0;
+              cumPrompt += usage.prompt_tokens ?? 0;
+              cumCompletion += usage.completion_tokens ?? 0;
+              setStreamStats((prev) =>
+                prev
+                  ? { ...prev, totalTokens: cumTotal, promptTokens: cumPrompt, completionTokens: cumCompletion }
+                  : prev,
+              );
+            }
+
+            // Emit AI text content (even when tool_calls are present)
+            const text = stripResultTags(extractText(msg.content));
+            if (text) {
+              addEvent({ type: "ai_message", content: text });
+            }
+
+            if (msg.tool_calls?.length) {
+              for (const tc of msg.tool_calls) {
+                toolCallArgs.set(tc.id, tc.args);
+                toolCallNames.set(tc.id, tc.name);
+                if (tc.name === "task") {
+                  // Emit delegate event for sub-agent dispatch
+                  addEvent({
+                    type: "delegate",
+                    content: (tc.args.description as string) ?? "",
+                    subagent: (tc.args.subagent_type as string) ?? "",
+                  });
+                } else {
+                  setPendingTool({ name: tc.name, args: tc.args });
+                }
+              }
+            } else {
+              setPendingTool(null);
+            }
+          } else if (msg.type === "tool") {
+            const content =
+              typeof msg.content === "string"
+                ? msg.content
+                : extractText(msg.content);
+            const tcId = msg.tool_call_id ?? "";
+            const args = toolCallArgs.get(tcId) ?? {};
+            const toolName = msg.name ?? toolCallNames.get(tcId) ?? "";
+            const status: "success" | "error" =
+              msg.status === "error" ? "error" : "success";
+
+            setPendingTool(null);
+
+            // Suppress task() tool results — already shown via sub-agent custom events
+            if (toolName === "task") continue;
+
+            if (toolName === "bash") {
+              addEvent({
+                type: "bash_result",
+                content,
+                toolName: "bash",
+                toolArgs: args,
+                status,
+              });
+            } else {
+              addEvent({
+                type: "tool_result",
+                content,
+                toolName,
+                toolArgs: args,
+                status,
+              });
+            }
+          }
+        }
+      }
+    },
+    [addEvent],
+  );
+
+  // ── Handle stream completion (shared by submit and resume) ─────
+
+  const handleStreamComplete = useCallback(
+    (abortController: AbortController) => {
+      if (!abortController.signal.aborted) {
+        abortRef.current = null;
+        runIdRef.current = null;
+        resetStreamState();
+
+        // Auto-submit queued message
+        const pending = queuedMessageRef.current;
+        if (pending) {
+          queuedMessageRef.current = null;
+          setQueuedMessage(null);
+          // Defer to next tick so React state settles
+          setTimeout(() => submitRef.current(pending), 0);
+        }
+      }
+    },
+    [resetStreamState],
+  );
+
+  // ── Interrupt (pause at checkpoint) ────────────────────────────
+
+  const interrupt = useCallback(() => {
+    // Abort local stream first (stops event processing immediately)
     abortRef.current?.abort();
     abortRef.current = null;
 
+    // Pause on server — preserves checkpoint state (don't await to keep responsive)
+    const threadId = threadIdRef.current;
+    const runId = runIdRef.current;
+    if (threadId && runId) {
+      clientRef.current.runs
+        .cancel(threadId, runId, true, "interrupt")
+        .catch(() => {
+          addEvent({ type: "system", content: "Warning: server pause failed." });
+        });
+    }
+
+    setPendingTool(null);
+    setStreamStats(null);
+    setActiveAgent(null);
+    setRunState("paused");
+    runIdRef.current = null;
+    addEvent({ type: "system", content: "Paused. Type /resume to continue, or send a new message." });
+  }, [addEvent]);
+
+  // ── Cancel (hard abort, no resume) ─────────────────────────────
+
+  const cancel = useCallback(() => {
+    // Abort local stream
+    abortRef.current?.abort();
+    abortRef.current = null;
+
+    // Hard cancel on server — destroys run state
+    const threadId = threadIdRef.current;
+    const runId = runIdRef.current;
+    if (threadId && runId) {
+      clientRef.current.runs
+        .cancel(threadId, runId, false, "rollback")
+        .catch(() => {
+          addEvent({ type: "system", content: "Warning: server cancel failed." });
+        });
+    }
+
+    runIdRef.current = null;
+    // Clear queued message on hard cancel
+    queuedMessageRef.current = null;
+    setQueuedMessage(null);
     resetStreamState();
     addEvent({ type: "system", content: "Cancelled." });
   }, [addEvent, resetStreamState]);
+
+  // ── Clear ──────────────────────────────────────────────────────
 
   const clearEvents = useCallback(() => {
     eventsRef.current = [];
     setEvents([]);
     threadIdRef.current = null;
     lastCountRef.current = 0;
+    runIdRef.current = null;
+    queuedMessageRef.current = null;
+    setQueuedMessage(null);
+    setRunState("idle");
   }, []);
+
+  // ── Submit (only when idle or paused) ──────────────────────────
 
   const submit = useCallback(
     (message: string): void => {
-      // Block submit while a stream is active to prevent race conditions
-      // where a second run cancels the first, leaving dangling tool calls
+      // If streaming/connecting, callers should use enqueue() instead
       if (abortRef.current) return;
 
+      // If paused, cancel the paused run before starting fresh
+      if (runStateRef.current === "paused") {
+        const threadId = threadIdRef.current;
+        const runId = runIdRef.current;
+        if (threadId && runId) {
+          clientRef.current.runs
+            .cancel(threadId, runId, false, "rollback")
+            .catch(() => {});
+        }
+        runIdRef.current = null;
+      }
+
+      setRunState("connecting");
       addEvent({ type: "user", content: message });
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
 
       const runStream = async () => {
         const client = clientRef.current;
@@ -155,6 +489,7 @@ export function useAgent({
         if (!threadIdRef.current) {
           const maxRetries = 5;
           for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            if (abortController.signal.aborted) return;
             try {
               const thread = await client.threads.create();
               threadIdRef.current = thread.thread_id;
@@ -164,6 +499,9 @@ export function useAgent({
                 const msg =
                   err instanceof Error ? err.message : "Failed to create thread";
                 setError(`Connection failed: ${msg}`);
+                // Clear queued message to prevent infinite retry loop
+                queuedMessageRef.current = null;
+                setQueuedMessage(null);
                 return;
               }
               // Server may still be loading graphs — wait and retry
@@ -172,90 +510,12 @@ export function useAgent({
           }
         }
 
-        const abortController = new AbortController();
-        abortRef.current = abortController;
+        if (abortController.signal.aborted) return;
 
-        setIsStreaming(true);
+        setRunState("streaming");
         setPendingTool(null);
         setActiveAgent("decepticon");
         setStreamStats({ startTime: Date.now(), totalTokens: 0, promptTokens: 0, completionTokens: 0 });
-
-        // Track tool_call args and names by ID for matching with results
-        const toolCallArgs = new Map<string, Record<string, unknown>>();
-        const toolCallNames = new Map<string, string>();
-        // Cumulative token counts
-        let cumTotal = 0;
-        let cumPrompt = 0;
-        let cumCompletion = 0;
-
-        // Handler for custom sub-agent events from StreamingRunnable
-        const handleCustomEvent = (data: SubagentCustomEvent) => {
-          switch (data.type) {
-            case "subagent_start":
-              setActiveAgent(data.agent);
-              addEvent({
-                type: "subagent_start",
-                content: data.prompt ?? `Starting ${data.agent}`,
-                subagent: data.agent,
-              });
-              break;
-
-            case "subagent_tool_call":
-              setPendingTool({
-                name: data.tool ?? "",
-                args: data.args ?? {},
-              });
-              break;
-
-            case "subagent_tool_result": {
-              setPendingTool(null);
-              const status: "success" | "error" =
-                data.status === "error" ? "error" : "success";
-
-              if (data.tool === "bash") {
-                addEvent({
-                  type: "bash_result",
-                  content: data.content ?? "",
-                  toolName: "bash",
-                  toolArgs: data.args ?? {},
-                  status,
-                  subagent: data.agent,
-                });
-              } else {
-                addEvent({
-                  type: "tool_result",
-                  content: data.content ?? "",
-                  toolName: data.tool ?? "",
-                  toolArgs: data.args ?? {},
-                  status,
-                  subagent: data.agent,
-                });
-              }
-              break;
-            }
-
-            case "subagent_message":
-              addEvent({
-                type: "ai_message",
-                content: data.text ?? "",
-                subagent: data.agent,
-              });
-              break;
-
-            case "subagent_end":
-              addEvent({
-                type: "subagent_end",
-                content: data.elapsed
-                  ? `Completed (${Math.floor(data.elapsed / 1000)}s)`
-                  : "Completed",
-                subagent: data.agent,
-                status: data.error ? "error" : "success",
-              });
-              setActiveAgent("decepticon");
-              setPendingTool(null);
-              break;
-          }
-        };
 
         try {
           const stream = client.runs.stream(
@@ -266,152 +526,129 @@ export function useAgent({
                 messages: [{ role: "user", content: message }],
               },
               ...STREAM_OPTIONS,
-              onDisconnect: "cancel",
+              onDisconnect: "continue",
               signal: abortController.signal,
             },
           );
 
-          for await (const event of stream) {
-            if (abortController.signal.aborted) break;
-
-            // Handle server-side errors (LLM connection failures, etc.)
-            if (event.event === "error") {
-              const errData = event.data as
-                | { message?: string; error?: string }
-                | string;
-              const errMsg =
-                typeof errData === "string"
-                  ? errData
-                  : errData?.message ?? errData?.error ?? "Server error";
-              setError(errMsg);
-              continue;
-            }
-
-            // Handle custom events (sub-agent streaming from StreamingRunnable)
-            if (event.event === "custom") {
-              const data = event.data as SubagentCustomEvent;
-              if (data && typeof data === "object" && "type" in data) {
-                handleCustomEvent(data);
-              }
-              continue;
-            }
-
-            if (event.event !== "values") continue;
-
-            const data = event.data as {
-              messages?: LangChainMessage[];
-            };
-            const messages = data.messages ?? [];
-            const newMessages = messages.slice(lastCountRef.current);
-            lastCountRef.current = messages.length;
-
-            for (const msg of newMessages) {
-              if (msg.type === "human") continue;
-
-              if (msg.type === "ai") {
-                // Extract token usage
-                const usage = msg.response_metadata?.token_usage;
-                if (usage) {
-                  cumTotal += usage.total_tokens ?? 0;
-                  cumPrompt += usage.prompt_tokens ?? 0;
-                  cumCompletion += usage.completion_tokens ?? 0;
-                  setStreamStats((prev) =>
-                    prev
-                      ? { ...prev, totalTokens: cumTotal, promptTokens: cumPrompt, completionTokens: cumCompletion }
-                      : prev,
-                  );
-                }
-
-                // Emit AI text content (even when tool_calls are present)
-                const text = stripResultTags(extractText(msg.content));
-                if (text) {
-                  addEvent({ type: "ai_message", content: text });
-                }
-
-                if (msg.tool_calls?.length) {
-                  for (const tc of msg.tool_calls) {
-                    toolCallArgs.set(tc.id, tc.args);
-                    toolCallNames.set(tc.id, tc.name);
-                    if (tc.name === "task") {
-                      // Emit delegate event for sub-agent dispatch
-                      addEvent({
-                        type: "delegate",
-                        content: (tc.args.description as string) ?? "",
-                        subagent: (tc.args.subagent_type as string) ?? "",
-                      });
-                    } else {
-                      setPendingTool({ name: tc.name, args: tc.args });
-                    }
-                  }
-                } else {
-                  setPendingTool(null);
-                }
-              } else if (msg.type === "tool") {
-                const content =
-                  typeof msg.content === "string"
-                    ? msg.content
-                    : extractText(msg.content);
-                const tcId = msg.tool_call_id ?? "";
-                const args = toolCallArgs.get(tcId) ?? {};
-                const toolName = msg.name ?? toolCallNames.get(tcId) ?? "";
-                const status: "success" | "error" =
-                  msg.status === "error" ? "error" : "success";
-
-                setPendingTool(null);
-
-                // Suppress task() tool results — already shown via sub-agent custom events
-                if (toolName === "task") continue;
-
-                if (toolName === "bash") {
-                  addEvent({
-                    type: "bash_result",
-                    content,
-                    toolName: "bash",
-                    toolArgs: args,
-                    status,
-                  });
-                } else {
-                  addEvent({
-                    type: "tool_result",
-                    content,
-                    toolName,
-                    toolArgs: args,
-                    status,
-                  });
-                }
-              }
-            }
-          }
+          await processStream(stream, abortController);
         } catch (err) {
-          // Ignore abort errors — triggered by cancel()
+          // Ignore abort errors — triggered by interrupt() or cancel()
           if (abortController.signal.aborted) return;
           const msg =
             err instanceof Error ? err.message : "Unknown streaming error";
           setError(msg);
         }
 
-        abortRef.current = null;
-        resetStreamState();
+        handleStreamComplete(abortController);
       };
 
       runStream().catch((err) => {
-        if (abortRef.current?.signal.aborted) return;
+        if (abortController.signal.aborted) return;
         setError(err instanceof Error ? err.message : "Unknown error");
         abortRef.current = null;
+        runIdRef.current = null;
         resetStreamState();
       });
     },
-    [addEvent],
+    [addEvent, processStream, handleStreamComplete, resetStreamState],
+  );
+
+  // Ref to submit for use in deferred auto-submit (avoids stale closure)
+  const submitRef = useRef(submit);
+  submitRef.current = submit;
+
+  // ── Resume (continue from pause point) ─────────────────────────
+
+  const resume = useCallback(
+    (value?: string): void => {
+      if (runStateRef.current !== "paused") {
+        addEvent({ type: "system", content: "Nothing to resume." });
+        return;
+      }
+
+      if (!threadIdRef.current) {
+        addEvent({ type: "system", content: "No thread to resume." });
+        setRunState("idle");
+        return;
+      }
+
+      if (value) {
+        addEvent({ type: "user", content: value });
+      }
+      addEvent({ type: "system", content: "Resuming..." });
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+
+      const runResume = async () => {
+        const client = clientRef.current;
+        setError(null);
+
+        // Sync lastCountRef with server state before resuming
+        try {
+          const state = await client.threads.getState(threadIdRef.current!);
+          const msgs = (state.values as { messages?: unknown[] })?.messages;
+          if (msgs) lastCountRef.current = msgs.length;
+        } catch {
+          // Proceed with current count — may cause some duplicate events
+        }
+
+        if (abortController.signal.aborted) return;
+
+        setRunState("streaming");
+        setPendingTool(null);
+        setActiveAgent("decepticon");
+        setStreamStats({ startTime: Date.now(), totalTokens: 0, promptTokens: 0, completionTokens: 0 });
+
+        try {
+          const stream = client.runs.stream(
+            threadIdRef.current!,
+            ASSISTANT_ID,
+            {
+              command: { resume: value ?? true },
+              ...STREAM_OPTIONS,
+              onDisconnect: "continue",
+              signal: abortController.signal,
+            },
+          );
+
+          await processStream(stream, abortController);
+        } catch (err) {
+          if (abortController.signal.aborted) return;
+          const msg =
+            err instanceof Error ? err.message : "Resume failed";
+          setError(msg);
+        }
+
+        handleStreamComplete(abortController);
+      };
+
+      runResume().catch((err) => {
+        if (abortController.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "Resume error");
+        abortRef.current = null;
+        runIdRef.current = null;
+        resetStreamState();
+      });
+    },
+    [addEvent, processStream, handleStreamComplete, resetStreamState],
   );
 
   return {
     submit,
+    interrupt,
     cancel,
+    resume,
+    enqueue,
+    clearQueuedMessage,
     events,
+    runState,
     isStreaming,
     pendingTool,
     streamStats,
     activeAgent,
+    queuedMessage,
     error,
     clearEvents,
     addSystemEvent,

--- a/clients/cli/src/hooks/useGlobalKeybindings.ts
+++ b/clients/cli/src/hooks/useGlobalKeybindings.ts
@@ -3,31 +3,48 @@
  *
  * Registers all global keyboard shortcuts via Ink's useInput.
  * - ctrl+o: Toggle transcript (expand/collapse) — single expansion control
- * - ctrl+c: Cancel stream / exit transcript / exit app
- * - Escape: Exit transcript mode
+ * - ctrl+c: Interrupt (pause) / cancel / exit — context-dependent
+ *   - Streaming: single = pause, double (within 500ms) = hard cancel
+ *   - Paused: cancel the paused run
+ *   - Idle with queue: clear the queue
+ *   - Idle: exit app
+ * - Escape: Exit transcript mode / clear queue
  */
 
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useInput } from "ink";
 import { useAppState, useSetAppState } from "../state/AppState.js";
 import type { ScreenMode } from "../types.js";
+import type { RunState } from "./useAgent.js";
 
 interface Props {
-  /** Called when ctrl+c should cancel the current stream. */
+  /** Called when ctrl+c should pause the current stream (single press). */
+  onInterrupt: () => void;
+  /** Called when ctrl+c should hard cancel (double press, or from paused). */
   onCancel: () => void;
-  /** Called when ctrl+c should exit the app (no stream running). */
+  /** Called when ctrl+c should exit the app (idle, no queue). */
   onExit: () => void;
-  /** Whether a stream is currently active. */
-  isStreaming: boolean;
+  /** Called to clear a queued message. */
+  onClearQueue?: () => void;
+  /** Current run lifecycle state. */
+  runState: RunState;
+  /** Whether a message is queued. */
+  hasQueuedMessage?: boolean;
 }
 
+const DOUBLE_PRESS_MS = 500;
+
 export function useGlobalKeybindings({
+  onInterrupt,
   onCancel,
   onExit,
-  isStreaming,
+  onClearQueue,
+  runState,
+  hasQueuedMessage = false,
 }: Props): void {
   const screen = useAppState((s) => s.screen);
   const setAppState = useSetAppState();
+  const lastCtrlCRef = useRef(0);
 
   const toggleScreen = useCallback(() => {
     setAppState((prev) => ({
@@ -53,18 +70,49 @@ export function useGlobalKeybindings({
       return;
     }
 
-    // ctrl+c: cancel takes priority over screen changes
+    // Escape: clear queued message (any screen mode)
+    if (key.escape && hasQueuedMessage) {
+      onClearQueue?.();
+      return;
+    }
+
+    // ctrl+c: context-dependent behavior
     if (key.ctrl && input === "c") {
-      if (isStreaming) {
-        onCancel();
-        // Also exit transcript if we were viewing it
+      const now = Date.now();
+      const isDoubleTap = (now - lastCtrlCRef.current) < DOUBLE_PRESS_MS;
+      lastCtrlCRef.current = now;
+
+      if (runState === "streaming" || runState === "connecting") {
+        if (isDoubleTap) {
+          // Double Ctrl+C while streaming → hard cancel (state lost)
+          onClearQueue?.();
+          onCancel();
+        } else {
+          // Single Ctrl+C while streaming → pause (state preserved)
+          onInterrupt();
+        }
+        // Also exit transcript if viewing it
         if (screen === "transcript") {
           exitTranscript();
         }
-      } else if (screen === "transcript") {
-        exitTranscript();
+      } else if (runState === "paused") {
+        // Ctrl+C while paused → hard cancel the paused run
+        onClearQueue?.();
+        onCancel();
+        if (screen === "transcript") {
+          exitTranscript();
+        }
       } else {
-        onExit();
+        // Idle state
+        if (hasQueuedMessage) {
+          // Clear queued message first, don't exit
+          onClearQueue?.();
+        } else if (screen === "transcript") {
+          exitTranscript();
+        } else {
+          // Truly idle, no queue → exit app
+          onExit();
+        }
       }
     }
   });

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -46,12 +46,6 @@ interface REPLProps {
   initialMessage?: string;
 }
 
-// ── Static item type for the prompt-mode <Static> list ──────────
-type StaticItem =
-  | { id: "__banner__"; kind: "banner" }
-  | { id: string; kind: "event"; event: AgentEvent }
-  | { id: string; kind: "session"; session: SubAgentSession };
-
 export function REPL({ initialMessage }: REPLProps) {
   const { exit } = useApp();
   const agent = useAgent();
@@ -70,9 +64,12 @@ export function REPL({ initialMessage }: REPLProps) {
 
   // ── Global keybindings ──────────────────────────────────────────
   useGlobalKeybindings({
+    onInterrupt: agent.interrupt,
     onCancel: agent.cancel,
     onExit: exit,
-    isStreaming: agent.isStreaming,
+    onClearQueue: agent.clearQueuedMessage,
+    runState: agent.runState,
+    hasQueuedMessage: agent.queuedMessage != null,
   });
 
   // ── Command handling ────────────────────────────────────────────
@@ -81,9 +78,10 @@ export function REPL({ initialMessage }: REPLProps) {
       addSystemEvent: agent.addSystemEvent,
       clearEvents: agent.clearEvents,
       submit: agent.submit,
+      resume: agent.resume,
       exit,
     }),
-    [agent.addSystemEvent, agent.clearEvents, agent.submit, exit],
+    [agent.addSystemEvent, agent.clearEvents, agent.submit, agent.resume, exit],
   );
 
   const handleSubmit = useCallback(
@@ -91,7 +89,7 @@ export function REPL({ initialMessage }: REPLProps) {
       const trimmed = input.trim();
       if (!trimmed) return;
 
-      // Slash command dispatch
+      // Slash commands always execute immediately (even during streaming)
       const parsed = parseSlashCommand(trimmed);
       if (parsed) {
         const cmd = findCommand(parsed.name);
@@ -107,7 +105,12 @@ export function REPL({ initialMessage }: REPLProps) {
         return;
       }
 
-      agent.submit(trimmed);
+      // If streaming/connecting → queue; if idle/paused → submit
+      if (agent.runState === "streaming" || agent.runState === "connecting") {
+        agent.enqueue(trimmed);
+      } else {
+        agent.submit(trimmed);
+      }
     },
     [agent, commandContext],
   );
@@ -226,7 +229,7 @@ export function REPL({ initialMessage }: REPLProps) {
           )}
 
           <ActivityIndicator
-            isStreaming={agent.isStreaming}
+            runState={agent.runState}
             streamStats={agent.streamStats}
           />
 
@@ -238,14 +241,16 @@ export function REPL({ initialMessage }: REPLProps) {
           {agent.error && <ErrorMessage content={agent.error} />}
 
           {/* Transcript mode hint */}
-          {!agent.isStreaming && agent.events.length > 0 && (
+          {agent.runState === "idle" && agent.events.length > 0 && (
             <CtrlOToExpand />
           )}
 
           <Prompt
-            isDisabled={agent.isStreaming}
+            runState={agent.runState}
             onSubmit={handleSubmit}
             activeAgent={agent.activeAgent}
+            queuedMessage={agent.queuedMessage}
+            onEditQueue={agent.enqueue}
           />
         </Box>
 

--- a/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
@@ -89,12 +89,12 @@ export default function LivePage() {
   }, [messages]);
 
   // Auto-select Soundwave for new engagements
+  const soundwave = agents.find((a) => a.id === "soundwave");
   useEffect(() => {
-    if (isNew && !selectedAgent) {
-      const soundwave = agents.find((a) => a.id === "soundwave");
-      if (soundwave) setSelectedAgent(soundwave);
+    if (isNew && !selectedAgent && soundwave) {
+      setSelectedAgent(soundwave);
     }
-  }, [isNew, selectedAgent]);
+  }, [isNew, selectedAgent, soundwave]);
 
   // Pre-fill initial prompt for new engagements (user must click send)
   useEffect(() => {

--- a/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { AGENTS, type AgentConfig } from "@/lib/agents";
+import { type AgentConfig } from "@/lib/agents";
 import { AgentSpline } from "@/components/agents/agent-spline";
 import { AgentCanvasProvider } from "@/components/agents/agent-canvas-provider";
 import { AgentGrid } from "@/components/agents/agent-grid";
@@ -59,9 +59,7 @@ export default function LivePage() {
   const initSent = useRef(false);
 
   const { agents } = useAgents();
-  const [selectedAgent, setSelectedAgent] = useState<AgentConfig | null>(
-    () => isNew ? (AGENTS.find((a) => a.id === "soundwave") ?? null) : null,
-  );
+  const [selectedAgent, setSelectedAgent] = useState<AgentConfig | null>(null);
   const [input, setInput] = useState("");
   const [selectedDoc, setSelectedDoc] = useState<DocumentRef | null>(null);
   const [docPanelOpen, setDocPanelOpen] = useState(false);
@@ -69,7 +67,10 @@ export default function LivePage() {
   const isUserScrolledRef = useRef(false);
   const prevMsgCountRef = useRef(0);
 
-  const { messages, isStreaming, error: chatError, sendMessage, stop } = useChat({
+  const {
+    messages, isStreaming, runState, error: chatError,
+    sendMessage, interrupt, resume,
+  } = useChat({
     engagementId,
     assistantId: selectedAgent?.id ?? "soundwave",
   });
@@ -87,6 +88,14 @@ export default function LivePage() {
     }, delay);
   }, [messages]);
 
+  // Auto-select Soundwave for new engagements
+  useEffect(() => {
+    if (isNew && !selectedAgent) {
+      const soundwave = agents.find((a) => a.id === "soundwave");
+      if (soundwave) setSelectedAgent(soundwave);
+    }
+  }, [isNew, selectedAgent]);
+
   // Pre-fill initial prompt for new engagements (user must click send)
   useEffect(() => {
     if (!isNew || initSent.current || !selectedAgent) return;
@@ -98,7 +107,7 @@ export default function LivePage() {
   }, [isNew, engagementId, selectedAgent]);
 
   function handleSend() {
-    if (!input.trim() || isStreaming) return;
+    if (!input.trim()) return;
     sendMessage(input.trim());
     setInput("");
   }
@@ -289,16 +298,23 @@ export default function LivePage() {
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSend()}
                   placeholder={`Message ${selectedAgent.name}...`}
-                  disabled={isStreaming}
                   className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm text-white placeholder-zinc-600 outline-none transition-colors focus:border-white/20 focus:ring-1 focus:ring-white/10 disabled:opacity-50"
                 />
                 {isStreaming ? (
                   <button
-                    onClick={() => stop()}
-                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-zinc-700 text-white transition-all hover:bg-zinc-600"
-                    title="Stop"
+                    onClick={() => interrupt()}
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-yellow-600 text-white transition-all hover:bg-yellow-500"
+                    title="Pause"
                   >
                     <X className="h-4 w-4" />
+                  </button>
+                ) : runState === "paused" ? (
+                  <button
+                    onClick={() => resume()}
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-600 text-white transition-all hover:bg-emerald-500"
+                    title="Resume"
+                  >
+                    <Send className="h-4 w-4" />
                   </button>
                 ) : (
                   <button

--- a/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { type AgentConfig } from "@/lib/agents";
+import { AGENTS, type AgentConfig } from "@/lib/agents";
 import { AgentSpline } from "@/components/agents/agent-spline";
 import { AgentCanvasProvider } from "@/components/agents/agent-canvas-provider";
 import { AgentGrid } from "@/components/agents/agent-grid";
@@ -59,7 +59,9 @@ export default function LivePage() {
   const initSent = useRef(false);
 
   const { agents } = useAgents();
-  const [selectedAgent, setSelectedAgent] = useState<AgentConfig | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<AgentConfig | null>(
+    () => isNew ? (AGENTS.find((a) => a.id === "soundwave") ?? null) : null,
+  );
   const [input, setInput] = useState("");
   const [selectedDoc, setSelectedDoc] = useState<DocumentRef | null>(null);
   const [docPanelOpen, setDocPanelOpen] = useState(false);
@@ -87,14 +89,6 @@ export default function LivePage() {
       container.scrollTop = container.scrollHeight;
     }, delay);
   }, [messages]);
-
-  // Auto-select Soundwave for new engagements
-  const soundwave = agents.find((a) => a.id === "soundwave");
-  useEffect(() => {
-    if (isNew && !selectedAgent && soundwave) {
-      setSelectedAgent(soundwave);
-    }
-  }, [isNew, selectedAgent, soundwave]);
 
   // Pre-fill initial prompt for new engagements (user must click send)
   useEffect(() => {

--- a/clients/web/src/hooks/useChat.ts
+++ b/clients/web/src/hooks/useChat.ts
@@ -212,7 +212,9 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
   );
 
   // Keep ref updated for deferred auto-submit
-  sendRef.current = sendMessageDirect;
+  useEffect(() => {
+    sendRef.current = sendMessageDirect;
+  }, [sendMessageDirect]);
 
   const sendMessage = useCallback(
     (content: string) => {

--- a/clients/web/src/hooks/useChat.ts
+++ b/clients/web/src/hooks/useChat.ts
@@ -127,7 +127,8 @@ function sdkMessagesToChatMessages(messages: Message[]): ChatMessage[] {
 export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatReturn {
   // Track custom events (sub-agent activity) in state so changes trigger re-renders
   const [customEvents, setCustomEvents] = useState<ChatMessage[]>([]);
-  const [runState, setRunState] = useState<WebRunState>("idle");
+  // Only track "paused" explicitly — "streaming" and "idle" are derived from SDK isLoading
+  const [isPaused, setIsPaused] = useState(false);
   const [queuedMessage, setQueuedMessage] = useState<string | null>(null);
   const queuedMessageRef = useRef<string | null>(null);
   const sendRef = useRef<((content: string) => void) | null>(null);
@@ -157,24 +158,22 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
     },
   });
 
-  // Sync runState with SDK isLoading and handle auto-submit of queued messages
+  // Derive runState from SDK isLoading + isPaused (no setState in effects)
+  const runState: WebRunState = stream.isLoading ? "streaming" : isPaused ? "paused" : "idle";
+
+  // Auto-submit queued message when stream completes (not when paused)
   const prevLoading = useRef(stream.isLoading);
   useEffect(() => {
-    // Detect transition: loading → not loading (stream completed)
-    if (prevLoading.current && !stream.isLoading) {
-      if (runState === "streaming") {
-        setRunState("idle");
-      }
-      // Auto-submit queued message — but not if user intentionally paused
+    if (prevLoading.current && !stream.isLoading && !isPaused) {
       const pending = queuedMessageRef.current;
-      if (pending && runState !== "paused") {
+      if (pending) {
         queuedMessageRef.current = null;
         setQueuedMessage(null);
         setTimeout(() => sendRef.current?.(pending), 0);
       }
     }
     prevLoading.current = stream.isLoading;
-  }, [stream.isLoading, runState]);
+  }, [stream.isLoading, isPaused]);
 
   // Merge SDK messages with custom events into a unified ChatMessage[]
   const messages = useMemo(() => {
@@ -189,7 +188,7 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
   const sendMessageDirect = useCallback(
     (content: string) => {
       setCustomEvents([]);
-      setRunState("streaming");
+      setIsPaused(false);
       stream.submit(
         { messages: [{ type: "human" as const, content, id: `user-${Date.now()}` }] },
         {
@@ -225,31 +224,31 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
         return;
       }
       // If paused, starting a new message implicitly cancels the paused run
-      if (runState === "paused") {
-        setRunState("idle");
+      if (isPaused) {
+        setIsPaused(false);
       }
       sendMessageDirect(content);
     },
-    [stream.isLoading, sendMessageDirect, runState],
+    [stream.isLoading, sendMessageDirect, isPaused],
   );
 
   const interrupt = useCallback(() => {
     stream.stop();
-    setRunState("paused");
+    setIsPaused(true);
   }, [stream]);
 
   const stopFn = useCallback(() => {
     stream.stop();
     queuedMessageRef.current = null;
     setQueuedMessage(null);
-    setRunState("idle");
+    setIsPaused(false);
   }, [stream]);
 
   const resume = useCallback(
     (value?: string) => {
-      if (runState !== "paused") return;
+      if (!isPaused) return;
       setCustomEvents([]);
-      setRunState("streaming");
+      setIsPaused(false);
       stream.submit(
         { command: { resume: value ?? true } },
         {

--- a/clients/web/src/hooks/useChat.ts
+++ b/clients/web/src/hooks/useChat.ts
@@ -161,15 +161,18 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
   // Derive runState from SDK isLoading + isPaused (no setState in effects)
   const runState: WebRunState = stream.isLoading ? "streaming" : isPaused ? "paused" : "idle";
 
-  // Auto-submit queued message when stream completes (not when paused)
+  // Auto-submit queued message when stream completes (not when paused).
+  // Uses setTimeout to avoid calling setState synchronously in an effect.
   const prevLoading = useRef(stream.isLoading);
   useEffect(() => {
     if (prevLoading.current && !stream.isLoading && !isPaused) {
       const pending = queuedMessageRef.current;
       if (pending) {
         queuedMessageRef.current = null;
-        setQueuedMessage(null);
-        setTimeout(() => sendRef.current?.(pending), 0);
+        setTimeout(() => {
+          setQueuedMessage(null);
+          sendRef.current?.(pending);
+        }, 0);
       }
     }
     prevLoading.current = stream.isLoading;
@@ -237,28 +240,25 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
     setIsPaused(true);
   }, [stream]);
 
-  const stopFn = useCallback(() => {
+  const stopFn = () => {
     stream.stop();
     queuedMessageRef.current = null;
     setQueuedMessage(null);
     setIsPaused(false);
-  }, [stream]);
+  };
 
-  const resume = useCallback(
-    (value?: string) => {
-      if (!isPaused) return;
-      setCustomEvents([]);
-      setIsPaused(false);
-      stream.submit(
-        { command: { resume: value ?? true } },
-        {
-          ...STREAM_OPTIONS,
-          multitaskStrategy: "interrupt",
-        },
-      );
-    },
-    [stream, runState],
-  );
+  const resume = (value?: string) => {
+    if (!isPaused) return;
+    setCustomEvents([]);
+    setIsPaused(false);
+    stream.submit(
+      { command: { resume: value ?? true } },
+      {
+        ...STREAM_OPTIONS,
+        multitaskStrategy: "interrupt",
+      },
+    );
+  };
 
   const enqueue = useCallback((message: string) => {
     queuedMessageRef.current = message;

--- a/clients/web/src/hooks/useChat.ts
+++ b/clients/web/src/hooks/useChat.ts
@@ -11,10 +11,15 @@
  * - Built-in error handling and `isLoading` state
  * - Sub-agent tracking via custom events from StreamingRunnable
  *
+ * Supports three run lifecycle operations:
+ * - interrupt(): Pause at checkpoint (state preserved)
+ * - resume(): Continue from pause point with optional feedback
+ * - Message queuing: type during streaming, auto-submit on completion
+ *
  * Proxied through Next.js rewrite: /lgs → LANGGRAPH_API_URL
  */
 
-import { useMemo, useCallback, useState } from "react";
+import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import { useStream } from "@langchain/langgraph-sdk/react";
 import type { ChatMessage } from "@/lib/chat/types";
 import type { Message } from "@langchain/langgraph-sdk";
@@ -24,6 +29,9 @@ import {
   extractText,
   stripResultTags,
 } from "@decepticon/streaming";
+
+/** Run lifecycle state. */
+export type WebRunState = "idle" | "streaming" | "paused";
 
 interface UseChatOptions {
   engagementId: string;
@@ -35,12 +43,24 @@ interface UseChatReturn {
   messages: ChatMessage[];
   /** True while the agent is streaming. */
   isStreaming: boolean;
+  /** Current run lifecycle state. */
+  runState: WebRunState;
   /** Error from the stream, if any. */
   error: string | null;
-  /** Send a user message. */
+  /** Send a user message (queues if streaming). */
   sendMessage: (content: string) => void;
-  /** Stop the current stream. */
+  /** Pause the current run (preserves checkpoint). */
+  interrupt: () => void;
+  /** Hard cancel the current run (destroys state). */
   stop: () => void;
+  /** Resume a paused run with optional feedback. */
+  resume: (value?: string) => void;
+  /** Queued message to auto-submit on completion. */
+  queuedMessage: string | null;
+  /** Enqueue a message for auto-submit after stream completes. */
+  enqueue: (message: string) => void;
+  /** Clear the queued message. */
+  clearQueuedMessage: () => void;
   /** The raw SDK stream for advanced usage. */
   stream: ReturnType<typeof useStream>;
 }
@@ -107,6 +127,10 @@ function sdkMessagesToChatMessages(messages: Message[]): ChatMessage[] {
 export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatReturn {
   // Track custom events (sub-agent activity) in state so changes trigger re-renders
   const [customEvents, setCustomEvents] = useState<ChatMessage[]>([]);
+  const [runState, setRunState] = useState<WebRunState>("idle");
+  const [queuedMessage, setQueuedMessage] = useState<string | null>(null);
+  const queuedMessageRef = useRef<string | null>(null);
+  const sendRef = useRef<((content: string) => void) | null>(null);
 
   // Connect directly to LangGraph server — NOT through Next.js rewrite proxy.
   // Next.js rewrite buffers SSE responses, breaking real-time streaming.
@@ -133,6 +157,25 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
     },
   });
 
+  // Sync runState with SDK isLoading and handle auto-submit of queued messages
+  const prevLoading = useRef(stream.isLoading);
+  useEffect(() => {
+    // Detect transition: loading → not loading (stream completed)
+    if (prevLoading.current && !stream.isLoading) {
+      if (runState === "streaming") {
+        setRunState("idle");
+      }
+      // Auto-submit queued message — but not if user intentionally paused
+      const pending = queuedMessageRef.current;
+      if (pending && runState !== "paused") {
+        queuedMessageRef.current = null;
+        setQueuedMessage(null);
+        setTimeout(() => sendRef.current?.(pending), 0);
+      }
+    }
+    prevLoading.current = stream.isLoading;
+  }, [stream.isLoading, runState]);
+
   // Merge SDK messages with custom events into a unified ChatMessage[]
   const messages = useMemo(() => {
     const sdkMessages = sdkMessagesToChatMessages(stream.messages ?? []);
@@ -143,15 +186,15 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
     return [...sdkMessages, ...customEvents].sort((a, b) => a.timestamp - b.timestamp);
   }, [stream.messages, customEvents]);
 
-  const sendMessage = useCallback(
+  const sendMessageDirect = useCallback(
     (content: string) => {
-      // Reset custom events for new turn
       setCustomEvents([]);
+      setRunState("streaming");
       stream.submit(
         { messages: [{ type: "human" as const, content, id: `user-${Date.now()}` }] },
         {
-          // Stream options go in submit(), not useStream()
           ...STREAM_OPTIONS,
+          multitaskStrategy: "interrupt",
           optimisticValues: (prev) => {
             const existing = (Array.isArray(prev.messages) ? prev.messages : []) as Message[];
             return {
@@ -168,9 +211,63 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
     [stream],
   );
 
-  const stop = useCallback(() => {
+  // Keep ref updated for deferred auto-submit
+  sendRef.current = sendMessageDirect;
+
+  const sendMessage = useCallback(
+    (content: string) => {
+      // If streaming, queue instead of interrupting
+      if (stream.isLoading) {
+        queuedMessageRef.current = content;
+        setQueuedMessage(content);
+        return;
+      }
+      // If paused, starting a new message implicitly cancels the paused run
+      if (runState === "paused") {
+        setRunState("idle");
+      }
+      sendMessageDirect(content);
+    },
+    [stream.isLoading, sendMessageDirect, runState],
+  );
+
+  const interrupt = useCallback(() => {
     stream.stop();
+    setRunState("paused");
   }, [stream]);
+
+  const stopFn = useCallback(() => {
+    stream.stop();
+    queuedMessageRef.current = null;
+    setQueuedMessage(null);
+    setRunState("idle");
+  }, [stream]);
+
+  const resume = useCallback(
+    (value?: string) => {
+      if (runState !== "paused") return;
+      setCustomEvents([]);
+      setRunState("streaming");
+      stream.submit(
+        { command: { resume: value ?? true } },
+        {
+          ...STREAM_OPTIONS,
+          multitaskStrategy: "interrupt",
+        },
+      );
+    },
+    [stream, runState],
+  );
+
+  const enqueue = useCallback((message: string) => {
+    queuedMessageRef.current = message;
+    setQueuedMessage(message);
+  }, []);
+
+  const clearQueuedMessage = useCallback(() => {
+    queuedMessageRef.current = null;
+    setQueuedMessage(null);
+  }, []);
 
   const error = stream.error
     ? stream.error instanceof Error
@@ -181,9 +278,15 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
   return {
     messages,
     isStreaming: stream.isLoading,
+    runState,
     error,
     sendMessage,
-    stop,
+    interrupt,
+    stop: stopFn,
+    resume,
+    queuedMessage,
+    enqueue,
+    clearQueuedMessage,
     stream,
   };
 }

--- a/langgraph.json
+++ b/langgraph.json
@@ -20,5 +20,8 @@
     "defender": "./decepticon/agents/defender.py:graph"
   },
   "env": ".env",
-  "python_version": "3.13"
+  "python_version": "3.13",
+  "http": {
+    "multitask_strategy": "interrupt"
+  }
 }


### PR DESCRIPTION
Closes #54
Supersedes #62

## Summary

Replaces PR #62's broken "cancel & restart" with correct **pause & resume** using LangGraph SDK's checkpoint-based interrupt. Also adds **Claude Code-style message queuing**.

### What was wrong with PR #62
PR #62 cancelled the current run and started a new one when the operator submitted during streaming. This **destroyed in-progress work** (tool calls, analysis, reasoning) — the opposite of what Issue #54 requested ("giving quick feedback **without losing context**").

### What this PR does

- **Pause (Ctrl+C)**: Stops the run at a checkpoint via `cancel(action: "interrupt")` — all state is preserved
- **Resume (/resume [feedback])**: Continues from the exact pause point using `Command({ resume })`
- **Message queuing**: Enter during streaming queues the message (not interrupt), auto-submitted on completion
- **Hard cancel (2x Ctrl+C)**: For when the operator truly wants to abort — uses `cancel(action: "rollback")`
- **Web parity**: Same interrupt/resume/queue capabilities in the web dashboard

### State machine

| State | Ctrl+C (1x) | Ctrl+C (2x) | Enter |
|-------|------------|-------------|-------|
| Streaming | Pause | Cancel | Queue message |
| Paused | Cancel | - | Submit (fresh run) |
| Idle | Exit app | - | Submit |

### Files changed (12)

**CLI:**
- useAgent.ts - RunState enum, interrupt()/cancel()/resume(), processStream() shared helper, enqueue(), auto-submit on completion, runIdRef from metadata event
- useGlobalKeybindings.ts - double Ctrl+C detection (500ms), state-aware routing
- REPL.tsx - queue routing (streaming to enqueue, idle to submit), wired interrupt/cancel/resume
- Prompt.tsx - queued message display, up-arrow to edit, dynamic keybinding hints per state
- ActivityIndicator.tsx - paused state indicator
- commands/resume.ts - /resume [feedback] slash command
- commands/types.ts, registry.ts, help.ts - command system updates

**Web:**
- useChat.ts - interrupt/resume/queue with multitaskStrategy: "interrupt"
- live/page.tsx - pause/resume buttons, enabled input during streaming

**Backend:**
- langgraph.json - multitask_strategy: "interrupt" for concurrent run safety

## Test plan

- [ ] Ctrl+C during streaming - "Paused" indicator, /resume continues from checkpoint
- [ ] /resume feedback injects operator feedback into resumed run
- [ ] 2x Ctrl+C - "Cancelled", no resume available
- [ ] Enter during streaming - message queued - auto-submitted on completion
- [ ] Up arrow while queued - edit queued message
- [ ] Escape - clear queue
- [ ] /resume when not paused - "Nothing to resume" error
- [ ] Slash commands (e.g. /help) execute immediately during streaming (not queued)
- [ ] Web pause button - "Resume" button appears - resumes correctly
- [ ] make lint passes
- [ ] make test-local passes