### PR TITLE
fix(docker): enable macOS Apple Silicon support via amd64 platform forcing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
   # LangGraph reaches sandbox via docker exec (Docker socket), not the network.
   sandbox:
     image: ghcr.io/purpleailab/decepticon-sandbox:${DECEPTICON_VERSION:-latest}
+    platform: linux/amd64
     build:
       context: .
       dockerfile: containers/sandbox.Dockerfile
@@ -250,6 +251,7 @@ services:
   # Agent connects via: sliver-client (pre-installed in sandbox)
   c2-sliver:
     image: ghcr.io/purpleailab/decepticon-c2-sliver:${DECEPTICON_VERSION:-latest}
+    platform: linux/amd64
     build:
       context: .
       dockerfile: containers/c2-sliver.Dockerfile
@@ -273,6 +275,7 @@ services:
   # Default creds: admin / password
   dvwa:
     image: vulnerables/web-dvwa
+    platform: linux/amd64
     container_name: decepticon-dvwa
     networks:
       - sandbox-net
@@ -285,6 +288,7 @@ services:
   # Default creds: msfadmin / msfadmin
   metasploitable2:
     image: tleemcjr/metasploitable2
+    platform: linux/amd64
     container_name: decepticon-msf2
     networks:
       - sandbox-net

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -764,7 +764,14 @@ curl -s https://api.anthropic.com/v1/messages \
   -d '{"model":"claude-haiku-4-5-20251001","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
 ```
 
-### Service Issues
+### Docker Issues
+
+**Apple Silicon (M1/M2/M3/M4): "no matching manifest for linux/arm64/v8"**
+
+This happens when Docker tries to pull an image that only exists for `linux/amd64` (like the Kali-based sandbox).
+
+**Solution:**
+The `docker-compose.yml` is pre-configured to force `platform: linux/amd64` for these services. Ensure you are using the latest version of the file. If you still encounter issues, enable "Use Rosetta for x86_64/amd64 emulation" in Docker Desktop settings.
 
 **Services won't start:**
 


### PR DESCRIPTION
Forces `platform: linux/amd64` for Kali sandbox, Sliver C2, DVWA, and Metasploitable2 services in `docker-compose.yml` to fix 'no matching manifest for linux/arm64/v8' errors on Apple Silicon Macs. Adds troubleshooting docs for Docker/Rosetta setup.