### PR TITLE
fix(docker): resolve OSS install failures on Kali Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       fail-fast: false   # one image failure must not cancel the rest
       matrix:
         include:
+          - image: decepticon-litellm
+            dockerfile: containers/litellm.Dockerfile
+            platforms: linux/amd64,linux/arm64
           - image: decepticon-langgraph
             dockerfile: containers/langgraph.Dockerfile
             platforms: linux/amd64,linux/arm64

--- a/clients/launcher/cmd/demo.go
+++ b/clients/launcher/cmd/demo.go
@@ -42,8 +42,11 @@ func runDemo(cmd *cobra.Command, args []string) error {
 	home := config.DecepticonHome()
 	demoDir := filepath.Join(home, "workspace", "demo")
 
-	// Download demo plan files
-	branch := config.Get(env, "DECEPTICON_BRANCH", "main")
+	// Download demo plan files — use release tag to stay in sync with installed version
+	branch := "v" + version
+	if version == "dev" || version == "" {
+		branch = config.Get(env, "DECEPTICON_BRANCH", "main")
+	}
 	planDir := filepath.Join(demoDir, "plan")
 	if err := os.MkdirAll(planDir, 0o755); err != nil {
 		return err

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -56,9 +56,13 @@ func runStart(cmd *cobra.Command, args []string) error {
 	home := config.DecepticonHome()
 	composePath := filepath.Join(home, "docker-compose.yml")
 	if _, err := os.Stat(composePath); os.IsNotExist(err) {
-		branch := config.Get(env, "DECEPTICON_BRANCH", "main")
+		// Use installed version tag; fall back to branch for dev builds
+		ref := "v" + version
+		if version == "dev" || version == "" {
+			ref = config.Get(env, "DECEPTICON_BRANCH", "main")
+		}
 		ui.Info("Downloading configuration files...")
-		if err := updater.SyncConfigFiles(branch); err != nil {
+		if err := updater.SyncConfigFiles(ref); err != nil {
 			return fmt.Errorf("sync config: %w", err)
 		}
 	}

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -125,7 +125,7 @@ func (c *Compose) RunInteractive(profiles []string, service string, env map[stri
 	for _, p := range profiles {
 		cmdArgs = append(cmdArgs, "--profile", p)
 	}
-	cmdArgs = append(cmdArgs, "run", "--rm")
+	cmdArgs = append(cmdArgs, "run", "--rm", "--no-build")
 	for k, v := range env {
 		cmdArgs = append(cmdArgs, "-e", k+"="+v)
 	}

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -206,8 +206,9 @@ func CheckAndUpdate(currentVersion string, env map[string]string) bool {
 
 	ui.Info(fmt.Sprintf("Update available: %s → %s", currentVersion, release.TagName))
 
-	branch := config.Get(env, "DECEPTICON_BRANCH", "main")
-	if err := SyncConfigFiles(branch); err != nil {
+	// Use release tag for config files to avoid main branch drift
+	ref := release.TagName // e.g., "v1.0.7"
+	if err := SyncConfigFiles(ref); err != nil {
 		ui.Warning("Config sync failed: " + err.Error())
 	}
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,8 @@ resolve_version() {
         info "No releases found, using latest from $BRANCH branch."
     else
         DECEPTICON_VERSION="$latest"
+        # Pin config downloads to the release tag (not the moving main branch)
+        RAW_BASE="https://raw.githubusercontent.com/$REPO/v$DECEPTICON_VERSION"
     fi
 }
 

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -263,7 +263,7 @@ case "${1:-}" in
         [[ -n "$_ver" ]] && export DECEPTICON_VERSION="$_ver"
 
         # Run CLI in foreground (interactive)
-        $COMPOSE_PROFILES run --rm cli
+        $COMPOSE_PROFILES run --rm --no-build cli
         ;;
 
     stop)
@@ -362,7 +362,7 @@ case "${1:-}" in
         ;&
 
     onboard)
-        $COMPOSE_PROFILES run --rm cli python -m decepticon.cli.app onboard
+        $COMPOSE_PROFILES run --rm --no-build cli python -m decepticon.cli.app onboard
         ;;
 
     demo)
@@ -383,9 +383,13 @@ case "${1:-}" in
         mkdir -p "$DECEPTICON_HOME/workspace/demo/exploit"
         mkdir -p "$DECEPTICON_HOME/workspace/demo/post-exploit"
         touch "$DECEPTICON_HOME/workspace/demo/findings.md"
+        # Use installed version tag for demo files (not the moving main branch)
+        _installed_ver=$(cat "$DECEPTICON_HOME/.version" 2>/dev/null || echo "")
+        _demo_base="$RAW_BASE"
+        [[ -n "$_installed_ver" ]] && _demo_base="https://raw.githubusercontent.com/$REPO/v${_installed_ver}"
         for f in roe.json conops.json opplan.json; do
             if [[ ! -f "$demo_dir/$f" ]]; then
-                curl -fsSL "$RAW_BASE/demo/plan/$f" -o "$demo_dir/$f" 2>/dev/null || {
+                curl -fsSL "$_demo_base/demo/plan/$f" -o "$demo_dir/$f" 2>/dev/null || {
                     echo -e "${RED}Failed to download $f. Run 'decepticon update' first.${NC}"
                     exit 1
                 }
@@ -409,7 +413,7 @@ case "${1:-}" in
         echo ""
 
         # Run CLI with auto-start message
-        $COMPOSE_PROFILES run --rm -e DECEPTICON_INITIAL_MESSAGE="Resume the demo engagement and execute all objectives." cli
+        $COMPOSE_PROFILES run --rm --no-build -e DECEPTICON_INITIAL_MESSAGE="Resume the demo engagement and execute all objectives." cli
         ;;
 
     victims)


### PR DESCRIPTION
## Summary

Fixes #74 — OSS users installing via `curl | bash` get `lstat /home/kali/.decepticon/containers: no such file or directory` because Docker Compose tries to build images locally when they're not cached.

- **Add `decepticon-litellm` to release CI/CD** — was never built or pushed to GHCR, causing the first failure in the compose dependency chain
- **Add `--no-build` to all `docker compose run` commands** — prevents fallback to local build when images aren't cached (both Go and bash launchers)
- **Pin config/demo downloads to release tag** — `install.sh`, Go launcher (`start`, `demo`, `updater`) and bash launcher now download `docker-compose.yml` and demo files from `v{version}` tag instead of the moving `main` branch

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Add `decepticon-litellm` to Docker build matrix |
| `clients/launcher/internal/compose/compose.go` | Add `--no-build` to `RunInteractive()` |
| `clients/launcher/cmd/start.go` | Use version tag for initial config sync |
| `clients/launcher/cmd/demo.go` | Use version tag for demo file downloads |
| `clients/launcher/internal/updater/updater.go` | Use `release.TagName` instead of branch for config sync |
| `scripts/install.sh` | Pin `RAW_BASE` to release tag after version resolve |
| `scripts/launcher.sh` | Add `--no-build` to 3 `run` commands + version-tagged demo downloads |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Fresh `curl | bash` install pulls pre-built images (no local build attempt)
- [ ] `decepticon onboard` works without source tree
- [ ] `decepticon demo` downloads files from release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)