### PR TITLE
feat(vulnresearch): add bug bounty methodology — BugBunny-style white-box hunting

### DIFF
--- a/decepticon/agents/analyst.py
+++ b/decepticon/agents/analyst.py
@@ -36,6 +36,7 @@ from decepticon.middleware.skills import DecepticonSkillsMiddleware
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import REFERENCES_TOOLS
+from decepticon.tools.research.bounty import BOUNTY_TOOLS
 from decepticon.tools.research.tools import RESEARCH_TOOLS
 
 
@@ -84,8 +85,9 @@ def create_analyst_agent():
     )
 
     # Research tools first → model defaults to graph operations;
-    # references tools offer payloads + external knowledge lookup.
-    tools = [*RESEARCH_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
+    # references tools offer payloads + external knowledge lookup;
+    # bounty tools provide scope checking and report formatting.
+    tools = [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
 
     agent = create_agent(
         llm,

--- a/decepticon/agents/prompts/analyst.md
+++ b/decepticon/agents/prompts/analyst.md
@@ -89,6 +89,36 @@ Use when you only have a running target (no source).
 4. Run nuclei, ffuf, sqlmap, dalfox, per-vuln skill prompts.
 5. For every hit, add a vulnerability + edge `enables` towards adjacent nodes.
 6. Call `plan_attack_chains(top_k=10)` to see which mediums combine into criticals.
+
+## Lane F — Trust boundary analysis (developer tools / CLI apps)
+Use when the target is a developer tool, CLI, IDE extension, or any app that
+loads configuration from the current working directory.
+1. Map config loading: `grep -rn 'readFile\|fs.read\|open(' --include='*.ts' --include='*.js' | grep -i 'config\|settings\|env'`.
+2. Check workspace trust: `grep -rn 'trust\|isTrusted\|workspace.*safe' --include='*.ts' --include='*.js'`.
+3. Trace env var injection: `grep -rn 'process\.env\|os\.environ' | grep -i 'command\|cmd\|exec\|proxy\|path'`.
+4. Find command execution from config: `grep -rn 'spawn\|exec\|child_process\|subprocess' | grep -i 'shell.*true\|config\|settings'`.
+5. Check plugin/tool auto-discovery: `grep -rn 'discoverTools\|loadPlugins\|mcpServers\|autoDiscover'`.
+6. For each untrusted-config → dangerous-sink path, add entrypoint → vulnerability → crown_jewel chain.
+7. Load `/skills/analyst/trust-boundary/SKILL.md` for detailed patterns and PoC construction.
+
+## Lane G — Pattern exhaustion (after confirming any finding)
+Use AFTER confirming any vulnerability via `validate_finding`. The goal is to
+find all instances of the same root cause pattern across the codebase.
+1. Classify the confirmed bug's root cause (missing auth, unvalidated input, shell:true, etc.).
+2. Build a grep/semgrep pattern that matches the root cause signature.
+3. Run the search across the entire codebase.
+4. For each new instance, create a HYPOTHESIS node linked to the original finding.
+5. Verify each candidate via `validate_finding`.
+6. Stop when all instances are checked or mitigated.
+7. Load `/skills/analyst/pattern-exhaustion/SKILL.md` for search patterns and exhaustion criteria.
+
+## Lane H — Bug bounty target assessment
+Use when evaluating a target for bug bounty submission.
+1. Check security advisory history: existing CVEs, GHSA credits, responsible disclosure policy.
+2. Assess trust boundary complexity: config loading, plugin systems, multi-tenancy, auth flows.
+3. Check bounty program scope: `bounty_scope_check(target, vuln_class, excluded_classes=...)`.
+4. Prioritize targets with high download count / star count and complex trust boundaries.
+5. Load `/skills/analyst/bounty-hunting/SKILL.md` for the full methodology.
 </HUNTING_LANES>
 
 <KNOWLEDGE_GRAPH_DISCIPLINE>
@@ -156,6 +186,10 @@ they apply — they update the graph for you and keep your state coherent:
 - `fuzz_record_crash(log, engine)` — parse ASan/UBSan into a vuln
 - `validate_finding(vuln_id, poc_cmd, success_patterns, negative_cmd, negative_patterns, cvss)`
                               — ZFP-validated PoC with CVSS
+- `bounty_scope_check(target, vuln_class, excluded_classes, in_scope_domains)`
+                              — verify finding is in program scope before reporting
+- `format_bounty_report(finding_id, platform, program_name, component_name)`
+                              — generate platform-ready bug bounty report from a FINDING node
 
 ALWAYS call `kg_stats` at iteration start and after any major action. If
 your iteration ends with zero new graph nodes, you wasted it.

--- a/decepticon/tools/research/bounty.py
+++ b/decepticon/tools/research/bounty.py
@@ -137,9 +137,7 @@ def bounty_scope_check(
                 break
         if not domain_match:
             in_scope = False
-            warnings.append(
-                f"Target '{target}' does not match any in-scope domain: {domains}"
-            )
+            warnings.append(f"Target '{target}' does not match any in-scope domain: {domains}")
 
     # Severity-based warnings
     low_impact_classes = {"information-disclosure", "version-disclosure", "verbose-error"}
@@ -240,9 +238,7 @@ def format_bounty_report(
         return _json({"error": f"FINDING node {finding_id} not found in graph"})
 
     if finding.kind != NodeKind.FINDING:
-        return _json(
-            {"error": f"Node {finding_id} is {finding.kind.value}, not finding"}
-        )
+        return _json({"error": f"Node {finding_id} is {finding.kind.value}, not finding"})
 
     # Pull linked vulnerability
     vuln = _find_linked_vuln(graph, finding_id)
@@ -252,9 +248,7 @@ def format_bounty_report(
     vuln_props = vuln.props if vuln else {}
     validated = props.get("validated", False)
     if not validated:
-        return _json(
-            {"error": "Finding is not validated — run validate_finding first"}
-        )
+        return _json({"error": "Finding is not validated — run validate_finding first"})
 
     cvss_vector = vuln_props.get("cvss_vector", props.get("cvss_vector", ""))
     cvss_score = vuln_props.get("cvss_score", props.get("cvss_score", 0.0))

--- a/decepticon/tools/research/bounty.py
+++ b/decepticon/tools/research/bounty.py
@@ -15,19 +15,16 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any
 
 from langchain_core.tools import tool
 
 from decepticon.core.logging import get_logger
 from decepticon.tools.research._state import _json, _load, _save
 from decepticon.tools.research.graph import (
-    Edge,
     EdgeKind,
     KnowledgeGraph,
     Node,
     NodeKind,
-    Severity,
 )
 
 log = get_logger("research.bounty")
@@ -265,7 +262,6 @@ def format_bounty_report(
     cwe_list = vuln_props.get("cwe", [])
     file_path = vuln_props.get("file", "")
     line = vuln_props.get("line", "")
-    evidence = vuln_props.get("evidence", "")
     stdout = props.get("stdout_excerpt", "")
     vuln_label = vuln.label if vuln else finding.label
 

--- a/decepticon/tools/research/bounty.py
+++ b/decepticon/tools/research/bounty.py
@@ -1,0 +1,353 @@
+"""Bug bounty tools — scope checking and report generation.
+
+Provides two tools for bug bounty workflows:
+
+- ``bounty_scope_check``  — validate target + vuln class against program scope
+- ``format_bounty_report`` — generate a platform-ready report from a FINDING node
+
+These complement the existing vulnresearch pipeline by adding bounty-specific
+quality gates after ``validate_finding`` confirms exploitability.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from langchain_core.tools import tool
+
+from decepticon.core.logging import get_logger
+from decepticon.tools.research._state import _json, _load, _save
+from decepticon.tools.research.graph import (
+    Edge,
+    EdgeKind,
+    KnowledgeGraph,
+    Node,
+    NodeKind,
+    Severity,
+)
+
+log = get_logger("research.bounty")
+
+# Common vuln classes that many programs exclude.
+_COMMONLY_EXCLUDED = {
+    "self-xss",
+    "rate-limiting",
+    "missing-rate-limit",
+    "clickjacking",
+    "content-spoofing",
+    "text-injection",
+    "csv-injection",
+    "missing-security-headers",
+    "missing-best-practices",
+    "social-engineering",
+    "physical-access",
+    "denial-of-service",
+    "dos",
+    "logout-csrf",
+    "login-csrf",
+    "open-redirect-low",
+    "email-enumeration",
+    "username-enumeration",
+    "version-disclosure",
+    "stack-trace",
+    "verbose-error",
+    "autocomplete",
+    "tabnabbing",
+}
+
+
+def _normalize_class(cls: str) -> str:
+    return cls.strip().lower().replace(" ", "-").replace("_", "-")
+
+
+@tool
+def bounty_scope_check(
+    target: str,
+    vuln_class: str,
+    program_url: str = "",
+    excluded_classes: str = "[]",
+    in_scope_domains: str = "[]",
+) -> str:
+    """Check whether a finding is in scope for a bug bounty program.
+
+    WHEN TO USE: Before writing or submitting any bug bounty report. Call this
+    after ``validate_finding`` succeeds to verify the target and vulnerability
+    class are not excluded by the program's policy.
+
+    A failed scope check is a rejected report waiting to happen. Run this
+    BEFORE spending time on report formatting.
+
+    Args:
+        target: The target hostname, URL, or package name under test.
+        vuln_class: The vulnerability class (e.g. "sqli", "ssrf", "xss",
+            "rce", "idor", "path-traversal", "dos").
+        program_url: URL of the bounty program scope page (informational).
+        excluded_classes: JSON array of vuln classes the program excludes.
+            Example: ``'["dos", "self-xss", "clickjacking"]'``
+        in_scope_domains: JSON array of in-scope domain patterns.
+            Example: ``'["*.example.com", "api.example.com"]'``
+
+    Returns:
+        JSON with ``in_scope`` (bool), ``warnings`` (list of strings),
+        and the recorded scope-check node id.
+    """
+    warnings: list[str] = []
+    in_scope = True
+
+    # Parse exclusions
+    try:
+        exclusions = {_normalize_class(c) for c in json.loads(excluded_classes)}
+    except (json.JSONDecodeError, TypeError):
+        exclusions = set()
+
+    # Parse in-scope domains
+    try:
+        domains = json.loads(in_scope_domains)
+    except (json.JSONDecodeError, TypeError):
+        domains = []
+
+    normalized_class = _normalize_class(vuln_class)
+
+    # Check against program exclusions
+    if normalized_class in exclusions:
+        in_scope = False
+        warnings.append(f"Vuln class '{vuln_class}' is explicitly excluded by the program")
+
+    # Check against commonly excluded classes
+    if normalized_class in _COMMONLY_EXCLUDED and normalized_class not in exclusions:
+        warnings.append(
+            f"Vuln class '{vuln_class}' is commonly excluded by bounty programs — "
+            "verify with the specific program's scope before submitting"
+        )
+
+    # Check domain scope if provided
+    if domains:
+        target_lower = target.lower()
+        domain_match = False
+        for pattern in domains:
+            pattern = pattern.lower().strip()
+            if pattern.startswith("*."):
+                suffix = pattern[1:]  # e.g. ".example.com"
+                if target_lower.endswith(suffix) or target_lower == pattern[2:]:
+                    domain_match = True
+                    break
+            elif target_lower == pattern or target_lower.endswith("/" + pattern):
+                domain_match = True
+                break
+        if not domain_match:
+            in_scope = False
+            warnings.append(
+                f"Target '{target}' does not match any in-scope domain: {domains}"
+            )
+
+    # Severity-based warnings
+    low_impact_classes = {"information-disclosure", "version-disclosure", "verbose-error"}
+    if normalized_class in low_impact_classes:
+        warnings.append(
+            "Low-impact finding — many programs ignore informational/low severity. "
+            "Consider whether this is worth submitting."
+        )
+
+    # Record in the knowledge graph
+    graph, path = _load()
+    scope_node = graph.upsert_node(
+        Node.make(
+            NodeKind.HYPOTHESIS,
+            f"scope-check: {target} / {vuln_class}",
+            key=f"scope-check::{target}::{normalized_class}",
+            target=target,
+            vuln_class=vuln_class,
+            in_scope=in_scope,
+            program_url=program_url,
+            checked_at=time.time(),
+            warnings=warnings,
+        )
+    )
+    _save(graph, path)
+
+    return _json(
+        {
+            "in_scope": in_scope,
+            "target": target,
+            "vuln_class": vuln_class,
+            "warnings": warnings,
+            "node_id": scope_node.id,
+        }
+    )
+
+
+def _find_linked_vuln(graph: KnowledgeGraph, finding_id: str) -> Node | None:
+    """Walk VALIDATES edges from a FINDING to find the linked VULNERABILITY."""
+    for edge in graph.edges.values():
+        if edge.src == finding_id and edge.kind == EdgeKind.VALIDATES:
+            vuln = graph.nodes.get(edge.dst)
+            if vuln and vuln.kind == NodeKind.VULNERABILITY:
+                return vuln
+    # Fallback: check MAPS_TO edges
+    for edge in graph.edges.values():
+        if edge.src == finding_id and edge.kind == EdgeKind.MAPS_TO:
+            vuln = graph.nodes.get(edge.dst)
+            if vuln and vuln.kind == NodeKind.VULNERABILITY:
+                return vuln
+    return None
+
+
+def _severity_label(score: float) -> str:
+    if score >= 9.0:
+        return "Critical"
+    if score >= 7.0:
+        return "High"
+    if score >= 4.0:
+        return "Medium"
+    if score > 0.0:
+        return "Low"
+    return "Informational"
+
+
+@tool
+def format_bounty_report(
+    finding_id: str,
+    platform: str = "hackerone",
+    program_name: str = "",
+    component_name: str = "",
+) -> str:
+    """Generate a bug bounty report from a validated FINDING node.
+
+    WHEN TO USE: After ``validate_finding`` confirms a vulnerability is real
+    and ``bounty_scope_check`` confirms it's in scope. Generates a
+    platform-ready report at ``workspace/findings/BOUNTY-{id}.md``.
+
+    The report follows the title convention: ``Component: VulnClass via Mechanism``
+    and includes full CVSS vector, PoC, and remediation — optimized for
+    acceptance rate, not word count.
+
+    Args:
+        finding_id: The FINDING node id from the knowledge graph (returned
+            by ``validate_finding``).
+        platform: Target platform — ``hackerone``, ``bugcrowd``, ``immunefi``,
+            or ``github``.
+        program_name: Name of the bounty program (informational).
+        component_name: Name of the affected component/package for the title.
+
+    Returns:
+        JSON with the report file path and a preview of the title + severity.
+    """
+    graph, kg_path = _load()
+
+    finding = graph.nodes.get(finding_id)
+    if finding is None:
+        return _json({"error": f"FINDING node {finding_id} not found in graph"})
+
+    if finding.kind != NodeKind.FINDING:
+        return _json(
+            {"error": f"Node {finding_id} is {finding.kind.value}, not finding"}
+        )
+
+    # Pull linked vulnerability
+    vuln = _find_linked_vuln(graph, finding_id)
+
+    # Extract data
+    props = finding.props
+    vuln_props = vuln.props if vuln else {}
+    validated = props.get("validated", False)
+    if not validated:
+        return _json(
+            {"error": "Finding is not validated — run validate_finding first"}
+        )
+
+    cvss_vector = vuln_props.get("cvss_vector", props.get("cvss_vector", ""))
+    cvss_score = vuln_props.get("cvss_score", props.get("cvss_score", 0.0))
+    severity = _severity_label(float(cvss_score)) if cvss_score else "Unknown"
+    cwe_list = vuln_props.get("cwe", [])
+    file_path = vuln_props.get("file", "")
+    line = vuln_props.get("line", "")
+    evidence = vuln_props.get("evidence", "")
+    stdout = props.get("stdout_excerpt", "")
+    vuln_label = vuln.label if vuln else finding.label
+
+    # Build title
+    comp = component_name or program_name or "Target"
+    # Strip "validated: " prefix from finding labels
+    clean_label = re.sub(r"^(validated|rejected):\s*", "", vuln_label)
+    title = f"{comp}: {clean_label}"
+
+    # Build CWE string
+    cwe_str = ", ".join(cwe_list) if isinstance(cwe_list, list) else str(cwe_list)
+
+    # Build report
+    report_lines = [
+        f"# {title}",
+        "",
+        "## Summary",
+        "",
+        f"{clean_label}.",
+        f"Affected file: `{file_path}`" + (f" (line {line})" if line else ""),
+        "",
+        "## Severity",
+        "",
+        f"**CVSS 3.1**: `{cvss_vector}` ({cvss_score} {severity})",
+        "",
+    ]
+
+    if cwe_str:
+        report_lines.extend([f"**CWE**: {cwe_str}", ""])
+
+    report_lines.extend(
+        [
+            "## Steps to Reproduce",
+            "",
+            "_(Fill in exact reproduction steps from the PoC command)_",
+            "",
+            "## Proof of Concept",
+            "",
+            "```",
+            stdout[:1200] if stdout else "_(attach PoC output)_",
+            "```",
+            "",
+            "## Impact",
+            "",
+            f"Validated with CVSS {cvss_score} ({severity}).",
+            "_(Describe only the demonstrated impact — do not extrapolate)_",
+            "",
+            "## Remediation",
+            "",
+            "_(Provide a specific code fix — not generic advice)_",
+            "",
+            "---",
+            f"_Generated by Decepticon vulnresearch pipeline for {platform}_",
+            f"_Program: {program_name}_" if program_name else "",
+            f"_Finding ID: {finding_id}_",
+        ]
+    )
+
+    report_content = "\n".join(report_lines)
+
+    # Write report file
+    short_id = finding_id[:8]
+    report_path = Path("/workspace/findings") / f"BOUNTY-{short_id}.md"
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report_content, encoding="utf-8")
+        wrote = True
+    except OSError as e:
+        log.warning("Could not write bounty report: %s", e)
+        wrote = False
+
+    return _json(
+        {
+            "title": title,
+            "severity": severity,
+            "cvss_score": cvss_score,
+            "cvss_vector": cvss_vector,
+            "platform": platform,
+            "report_path": str(report_path) if wrote else None,
+            "preview": report_content[:500],
+        }
+    )
+
+
+BOUNTY_TOOLS = [bounty_scope_check, format_bounty_report]

--- a/skills/analyst/bounty-hunting/SKILL.md
+++ b/skills/analyst/bounty-hunting/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: bounty-hunting-methodology
+description: Bug bounty white-box hunting methodology. Load when the target is an open-source project with a security advisory program, bug bounty, or responsible disclosure policy.
+---
+
+# Bug Bounty Hunting Methodology
+
+You are not scanning. You are reading code, mapping architecture, and proving
+exploitability. Volume is the enemy — signal is the metric. Every report must
+survive triage by an experienced security engineer.
+
+## Target Assessment
+
+Before committing iteration budget, evaluate the target:
+
+1. **Impact surface**: downloads/week, GitHub stars, dependency depth. A vuln in
+   lodash or React Router has 10-100x the impact of a vuln in a 200-star project.
+2. **Trust boundary complexity**: Does the app load config from untrusted sources?
+   Handle plugins? Parse user-controlled serialized data? Multi-tenant auth?
+   Complex trust boundaries = more attack surface.
+3. **Security advisory history**: Check `github.com/advisories?query=<package>`.
+   Projects that accept and credit researchers will work with you. Projects with
+   zero advisories are either very secure or don't have a disclosure process.
+4. **Reward program**: HackerOne, Bugcrowd, Immunefi, GitHub Security Advisories,
+   Google VRP. Check scope, excluded vuln classes, and reward tiers.
+
+Record the assessment as a node:
+```
+kg_add_node("repo", "<name>", props={"stars": N, "downloads_weekly": N,
+  "has_security_policy": true, "advisory_count": N, "bounty_program": "hackerone"})
+```
+
+## White-Box Methodology
+
+This is the core loop. Fork. Read. Trace. Prove.
+
+### Step 1 — Map the project
+```bash
+find /workspace/target -name 'package.json' -o -name 'pyproject.toml' \
+  -o -name 'go.mod' -o -name 'Cargo.toml' -o -name 'composer.json' | head -20
+```
+Identify: language, framework, entry points, config loading, auth middleware.
+
+### Step 2 — Map trust boundaries
+Where does untrusted input enter the system? Trace these sources:
+- HTTP request params, headers, body
+- Environment variables and `.env` files
+- Config files from current directory (`.gemini/settings.json`, `.vscode/settings.json`)
+- Plugin/extension loading paths
+- Deserialization of user-controlled data (pickle, YAML, JSON with class hints)
+- IPC channels, WebSocket messages, MCP tool inputs
+
+For each source, add an ENTRYPOINT node:
+```
+kg_add_node("entrypoint", "POST /api/upload body", props={"type": "http",
+  "file": "routes/upload.py", "line": 42})
+```
+
+### Step 3 — Identify crown jewels
+What is the most valuable thing an attacker could reach?
+- Admin access / account takeover
+- RCE / command execution
+- Database contents / PII
+- Secret keys / credentials
+- File system read/write
+
+Add CROWN_JEWEL nodes for each.
+
+### Step 4 — Trace source → sink
+For each entrypoint, trace the data flow to dangerous sinks:
+- `exec()`, `eval()`, `spawn()`, `subprocess.run()`, `os.system()`
+- `db.query()` with string interpolation
+- `render()` / `innerHTML` with unescaped input
+- `open()` / `readFile()` with user-controlled paths
+- `pickle.loads()`, `yaml.unsafe_load()`, `JSON.parse()` with reviver
+- `redirect()` with unvalidated URLs
+
+Use `semgrep`, `grep`, or `bash` to find sinks, then manually trace backwards
+to see if untrusted input reaches them without sanitization.
+
+### Step 5 — Prove or discard
+Every finding MUST go through `validate_finding` with:
+- A working `poc_command`
+- `success_patterns` that uniquely match the exploit signal
+- A `negative_command` (same request without payload)
+- `negative_patterns` matching the baseline response
+- Full `cvss_vector` string
+
+If you cannot reproduce it, it is NOT a finding. Record the failure and move on.
+
+## High-Value Vulnerability Classes
+
+Prioritize by typical bounty payout and acceptance rate:
+
+1. **Remote Code Execution** — deserialization, template injection, command injection,
+   unsafe `eval`/`exec`, `shell: true` with user input. Highest payouts.
+2. **Access Control Bypass** — IDOR, BOLA, missing ownership validation, broken
+   function-level authorization. Most common accepted finding class.
+3. **Authentication Bypass** — token leakage, session fixation, OAuth state confusion,
+   JWT `alg=none`, password reset flaws.
+4. **Path Traversal / File Write** — directory escape in upload/download handlers,
+   session file storage with crafted IDs, zip slip.
+5. **Server-Side Request Forgery** — redirect bypass, DNS rebinding, cloud metadata
+   access via internal URL parameters.
+6. **Injection** — SQLi, XSS (stored > reflected), LDAP injection, GraphQL injection.
+7. **Information Disclosure** — API key leakage, user enumeration via error codes,
+   schema/debug endpoint exposure, directory listing.
+
+## Report Title Convention
+
+Every report title MUST follow: `[Impact] via [Mechanism] in [Component]`
+
+Good:
+- "Path traversal in plugin file upload enables arbitrary directory deletion and file write"
+- "Cloud function validator bypass via prototype chain traversal"
+- "Unauthenticated SSRF via HTTP redirect bypass in LiveLinks proxy"
+
+Bad:
+- "XSS vulnerability found" (no mechanism, no component)
+- "Possible SQL injection" (speculative)
+- "Security issue in API" (says nothing)
+
+## What NOT to Do
+
+- Do NOT submit without a validated PoC
+- Do NOT inflate CVSS beyond demonstrated impact
+- Do NOT submit theoretical findings ("an attacker could potentially...")
+- Do NOT spam multiple low-quality reports — one rejected report damages signal
+- Do NOT submit to out-of-scope targets
+- Do NOT submit duplicate findings without checking `kg_query(kind="finding")`

--- a/skills/analyst/pattern-exhaustion/SKILL.md
+++ b/skills/analyst/pattern-exhaustion/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: pattern-exhaustion
+description: Systematic pattern exhaustion methodology. Load after finding any confirmed vulnerability to search for all instances of the same root cause pattern across the codebase.
+---
+
+# Pattern Exhaustion
+
+When you find a vulnerability, you have found a PATTERN. The same developer
+who wrote one broken auth check likely wrote twenty. The same framework that
+misses one guard has a systemic design gap. One root cause → multiple CVEs.
+
+Real-world examples:
+- Parse Server: 4 advisories from guard bypass patterns (prototype chain,
+  falsy-value guard, protected-field bypass, complexity validator)
+- zrok: 3 advisories from access control (symlink traversal, broken ownership,
+  reflected XSS in callback)
+- AVideo: 3 advisories from deployment config (SSRF, exposed installer,
+  memcached session leak)
+
+## The Exhaustion Loop
+
+### 1. Classify the root cause
+
+After confirming a vulnerability, classify its root cause pattern:
+
+| Root Cause | Search Pattern |
+|---|---|
+| Missing auth/authz check | `grep -rn 'def handle_\|router\.\(get\|post\|put\|delete\)' \| grep -v 'auth\|permission\|require\|middleware'` |
+| Unvalidated path parameter | `grep -rn 'req\.params\|request\.args\|ctx\.params' \| grep -v 'sanitize\|validate\|path\.resolve\|path\.normalize'` |
+| SQL string interpolation | `grep -rn 'f"SELECT\|f"INSERT\|f"UPDATE\|query(.*\+.*\|query(.*\$\{' --include='*.py' --include='*.ts' --include='*.js'` |
+| shell: true with user input | `grep -rn 'shell:\s*true\|shell=True\|os\.system\|subprocess\.call.*shell' --include='*.py' --include='*.ts' --include='*.js'` |
+| Missing ownership validation | `grep -rn 'delete\|update\|modify' --include='*.py' --include='*.ts' \| grep -v 'owner\|author\|created_by\|user_id.*=='` |
+| Default-open feature flag | `grep -rn 'enabled.*=.*false\|feature.*disabled\|trust.*=.*true' --include='*.ts' --include='*.py'` |
+| Unsafe deserialization | `grep -rn 'pickle\.loads\|yaml\.load\|yaml\.unsafe\|unserialize\|JSON\.parse.*reviver\|eval(' --include='*.py' --include='*.js' --include='*.php'` |
+| Type confusion in guard | `grep -rn 'typeof.*==\|instanceof\|is_array\|Array\.isArray' --include='*.ts' --include='*.js' --include='*.php'` |
+| Missing CSRF/state check | `grep -rn 'state=\|csrf\|nonce' --include='*.py' --include='*.ts' \| grep -v 'verify\|validate\|check'` |
+| Prototype pollution | `grep -rn 'Object\.assign\|merge(\|extend(\|deepMerge\|_.merge\|lodash' --include='*.js' --include='*.ts'` |
+
+For semgrep (when installed):
+```bash
+# Generic: user input reaching dangerous sink without sanitization
+semgrep --config auto --severity ERROR /workspace/target/src/ --sarif -o /workspace/exhaustion.sarif
+kg_ingest_sarif("/workspace/exhaustion.sarif", "pattern-exhaustion")
+```
+
+### 2. Enumerate all instances
+
+Run the search. For EACH hit:
+1. Check: is this the SAME pattern as the confirmed vuln?
+2. Check: is there a mitigation the original instance lacked?
+3. Check: is this in test/fixture/example code? (reject if so)
+4. If potentially exploitable, create a HYPOTHESIS node:
+
+```
+kg_add_node("hypothesis", "Missing ownership check in DELETE /api/v2/unaccess",
+  props={"pattern": "missing_ownership_validation", "file": "api/routes.py",
+  "line": 87, "related_finding": "<original_finding_id>",
+  "key": "api/routes.py:handle_unaccess:missing_ownership"})
+```
+
+Link to the original vulnerability:
+```
+kg_add_edge(new_hypothesis_id, original_vuln_id, "chains_to", weight=0.3)
+```
+
+### 3. Prioritize by impact
+
+Not all instances are equal. Prioritize:
+- **Unauthenticated endpoints** over authenticated ones
+- **Write/delete operations** over read-only
+- **Production code paths** over admin/debug routes
+- **External-facing** over internal-only
+
+### 4. Verify each instance
+
+Feed the top candidates to the verifier via `validate_finding`. Each
+confirmed instance becomes a separate FINDING node.
+
+### 5. Exhaustion criteria
+
+Stop the pattern search when:
+- All instances have been checked (grep returns no unchecked matches)
+- Remaining instances have proper mitigations in place
+- The pattern no longer applies (different framework version, different code path)
+- You've hit 10+ findings from the same pattern (diminishing returns on signal)
+
+Record the exhaustion state:
+```
+kg_add_node("hypothesis", "pattern exhaustion complete: missing_ownership",
+  props={"pattern": "missing_ownership_validation", "status": "exhausted",
+  "total_instances": 15, "confirmed": 4, "rejected": 11})
+```
+
+## Graph Structure
+
+After exhaustion, the graph should show:
+```
+VULNERABILITY (original finding)
+  ← chains_to ← FINDING (variant 1)
+  ← chains_to ← FINDING (variant 2)
+  ← chains_to ← FINDING (variant 3)
+  ← chains_to ← HYPOTHESIS (rejected variant, status=rejected)
+```
+
+This makes it easy for the report generator to group related findings
+under a single root cause narrative.

--- a/skills/analyst/trust-boundary/SKILL.md
+++ b/skills/analyst/trust-boundary/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: trust-boundary-analysis
+description: Trust boundary mapping and startup sequence audit for developer tools, CLI apps, and plugin systems. Load when the target is a developer tool, CLI, IDE extension, or any application that loads config from the current directory.
+---
+
+# Trust Boundary Analysis
+
+This skill targets the vulnerability class that produced 5 RCE vectors in
+Google Gemini CLI from a single architectural flaw: missing workspace trust.
+Developer tools that auto-load configuration from untrusted directories are
+a rich attack surface.
+
+## When to Use
+
+Apply this skill when the target:
+- Loads `.env`, `settings.json`, or config files from the current working directory
+- Has a plugin/extension system that auto-discovers and loads code
+- Spawns child processes with configuration-controlled commands
+- Is a CLI tool, IDE extension, language server, or build tool
+- Uses MCP (Model Context Protocol) servers configured via project files
+
+## Startup Sequence Audit
+
+For any CLI tool or developer application, trace the full initialization:
+
+### 1. Config file discovery
+```bash
+grep -rn 'readFile\|readFileSync\|fs.read\|open(' --include='*.ts' --include='*.js' \
+  /workspace/target/src/ | grep -i 'config\|settings\|env\|rc\|\.json'
+```
+
+Map the search order. Common dangerous patterns:
+- `cwd/.tool/config.json` → `cwd/.env` → `~/.tool/config` → `/etc/tool/config`
+- If the local (cwd) config is loaded BEFORE the user's global config, the
+  attacker's repo-level config wins.
+
+Record each config loading point:
+```
+kg_add_node("code_location", "loadConfig() reads .env from cwd",
+  props={"file": "src/config/settings.ts", "line": 42, "trust_level": "untrusted"})
+```
+
+### 2. Environment variable injection
+```bash
+grep -rn 'process\.env\|os\.environ\|env::var\|getenv' --include='*.ts' \
+  --include='*.py' --include='*.rs' /workspace/target/src/
+```
+
+Check: Are env vars from `.env` files injected into `process.env`? Which vars
+control dangerous behavior? Look for:
+- `*_COMMAND`, `*_CMD`, `*_EXEC` → shell execution
+- `*_PROXY` → SSRF / network interception
+- `*_PATH`, `*_DIR` → path traversal
+- `*_URL` → open redirect / SSRF
+- `DEBUG`, `NODE_ENV` → bypass security controls
+
+### 3. Workspace trust check
+```bash
+grep -rn 'trust\|isTrusted\|workspace.*safe\|folder.*trust' --include='*.ts' \
+  --include='*.js' /workspace/target/src/
+```
+
+Look for the pattern:
+```javascript
+// DANGEROUS: trust disabled by default
+if (!settings.folderTrustEnabled) {
+  return { isTrusted: true };  // ← All workspaces trusted
+}
+```
+
+If no trust check exists, every config is loaded blindly. This is the root cause.
+
+### 4. Command execution from config
+```bash
+grep -rn 'spawn\|exec\|execSync\|child_process\|subprocess\|os\.system\|Popen' \
+  --include='*.ts' --include='*.js' --include='*.py' /workspace/target/src/
+```
+
+For each `spawn`/`exec` call, check:
+- Is `shell: true` set? → shell injection via crafted values
+- Does the command come from config? → attacker-controlled execution
+- Is there any validation/allowlist on the command?
+
+### 5. Plugin/tool auto-discovery
+```bash
+grep -rn 'discoverTools\|loadPlugins\|autoDiscover\|mcpServers\|toolDiscovery' \
+  --include='*.ts' --include='*.js' /workspace/target/src/
+```
+
+Check: Are plugins/tools loaded from project-level config BEFORE any user
+confirmation? MCP servers, language server plugins, and build tool extensions
+are common vectors.
+
+## Trust Boundary Graph Modeling
+
+Map the attack flow as a chain in the knowledge graph:
+
+```
+ENTRYPOINT (malicious .env file in cloned repo)
+  → enables → ENV_INJECT (process.env poisoned)
+    → enables → SHELL_EXEC (spawn with shell:true)
+      → reaches → CROWN_JEWEL (arbitrary code execution)
+```
+
+Use low edge weights (0.2–0.4) for automatic/silent steps. Use higher weights
+(1.0+) for steps requiring user interaction.
+
+Then call `plan_attack_chains(top_k=5)` to surface the cheapest paths.
+
+## Shell Quoting Vulnerabilities
+
+When config values flow into shell commands, check for:
+
+1. **Direct interpolation**: `` `command ${userValue}` `` → injection via `; id`
+2. **Single-quote escape**: `osascript -e '${path}'` → escape via `'` in path
+3. **Env var in shell context**: `PROXY_CMD="curl evil.com"` → executed as-is
+4. **Argument injection**: `spawn('git', ['clone', userUrl])` → `--upload-pack=` prefix
+
+For each, the PoC pattern is:
+- Craft input that breaks out of the quoting context
+- Inject a command that proves execution (`id`, `env`, write a sentinel file)
+- Use `validate_finding` with the sentinel as the success pattern
+
+## Negative Control
+
+Always test: does the same code path execute WITHOUT the malicious config?
+The negative control is the same operation with a clean/empty config directory.
+If the behavior occurs regardless, it's not a vulnerability — it's expected.

--- a/skills/verifier/bounty-report/SKILL.md
+++ b/skills/verifier/bounty-report/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: bounty-report-formatter
+description: Bug bounty report formatting for HackerOne, Bugcrowd, Immunefi, and GitHub Security Advisories. Load after validate_finding succeeds and the finding needs to be submitted to a bounty program.
+---
+
+# Bug Bounty Report Formatter
+
+Format validated findings as platform-ready bug bounty reports that
+survive triage. Optimized for acceptance rate, not word count. The
+standard this targets: 7.00 HackerOne signal — precision over volume.
+
+## Title Convention
+
+Format: `[Component]: [Vulnerability Class] via [Mechanism]`
+
+Good titles (from real accepted advisories):
+- `zrok: WebDAV drive backend follows symlinks outside DriveRoot, enabling host filesystem read/write`
+- `Parse Server: cloud function validator bypass via prototype chain traversal`
+- `Directus: TUS Upload Authorization Bypass Allows Arbitrary File Overwrite`
+- `lodash: Code Injection via _.template imports key names`
+- `AVideo: Unauthenticated SSRF via HTTP redirect bypass in LiveLinks proxy`
+- `OpenFGA: Unauthenticated playground endpoint discloses preshared API key`
+
+Rules:
+- Component name first (the project/package name)
+- Vulnerability class in plain English (not CWE numbers in the title)
+- Mechanism must be specific (not "via user input" — say "via prototype chain traversal")
+- No adjectives like "critical" or "severe" in the title
+- Under 120 characters
+
+## Report Template
+
+Write to `workspace/findings/BOUNTY-{finding_id}.md`:
+
+```markdown
+# {Title}
+
+## Summary
+
+{One paragraph. State what the bug is, where it lives (file:line or endpoint),
+and what impact it has. Three sentences maximum.}
+
+## Severity
+
+**CVSS 3.1**: {full vector string} ({score} {severity_label})
+
+| Metric | Value | Justification |
+|--------|-------|---------------|
+| AV | Network | Exploitable over HTTP |
+| AC | Low | No special conditions |
+| PR | None | No authentication required |
+| UI | None | No user interaction |
+| S | Unchanged | Impact limited to vulnerable component |
+| C | High | Full read access to filesystem |
+| I | None | No write capability demonstrated |
+| A | None | No availability impact |
+
+## Affected Version
+
+- Package: {name}
+- Version: {exact version or range}
+- Commit: {commit hash if applicable}
+
+## Steps to Reproduce
+
+1. {Exact setup step — e.g., "Clone the repository: `git clone ...`"}
+2. {Exact action — e.g., "Start the server: `npm start`"}
+3. {Exact exploit — e.g., "Send the following request:"}
+
+## Proof of Concept
+
+\```bash
+{Exact command that demonstrates the vulnerability}
+\```
+
+**Expected response (vulnerable):**
+\```
+{Exact output showing exploitation}
+\```
+
+**Baseline response (not vulnerable):**
+\```
+{Output from the same request without the payload}
+\```
+
+## Impact
+
+{What an attacker can actually do with this bug. Only state impacts you
+demonstrated in the PoC. Do NOT extrapolate to theoretical scenarios.}
+
+## Remediation
+
+{Specific code fix. Show the diff or the corrected code.}
+
+\```diff
+- const user = db.query(`SELECT * FROM users WHERE id=${req.params.id}`)
++ const user = db.query(`SELECT * FROM users WHERE id=$1`, [req.params.id])
+\```
+```
+
+## Quality Checklist
+
+Before writing the report, verify each item:
+
+- [ ] Title follows `Component: VulnClass via Mechanism` format
+- [ ] Summary is ≤3 sentences
+- [ ] CVSS vector string is complete (not just a number)
+- [ ] Every CVSS metric has a justification (not default values)
+- [ ] Steps to reproduce are exact commands, not descriptions
+- [ ] PoC is a single copy-pasteable command
+- [ ] Baseline/negative response is included (proves the PoC is meaningful)
+- [ ] Impact describes only demonstrated effects
+- [ ] Remediation is a specific code fix, not generic advice
+- [ ] Affected version is exact (not "all versions" unless verified)
+- [ ] Total report is under 500 words (excluding code blocks)
+- [ ] No filler phrases: "an attacker could potentially", "this might allow",
+      "it is recommended to", "in certain conditions"
+- [ ] No severity inflation beyond what the PoC proves
+- [ ] Finding is in scope for the target program
+- [ ] Not a duplicate of an existing finding (`kg_query(kind="finding")`)
+
+## Platform-Specific Notes
+
+### HackerOne
+- Use their severity rating (maps from CVSS)
+- Reference CWE numbers in the weakness field
+- Attach PoC scripts as files if longer than 10 lines
+- Include the CVSS calculator link: `https://www.first.org/cvss/calculator/3.1#CVSS:3.1/...`
+
+### Bugcrowd
+- Map to their Vulnerability Rating Taxonomy (VRT)
+- P1 = Critical (9.0-10.0), P2 = High (7.0-8.9), P3 = Medium (4.0-6.9), P4 = Low (0.1-3.9)
+
+### GitHub Security Advisories
+- Use the GHSA template: affected package, affected versions, patched versions
+- Include the CWE in the advisory metadata
+- Credit field: your username or team name
+
+### Immunefi
+- Web3/DeFi focus: quantify financial impact when possible
+- Include affected contract addresses if applicable
+- Reference the specific bounty program's scope document

--- a/tests/unit/research/test_bounty.py
+++ b/tests/unit/research/test_bounty.py
@@ -8,12 +8,8 @@ backend.
 
 from __future__ import annotations
 
-import importlib
 import sys
 from unittest.mock import MagicMock
-
-import pytest
-
 
 # ── Stub heavy transitive imports ────────────────────────────────────────
 # ``decepticon.tools.research.bounty`` transitively pulls in
@@ -51,8 +47,8 @@ def _ensure_stubs() -> None:
 _ensure_stubs()
 
 from decepticon.tools.research.bounty import (  # noqa: E402
-    BOUNTY_TOOLS,
     _COMMONLY_EXCLUDED,
+    BOUNTY_TOOLS,
     _normalize_class,
     _severity_label,
 )

--- a/tests/unit/research/test_bounty.py
+++ b/tests/unit/research/test_bounty.py
@@ -1,0 +1,180 @@
+"""Unit tests for bug bounty tools — pure functions and constants.
+
+NOTE: The full tool surface (``bounty_scope_check``, ``format_bounty_report``)
+requires the ``deepagents`` runtime and Docker sandbox. These tests validate
+the pure-function helpers and data structures that can run without the full
+backend.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ── Stub heavy transitive imports ────────────────────────────────────────
+# ``decepticon.tools.research.bounty`` transitively pulls in
+# ``decepticon.backends.docker_sandbox`` which requires ``deepagents``.
+# We stub just enough of the import chain so the pure functions load.
+
+
+def _ensure_stubs() -> None:
+    """Insert lightweight stubs for modules that require runtime infra."""
+    stubs = [
+        "deepagents",
+        "deepagents.middleware",
+        "deepagents.middleware.patch_tool_calls",
+        "deepagents.middleware.summarization",
+        "deepagents.middleware.subagents",
+        "deepagents.backends",
+        "deepagents.backends.protocol",
+        "deepagents.backends.sandbox",
+        "langchain",
+        "langchain.agents",
+        "langchain.agents.middleware",
+        "langchain_anthropic",
+        "langchain_anthropic.middleware",
+        "docker",
+        "docker.models",
+        "docker.models.containers",
+        "docker.errors",
+        "neo4j",
+    ]
+    for name in stubs:
+        if name not in sys.modules:
+            sys.modules[name] = MagicMock()
+
+
+_ensure_stubs()
+
+from decepticon.tools.research.bounty import (  # noqa: E402
+    BOUNTY_TOOLS,
+    _COMMONLY_EXCLUDED,
+    _normalize_class,
+    _severity_label,
+)
+from decepticon.tools.research.graph import (  # noqa: E402
+    Edge,
+    EdgeKind,
+    KnowledgeGraph,
+    Node,
+    NodeKind,
+)
+
+
+class TestNormalizeClass:
+    def test_basic_normalization(self) -> None:
+        assert _normalize_class("SQL Injection") == "sql-injection"
+        assert _normalize_class("  Self XSS  ") == "self-xss"
+        assert _normalize_class("Rate_Limiting") == "rate-limiting"
+
+    def test_already_normalized(self) -> None:
+        assert _normalize_class("ssrf") == "ssrf"
+        assert _normalize_class("path-traversal") == "path-traversal"
+
+    def test_empty_string(self) -> None:
+        assert _normalize_class("") == ""
+
+
+class TestSeverityLabel:
+    def test_critical(self) -> None:
+        assert _severity_label(9.8) == "Critical"
+        assert _severity_label(9.0) == "Critical"
+
+    def test_high(self) -> None:
+        assert _severity_label(8.5) == "High"
+        assert _severity_label(7.0) == "High"
+
+    def test_medium(self) -> None:
+        assert _severity_label(6.9) == "Medium"
+        assert _severity_label(4.0) == "Medium"
+
+    def test_low(self) -> None:
+        assert _severity_label(3.9) == "Low"
+        assert _severity_label(0.1) == "Low"
+
+    def test_info(self) -> None:
+        assert _severity_label(0.0) == "Informational"
+
+    def test_boundary_values(self) -> None:
+        assert _severity_label(10.0) == "Critical"
+        assert _severity_label(7.0) == "High"  # exactly 7.0 is High
+        assert _severity_label(4.0) == "Medium"  # exactly 4.0 is Medium
+
+
+class TestCommonlyExcluded:
+    def test_self_xss_excluded(self) -> None:
+        assert "self-xss" in _COMMONLY_EXCLUDED
+
+    def test_dos_excluded(self) -> None:
+        assert "dos" in _COMMONLY_EXCLUDED
+        assert "denial-of-service" in _COMMONLY_EXCLUDED
+
+    def test_clickjacking_excluded(self) -> None:
+        assert "clickjacking" in _COMMONLY_EXCLUDED
+
+    def test_high_impact_classes_not_excluded(self) -> None:
+        """RCE, SQLi, SSRF, XSS etc should never be in the exclusion set."""
+        assert "rce" not in _COMMONLY_EXCLUDED
+        assert "sqli" not in _COMMONLY_EXCLUDED
+        assert "sql-injection" not in _COMMONLY_EXCLUDED
+        assert "ssrf" not in _COMMONLY_EXCLUDED
+        assert "xss" not in _COMMONLY_EXCLUDED
+        assert "idor" not in _COMMONLY_EXCLUDED
+        assert "path-traversal" not in _COMMONLY_EXCLUDED
+        assert "rce" not in _COMMONLY_EXCLUDED
+
+
+class TestFindLinkedVuln:
+    """Test _find_linked_vuln with real graph objects."""
+
+    def test_finds_via_validates_edge(self) -> None:
+        from decepticon.tools.research.bounty import _find_linked_vuln
+
+        graph = KnowledgeGraph()
+        vuln = Node.make(NodeKind.VULNERABILITY, "test vuln", key="v1")
+        finding = Node.make(NodeKind.FINDING, "test finding", key="f1")
+        graph.upsert_node(vuln)
+        graph.upsert_node(finding)
+        graph.upsert_edge(Edge.make(finding.id, vuln.id, EdgeKind.VALIDATES))
+
+        result = _find_linked_vuln(graph, finding.id)
+        assert result is not None
+        assert result.id == vuln.id
+
+    def test_finds_via_maps_to_edge(self) -> None:
+        from decepticon.tools.research.bounty import _find_linked_vuln
+
+        graph = KnowledgeGraph()
+        vuln = Node.make(NodeKind.VULNERABILITY, "test vuln", key="v2")
+        finding = Node.make(NodeKind.FINDING, "test finding", key="f2")
+        graph.upsert_node(vuln)
+        graph.upsert_node(finding)
+        graph.upsert_edge(Edge.make(finding.id, vuln.id, EdgeKind.MAPS_TO))
+
+        result = _find_linked_vuln(graph, finding.id)
+        assert result is not None
+        assert result.id == vuln.id
+
+    def test_returns_none_when_no_link(self) -> None:
+        from decepticon.tools.research.bounty import _find_linked_vuln
+
+        graph = KnowledgeGraph()
+        finding = Node.make(NodeKind.FINDING, "orphan", key="f3")
+        graph.upsert_node(finding)
+
+        result = _find_linked_vuln(graph, finding.id)
+        assert result is None
+
+
+class TestBountyToolsExport:
+    def test_bounty_tools_has_two_entries(self) -> None:
+        assert len(BOUNTY_TOOLS) == 2
+
+    def test_tool_names(self) -> None:
+        names = {t.name for t in BOUNTY_TOOLS}
+        assert "bounty_scope_check" in names
+        assert "format_bounty_report" in names


### PR DESCRIPTION
## Summary

Adds BugBunny-style bug bounty methodology to the vulnresearch pipeline. Based on reverse-engineering the public track record of [BugBunny.ai](https://bugbunny.ai/) (29 CVEs, 7.00 HackerOne signal, 26 GitHub security advisory credits) — specifically their white-box source analysis approach, trust boundary auditing, and pattern exhaustion technique.

## What changed

### New skills (4 files)
- **`skills/analyst/bounty-hunting/SKILL.md`** — White-box hunting methodology: target assessment (download count, trust boundary complexity, advisory history), evidence standards, report title conventions
- **`skills/analyst/trust-boundary/SKILL.md`** — Startup sequence audit for developer tools/CLI apps: config loading order, env var injection, workspace trust defaults, shell quoting vulnerabilities. Inspired by the [Gemini CLI 5-RCE research](https://bugbunny.ai/blog/google-gemini-cli-rce-2025)
- **`skills/analyst/pattern-exhaustion/SKILL.md`** — One root cause → multiple CVEs: classify pattern, systematic grep/semgrep search, variant generation, exhaustion criteria. Modeled on BugBunny finding 4 advisories in Parse Server from one guard bypass pattern
- **`skills/verifier/bounty-report/SKILL.md`** — Platform-ready report formatting for HackerOne/Bugcrowd/Immunefi/GitHub with quality checklist

### New tools (1 file)
- **`decepticon/tools/research/bounty.py`**
  - `bounty_scope_check` — Validates target + vuln class against program scope and commonly excluded classes before reporting
  - `format_bounty_report` — Generates platform-ready report from a validated FINDING node in the knowledge graph

### Modified files (2 files)
- **`decepticon/agents/analyst.py`** — Wired `BOUNTY_TOOLS` into the analyst agent tool surface
- **`decepticon/agents/prompts/analyst.md`** — Added three new hunting lanes:
  - Lane F: Trust boundary analysis (developer tools / CLI apps)
  - Lane G: Pattern exhaustion (after confirming any finding)
  - Lane H: Bug bounty target assessment

### Tests (1 file)
- **`tests/unit/research/test_bounty.py`** — 18 unit tests covering pure functions, graph linking, exports

## Why this matters

The vulnresearch pipeline already has strong foundations (ZFP validation, knowledge graph, attack chain planning). What was missing was **bounty-specific methodology** — the techniques that separate a 7.00 HackerOne signal from AI slop:

1. **White-box over black-box** — Read source, trace trust boundaries, find architectural flaws (not just fuzz endpoints)
2. **Pattern exhaustion** — One confirmed finding → systematic search for all instances of the same root cause
3. **Trust boundary analysis** — Dedicated lane for developer tools that auto-load untrusted config
4. **Report quality** — Platform-specific formatting optimized for acceptance rate, not word count
5. **Scope enforcement** — Pre-submission validation against program exclusions

## Risk assessment

- Skills are pure markdown guidance — zero runtime risk
- New hunting lanes are additive (F, G, H after existing A–E) — agent picks based on relevance
- `bounty.py` uses the same `_load`/`_save`/`_json` primitives as all existing tools
- Only modification to existing code: one import + tool list expansion in `analyst.py`