### PR TITLE
ci(release): native arm runner for web image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Multi-arch images that build well under QEMU (Python wheels, simple
+  # binaries). Web is split out below because Next.js compile under arm64
+  # emulation made it the long pole (~21 min vs <5 min for the rest).
   docker:
     name: Build & push ${{ matrix.image }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false   # one image failure must not cancel the rest
+      fail-fast: false
       matrix:
         include:
           - image: decepticon-litellm
@@ -53,9 +56,6 @@ jobs:
             platforms: linux/amd64
           - image: decepticon-cli
             dockerfile: containers/cli.Dockerfile
-            platforms: linux/amd64,linux/arm64
-          - image: decepticon-web
-            dockerfile: containers/web.Dockerfile
             platforms: linux/amd64,linux/arm64
           - image: decepticon-c2-sliver
             dockerfile: containers/c2-sliver.Dockerfile
@@ -127,3 +127,134 @@ jobs:
         with:
           name: sbom-${{ matrix.image }}
           path: sbom-${{ matrix.image }}.cdx.json
+
+  # Web image: split per platform onto native runners. arm64 emulation
+  # used to dominate the release (~21 min for web alone vs <5 min for
+  # everything else). Each runner builds and pushes by digest only;
+  # docker-web-merge stitches the digests into a multi-arch manifest.
+  # Pattern: https://docs.docker.com/build/ci/github-actions/multi-platform/
+  docker-web:
+    name: Build & push decepticon-web (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: amd64
+            runs-on: ubuntu-latest
+          - platform: arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: containers/web.Dockerfile
+          platforms: linux/${{ matrix.platform }}
+          provenance: mode=max
+          sbom: true
+          outputs: type=image,name=ghcr.io/purpleailab/decepticon-web,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=web-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=web-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-digest-${{ matrix.platform }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-web-merge:
+    name: Merge web manifest + sign + SBOM
+    needs: docker-web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: web-digest-*
+          merge-multiple: true
+
+      - name: Create multi-arch manifest
+        id: manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/purpleailab/decepticon-web:${{ steps.version.outputs.version }} \
+            --tag ghcr.io/purpleailab/decepticon-web:latest \
+            $(printf 'ghcr.io/purpleailab/decepticon-web@sha256:%s ' *)
+          digest=$(docker buildx imagetools inspect \
+            ghcr.io/purpleailab/decepticon-web:${{ steps.version.outputs.version }} \
+            --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Cosign sign manifest (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "ghcr.io/purpleailab/decepticon-web@${DIGEST}"
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/purpleailab/decepticon-web:${{ steps.version.outputs.version }}
+          format: cyclonedx-json
+          output-file: sbom-decepticon-web.cdx.json
+
+      - name: Attest SBOM with cosign
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate sbom-decepticon-web.cdx.json \
+            --type cyclonedx \
+            "ghcr.io/purpleailab/decepticon-web@${DIGEST}"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-decepticon-web
+          path: sbom-decepticon-web.cdx.json


### PR DESCRIPTION
## Summary

QEMU-emulated arm64 build of the web image dominated the release pipeline: **~21 min for web alone** vs <5 min for every other image. The Next.js compile + native-module link is CPU-heavy and runs 5-10x slower under emulation.

This PR splits the web build per platform onto **native runners**:
- `ubuntu-latest` → linux/amd64
- `ubuntu-24.04-arm` → linux/arm64 (free for public repos as of 2025)

Each runner builds and pushes by digest only; a new `docker-web-merge` job stitches the digests into a multi-arch manifest with `docker buildx imagetools create`, then signs the manifest and attests its SBOM.

Pattern from Docker docs: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

## Why only web

| Image | Multi-arch under QEMU | Notes |
|---|---|---|
| litellm | ~4 min | Python wheels (precompiled, no QEMU compile) |
| langgraph | ~4 min | Same |
| cli | ~3 min | TS transpile only |
| sandbox | ~4 min | amd64-only |
| c2-sliver | ~1 min | amd64-only |
| **web** | **~21 min** | Next.js production build + node-pty/sharp native compile under QEMU |

Splitting only web keeps the YAML overhead minimal where it matters; other images keep the simpler single-runner QEMU matrix.

## Expected impact

- **Web release time: 21 min → ~5-7 min** (each native runner builds in roughly the same time as amd64 currently)
- Total release wall-clock: dominated by web → also drops to ~7 min
- Manifest-merge job adds ~30s for `imagetools create` + cosign sign + SBOM
- All security artifacts preserved: cosign keyless sign on the manifest digest, CycloneDX SBOM attest, GHA cache scoped per platform

## Test plan

- [ ] Reviewer: tag a test release (or push to a fork) and verify both \`docker-web (amd64)\` and \`docker-web (arm64)\` complete on their respective runners
- [ ] Reviewer: \`docker buildx imagetools inspect ghcr.io/purpleailab/decepticon-web:<tag>\` shows both \`linux/amd64\` and \`linux/arm64\` in the manifest list
- [ ] Reviewer: \`cosign verify ghcr.io/purpleailab/decepticon-web:<tag>\` (keyless) succeeds against the merged manifest
- [ ] Reviewer: SBOM artifact attached to release contains both platform's components