### PR TITLE
fix(llm): Ollama local LLM end-to-end — strict probe + ollama_chat/ enforcement

### DIFF
--- a/clients/launcher/cmd/ollama_models.go
+++ b/clients/launcher/cmd/ollama_models.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ollamaProbeClient is the HTTP client for onboard-time model
+// discovery. Tests swap it via withOllamaProbeClient.
+var ollamaProbeClient = &http.Client{Timeout: 1500 * time.Millisecond}
+
+// ollamaProbeMaxBody caps response reads. /api/tags and /api/show
+// payloads are tiny in practice; the cap is defense-in-depth against
+// a misconfigured reverse proxy returning an unbounded HTML page.
+const ollamaProbeMaxBody = 2 << 20 // 2 MiB
+
+// ollamaProbeResult drives the wizard's UI branch. Reachable=true with
+// empty ToolCapableModels means Ollama is up but has nothing usable
+// pulled; Reachable=false means we couldn't reach it at all.
+type ollamaProbeResult struct {
+	Reachable         bool
+	ToolCapableModels []string
+}
+
+// probeOllamaForOnboard returns models on the host that advertise
+// ``tools``. Multi-candidate URL strategy mirrors the host-side
+// reachability probe; the first candidate to answer /api/tags wins.
+// Per-model /api/show calls run in parallel so a power user with many
+// pulled models still finishes inside the wizard's overall budget.
+func probeOllamaForOnboard(baseURL string) ollamaProbeResult {
+	for _, candidate := range candidateProbeURLs(baseURL) {
+		models, ok := fetchOllamaTags(candidate)
+		if !ok {
+			continue
+		}
+		return ollamaProbeResult{
+			Reachable:         true,
+			ToolCapableModels: filterToolCapable(candidate, models),
+		}
+	}
+	return ollamaProbeResult{}
+}
+
+// filterToolCapable returns the subset of ``models`` whose /api/show
+// response advertises the ``tools`` capability. Each call goes out
+// concurrently — Ollama answers /api/show locally and the wizard's
+// overall budget is small, so serializing the calls would only matter
+// for users with many pulled models, but parallelizing costs nothing.
+func filterToolCapable(baseURL string, models []string) []string {
+	results := make([]bool, len(models))
+	var wg sync.WaitGroup
+	for i, m := range models {
+		wg.Add(1)
+		go func(i int, m string) {
+			defer wg.Done()
+			results[i] = hasOllamaToolsCapability(baseURL, m)
+		}(i, m)
+	}
+	wg.Wait()
+	capable := make([]string, 0, len(models))
+	for i, ok := range results {
+		if ok {
+			capable = append(capable, models[i])
+		}
+	}
+	return capable
+}
+
+type ollamaTag struct {
+	Name string `json:"name"`
+}
+
+type ollamaTagsResponse struct {
+	Models []ollamaTag `json:"models"`
+}
+
+type ollamaShowResponse struct {
+	Capabilities []string `json:"capabilities"`
+}
+
+// fetchOllamaTags returns the /api/tags model names plus an ok flag —
+// distinguishes "answered with zero models" from "no answer" since
+// both produce empty slices but mean different things to the wizard.
+func fetchOllamaTags(baseURL string) ([]string, bool) {
+	resp, err := ollamaProbeClient.Get(strings.TrimRight(baseURL, "/") + "/api/tags")
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, false
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ollamaProbeMaxBody))
+	if err != nil {
+		return nil, false
+	}
+	var data ollamaTagsResponse
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, false
+	}
+	out := make([]string, 0, len(data.Models))
+	for _, m := range data.Models {
+		if name := strings.TrimSpace(m.Name); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out, true
+}
+
+// hasOllamaToolsCapability returns true only when /api/show lists
+// ``tools`` in capabilities. Older Ollama (< 0.3) without the field
+// reports false — the wizard's strict list stays trustworthy.
+func hasOllamaToolsCapability(baseURL, model string) bool {
+	payload, err := json.Marshal(map[string]string{"name": model})
+	if err != nil {
+		return false
+	}
+	resp, err := ollamaProbeClient.Post(
+		strings.TrimRight(baseURL, "/")+"/api/show",
+		"application/json",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ollamaProbeMaxBody))
+	if err != nil {
+		return false
+	}
+	var data ollamaShowResponse
+	if err := json.Unmarshal(body, &data); err != nil {
+		return false
+	}
+	for _, c := range data.Capabilities {
+		if c == "tools" {
+			return true
+		}
+	}
+	return false
+}

--- a/clients/launcher/cmd/ollama_models_test.go
+++ b/clients/launcher/cmd/ollama_models_test.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withOllamaProbeClient swaps ollamaProbeClient for one test.
+func withOllamaProbeClient(t *testing.T, c *http.Client) {
+	t.Helper()
+	prev := ollamaProbeClient
+	ollamaProbeClient = c
+	t.Cleanup(func() { ollamaProbeClient = prev })
+}
+
+// ollamaTestServer fakes /api/tags and /api/show. A nil capabilities
+// entry simulates older Ollama (no capabilities field); a missing
+// entry causes /api/show to 404.
+func ollamaTestServer(t *testing.T, capabilities map[string][]string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
+		models := make([]map[string]string, 0, len(capabilities))
+		for name := range capabilities {
+			models = append(models, map[string]string{"name": name})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"models": models})
+	})
+	mux.HandleFunc("/api/show", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		var req struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "decode body", http.StatusBadRequest)
+			return
+		}
+		caps, ok := capabilities[req.Name]
+		if !ok {
+			http.Error(w, "model not found", http.StatusNotFound)
+			return
+		}
+		if caps == nil {
+			// Older Ollama: omit capabilities field entirely.
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": caps})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func sortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+func TestProbeOllamaForOnboard_FiltersToToolSupporters(t *testing.T) {
+	withProbeStubs(t, false, "")
+	srv := ollamaTestServer(t, map[string][]string{
+		"qwen3-coder:30b": {"completion", "tools"},
+		"llama3.2":        {"completion", "tools"},
+		"gemma:2b":        {"completion"},
+	})
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	got := probeOllamaForOnboard(srv.URL)
+	if !got.Reachable {
+		t.Fatalf("expected Reachable=true when /api/tags answers")
+	}
+
+	// Tags response order isn't guaranteed (map iteration), so compare
+	// as a sorted slice rather than relying on order.
+	if !reflect.DeepEqual(sortedCopy(got.ToolCapableModels), []string{"llama3.2", "qwen3-coder:30b"}) {
+		t.Errorf("expected only tool-capable models, got %v", got.ToolCapableModels)
+	}
+	for _, m := range got.ToolCapableModels {
+		if m == "gemma:2b" {
+			t.Errorf("gemma:2b lacks tools capability and must not be returned")
+		}
+	}
+}
+
+func TestProbeOllamaForOnboard_EmptyTagsIsReachableButNoModels(t *testing.T) {
+	// Ollama up but no models pulled: Reachable=true with empty
+	// ToolCapableModels, distinct from the unreachable case.
+	withProbeStubs(t, false, "")
+	srv := ollamaTestServer(t, map[string][]string{})
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	got := probeOllamaForOnboard(srv.URL)
+	if !got.Reachable {
+		t.Errorf("empty tags response should still mark Ollama as reachable")
+	}
+	if len(got.ToolCapableModels) != 0 {
+		t.Errorf("expected empty tool-capable list, got %v", got.ToolCapableModels)
+	}
+}
+
+func TestProbeOllamaForOnboard_AllModelsLackToolsReturnsEmpty(t *testing.T) {
+	withProbeStubs(t, false, "")
+	srv := ollamaTestServer(t, map[string][]string{
+		"gemma:2b":   {"completion"},
+		"phi-3:mini": {"completion"},
+	})
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	got := probeOllamaForOnboard(srv.URL)
+	if !got.Reachable {
+		t.Errorf("Ollama with non-empty tags must be reachable")
+	}
+	if len(got.ToolCapableModels) != 0 {
+		t.Errorf("no models advertise tools — expected empty slice, got %v", got.ToolCapableModels)
+	}
+}
+
+func TestProbeOllamaForOnboard_OllamaDownReturnsUnreachable(t *testing.T) {
+	withProbeStubs(t, false, "")
+	withOllamaProbeClient(t, &http.Client{Timeout: 250 * time.Millisecond})
+
+	// Closed port — connection refused fires fast.
+	got := probeOllamaForOnboard("http://127.0.0.1:1") // port 1: tcpmux, almost never bound
+	if got.Reachable {
+		t.Errorf("unreachable Ollama must mark Reachable=false")
+	}
+	if got.ToolCapableModels != nil {
+		t.Errorf("unreachable Ollama must yield nil models, got %v", got.ToolCapableModels)
+	}
+}
+
+func TestProbeOllamaForOnboard_MissingCapabilitiesIsTreatedAsIncompatible(t *testing.T) {
+	// Older Ollama (< 0.3) lacks the capabilities field — wizard must
+	// fail closed since tool support can't be confirmed.
+	withProbeStubs(t, false, "")
+	srv := ollamaTestServer(t, map[string][]string{
+		"old-model": nil, // no capabilities key
+	})
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	got := probeOllamaForOnboard(srv.URL)
+	if !got.Reachable {
+		t.Errorf("Ollama responded with /api/tags so it must be reachable")
+	}
+	if len(got.ToolCapableModels) != 0 {
+		t.Errorf("model without capabilities field must not be marked tool-capable, got %v", got.ToolCapableModels)
+	}
+}
+
+func TestProbeOllamaForOnboard_TrimsTrailingSlash(t *testing.T) {
+	withProbeStubs(t, false, "")
+	srv := ollamaTestServer(t, map[string][]string{
+		"llama3.2": {"completion", "tools"},
+	})
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	got := probeOllamaForOnboard(srv.URL + "/")
+	if !got.Reachable {
+		t.Errorf("trailing-slash URL should still reach the server")
+	}
+	if !reflect.DeepEqual(got.ToolCapableModels, []string{"llama3.2"}) {
+		t.Errorf("trailing-slash URL should be normalized; got %v", got.ToolCapableModels)
+	}
+}
+
+func TestProbeOllamaForOnboard_MalformedTagsBodyIsTolerated(t *testing.T) {
+	// 200-OK with non-JSON body must yield Reachable=false, not panic.
+	withProbeStubs(t, false, "")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html>oops</html>"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	got := probeOllamaForOnboard(srv.URL)
+	if got.Reachable {
+		t.Errorf("malformed body must not count as reachable")
+	}
+	if got.ToolCapableModels != nil {
+		t.Errorf("malformed body should yield nil models, got %v", got.ToolCapableModels)
+	}
+}
+
+func TestHasOllamaToolsCapability_PostsExpectedBody(t *testing.T) {
+	// /api/show is POST-only and reads the model name from the JSON body.
+	withProbeStubs(t, false, "")
+	var receivedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/show", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"tools"}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	withOllamaProbeClient(t, &http.Client{Timeout: 2 * time.Second})
+
+	if !hasOllamaToolsCapability(srv.URL, "qwen3-coder:30b") {
+		t.Errorf("expected tools capability for the served response")
+	}
+	if !strings.Contains(receivedBody, `"name":"qwen3-coder:30b"`) {
+		t.Errorf("expected POST body to carry model name, got %q", receivedBody)
+	}
+}

