### PR TITLE
fix(launcher): OSS launch regression + auto-update hardening

### DIFF
--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -125,7 +125,13 @@ func (c *Compose) RunInteractive(profiles []string, service string, env map[stri
 	for _, p := range profiles {
 		cmdArgs = append(cmdArgs, "--profile", p)
 	}
-	cmdArgs = append(cmdArgs, "run", "--rm", "--no-build")
+	// Note: --no-build is intentionally absent. `docker compose run` does
+	// not accept --no-build (only `up` does); passing it raises
+	// "unknown flag: --no-build" on every Compose version. The original
+	// concern (OSS users without source triggering a build) doesn't
+	// apply here because the cli image is pulled at install time and
+	// `run` only builds when the image is missing.
+	cmdArgs = append(cmdArgs, "run", "--rm")
 	for k, v := range env {
 		cmdArgs = append(cmdArgs, "-e", k+"="+v)
 	}

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -190,6 +190,13 @@ func WriteVersion(version string) error {
 }
 
 // CheckAndUpdate performs auto-update check. Returns true if update was applied.
+//
+// Update order is binary-first, then config files. If the binary update fails
+// we abort entirely so we never end up with new compose/litellm files driving
+// an old launcher (which has caused breakage in past releases when image
+// tags or compose schema changed). If config sync fails after a successful
+// binary update we keep the new binary and leave .version unwritten so the
+// next launch retries config sync.
 func CheckAndUpdate(currentVersion string, env map[string]string) bool {
 	if config.Get(env, "AUTO_UPDATE", "true") == "false" {
 		return false
@@ -206,15 +213,19 @@ func CheckAndUpdate(currentVersion string, env map[string]string) bool {
 
 	ui.Info(fmt.Sprintf("Update available: %s → %s", currentVersion, release.TagName))
 
-	// Use release tag for config files to avoid main branch drift
-	ref := release.TagName // e.g., "v1.0.7"
-	if err := SyncConfigFiles(ref); err != nil {
-		ui.Warning("Config sync failed: " + err.Error())
-	}
-
 	if err := SelfUpdate(release); err != nil {
 		ui.Warning("Self-update failed: " + err.Error())
 		return false
+	}
+
+	// Use release tag for config files to avoid main branch drift
+	ref := release.TagName // e.g., "v1.0.7"
+	if err := SyncConfigFiles(ref); err != nil {
+		ui.Warning("Binary updated but config sync failed: " + err.Error())
+		ui.Warning("Run 'decepticon update' to retry config sync.")
+		// Do not WriteVersion — leaving .version stale lets the next run
+		// retry the sync via this same code path.
+		return true
 	}
 
 	_ = WriteVersion(release.TagName)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,6 +161,37 @@ create_launcher() {
     chmod 755 "$bin_dir/decepticon"
 }
 
+# ── Detect stale `decepticon` in PATH ─────────────────────────────
+# A previous install via `npm link`, manual symlink, or alternate package
+# manager can leave a `decepticon` executable elsewhere on PATH. That stale
+# entry will shadow our launcher and produce confusing errors (e.g. node
+# MODULE_NOT_FOUND). Surface the conflict so the user can clean it up.
+detect_stale_launcher() {
+    local bin_dir="$1"
+    local found=()
+    local seen=":"
+    local IFS=':'
+    for d in $PATH; do
+        [[ -z "$d" ]] && continue
+        # Dedupe — PATH often lists the same dir twice (.bashrc + .profile etc.)
+        case "$seen" in *":$d:"*) continue;; esac
+        seen="$seen$d:"
+        if [[ -e "$d/decepticon" && "$d" != "$bin_dir" ]]; then
+            found+=("$d/decepticon")
+        fi
+    done
+
+    if [[ ${#found[@]} -gt 0 ]]; then
+        echo ""
+        warn "Found other 'decepticon' executable(s) on PATH:"
+        for f in "${found[@]}"; do
+            echo "  $f"
+        done
+        warn "These may shadow the launcher just installed at $bin_dir/decepticon."
+        echo -e "${DIM}Remove them, then run 'hash -r' or restart your shell.${NC}"
+    fi
+}
+
 # ── PATH setup (bash/zsh/fish) ────────────────────────────────────
 setup_path() {
     local bin_dir="$1"
@@ -271,6 +302,10 @@ main() {
     # PATH
     setup_path "$bin_dir"
 
+    # Stale launcher detection (runs after PATH setup so $bin_dir is the
+    # source of truth for "where the new launcher lives")
+    detect_stale_launcher "$bin_dir"
+
     # Docker images
     pull_images "$install_dir"
 
@@ -287,12 +322,20 @@ main() {
     echo -e "     ${BOLD}decepticon${NC}"
     echo ""
 
-    # Hint to reload shell
-    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$bin_dir"; then
-        echo -e "  ${DIM}Restart your shell or run:${NC}"
-        echo -e "     ${BOLD}export PATH=\"$bin_dir:\$PATH\"${NC}"
-        echo ""
-    fi
+    # Reload-shell hint — always show it.
+    # Two failure modes a user can hit on a fresh shell:
+    #   (a) $bin_dir was just added to .bashrc/.zshrc/etc. but the current
+    #       shell hasn't sourced it yet → `decepticon` not found.
+    #   (b) The shell already has $bin_dir on PATH but a stale `decepticon`
+    #       (e.g. removed npm shim) is cached in its hash table → the wrong
+    #       binary is invoked or "No such file or directory" is reported.
+    # Spelling both fixes out unconditionally is cheaper than diagnosing
+    # either failure after the fact.
+    echo -e "  ${DIM}Reload your shell to pick up the new launcher:${NC}"
+    echo -e "     ${BOLD}exec \$SHELL${NC}     ${DIM}# or open a new terminal${NC}"
+    echo -e "  ${DIM}If $bin_dir is already on PATH (e.g. you upgraded), refresh the cache:${NC}"
+    echo -e "     ${BOLD}hash -r${NC}"
+    echo ""
 }
 
 main "$@"

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -66,10 +66,17 @@ check_for_update() {
 
     [[ -z "$latest" ]] && return  # offline / API error -- skip silently
 
-    # sort -V puts the higher version last; skip if current is already >= latest
-    local newer
-    newer=$(printf '%s\n%s' "$latest" "$current" | sort -V | tail -1)
-    [[ "$newer" == "$current" ]] && return  # already up to date or ahead
+    # Special case: install.sh writes ".version=latest" when no GitHub release
+    # existed at install time. `sort -V` orders the literal string "latest"
+    # AFTER any numeric version, so the comparison below would always treat
+    # the user as up-to-date and never auto-update. Force the upgrade path
+    # explicitly.
+    if [[ "$current" != "latest" ]]; then
+        # sort -V puts the higher version last; skip if current is already >= latest
+        local newer
+        newer=$(printf '%s\n%s' "$latest" "$current" | sort -V | tail -1)
+        [[ "$newer" == "$current" ]] && return  # already up to date or ahead
+    fi
 
     echo -e "${CYAN}Auto-updating: ${BOLD}v${current}${NC}${CYAN} -> ${BOLD}v${latest}${NC}"
 
@@ -263,7 +270,7 @@ case "${1:-}" in
         [[ -n "$_ver" ]] && export DECEPTICON_VERSION="$_ver"
 
         # Run CLI in foreground (interactive)
-        $COMPOSE_PROFILES run --rm --no-build cli
+        $COMPOSE_PROFILES run --rm cli
         ;;
 
     stop)
@@ -362,7 +369,7 @@ case "${1:-}" in
         ;&
 
     onboard)
-        $COMPOSE_PROFILES run --rm --no-build cli python -m decepticon.cli.app onboard
+        $COMPOSE_PROFILES run --rm cli python -m decepticon.cli.app onboard
         ;;
 
     demo)
@@ -413,7 +420,7 @@ case "${1:-}" in
         echo ""
 
         # Run CLI with auto-start message
-        $COMPOSE_PROFILES run --rm --no-build -e DECEPTICON_INITIAL_MESSAGE="Resume the demo engagement and execute all objectives." cli
+        $COMPOSE_PROFILES run --rm -e DECEPTICON_INITIAL_MESSAGE="Resume the demo engagement and execute all objectives." cli
         ;;
 
     victims)


### PR DESCRIPTION
## Summary

Resolves a CLI launch regression and three supporting OSS-user issues found while reproducing a fresh install.

- **(regression) `docker compose run --no-build` → "unknown flag"** — PR #76 added `--no-build` to both `compose up` and `compose run`. The flag is valid for `up` but does not exist on `run` in any Compose release, so every user hit `unknown flag: --no-build` when the launcher tried to start the CLI. Removed from `RunInteractive` (Go) and the three `run` call sites in `scripts/launcher.sh` (start / onboard / demo). `up --no-build` is kept (valid). The earlier fix in `e61bc7a` was inadvertently reverted by #76.
- **`install.sh` stale-launcher detection** — surfaces shadowing `decepticon` entries on PATH (npm-link leftovers, manual symlinks, alternate package managers) so a first-run user does not hit confusing `MODULE_NOT_FOUND` from another package's shim. Reload-shell instructions (`exec $SHELL` / `hash -r`) are now always printed instead of conditionally.
- **Auto-update atomicity** (`internal/updater/updater.go`) — `SelfUpdate` now runs before `SyncConfigFiles`. The old order could leave new compose/litellm files driving an old launcher if the binary update failed. New order aborts on binary failure and retries config sync on the next launch when only that step fails (leaving `.version` stale drives the retry).
- **Bash `.version=latest` sentinel** — `install.sh` writes the literal `"latest"` when no GitHub release exists at install time, and `sort -V` orders that string after every numeric version, so users installed at that point would never auto-update. The comparison is now bypassed for the sentinel value.

## Test plan

- [x] `cd clients/launcher && go build ./...` — builds clean
- [x] `cd clients/launcher && go test -count=1 ./...` — all packages pass
- [x] `bash -n scripts/install.sh && bash -n scripts/launcher.sh` — syntax OK
- [x] Functional test: `detect_stale_launcher` correctly lists shadowing entries (with PATH dedup)
- [x] Functional test: `.version=latest` sentinel branch proceeds to update where the old logic would skip
- [ ] End-to-end: fresh install on amd64 Linux → `decepticon` launches CLI without `unknown flag: --no-build`
- [ ] End-to-end: bash-launcher → Go-binary auto-migration on next run still works
- [ ] End-to-end: auto-update with simulated binary-failure leaves config and `.version` untouched