### PR TITLE
fix: web terminal fetch failed + Docker Compose compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
 # Both dev and prod run identical Docker containers.
 # The only difference: `watch` syncs local source changes into containers.
 
-COMPOSE     := docker compose
-COMPOSE_CLI := $(COMPOSE) --profile cli
+COMPOSE       := docker compose
+COMPOSE_WATCH := docker compose -f docker-compose.yml -f docker-compose.watch.yml
+COMPOSE_CLI   := $(COMPOSE) --profile cli
 
 # Ensure DECEPTICON_HOME is always set so Docker Compose bind mounts resolve
 # correctly. Docker Compose cannot expand ~ in default values, so we must
@@ -24,7 +25,7 @@ export DECEPTICON_HOME ?= $(HOME)/.decepticon
 
 ## Build images and start with hot-reload (source changes auto-sync)
 dev:
-	$(COMPOSE) watch
+	$(COMPOSE_WATCH) watch
 
 ## Run interactive CLI in Docker (prod-like, requires `make dev` for backend)
 cli:
@@ -32,7 +33,7 @@ cli:
 
 ## Run interactive CLI locally (dev mode — starts backend with hot-reload, then local CLI)
 cli-dev: infra
-	@$(COMPOSE) watch --no-up --quiet langgraph &
+	@$(COMPOSE_WATCH) watch --no-up --quiet langgraph &
 	cd clients/cli && DECEPTICON_API_URL=$${DECEPTICON_API_URL:-http://localhost:2024} npm run dev
 
 # ── Production-like ──────────────────────────────────────────────
@@ -114,7 +115,7 @@ web:
 ## Start web dashboard in dev mode (Next.js + terminal WebSocket server)
 ## Automatically starts infra services with hot-reload, then local web.
 web-dev: infra web-db-ensure
-	@$(COMPOSE) watch --no-up --quiet langgraph &
+	@$(COMPOSE_WATCH) watch --no-up --quiet langgraph &
 	@echo "[web-dev] Starting terminal server (ws://localhost:3003)..."
 	@cd clients/web && npx tsx server/terminal-server.ts &
 	@echo "[web-dev] Starting Next.js dev server (http://localhost:3000)..."

--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -79,6 +79,11 @@ wss.on("connection", async (ws: WebSocket, req) => {
     FORCE_COLOR: "1",
     DECEPTICON_AGENT: agentId,
     DECEPTICON_ENGAGEMENT_ID: engagementId,
+    // Explicitly set DECEPTICON_API_URL so the CLI subprocess resolves the
+    // correct internal Docker hostname (e.g. http://langgraph:2024) rather
+    // than falling back to localhost:2024, which is unreachable inside the
+    // web container.
+    DECEPTICON_API_URL: LANGGRAPH_API_URL,
   };
   if (threadId) {
     env.DECEPTICON_THREAD_ID = threadId;

--- a/docker-compose.watch.yml
+++ b/docker-compose.watch.yml
@@ -1,0 +1,52 @@
+# docker-compose.watch.yml — hot-reload overrides for development
+#
+# Requires Docker Compose 2.22+ (introduces the `develop.watch` key).
+# Kept separate from docker-compose.yml so OSS users on older Compose
+# versions don't hit "Additional property develop is not allowed".
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.watch.yml watch
+#   # or via make:
+#   make dev
+services:
+  langgraph:
+    develop:
+      watch:
+        - action: sync
+          path: ./decepticon
+          target: /app/decepticon
+        - action: sync
+          path: ./skills
+          target: /app/skills
+        - action: sync
+          path: ./langgraph.json
+          target: /app/langgraph.json
+        - action: rebuild
+          path: ./pyproject.toml
+        - action: rebuild
+          path: ./containers/langgraph.Dockerfile
+
+  web:
+    develop:
+      watch:
+        - action: sync
+          path: ./clients/web/src
+          target: /app/clients/web/src
+        - action: sync
+          path: ./clients/web/public
+          target: /app/clients/web/public
+        - action: rebuild
+          path: ./clients/web/package.json
+        - action: rebuild
+          path: ./containers/web.Dockerfile
+
+  cli:
+    develop:
+      watch:
+        - action: sync
+          path: ./clients/cli/src
+          target: /app/src
+        - action: rebuild
+          path: ./clients/cli/package.json
+        - action: rebuild
+          path: ./containers/cli.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,22 +154,6 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
-    # Dev hot-reload: activate with `docker compose watch` (ignored by `docker compose up`)
-    develop:
-      watch:
-        - action: sync
-          path: ./decepticon
-          target: /app/decepticon
-        - action: sync
-          path: ./skills
-          target: /app/skills
-        - action: sync
-          path: ./langgraph.json
-          target: /app/langgraph.json
-        - action: rebuild
-          path: ./pyproject.toml
-        - action: rebuild
-          path: ./containers/langgraph.Dockerfile
 
   # Web Dashboard — Next.js UI
   # Migrations run automatically at startup via web-entrypoint.sh (prisma migrate deploy).
@@ -199,18 +183,6 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
-    develop:
-      watch:
-        - action: sync
-          path: ./clients/web/src
-          target: /app/clients/web/src
-        - action: sync
-          path: ./clients/web/public
-          target: /app/clients/web/public
-        - action: rebuild
-          path: ./clients/web/package.json
-        - action: rebuild
-          path: ./containers/web.Dockerfile
 
   # Ink CLI — Interactive terminal UI
   # Runs via: docker compose run --rm cli
@@ -234,15 +206,6 @@ services:
       - decepticon-net
     profiles:
       - cli
-    develop:
-      watch:
-        - action: sync
-          path: ./clients/cli/src
-          target: /app/src
-        - action: rebuild
-          path: ./clients/cli/package.json
-        - action: rebuild
-          path: ./containers/cli.Dockerfile
 
   # ── C2 Infrastructure (profile-based, default: c2-sliver) ───────────
   # Each C2 framework runs as a profile-based service on sandbox-net.


### PR DESCRIPTION
## Summary

- **Bug #78 — web terminal `fetch failed`**: `terminal-server.ts` spawns the CLI subprocess with `process.env` spread, which includes `LANGGRAPH_API_URL=http://langgraph:2024`, but the CLI reads `DECEPTICON_API_URL`. Without an explicit mapping, the CLI fell back to `localhost:2024`, which is unreachable inside the web container. Added `DECEPTICON_API_URL: LANGGRAPH_API_URL` to the PTY env.
- **`develop:` Compose compat fix**: The `develop.watch` key was introduced in Docker Compose 2.22. Users on Kali Linux and other distros with older versions saw `services.langgraph Additional property develop is not allowed`, preventing any service from starting. Moved all `develop:` blocks to a new `docker-compose.watch.yml` override file. `docker compose up` is unaffected; `make dev` uses the override automatically.

## Changes

- `clients/web/server/terminal-server.ts` — pass `DECEPTICON_API_URL` to CLI PTY env
- `docker-compose.yml` — remove `develop:` sections
- `docker-compose.watch.yml` — new file with `develop:` sections (Compose 2.22+ only)
- `Makefile` — `COMPOSE_WATCH` variable uses `-f docker-compose.watch.yml`; watch targets updated

## Test plan

- [ ] `docker compose config` on Docker Compose < 2.22 — no validation errors
- [ ] `make dev` — hot-reload still works (watch file used)
- [ ] Start web dashboard, send message in terminal — no "fetch failed" error
- [ ] `docker compose run --rm cli` — CLI connects to LangGraph normally