### PR TITLE
docs: align documentation with code reality, slim README, switch XBOW fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "benchmark/xbow-validation-benchmarks"]
 	path = benchmark/xbow-validation-benchmarks
-	url = https://github.com/xbow-engineering/validation-benchmarks
+	url = https://github.com/PurpleAILAB/xbow-validation-benchmarks

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ decepticon onboard   # Interactive setup wizard (provider, API key, model profil
 decepticon           # Start everything: terminal CLI + web dashboard at http://localhost:3000
 ```
 
-→ **[Quick start](docs/getting-started.md)** · **[Full agentic setup walkthrough](docs/setup-guide.md#agentic-setup--end-to-end-walkthrough)**
+→ **[Quick start](docs/getting-started.md)** · **[Full setup walkthrough](docs/setup-guide.md)**
 
 ---
 
@@ -65,148 +65,76 @@ We're building Decepticon as an **Offensive Vaccine** for the AI-driven threat l
 
 ---
 
+## Benchmark Results
+
+| Benchmark | Difficulty | Pass Rate |
+|-----------|------------|-----------|
+| [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | Hard (Level 3) | **7 / 8** |
+
+→ **[Full benchmark index](benchmark/results/README.md)**
+
+---
+
 ## What is Decepticon?
 
 The "AI + hacking" space is full of demos that run nmap and print a report. That's not what this is.
 
 **Decepticon is a professional autonomous Red Team agent.** It executes realistic attack chains — reconnaissance, exploitation, privilege escalation, lateral movement, C2 — the way a real adversary would, not the way a scanner does.
 
-But more importantly: it operates under the discipline that separates red teamers from script kiddies.
+But more importantly: it operates under the discipline that separates red teamers from script kiddies. Before a single packet leaves the wire, Decepticon generates a complete engagement package — **RoE**, **ConOps**, **Deconfliction Plan**, and **OPPLAN** with MITRE ATT&CK mapping — and every action runs inside those defined rules.
 
-Before a single packet leaves the wire, Decepticon generates a complete engagement package:
-
-- **RoE** (Rules of Engagement) — Authorized scope, exclusions, testing window, escalation contacts
-- **ConOps** (Concept of Operations) — Threat actor profile, methodology, TTPs
-- **Deconfliction Plan** — Source IPs, time windows, shared codes for real-time SOC deconfliction
-- **OPPLAN** (Operations Plan) — Full mission plan with objectives, kill chain phases, and MITRE ATT&CK mapping
-
-Every action operates inside defined rules. The agent doesn't just hack — it runs a professional Red Team operation that happens to be autonomous.
+→ **[Engagement workflow deep dive](docs/engagement-workflow.md)**
 
 ---
 
 ## Why Decepticon?
 
-**Real kill chains, not checkbox scans.**
-Decepticon reads an OPPLAN and pursues objectives through whatever path opens up — pivoting, adapting, chaining techniques — the way a real attacker would.
+**Real kill chains, not checkbox scans.** Decepticon reads an OPPLAN and pursues objectives through whatever path opens up — pivoting, adapting, chaining techniques.
 
-**Interactive shells, actually.**
-Real offensive tools are interactive — `msfconsole`, `sliver-client`, `evil-winrm`. Most AI agents fire one-shot commands and give up. Decepticon runs every command inside persistent tmux sessions with automatic prompt detection. When a tool drops you into an interactive prompt, the agent sends follow-up commands. No workarounds.
+**Interactive shells, actually.** Real offensive tools are interactive (`msfconsole`, `sliver-client`, `evil-winrm`). Decepticon runs every command inside persistent tmux sessions with automatic prompt detection — so when a tool drops into an interactive prompt, the agent sends follow-up commands without workarounds.
 
-**Real infrastructure isolation.**
-All commands run inside a hardened Kali Linux sandbox on a dedicated operational network (`sandbox-net`), fully isolated from management (`decepticon-net`). LLM gateway, databases, and agent API live on one network; sandbox, C2 server, and targets live on another. Zero cross-network access. The agent controls the sandbox via Docker socket only.
+**Hardened sandbox isolation.** All commands run inside a Kali Linux sandbox on a dedicated operational network (`sandbox-net`), separate from the management plane (`decepticon-net`). LangGraph drives the sandbox via the Docker socket. → **[Architecture](docs/architecture.md)**
 
-**Offense serves defense.**
-The [Offensive Vaccine](docs/offensive-vaccine.md) loop turns every finding into a defense improvement — automatically. Attack → defend → verify, at machine speed. This is Step 1 toward infrastructure that hardens itself.
+**Offense serves defense.** The [Offensive Vaccine](docs/offensive-vaccine.md) loop turns every finding into a defense improvement — automatically. Attack → defend → verify, at machine speed.
 
 ---
 
 ## Architecture
 
-Two isolated networks. Management and operations share zero network access.
-
 <div align="center">
   <img src="assets/decepticon_infra.svg" alt="Decepticon Infrastructure" width="680">
 </div>
 
-→ **[Architecture deep dive](docs/architecture.md)**
+Two-network design — management services (LiteLLM, PostgreSQL, LangGraph, Web) on `decepticon-net`; sandbox, C2 server, and targets on `sandbox-net`. Neo4j is dual-homed so the agent (on management) can persist findings written from inside the sandbox.
+
+→ **[Architecture deep dive](docs/architecture.md)** · **[Knowledge graph](docs/knowledge-graph.md)**
 
 ---
 
 ## Agents
 
-16 specialist agents organized by kill chain phase. Each agent starts with a fresh context window per objective — no accumulated noise.
+17 specialist agents organized by kill chain phase, with a fresh context window per objective — no accumulated noise.
 
-| Phase | Agents |
-|-------|--------|
-| **Orchestration** | Decepticon (main), Soundwave (planning + docs) |
-| **Reconnaissance** | Recon, Scanner |
-| **Exploitation** | Exploit, Exploiter, Detector, Verifier, Patcher |
-| **Post-Exploitation** | Post-Exploit |
-| **Defense** | Defender (Offensive Vaccine loop) |
-| **Specialists** | AD Operator, Cloud Hunter, Contract Auditor, Reverser, Analyst |
+Orchestration · Reconnaissance · Exploitation · Post-Exploitation · Vulnerability Research · Defense · Domain Specialists (AD, Cloud, Smart Contracts, Reversing, Analyst).
 
-The vulnerability research pipeline (Scanner → Detector → Verifier → Exploiter → Patcher) handles the full lifecycle from discovery through proof-of-concept to patch proposal.
-
-→ **[Agent details and middleware stack](docs/agents.md)**
+→ **[Full agent roster and middleware stack](docs/agents.md)**
 
 ---
 
-## Models
+## Models & Providers
 
-Tier-based, credentials-aware fallback chain. You tell Decepticon which credentials you have — Anthropic API, Claude Code OAuth, ChatGPT subscription, OpenAI API, Google API, DeepSeek API, xAI API, Mistral API, MiniMax API, and more — in priority order; it builds the primary→fallback chain at every tier from there.
-
-The active **profile** decides each agent's tier:
+Tier-based, credentials-aware fallback chain. You declare which credentials you have in priority order; Decepticon builds the primary→fallback chain at every tier from there.
 
 | Profile | Tier per agent | Use case |
 |---------|----------------|----------|
-| **eco** (default) | per-agent (HIGH for orchestrator/exploiter/patcher/analyst, MID for execution, LOW for recon/scanner/soundwave) | Production |
-| **max** | every agent on HIGH | High-value targets |
-| **test** | every agent on LOW | Development / CI |
+| **eco** (default) | Per-agent (HIGH for orchestrator/exploiter/patcher/analyst, MID for execution, LOW for recon/soundwave) | Production |
+| **max** | Every agent on HIGH | High-value targets |
+| **test** | Every agent on LOW | Development / CI |
 
-**Tier × method matrix** (partial — see [Models](docs/models.md) for full table):
+**Tier-mapped providers**: Anthropic, OpenAI, Google Gemini, MiniMax, DeepSeek, xAI, Mistral, OpenRouter, Nvidia NIM, Ollama (local).
+**Subscription OAuth**: Claude Max/Pro/Team, ChatGPT Pro/Plus/Team, Gemini Advanced, Copilot Pro, SuperGrok, Perplexity Pro.
 
-|                   | HIGH                    | MID                      | LOW                                |
-|-------------------|--------------------------|---------------------------|-------------------------------------|
-| `anthropic_api`   | claude-opus-4-7          | claude-sonnet-4-6         | claude-haiku-4-5                    |
-| `anthropic_oauth` | auth/claude-opus-4-7     | auth/claude-sonnet-4-6    | auth/claude-haiku-4-5               |
-| `openai_api`      | gpt-5.5                  | gpt-5.4                   | gpt-5-nano                        |
-| `openai_oauth`    | auth/gpt-5.5             | auth/gpt-5.4              | auth/gpt-5-nano                    |
-| `google_api`      | gemini-2.5-pro           | gemini-2.5-flash          | gemini-2.5-flash-lite               |
-| `deepseek_api`    | deepseek-reasoner        | deepseek-chat             | deepseek-chat                      |
-
-Configure with `decepticon onboard`; set the profile via `DECEPTICON_MODEL_PROFILE=eco` in `.env`. Provider outage or rate limit → seamless fallback to the next method in your priority list.
-
-→ **[Full model reference](docs/models.md)**
-
----
-
-## Supported Providers
-
-Decepticon connects to **18+ LLM providers** via API keys, plus **6 subscription-based OAuth handlers** that route through your existing subscriptions — no per-token billing.
-
-### API Key Providers
-
-| Provider | Provider | Provider |
-|----------|----------|----------|
-| Anthropic | OpenAI | DeepSeek |
-| Google Gemini | xAI (Grok) | Mistral |
-| Cohere | Groq | Together AI |
-| Fireworks AI | Perplexity | MiniMax |
-| OpenRouter | Azure OpenAI | AWS Bedrock |
-| Replicate | Ollama (local) | Custom OpenAI-compatible |
-
-### Subscription OAuth (No API Billing)
-
-Use your existing monthly subscription instead of pay-per-token API access:
-
-| Subscription | Price | Provider ID |
-|---|---|---|
-| **Claude Max / Pro / Team** | $20–$100/mo | `auth` |
-| **ChatGPT Pro / Plus / Team** | $20–$200/mo | `auth` |
-| **Google Gemini Advanced** | $20/mo | `gemini-sub` |
-| **Microsoft Copilot Pro** | $20/mo | `copilot` |
-| **xAI SuperGrok** | X Premium+ | `grok-sub` |
-| **Perplexity Pro** | $20/mo | `pplx-sub` |
-
-```bash
-# Example: Use Claude Max subscription (no API cost)
-DECEPTICON_AUTH_CLAUDE_CODE=true
-
-# Example: Use ChatGPT Pro subscription
-DECEPTICON_AUTH_CHATGPT=true
-```
-
-→ **[Full setup guide with OAuth instructions](docs/setup-guide.md)**
-
----
-
-## Benchmark Results
-
-| Benchmark | Difficulty | Pass Rate |
-|-----------|------------|-----------|
-| [XBOW validation-benchmarks](https://github.com/xbow-engineering/validation-benchmarks) | Hard (Level 3) | **7 / 8** |
-
-→ **[Full benchmark index](benchmark/results/README.md)**
+Configure via `decepticon onboard`. → **[Full model reference & fallback examples](docs/models.md)**
 
 ---
 
@@ -245,7 +173,7 @@ make cli     # Open the interactive CLI (separate terminal)
 
 ## Community
 
-Join the [Discord](https://discord.gg/TZUYsZgrRG) — ask questions, share engagement logs, discuss techniques, or just connect with others building at the intersection of offense and defense.
+Join the [Discord](https://discord.gg/TZUYsZgrRG) — ask questions, share engagement logs, discuss techniques.
 
 ---
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -50,13 +50,10 @@
 ```bash
 curl -fsSL https://decepticon.red/install | bash
 decepticon onboard   # 대화형 설정 위자드 (프로바이더, API 키, 모델 프로필)
