### PR TITLE
fix(launcher): block CLI entry until services functionally ready

### DIFF
--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -46,10 +46,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	if config.Get(env, "DECEPTICON_MODEL_PROVIDER", "api") == "api" {
-		if err := config.ValidateAPIKeys(env); err != nil {
-			ui.Warning(err.Error())
-		}
+	if err := config.ValidateAuth(env); err != nil {
+		return err
 	}
 
 	// 2.3. Ensure config files exist (docker-compose.yml, litellm.yaml, workspace)

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
@@ -70,14 +71,33 @@ func (c *Compose) run(args []string, interactive bool) error {
 	return nil
 }
 
-// Up starts services in detached mode with the given profiles.
+// Up starts services in detached mode and blocks until healthchecks pass.
+//
+// `--wait` (Docker Compose 2.0+) makes `up` block until each service's compose
+// healthcheck transitions to healthy, eliminating the need for the launcher to
+// re-implement HTTP polling.
+//
+// `--wait-timeout` is the single user-facing patience knob. Override via
+// DECEPTICON_STARTUP_TIMEOUT_SECONDS for slower hardware. Default 600s
+// covers most environments after measuring 136s LiteLLM cold start in CI.
 func (c *Compose) Up(profiles ...string) error {
 	args := []string{}
 	for _, p := range profiles {
 		args = append(args, "--profile", p)
 	}
-	args = append(args, "up", "-d", "--no-build")
+	args = append(args, "up", "-d", "--no-build", "--wait", "--wait-timeout", startupTimeoutSeconds())
 	return c.run(args, false)
+}
+
+// startupTimeoutSeconds returns the --wait-timeout value as a string.
+// User override via DECEPTICON_STARTUP_TIMEOUT_SECONDS; falls back to 600s.
+func startupTimeoutSeconds() string {
+	if v := os.Getenv("DECEPTICON_STARTUP_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return strconv.Itoa(n)
+		}
+	}
+	return "600"
 }
 
 // Down stops and removes containers using all profiles for clean teardown.

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -149,14 +149,101 @@ func IsPlaceholder(val string) bool {
 	return strings.HasSuffix(val, PlaceholderSuffix) || val == ""
 }
 
-// ValidateAPIKeys checks that at least one API key is a real value.
-func ValidateAPIKeys(env map[string]string) error {
-	for _, name := range APIKeyNames {
-		if val, ok := env[name]; ok && !IsPlaceholder(val) {
-			return nil
+// keyFormatRules maps an API key env var to its expected prefix and human-readable hint.
+// Format checks are intentionally lenient — providers occasionally evolve key shapes
+// (OpenAI shipped sk-proj-* in 2024, Anthropic sk-ant-api03-* etc.). The check only
+// rejects values that are obviously malformed (typos, missing prefix).
+var keyFormatRules = map[string]struct {
+	Prefix string
+	Hint   string
+}{
+	"ANTHROPIC_API_KEY": {Prefix: "sk-ant-", Hint: "Anthropic keys start with 'sk-ant-'"},
+	"OPENAI_API_KEY":    {Prefix: "sk-", Hint: "OpenAI keys start with 'sk-'"},
+	"GOOGLE_API_KEY":    {Prefix: "AIza", Hint: "Google keys start with 'AIza'"},
+}
+
+// validateKeyFormat returns an empty string if the key looks valid, or a reason if not.
+func validateKeyFormat(name, val string) string {
+	if len(val) < 20 {
+		return "value is too short to be a valid API key"
+	}
+	if rule, ok := keyFormatRules[name]; ok {
+		if !strings.HasPrefix(val, rule.Prefix) {
+			return rule.Hint
 		}
 	}
-	return fmt.Errorf("no valid API key found; run 'decepticon onboard' to configure")
+	return ""
+}
+
+// ValidateAPIKeys checks that at least one API key is set with a valid format.
+// Returns a fatal error listing both unset keys and any format problems found.
+func ValidateAPIKeys(env map[string]string) error {
+	var validNames []string
+	invalidReasons := make(map[string]string)
+
+	for _, name := range APIKeyNames {
+		val := env[name]
+		if val == "" || IsPlaceholder(val) {
+			continue
+		}
+		if reason := validateKeyFormat(name, val); reason != "" {
+			invalidReasons[name] = reason
+			continue
+		}
+		validNames = append(validNames, name)
+	}
+
+	if len(validNames) > 0 {
+		return nil
+	}
+
+	var msg strings.Builder
+	msg.WriteString("no valid API key found.")
+	if len(invalidReasons) > 0 {
+		msg.WriteString(" Detected malformed key(s):")
+		for name, reason := range invalidReasons {
+			msg.WriteString(fmt.Sprintf("\n  %s: %s", name, reason))
+		}
+	}
+	msg.WriteString("\nRun 'decepticon onboard --reset' to reconfigure credentials.")
+	return fmt.Errorf("%s", msg.String())
+}
+
+// ValidateAuth ensures authentication is configured for the chosen provider mode.
+// "api" mode → at least one well-formed API key must be set.
+// "auth" mode → Claude Code credentials file must exist (LiteLLM mounts it read-only).
+func ValidateAuth(env map[string]string) error {
+	mode := Get(env, "DECEPTICON_MODEL_PROVIDER", "api")
+	switch mode {
+	case "api":
+		return ValidateAPIKeys(env)
+	case "auth":
+		return validateClaudeCredentials()
+	default:
+		return fmt.Errorf("unknown DECEPTICON_MODEL_PROVIDER: %q (expected 'api' or 'auth')", mode)
+	}
+}
+
+// validateClaudeCredentials verifies ~/.claude/.credentials.json exists and is a file.
+// Compose mounts this path into the LiteLLM container; if it's missing Docker creates
+// a directory at the bind target and authentication fails opaquely at runtime.
+func validateClaudeCredentials() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("locate home directory: %w", err)
+	}
+	path := filepath.Join(home, ".claude", ".credentials.json")
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("Claude Code credentials not found at %s\nRun 'claude /login' (Claude Code CLI) to authenticate, then retry.", path)
+	}
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("expected credentials file at %s but found a directory.\nRemove it and run 'claude /login' to re-authenticate.", path)
+	}
+	return nil
 }
 
 // AppendEnvLine appends a KEY=VALUE line to an existing .env file.

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -87,8 +87,8 @@ func TestValidateAPIKeys(t *testing.T) {
 		t.Error("expected error for all-placeholder keys")
 	}
 
