### PR TITLE
fix(launcher): loosen anthropic key prefix and validate oauth credentials content

### DIFF
--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -157,7 +158,7 @@ var keyFormatRules = map[string]struct {
 	Prefix string
 	Hint   string
 }{
-	"ANTHROPIC_API_KEY": {Prefix: "sk-ant-", Hint: "Anthropic keys start with 'sk-ant-'"},
+	"ANTHROPIC_API_KEY": {Prefix: "sk-", Hint: "Anthropic keys start with 'sk-'"},
 	"OPENAI_API_KEY":    {Prefix: "sk-", Hint: "OpenAI keys start with 'sk-'"},
 	"GOOGLE_API_KEY":    {Prefix: "AIza", Hint: "Google keys start with 'AIza'"},
 }
@@ -224,9 +225,11 @@ func ValidateAuth(env map[string]string) error {
 	}
 }
 
-// validateClaudeCredentials verifies ~/.claude/.credentials.json exists and is a file.
-// Compose mounts this path into the LiteLLM container; if it's missing Docker creates
-// a directory at the bind target and authentication fails opaquely at runtime.
+// validateClaudeCredentials verifies ~/.claude/.credentials.json exists, is a regular
+// file, parses as JSON, and carries an access token in one of the shapes the LiteLLM
+// claude_code_handler accepts (claudeAiOauth.accessToken, top-level accessToken, or
+// legacy oauthToken). Compose mounts this path into the LiteLLM container; if it's
+// missing or empty, authentication fails opaquely on the first prompt instead of here.
 func validateClaudeCredentials() error {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -243,7 +246,37 @@ func validateClaudeCredentials() error {
 	if info.IsDir() {
 		return fmt.Errorf("expected credentials file at %s but found a directory.\nRemove it and run 'claude /login' to re-authenticate.", path)
 	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w\nCheck file permissions and re-run.", path, err)
+	}
+	var creds map[string]any
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		return fmt.Errorf("credentials file at %s is not valid JSON: %w\nRun 'claude /login' to re-authenticate.", path, err)
+	}
+	if extractClaudeAccessToken(creds) == "" {
+		return fmt.Errorf("no access token found in %s\nRun 'claude /login' to re-authenticate.", path)
+	}
 	return nil
+}
+
+// extractClaudeAccessToken walks the credentials JSON in the same resolution order as
+// the LiteLLM handler (config/claude_code_handler.py): current nested format first,
+// then legacy top-level keys. Returns "" if no usable token is present.
+func extractClaudeAccessToken(creds map[string]any) string {
+	if oauth, ok := creds["claudeAiOauth"].(map[string]any); ok {
+		if tok, _ := oauth["accessToken"].(string); tok != "" {
+			return tok
+		}
+	}
+	if tok, _ := creds["accessToken"].(string); tok != "" {
+		return tok
+	}
+	if tok, _ := creds["oauthToken"].(string); tok != "" {
+		return tok
+	}
+	return ""
 }
 
 // AppendEnvLine appends a KEY=VALUE line to an existing .env file.

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -127,16 +127,53 @@ func TestValidateAuth_AuthMode(t *testing.T) {
 		t.Error("expected error when ~/.claude/.credentials.json is missing")
 	}
 
-	// auth mode with credentials file → ok
 	credDir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(credDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(credDir, ".credentials.json"), []byte("{}"), 0o600); err != nil {
+	credPath := filepath.Join(credDir, ".credentials.json")
+
+	// malformed JSON → error
+	if err := os.WriteFile(credPath, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateAuth(env); err == nil {
+		t.Error("expected error for malformed credentials JSON")
+	}
+
+	// valid JSON but no access token → error
+	if err := os.WriteFile(credPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateAuth(env); err == nil {
+		t.Error("expected error when credentials JSON has no access token")
+	}
+
+	// current nested format (claudeAiOauth.accessToken) → ok
+	current := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-test-token-of-sufficient-length"}}`
+	if err := os.WriteFile(credPath, []byte(current), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := ValidateAuth(env); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Errorf("unexpected error for current format: %v", err)
+	}
+
+	// legacy top-level accessToken → ok
+	legacy := `{"accessToken":"sk-ant-oat01-legacy-token"}`
+	if err := os.WriteFile(credPath, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateAuth(env); err != nil {
+		t.Errorf("unexpected error for legacy accessToken format: %v", err)
+	}
+
+	// legacy oauthToken → ok
+	legacyOAuth := `{"oauthToken":"sk-ant-oat01-emulator-token"}`
+	if err := os.WriteFile(credPath, []byte(legacyOAuth), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateAuth(env); err != nil {
+		t.Errorf("unexpected error for legacy oauthToken format: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

OSS users with legitimate Anthropic keys are getting hard-blocked at launch:

```
✗ no valid API key found. Detected malformed key(s):
  ANTHROPIC_API_KEY: Anthropic keys start with 'sk-ant-'
Run 'decepticon onboard --reset' to reconfigure credentials.
```

Two issues introduced in #82, fixed here:

- **API key check too strict.** The exact `sk-ant-` prefix rejected partner /
  gateway-issued keys (and any future Anthropic key shape that diverges from
  today's `sk-ant-api03-*` / `sk-ant-admin01-*` / `sk-ant-oat01-*`). Loosened
  to `sk-` to match OpenAI's leniency level. The launcher's job is to catch
  obvious typos; LiteLLM remains the authoritative gate for invalid keys.
- **OAuth check too loose.** `validateClaudeCredentials` only confirmed the
  file existed and wasn't a directory — an empty `{}` or malformed JSON
  passed validation and then died opaquely on the first prompt. The exact
  pattern #82 was meant to prevent, just on the OAuth side. It now parses
  the JSON and verifies an access token is present in any of the three
  shapes the LiteLLM `claude_code_handler` accepts:
    - current: `claudeAiOauth.accessToken`
    - legacy: top-level `accessToken`
    - emulator: top-level `oauthToken`

  Prefix on the OAuth token is intentionally **not** enforced (lenient
  philosophy mirroring the API key change).

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` (all green)
- [x] `TestValidateAuth_AuthMode` extended to cover malformed JSON,
      empty `{}`, and all three accepted token shapes
- [x] `TestValidateAPIKeys_RejectsBadFormat/missing_prefix` still rejects
      `no-prefix-key-of-decent-length` — strict-enough to catch typos,
      lenient-enough for partner formats
- [ ] Reviewer: smoke-test on a host where the prior error reproduced —
      confirm `decepticon` enters CLI without false-malformed errors
- [ ] Reviewer: confirm `auth` mode with a stale `~/.claude/.credentials.json`
      (no token field) now fails fast at the launcher with a clear hint
      instead of opaquely at first prompt

## Related

Fixes regression introduced in #82.