### PR TITLE
ci(release): atomic publish — pin OSS users during in-flight releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,11 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
+          # Only publish the version tag here — `:latest` is promoted by the
+          # publish-release job AFTER every image has been verified on GHCR,
+          # so a half-finished release never updates the moving tag.
           tags: |
             ghcr.io/purpleailab/${{ matrix.image }}:${{ steps.version.outputs.version }}
-            ghcr.io/purpleailab/${{ matrix.image }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -219,9 +221,10 @@ jobs:
         id: manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
+          # Same rule as the docker matrix: only the version tag here.
+          # `:latest` is promoted by publish-release after verification.
           docker buildx imagetools create \
             --tag ghcr.io/purpleailab/decepticon-web:${{ steps.version.outputs.version }} \
-            --tag ghcr.io/purpleailab/decepticon-web:latest \
             $(printf 'ghcr.io/purpleailab/decepticon-web@sha256:%s ' *)
           digest=$(docker buildx imagetools inspect \
             ghcr.io/purpleailab/decepticon-web:${{ steps.version.outputs.version }} \
@@ -258,3 +261,76 @@ jobs:
         with:
           name: sbom-decepticon-web
           path: sbom-decepticon-web.cdx.json
+
+  # Atomic release gate. Waits until every Docker image AND the launcher
+  # binaries are pushed, verifies each :<version> manifest exists on GHCR,
+  # then promotes :<version> → :latest and flips the GitHub release from
+  # draft → published. Until this job succeeds:
+  #   - GitHub `releases/latest` keeps returning the previous version, so
+  #     the launcher's auto-update never points users at images that are
+  #     still mid-push.
+  #   - The :latest tag is not moved, so `${DECEPTICON_VERSION:-latest}`
+  #     fallbacks keep resolving to the previous (working) release.
+  publish-release:
+    name: Verify images & publish release
+    needs: [launcher, docker, docker-web-merge]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify all version-tagged images exist on GHCR
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          images=(
+            decepticon-litellm
+            decepticon-langgraph
+            decepticon-sandbox
+            decepticon-cli
+            decepticon-c2-sliver
+            decepticon-web
+          )
+          for img in "${images[@]}"; do
+            ref="ghcr.io/purpleailab/${img}:${VERSION}"
+            echo "Verifying ${ref}"
+            docker buildx imagetools inspect "${ref}" >/dev/null
+          done
+
+      - name: Promote :<version> → :latest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          images=(
+            decepticon-litellm
+            decepticon-langgraph
+            decepticon-sandbox
+            decepticon-cli
+            decepticon-c2-sliver
+            decepticon-web
+          )
+          for img in "${images[@]}"; do
+            src="ghcr.io/purpleailab/${img}:${VERSION}"
+            dst="ghcr.io/purpleailab/${img}:latest"
+            echo "Promoting ${src} → ${dst}"
+            docker buildx imagetools create --tag "${dst}" "${src}"
+          done
+
+      - name: Publish GitHub release (undraft)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "v${{ steps.version.outputs.version }}" --draft=false

--- a/clients/launcher/.goreleaser.yml
+++ b/clients/launcher/.goreleaser.yml
@@ -35,7 +35,13 @@ release:
   github:
     owner: PurpleAILAB
     name: Decepticon
-  draft: false
+  # Publish as draft so the GitHub `releases/latest` endpoint (used by the
+  # launcher's auto-update) does NOT see this version until every Docker
+  # image is verified on GHCR. The publish-release job in
+  # .github/workflows/release.yml flips draft → published once all images
+  # exist, closing the release-atomicity gap that previously let the
+  # launcher pull a tag whose images were still mid-push.
+  draft: true
   prerelease: auto
   name_template: "v{{.Version}}"
 


### PR DESCRIPTION
## Summary

- GitHub release published as **draft first**; `releases/latest` skips drafts so the launcher's `CheckAndUpdate` keeps pointing at the previous version until the new one is fully baked.
- `:latest` Docker tag no longer pushed by the per-image build jobs — only `:<version>` is published there.
- New **`publish-release`** job (needs: `launcher` + `docker` + `docker-web-merge`) verifies every expected `:<version>` manifest on GHCR, promotes `:<version>` → `:latest` (digest preserved → cosign signatures still verify), then flips the GitHub release from draft to published.

Until `publish-release` succeeds, no signal (release object, binaries, images, `:latest`) becomes visible to OSS users — closing the release-atomicity gap that previously let the launcher pull a tag whose images were still mid-push.

## Test plan

- [ ] Cut a test tag (e.g. `v1.0.11-rc.1`) and confirm:
  - [ ] GoReleaser creates a **draft** release; binaries are not downloadable from the public URL during the window
  - [ ] `gh api repos/PurpleAILAB/Decepticon/releases/latest` still returns the previous published release while the workflow runs
  - [ ] `docker buildx imagetools inspect ghcr.io/purpleailab/decepticon-langgraph:<rc>` succeeds after the docker matrix job
  - [ ] `:latest` does NOT move to the rc until `publish-release` runs
  - [ ] After `publish-release` finishes: release becomes public, every `:latest` points at the rc digest, cosign signature still verifies on `:latest`
- [ ] Failure-path drill: deliberately fail one docker matrix entry (e.g. invalid Dockerfile change in a separate branch tag), confirm:
  - [ ] `publish-release` does not run (one of its `needs` failed)
  - [ ] Draft release stays draft, no `:latest` moves
  - [ ] No OSS user impact