-decepticon           # 터미널 CLI 실행
+decepticon           # 전체 실행: 터미널 CLI + 웹 대시보드 (http://localhost:3000)
 ```
 
-
-웹 대시보드는 기본 스택에 포함되어 있어 `decepticon` 실행 후 <http://localhost:3000> 에서 바로 사용할 수 있습니다.
-
-→ **[전체 설치 가이드](docs/getting-started.md)**
+→ **[빠른 시작](docs/getting-started.md)** · **[전체 셋업 가이드](docs/setup-guide.md)**
 
 ---
 
@@ -68,97 +65,76 @@ AI 기반 위협 환경에 맞선 **공격형 백신**을 만들고 있습니다
 
 ---
 
+## 벤치마크 결과
+
+| 벤치마크 | 난이도 | 통과율 |
+|---------|--------|--------|
+| [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | Hard (Level 3) | **7 / 8** |
+
+→ **[벤치마크 전체 인덱스](benchmark/results/README.md)**
+
+---
+
 ## Decepticon이란?
 
 AI + 해킹 도구들은 대부분 nmap 돌리고 리포트 출력하는 데모입니다. Decepticon은 다릅니다.
 
 **Decepticon은 전문 자율 레드팀 에이전트입니다.** 실제 공격자처럼 현실적인 공격 체인을 실행합니다 — 정찰, 초기 침투, 권한 상승, 횡이동, C2 — 스캐너가 아닌 실제 공격자의 방식으로.
 
-더 중요한 것은: 스크립트 키디와 레드티머를 구분하는 전문성을 갖추고 있다는 점입니다.
+더 중요한 것은: 스크립트 키디와 레드티머를 구분하는 전문성을 갖추고 있다는 점입니다. 첫 번째 패킷이 나가기 전에 Decepticon은 완전한 인게이지먼트 패키지 — **RoE**, **ConOps**, **디컨플릭션 플랜**, MITRE ATT&CK 매핑이 포함된 **OPPLAN** — 을 생성하고, 모든 행동은 그 규칙 안에서만 동작합니다.
 
-첫 번째 패킷이 나가기 전에 Decepticon은 완전한 인게이지먼트 패키지를 생성합니다:
-
-- **RoE** (교전 규칙) — 허가된 범위, 제외 항목, 테스트 시간대, 에스컬레이션 연락처
-- **ConOps** (작전 개념) — 위협 행위자 프로필, 방법론, 전술/기법/절차(TTPs)
-- **디컨플릭션 플랜** — 소스 IP, 시간대, SOC와의 실시간 디컨플릭션 코드
-- **OPPLAN** (작전 계획) — MITRE ATT&CK 매핑이 포함된 목표, 킬체인 단계, 수용 기준
-
-모든 행동은 정의된 규칙 내에서 동작합니다. 에이전트는 단순히 해킹하는 것이 아니라 자율로 수행되는 전문 레드팀 작전을 운용합니다.
+→ **[인게이지먼트 워크플로 상세](docs/engagement-workflow.md)**
 
 ---
 
 ## 왜 Decepticon인가?
 
-**체크리스트 스캔이 아닌 실제 킬체인.**
-Decepticon은 OPPLAN을 읽고 열린 경로를 통해 목표를 추적합니다 — 피벗, 적응, 기술 체이닝 — 실제 공격자처럼.
+**체크리스트 스캔이 아닌 실제 킬체인.** Decepticon은 OPPLAN을 읽고 열린 경로를 통해 목표를 추적합니다 — 피벗, 적응, 기술 체이닝.
 
-**진짜 인터랙티브 셸.**
-실제 공격 도구들은 인터랙티브합니다 — `msfconsole`, `sliver-client`, `evil-winrm`. 대부분의 AI 에이전트는 단일 명령을 실행하고 끝냅니다. Decepticon은 영구 tmux 세션에서 명령을 실행하고 인터랙티브 프롬프트를 자동 감지합니다. 도구가 프롬프트를 띄우면 에이전트가 후속 명령을 보냅니다. 우회책 없이.
+**진짜 인터랙티브 셸.** 실제 공격 도구들은 인터랙티브합니다 (`msfconsole`, `sliver-client`, `evil-winrm`). Decepticon은 영구 tmux 세션에서 명령을 실행하고 인터랙티브 프롬프트를 자동 감지합니다 — 도구가 프롬프트를 띄우면 우회책 없이 후속 명령을 보냅니다.
 
-**실제 인프라 격리.**
-모든 명령은 전용 운영 네트워크(`sandbox-net`)의 하드닝된 Kali Linux 샌드박스에서 실행됩니다. LLM 게이트웨이, 데이터베이스, 에이전트 API는 한 네트워크에, 샌드박스, C2 서버, 타깃은 다른 네트워크에 있습니다. 교차 네트워크 접근 없음. Docker 소켓으로만 샌드박스를 제어합니다.
+**하드닝된 샌드박스 격리.** 모든 명령은 운영 네트워크(`sandbox-net`)의 Kali Linux 샌드박스에서 실행되며, 관리망(`decepticon-net`)과 분리되어 있습니다. LangGraph는 Docker 소켓으로 샌드박스를 제어합니다. → **[아키텍처](docs/architecture.md)**
 
-**공격이 방어를 만든다.**
-[공격형 백신](docs/offensive-vaccine.md) 루프는 발견된 모든 취약점을 자동으로 방어 개선으로 전환합니다. 공격 → 방어 → 검증, 머신 속도로. 이것이 스스로 강화되는 인프라를 향한 첫 단계입니다.
+**공격이 방어를 만든다.** [공격형 백신](docs/offensive-vaccine.md) 루프는 발견된 모든 취약점을 자동으로 방어 개선으로 전환합니다. 공격 → 방어 → 검증, 머신 속도로.
 
 ---
 
 ## 아키텍처
 
-두 개의 격리된 네트워크. 관리망과 운영망은 네트워크 접근이 완전히 없습니다.
-
 <div align="center">
   <img src="assets/decepticon_infra.svg" alt="Decepticon Infrastructure" width="680">
 </div>
 
-→ **[아키텍처 상세](docs/architecture.md)**
+두 개의 네트워크로 분리된 설계 — 관리 서비스(LiteLLM, PostgreSQL, LangGraph, Web)는 `decepticon-net`, 샌드박스 / C2 서버 / 타깃은 `sandbox-net`. Neo4j는 양 네트워크에 듀얼-홈으로 두어 관리망의 에이전트가 샌드박스 내부에서 기록한 발견 사항을 영속화할 수 있게 합니다.
+
+→ **[아키텍처 상세](docs/architecture.md)** · **[지식 그래프](docs/knowledge-graph.md)**
 
 ---
 
 ## 에이전트
 
-킬체인 단계별로 구성된 16개의 전문 에이전트. 각 에이전트는 목표마다 새로운 컨텍스트 윈도우로 시작 — 누적 노이즈 없음.
+킬체인 단계별로 구성된 17개의 전문 에이전트. 각 에이전트는 목표마다 새로운 컨텍스트 윈도우로 시작 — 누적 노이즈 없음.
 
-| 단계 | 에이전트 |
-|------|---------|
-| **오케스트레이션** | Decepticon (메인), Soundwave (계획 + 문서) |
-| **정찰** | Recon, Scanner |
-| **초기 침투** | Exploit, Exploiter, Detector, Verifier, Patcher |
-| **사후 익스플로잇** | Post-Exploit |
-| **방어** | Defender (공격형 백신 루프) |
-| **스페셜리스트** | AD Operator, Cloud Hunter, Contract Auditor, Reverser, Analyst |
+오케스트레이션 · 정찰 · 초기 침투 · 사후 익스플로잇 · 취약점 연구 · 방어 · 도메인 스페셜리스트 (AD, Cloud, 스마트 컨트랙트, 리버싱, Analyst).
 
-취약점 연구 파이프라인(Scanner → Detector → Verifier → Exploiter → Patcher)은 발견부터 PoC, 패치 제안까지 전체 라이프사이클을 처리합니다.
-
-→ **[에이전트 상세 및 미들웨어 스택](docs/agents.md)**
+→ **[에이전트 전체 목록 및 미들웨어 스택](docs/agents.md)**
 
 ---
 
-## 모델
+## 모델 & 프로바이더
 
-Tier 기반, 자격증명-aware 폴백 체인. 사용 가능한 자격증명(Anthropic API, Claude Code OAuth, OpenAI API, Google API, MiniMax API)을 우선순위 순으로 알려주면, 모든 tier에서 primary→fallback 체인이 자동 구성됩니다.
-
-활성 **프로파일**이 각 에이전트의 tier를 결정:
+Tier 기반 자격증명-aware 폴백 체인. 사용 가능한 자격증명을 우선순위 순으로 알려주면, 모든 tier에서 primary→fallback 체인이 자동 구성됩니다.
 
 | 프로파일 | 에이전트당 tier | 사용 케이스 |
 |----------|------------------|-------------|
-| **eco** (기본) | 에이전트별 (orchestrator/exploiter/patcher/analyst=HIGH, execution=MID, recon/scanner/soundwave=LOW) | 프로덕션 |
+| **eco** (기본) | 에이전트별 (orchestrator/exploiter/patcher/analyst=HIGH, execution=MID, recon/soundwave=LOW) | 프로덕션 |
 | **max** | 모든 에이전트 HIGH | 고가치 타깃 |
 | **test** | 모든 에이전트 LOW | 개발 / CI |
 
-**Tier × Method 매트릭스**:
+**Tier가 매핑된 프로바이더**: Anthropic, OpenAI, Google Gemini, MiniMax, DeepSeek, xAI, Mistral, OpenRouter, Nvidia NIM, Ollama (로컬).
+**구독 OAuth**: Claude Max/Pro/Team, ChatGPT Pro/Plus/Team, Gemini Advanced, Copilot Pro, SuperGrok, Perplexity Pro.
 
-|                   | HIGH                    | MID                      | LOW                                |
-|-------------------|--------------------------|---------------------------|-------------------------------------|
-| `anthropic_api`   | claude-opus-4-7          | claude-sonnet-4-6         | claude-haiku-4-5                    |
-| `anthropic_oauth` | auth/claude-opus-4-7     | auth/claude-sonnet-4-6    | auth/claude-haiku-4-5               |
-| `openai_api`      | gpt-5.5                  | gpt-5.4                   | gpt-5-nano                        |
-| `google_api`      | gemini-2.5-pro           | gemini-2.5-flash          | gemini-2.5-flash-lite               |
-| `minimax_api`     | MiniMax-M2.5             | MiniMax-M2.5-lightning              | — *(다음 method로 fall-through)*    |
-
-`decepticon onboard`로 설정. `.env`에서 `DECEPTICON_MODEL_PROFILE=eco`로 프로파일 변경. 프로바이더 장애나 속도 제한 시 우선순위의 다음 method로 자동 폴백.
-
-→ **[모델 전체 레퍼런스](docs/models.md)**
+`decepticon onboard`로 설정. → **[모델 전체 레퍼런스 및 폴백 예시](docs/models.md)**
 
 ---
 
@@ -167,6 +143,7 @@ Tier 기반, 자격증명-aware 폴백 체인. 사용 가능한 자격증명(Ant
 | 주제 | 문서 |
 |------|------|
 | 설치 및 첫 인게이지먼트 | [시작하기](docs/getting-started.md) |
+| 셋업 / OAuth / 프로바이더 / 대시보드 전체 | [셋업 가이드](docs/setup-guide.md) |
 | 모든 CLI 커맨드와 단축키 | [CLI 레퍼런스](docs/cli-reference.md) |
 | 모든 `make` 타깃 | [Makefile 레퍼런스](docs/makefile-reference.md) |
 | 에이전트 목록 및 미들웨어 | [에이전트](docs/agents.md) |
@@ -196,7 +173,7 @@ make cli     # 인터랙티브 CLI 열기 (별도 터미널)
 
 ## 커뮤니티
 
-[Discord](https://discord.gg/TZUYsZgrRG)에서 질문하고, 인게이지먼트 로그를 공유하고, 기술을 토론하거나 공격과 방어의 교차점에서 일하는 사람들과 연결하세요.
+[Discord](https://discord.gg/TZUYsZgrRG)에서 질문하고, 인게이지먼트 로그를 공유하고, 기술을 토론하세요.
 
 ---
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -10,7 +10,7 @@ Decepticon 메인 에이전트의 전체 파이프라인(OPPLAN 생성 → sub-a
 - xbow 벤치마크 서브모듈 초기화:
 
 ```bash