-	// One real key → ok
-	env["ANTHROPIC_API_KEY"] = "sk-ant-real-key"
+	// One real, well-formed key → ok
+	env["ANTHROPIC_API_KEY"] = "sk-ant-api03-realkeythatislongenough"
 	if err := ValidateAPIKeys(env); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -96,6 +96,54 @@ func TestValidateAPIKeys(t *testing.T) {
 	// Empty env → error
 	if err := ValidateAPIKeys(map[string]string{}); err == nil {
 		t.Error("expected error for empty env")
+	}
+}
+
+func TestValidateAPIKeys_RejectsBadFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{"missing prefix", map[string]string{"ANTHROPIC_API_KEY": "no-prefix-key-of-decent-length"}},
+		{"too short", map[string]string{"OPENAI_API_KEY": "sk-short"}},
+		{"google missing prefix", map[string]string{"GOOGLE_API_KEY": "sk-wrongprefix-key-long-enough-here"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAPIKeys(tt.env); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateAuth_AuthMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	env := map[string]string{"DECEPTICON_MODEL_PROVIDER": "auth"}
+
+	// auth mode without credentials file → error
+	if err := ValidateAuth(env); err == nil {
+		t.Error("expected error when ~/.claude/.credentials.json is missing")
+	}
+
+	// auth mode with credentials file → ok
+	credDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(credDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, ".credentials.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateAuth(env); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateAuth_UnknownMode(t *testing.T) {
+	env := map[string]string{"DECEPTICON_MODEL_PROVIDER": "telepathy"}
+	if err := ValidateAuth(env); err == nil {
+		t.Error("expected error for unknown provider mode")
 	}
 }
 

--- a/clients/launcher/internal/health/health.go
+++ b/clients/launcher/internal/health/health.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
@@ -14,15 +17,32 @@ import (
 const (
 	DefaultLangGraphPort = "2024"
 	DefaultLiteLLMPort   = "4000"
+	DefaultNeo4jHTTPPort = "7474"
 	DefaultWebPort       = "3000"
-
-	LangGraphTimeout = 90 * time.Second
-	LiteLLMTimeout   = 60 * time.Second
-	WebTimeout       = 60 * time.Second
-	PollInterval     = 2 * time.Second
 )
 
-// CheckLangGraph polls the LangGraph API until the decepticon assistant is loaded.
+// Timeouts are var (not const) so tests can shrink them.
+var (
+	// LangGraph healthcheck (compose) only verifies /ok responds. The graph may
+	// still be compiling — this functional probe waits for the decepticon
+	// assistant to appear in /assistants/search.
+	LangGraphTimeout = 60 * time.Second
+
+	// Reserved for ad-hoc diagnostics commands.
+	LiteLLMTimeout = 90 * time.Second
+	Neo4jTimeout   = 90 * time.Second
+	WebTimeout     = 60 * time.Second
+
+	PollInterval = 2 * time.Second
+)
+
+// CheckLangGraph polls /assistants/search until the response references the
+// decepticon assistant. Compose's healthcheck only verifies that /ok serves;
+// graph compilation can still be in progress, so this functional probe is the
+// only signal that the agent is actually callable.
+//
+// DECEPTICON_STARTUP_TIMEOUT_SECONDS overrides LangGraphTimeout for slow
+// environments where graph compile is the long pole.
 func CheckLangGraph(env map[string]string) error {
 	port := config.Get(env, "LANGGRAPH_PORT", DefaultLangGraphPort)
 	url := fmt.Sprintf("http://localhost:%s/assistants/search", port)
@@ -32,24 +52,35 @@ func CheckLangGraph(env map[string]string) error {
 		"limit":    1,
 	})
 
-	deadline := time.Now().Add(LangGraphTimeout)
+	timeout := LangGraphTimeout
+	if v := os.Getenv("DECEPTICON_STARTUP_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			timeout = time.Duration(n) * time.Second
+		}
+	}
+	deadline := time.Now().Add(timeout)
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	for time.Now().Before(deadline) {
 		resp, err := client.Post(url, "application/json", bytes.NewReader(body))
 		if err == nil {
-			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				return nil
+				respBody, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				if bytes.Contains(respBody, []byte(`"decepticon"`)) {
+					return nil
+				}
+			} else {
+				resp.Body.Close()
 			}
 		}
 		time.Sleep(PollInterval)
 	}
 
-	return fmt.Errorf("LangGraph server not ready after %s (port %s)", LangGraphTimeout, port)
+	return fmt.Errorf("LangGraph assistant not loaded after %s (port %s)", timeout, port)
 }
 
