### PR TITLE
feat(cli,web): thread persistence and session resume

### DIFF
--- a/clients/cli/src/app.tsx
+++ b/clients/cli/src/app.tsx
@@ -4,13 +4,13 @@ import { REPL } from "./screens/REPL.js";
 
 interface AppProps {
   initialMessage?: string;
-  continueThread?: boolean;
+  resumeThread?: boolean;
 }
 
-export function App({ initialMessage, continueThread }: AppProps) {
+export function App({ initialMessage, resumeThread }: AppProps) {
   return (
     <AppStateProvider>
-      <REPL initialMessage={initialMessage} continueThread={continueThread} />
+      <REPL initialMessage={initialMessage} resumeThread={resumeThread} />
     </AppStateProvider>
   );
 }

--- a/clients/cli/src/app.tsx
+++ b/clients/cli/src/app.tsx
@@ -4,12 +4,13 @@ import { REPL } from "./screens/REPL.js";
 
 interface AppProps {
   initialMessage?: string;
+  continueThread?: boolean;
 }
 
-export function App({ initialMessage }: AppProps) {
+export function App({ initialMessage, continueThread }: AppProps) {
   return (
     <AppStateProvider>
-      <REPL initialMessage={initialMessage} />
+      <REPL initialMessage={initialMessage} continueThread={continueThread} />
     </AppStateProvider>
   );
 }

--- a/clients/cli/src/commands/resume.ts
+++ b/clients/cli/src/commands/resume.ts
@@ -2,9 +2,9 @@ import type { Command } from "./types.js";
 
 const resume: Command = {
   name: "resume",
-  description: "Resume a paused run with optional feedback",
+  description: "Resume paused run or continue previous session",
   aliases: ["r"],
-  argumentHint: "[feedback]",
+  argumentHint: "[message]",
   execute(args, ctx) {
     ctx.resume(args || undefined);
   },

--- a/clients/cli/src/components/Prompt.tsx
+++ b/clients/cli/src/components/Prompt.tsx
@@ -204,6 +204,9 @@ export const Prompt = React.memo(function Prompt({
         />
       </Box>
 
+      <Text dimColor>{"─".repeat(columns)}</Text>
+
+      {/* Autocomplete menu — below the input divider, Claude Code style */}
       {showMenu && (
         <Box flexDirection="column" marginLeft={2}>
           {filteredCommands.map((cmd, i) => (
@@ -219,8 +222,6 @@ export const Prompt = React.memo(function Prompt({
           ))}
         </Box>
       )}
-
-      <Text dimColor>{"─".repeat(columns)}</Text>
 
       {/* Compact status line — always visible */}
       <StatusLine activeAgent={activeAgent} />

--- a/clients/cli/src/components/Prompt.tsx
+++ b/clients/cli/src/components/Prompt.tsx
@@ -98,9 +98,7 @@ export const Prompt = React.memo(function Prompt({
     for (const c of cmds) {
       if (c.isHidden) continue;
       entries.push({ cmd: `/${c.name}`, desc: c.description });
-      for (const alias of c.aliases ?? []) {
-        entries.push({ cmd: `/${alias}`, desc: c.description });
-      }
+      // Aliases work for execution but are hidden from autocomplete
     }
     return entries;
   }, []);

--- a/clients/cli/src/components/SessionPicker.tsx
+++ b/clients/cli/src/components/SessionPicker.tsx
@@ -1,0 +1,139 @@
+/**
+ * SessionPicker — Interactive session resume UI (Claude Code style).
+ *
+ * Shows a searchable list of previous sessions. Arrow keys to navigate,
+ * Enter to select, Escape to cancel.
+ */
+
+import React, { useState, useMemo } from "react";
+import { Box, Text, useInput } from "ink";
+import { useTerminalSize } from "../hooks/useTerminalSize.js";
+import type { ThreadEntry } from "../utils/threadStore.js";
+
+interface SessionPickerProps {
+  sessions: ThreadEntry[];
+  onSelect: (session: ThreadEntry) => void;
+  onCancel: () => void;
+}
+
+function formatTimeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins} minute${mins !== 1 ? "s" : ""} ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days !== 1 ? "s" : ""} ago`;
+}
+
+export const SessionPicker = React.memo(function SessionPicker({
+  sessions,
+  onSelect,
+  onCancel,
+}: SessionPickerProps) {
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [search, setSearch] = useState("");
+  const { columns } = useTerminalSize();
+
+  const filtered = useMemo(() => {
+    if (!search) return sessions;
+    const q = search.toLowerCase();
+    return sessions.filter((s) => s.title.toLowerCase().includes(q));
+  }, [sessions, search]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (key.return) {
+      const session = filtered[selectedIdx];
+      if (session) onSelect(session);
+      return;
+    }
+    if (key.upArrow) {
+      setSelectedIdx((prev) => Math.max(0, prev - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setSelectedIdx((prev) => Math.min(filtered.length - 1, prev + 1));
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setSearch((prev) => prev.slice(0, -1));
+      setSelectedIdx(0);
+      return;
+    }
+    // Printable character — append to search
+    if (input && !key.ctrl && !key.meta) {
+      setSearch((prev) => prev + input);
+      setSelectedIdx(0);
+    }
+  });
+
+  const maxVisible = 10;
+  const startIdx = Math.max(0, selectedIdx - maxVisible + 1);
+  const visibleSessions = filtered.slice(startIdx, startIdx + maxVisible);
+  const total = filtered.length;
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text dimColor>{"─".repeat(columns)}</Text>
+
+      {/* Header */}
+      <Box marginLeft={1}>
+        <Text bold>Resume Session</Text>
+        <Text dimColor>{` (${selectedIdx + 1} of ${total})`}</Text>
+      </Box>
+
+      {/* Search box */}
+      <Box marginLeft={1} marginTop={0}>
+        <Text dimColor>{"Search: "}</Text>
+        <Text>{search || ""}</Text>
+        <Text dimColor>{search ? "" : "(type to filter)"}</Text>
+      </Box>
+
+      {/* Session list */}
+      <Box flexDirection="column" marginTop={1} marginLeft={1}>
+        {visibleSessions.length === 0 ? (
+          <Text dimColor>  No sessions found.</Text>
+        ) : (
+          visibleSessions.map((session, i) => {
+            const globalIdx = startIdx + i;
+            const isSelected = globalIdx === selectedIdx;
+            const timeAgo = formatTimeAgo(session.lastUsed);
+            const title = session.title.length > 70
+              ? session.title.slice(0, 67) + "..."
+              : session.title;
+
+            return (
+              <Box key={session.threadId} flexDirection="column">
+                <Text>
+                  <Text color={isSelected ? "red" : undefined} bold={isSelected}>
+                    {isSelected ? ">" : " "}{" "}
+                  </Text>
+                  <Text bold={isSelected} color={isSelected ? "white" : undefined}>
+                    {title}
+                  </Text>
+                </Text>
+                <Text dimColor>
+                  {"    "}{timeAgo}
+                </Text>
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      {/* Footer hints */}
+      <Box marginTop={1} marginLeft={1}>
+        <Text dimColor>
+          {"Enter to select \u00B7 Esc to cancel \u00B7 Type to search"}
+        </Text>
+      </Box>
+
+      <Text dimColor>{"─".repeat(columns)}</Text>
+    </Box>
+  );
+});

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -16,7 +16,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { Client } from "@langchain/langgraph-sdk";
-import { saveThread, touchThread, listThreads, loadThreadByIndex, clearThread } from "../utils/threadStore.js";
+import { saveThread, touchThread, loadThreadByIndex, clearThread } from "../utils/threadStore.js";
 import type { AgentEvent } from "../types.js";
 import {
   type SubagentCustomEvent,
@@ -627,46 +627,17 @@ export function useAgent({
         return;
       }
 
-      // Case 2: Idle with no thread — list or select previous sessions
-      if (!hasThread && runStateRef.current === "idle") {
-        const sessions = listThreads();
-        if (sessions.length === 0) {
-          addEvent({ type: "system", content: "No previous sessions found." });
-          return;
-        }
-
-        // If value is a number, select that session
-        const idx = value ? parseInt(value, 10) : NaN;
-        if (!isNaN(idx)) {
-          const selected = loadThreadByIndex(idx - 1); // 1-based for user
-          if (!selected) {
-            addEvent({ type: "system", content: `Invalid session number. Use 1-${sessions.length}.` });
-            return;
-          }
-          threadIdRef.current = selected.threadId;
-          touchThread(selected.threadId);
-          addEvent({ type: "system", content: `Resumed: "${selected.title}"` });
-          return;
-        }
-
-        // No index given — show the list
-        const lines = sessions.map((s, i) => {
-          const date = new Date(s.lastUsed).toLocaleString();
-          return `  ${i + 1}. ${s.title}  (${date})`;
-        });
-        addEvent({
-          type: "system",
-          content: `Previous sessions:\n${lines.join("\n")}\n\nUse /resume <number> to continue a session.`,
-        });
+      // Case 2: Load a specific thread by ID (from session picker or --resume)
+      if (value && runStateRef.current === "idle") {
+        threadIdRef.current = value;
+        touchThread(value);
+        lastCountRef.current = 0;
+        addEvent({ type: "system", content: "Resumed previous session." });
         return;
       }
 
-      // Case 3: Already in a session or streaming — nothing to do
-      if (hasThread && runStateRef.current === "idle") {
-        addEvent({ type: "system", content: "Already in an active session. Send a message to continue." });
-      } else {
-        addEvent({ type: "system", content: "Nothing to resume." });
-      }
+      // Case 3: Nothing to resume
+      addEvent({ type: "system", content: "Nothing to resume." });
     },
     [addEvent, processStream, handleStreamComplete, resetStreamState],
   );

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -631,8 +631,29 @@ export function useAgent({
       if (value && runStateRef.current === "idle") {
         threadIdRef.current = value;
         touchThread(value);
-        lastCountRef.current = 0;
-        addEvent({ type: "system", content: "Resumed previous session." });
+        addEvent({ type: "system", content: "Restoring session..." });
+
+        // Fetch thread state and restore conversation history
+        const client = clientRef.current;
+        client.threads.getState(value).then((state) => {
+          const msgs = (state.values as { messages?: LangChainMessage[] })?.messages ?? [];
+          lastCountRef.current = msgs.length;
+
+          for (const msg of msgs) {
+            if (msg.type === "human") {
+              const text = extractText(msg.content);
+              if (text) addEvent({ type: "user", content: text });
+            } else if (msg.type === "ai") {
+              const text = stripResultTags(extractText(msg.content));
+              if (text) addEvent({ type: "ai_message", content: text });
+            }
+          }
+
+          addEvent({ type: "system", content: "Session restored. Send a message to continue." });
+        }).catch(() => {
+          addEvent({ type: "system", content: "Could not restore history. Thread loaded — send a message to continue." });
+          lastCountRef.current = 0;
+        });
         return;
       }
 

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -629,6 +629,10 @@ export function useAgent({
 
       // Case 2: Load a specific thread by ID (from session picker or --resume)
       if (value && runStateRef.current === "idle") {
+        // Clear current events before restoring a different session
+        eventsRef.current = [];
+        setEvents([]);
+
         threadIdRef.current = value;
         touchThread(value);
         addEvent({ type: "system", content: "Restoring session..." });

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -16,6 +16,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { Client } from "@langchain/langgraph-sdk";
+import { saveThread, touchThread, listThreads, loadThreadByIndex, clearThread } from "../utils/threadStore.js";
 import type { AgentEvent } from "../types.js";
 import {
   type SubagentCustomEvent,
@@ -46,6 +47,8 @@ interface LangChainMessage {
 
 interface UseAgentOptions {
   apiUrl?: string;
+  /** Load the previous thread from disk (--continue flag). */
+  continueThread?: boolean;
 }
 
 interface PendingTool {
@@ -95,9 +98,12 @@ const ASSISTANT_ID = "decepticon";
 
 export function useAgent({
   apiUrl = process.env.DECEPTICON_API_URL || "http://localhost:2024",
+  continueThread = false,
 }: UseAgentOptions = {}): UseAgentReturn {
   const clientRef = useRef(new Client({ apiUrl }));
-  const threadIdRef = useRef<string | null>(null);
+  // Load persisted thread if --continue flag is set
+  const savedThread = continueThread ? loadThreadByIndex(0) : null;
+  const threadIdRef = useRef<string | null>(savedThread?.threadId ?? null);
   const eventsRef = useRef<AgentEvent[]>([]);
   const lastCountRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
@@ -454,6 +460,7 @@ export function useAgent({
     queuedMessageRef.current = null;
     setQueuedMessage(null);
     setRunState("idle");
+    clearThread();
   }, []);
 
   // ── Submit (only when idle or paused) ──────────────────────────
@@ -493,6 +500,7 @@ export function useAgent({
             try {
               const thread = await client.threads.create();
               threadIdRef.current = thread.thread_id;
+              saveThread(thread.thread_id, ASSISTANT_ID, message);
               break;
             } catch (err) {
               if (attempt === maxRetries) {
@@ -558,79 +566,107 @@ export function useAgent({
   const submitRef = useRef(submit);
   submitRef.current = submit;
 
-  // ── Resume (continue from pause point) ─────────────────────────
+  // ── Resume (pause point OR previous session) ───────────────────
 
   const resume = useCallback(
     (value?: string): void => {
-      if (runStateRef.current !== "paused") {
-        addEvent({ type: "system", content: "Nothing to resume." });
-        return;
-      }
+      const isPaused = runStateRef.current === "paused";
+      const hasThread = !!threadIdRef.current;
 
-      if (!threadIdRef.current) {
-        addEvent({ type: "system", content: "No thread to resume." });
-        setRunState("idle");
-        return;
-      }
+      // Case 1: Paused — resume from checkpoint with Command({ resume })
+      if (isPaused && hasThread) {
+        if (value) addEvent({ type: "user", content: value });
+        addEvent({ type: "system", content: "Resuming from checkpoint..." });
 
-      if (value) {
-        addEvent({ type: "user", content: value });
-      }
-      addEvent({ type: "system", content: "Resuming..." });
+        const abortController = new AbortController();
+        abortRef.current = abortController;
 
-      const abortController = new AbortController();
-      abortRef.current = abortController;
+        const runResume = async () => {
+          const client = clientRef.current;
+          setError(null);
 
-      const runResume = async () => {
-        const client = clientRef.current;
-        setError(null);
+          try {
+            const state = await client.threads.getState(threadIdRef.current!);
+            const msgs = (state.values as { messages?: unknown[] })?.messages;
+            if (msgs) lastCountRef.current = msgs.length;
+          } catch { /* proceed with current count */ }
 
-        // Sync lastCountRef with server state before resuming
-        try {
-          const state = await client.threads.getState(threadIdRef.current!);
-          const msgs = (state.values as { messages?: unknown[] })?.messages;
-          if (msgs) lastCountRef.current = msgs.length;
-        } catch {
-          // Proceed with current count — may cause some duplicate events
-        }
-
-        if (abortController.signal.aborted) return;
-
-        setRunState("streaming");
-        setPendingTool(null);
-        setActiveAgent("decepticon");
-        setStreamStats({ startTime: Date.now(), totalTokens: 0, promptTokens: 0, completionTokens: 0 });
-
-        try {
-          const stream = client.runs.stream(
-            threadIdRef.current!,
-            ASSISTANT_ID,
-            {
-              command: { resume: value ?? true },
-              ...STREAM_OPTIONS,
-              onDisconnect: "continue",
-              signal: abortController.signal,
-            },
-          );
-
-          await processStream(stream, abortController);
-        } catch (err) {
           if (abortController.signal.aborted) return;
-          const msg =
-            err instanceof Error ? err.message : "Resume failed";
-          setError(msg);
+
+          setRunState("streaming");
+          setPendingTool(null);
+          setActiveAgent("decepticon");
+          setStreamStats({ startTime: Date.now(), totalTokens: 0, promptTokens: 0, completionTokens: 0 });
+
+          try {
+            const stream = client.runs.stream(
+              threadIdRef.current!,
+              ASSISTANT_ID,
+              {
+                command: { resume: value ?? true },
+                ...STREAM_OPTIONS,
+                onDisconnect: "continue",
+                signal: abortController.signal,
+              },
+            );
+            await processStream(stream, abortController);
+          } catch (err) {
+            if (abortController.signal.aborted) return;
+            setError(err instanceof Error ? err.message : "Resume failed");
+          }
+          handleStreamComplete(abortController);
+        };
+
+        runResume().catch((err) => {
+          if (abortController.signal.aborted) return;
+          setError(err instanceof Error ? err.message : "Resume error");
+          abortRef.current = null;
+          runIdRef.current = null;
+          resetStreamState();
+        });
+        return;
+      }
+
+      // Case 2: Idle with no thread — list or select previous sessions
+      if (!hasThread && runStateRef.current === "idle") {
+        const sessions = listThreads();
+        if (sessions.length === 0) {
+          addEvent({ type: "system", content: "No previous sessions found." });
+          return;
         }
 
-        handleStreamComplete(abortController);
-      };
+        // If value is a number, select that session
+        const idx = value ? parseInt(value, 10) : NaN;
+        if (!isNaN(idx)) {
+          const selected = loadThreadByIndex(idx - 1); // 1-based for user
+          if (!selected) {
+            addEvent({ type: "system", content: `Invalid session number. Use 1-${sessions.length}.` });
+            return;
+          }
+          threadIdRef.current = selected.threadId;
+          touchThread(selected.threadId);
+          addEvent({ type: "system", content: `Resumed: "${selected.title}"` });
+          return;
+        }
 
-      runResume().catch((err) => {
-        if (abortController.signal.aborted) return;
-        setError(err instanceof Error ? err.message : "Resume error");
-        abortRef.current = null;
-        runIdRef.current = null;
-        resetStreamState();
-      });
+        // No index given — show the list
+        const lines = sessions.map((s, i) => {
+          const date = new Date(s.lastUsed).toLocaleString();
+          return `  ${i + 1}. ${s.title}  (${date})`;
+        });
+        addEvent({
+          type: "system",
+          content: `Previous sessions:\n${lines.join("\n")}\n\nUse /resume <number> to continue a session.`,
+        });
+        return;
+      }
+
+      // Case 3: Already in a session or streaming — nothing to do
+      if (hasThread && runStateRef.current === "idle") {
+        addEvent({ type: "system", content: "Already in an active session. Send a message to continue." });
+      } else {
+        addEvent({ type: "system", content: "Nothing to resume." });
+      }
     },
     [addEvent, processStream, handleStreamComplete, resetStreamState],
   );

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -47,8 +47,8 @@ interface LangChainMessage {
 
 interface UseAgentOptions {
   apiUrl?: string;
-  /** Load the previous thread from disk (--continue flag). */
-  continueThread?: boolean;
+  /** Load the previous thread from disk (--resume flag). */
+  resumeThread?: boolean;
 }
 
 interface PendingTool {
@@ -98,11 +98,11 @@ const ASSISTANT_ID = "decepticon";
 
 export function useAgent({
   apiUrl = process.env.DECEPTICON_API_URL || "http://localhost:2024",
-  continueThread = false,
+  resumeThread = false,
 }: UseAgentOptions = {}): UseAgentReturn {
   const clientRef = useRef(new Client({ apiUrl }));
-  // Load persisted thread if --continue flag is set
-  const savedThread = continueThread ? loadThreadByIndex(0) : null;
+  // Load persisted thread if --resume flag is set
+  const savedThread = resumeThread ? loadThreadByIndex(0) : null;
   const threadIdRef = useRef<string | null>(savedThread?.threadId ?? null);
   const eventsRef = useRef<AgentEvent[]>([]);
   const lastCountRef = useRef(0);

--- a/clients/cli/src/index.tsx
+++ b/clients/cli/src/index.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import { render } from "ink";
 import { App } from "./app.js";
 
+const args = process.argv.slice(2);
+const continueThread = args.includes("--continue") || args.includes("-c");
 const initialMessage = process.env.DECEPTICON_INITIAL_MESSAGE || undefined;
 
-const instance = render(<App initialMessage={initialMessage} />, {
+const instance = render(<App initialMessage={initialMessage} continueThread={continueThread} />, {
   patchConsole: true,
   exitOnCtrlC: false,
 });

--- a/clients/cli/src/index.tsx
+++ b/clients/cli/src/index.tsx
@@ -4,10 +4,10 @@ import { render } from "ink";
 import { App } from "./app.js";
 
 const args = process.argv.slice(2);
-const continueThread = args.includes("--continue") || args.includes("-c");
+const resumeThread = args.includes("--resume") || args.includes("-r");
 const initialMessage = process.env.DECEPTICON_INITIAL_MESSAGE || undefined;
 
-const instance = render(<App initialMessage={initialMessage} continueThread={continueThread} />, {
+const instance = render(<App initialMessage={initialMessage} resumeThread={resumeThread} />, {
   patchConsole: true,
   exitOnCtrlC: false,
 });

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -273,6 +273,9 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
               sessions={listThreads()}
               onSelect={(session: ThreadEntry) => {
                 setShowSessionPicker(false);
+                // Clear terminal — Ink's <Static> is append-only, so previous
+                // session output stays on screen unless we reset the terminal.
+                process.stdout.write("\x1B[2J\x1B[H");
                 agent.resume(session.threadId);
               }}
               onCancel={() => setShowSessionPicker(false)}

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -58,6 +58,8 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
   const sessions = useSubAgentSessions(agent.events);
   const screen = useAppState((s) => s.screen);
   const [showSessionPicker, setShowSessionPicker] = useState(false);
+  // Increment to force <Static> re-mount on session switch (resets its internal render history)
+  const [sessionKey, setSessionKey] = useState(0);
 
   // Auto-submit initial message (e.g. demo mode)
   const autoStarted = useRef(false);
@@ -218,7 +220,7 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
       <Box flexDirection="row">
         <Box flexDirection="column" flexGrow={1}>
           {/* Static region: banner + completed events + completed sessions */}
-          <Static items={staticItems}>
+          <Static key={sessionKey} items={staticItems}>
             {(item) => (
               <Box key={item.id}>
                 {item.kind === "banner" ? (
@@ -273,9 +275,10 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
               sessions={listThreads()}
               onSelect={(session: ThreadEntry) => {
                 setShowSessionPicker(false);
-                // Clear terminal — Ink's <Static> is append-only, so previous
-                // session output stays on screen unless we reset the terminal.
+                // Clear terminal + force <Static> re-mount so previous session
+                // output is fully removed (Static is append-only internally).
                 process.stdout.write("\x1B[2J\x1B[H");
+                setSessionKey((k) => k + 1);
                 agent.resume(session.threadId);
               }}
               onCancel={() => setShowSessionPicker(false)}

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -44,11 +44,12 @@ export type Screen = ScreenMode;
 
 interface REPLProps {
   initialMessage?: string;
+  continueThread?: boolean;
 }
 
-export function REPL({ initialMessage }: REPLProps) {
+export function REPL({ initialMessage, continueThread }: REPLProps) {
   const { exit } = useApp();
-  const agent = useAgent();
+  const agent = useAgent({ continueThread });
   const opplan = useOpplan(agent.events);
   const sessions = useSubAgentSessions(agent.events);
   const screen = useAppState((s) => s.screen);

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -12,6 +12,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { Box, Text, Static, useApp } from "ink";
 import { useAgent } from "../hooks/useAgent.js";
@@ -38,6 +39,9 @@ import { ToolGroupSummary } from "../components/messages/ToolGroupSummary.js";
 import type { CommandContext } from "../commands/types.js";
 import type { AgentEvent, ScreenMode, SubAgentSession } from "../types.js";
 import { ErrorMessage } from "../components/messages/ErrorMessage.js";
+import { SessionPicker } from "../components/SessionPicker.js";
+import { listThreads } from "../utils/threadStore.js";
+import type { ThreadEntry } from "../utils/threadStore.js";
 import type { ToolGroup } from "../utils/groupEvents.js";
 
 export type Screen = ScreenMode;
@@ -53,6 +57,7 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
   const opplan = useOpplan(agent.events);
   const sessions = useSubAgentSessions(agent.events);
   const screen = useAppState((s) => s.screen);
+  const [showSessionPicker, setShowSessionPicker] = useState(false);
 
   // Auto-submit initial message (e.g. demo mode)
   const autoStarted = useRef(false);
@@ -93,6 +98,23 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
       // Slash commands always execute immediately (even during streaming)
       const parsed = parseSlashCommand(trimmed);
       if (parsed) {
+        // /resume with no args → open interactive session picker
+        if ((parsed.name === "resume" || parsed.name === "r") && !parsed.args) {
+          // If paused, resume from checkpoint directly
+          if (agent.runState === "paused") {
+            agent.resume();
+            return;
+          }
+          // Otherwise show session picker
+          const savedSessions = listThreads();
+          if (savedSessions.length === 0) {
+            agent.addSystemEvent("No previous sessions found.");
+            return;
+          }
+          setShowSessionPicker(true);
+          return;
+        }
+
         const cmd = findCommand(parsed.name);
         if (cmd) {
           const result = cmd.execute(parsed.args, commandContext);
@@ -246,13 +268,24 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
             <CtrlOToExpand />
           )}
 
-          <Prompt
-            runState={agent.runState}
-            onSubmit={handleSubmit}
-            activeAgent={agent.activeAgent}
-            queuedMessage={agent.queuedMessage}
-            onEditQueue={agent.enqueue}
-          />
+          {showSessionPicker ? (
+            <SessionPicker
+              sessions={listThreads()}
+              onSelect={(session: ThreadEntry) => {
+                setShowSessionPicker(false);
+                agent.resume(session.threadId);
+              }}
+              onCancel={() => setShowSessionPicker(false)}
+            />
+          ) : (
+            <Prompt
+              runState={agent.runState}
+              onSubmit={handleSubmit}
+              activeAgent={agent.activeAgent}
+              queuedMessage={agent.queuedMessage}
+              onEditQueue={agent.enqueue}
+            />
+          )}
         </Box>
 
       </Box>

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -44,12 +44,12 @@ export type Screen = ScreenMode;
 
 interface REPLProps {
   initialMessage?: string;
-  continueThread?: boolean;
+  resumeThread?: boolean;
 }
 
-export function REPL({ initialMessage, continueThread }: REPLProps) {
+export function REPL({ initialMessage, resumeThread }: REPLProps) {
   const { exit } = useApp();
-  const agent = useAgent({ continueThread });
+  const agent = useAgent({ resumeThread });
   const opplan = useOpplan(agent.events);
   const sessions = useSubAgentSessions(agent.events);
   const screen = useAppState((s) => s.screen);

--- a/clients/cli/src/utils/threadStore.ts
+++ b/clients/cli/src/utils/threadStore.ts
@@ -1,0 +1,87 @@
+/**
+ * Thread persistence — save/load LangGraph thread IDs to disk.
+ *
+ * Stores a history of recent threads so the CLI can list and resume
+ * previous sessions with `/resume`.
+ *
+ * Storage location: ~/.decepticon/threads.json
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export interface ThreadEntry {
+  /** LangGraph thread ID. */
+  threadId: string;
+  /** Assistant ID used with this thread. */
+  assistantId: string;
+  /** ISO timestamp when the thread was last used. */
+  lastUsed: string;
+  /** First user message — serves as session title. */
+  title: string;
+}
+
+const MAX_ENTRIES = 20;
+const STORE_DIR = join(homedir(), ".decepticon");
+const STORE_PATH = join(STORE_DIR, "threads.json");
+
+function readStore(): ThreadEntry[] {
+  try {
+    if (!existsSync(STORE_PATH)) return [];
+    const raw = readFileSync(STORE_PATH, "utf-8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(entries: ThreadEntry[]): void {
+  try {
+    if (!existsSync(STORE_DIR)) {
+      mkdirSync(STORE_DIR, { recursive: true });
+    }
+    writeFileSync(STORE_PATH, JSON.stringify(entries, null, 2), "utf-8");
+  } catch {
+    // Non-critical — don't crash if storage fails
+  }
+}
+
+/** Save or update a thread entry. Keeps the most recent MAX_ENTRIES. */
+export function saveThread(threadId: string, assistantId: string, title: string): void {
+  const entries = readStore().filter((e) => e.threadId !== threadId);
+  entries.unshift({
+    threadId,
+    assistantId,
+    lastUsed: new Date().toISOString(),
+    title: title.slice(0, 100),
+  });
+  writeStore(entries.slice(0, MAX_ENTRIES));
+}
+
+/** Update the lastUsed timestamp for an existing thread. */
+export function touchThread(threadId: string): void {
+  const entries = readStore();
+  const entry = entries.find((e) => e.threadId === threadId);
+  if (entry) {
+    entry.lastUsed = new Date().toISOString();
+    writeStore(entries);
+  }
+}
+
+/** Load all saved thread entries, most recent first. */
+export function listThreads(): ThreadEntry[] {
+  return readStore();
+}
+
+/** Load a single thread by index (0-based). */
+export function loadThreadByIndex(index: number): ThreadEntry | null {
+  const entries = readStore();
+  return entries[index] ?? null;
+}
+
+/** Clear all saved threads (e.g., on /clear). */
+export function clearThread(): void {
+  writeStore([]);
+}

--- a/clients/web/src/hooks/useChat.ts
+++ b/clients/web/src/hooks/useChat.ts
@@ -124,7 +124,28 @@ function sdkMessagesToChatMessages(messages: Message[]): ChatMessage[] {
 
 // ── Hook ────────────────────────────────────────────────────────
 
-export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatReturn {
+/** Load persisted thread ID for an engagement from localStorage. */
+function loadEngagementThread(engagementId: string): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const stored = localStorage.getItem(`decepticon:thread:${engagementId}`);
+    return stored ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Save thread ID for an engagement to localStorage. */
+function saveEngagementThread(engagementId: string, threadId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(`decepticon:thread:${engagementId}`, threadId);
+  } catch {
+    // Non-critical
+  }
+}
+
+export function useChat({ engagementId, assistantId = "soundwave" }: UseChatOptions): UseChatReturn {
   // Track custom events (sub-agent activity) in state so changes trigger re-renders
   const [customEvents, setCustomEvents] = useState<ChatMessage[]>([]);
   // Only track "paused" explicitly — "streaming" and "idle" are derived from SDK isLoading
@@ -132,6 +153,9 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
   const [queuedMessage, setQueuedMessage] = useState<string | null>(null);
   const queuedMessageRef = useRef<string | null>(null);
   const sendRef = useRef<((content: string) => void) | null>(null);
+
+  // Load persisted thread ID for this engagement
+  const persistedThreadId = loadEngagementThread(engagementId);
 
   // Connect directly to LangGraph server — NOT through Next.js rewrite proxy.
   // Next.js rewrite buffers SSE responses, breaking real-time streaming.
@@ -143,7 +167,8 @@ export function useChat({ assistantId = "soundwave" }: UseChatOptions): UseChatR
   const stream = useStream({
     apiUrl,
     assistantId,
-    threadId: undefined, // Let SDK auto-create UUID threads; engagementId reserved for future thread mapping
+    threadId: persistedThreadId, // Reuse persisted thread for conversation continuity
+    onThreadId: (threadId: string) => saveEngagementThread(engagementId, threadId),
     // Callbacks
     onCustomEvent: (data: unknown) => {
       const event = data as SubagentCustomEvent;


### PR DESCRIPTION
## Summary

Persist LangGraph thread IDs so conversations survive CLI restarts and web page refreshes. `/resume` opens a Claude Code-style interactive session picker.

### CLI
- `threadStore.ts` — saves up to 20 thread entries to `~/.decepticon/threads.json`
- `--resume` / `-r` flag — loads most recent thread on startup
- `/resume` — opens interactive session picker (arrow keys, search, Enter/Esc)
- `/resume` when paused — resumes from checkpoint (existing behavior)
- `SessionPicker.tsx` — searchable session list with keyboard navigation
- Session switch clears terminal and restores selected session's conversation history
- `/clear` — clears persisted threads
- Autocomplete shows full command names only (aliases hidden)

### Web
- `useChat.ts` — localStorage thread mapping per engagement ID (`decepticon:thread:<id>`)
- Page refresh preserves conversation on same engagement

### Files changed

| File | Change |
|------|--------|
| `utils/threadStore.ts` | New — thread persistence store |
| `components/SessionPicker.tsx` | New — interactive session picker UI |
| `useAgent.ts` | Save on thread creation, load on `--resume`, session restore with history |
| `index.tsx` | Parse `--resume` / `-r` flag |
| `app.tsx` + `REPL.tsx` | Pass `resumeThread` prop, session picker integration, Static re-mount |
| `Prompt.tsx` | Autocomplete hides aliases |
| `resume.ts` | Updated description |
| `useChat.ts` | localStorage engagement-to-thread mapping |

## Test plan

- [ ] CLI: `/resume` opens interactive session picker
- [ ] CLI: Arrow keys navigate, type to search, Enter selects, Esc cancels
- [ ] CLI: Selected session's conversation history is restored (clean screen)
- [ ] CLI: Switching sessions multiple times does not accumulate output
- [ ] CLI: `/resume` when paused resumes from checkpoint
- [ ] CLI: `--resume` flag loads most recent thread on startup
- [ ] CLI: `/clear` clears persisted threads
- [ ] CLI: Autocomplete shows `/resume` not `/r`
- [ ] Web: Refresh page on live engagement — messages preserved
- [ ] Web: Different engagements use different threads
- [ ] `make lint` passes
- [ ] `make test-local` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)