-git submodule add https://github.com/xbow-engineering/validation-benchmarks benchmark/xbow-validation-benchmarks
+git submodule add https://github.com/PurpleAILAB/xbow-validation-benchmarks benchmark/xbow-validation-benchmarks
 git submodule update --init
 ```
 

--- a/benchmark/results/README.md
+++ b/benchmark/results/README.md
@@ -1,6 +1,6 @@
 # Decepticon — XBOW Level-3 Benchmark Passes
 
-Decepticon's red-team agent system on the [XBOW validation benchmarks](https://github.com/xbow-engineering/validation-benchmarks) — Level 3 (highest difficulty) confirmed passes.
+Decepticon's red-team agent system on the [XBOW validation benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) — Level 3 (highest difficulty) confirmed passes.
 
 ## Results
 

--- a/decepticon/agents/analyst.py
+++ b/decepticon/agents/analyst.py
@@ -11,9 +11,9 @@ Tool surface (in addition to bash):
     kg_ingest_sarif, cve_lookup, cve_by_package, plan_attack_chains,
     fuzz_classify, fuzz_harness, fuzz_record_crash, validate_finding
 
-Middleware stack — mirrors exploit.py but adds nothing bash-destructive
-beyond SafeCommandMiddleware (the analyst runs fewer shell commands in
-favour of first-class research tools).
+Middleware stack — mirrors exploit.py. The analyst runs fewer shell
+commands in favour of first-class research tools (semgrep, bandit,
+gitleaks, KG operations).
 """
 
 from __future__ import annotations
@@ -45,8 +45,6 @@ def create_analyst_agent():
         source-review workloads.
       - Research tools come *before* bash in the tool list so the LLM
         defaults to graph-updating operations over raw shell commands.
-      - SafeCommandMiddleware still applies — analyst sometimes runs
-        semgrep/bandit/gitleaks via bash which is fine.
       - Skills routed through /skills/analyst/ + /skills/shared/.
     """
     config = load_config()

--- a/decepticon/agents/decepticon.py
+++ b/decepticon/agents/decepticon.py
@@ -10,14 +10,14 @@ Uses create_agent() directly (not create_deep_agent()) to control the
 middleware stack precisely.
 
 Middleware stack (selected for orchestration):
-  1. SafeCommandMiddleware — block session-destroying bash commands
-  2. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
-  3. FilesystemMiddleware — file ops for reading/updating engagement docs
+  1. EngagementContextMiddleware — inject engagement metadata (slug, target, RoE)
+  2. DecepticonSkillsMiddleware — progressive disclosure of SKILL.md knowledge
+  3. FilesystemMiddlewareNoExecute — file ops for reading/updating engagement docs
   4. SubAgentMiddleware — task() tool for delegating to sub-agents
   5. OPPLANMiddleware — OPPLAN CRUD tools (create/add/get/list/update objectives)
-  6. ModelFallbackMiddleware — opus 4.6 → gpt-5.4 fallback on primary failure
+  6. ModelFallbackMiddleware — primary → fallback on provider failure (chain from Credentials inventory)
   7. SummarizationMiddleware — auto-compact for long orchestration sessions
-  8. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
+  8. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic models
   9. PatchToolCallsMiddleware — repair dangling tool calls
 
 OPPLAN replaces TodoListMiddleware with domain-specific objective tracking:
@@ -61,7 +61,7 @@ def create_decepticon_agent():
       - Explicit middleware stack instead of create_deep_agent() defaults
       - SubAgentMiddleware: task() tool for delegating to specialist sub-agents
       - OPPLANMiddleware: 5 CRUD tools for objective tracking (Claude Code V2 Task pattern)
-      - ModelFallbackMiddleware: opus 4.6 primary → gpt-5.4 fallback on failure
+      - ModelFallbackMiddleware: primary → fallback chain built from the user's Credentials inventory
     Returns a compiled LangGraph agent ready for invocation.
     """
     config = load_config()

--- a/decepticon/agents/defender.py
+++ b/decepticon/agents/defender.py
@@ -4,13 +4,12 @@ Uses create_agent() directly (not create_deep_agent()) to control the
 middleware stack precisely.
 
 Middleware stack (selected for defense):
-  1. SafeCommandMiddleware    — block offensive/destructive bash patterns
-  2. SkillsMiddleware         — progressive disclosure of defender SKILL.md knowledge
-  3. FilesystemMiddlewareNoExecute — ls/read/write/edit/glob/grep tools (no execute; use bash)
-  4. ModelFallbackMiddleware  — haiku 4.5 → gemini 2.5 flash fallback on primary failure
-  5. SummarizationMiddleware  — auto-compact when context budget exceeded
-  6. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
-  7. PatchToolCallsMiddleware  — repair dangling tool calls
+  1. DecepticonSkillsMiddleware — progressive disclosure of defender SKILL.md knowledge
+  2. FilesystemMiddlewareNoExecute — ls/read/write/edit/glob/grep tools (no execute; use bash)
+  3. ModelFallbackMiddleware  — primary → fallback on provider failure
+  4. SummarizationMiddleware  — auto-compact when context budget exceeded
+  5. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic models
+  6. PatchToolCallsMiddleware  — repair dangling tool calls
 
 Backend: DockerSandbox (single backend; /skills/ is bind-mounted into the
 sandbox container — see docker-compose.yml).
@@ -43,7 +42,7 @@ from decepticon.tools.research.tools import kg_neighbors, kg_query, kg_stats
 def create_defender_agent():
     """Initialize the Defender Agent using langchain create_agent() directly.
 
-    Context engineering decisions:      - SafeCommandMiddleware: blocks offensive/destructive patterns before execution
+    Context engineering decisions:
       - ModelFallbackMiddleware: primary → fallback on failure
       - No TodoListMiddleware: defense-brief.json handles task tracking
       - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,74 +1,59 @@
 # Agents
 
-Decepticon uses 16 specialist agents organized by kill chain phase. Each agent starts with a **fresh context window** per objective — no accumulated noise, no context degradation. Findings persist to disk (`workspace/`) and the knowledge graph, not agent memory.
+Decepticon ships **17 specialist agents** organized by kill chain phase. Each agent starts with a **fresh context window** per objective — no accumulated noise, no context degradation. Findings persist to disk (`workspace/`) and the knowledge graph, not agent memory.
 
 ---
 
 ## Agent Roster
 
-### Orchestration
+### Orchestrators
 
 | Agent | Role |
 |-------|------|
-| **Decepticon** | Main orchestrator. Manages OPPLAN state, dispatches objectives to specialist agents, tracks dependencies and status transitions. |
-| **Soundwave** | Engagement planner. Interviews the operator and generates RoE, ConOps, Deconfliction Plan, and OPPLAN. Also handles threat actor profiling. |
+| **Decepticon** | Main red-team orchestrator. Reads the OPPLAN, dispatches objectives to specialist sub-agents, and tracks status transitions. Sub-agents: `recon`, `exploit`, `postexploit`, `analyst`, `reverser`, `contract_auditor`, `cloud_hunter`, `ad_operator`. |
+| **Vulnresearch** | Vulnerability research orchestrator — runs the five-stage pipeline (`scanner → detector → verifier → exploiter → patcher`) with state passed between stages exclusively through the knowledge graph. |
+| **Soundwave** | Engagement planner. Standalone graph (not a sub-agent of Decepticon). Interviews the operator and generates RoE, ConOps, Deconfliction Plan, and OPPLAN. |
 
 ### Reconnaissance
 
 | Agent | Role |
 |-------|------|
-| **Recon** | Port scanning, service enumeration, DNS resolution, subdomain discovery, and OSINT. Populates the knowledge graph with hosts and services. |
-| **Scanner** | Automated vulnerability scanning (Nuclei, Nessus-compatible). Rates findings by severity, maps to CVEs, and seeds the KG. |
+| **Recon** | Port scanning, service enumeration, DNS, subdomain discovery, OSINT. Populates the knowledge graph with hosts and services. |
 
-### Exploitation
+### Vulnerability Research Pipeline
+
+Sub-agents of the **Vulnresearch** orchestrator. State flows between stages via the knowledge graph; each stage runs with fresh context.
+
+| Stage | Agent | Output |
+|-------|-------|--------|
+| Discovery | **Scanner** | Vulnerability candidates with CVE/CVSS |
+| Analysis | **Detector** | Confidence-rated findings, detection rules |
+| Confirmation | **Verifier** | Verified findings (2+ methods for CRITICAL/HIGH) |
+| Exploitation | **Exploiter** | Working proof-of-concept |
+| Remediation | **Patcher** | Patch code or configuration fix |
+
+### Exploitation & Post-Exploitation
 
 | Agent | Role |
 |-------|------|
-| **Exploit** | Initial access and exploitation tactics. Executes attack chains based on findings from Recon and Scanner. |
-| **Exploiter** | Proof-of-concept generation. Produces verified, working exploits for confirmed vulnerabilities. |
-| **Detector** | Vulnerability detection and analysis. Generates detection rules and rates confidence/severity. |
-| **Verifier** | Confirms vulnerabilities are real using two independent methods before escalating CRITICAL or HIGH findings. |
-| **Patcher** | Generates remediation code and configuration fixes for verified vulnerabilities. |
-
-### Post-Exploitation
-
-| Agent | Role |
-|-------|------|
-| **Post-Exploit** | Privilege escalation, lateral movement, credential harvesting, and persistence. Operates via C2 sessions once initial access is established. |
+| **Exploit** | Initial access and exploitation tactics. Web/AD attacks (SQLi, SSTI, Kerberoasting, ADCS abuse, credential attacks). |
+| **Post-Exploit** | Privilege escalation, lateral movement, credential harvesting, persistence. Operates via C2 sessions once initial access is established. |
 
 ### Defense
 
 | Agent | Role |
 |-------|------|
-| **Defender** | Executes the Offensive Vaccine loop. Receives a defense brief for each finding, applies mitigations, and tracks results in the knowledge graph. |
+| **Defender** | Standalone graph for the Offensive Vaccine loop. Receives a defense brief for each finding, applies mitigations, and tracks results in the knowledge graph. |
 
 ### Domain Specialists
 
 | Agent | Role |
 |-------|------|
-| **AD Operator** | Active Directory attacks — Kerberoasting, Pass-the-Hash, DCSync, BloodHound path analysis. |
-| **Cloud Hunter** | Cloud infrastructure attacks — IAM privilege escalation, S3 bucket exposure, metadata service abuse. |
-| **Contract Auditor** | Smart contract and blockchain security analysis. |
-| **Reverser** | Binary analysis and reverse engineering. Integrates with static and dynamic analysis tools. |
-| **Analyst** | Research, data aggregation, and final report generation. Queries the knowledge graph to produce executive summaries and technical findings. |
-
----
-
-## Vulnerability Research Pipeline
-
-The five exploitation agents form a sequential pipeline from discovery to remediation:
-
-```
-Scanner → Detector → Verifier → Exploiter → Patcher
-```
-
-| Stage | Agent | Output |
-|-------|-------|--------|
-| Discovery | Scanner | Vulnerability candidates with CVE/CVSS |
-| Analysis | Detector | Confidence-rated findings, detection rules |
-| Confirmation | Verifier | Verified findings (2+ methods for CRITICAL/HIGH) |
-| Exploitation | Exploiter | Working proof-of-concept |
-| Remediation | Patcher | Patch code or configuration fix |
+| **AD Operator** | Active Directory attacks — Kerberoasting, AS-REP roasting, ADCS ESC1-ESC15, DCSync, BloodHound path analysis. |
+| **Cloud Hunter** | Cloud infrastructure attacks — IAM privilege escalation, S3 bucket exposure, Kubernetes RBAC escapes, metadata service abuse. |
+| **Contract Auditor** | Solidity / EVM smart contract audits — reentrancy, oracle manipulation, flash loan abuse, access control. |
+| **Reverser** | Binary analysis and reverse engineering — ELF/PE/Mach-O triage, packer detection, ROP gadget inventories, Ghidra/radare2 recon. |
+| **Analyst** | Vulnerability research and reporting — source code review, static analysis (semgrep/bandit/gitleaks), dependency CVE sweeps, multi-hop exploit chain construction. |
 
 ---
 
@@ -91,29 +76,44 @@ Each agent runs with a configurable middleware stack. Middleware is applied in o
 
 | Middleware | Purpose |
 |------------|---------|
-| `SkillsMiddleware` | Loads skill frontmatter at startup, filters by agent role, injects matching skills into the system prompt. Full skill content available on-demand. |
-| `FilesystemMiddleware` | Provides `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep` tools backed by the sandbox or host filesystem. |
-| `SafeCommandMiddleware` | Blocks session-destroying commands (`pkill`, `killall`, `rm -rf /`, `nsenter`, `docker exec`). |
-| `SubAgentMiddleware` | Allows the orchestrator to delegate objectives to specialist agents. |
-| `OPPLANMiddleware` | Injects the current OPPLAN progress table into every LLM call. Provides CRUD tools for objective management. |
-| `ModelFallbackMiddleware` | Switches to a fallback model on provider outage or rate limit. |
-| `SummarizationMiddleware` | Compresses conversation history when the context window approaches capacity. |
-| `PromptCachingMiddleware` | Caches static system prompt content to reduce token costs. |
-| `PatchToolCallsMiddleware` | Sanitizes and normalizes tool call formats for compatibility across model providers. |
+| `EngagementContextMiddleware` | Injects engagement metadata (slug, target, RoE summary) into the system prompt for the orchestrator. |
+| `DecepticonSkillsMiddleware` | Loads SKILL.md frontmatter at startup, filters by agent role, and injects matching skill descriptions into the system prompt. Full skill content is fetched on demand via `read_file`. |
+| `FilesystemMiddlewareNoExecute` | Provides `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep` tools backed by the sandbox filesystem. Execute is intentionally disabled — agents use the dedicated `bash` tool for command execution. |
+| `SubAgentMiddleware` | Allows orchestrators (Decepticon, Vulnresearch) to delegate objectives to specialist sub-agents via the `task()` tool. |
+| `OPPLANMiddleware` | Injects the current OPPLAN progress table into every LLM call and provides 5 CRUD tools for objective management (Claude Code V2 Task pattern). |
+| `ModelFallbackMiddleware` | Switches to a fallback model on provider outage, rate limit, or context overflow. Walks the fallback chain built from the user's credentials inventory. |
+| `SummarizationMiddleware` | Auto-compacts conversation history when the context window approaches capacity. |
+| `AnthropicPromptCachingMiddleware` | Caches static system prompt content for Anthropic models to reduce token costs. Silently no-ops on non-Anthropic providers. |
+| `PatchToolCallsMiddleware` | Sanitizes and normalizes tool call formats for compatibility across model providers (e.g. repairs dangling tool calls). |
 
 ### Stack per Agent Role
 
-**Decepticon (Orchestrator)**
+**Decepticon (Orchestrator)** — full stack with engagement context and sub-agent dispatch.
+
 ```