-// CheckLiteLLM polls the LiteLLM health endpoint.
+// CheckLiteLLM polls the LiteLLM health endpoint. Kept for diagnostics.
 func CheckLiteLLM(env map[string]string) error {
 	port := config.Get(env, "LITELLM_PORT", DefaultLiteLLMPort)
 	url := fmt.Sprintf("http://localhost:%s/health/readiness", port)
@@ -71,7 +102,29 @@ func CheckLiteLLM(env map[string]string) error {
 	return fmt.Errorf("LiteLLM proxy not ready after %s (port %s)", LiteLLMTimeout, port)
 }
 
-// CheckWeb polls the web dashboard.
+// CheckNeo4j polls the Neo4j HTTP endpoint. Kept for diagnostics.
+func CheckNeo4j(env map[string]string) error {
+	port := config.Get(env, "NEO4J_HTTP_PORT", DefaultNeo4jHTTPPort)
+	url := fmt.Sprintf("http://localhost:%s", port)
+
+	deadline := time.Now().Add(Neo4jTimeout)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+				return nil
+			}
+		}
+		time.Sleep(PollInterval)
+	}
+
+	return fmt.Errorf("Neo4j not ready after %s (port %s)", Neo4jTimeout, port)
+}
+
+// CheckWeb polls the web dashboard. Kept for diagnostics.
 func CheckWeb(env map[string]string) error {
 	port := config.Get(env, "WEB_PORT", DefaultWebPort)
 	url := fmt.Sprintf("http://localhost:%s", port)
@@ -93,31 +146,20 @@ func CheckWeb(env map[string]string) error {
 	return fmt.Errorf("web dashboard not ready after %s (port %s)", WebTimeout, port)
 }
 
-// WaitForServices runs all health checks with status output.
+// WaitForServices verifies the agent stack is functionally ready.
+//
+// Infrastructure readiness (postgres, neo4j, litellm, langgraph http server,
+// web) is delegated to Docker Compose healthchecks via `compose up --wait`,
+// so by the time this runs every container is already healthy. The remaining
+// gap is graph-compile readiness inside LangGraph: /ok answers before the
+// decepticon graph finishes compiling, so we probe /assistants/search until
+// the assistant is registered.
 func WaitForServices(env map[string]string) error {
-	ui.Info("Waiting for LangGraph server...")
+	ui.Info("Verifying agent stack...")
 	if err := CheckLangGraph(env); err != nil {
 		ui.Error(err.Error())
 		return err
 	}
-	ui.Success("LangGraph server ready")
-
-	ui.Info("Waiting for LiteLLM proxy...")
-	if err := CheckLiteLLM(env); err != nil {
-		ui.Warning(err.Error() + " (first LLM call may fail)")
-		// Non-fatal: continue
-	} else {
-		ui.Success("LiteLLM proxy ready")
-	}
-
-	ui.Info("Waiting for web dashboard...")
-	if err := CheckWeb(env); err != nil {
-		ui.Warning(err.Error())
-		// Non-fatal
-	} else {
-		port := config.Get(env, "WEB_PORT", DefaultWebPort)
-		ui.Success(fmt.Sprintf("Web dashboard ready at http://localhost:%s", port))
-	}
-
+	ui.Success("Agent stack ready")
 	return nil
 }

--- a/clients/launcher/internal/health/health_test.go
+++ b/clients/launcher/internal/health/health_test.go
@@ -4,27 +4,47 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestCheckLangGraph_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" && r.URL.Path == "/assistants/search" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`[{"assistant_id": "decepticon"}]`))
+			w.Write([]byte(`[{"assistant_id": "abc", "graph_id": "decepticon"}]`))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
-	// Extract port from test server
 	port := server.Listener.Addr().String()
-	// Override by using the full URL check
 	env := map[string]string{"LANGGRAPH_PORT": port[len("127.0.0.1:"):]}
 
 	err := CheckLangGraph(env)
 	if err != nil {
 		t.Errorf("CheckLangGraph() unexpected error: %v", err)
+	}
+}
+
+// 200 with an empty array means the API booted but the graph isn't compiled.
+// CheckLangGraph must reject this and keep polling until timeout.
+func TestCheckLangGraph_RejectsEmptyBody(t *testing.T) {
+	prev := LangGraphTimeout
+	LangGraphTimeout = 1 * time.Second
+	defer func() { LangGraphTimeout = prev }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	port := server.Listener.Addr().String()
+	env := map[string]string{"LANGGRAPH_PORT": port[len("127.0.0.1:"):]}
+
+	if err := CheckLangGraph(env); err == nil {
+		t.Error("CheckLangGraph() should fail when body lacks decepticon assistant")
 	}
 }
 
