### PR TITLE
feat(llm): upgrade DeepSeek to V4 model names (v4-pro, v4-flash)

### DIFF
--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -316,7 +316,7 @@ litellm_settings:
     # MiniMax (no LOW tier)
     - {"minimax/MiniMax-M2.5": ["minimax/MiniMax-M2.5-lightning"]}
     # DeepSeek
-    - {"deepseek/deepseek-reasoner": ["deepseek/deepseek-chat"]}
+    - {"deepseek/deepseek-v4-pro": ["deepseek/deepseek-v4-flash"]}
     # xAI direct + SuperGrok subscription (no LOW tier on either)
     - {"xai/grok-3": ["xai/grok-3-mini"]}
     - {"grok-sub/grok-3": ["grok-sub/grok-3-mini"]}

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -116,6 +116,18 @@ model_list:
       model: auth/claude-haiku-4-5
 
   # ── DeepSeek ─────────────────────────────────────────────────────────
+  # V4 models (released 2026-04-24, 1M context, thinking + non-thinking)
+  - model_name: deepseek/deepseek-v4-pro
+    litellm_params:
+      model: deepseek/deepseek-v4-pro
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+  - model_name: deepseek/deepseek-v4-flash
+    litellm_params:
+      model: deepseek/deepseek-v4-flash
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+  # Legacy names (deprecated 2026-07-24, kept for fallback)
   - model_name: deepseek/deepseek-chat
     litellm_params:
       model: deepseek/deepseek-chat

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -137,9 +137,9 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.MID: "gemini-sub/gemini-2.5-flash",
     },
     AuthMethod.DEEPSEEK_API: {
-        Tier.HIGH: "deepseek/deepseek-reasoner",
-        Tier.MID: "deepseek/deepseek-chat",
-        Tier.LOW: "deepseek/deepseek-chat",
+        Tier.HIGH: "deepseek/deepseek-v4-pro",
+        Tier.MID: "deepseek/deepseek-v4-flash",
+        Tier.LOW: "deepseek/deepseek-v4-flash",
     },
     AuthMethod.XAI_API: {
         Tier.HIGH: "xai/grok-3",

--- a/docs/models.md
+++ b/docs/models.md
@@ -29,7 +29,7 @@ For each agent, Decepticon resolves a tier (from the profile) and walks your Aut
 | `google_api`          | `gemini/gemini-2.5-pro`                   | `gemini/gemini-2.5-flash`                     | `gemini/gemini-2.5-flash-lite`                |
 | `google_oauth`        | `gemini-sub/gemini-2.5-pro`               | `gemini-sub/gemini-2.5-flash`                 | — *(falls through)*                           |
 | `minimax_api`         | `minimax/MiniMax-M2.5`                    | `minimax/MiniMax-M2.5-lightning`              | — *(falls through)*                           |
-| `deepseek_api`        | `deepseek/deepseek-reasoner`              | `deepseek/deepseek-chat`                      | `deepseek/deepseek-chat`                      |
+| `deepseek_api`        | `deepseek/deepseek-v4-pro`                | `deepseek/deepseek-v4-flash`                   | `deepseek/deepseek-v4-flash`                   |
 | `xai_api`             | `xai/grok-3`                              | `xai/grok-3-mini`                             | — *(falls through)*                           |
 | `grok_oauth`          | `grok-sub/grok-3`                         | `grok-sub/grok-3-mini`                        | — *(falls through)*                           |
 | `mistral_api`         | `mistral/mistral-large-latest`            | `mistral/codestral-latest`                    | — *(falls through)*                           |

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -54,7 +54,7 @@ class TestLLMFactory:
         assert names == [
             "openai/gpt-5-nano",
             "gemini/gemini-2.5-flash-lite",
-            "deepseek/deepseek-chat",
+            "deepseek/deepseek-v4-flash",
             "openrouter/anthropic/claude-haiku-4-5",
             "nvidia_nim/meta/llama-3.2-3b-instruct",
         ]
@@ -66,7 +66,7 @@ class TestLLMFactory:
             "openai/gpt-5.5",
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M2.5",
-            "deepseek/deepseek-reasoner",
+            "deepseek/deepseek-v4-pro",
             "xai/grok-3",
             "mistral/mistral-large-latest",
             "openrouter/anthropic/claude-opus-4-7",

--- a/tests/unit/llm/test_models.py
+++ b/tests/unit/llm/test_models.py
@@ -385,7 +385,7 @@ class TestLLMModelMapping:
             "openai/gpt-5.5",
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M2.5",
-            "deepseek/deepseek-reasoner",
+            "deepseek/deepseek-v4-pro",
             "xai/grok-3",
             "mistral/mistral-large-latest",
             "openrouter/anthropic/claude-opus-4-7",

--- a/tests/unit/llm/test_router.py
+++ b/tests/unit/llm/test_router.py
@@ -31,7 +31,7 @@ class TestModelRouter:
             "anthropic/claude-haiku-4-5",
             "openai/gpt-5-nano",
             "gemini/gemini-2.5-flash-lite",
-            "deepseek/deepseek-chat",
+            "deepseek/deepseek-v4-flash",
             "openrouter/anthropic/claude-haiku-4-5",
             "nvidia_nim/meta/llama-3.2-3b-instruct",
         ]
@@ -43,7 +43,7 @@ class TestModelRouter:
             "openai/gpt-5.5",
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M2.5",
-            "deepseek/deepseek-reasoner",
+            "deepseek/deepseek-v4-pro",
             "xai/grok-3",
             "mistral/mistral-large-latest",
             "openrouter/anthropic/claude-opus-4-7",


### PR DESCRIPTION
## Summary

Upgrades DeepSeek model IDs from the deprecated `deepseek-chat`/`deepseek-reasoner` to the new V4 names released 2026-04-24.

## Changes

### `decepticon/llm/models.py`
- `Tier.HIGH`: `deepseek/deepseek-reasoner` → `deepseek/deepseek-v4-pro`
- `Tier.MID`: `deepseek/deepseek-chat` → `deepseek/deepseek-v4-flash`
- `Tier.LOW`: `deepseek/deepseek-chat` → `deepseek/deepseek-v4-flash`

### `config/litellm.yaml`
- Added `deepseek/deepseek-v4-pro` and `deepseek/deepseek-v4-flash` LiteLLM entries
- Kept legacy `deepseek-chat`/`deepseek-reasoner` entries as fallback until deprecation

## Why

Per [DeepSeek API docs](https://api-docs.deepseek.com/news/news260424):
- `deepseek-chat` and `deepseek-reasoner` will be **fully retired 2026-07-24**
- Both V4 models support 1M context, thinking mode (high/max effort), tool calls, and 384K max output
- V4-Pro is 75% off until 2026-05-31

## Model specs

| Model | Params | Context | Max Output |
|-------|--------|---------|------------|
| deepseek-v4-pro | 1.6T total / 49B active | 1M | 384K |
| deepseek-v4-flash | 284B total / 13B active | 1M | 384K |

## `.env` configuration

```bash
DEEPSEEK_API_KEY=<your key>
DECEPTICON_AUTH_PRIORITY=deepseek_api
DECEPTICON_MODEL_PROFILE=max
```

With `max` profile, all 17 agents use `deepseek-v4-pro`. With `eco` profile, orchestrator/exploiter/patcher/analyst get V4-Pro, recon/scanner get V4-Flash.