### PR TITLE
fix(launcher): keep services running on CLI exit

### DIFF
--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -106,7 +106,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 		cliEnv["WEB_PORT"] = port
 	}
 
-	// Pass through terminal
+	// Pass through terminal. Services are intentionally left running on CLI exit
+	// so re-entry is fast (cold start is ~75s); use 'decepticon stop' to shut
+	// the stack down.
 	if err := c.RunInteractive(
 		[]string{compose.Profiles.CLI},
 		"cli",
@@ -115,15 +117,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("CLI exited: %w", err)
 	}
 
-	// 6. Stop services after CLI exits
-	ui.DimText("CLI exited. Stopping services...")
-	_ = c.Down()
-
-	// Check if decepticon is running outside docker (dev mode)
-	if os.Getenv("DECEPTICON_DEV") == "true" {
-		ui.DimText("Dev mode: services kept running")
-	}
-
+	ui.DimText("CLI exited. Services kept running — run 'decepticon stop' to shut down.")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Currently \`decepticon\` auto-tears down the entire docker stack the moment
the CLI exits (Ctrl+C or normal). Two problems:

- **Forced ~75s cold start on every re-entry.** Per #82's measurements,
  LiteLLM/LangGraph cold-boot is ~75s on a warm Postgres volume. Running
  \`decepticon\` → exit → \`decepticon\` again means a 1m+ wait every time.
- **Duplicates \`decepticon stop\`.** The launcher already exposes \`decepticon
  stop\` for explicit shutdown, so the auto-Down is just an undocumented
  second exit path.
- **Dead code.** The \`DECEPTICON_DEV=true\` branch printing
  \"Dev mode: services kept running\" runs *after* \`c.Down()\` already
  executed — the message was a lie.

This PR drops the auto-Down. CLI exit now leaves the stack up for fast
re-entry; \`decepticon stop\` is the explicit shutdown.

## Behavior change

Before:
\`\`\`
\$ decepticon          # services up + CLI
^C                    # CLI exits
                      # ↓ auto: docker compose down (slow)
                      # ↓ next 'decepticon' = 75s cold start
\`\`\`

After:
\`\`\`
\$ decepticon          # services up + CLI
^C                    # CLI exits, stack stays up
\$ decepticon          # CLI re-attaches in seconds
\$ decepticon stop     # explicit shutdown when done
\`\`\`

## Test plan

- [x] \`go build ./... && go vet ./... && go test ./...\` (all green)
- [ ] Reviewer: \`decepticon\` → enter CLI → Ctrl+C → confirm services
      remain (\`docker ps\` shows langgraph/litellm/postgres/neo4j up)
- [ ] Reviewer: \`decepticon\` again → CLI re-enters without cold-start wait
- [ ] Reviewer: \`decepticon stop\` cleanly tears the stack down

## Notes

\`demo.go\` already had the correct behavior (no auto-Down on exit). This
PR brings \`start.go\` in line.