--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -4,12 +4,19 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"charm.land/huh/v2"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
 	"github.com/spf13/cobra"
 )
+
+// onboardOllamaProbeBudget bounds the wait for the background Ollama
+// discovery probe at form-construction time. Per-request timeout
+// (ollama_models.go) is much shorter; this is the worst-case across
+// all candidate URLs.
+const onboardOllamaProbeBudget = 3 * time.Second
 
 var resetFlag bool
 
@@ -44,12 +51,18 @@ const (
 	methodOllamaLocal      = "ollama_local"
 )
 
-// Default Ollama wiring shown to OSS users. host.docker.internal works
-// out of the box on macOS, Docker Desktop on Windows/WSL2, and on
-// Linux thanks to the ``extra_hosts: [host.docker.internal:host-gateway]``
-// entry on the litellm service in docker-compose.yml. WSL2 users who
-// installed Ollama *inside* the WSL distro itself (rather than on the
-// Windows host) need to override this with http://localhost:11434.
+// Default Ollama wiring shown to OSS users. ``host.docker.internal``
+// is the universal answer regardless of where Ollama runs (macOS host,
+// WSL2 distro, native Linux): from inside Decepticon's containers it
+// resolves to the host network namespace via the
+// ``extra_hosts: [host.docker.internal:host-gateway]`` entry on the
+// litellm service in docker-compose.yml. ``localhost`` is never the
+// right answer here — that's the container itself.
+//
+// The host's Ollama must additionally be bound to 0.0.0.0 (the default
+// 127.0.0.1 binding only accepts host-side connections); the wizard
+// surfaces this requirement to the user.
+//
 // The default model is the smallest/fastest one most laptops can
 // actually run; users with a GPU will pick something like qwen3-coder:30b.
 const (
@@ -91,6 +104,14 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Kick off Ollama discovery in the background so the network
+	// round-trip overlaps with huh's startup work; the OLLAMA_MODEL
+	// field type depends on the result (Select vs remediation Note).
+	probeCh := make(chan ollamaProbeResult, 1)
+	go func() {
+		probeCh <- probeOllamaForOnboard(defaultOllamaAPIBase)
+	}()
+
 	var (
 		methods                []string
 		anthropicKey           string
@@ -113,6 +134,19 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		useLangSmith           bool
 		langSmithKey           string
 	)
+
+	// Block on the probe (zero-value result on timeout means
+	// "unreachable" — drops through to the remediation Note).
+	// time.NewTimer + Stop avoids the time.After timer leak when the
+	// probe finishes first.
+	probeTimer := time.NewTimer(onboardOllamaProbeBudget)
+	var ollamaProbe ollamaProbeResult
+	select {
+	case ollamaProbe = <-probeCh:
+		probeTimer.Stop()
+	case <-probeTimer.C:
+	}
+	ollamaModelField := buildOllamaModelField(ollamaProbe, &ollamaModel)
 
 	form := huh.NewForm(
 		// Intro
@@ -331,29 +365,20 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		).Title("2 / 4  ·  Perplexity Pro").
 			WithHideFunc(func() bool { return !contains(methods, methodPerplexityOAuth) }),
 
-		// Step 2g: Local Ollama
-		// No API key — the user provides only the endpoint and the model
-		// tag they pulled (``ollama pull qwen3-coder:30b``). The proxy
-		// dynamically registers ``ollama_chat/<model>`` at startup via
-		// litellm_dynamic_config.py — no yaml editing needed. The
-		// ``ollama_chat/`` provider routes to /api/chat which is the
-		// only Ollama endpoint that supports tool/function calling, and
-		// every Decepticon agent uses tools.
+		// Step 2g: Local Ollama. The OLLAMA_MODEL field is built from
+		// the host probe (buildOllamaModelField): a strict Select when
+		// tool-capable models are pulled, a remediation Note otherwise.
+		// The post-form gate refuses to write .env in the Note cases.
 		huh.NewGroup(
 			huh.NewNote().
 				Title("Local Ollama").
-				Description("Ollama must already be running on your host\n(`ollama serve`) with the model pulled\n(`ollama pull <name>`).\n\nLeave the URL as-is on macOS / Linux Docker /\nDocker Desktop on Windows or WSL2 with Ollama\nrunning on the Windows host.\n\nIf Ollama runs INSIDE your WSL distro instead,\nchange it to http://localhost:11434.\n\nFor remote / custom setups use the full URL."),
+				Description("Ollama must already be running on your host with\nat least one tool-capable model pulled. Launch it\nbound to all interfaces so the Decepticon container\ncan reach it:\n\n  OLLAMA_HOST=0.0.0.0:11434 ollama serve\n\nThe default 127.0.0.1 binding only accepts host-side\nconnections — containers won't see it.\n\nThe default URL `host.docker.internal:11434` works\non macOS, Linux, and WSL2 (with or without Docker\nDesktop). Only change it for remote / custom setups.\nNote: the model list is probed against the default URL\nat wizard start; if you customize OLLAMA_API_BASE,\nfinish the wizard then re-run 'decepticon onboard\n--reset' so the probe targets the new endpoint."),
 			huh.NewInput().
 				Title("OLLAMA_API_BASE").
 				Placeholder(defaultOllamaAPIBase).
 				Value(&ollamaAPIBase).
 				Validate(nonEmpty),
-			huh.NewInput().
-				Title("OLLAMA_MODEL").
-				Description("Any tag you pulled. Examples: qwen3-coder:30b,\nllama3.2, deepseek-r1:14b, mistral-small3.").
-				Placeholder(defaultOllamaModel).
-				Value(&ollamaModel).
-				Validate(nonEmpty),
+			ollamaModelField,
 		).Title("2 / 4  ·  Local LLM (Ollama)").
 			WithHideFunc(func() bool { return !contains(methods, methodOllamaLocal) }),
 
@@ -394,6 +419,14 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 
 	if err := form.Run(); err != nil {
 		return fmt.Errorf("setup cancelled: %w", err)
+	}
+
+	// Strict-mode gate: refuse to write .env when the user picked
+	// Ollama but the host probe found no tool-capable model. The
+	// in-form Note shows the same remediation; this is the boundary
+	// guarantee that a broken setup never ships.
+	if contains(methods, methodOllamaLocal) && len(ollamaProbe.ToolCapableModels) == 0 {
+		return ollamaUnusableError(ollamaProbe, ollamaAPIBase)
 	}
 
 	// huh.MultiSelect returns selected values in option order, not the
@@ -508,4 +541,60 @@ func boolStr(b bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+// buildOllamaModelField returns the OLLAMA_MODEL form field that
+// matches the host probe outcome: strict Select when tool-capable
+// models are pulled, otherwise a remediation Note (different message
+// for the reachable-but-no-tools case vs unreachable Ollama).
+func buildOllamaModelField(probe ollamaProbeResult, selected *string) huh.Field {
+	if len(probe.ToolCapableModels) > 0 {
+		options := make([]huh.Option[string], 0, len(probe.ToolCapableModels))
+		for _, m := range probe.ToolCapableModels {
+			options = append(options, huh.NewOption(m, m))
+		}
+		if !slices.Contains(probe.ToolCapableModels, *selected) {
+			*selected = probe.ToolCapableModels[0]
+		}
+		return huh.NewSelect[string]().
+			Title("OLLAMA_MODEL").
+			Description("Tool-capable models found on your host. Decepticon\nagents always emit tool calls — these are the only\nmodels the wizard will accept.").
+			Options(options...).
+			Value(selected)
+	}
+
+	if probe.Reachable {
+		return huh.NewNote().
+			Title("OLLAMA_MODEL — no tool-capable models found").
+			Description("Ollama is reachable but none of your pulled models\nadvertise the 'tools' capability. Decepticon agents\nalways emit tool calls, so a model without tool\nsupport cannot power them.\n\n  ollama pull qwen3-coder:30b\n  ollama show qwen3-coder:30b   # capabilities should list 'tools'\n\nThen press Esc and re-run 'decepticon onboard'.")
+	}
+
+	return huh.NewNote().
+		Title("OLLAMA_MODEL — Ollama not reachable").
+		Description("Could not reach Ollama at " + defaultOllamaAPIBase + ".\n\nMost likely Ollama isn't running or is bound to\n127.0.0.1 only (which the Decepticon container can't\nsee). Launch it on all interfaces, pull a tool-capable\nmodel, then re-run the wizard:\n\n  OLLAMA_HOST=0.0.0.0:11434 ollama serve\n  ollama pull qwen3-coder:30b\n  ollama show qwen3-coder:30b   # capabilities should list 'tools'\n\nThen press Esc and re-run 'decepticon onboard'.")
+}
+
+// ollamaUnusableError surfaces the post-form remediation when the user
+// picked Ollama but the probe found nothing usable. Two flavors so the
+// hint matches whichever in-form Note was shown.
+func ollamaUnusableError(probe ollamaProbeResult, baseURL string) error {
+	if probe.Reachable {
+		return fmt.Errorf(
+			"Ollama selected but no tool-capable models found on the host.\n" +
+				"Decepticon agents always emit tool calls — pull a tool-capable\n" +
+				"model and verify it advertises tools, then re-run:\n\n" +
+				"  ollama pull qwen3-coder:30b\n" +
+				"  ollama show qwen3-coder:30b   # capabilities should list 'tools'\n" +
+				"  decepticon onboard --reset")
+	}
+	return fmt.Errorf(
+		"Ollama selected but the host probe could not reach %s.\n"+
+			"Make sure Ollama is running and bound to all interfaces (the\n"+
+			"default 127.0.0.1 binding is invisible to containers), then\n"+
+			"pull a tool-capable model and re-run:\n\n"+
+			"  OLLAMA_HOST=0.0.0.0:11434 ollama serve\n"+
+			"  ollama pull qwen3-coder:30b\n"+
+			"  ollama show qwen3-coder:30b   # capabilities should list 'tools'\n"+
+			"  decepticon onboard --reset",
+		baseURL)
 }

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -19,19 +19,32 @@ NVIDIA_API_KEY=your-nvidia-key-here
 # Set both to run Decepticon against a local model — no cloud API key
 # needed. Add ``ollama_local`` to DECEPTICON_AUTH_PRIORITY (or run
 # ``decepticon onboard`` and pick the Ollama option, which writes both).
-# OLLAMA_MODEL is any tag you pulled (``ollama pull qwen3-coder:30b``);
-# the proxy registers ``ollama_chat/<model>`` automatically at startup,
-# routing through Ollama's /api/chat endpoint to keep tool calling working.
+#
+# OLLAMA_MODEL is any tag you pulled (``ollama pull qwen3-coder:30b``).
+# It must advertise the ``tools`` capability (``ollama show <model>``)
+# — every Decepticon agent emits tool calls, so a tool-incapable model
+# fails on the first request. ``decepticon onboard`` enforces this: the
+# wizard probes /api/tags + /api/show on your host and only lists
+# models whose capabilities include ``tools``; it refuses to write
+# this file when nothing tool-capable is pulled. The proxy registers
+# ``ollama_chat/<model>`` automatically at startup, routing through
+# Ollama's /api/chat endpoint (the legacy ``ollama/`` provider hits
+# /api/generate which has no tool-calling support and is rejected at
+# config-merge time).
 #
 # OLLAMA_API_BASE points the LiteLLM container at your Ollama server.
-# Pick the URL that matches where Ollama runs:
-#   - macOS / Docker Desktop on Windows / Linux Docker:
-#       http://host.docker.internal:11434
-#   - WSL2 + Docker Desktop, Ollama on the Windows host:
-#       http://host.docker.internal:11434
-#   - WSL2, Ollama installed inside the WSL distro:
-#       http://localhost:11434
-#   - Remote Ollama on another host: http://<host-or-ip>:11434
+# ``host.docker.internal:11434`` is the right answer in every supported
+# environment — macOS, native Linux, and WSL2 (with or without Docker
+# Desktop) — including the case where Ollama runs in the same WSL
+# distro as Decepticon. From inside a container ``localhost`` is the
+# container itself, so it can never reach Ollama on the host.
+# Use a different URL only for remote / custom Ollama setups.
+#
+# Ollama itself must listen on all interfaces or the litellm container
+# can't reach it (the default ``127.0.0.1`` binding accepts host-side
+# connections only):
+#   OLLAMA_HOST=0.0.0.0:11434 ollama serve
+# (or set ``Environment=OLLAMA_HOST=0.0.0.0:11434`` in the systemd unit).
 # OLLAMA_API_BASE=http://host.docker.internal:11434
 # OLLAMA_MODEL=qwen3-coder:30b
 

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -3,8 +3,12 @@
 The checked-in ``config/litellm.yaml`` contains the default Decepticon routes.
 Operators can additionally set ``DECEPTICON_MODEL`` / per-role overrides to any
 LiteLLM model string (for example ``openrouter/anthropic/claude-3.7-sonnet`` or
-``ollama/qwen2.5-coder:32b``).  This module appends only those requested routes
+``ollama_chat/qwen3-coder:30b``).  This module appends only those requested routes
 at container startup so the proxy accepts the same model names the agents use.
+
+For Ollama only the ``ollama_chat/`` provider is accepted — the legacy
+``ollama/`` (``/api/generate``) lacks tool calling per LiteLLM's own
+``supports_function_calling`` check, and Decepticon agents always emit tool calls.
 
 No secret values are read or logged here; generated routes reference environment
 variables using LiteLLM's ``os.environ/NAME`` syntax.
@@ -50,15 +54,14 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
 ALLOWED_DYNAMIC_PROVIDERS = frozenset(
     {
         *PROVIDER_API_KEY_ENV,
-        "ollama",
-        # ``ollama_chat`` is the recommended provider for tool/function
-        # calling — it routes to Ollama's /api/chat endpoint. Decepticon
-        # agents always need tools, so the launcher onboard wires the
-        # local-LLM auth method through this prefix.
+        # ``ollama_chat`` (LiteLLM /api/chat) is the only Ollama provider
+        # accepted — the legacy ``ollama`` (/api/generate) lacks tool
+        # calling and is rejected by validate_model_name() with a
+        # remediation hint, before reaching this set.
         "ollama_chat",
-        # ``auth/`` (subscription OAuth) is listed but rejected by validate()
-        # — kept here so the unrecognized-provider error doesn't fire first
-        # and confuse the user with a misleading "use custom/<model>" hint.
+        # ``auth/`` is listed but rejected by validate() — kept here so
+        # the unrecognized-provider error doesn't fire first and
+        # confuse the user with a misleading "use custom/<model>" hint.
         "auth",
         "gemini_sub",
         "copilot",
@@ -113,19 +116,16 @@ def _extra_models_from_env(value: str | None) -> set[str]:
 
 
 def _ollama_model_from_env(source: Mapping[str, str]) -> str | None:
-    """Derive a LiteLLM model id from OLLAMA_* env vars.
+    """Derive ``ollama_chat/<model>`` from OLLAMA_API_BASE / OLLAMA_MODEL.
 
-    The OSS local-LLM path uses two env vars:
-      OLLAMA_API_BASE — endpoint (e.g. http://host.docker.internal:11434)
-      OLLAMA_MODEL    — pulled model tag (e.g. qwen3-coder:30b)
+    Uses ``ollama_chat`` (not legacy ``ollama``) so /api/chat with
+    tool calling is hit. Defaults to ``llama3.2`` when only the base
+    URL is set, matching the agent factory.
 
-    When either is set, the proxy needs an ``ollama_chat/<model>`` route
-    registered so agents can call it. ``ollama_chat`` (not ``ollama``) is
-    deliberate — only that provider exposes Ollama's tool-calling path,
-    and every Decepticon agent uses tools. We default to a small llama3
-    when the user wired up the base URL but didn't pick a model — the
-    agent factory uses the same default in that scenario, so the proxy
-    and the client agree on the model id.
+    A user value is treated as already-qualified only when it starts
+    with an Ollama provider prefix; a bare slash is not enough,
+    because Ollama tags can contain slashes (HF-hosted GGUFs like
+    ``hf.co/<author>/<model>:<quant>``).
     """
     base = _clean_model(source.get("OLLAMA_API_BASE"))
     model = _clean_model(source.get("OLLAMA_MODEL"))
@@ -133,9 +133,12 @@ def _ollama_model_from_env(source: Mapping[str, str]) -> str | None:
         return None
     if model is None:
         model = "llama3.2"
-    if "/" in model:
-        # User passed a fully-qualified id (``ollama_chat/qwen3-coder:30b``)
-        # — accept verbatim so the agent and proxy stay aligned.
+    lower = model.lower()
+    if lower.startswith("ollama_chat/") or lower.startswith("ollama/"):
+        # Pass legacy ``ollama/`` through verbatim — validate_model_name()
+        # rejects it with a remediation hint pointing at ``ollama_chat/``.
+        # Auto-rewriting would hide the user's mistake and leave a stale
+        # ``OLLAMA_MODEL`` line in their .env disagreeing with the proxy.
         return model
     return f"ollama_chat/{model}"
 
@@ -177,6 +180,16 @@ def validate_model_name(model_name: str) -> None:
     provider = _provider_prefix(model_name)
     if provider == "auth":
         raise ValueError("auth/* routes are not allowed as dynamic API-key model routes")
+    if provider == "ollama":
+        # Legacy ``ollama/`` (/api/generate) lacks tool calling — fail
+        # closed since Decepticon agents always emit tool calls.
+        slug = model_name.split("/", 1)[1]
+        raise ValueError(
+            f"model {model_name!r} uses the legacy ollama/ provider, which "
+            "routes to /api/generate and does not support tool/function "
+            "calling. Decepticon agents always emit tool calls — use "
+            f"ollama_chat/{slug} (routes to /api/chat) instead."
+        )
     if provider not in ALLOWED_DYNAMIC_PROVIDERS:
         raise ValueError(
             f"unsupported model provider {provider!r} for {model_name!r}; "
@@ -188,7 +201,7 @@ def _derived_api_key_env(provider: str) -> str:
     return f"{provider.upper()}_API_KEY"
 
 
-def build_model_entry(model_name: str, env: Mapping[str, str] | None = None) -> dict[str, Any]:
+def build_model_entry(model_name: str) -> dict[str, Any]:
     """Build a LiteLLM ``model_list`` entry for a requested model ID.
 
     The generated route keeps ``model_name`` identical to the string used by the
@@ -210,10 +223,11 @@ def build_model_entry(model_name: str, env: Mapping[str, str] | None = None) -> 
         }
     else:
         params = {"model": model_name}
-        if provider in {"ollama", "ollama_chat"}:
-            # Ollama runs locally and has no API key; both the legacy
-            # /api/generate (ollama/) and the modern /api/chat
-            # (ollama_chat/) routes share the same base URL env var.
+        if provider == "ollama_chat":
+            # Ollama runs locally and has no API key. The legacy ``ollama``
+            # provider is rejected upstream by validate_model_name so only
+            # ``ollama_chat/`` (which routes to /api/chat with tool support)
+            # reaches this branch.
             params["api_base"] = "os.environ/OLLAMA_API_BASE"
         else:
             api_key_env = PROVIDER_API_KEY_ENV.get(provider, _derived_api_key_env(provider))
@@ -234,7 +248,7 @@ def merge_dynamic_models(
         validate_model_name(model_name)
         if model_name in existing:
             continue
-        model_list.append(build_model_entry(model_name, env))
+        model_list.append(build_model_entry(model_name))
         existing.add(model_name)
 
     merged["model_list"] = model_list

--- a/config/litellm_startup.py
+++ b/config/litellm_startup.py
@@ -10,12 +10,14 @@ Usage in docker-compose.yml:
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 # Register custom OAuth handler before LiteLLM processes the config
 sys.path.insert(0, "/app")
 from litellm_dynamic_config import collect_requested_models, write_dynamic_config  # noqa: E402
+from ollama_probe import extract_ollama_models, has_ollama_route, probe  # noqa: E402
 
 
 def _replace_config_arg() -> None:
@@ -56,6 +58,25 @@ def _replace_config_arg() -> None:
 
 
 _replace_config_arg()
+
+
+def _probe_ollama_if_configured() -> None:
+    """Best-effort Ollama reachability + tool-capability probe; never
+    blocks proxy boot."""
+    try:
+        requested = collect_requested_models()
+        if not has_ollama_route(requested):
+            return
+        models = extract_ollama_models(requested)
+        base = os.environ.get("OLLAMA_API_BASE", "").strip()
+        for line in probe(base, models):
+            print(f"[decepticon ollama] {line}", flush=True)
+    except Exception as exc:  # noqa: BLE001
+        # Observability-only — never let a probe bug crash proxy boot.
+        print(f"[decepticon ollama] probe failed unexpectedly: {exc}", flush=True)
+
+
+_probe_ollama_if_configured()
 
 from collections.abc import AsyncIterator, Iterator  # noqa: E402
 from typing import Any  # noqa: E402

--- a/config/ollama_probe.py
+++ b/config/ollama_probe.py
@@ -1,0 +1,234 @@
+"""Container-side Ollama reachability + tool-capability probe.
+
+Two checks: ``GET /api/tags`` for reachability (with diagnostics for
+the localhost trap and the 127.0.0.1-binding case), and
+``POST /api/show`` to require the model's ``capabilities`` includes
+``tools`` — Decepticon agents always emit tool calls. Best-effort:
+never blocks proxy boot, just logs ``[decepticon ollama]`` lines.
+
+Lives next to ``litellm_startup.py`` rather than inside it so the
+unit tests can load it via ``importlib`` without dragging in the
+startup script's heavy import-time side effects.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+# Ollama's tools capability is reported under ``capabilities`` in
+# /api/show responses on Ollama 0.3+ (released 2024-08). Models like
+# qwen3-coder, llama3.3, mistral-small3 advertise it; smaller or
+# legacy models often don't.
+_TOOLS_CAPABILITY = "tools"
+
+_OLLAMA_PROVIDER_PREFIXES = ("ollama_chat", "ollama")
+
+_HttpOpener = Callable[[Any, float], Any]
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of one probe step. ``message=None`` means silent pass."""
+
+    ok: bool
+    message: str | None = None
+
+
+def has_ollama_route(model_ids: Iterable[str]) -> bool:
+    """True when at least one requested model uses an Ollama provider."""
+    for model_id in model_ids:
+        prefix = model_id.split("/", 1)[0].lower()
+        if prefix in _OLLAMA_PROVIDER_PREFIXES:
+            return True
+    return False
+
+
+def extract_ollama_models(model_ids: Iterable[str]) -> list[str]:
+    """Strip the Ollama provider prefix; skip non-Ollama and bare-prefix entries."""
+    out: list[str] = []
+    for model_id in model_ids:
+        prefix, _, tag = model_id.partition("/")
+        if prefix.lower() in _OLLAMA_PROVIDER_PREFIXES and tag:
+            out.append(tag)
+    return out
+
+
+def _default_opener(url_or_request: Any, timeout: float) -> Any:
+    return urllib.request.urlopen(url_or_request, timeout=timeout)
+
+
+def _classify_transport_error(base_url: str, err: BaseException) -> str:
+    """Translate a transport error into a one-line operator hint."""
+    text = str(err).lower()
+    reason = str(getattr(err, "reason", err)).lower()
+    combined = f"{text} {reason}"
+
+    if "refused" in combined:
+        return (
+            f"Cannot reach {base_url}: connection refused. Ollama is most "
+            "likely bound to 127.0.0.1 only — relaunch with "
+            "OLLAMA_HOST=0.0.0.0:11434 ollama serve so the litellm "
+            "container can reach it."
+        )
+    dns_signals = (
+        "name or service not known",
+        "name resolution",
+        "nodename nor servname",
+        "temporary failure in name resolution",
+        "no address associated",
+    )
+    if any(signal in combined for signal in dns_signals):
+        return (
+            f"Cannot resolve host for {base_url}. The litellm service in "
+            "docker-compose.yml needs "
+            "extra_hosts: ['host.docker.internal:host-gateway'] for the "
+            "default URL to resolve."
+        )
+    return f"Cannot reach {base_url}: {err}"
+
+
+def reachability(
+    base_url: str,
+    *,
+    timeout: float = 2.0,
+    opener: _HttpOpener | None = None,
+) -> ProbeResult:
+    """Probe ``base_url/api/tags``. Pre-flight rejects loopback hosts —
+    from inside a container they're never the host running Ollama."""
+    if not base_url.strip():
+        return ProbeResult(False, "OLLAMA_API_BASE is empty.")
+
+    parts = urlsplit(base_url)
+    host = (parts.hostname or "").lower()
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return ProbeResult(
+            False,
+            f"OLLAMA_API_BASE={base_url} points at the container's own "
+            "loopback. From inside Docker localhost is the container, "
+            "never the host. Use http://host.docker.internal:11434 — "
+            "compose's extra_hosts mapping resolves that to the host.",
+        )
+
+    open_url = opener or _default_opener
+    try:
+        with open_url(f"{base_url.rstrip('/')}/api/tags", timeout) as resp:
+            status = getattr(resp, "status", 200)
+            if status >= 400:
+                return ProbeResult(
+                    False,
+                    f"Ollama responded with HTTP {status} at {base_url}.",
+                )
+            return ProbeResult(True)
+    except urllib.error.HTTPError as err:
+        return ProbeResult(
+            False,
+            f"Ollama responded with HTTP {err.code} at {base_url}: {err.reason}",
+        )
+    except (urllib.error.URLError, OSError) as err:
+        return ProbeResult(False, _classify_transport_error(base_url, err))
+
+
+def tool_capability(
+    base_url: str,
+    model: str,
+    *,
+    timeout: float = 5.0,
+    opener: _HttpOpener | None = None,
+) -> ProbeResult:
+    """Confirm ``model`` advertises ``tools`` via ``/api/show`` capabilities."""
+    if not base_url.strip() or not model.strip():
+        return ProbeResult(False, "Missing OLLAMA_API_BASE or model name for capability probe.")
+
+    open_url = opener or _default_opener
+    payload = json.dumps({"name": model}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/show",
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with open_url(request, timeout) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            return ProbeResult(
+                False,
+                f"Ollama model {model!r} is not pulled on this host. Run: ollama pull {model}",
+            )
+        return ProbeResult(
+            False,
+            f"Ollama /api/show returned HTTP {err.code} for {model!r}: {err.reason}",
+        )
+    except (urllib.error.URLError, OSError) as err:
+        return ProbeResult(False, _classify_transport_error(base_url, err))
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return ProbeResult(False, f"Ollama /api/show returned non-JSON body for {model!r}.")
+
+    capabilities = data.get("capabilities")
+    if not isinstance(capabilities, list):
+        # Older Ollama versions (< 0.3) don't ship the capabilities
+        # field. We can't determine tool support — emit a soft hint
+        # and let the request path surface the real verdict.
+        return ProbeResult(
+            True,
+            f"Ollama at {base_url} did not report capabilities for "
+            f"{model!r} (Ollama < 0.3?). Tool calling may still work; "
+            "if requests fail, upgrade Ollama and re-pull the model.",
+        )
+
+    if _TOOLS_CAPABILITY in capabilities:
+        return ProbeResult(True)
+
+    return ProbeResult(
+        False,
+        f"Model {model!r} does not advertise the 'tools' capability "
+        f"(reported: {capabilities}). Decepticon agents always emit "
+        "tool calls — pull a tool-capable model instead "
+        "(e.g. qwen3-coder, llama3.3, mistral-small3) and set "
+        "OLLAMA_MODEL accordingly.",
+    )
+
+
+def probe(
+    base_url: str,
+    models: Iterable[str],
+    *,
+    opener: _HttpOpener | None = None,
+) -> list[str]:
+    """Reachability + per-model tool-capability. Returns operator log
+    lines; empty means clean. Reachability failure short-circuits."""
+    lines: list[str] = []
+
+    reach = reachability(base_url, opener=opener)
+    if reach.message:
+        lines.append(reach.message)
+    if not reach.ok:
+        return lines
+
+    for model in models:
+        cap = tool_capability(base_url, model, opener=opener)
+        if cap.message:
+            lines.append(cap.message)
+
+    return lines
+
+
+__all__ = [
+    "ProbeResult",
+    "extract_ollama_models",
+    "has_ollama_route",
+    "probe",
+    "reachability",
+    "tool_capability",
+]

--- a/containers/litellm.Dockerfile
+++ b/containers/litellm.Dockerfile
@@ -10,4 +10,5 @@ COPY config/copilot_handler.py /app/copilot_handler.py
 COPY config/grok_handler.py /app/grok_handler.py
 COPY config/perplexity_handler.py /app/perplexity_handler.py
 COPY config/litellm_dynamic_config.py /app/litellm_dynamic_config.py
+COPY config/ollama_probe.py /app/ollama_probe.py
 COPY config/litellm_startup.py /app/litellm_startup.py

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -71,7 +71,7 @@ Manual testing procedures for verifying the LLM gateway features.
 ## Scenario 3: OpenAI-Compatible Gateway or Local Model
 
 ### Prerequisites
-- A local or private gateway that exposes an OpenAI-compatible `/v1` API, or Ollama for `ollama/*` models
+- A local or private gateway that exposes an OpenAI-compatible `/v1` API, or Ollama for `ollama_chat/*` models
 
 ### Steps
 1. Configure a custom gateway:
@@ -81,10 +81,12 @@ Manual testing procedures for verifying the LLM gateway features.
    CUSTOM_OPENAI_API_BASE=https://gateway.example.test/v1
    CUSTOM_OPENAI_API_KEY=...
    ```
-2. Or configure Ollama:
+2. Or configure Ollama (always `ollama_chat/`, never `ollama/` —
+   the legacy `ollama/` provider hits `/api/generate` and does not
+   support tool calling, which every Decepticon agent depends on):
    ```bash
    DECEPTICON_MODEL_PROFILE=custom
-   DECEPTICON_MODEL=ollama/llama3.2
+   DECEPTICON_MODEL=ollama_chat/llama3.2
    OLLAMA_API_BASE=http://host.docker.internal:11434
    ```
 3. Start services and call the selected model through LiteLLM.
@@ -101,18 +103,22 @@ Manual testing procedures for verifying the LLM gateway features.
 ## Scenario 4: Ollama Local Provider
 
 ### Prerequisites
-- Ollama installed and running (`ollama serve`)
-- At least one model pulled (`ollama pull llama3.2`)
+- Ollama installed and bound to all interfaces so the litellm
+  container can reach it: `OLLAMA_HOST=0.0.0.0:11434 ollama serve`
+- A tool-capable model pulled (`ollama pull qwen3-coder:30b` or
+  similar) — verify with `ollama show <model>` that the listed
+  capabilities include `tools`. Decepticon agents always emit tool
+  calls, so a tool-incapable model fails on the first request.
 
 ### Steps
-1. Verify Ollama is running:
+1. Verify Ollama is running and listening on all interfaces:
    ```bash
    curl http://localhost:11434/api/tags
    ```
-2. Set in `.env`:
+2. Set in `.env` (always `ollama_chat/`, never `ollama/`):
    ```
    DECEPTICON_MODEL_PROFILE=custom
-   DECEPTICON_MODEL=ollama/llama3.2
+   DECEPTICON_MODEL=ollama_chat/llama3.2
    OLLAMA_API_BASE=http://host.docker.internal:11434
    ```
 3. Start services: `make dev`
@@ -121,17 +127,29 @@ Manual testing procedures for verifying the LLM gateway features.
    curl -X POST http://localhost:4000/chat/completions \
      -H "Authorization: Bearer sk-decepticon-master" \
      -H "Content-Type: application/json" \
-     -d '{"model": "ollama/llama3.2", "messages": [{"role": "user", "content": "Say hello"}]}'
+     -d '{"model": "ollama_chat/llama3.2", "messages": [{"role": "user", "content": "Say hello"}]}'
    ```
 
 ### Expected
 - Response from local Ollama model
 - No external API calls made
+- LiteLLM startup log shows the container-side reachability +
+  tool-capability probe verdict for `OLLAMA_API_BASE`
 
 ### Troubleshooting
-- Connection refused: Ensure Ollama is running on the configured port
-- In Docker: Verify `extra_hosts: ["host.docker.internal:host-gateway"]` in docker-compose.yml
-- Set `OLLAMA_API_BASE=http://host.docker.internal:11434` for Docker access
+- Connection refused (from inside container): Ollama is likely bound
+  to `127.0.0.1` only — relaunch with `OLLAMA_HOST=0.0.0.0:11434
+  ollama serve`. The default binding accepts host-side connections
+  only, never container-side.
+- Name resolution failure: Verify
+  `extra_hosts: ["host.docker.internal:host-gateway"]` is present on
+  the litellm service in `docker-compose.yml`.
+- `localhost:11434` from a container is **always wrong** — that's the
+  container's own loopback, not the host. Use `host.docker.internal`.
+- Tool/function call errors: confirm `ollama show <model>` lists
+  `tools` in capabilities, and that the LiteLLM model id starts with
+  `ollama_chat/` (the legacy `ollama/` provider hits `/api/generate`
+  and does not support tool calling).
 
 
 ## Scenario 5: Onboard Wizard Complete Flow

--- a/docs/models.md
+++ b/docs/models.md
@@ -181,12 +181,28 @@ OLLAMA_MODEL=qwen3-coder:30b
 | exploit (MID)    | `ollama_chat/qwen3-coder:30b`    | —        |
 | recon (LOW)      | `ollama_chat/qwen3-coder:30b`    | —        |
 
-Same model across all tiers because local hardware typically can't run
-three different models simultaneously. The launcher probes Ollama's
-`/api/tags` at startup and warns if it's unreachable, but doesn't block
-— you can launch Ollama after Decepticon's stack comes up. The
-`ollama_chat/` provider routes to Ollama's `/api/chat` endpoint, the
-only one that supports tool/function calling.
+Same model across all tiers because local hardware typically can't
+run three different models simultaneously. The `ollama_chat/` provider
+routes to Ollama's `/api/chat` endpoint, the only one that supports
+tool/function calling — the legacy `ollama/` provider hits
+`/api/generate` and is rejected at LiteLLM-config-merge time because
+Decepticon agents always emit tool calls.
+
+Two probes guard the wiring end-to-end:
+
+1. **`decepticon onboard`** — the wizard hits `/api/tags` and
+   `/api/show` on the host, filters to models that report `tools` in
+   their capabilities, and presents only that list as the
+   `OLLAMA_MODEL` choice. If Ollama is unreachable or has no
+   tool-capable models pulled, the wizard refuses to write `.env`
+   and prints the exact remediation steps.
+
+2. **litellm container startup** — re-runs the same checks from
+   inside the container, the only place that can detect
+   `OLLAMA_HOST=127.0.0.1`-only bindings (which look fine to the
+   wizard's host probe but are invisible from the container). Every
+   diagnostic appears in `decepticon logs litellm` prefixed with
+   `[decepticon ollama]`.
 
 ### Local Ollama + cloud fallback
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -52,13 +52,20 @@ Native Windows (PowerShell / cmd) is **not supported** — install WSL2 first.
 
 Decepticon runs end-to-end on WSL2 with two valid Docker setups:
 
-1. **Docker Desktop with WSL2 backend** (the common path) — Docker Desktop registers `host.docker.internal` automatically, so the default `OLLAMA_API_BASE=http://host.docker.internal:11434` reaches an Ollama server running on the **Windows host**. The launcher's host-side reachability probe also handles this case.
+1. **Docker Desktop with WSL2 backend** (the common path) — Docker Desktop registers `host.docker.internal` automatically.
+2. **Native Docker inside the WSL distro** (no Docker Desktop) — Decepticon's `docker-compose.yml` adds the `host.docker.internal:host-gateway` mapping itself, so containers reach the host either way.
 
-2. **Native Docker inside the WSL distro** (no Docker Desktop) — `host.docker.internal` is *not* set up automatically. The launcher resolves it to the WSL2 default nameserver (Windows host) for its probe. If Ollama is running **inside the WSL distro itself**, set `OLLAMA_API_BASE=http://localhost:11434` instead.
+The default `OLLAMA_API_BASE=http://host.docker.internal:11434` is the right value in **all** environments — including the case where Ollama runs *inside* the same WSL distro as Decepticon. From inside a container, `localhost` is the container itself, so it can never reach Ollama on the host. Use `host.docker.internal`.
+
+Ollama must additionally listen on all interfaces — the default `127.0.0.1` binding is invisible to containers. Launch it with:
+
+```bash
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
 
 Other WSL caveats:
 - Install Decepticon under your WSL home (`~/.decepticon`), not on a Windows-mounted drive (`/mnt/c/...`) — bind-mounted I/O across the boundary is much slower.
-- WSL2 mirrored networking (Windows 11 22H2+) collapses the host/distro split; both `host.docker.internal` and `localhost` typically work for Windows-host services.
+- WSL2 mirrored networking (Windows 11 22H2+) collapses the *Windows host ↔ WSL distro* split, but Docker bridge networks remain isolated. The `host.docker.internal` requirement still applies.
 
 ---
 
@@ -161,24 +168,44 @@ billing, no key.
 **Setup:**
 
 1. Install Ollama on your host: <https://ollama.com/download>.
-2. Pull any model — for tool-heavy agents pick one with strong function
-   calling (Qwen3-Coder, Llama 3.3, DeepSeek-R1):
+2. Pull a tool-capable model — Decepticon agents always call tools, so
+   the chosen model **must** advertise the `tools` capability. Known
+   working families: Qwen3-Coder, Llama 3.3, DeepSeek-R1, Mistral
+   Small 3, Hermes-3:
    ```bash
    ollama pull qwen3-coder:30b
+   ollama show qwen3-coder:30b   # capabilities should include "tools"
    ```
-3. Start the Ollama server (it usually launches automatically):
+3. Start the Ollama server bound to all interfaces so the Decepticon
+   container can reach it (the default `127.0.0.1` binding only accepts
+   host-side connections):
    ```bash
-   ollama serve
+   OLLAMA_HOST=0.0.0.0:11434 ollama serve
    ```
+   On systems where Ollama runs as a service (e.g. systemd), set
+   `Environment=OLLAMA_HOST=0.0.0.0:11434` in the unit and restart it.
 4. Run `decepticon onboard` and pick **"Local LLM (Ollama)"**. The
    wizard prompts for:
-   - `OLLAMA_API_BASE` — default `http://host.docker.internal:11434`
-     works on Mac, Windows, and Linux Docker (the litellm service has
-     `extra_hosts: host.docker.internal:host-gateway`)
-   - `OLLAMA_MODEL` — the tag you pulled (e.g. `qwen3-coder:30b`)
-5. Run `decepticon`. The launcher probes `<URL>/api/tags` and warns if
-   Ollama isn't reachable — startup proceeds either way so you can
-   launch Ollama afterwards.
+   - `OLLAMA_API_BASE` — leave the default `http://host.docker.internal:11434`.
+     This works on macOS, Linux, and WSL2 (with or without Docker
+     Desktop) because `docker-compose.yml` adds the
+     `host.docker.internal:host-gateway` mapping. **`localhost` is
+     never the right answer** — from inside a container that's the
+     container itself, not the host.
+   - `OLLAMA_MODEL` — the wizard probes your running Ollama at the
+     default URL, lists every pulled model whose `/api/show`
+     capabilities include `tools`, and presents that filtered list as
+     the only valid choice. You cannot type a tag manually: Decepticon
+     agents always emit tool calls, so a non-tool-capable model would
+     break on the first request. If the wizard finds nothing
+     tool-capable (or cannot reach Ollama), it refuses to write `.env`
+     and prints the exact remediation steps.
+5. Run `decepticon`. A second probe inside the litellm container
+   re-verifies reachability and tool-capability after the stack starts
+   — the in-wizard host probe can't tell whether Ollama is bound to
+   `0.0.0.0` (visible to the container) versus `127.0.0.1` only
+   (invisible). Either probe failing prints a clear diagnostic in
+   `decepticon logs litellm`.
 
 **How it works:**
 

--- a/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/tests/unit/llm/test_litellm_dynamic_config.py
@@ -24,20 +24,20 @@ def test_collect_requested_models_includes_global_and_role_overrides() -> None:
     env = {
         "DECEPTICON_MODEL": "openrouter/anthropic/claude-3.7-sonnet",
         "DECEPTICON_MODEL_FALLBACK": "groq/llama-3.3-70b-versatile",
-        "DECEPTICON_MODEL_RECON": "ollama/qwen2.5-coder:32b",
+        "DECEPTICON_MODEL_RECON": "ollama_chat/qwen2.5-coder:32b",
         "DECEPTICON_MODEL_RECON_FALLBACK": "openai/gpt-4.1-mini",
     }
 
     assert collect_requested_models(env) == {
         "openrouter/anthropic/claude-3.7-sonnet",
         "groq/llama-3.3-70b-versatile",
-        "ollama/qwen2.5-coder:32b",
+        "ollama_chat/qwen2.5-coder:32b",
         "openai/gpt-4.1-mini",
     }
 
 
 def test_build_model_entry_uses_provider_specific_api_key_env() -> None:
-    entry = build_model_entry("openrouter/anthropic/claude-3.7-sonnet", {})
+    entry = build_model_entry("openrouter/anthropic/claude-3.7-sonnet")
 
     assert entry["model_name"] == "openrouter/anthropic/claude-3.7-sonnet"
     assert entry["litellm_params"] == {
@@ -47,14 +47,21 @@ def test_build_model_entry_uses_provider_specific_api_key_env() -> None:
 
 
 def test_build_model_entry_supports_custom_openai_compatible_endpoint() -> None:
-    env = {"CUSTOM_OPENAI_API_BASE": "https://llm.example.test/v1"}
-
-    entry = build_model_entry("custom/qwen3-coder", env)
+    entry = build_model_entry("custom/qwen3-coder")
 
     assert entry["litellm_params"] == {
         "model": "openai/qwen3-coder",
         "api_key": "os.environ/CUSTOM_OPENAI_API_KEY",
         "api_base": "os.environ/CUSTOM_OPENAI_API_BASE",
+    }
+
+
+def test_build_model_entry_routes_ollama_chat_to_api_base() -> None:
+    entry = build_model_entry("ollama_chat/qwen3-coder:30b")
+
+    assert entry["litellm_params"] == {
+        "model": "ollama_chat/qwen3-coder:30b",
+        "api_base": "os.environ/OLLAMA_API_BASE",
     }
 
 
@@ -67,9 +74,44 @@ def test_validate_model_name_rejects_bare_or_internal_routes() -> None:
         validate_model_name("unknown/model")
 
 
+def test_validate_model_name_rejects_legacy_ollama_with_remediation() -> None:
+    """``ollama/`` (legacy /api/generate) does not support tool calling per
+    LiteLLM's own ``supports_function_calling`` assertion. Decepticon agents
+    always emit tool calls, so accepting it would silently break the first
+    request — fail closed at config-merge time and point at ``ollama_chat/``.
+    """
+    with pytest.raises(ValueError, match="ollama_chat/llama3.2"):
+        validate_model_name("ollama/llama3.2")
+    with pytest.raises(ValueError, match="tool/function"):
+        validate_model_name("ollama/qwen2.5-coder:32b")
+
+
 def test_merge_dynamic_models_rejects_invalid_env_model() -> None:
     with pytest.raises(ValueError, match="provider/model"):
         merge_dynamic_models({"model_list": []}, {"DECEPTICON_MODEL": "gpt-4.1"})
+
+
+def test_merge_dynamic_models_rejects_legacy_ollama_env() -> None:
+    with pytest.raises(ValueError, match="ollama_chat/"):
+        merge_dynamic_models(
+            {"model_list": []},
+            {"DECEPTICON_MODEL_RECON": "ollama/qwen2.5-coder:32b"},
+        )
+
+
+def test_collect_requested_models_wraps_hf_hosted_gguf_with_ollama_chat() -> None:
+    """HuggingFace-hosted Ollama models embed slashes in the tag itself
+    (``hf.co/<author>/<model>:<quant>``). The resolver must wrap them
+    with ``ollama_chat/`` rather than treating the bare slash as a
+    provider/model split — otherwise validate_model_name would reject
+    ``hf.co`` as an unknown provider.
+    """
+    env = {
+        "OLLAMA_API_BASE": "http://host.docker.internal:11434",
+        "OLLAMA_MODEL": "hf.co/lmstudio-community/Qwen3-Coder-30B-GGUF:Q4_K_M",
+    }
+    models = collect_requested_models(env)
+    assert "ollama_chat/hf.co/lmstudio-community/Qwen3-Coder-30B-GGUF:Q4_K_M" in models
 
 
 def test_merge_dynamic_models_keeps_existing_entries_and_appends_missing() -> None:

--- a/tests/unit/llm/test_ollama_probe.py
+++ b/tests/unit/llm/test_ollama_probe.py
@@ -1,0 +1,340 @@
+"""Unit tests for the container-side Ollama probe at config/ollama_probe.py.
+
+config/ isn't a Python package — load via importlib, same pattern as
+test_litellm_dynamic_config.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import socket
+import sys
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[3] / "config" / "ollama_probe.py"
+_MODULE_NAME = "decepticon_ollama_probe"
+_spec = importlib.util.spec_from_file_location(_MODULE_NAME, _MODULE_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+# Register in sys.modules BEFORE exec_module: Python 3.13's
+# ``@dataclass`` walks ``sys.modules[cls.__module__].__dict__`` to
+# resolve forward references, and crashes with AttributeError on a
+# missing entry. ``test_litellm_dynamic_config.py`` happens to work
+# without this only because it doesn't define any dataclasses.
+sys.modules[_MODULE_NAME] = _module
+_spec.loader.exec_module(_module)
+
+ProbeResult = _module.ProbeResult
+extract_ollama_models = _module.extract_ollama_models
+has_ollama_route = _module.has_ollama_route
+probe = _module.probe
+reachability = _module.reachability
+tool_capability = _module.tool_capability
+
+
+# ── Fake response / opener helpers ────────────────────────────────────
+
+
+class _FakeResponse:
+    """Stand-in for an ``http.client.HTTPResponse``-shaped object."""
+
+    def __init__(self, status: int = 200, body: bytes = b"") -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+
+def _opener_returning(response: _FakeResponse) -> Any:
+    """Return an opener that yields ``response`` regardless of input."""
+
+    def _opener(url_or_request: Any, timeout: float) -> _FakeResponse:
+        del url_or_request, timeout
+        return response
+
+    return _opener
+
+
+def _opener_raising(exc: BaseException) -> Any:
+    def _opener(url_or_request: Any, timeout: float) -> _FakeResponse:
+        del url_or_request, timeout
+        raise exc
+
+    return _opener
+
+
+# ── has_ollama_route ──────────────────────────────────────────────────
+
+
+class TestHasOllamaRoute:
+    def test_detects_ollama_chat_provider(self) -> None:
+        assert has_ollama_route(["ollama_chat/llama3.2"]) is True
+
+    def test_detects_legacy_ollama_provider(self) -> None:
+        # Detection is provider-prefix based — even though ollama/ is
+        # rejected by validate_model_name, a stray entry should still
+        # signal that the probe should run (so the operator gets a
+        # diagnostic instead of silence).
+        assert has_ollama_route(["ollama/llama3.2"]) is True
+
+    def test_ignores_non_ollama_routes(self) -> None:
+        assert has_ollama_route(["openai/gpt-5", "anthropic/claude-haiku-4-5"]) is False
+
+    def test_empty_iterable(self) -> None:
+        assert has_ollama_route([]) is False
+
+    def test_mixed_iterable_with_one_ollama(self) -> None:
+        assert has_ollama_route(["openai/gpt-5", "ollama_chat/qwen3-coder:30b"]) is True
+
+
+# ── extract_ollama_models ─────────────────────────────────────────────
+
+
+class TestExtractOllamaModels:
+    def test_strips_provider_prefix(self) -> None:
+        assert extract_ollama_models(["ollama_chat/qwen3-coder:30b"]) == ["qwen3-coder:30b"]
+
+    def test_skips_non_ollama_entries(self) -> None:
+        assert extract_ollama_models(
+            ["openai/gpt-5", "ollama_chat/llama3.2", "anthropic/claude"]
+        ) == ["llama3.2"]
+
+    def test_skips_provider_only_entries(self) -> None:
+        assert extract_ollama_models(["ollama_chat/"]) == []
+
+    def test_preserves_input_order(self) -> None:
+        # Stable ordering matters for deterministic probe output.
+        ids = ["ollama_chat/a", "ollama_chat/b", "ollama_chat/c"]
+        assert extract_ollama_models(ids) == ["a", "b", "c"]
+
+
+# ── reachability ──────────────────────────────────────────────────────
+
+
+class TestReachability:
+    def test_empty_base_url_is_diagnosed(self) -> None:
+        result = reachability("")
+        assert result.ok is False
+        assert result.message is not None
+        assert "empty" in result.message.lower()
+
+    def test_localhost_is_rejected_with_loopback_hint(self) -> None:
+        result = reachability("http://localhost:11434")
+        assert result.ok is False
+        assert result.message is not None
+        assert "host.docker.internal" in result.message
+        assert "localhost" in result.message.lower()
+
+    def test_127_0_0_1_is_rejected(self) -> None:
+        result = reachability("http://127.0.0.1:11434")
+        assert result.ok is False
+        assert result.message is not None
+        assert "host.docker.internal" in result.message
+
+    def test_ipv6_loopback_is_rejected(self) -> None:
+        result = reachability("http://[::1]:11434")
+        assert result.ok is False
+        assert result.message is not None
+
+    def test_connection_refused_suggests_ollama_host_zero(self) -> None:
+        opener = _opener_raising(
+            urllib.error.URLError(ConnectionRefusedError("Connection refused"))
+        )
+        result = reachability("http://host.docker.internal:11434", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "OLLAMA_HOST=0.0.0.0" in result.message
+
+    def test_dns_failure_points_to_extra_hosts(self) -> None:
+        opener = _opener_raising(
+            urllib.error.URLError(socket.gaierror("Name or service not known"))
+        )
+        result = reachability("http://host.docker.internal:11434", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "extra_hosts" in result.message
+
+    def test_success_returns_ok_with_no_message(self) -> None:
+        opener = _opener_returning(_FakeResponse(status=200))
+        result = reachability("http://host.docker.internal:11434", opener=opener)
+        assert result.ok is True
+        assert result.message is None
+
+    def test_non_2xx_status_is_reported(self) -> None:
+        opener = _opener_returning(_FakeResponse(status=500))
+        result = reachability("http://host.docker.internal:11434", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "500" in result.message
+
+    def test_http_error_4xx_is_reported(self) -> None:
+        opener = _opener_raising(
+            urllib.error.HTTPError(
+                url="http://host.docker.internal:11434/api/tags",
+                code=403,
+                msg="Forbidden",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=BytesIO(b""),
+            )
+        )
+        result = reachability("http://host.docker.internal:11434", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "403" in result.message
+
+
+# ── tool_capability ───────────────────────────────────────────────────
+
+
+def _show_response(capabilities: list[str] | None = None, **extra: Any) -> _FakeResponse:
+    body: dict[str, Any] = dict(extra)
+    if capabilities is not None:
+        body["capabilities"] = capabilities
+    return _FakeResponse(status=200, body=json.dumps(body).encode("utf-8"))
+
+
+class TestToolCapability:
+    def test_empty_inputs_short_circuit(self) -> None:
+        assert tool_capability("", "qwen3-coder").ok is False
+        assert tool_capability("http://host.docker.internal:11434", "").ok is False
+
+    def test_capabilities_with_tools_passes(self) -> None:
+        opener = _opener_returning(_show_response(["completion", "tools"]))
+        result = tool_capability(
+            "http://host.docker.internal:11434", "qwen3-coder:30b", opener=opener
+        )
+        assert result.ok is True
+        assert result.message is None
+
+    def test_capabilities_without_tools_fails_with_remediation(self) -> None:
+        opener = _opener_returning(_show_response(["completion"]))
+        result = tool_capability("http://host.docker.internal:11434", "gemma:2b", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "gemma:2b" in result.message
+        assert "'tools'" in result.message
+
+    def test_missing_capabilities_field_returns_soft_hint(self) -> None:
+        # Older Ollama versions don't ship capabilities — we can't
+        # determine tool support, so we don't block, but we surface a
+        # hint pointing at the version mismatch.
+        opener = _opener_returning(_show_response())  # no capabilities key
+        result = tool_capability("http://host.docker.internal:11434", "llama3.2", opener=opener)
+        assert result.ok is True
+        assert result.message is not None
+        assert "0.3" in result.message
+
+    def test_404_indicates_model_not_pulled(self) -> None:
+        opener = _opener_raising(
+            urllib.error.HTTPError(
+                url="http://host.docker.internal:11434/api/show",
+                code=404,
+                msg="Not Found",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=BytesIO(b""),
+            )
+        )
+        result = tool_capability(
+            "http://host.docker.internal:11434", "qwen3-coder:30b", opener=opener
+        )
+        assert result.ok is False
+        assert result.message is not None
+        assert "ollama pull qwen3-coder:30b" in result.message
+
+    def test_non_json_body_is_diagnosed(self) -> None:
+        opener = _opener_returning(_FakeResponse(status=200, body=b"<html>nope</html>"))
+        result = tool_capability("http://host.docker.internal:11434", "llama3.2", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "non-JSON" in result.message
+
+    def test_transport_error_uses_shared_classifier(self) -> None:
+        opener = _opener_raising(urllib.error.URLError(ConnectionRefusedError("refused")))
+        result = tool_capability("http://host.docker.internal:11434", "llama3.2", opener=opener)
+        assert result.ok is False
+        assert result.message is not None
+        assert "OLLAMA_HOST=0.0.0.0" in result.message
+
+
+# ── probe (composition) ───────────────────────────────────────────────
+
+
+class TestProbeComposition:
+    def test_unreachable_short_circuits_before_capability_check(self) -> None:
+        # Reachability fails (localhost) — we should NOT attempt /api/show
+        # for each model; one diagnostic line is enough.
+        lines = probe(
+            "http://localhost:11434",
+            ["llama3.2", "qwen3-coder:30b"],
+        )
+        assert len(lines) == 1
+        assert "host.docker.internal" in lines[0]
+
+    def test_reachable_with_tool_capable_models_yields_no_lines(self) -> None:
+        # Build an opener that returns OK for /api/tags AND the show
+        # response for either model.
+        tags_response = _FakeResponse(status=200, body=b'{"models":[]}')
+        show_response = _show_response(["completion", "tools"])
+
+        def _opener(url_or_request: Any, timeout: float) -> _FakeResponse:
+            del timeout
+            url = (
+                url_or_request.full_url
+                if hasattr(url_or_request, "full_url")
+                else str(url_or_request)
+            )
+            if url.endswith("/api/tags"):
+                return tags_response
+            return show_response
+
+        lines = probe(
+            "http://host.docker.internal:11434",
+            ["llama3.2"],
+            opener=_opener,
+        )
+        assert lines == []
+
+    def test_reachable_but_model_lacks_tools_is_reported(self) -> None:
+        tags_response = _FakeResponse(status=200, body=b'{"models":[]}')
+        show_response = _show_response(["completion"])
+
+        def _opener(url_or_request: Any, timeout: float) -> _FakeResponse:
+            del timeout
+            url = (
+                url_or_request.full_url
+                if hasattr(url_or_request, "full_url")
+                else str(url_or_request)
+            )
+            return tags_response if url.endswith("/api/tags") else show_response
+
+        lines = probe(
+            "http://host.docker.internal:11434",
+            ["gemma:2b"],
+            opener=_opener,
+        )
+        assert len(lines) == 1
+        assert "gemma:2b" in lines[0]
+        assert "'tools'" in lines[0]
+
+
+# ── ProbeResult dataclass ─────────────────────────────────────────────
+
+
+def test_probe_result_is_immutable() -> None:
+    result = ProbeResult(ok=True)
+    with pytest.raises(Exception):
+        result.ok = False  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Resolves two reported Ollama integration bugs from Discord:
1. **WSL2 localhost trap** — Ollama in the same WSL distro as Decepticon was unreachable from the litellm container, made worse by misleading `localhost:11434` guidance in the wizard
2. **Tool-incapable model selection** — users could pick any Ollama model in the wizard, including ones without `tools` capability; agents crashed on the first prompt with an opaque LiteLLM error

The fix is a layered defense:

- `validate_model_name` rejects legacy `ollama/` (no tool calling per LiteLLM official docs); only `ollama_chat/` is allowed
- New onboard wizard probe enumerates `/api/tags` + `/api/show` capabilities, presents only tool-capable models in a strict Select (no free input), and refuses to write `.env` when nothing usable is found
- New container-side probe in `litellm_startup.py` re-checks reachability + tool capability after the stack starts — catches the `127.0.0.1`-only Ollama binding that the host-side probe can't see
- Documentation (`setup-guide.md`, `models.md`, `e2e-testing-guide.md`, `env.example`) aligned with the new strict flow + `OLLAMA_HOST=0.0.0.0:11434` requirement

## Commits (4, structured by domain)

| Commit | Scope |
|---|---|
| `fix(llm): require ollama_chat/ provider for tool-capable Ollama support` | LiteLLM dynamic config validation + tests + HF-hosted GGUF wrapping |
| `feat(litellm): container-side Ollama reachability + tool-capability probe` | New `config/ollama_probe.py` + 29 tests + Dockerfile copy |
| `feat(onboard): strict tool-capable model wizard with host-side Ollama probe` | Go probe (`ollama_models.go`), parallel `/api/show` fan-out, strict Select wizard, post-form gate |
| `docs(ollama): align setup/e2e/models/env guidance with strict probe flow` | Docs + `env.example` |

## Verification

| Gate | Result |
|---|---|
| `uv run ruff check .` | ✅ All checks passed |
| `uv run ruff format --check .` | ✅ 224 files |
| `uv run basedpyright --level error` | ✅ 0 errors, 0 warnings, 0 notes |
| `uv run pytest -n auto -q -m "not slow"` | ✅ **748 passed** |
| `cd clients/launcher && go vet ./... && go test ./...` | ✅ all packages OK |

Independent code review (oh-my-claudecode/code-reviewer): COMMENT — no CRITICAL. HIGH (timer leak) + MEDIUM x2 + LOW x2 all addressed in the commits.

## Test plan
- [ ] `make quality` — full PR gate green
- [ ] `make dogfood` — exercises the actual onboard wizard + Ollama selection in an isolated `.dogfood/` `$DECEPTICON_HOME`. Verify with both:
  - Ollama running, `qwen3-coder:30b` pulled → wizard offers Select dropdown, picks the model, stack comes up cleanly
  - Ollama down → wizard refuses with "Ollama not reachable" remediation Note
  - Ollama up but only `gemma:2b` pulled (no tools) → wizard refuses with "no tool-capable models" Note
- [ ] Probe `[decepticon ollama]` lines surface in `decepticon logs litellm` for the misconfigured cases