-SafeCommand → Skills → Filesystem → SubAgent → OPPLAN → ModelFallback → Summarization → PromptCaching → PatchToolCalls
+EngagementContext → Skills → FilesystemNoExecute → SubAgent → OPPLAN
+                  → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```
 
-**Soundwave (Planner)**
+**Vulnresearch (Orchestrator)** — same as Decepticon but without `EngagementContextMiddleware`.
+
 ```
-Skills → Filesystem → ModelFallback → Summarization → PromptCaching → PatchToolCalls
+Skills → FilesystemNoExecute → SubAgent → OPPLAN
+       → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```
 
-**Specialist agents (Recon, Exploit, Post-Exploit, etc.)**
+**Specialist sub-agents (Recon, Exploit, Post-Exploit, Scanner, Detector, etc.)**
+
 ```
-Skills → Filesystem → SafeCommand → ModelFallback → Summarization → PromptCaching → PatchToolCalls
+Skills → FilesystemNoExecute
+       → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
+```
+
+Specialists also have the `bash` tool for command execution inside the sandbox; `FilesystemMiddlewareNoExecute` covers all file I/O.
+
+**Soundwave (Planner)** — no `bash`, no sub-agents (document generation only).
+
+```
+Skills → FilesystemNoExecute
+       → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Decepticon runs on two completely isolated Docker networks. Management infrastructure (LLM proxy, databases, agent API) and operational infrastructure (sandbox, C2, targets) share zero network access. The only bridge is the Docker socket — LangGraph controls the sandbox exclusively through it.
+Decepticon runs on two Docker networks. Management infrastructure (LLM proxy, databases, agent API) and operational infrastructure (sandbox, C2, targets) are separated so that no offensive tool inside the sandbox can reach the LLM gateway, the API surface, or your credentials over the network. The agent drives the sandbox via the Docker socket, never via TCP.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -14,20 +14,25 @@ Decepticon runs on two completely isolated Docker networks. Management infrastru
 │                  LangGraph Platform (port 2024)               │
 │              Agent Orchestration & Event Streaming            │
 └──────────┬───────────────────────────────────────────────────┘