@@ -44,6 +64,20 @@ func TestCheckLiteLLM_Success(t *testing.T) {
 	err := CheckLiteLLM(env)
 	if err != nil {
 		t.Errorf("CheckLiteLLM() unexpected error: %v", err)
+	}
+}
+
+func TestCheckNeo4j_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	port := server.Listener.Addr().String()
+	env := map[string]string{"NEO4J_HTTP_PORT": port[len("127.0.0.1:"):]}
+
+	if err := CheckNeo4j(env); err != nil {
+		t.Errorf("CheckNeo4j() unexpected error: %v", err)
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,20 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Cold-start cost (prisma migrate + model-routing load + uvicorn bind):
+    # measured 136s on a fresh PostgreSQL volume; varies with disk speed.
+    # start_period absorbs environment variability — failures during this
+    # window don't count toward retries. test success at any moment flips
+    # healthy immediately, so the cushion costs no time on fast hosts.
+    # retries is the post-cushion grace for transient failures only;
+    # the launcher's --wait-timeout (DECEPTICON_STARTUP_TIMEOUT_SECONDS)
+    # is the single user-facing patience knob.
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/readiness')"]
       interval: 5s
       timeout: 3s
-      retries: 20
-      start_period: 10s
+      retries: 12
+      start_period: 300s
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
@@ -84,10 +92,10 @@ services:
       - decepticon-net
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:7474 || exit 1"]
-      interval: 15s
+      interval: 5s
       timeout: 5s
-      retries: 10
-      start_period: 30s
+      retries: 12
+      start_period: 90s
     restart: unless-stopped
 
   # Evasive Red Team Sandbox
@@ -142,15 +150,26 @@ services:
       # Neo4j is the sole KG backend (no DECEPTICON_KG_BACKEND needed)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # Relaxed startup: langgraph has built-in retry for litellm/neo4j connections,
-    # so we don't block on healthchecks — cuts cold start by ~30-40s.
+    # Wait for litellm to be healthy: langgraph has retry logic but the launcher
+    # uses `compose up --wait` and needs healthy as the single readiness signal.
     depends_on:
       litellm:
-        condition: service_started
+        condition: service_healthy
       sandbox:
         condition: service_started
       neo4j:
-        condition: service_started
+        condition: service_healthy
+    # python urllib — same pattern as the litellm healthcheck. Runs entirely
+    # inside the container so host OS (Linux / macOS / Windows) is irrelevant;
+    # avoids relying on curl/wget being present in the langgraph base image.
+    # start_period covers FastAPI + graph-server boot after litellm flips
+    # healthy; retries is post-cushion grace.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:2024/ok')"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 90s
     networks:
       - decepticon-net
     restart: unless-stopped
@@ -177,9 +196,20 @@ services:
       - ${DECEPTICON_HOME:-~/.decepticon}/workspace:/workspace
     depends_on:
       langgraph:
-        condition: service_started
+        condition: service_healthy
       postgres:
         condition: service_healthy
+    # node http.get — Next.js standalone images include node but not curl/wget.
+    # `r.resume()` drains the body so the request finishes; without it the
+    # callback can resolve before close, leaving the process hanging until
+    # docker's healthcheck timeout fires. start_period covers prisma migrate
+    # + Next.js boot; retries is post-cushion grace.
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/', r => { r.resume(); process.exit(r.statusCode < 500 ? 0 : 1); }).on('error', () => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
     networks:
       - decepticon-net
     restart: unless-stopped
@@ -201,7 +231,7 @@ services:
       - DECEPTICON_VERSION=${DECEPTICON_VERSION:-}
     depends_on:
       langgraph:
-        condition: service_started
+        condition: service_healthy
     networks:
       - decepticon-net
     profiles:


### PR DESCRIPTION
## Summary

OSS users running `decepticon` could enter the CLI before the agent stack
was actually ready, so the first prompt failed with opaque connection
or auth errors. This PR makes "everything ready" a hard gate.

- **`compose --wait` drives infra readiness.** Adds healthchecks for
  langgraph (`python urllib /ok`) and web (`node http.get /`). All
  retries/start_period values are tuned to absorb cold-start variance
  (measured 136s LiteLLM on a fresh PostgreSQL volume) without
  slowing fast hosts — `test` success flips healthy immediately.
- **Functional probe verifies graph compilation.** `/ok` answers before
  LangGraph finishes compiling the decepticon graph; the launcher polls
  `/assistants/search` until the body references it.
- **Auth checked before docker.** `ValidateAuth` covers both api-key
  and OAuth modes — per-provider key format (anthropic/openai/google),
  required Claude credentials file for `auth` mode. Replaces the prior
  warning-only check with a fatal error.
- **Single user-facing knob.** `DECEPTICON_STARTUP_TIMEOUT_SECONDS`
  overrides `compose --wait --wait-timeout` for slow hardware
  (default 600s).

## Why hardcoded timeouts are minimized

`retries × interval` and `start_period` are picked so that **test
success at any moment flips healthy** — fast hosts are not slowed.
`--wait-timeout` is the single user-overridable cap, decoupling
"how long to wait" from any compose-level constants.

## Test plan

- [x] `go build ./... && go test ./...` (all packages green)
- [x] Cold-start E2E (volumes preserved, all containers down):
  - 75s → Agent stack ready
  - immediate `curl /runs/stream` → 5s to first model token (`auth/claude-haiku-4-5`)
- [x] Healthcheck commands verified executable inside their containers
  (python in litellm/langgraph, wget in neo4j, node in web,
  pg_isready in postgres)
- [ ] Reviewer: cold install on a fresh host (no `~/.decepticon` volume)
- [ ] Reviewer: `DECEPTICON_STARTUP_TIMEOUT_SECONDS=120 decepticon` on
  slow hardware behaves as expected (early fatal vs success)

## Related

Follow-up to #81 (which fixed the CLI launch regression and auto-update
ordering). #81 unblocked launching the CLI; this PR ensures the CLI
only enters after the stack can actually answer.