-           │                             │ Docker socket only
-┌──────────▼──────────┐       ┌──────────▼──────────────────┐
-│   decepticon-net    │       │       sandbox-net            │
-│                     │       │                              │
-│  LiteLLM  :4000     │       │  Sandbox (Kali Linux)        │
-│  PostgreSQL :5432   │       │  Neo4j        :7687/:7474    │
-│  LangGraph  :2024   │       │  C2 Server    (Sliver)       │
+           │                              │ Docker socket only
+┌──────────▼──────────┐                   │
+│   decepticon-net    │       ┌───────────▼──────────────────┐
+│                     │       │       sandbox-net            │
+│  LiteLLM    :4000   │       │                              │
+│  PostgreSQL :5432   │       │  Sandbox (Kali Linux)        │
+│  LangGraph  :2024   │       │  C2 Server (Sliver)          │
 │  Web        :3000   │       │  Victim targets              │
+│                     │       │                              │
+│  Neo4j ◀────────────┼───────┼──▶ Neo4j  :7687/:7474        │
+│  (dual-homed bolt:// for agent + sandbox writes)            │
 └─────────────────────┘       └──────────────────────────────┘
        Management                       Operations
    (LLM, persistence, UI)        (exploitation, C2, targets)
 ```
 
-**No cross-network access.** Services on `decepticon-net` cannot reach `sandbox-net` and vice versa. LangGraph communicates with the sandbox exclusively via the Docker socket — not the network.
+**Network boundaries.** The sandbox cannot reach LiteLLM, PostgreSQL, the LangGraph API, or the web dashboard — none of the management services are routable from `sandbox-net`. The agent inside LangGraph cannot reach attack tooling over a TCP socket; the only channel into the sandbox is `docker exec` via the Docker socket bind-mount.
+
+**Neo4j is the one shared service** — it sits on both networks because the sandbox writes findings into it (`bolt://neo4j:7687` from inside Kali) and the agent reads them back (`bolt://neo4j:7687` from inside LangGraph). It's a knowledge store, not a privileged service: the agent's credentials never traverse it, and a compromised sandbox can't pivot through Neo4j to LiteLLM or the API surface.
 
 ---
 
@@ -35,13 +40,13 @@ Decepticon runs on two completely isolated Docker networks. Management infrastru
 
 ### LiteLLM Proxy (`decepticon-net`, port 4000)
 
-Routes all LLM requests to Anthropic, OpenAI, and Google backends. Provides:
+Routes all LLM requests to provider backends (Anthropic, OpenAI, Google, MiniMax, DeepSeek, xAI, Mistral, OpenRouter, Nvidia NIM, Ollama, plus 6 subscription OAuth handlers). Provides:
 - Unified API endpoint for all agents
-- Automatic failover when a provider is unavailable
+- Automatic fallback chain when a provider is unavailable
 - Usage tracking and rate limiting per provider
 - Billing aggregation across models
 
-Configuration: `config/litellm.yaml`
+Configuration: `config/litellm.yaml`. Dynamic model registration: `config/litellm_dynamic_config.py` (Ollama, custom gateways, ad-hoc overrides).
 
 ### LangGraph Platform (`decepticon-net`, port 2024)
 
@@ -49,19 +54,18 @@ Hosts and orchestrates all agents. Provides:
 - Agent lifecycle management (spawn, execute, terminate)
 - Event streaming via Server-Sent Events (SSE)
 - State persistence between agent runs
-- The LangGraph SDK endpoint consumed by both CLI and Web Dashboard
+- The LangGraph SDK endpoint consumed by both the CLI and Web Dashboard
 
 ### PostgreSQL (`decepticon-net`, port 5432)
 
 Persistent relational storage for:
-- Engagement records
-- Finding metadata
-- OPPLAN objectives and status
+- LiteLLM virtual keys, spend logs, user budgets
+- Web dashboard data (engagements, findings, OPPLAN objectives, defense actions)
 - User accounts (EE mode) or the single local user (OSS mode)
 
-Managed via Prisma ORM in the web dashboard.
+Two logical databases: `litellm` (managed by LiteLLM) and `decepticon_web` (managed via Prisma in the web dashboard).
 
-### Neo4j Knowledge Graph (`sandbox-net`, port 7687 / browser 7474)
+### Neo4j Knowledge Graph (`sandbox-net` + `decepticon-net`, port 7687 / browser 7474)
 
 Graph database for the attack graph. Stores:
 - Hosts, services, vulnerabilities, credentials, accounts
@@ -69,17 +73,17 @@ Graph database for the attack graph. Stores:
 - Attack chain paths for multi-hop planning
 - Defense actions from the Offensive Vaccine loop
 
-Lives on `sandbox-net` because it stores operational findings that must not cross to management infrastructure.
+**Dual-homed by design**: the sandbox writes operational findings into the graph (`cypher-shell` from inside Kali), and the agent in LangGraph reads them back to plan the next objective. Both networks see the same Neo4j instance on the same `bolt://neo4j:7687` URI.
 
 ### Sandbox (`sandbox-net`)
 
 Hardened Kali Linux container. Runs:
 - All agent-issued bash commands (via persistent tmux sessions)
-- Offensive tools: nmap, sqlmap, Impacket, Metasploit, nuclei
+- Offensive tools: nmap, sqlmap, Impacket, Metasploit, Nuclei
 - Sliver C2 client (`sliver-client`) with auto-generated operator config
 - Interactive sessions for tools like `msfconsole`, `evil-winrm`
 
-The sandbox is the only place where commands actually execute. LangGraph reaches it via Docker socket, not the network.
+The sandbox is the only place where commands actually execute. LangGraph reaches it via the Docker socket, not the network.
 
 ### C2 Server (`sandbox-net`, Sliver)
 
@@ -90,7 +94,7 @@ Sliver team server runs alongside the sandbox on the operational network. Featur
 
 Activated via `COMPOSE_PROFILES=c2-sliver` (default). Future profiles: `c2-havoc`.
 
-### Web Dashboard (`decepticon-net`, port 3000)
+### Web Dashboard (`decepticon-net`, port 3000 + terminal WebSocket on 3003)
 
 Next.js 16 application providing a browser-based control plane. See [Web Dashboard](web-dashboard.md).
 
@@ -105,6 +109,7 @@ Agents execute commands through a thin `bash` tool backed by `DockerSandbox.exec
 **Interactive prompt detection** — when a tool presents an interactive prompt (`msf6 >`, `sliver >`, `PS C:\>`), the agent detects it and sends follow-up commands rather than waiting forever.
 
 **Output management:**
+
 | Output size | Handling |
 |-------------|---------|
 | ≤ 15K chars | Returned inline in the tool result |
@@ -125,13 +130,13 @@ Orchestrator reads OPPLAN
         │
         ▼
   Spawn specialist agent (fresh context)
-  ┌─────────────────────────────────────┐
-  │  System prompt: RoE + skills + OPPLAN status  │
-  │  Tools: bash → sandbox (via Docker socket)    │
-  │         read_file / write_file → workspace/   │
-  │         kg_* → Neo4j (bolt://neo4j:7687)      │
-  │         cve_lookup → NVD / OSV / EPSS APIs    │
-  └─────────────────────────────────────┘
+  ┌─────────────────────────────────────────────┐
+  │  System prompt: RoE + skills + OPPLAN status │
+  │  Tools: bash → sandbox (via Docker socket)   │
+  │         read_file / write_file → workspace/  │
+  │         kg_* → Neo4j (bolt://neo4j:7687)     │
+  │         cve_lookup → NVD / OSV / EPSS APIs   │
+  └─────────────────────────────────────────────┘
         │
         ▼
   Agent executes, writes findings to workspace/
@@ -153,8 +158,8 @@ Orchestrator reads OPPLAN
 
 | Boundary | Enforcement |
 |----------|-------------|
-| Sandbox ↔ Management | Separate Docker networks, no routing |
-| LangGraph ↔ Sandbox | Docker socket only (no network port) |
-| Agent commands | `SafeCommandMiddleware` blocks destructive ops |
-| Credential isolation | API keys live on `decepticon-net`; sandbox never sees them |
-| Host isolation | All commands run inside Docker; no host filesystem access |
+| Sandbox → Management services | Separate Docker networks; LiteLLM/PostgreSQL/LangGraph/Web are not routable from `sandbox-net` |
+| LangGraph → Sandbox | Docker socket only (no TCP) |
+| Sandbox → Neo4j | Allowed (intentional shared service for attack graph writes) |
+| Credential isolation | Provider API keys live on `decepticon-net`; the sandbox never sees them |
+| Host isolation | All commands run inside Docker; no host filesystem access except the engagement-scoped `/workspace` bind mount |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -101,8 +101,14 @@ These can be set in your `.env` file (configure with `decepticon onboard`) or as
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DECEPTICON_MODEL_PROFILE` | `eco` | Tier preset: `eco` (per-agent), `max` (all HIGH), or `test` (all LOW) |
-| `DECEPTICON_AUTH_PRIORITY` | `anthropic_oauth,anthropic_api,openai_api,google_api,minimax_api` | Comma-separated AuthMethod priority — first method primary, rest are fallbacks |
-| `DECEPTICON_AUTH_CLAUDE_CODE` | `false` | Set `true` to route Anthropic models via Claude Code OAuth (auth/* in LiteLLM) |
+| `DECEPTICON_AUTH_PRIORITY` | `anthropic_oauth,anthropic_api,openai_oauth,openai_api,google_api,minimax_api,deepseek_api,xai_api,mistral_api,openrouter_api,nvidia_api,ollama_local` | Comma-separated AuthMethod priority — first method primary, rest are fallbacks. Methods whose credential isn't configured are skipped at runtime. |
+| `DECEPTICON_AUTH_CLAUDE_CODE` | `false` | Set `true` to route Anthropic models via Claude Code OAuth (`auth/claude-*` in LiteLLM) |
+| `DECEPTICON_AUTH_CHATGPT` | `false` | Set `true` to route OpenAI models via ChatGPT subscription OAuth (`auth/gpt-*`) |
+| `DECEPTICON_AUTH_GEMINI` | `false` | Set `true` to route Google models via Gemini Advanced OAuth (`gemini-sub/*`) |
+| `DECEPTICON_AUTH_COPILOT` | `false` | Set `true` for Microsoft Copilot Pro OAuth (`copilot/*`) |
+| `DECEPTICON_AUTH_GROK` | `false` | Set `true` for xAI SuperGrok OAuth (`grok-sub/*`) |
+| `DECEPTICON_AUTH_PERPLEXITY` | `false` | Set `true` for Perplexity Pro OAuth (`pplx-sub/*`) |
+| `OLLAMA_API_BASE` / `OLLAMA_MODEL` | unset | When set, registers `ollama_chat/<OLLAMA_MODEL>` and enables the `ollama_local` AuthMethod |
 
 See [Models](models.md) for the full Tier × AuthMethod matrix and chain examples.
 
@@ -122,6 +128,10 @@ See [Models](models.md) for the full Tier × AuthMethod matrix and chain example
 | `LANGGRAPH_PORT` | `2024` | LangGraph API server port |
 | `LITELLM_PORT` | `4000` | LiteLLM proxy port |
 | `POSTGRES_PORT` | `5432` | PostgreSQL port |
+| `WEB_PORT` | `3000` | Web dashboard port |
+| `TERMINAL_PORT` | `3003` | Terminal WebSocket bridge for the embedded CLI |
+
+Neo4j ports (`7474` browser, `7687` bolt) are fixed in `docker-compose.yml`.
 
 ### C2 Framework
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,8 +13,8 @@ git clone https://github.com/PurpleAILAB/Decepticon.git
 cd Decepticon
 
 # Copy and configure environment
-cp clients/launcher/internal/config/env.example .env
-# Edit .env — set at least one provider key, or set DECEPTICON_MODEL=ollama/<model>
+cp .env.example .env
+# Edit .env — set at least one provider key, or set OLLAMA_API_BASE + OLLAMA_MODEL for local Ollama
 
 # Start services with hot-reload
 make dev

--- a/docs/design/opplan-middleware.md
+++ b/docs/design/opplan-middleware.md
@@ -566,19 +566,18 @@ def after_model(self, state, runtime):
 ```python
 # Before
 middleware = [
-    SafeCommandMiddleware(),
-    SkillsMiddleware(...),
-    FilesystemMiddleware(...),
+    DecepticonSkillsMiddleware(...),
+    FilesystemMiddlewareNoExecute(...),
     SubAgentMiddleware(..., subagents=[planner, recon, exploit, postexploit]),
     TodoListMiddleware(),  # ← 제거
 ]
 
 # After
 middleware = [
-    SafeCommandMiddleware(),
-    SkillsMiddleware(...),
-    FilesystemMiddleware(...),
-    SubAgentMiddleware(..., subagents=[soundwave, recon, exploit, postexploit]),
+    EngagementContextMiddleware(),
+    DecepticonSkillsMiddleware(...),
+    FilesystemMiddlewareNoExecute(...),
+    SubAgentMiddleware(..., subagents=[recon, exploit, postexploit, analyst, reverser, contract_auditor, cloud_hunter, ad_operator]),
     OPPLANMiddleware(),  # ← 교체 (5-tool CRUD)
 ]
 ```

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -149,15 +149,10 @@ Manual testing procedures for verifying the LLM gateway features.
    ```bash
    cat ~/.decepticon/.env
    ```
-4. Verify deprecated alias still works:
-   ```bash
-   decepticon config  # Should show deprecation notice then run onboard
-   ```
 
 ### Expected
 - Interactive wizard completes all setup steps
 - `.env` file written to `~/.decepticon/.env`
-- `decepticon config` shows deprecation notice
 
 
 ## Scenario 6: Fallback Chain Activation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,10 @@
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2
 - An LLM provider credential — one of:
-  - API key (Anthropic, OpenAI, DeepSeek, Google, xAI, Mistral, Groq, Cohere, Together, Fireworks, Perplexity, MiniMax, OpenRouter, Azure, AWS Bedrock, Replicate)
-  - Claude Max/Pro/Team subscription (OAuth via Claude Code CLI)
-  - ChatGPT Pro/Plus/Team subscription (session token from browser)
-  - OpenAI-compatible gateway (LM Studio, vLLM, Ollama)
+  - **Tier-mapped API keys** (works out of the box): Anthropic, OpenAI, Google Gemini, MiniMax, DeepSeek, xAI, Mistral, OpenRouter, Nvidia NIM
+  - **Local LLM**: Ollama (`OLLAMA_API_BASE` + `OLLAMA_MODEL`)
+  - **Subscription OAuth** (no per-token billing): Claude Max/Pro/Team, ChatGPT Pro/Plus/Team, Gemini Advanced, Microsoft Copilot Pro, xAI SuperGrok, Perplexity Pro
+  - **Other providers** (Groq, Cohere, Together, Fireworks, Perplexity API, Azure, AWS Bedrock, Replicate, custom OpenAI-compatible gateway): supported via `DECEPTICON_MODEL` / `DECEPTICON_LITELLM_MODELS` ad-hoc registration
 
 That's it. Everything else runs inside containers.
 
@@ -31,10 +31,10 @@ decepticon onboard
 
 The interactive setup wizard guides you through:
 
-1. **Authentication** — API key, Claude subscription OAuth, or ChatGPT subscription OAuth
-2. **Provider** — Anthropic, OpenAI, DeepSeek, Google, xAI, Mistral, Cohere, Groq, Together, Fireworks, Perplexity, MiniMax, OpenRouter, Azure, Bedrock, Replicate, Custom, or Ollama
+1. **Authentication** — API key, subscription OAuth (Claude / ChatGPT / Gemini / Copilot / SuperGrok / Perplexity), or local Ollama
+2. **Provider** — choose one of the tier-mapped providers, configure OAuth, or point at a local Ollama
 3. **Credentials** — API key, OAuth token, or endpoint URL (depending on auth method)
-4. **Model Profile** — `eco` (balanced), `max` (performance), `test` (development), or `custom` (any LiteLLM model string via `DECEPTICON_MODEL`)
+4. **Model Profile** — `eco` (balanced), `max` (performance), `test` (development)
 5. **LangSmith** — Optional tracing for LLM observability
 
 For detailed provider setup including OAuth configuration, see [Setup Guide](setup-guide.md).
@@ -50,7 +50,7 @@ Configuration is saved to `~/.decepticon/.env`. Run `decepticon onboard --reset`
 decepticon
 ```
 
-Starts all services (LiteLLM, LangGraph, Neo4j, sandbox) and opens the interactive terminal UI.
+Starts all services (PostgreSQL, LiteLLM, LangGraph, Neo4j, sandbox, C2 server, web dashboard) and opens the interactive terminal UI.
 
 **Web Dashboard** (browser):
 

--- a/docs/makefile-reference.md
+++ b/docs/makefile-reference.md
@@ -45,7 +45,7 @@ The `up` flags (`--no-build --wait --wait-timeout`) match the launcher's `compos
 |--------|-------------|
 | `make status` | Show running service status (`docker compose ps`) |
 | `make logs [SVC=service]` | Follow logs (default: `langgraph`). Override: `make logs SVC=litellm` |
-| `make health` | KG backend + Neo4j + Web health checks (parity with `decepticon health`) |
+| `make health` | KG backend + Neo4j + Web health checks (broader than `decepticon kg-health`, which only checks the KG) |
 | `make clean` | Stop services and remove all volumes (parity with `decepticon remove`) |
 
 ---

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -80,7 +80,7 @@ decepticon onboard
 Or edit `~/.decepticon/.env` directly:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=api
+DECEPTICON_AUTH_PRIORITY=anthropic_api,openai_api
 ANTHROPIC_API_KEY=sk-ant-api03-...
 OPENAI_API_KEY=sk-proj-...
 ```
@@ -92,7 +92,7 @@ OPENAI_API_KEY=sk-proj-...
 | Anthropic | `ANTHROPIC_API_KEY` | `sk-ant-...` | [console.anthropic.com](https://console.anthropic.com) |
 | OpenAI | `OPENAI_API_KEY` | `sk-proj-...` | [platform.openai.com](https://platform.openai.com) |
 | DeepSeek | `DEEPSEEK_API_KEY` | `sk-...` | [platform.deepseek.com](https://platform.deepseek.com) |
-| Google | `GOOGLE_API_KEY` | `AIza...` | [aistudio.google.com](https://aistudio.google.com) |
+| Google | `GEMINI_API_KEY` | `AIza...` | [aistudio.google.com](https://aistudio.google.com) |
 | xAI | `XAI_API_KEY` | `xai-...` | [console.x.ai](https://console.x.ai) |
 | Mistral | `MISTRAL_API_KEY` | `...` | [console.mistral.ai](https://console.mistral.ai) |
 | Cohere | `COHERE_API_KEY` | `...` | [dashboard.cohere.com](https://dashboard.cohere.com) |
@@ -218,7 +218,8 @@ decepticon onboard
 Or edit `~/.decepticon/.env`:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=auth
+DECEPTICON_AUTH_PRIORITY=anthropic_oauth,anthropic_api
+DECEPTICON_AUTH_CLAUDE_CODE=true
 DECEPTICON_MODEL_PROFILE=eco
 ```
 
@@ -257,11 +258,11 @@ Use your ChatGPT Pro, Plus, or Team subscription instead of OpenAI API billing.
 
 **Supported tiers:**
 
-| Tier | Models Available |
-|------|-----------------|
-| ChatGPT Plus ($20/mo) | GPT-4o, o1, o3-mini |
-| ChatGPT Pro ($200/mo) | GPT-4o, o1, o3, GPT-4.5 |
-| ChatGPT Team | GPT-4o, o1, o3-mini + admin controls |
+| Tier | Models Available (via `auth/gpt-5.x` route) |
+|------|--------------------------------------------|
+| ChatGPT Plus ($20/mo) | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` |
+| ChatGPT Pro ($200/mo) | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` |
+| ChatGPT Team | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` + admin controls |
 
 **Setup:**
 
@@ -330,7 +331,7 @@ Use your Google One AI Premium subscription ($20/mo).
 2. Configure:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=gemini-sub
+DECEPTICON_AUTH_GEMINI=true
 GEMINI_ACCESS_TOKEN=ya29.a0...your-google-oauth-token
 ```
 
@@ -353,7 +354,7 @@ Use your Copilot Pro subscription ($20/mo) for GPT-4o/o1 access.
 2. Configure:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=copilot
+DECEPTICON_AUTH_COPILOT=true
 COPILOT_ACCESS_TOKEN=eyJ...your-ms-token
 ```
 
@@ -377,7 +378,7 @@ Use your X Premium+ subscription for Grok-3 access.
 2. Configure:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=grok-sub
+DECEPTICON_AUTH_GROK=true
 GROK_SESSION_TOKEN=your-x-auth-token
 ```
 
@@ -395,7 +396,7 @@ Use your Perplexity Pro subscription ($20/mo) for Sonar Pro access.
 2. Configure:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=pplx-sub
+DECEPTICON_AUTH_PERPLEXITY=true
 PERPLEXITY_SESSION_TOKEN=your-session-token
 ```
 
@@ -411,14 +412,14 @@ Complete list of all supported LLM providers and their pre-configured models:
 |----------|--------|-----------|------|
 | **Subscriptions (OAuth — no API billing)** | | | |
 | Claude Max/Pro/Team | Opus, Sonnet, Haiku | OAuth | $20–$100/mo |
-| ChatGPT Pro/Plus/Team | GPT-4o, o1, o3, GPT-4.5 | OAuth | $20–$200/mo |
+| ChatGPT Pro/Plus/Team | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` | OAuth | $20–$200/mo |
 | Gemini Advanced | Gemini 2.5 Pro/Flash | OAuth | $20/mo |
-| Copilot Pro | GPT-4o, o1 | OAuth | $20/mo |
+| Copilot Pro | `copilot/gpt-4o`, `copilot/o1`, `copilot/o3-mini` | OAuth | $20/mo |
 | SuperGrok | Grok-3, Grok-3 Mini | OAuth | X Premium+ |
 | Perplexity Pro | Sonar Pro, Sonar | OAuth | $20/mo |
 | **API Key Providers (pay-per-token)** | | | |
-| Anthropic | Claude Opus 4.6, Sonnet 4.6, Haiku 4.5 | API key | Per token |
-| OpenAI | GPT-5.4, GPT-4.1, GPT-4o, o1, o3-mini | API key | Per token |
+| Anthropic | Claude Opus 4.7, Sonnet 4.6, Haiku 4.5 | API key | Per token |
+| OpenAI | GPT-5.5, GPT-5.4, GPT-5-nano | API key | Per token |
 | DeepSeek | DeepSeek Chat, DeepSeek Reasoner | API key | Per token |
 | Google | Gemini 2.5 Flash, Gemini 2.5 Pro | API key | Per token |
 | xAI | Grok-3, Grok-3 Mini | API key | Per token |
@@ -428,7 +429,7 @@ Complete list of all supported LLM providers and their pre-configured models:
 | Together AI | Llama 3.3 70B Turbo + any | API key | Per token |
 | Fireworks AI | Llama 405B + any | API key | Per token |
 | Perplexity | Sonar Pro, Sonar | API key | Per token |
-| MiniMax | MiniMax M2.7, M2.7 Highspeed | API key | Per token |
+| MiniMax | MiniMax-M2.5, MiniMax-M2.5-lightning | API key | Per token |
 | OpenRouter | Any model via routing | API key | Per token |
 | Azure OpenAI | Any Azure-deployed model | API key + endpoint | Per token |
 | AWS Bedrock | Any Bedrock model | AWS credentials | Per token |
@@ -467,8 +468,8 @@ DECEPTICON_MODEL_PROFILE=eco
 Per-role overrides (any profile):
 
 ```bash
-DECEPTICON_MODEL_RECON=ollama/qwen2.5-coder:32b
-DECEPTICON_MODEL_EXPLOIT=anthropic/claude-opus-4-6
+DECEPTICON_MODEL_RECON=ollama_chat/qwen3-coder:30b
+DECEPTICON_MODEL_EXPLOIT=anthropic/claude-opus-4-7
 DECEPTICON_MODEL_EXPLOIT_TEMPERATURE=0.2
 ```
 
@@ -511,11 +512,12 @@ See [Web Dashboard](web-dashboard.md) for the full feature reference.
 decepticon                  # Launch platform (all services + interactive CLI)
 decepticon onboard          # Setup wizard (auth, provider, profile)
 decepticon onboard --reset  # Re-run setup from scratch
-decepticon config           # Edit ~/.decepticon/.env in $EDITOR
 decepticon stop             # Stop all services, keep data
 decepticon status           # Show running services
 decepticon logs [service]   # Follow service logs
-decepticon version          # Show version info
+decepticon update           # Check for and apply updates
+decepticon remove           # Uninstall Decepticon completely
+decepticon --version        # Show installed version
 ```
 
 ### Service Management
@@ -595,7 +597,7 @@ Once running, you have:
 | Service | Port | Purpose |
 |---------|------|---------|
 | **LiteLLM** | 4000 | LLM API gateway — routes to providers, tracks usage, handles fallback |
-| **LangGraph** | 2024 | Agent runtime — hosts all 16 agents as a streaming API |
+| **LangGraph** | 2024 | Agent runtime — hosts all 17 agents as a streaming API |
 | **Neo4j** | 7474/7687 | Knowledge graph — persistent attack chain memory |
 | **Sandbox** | (internal) | Isolated Kali Linux — runs all offensive tools |
 | **Web Dashboard** | 3000 | Browser UI — real-time monitoring, graph visualization |
@@ -710,15 +712,15 @@ decepticon           # Shows engagement picker → select existing
 
 ```bash
 decepticon stop
-# Edit ~/.decepticon/.env → change DECEPTICON_MODEL_PROVIDER or API keys
+# Edit ~/.decepticon/.env → change DECEPTICON_AUTH_PRIORITY, DECEPTICON_AUTH_* toggles, or API keys
 decepticon
 ```
 
 **Check service health:**
 
 ```bash
-decepticon status    # Container status
-decepticon health    # Deep health diagnostics (LangGraph, LiteLLM, Neo4j)
+decepticon status       # Container status (docker compose ps)
+decepticon kg-health    # Knowledge graph diagnostics (LangGraph + Neo4j connection)
 ```
 
 **View logs for specific service:**
@@ -742,17 +744,19 @@ You can configure multiple providers simultaneously. The model profile controls 
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-proj-...
 DEEPSEEK_API_KEY=sk-...
-GOOGLE_API_KEY=AIza...
+GEMINI_API_KEY=AIza...
 ```
 
 ### Hybrid Auth (OAuth + API Keys)
 
-When using `DECEPTICON_MODEL_PROVIDER=auth`, Anthropic models route through OAuth while fallback models (GPT, Gemini) use their API keys. Both can be active simultaneously:
+Set `DECEPTICON_AUTH_CLAUDE_CODE=true` to route Anthropic models through Claude Code OAuth while keeping API-key fallbacks active. The `DECEPTICON_AUTH_PRIORITY` list controls order:
 
 ```bash
-DECEPTICON_MODEL_PROVIDER=auth        # Primary: Claude via OAuth
+DECEPTICON_AUTH_PRIORITY=anthropic_oauth,anthropic_api,openai_api,google_api
+DECEPTICON_AUTH_CLAUDE_CODE=true      # Primary: Claude via OAuth (auth/* in LiteLLM)
+ANTHROPIC_API_KEY=sk-ant-...          # Fallback: Anthropic API
 OPENAI_API_KEY=sk-proj-...            # Fallback: GPT via API key
-GOOGLE_API_KEY=AIza...                # Fallback: Gemini via API key
+GEMINI_API_KEY=AIza...                # Fallback: Gemini via API key
 ```
 
 ### LangSmith Tracing

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -35,7 +35,7 @@ Skills live in `skills/` organized by agent role:
 | Directory | Agent(s) | Coverage |
 |-----------|---------|----------|
 | `skills/soundwave/` | Soundwave | RoE templates, ConOps, OPPLAN generation, threat profiles |
-| `skills/shared/` | Recon, Exploit, Post-Exploit | OPSEC, defense evasion, workflow protocols, finding format, deconfliction |
+| `skills/shared/` | Every non-planning agent | OPSEC, defense evasion, workflow protocols, finding format, deconfliction |
 | `skills/recon/` | Recon | Passive recon, active recon, web recon, cloud recon, OSINT, reporting |
 | `skills/exploit/` | Exploit | Web exploitation, Active Directory attacks |
 | `skills/scanner/` | Scanner | Vulnerability scanning, automated tool integration |
@@ -49,8 +49,9 @@ Skills live in `skills/` organized by agent role:
 | `skills/detector/` | Detector | Detection rule generation, IOC extraction |
 | `skills/patcher/` | Patcher | Remediation code, configuration hardening |
 | `skills/analyst/` | Analyst | Research, graph querying, executive summaries |
-| `skills/vulnresearch/` | Scanner, Detector | Vulnerability research pipeline |
-| `skills/decepticon/` | Decepticon | Core orchestration procedures |
+| `skills/vulnresearch/` | Vulnresearch (orchestrator), Scanner, Detector | Five-stage vulnerability research pipeline coordination |
+| `skills/decepticon/` | Decepticon | Core orchestration procedures (engagement lifecycle, kill-chain analysis, final report) |
+| `skills/benchmark/` | CTF / XBOW benchmark mode | Activated when `BENCHMARK_MODE=1` — flag-capture rules and challenge context handling |
 
 ---
 
@@ -180,7 +181,8 @@ The skill is automatically available to agents whose source paths include your s
 
 | Agent | Skill sources |
 |-------|--------------|
-| Decepticon | `skills/decepticon/` |
+| Decepticon | `skills/decepticon/`, `skills/shared/` |
+| Vulnresearch | `skills/vulnresearch/`, `skills/shared/` |
 | Soundwave | `skills/soundwave/` |
 | Recon | `skills/recon/`, `skills/shared/` |
 | Scanner | `skills/scanner/`, `skills/vulnresearch/`, `skills/shared/` |
@@ -196,4 +198,4 @@ The skill is automatically available to agents whose source paths include your s
 | Reverser | `skills/reverser/`, `skills/shared/` |
 | Analyst | `skills/analyst/`, `skills/shared/` |
 
-`skills/shared/` (OPSEC, defense evasion, workflow) is injected into every non-planning agent.
+`skills/shared/` (OPSEC, defense evasion, workflow) is injected into every non-planning agent. Soundwave is the only agent that does not load `skills/shared/` — it is a document-generation planner, not an operational agent.

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -65,7 +65,7 @@ Interactive visualization of the Neo4j knowledge graph:
 - Color-coded by node type (Host, Service, Vulnerability, Credential)
 - Live — updates as the agent adds nodes and edges
 
-Powered by [React Flow](https://reactflow.dev/) with Three.js for 3D rendering.
+Powered by [React Flow](https://reactflow.dev/) with `d3-force` for graph layout. Selected agent visualizations also use `@react-three/fiber` for 3D effects.
 
 ### OPPLAN Tracker
 


### PR DESCRIPTION
## Summary

Comprehensive documentation cleanup pass to remove claims that don't match the code, slim down the root README following best practice (concise root + links to detailed docs), and switch all XBOW benchmark references to the PurpleAILAB fork.

## What changed

### Removed claims that didn't match code

- **`SafeCommandMiddleware`** — documented as a security guardrail in `agents.md` and several agent docstrings, but **no class definition exists in the codebase**. Removed from docs and docstrings to stop advertising a security control that isn't implemented.
- **`DECEPTICON_MODEL_PROVIDER`** — documented in 7 places in `setup-guide.md` as the canonical OAuth toggle, but **never read anywhere in the code**. Replaced with the actual env vars (`DECEPTICON_AUTH_PRIORITY`, `DECEPTICON_AUTH_CLAUDE_CODE`, `DECEPTICON_AUTH_CHATGPT`, `DECEPTICON_AUTH_GEMINI`, `DECEPTICON_AUTH_COPILOT`, `DECEPTICON_AUTH_GROK`, `DECEPTICON_AUTH_PERPLEXITY`).
- **`decepticon health`, `decepticon config`** — documented in `setup-guide.md` / `cli-reference.md` / `makefile-reference.md` / `e2e-testing-guide.md`, but **not implemented in the launcher**. Replaced with `decepticon kg-health` (the real command) where applicable.

### Corrected model and env var names

- `claude-opus-4-6` → `claude-opus-4-7` (matches `decepticon/llm/models.py:107`)
- `MiniMax M2.7, M2.7 Highspeed` → `MiniMax-M2.5, MiniMax-M2.5-lightning`
- `gpt-5.5 / gpt-5.4 / gpt-5-nano` → `openai/gpt-5.5 / openai/gpt-5.4 / openai/gpt-5-nano` (provider prefix added for consistency)
- `GOOGLE_API_KEY` → `GEMINI_API_KEY` (Decepticon standardised on the newer Gemini variable; only one stale doc table referenced the legacy name)
- ChatGPT OAuth model list (\`GPT-4o, o1, o3, GPT-4.5\`) → actual `auth/gpt-5.x` route names

### Reflected actual architecture

- **Neo4j is dual-homed** on both `sandbox-net` and `decepticon-net` (the agent reads, the sandbox writes) — the README/architecture diagrams claimed "Zero cross-network access" which contradicts \`docker-compose.yml\`. Architecture diagram and surrounding text now describe Neo4j as the one shared knowledge store, with the security boundary table updated to reflect this.
- **17 agents, not 16** — `agents.md` and the README forgot the **Vulnresearch** orchestrator (\`decepticon/agents/vulnresearch.py\`, registered in \`AGENT_TIERS\`). Added it as a second orchestrator (Decepticon for red-team, Vulnresearch for the 5-stage vuln pipeline).
- **Middleware stack** — `agents.md` listed the wrong middleware names. Replaced with what the code actually uses: \`EngagementContextMiddleware\`, \`DecepticonSkillsMiddleware\`, \`FilesystemMiddlewareNoExecute\`, \`AnthropicPromptCachingMiddleware\` (Anthropic-only, no-ops elsewhere).

### Slim README

- `README.md` 266 → 194 lines following best practice — root should be concise, with detailed content in `docs/`.
- `README_KO.md` synchronised (same structure, 194 lines).
- Section order at user request: **Install → Sponsor → Benchmark Results → What is Decepticon → …**
- Provider list condensed to "tier-mapped (10) + subscription OAuth (6)" instead of "18+ providers" (only 10 providers have real \`METHOD_MODELS\` entries; the rest were marketing).

### XBOW fork

- README, `benchmark/README.md`, `benchmark/results/README.md`, and `.gitmodules` now point at \`PurpleAILAB/xbow-validation-benchmarks\` (the project fork with buster-EOL patches and the \`decepticon\` branch).

### Smaller cleanup items

- `cli-reference.md`: complete OAuth env var table; added \`WEB_PORT\` / \`TERMINAL_PORT\`; \`AUTH_PRIORITY\` default now matches \`.env.example\`.
- `getting-started.md`: providers split into tier-mapped / OAuth / ad-hoc to match code reality.
- `skills.md`: added Vulnresearch orchestrator + \`skills/benchmark/\` to the mapping tables.
- `web-dashboard.md`: corrected "Three.js for 3D rendering" → \`d3-force\` for graph layout (\`@react-three/fiber\` for selected agent visualisations only).
- `contributing.md`: \`cp .env.example .env\` (was pointing at a stale path under \`clients/launcher/internal/config/\`).
- `e2e-testing-guide.md`: dropped a scenario that tested a deprecated \`decepticon config\` alias which doesn't exist in code.
- `design/opplan-middleware.md`: code example updated to current middleware names.

## Out of scope (deliberate)

These two findings from the review were left for follow-up PRs:

1. **`SafeCommandMiddleware` real implementation** — this PR removes the docs claim. If destructive-command blocking is desired, a separate PR should add the actual middleware.
2. **Defender sub-agent wiring** — Defender exists as a graph but is not registered in the orchestrator's \`SubAgentMiddleware\`, so the documented Offensive Vaccine loop has no current call path. Out of scope here; tracked for follow-up.

## Verification

- \`uv run ruff check\` ✅
- \`uv run ruff format --check\` ✅
- \`uv run basedpyright --level error\` ✅
- All Python edits are docstring-only — no behaviour change.

## Test plan

- [ ] Render README on github.com to verify Sponsor + Benchmark land directly under Install.
- [ ] Confirm \`docs/agents.md\` middleware stack matches \`decepticon/agents/decepticon.py\` lines 199-216.
- [ ] Confirm XBOW link redirects to PurpleAILAB fork.
- [ ] Confirm \`.gitmodules\` URL change does not break \`git submodule update --init\` (fork must contain the same submodule layout).