### PR TITLE
fix(llm,config,cli): DeepSeek V4 Pro reasoning_content streaming + OAuth route gating + /file command

### DIFF
--- a/clients/cli/src/commands/file.ts
+++ b/clients/cli/src/commands/file.ts
@@ -1,0 +1,54 @@
+/**
+ * /file <path> — Load a prompt from a file and submit it.
+ *
+ * Reads the contents of the given file and submits it as a message to the
+ * agent. Designed for long multi-line prompts (engagement briefs, VDP
+ * scopes, etc.) that are impractical to paste into the single-line input.
+ *
+ * Usage:
+ *   /file /tmp/telenor-vdp.md
+ *   /file ~/engagement-brief.txt
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import type { Command } from "./types.js";
+
+const file: Command = {
+  name: "file",
+  description: "Load a prompt from a file and send it",
+  aliases: ["f"],
+  argumentHint: "<path>",
+  execute(args, ctx) {
+    const raw = args.trim();
+    if (!raw) {
+      ctx.addSystemEvent(
+        "Usage: /file <path>  — reads the file and sends its contents as a message.",
+      );
+      return;
+    }
+
+    // Expand ~ to home directory
+    const expanded = raw.startsWith("~")
+      ? resolve(homedir(), raw.slice(2))
+      : resolve(raw);
+
+    try {
+      const content = readFileSync(expanded, "utf-8").trim();
+      if (!content) {
+        ctx.addSystemEvent(`File is empty: ${expanded}`);
+        return;
+      }
+
+      ctx.addSystemEvent(`Loaded ${content.length} chars from ${expanded}`);
+      ctx.submit(content);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Unknown error reading file";
+      ctx.addSystemEvent(`Failed to read file: ${message}`);
+    }
+  },
+};
+
+export default file;

--- a/clients/cli/src/commands/registry.ts
+++ b/clients/cli/src/commands/registry.ts
@@ -8,11 +8,12 @@
 import type { Command } from "./types.js";
 import help from "./help.js";
 import clear from "./clear.js";
+import file from "./file.js";
 import quit from "./quit.js";
 import resume from "./resume.js";
 
 /** All registered commands. Add new commands here. */
-const COMMANDS: Command[] = [help, clear, quit, resume];
+const COMMANDS: Command[] = [help, clear, file, quit, resume];
 
 /** Get all registered commands. */
 export function getCommands(): Command[] {

--- a/clients/cli/src/components/messages/UserMessage.tsx
+++ b/clients/cli/src/components/messages/UserMessage.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Box, Text } from "ink";
 import { CtrlOToExpand } from "../shell/CtrlOToExpand.js";
 
-const TRUNCATE_HEAD_CHARS = 2500;
-const TRUNCATE_TAIL_CHARS = 2500;
+const TRUNCATE_HEAD_CHARS = 8000;
+const TRUNCATE_TAIL_CHARS = 2000;
 
 interface Props {
   content: string;

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -195,58 +195,14 @@ model_list:
       model: nvidia_nim/meta/llama-3.2-3b-instruct
       api_key: os.environ/NVIDIA_API_KEY
 
-  # ── ChatGPT / Codex OAuth (subscription) ─────────────────────────────
-  # Keep Decepticon's stable auth/gpt-* aliases, but route the actual
-  # upstream call through LiteLLM's native chatgpt provider. That provider
-  # uses Codex OAuth tokens from CHATGPT_TOKEN_DIR/auth.json and talks to
-  # chatgpt.com/backend-api/codex instead of OpenAI API-key billing.
-  - model_name: auth/gpt-5.5
-    litellm_params:
-      model: chatgpt/gpt-5.5
-
-  - model_name: auth/gpt-5.4
-    litellm_params:
-      model: chatgpt/gpt-5.4
-
-  - model_name: auth/gpt-5-nano
-    litellm_params:
-      model: chatgpt/gpt-5-nano
-
-  # ── Gemini Advanced subscription ───────────────────────────────────
-  - model_name: gemini-sub/gemini-2.5-pro
-    litellm_params:
-      model: gemini-sub/gemini-2.5-pro
-
-  - model_name: gemini-sub/gemini-2.5-flash
-    litellm_params:
-      model: gemini-sub/gemini-2.5-flash
-
-  # ── Copilot Pro subscription ─────────────────────────────────────
-  - model_name: copilot/gpt-4o
-    litellm_params:
-      model: copilot/gpt-4o
-
-  - model_name: copilot/o1
-    litellm_params:
-      model: copilot/o1
-
-  # ── SuperGrok subscription ──────────────────────────────────────
-  - model_name: grok-sub/grok-3
-    litellm_params:
-      model: grok-sub/grok-3
-
-  - model_name: grok-sub/grok-3-mini
-    litellm_params:
-      model: grok-sub/grok-3-mini
-
-  # ── Perplexity Pro subscription ─────────────────────────────────
-  - model_name: pplx-sub/sonar-pro
-    litellm_params:
-      model: pplx-sub/sonar-pro
-
-  - model_name: pplx-sub/sonar
-    litellm_params:
-      model: pplx-sub/sonar
+  # ── Subscription OAuth routes ──────────────────────────────────────────
+  # ChatGPT (auth/gpt-*), Gemini Advanced (gemini-sub/*), Copilot
+  # (copilot/*), SuperGrok (grok-sub/*), and Perplexity Pro (pplx-sub/*)
+  # are registered DYNAMICALLY by litellm_dynamic_config.py, gated on
+  # their respective DECEPTICON_AUTH_* flags. Registering them statically
+  # here caused LiteLLM's native providers to attempt OAuth handshakes at
+  # startup even when the user disabled the auth method, blocking the
+  # container health check and making it unhealthy.
 
   # ── Local LLM (Ollama) ──────────────────────────────────────────────
   # Ollama routes are registered dynamically at proxy startup by
@@ -305,29 +261,23 @@ litellm_settings:
     # OpenAI direct API
     - {"openai/gpt-5.5": ["openai/gpt-5.4"]}
     - {"openai/gpt-5.4": ["openai/gpt-5-nano"]}
-    # OpenAI / ChatGPT subscription path
-    - {"auth/gpt-5.5": ["auth/gpt-5.4"]}
+    # OpenAI / ChatGPT subscription fallbacks (registered dynamically)
     # Google Gemini API path
     - {"gemini/gemini-2.5-pro": ["gemini/gemini-2.5-flash"]}
     - {"gemini/gemini-2.5-flash": ["gemini/gemini-2.5-flash-lite"]}
-    # Gemini Advanced subscription path (no LOW tier)
-    - {"gemini-sub/gemini-2.5-pro": ["gemini-sub/gemini-2.5-flash"]}
+    # Gemini Advanced subscription fallbacks (registered dynamically)
     # MiniMax (no LOW tier)
     - {"minimax/MiniMax-M2.5": ["minimax/MiniMax-M2.5-lightning"]}
     # DeepSeek
     - {"deepseek/deepseek-v4-pro": ["deepseek/deepseek-v4-flash"]}
-    # xAI direct + SuperGrok subscription (no LOW tier on either)
+    # xAI direct API
     - {"xai/grok-3": ["xai/grok-3-mini"]}
-    - {"grok-sub/grok-3": ["grok-sub/grok-3-mini"]}
     # Mistral (no LOW tier)
     - {"mistral/mistral-large-latest": ["mistral/codestral-latest"]}
     # Nvidia NIM
     - {"nvidia_nim/meta/llama-3.3-70b-instruct": ["nvidia_nim/nvidia/llama-3.1-nemotron-70b-instruct"]}
     - {"nvidia_nim/nvidia/llama-3.1-nemotron-70b-instruct": ["nvidia_nim/meta/llama-3.2-3b-instruct"]}
-    # Copilot subscription
-    - {"copilot/gpt-4o": ["copilot/o1"]}
-    # Perplexity Pro subscription (no LOW tier)
-    - {"pplx-sub/sonar-pro": ["pplx-sub/sonar"]}
+    # Copilot, SuperGrok, Perplexity fallbacks (registered dynamically)
   num_retries: 3
   retry_after: 30
 

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -236,11 +236,107 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
     return {"model_name": model_name, "litellm_params": params}
 
 
+# ── Subscription OAuth routes ───────────────────────────────────────────
+# These were previously static in litellm.yaml. LiteLLM's native providers
+# (chatgpt, gemini-sub, copilot, grok-sub, pplx-sub) attempt OAuth
+# handshakes at startup when they see their routes. If the user hasn't
+# enabled the auth method, the handshake blocks → times out → container
+# becomes unhealthy. Gating on DECEPTICON_AUTH_* prevents that.
+
+_SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
+    # env flag → model_list entries
+    "DECEPTICON_AUTH_CHATGPT": [
+        {"model_name": "auth/gpt-5.5", "litellm_params": {"model": "chatgpt/gpt-5.5"}},
+        {"model_name": "auth/gpt-5.4", "litellm_params": {"model": "chatgpt/gpt-5.4"}},
+        {"model_name": "auth/gpt-5-nano", "litellm_params": {"model": "chatgpt/gpt-5-nano"}},
+    ],
+    "DECEPTICON_AUTH_GEMINI": [
+        {
+            "model_name": "gemini-sub/gemini-2.5-pro",
+            "litellm_params": {"model": "gemini-sub/gemini-2.5-pro"},
+        },
+        {
+            "model_name": "gemini-sub/gemini-2.5-flash",
+            "litellm_params": {"model": "gemini-sub/gemini-2.5-flash"},
+        },
+    ],
+    "DECEPTICON_AUTH_COPILOT": [
+        {"model_name": "copilot/gpt-4o", "litellm_params": {"model": "copilot/gpt-4o"}},
+        {"model_name": "copilot/o1", "litellm_params": {"model": "copilot/o1"}},
+    ],
+    "DECEPTICON_AUTH_GROK": [
+        {"model_name": "grok-sub/grok-3", "litellm_params": {"model": "grok-sub/grok-3"}},
+        {"model_name": "grok-sub/grok-3-mini", "litellm_params": {"model": "grok-sub/grok-3-mini"}},
+    ],
+    "DECEPTICON_AUTH_PERPLEXITY": [
+        {"model_name": "pplx-sub/sonar-pro", "litellm_params": {"model": "pplx-sub/sonar-pro"}},
+        {"model_name": "pplx-sub/sonar", "litellm_params": {"model": "pplx-sub/sonar"}},
+    ],
+}
+
+# Fallback entries for subscription routes — appended to litellm_settings.fallbacks
+_SUBSCRIPTION_FALLBACKS: dict[str, list[dict[str, list[str]]]] = {
+    "DECEPTICON_AUTH_CHATGPT": [
+        {"auth/gpt-5.5": ["auth/gpt-5.4"]},
+    ],
+    "DECEPTICON_AUTH_GEMINI": [
+        {"gemini-sub/gemini-2.5-pro": ["gemini-sub/gemini-2.5-flash"]},
+    ],
+    "DECEPTICON_AUTH_COPILOT": [
+        {"copilot/gpt-4o": ["copilot/o1"]},
+    ],
+    "DECEPTICON_AUTH_GROK": [
+        {"grok-sub/grok-3": ["grok-sub/grok-3-mini"]},
+    ],
+    "DECEPTICON_AUTH_PERPLEXITY": [
+        {"pplx-sub/sonar-pro": ["pplx-sub/sonar"]},
+    ],
+}
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().lower() in ("true", "1", "yes", "on")
+
+
+def _inject_subscription_routes(
+    config: MutableMapping[str, Any], env: Mapping[str, str] | None = None
+) -> None:
+    """Conditionally add subscription OAuth model routes and fallbacks.
+
+    Only registers routes for providers whose ``DECEPTICON_AUTH_*`` flag is
+    truthy.  This prevents LiteLLM's native OAuth providers from attempting
+    device-code or session-token handshakes at startup when the user hasn't
+    enabled the auth method.
+    """
+    source = env if env is not None else os.environ
+    model_list = config.setdefault("model_list", [])
+    existing = {e.get("model_name") for e in model_list if isinstance(e, dict)}
+
+    settings = config.setdefault("litellm_settings", {})
+    fallbacks = settings.setdefault("fallbacks", [])
+
+    for flag, routes in _SUBSCRIPTION_ROUTES.items():
+        if not _is_truthy(source.get(flag, "")):
+            continue
+        for route in routes:
+            if route["model_name"] not in existing:
+                model_list.append(route)
+                existing.add(route["model_name"])
+        # Add corresponding fallbacks
+        for fb in _SUBSCRIPTION_FALLBACKS.get(flag, []):
+            if fb not in fallbacks:
+                fallbacks.append(fb)
+
+
 def merge_dynamic_models(
     config: MutableMapping[str, Any], env: Mapping[str, str] | None = None
 ) -> dict[str, Any]:
     """Append requested models not already present in a LiteLLM config."""
     merged = copy.deepcopy(dict(config))
+
+    # Conditionally inject subscription OAuth routes
+    _inject_subscription_routes(merged, env)
+
     model_list = list(merged.get("model_list") or [])
     existing = {entry.get("model_name") for entry in model_list if isinstance(entry, dict)}
 

--- a/decepticon/llm/factory.py
+++ b/decepticon/llm/factory.py
@@ -336,74 +336,92 @@ class _DeepSeekThinkingChatOpenAI(_ProxiedChatOpenAI):
 
         return payload
 
-    def _create_message_dicts(
-        self,
-        messages: list[BaseMessage],
-        stop: list[str] | None = None,
-    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-        """Override to inject reasoning_content into serialized message dicts."""
-        message_dicts, params = super()._create_message_dicts(messages, stop=stop)
-
-        # Pair up LangChain messages with their serialized dicts and inject
-        # reasoning_content where present. This is more reliable than the
-        # payload-level injection since we have direct access to the source
-        # AIMessage objects.
-        for lc_msg, msg_dict in zip(messages, message_dicts):
-            if (
-                isinstance(lc_msg, AIMessage)
-                and "reasoning_content" not in msg_dict
-                and lc_msg.additional_kwargs.get("reasoning_content")
-            ):
-                msg_dict["reasoning_content"] = lc_msg.additional_kwargs["reasoning_content"]
-
-        # Ensure thinking mode params are in the request
-        params.setdefault("extra_body", {})
-        params["extra_body"]["thinking"] = {"type": "enabled"}
-        params["reasoning_effort"] = "high"
-
-        return message_dicts, params
-
     def _generate(self, messages: list[BaseMessage], *args: Any, **kwargs: Any) -> Any:
         """Wrap _generate to preserve reasoning_content in the response."""
         result = super()._generate(messages, *args, **kwargs)
-        self._extract_reasoning_content(result)
+        # _create_chat_result already handled extraction; this is a no-op safety net.
         return result
 
     async def _agenerate(self, messages: list[BaseMessage], *args: Any, **kwargs: Any) -> Any:
         """Wrap _agenerate to preserve reasoning_content in the response."""
         result = await super()._agenerate(messages, *args, **kwargs)
-        self._extract_reasoning_content(result)
         return result
 
-    @staticmethod
-    def _extract_reasoning_content(result: Any) -> None:
-        """Extract reasoning_content from raw response into AIMessage.additional_kwargs.
+    def _convert_chunk_to_generation_chunk(
+        self,
+        chunk: dict,
+        default_chunk_class: type,
+        base_generation_info: dict | None,
+    ) -> Any:
+        """Intercept streaming chunks to capture ``reasoning_content``.
 
-        The OpenAI SDK parses reasoning_content from the response but LangChain's
-        _convert_dict_to_message ignores it. We recover it from the raw response
-        object stored in generation_info or the response_metadata.
+        DeepSeek sends ``reasoning_content`` inside ``choices[0].delta``
+        during streaming.  LangChain's ``_convert_delta_to_message_chunk``
+        ignores it, so it never reaches ``AIMessageChunk.additional_kwargs``.
+
+        We call the parent to build the ``ChatGenerationChunk`` normally,
+        then fish ``reasoning_content`` out of the raw delta dict and inject
+        it into the chunk message's ``additional_kwargs``.  When LangChain
+        aggregates chunks via ``AIMessageChunk.__add__``, ``merge_dicts``
+        concatenates the string fragments into the full reasoning trace,
+        which ``_get_request_payload`` then injects back into the API
+        request on subsequent turns.
         """
-        for generation in getattr(result, "generations", []):
+        gen_chunk = super()._convert_chunk_to_generation_chunk(
+            chunk, default_chunk_class, base_generation_info
+        )
+        if gen_chunk is None:
+            return None
+
+        # Extract reasoning_content from the raw delta
+        choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices", [])
+        if choices:
+            delta = choices[0].get("delta") or {}
+            rc = delta.get("reasoning_content")
+            if rc and isinstance(gen_chunk.message, AIMessage):
+                gen_chunk.message.additional_kwargs.setdefault("reasoning_content", "")
+                gen_chunk.message.additional_kwargs["reasoning_content"] += rc
+
+        return gen_chunk
+
+    def _create_chat_result(self, response: Any, generation_info: dict | None = None) -> Any:
+        """Override to capture ``reasoning_content`` from the response dict.
+
+        ``_create_chat_result`` receives either the raw OpenAI ``ChatCompletion``
+        object or its ``.model_dump()`` dict.  Either way, each choice's
+        ``message`` dict contains ``reasoning_content`` (the OpenAI SDK v1.x
+        preserves it via ``model_extra``).  LangChain's ``_convert_dict_to_message``
+        ignores it, so we fish it out of the response dict and inject it into
+        the resulting ``AIMessage.additional_kwargs`` after the parent builds
+        the ``ChatResult``.
+        """
+        # Get the response as a dict so we can access reasoning_content
+        import openai as _openai
+
+        if isinstance(response, _openai.BaseModel):
+            response_dict = response.model_dump(
+                exclude={"choices": {"__all__": {"message": {"parsed"}}}}
+            )
+        elif isinstance(response, dict):
+            response_dict = response
+        else:
+            response_dict = {}
+
+        result = super()._create_chat_result(response, generation_info)
+
+        # Pair up choices with generations and inject reasoning_content
+        choices = response_dict.get("choices") or []
+        for choice, generation in zip(choices, result.generations):
             msg = getattr(generation, "message", None)
             if not isinstance(msg, AIMessage):
                 continue
-            # Already set (future-proofing)
             if msg.additional_kwargs.get("reasoning_content"):
                 continue
-            # Try generation_info → message → reasoning_content
-            gen_info = getattr(generation, "generation_info", {}) or {}
-            rc = gen_info.get("reasoning_content")
-            if not rc:
-                # Try response_metadata
-                rm = getattr(msg, "response_metadata", {}) or {}
-                rc = rm.get("reasoning_content")
-            if not rc:
-                # Try the raw OpenAI Choice object if available
-                raw = gen_info.get("message", {})
-                if isinstance(raw, dict):
-                    rc = raw.get("reasoning_content")
+            rc = (choice.get("message") or {}).get("reasoning_content")
             if rc:
                 msg.additional_kwargs["reasoning_content"] = rc
+
+        return result
 
 
 def _reraise_if_connection_error(exc: Exception) -> None:

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -377,3 +377,421 @@ class TestActionableErrorTranslation:
         exc = ValueError("something completely unrelated")
         # Should not raise from the helper.
         self._translate(exc, "anthropic/claude-opus-4-7")
+
+
+# ── DeepSeek V4 Pro reasoning_content passthrough ────────────────────────
+
+
+class TestDeepSeekReasoningContent:
+    """Verify reasoning_content survives both the non-streaming and streaming
+    paths so it can be sent back on subsequent API turns."""
+
+    def test_create_chat_result_extracts_reasoning_content(self):
+        """Non-streaming: _create_chat_result captures reasoning_content
+        from the response dict's choice message."""
+        from unittest.mock import patch
+
+        from langchain_core.messages import AIMessage
+        from langchain_core.outputs import ChatGeneration, ChatResult
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        # Simulate the OpenAI response dict with reasoning_content
+        response_dict = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Four",
+                        "reasoning_content": "I think therefore I am",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {},
+        }
+
+        # Mock the parent's _create_chat_result to return a ChatResult without reasoning_content
+        msg = AIMessage(content="Four", additional_kwargs={})
+        parent_result = ChatResult(generations=[ChatGeneration(message=msg)])
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_create_chat_result",
+            return_value=parent_result,
+        ):
+            instance = object.__new__(_DeepSeekThinkingChatOpenAI)
+            result = instance._create_chat_result(response_dict)
+
+        assert (
+            result.generations[0].message.additional_kwargs["reasoning_content"]
+            == "I think therefore I am"
+        )
+
+    def test_create_chat_result_skips_when_absent(self):
+        """Non-streaming: no crash when reasoning_content is missing."""
+        from unittest.mock import patch
+
+        from langchain_core.messages import AIMessage
+        from langchain_core.outputs import ChatGeneration, ChatResult
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        response_dict = {
+            "choices": [
+                {"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}
+            ],
+            "usage": {},
+        }
+
+        msg = AIMessage(content="hi", additional_kwargs={})
+        parent_result = ChatResult(generations=[ChatGeneration(message=msg)])
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_create_chat_result",
+            return_value=parent_result,
+        ):
+            instance = object.__new__(_DeepSeekThinkingChatOpenAI)
+            result = instance._create_chat_result(response_dict)
+
+        assert "reasoning_content" not in result.generations[0].message.additional_kwargs
+
+    def test_convert_chunk_injects_reasoning_content(self):
+        """Streaming: _convert_chunk_to_generation_chunk captures
+        reasoning_content from the raw delta and injects it into
+        AIMessageChunk.additional_kwargs."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        # Build a fake raw SSE chunk dict with reasoning_content in the delta
+        raw_chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "Let me think...",
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+
+        # The parent's _convert_chunk_to_generation_chunk builds the
+        # ChatGenerationChunk but ignores reasoning_content. We mock it
+        # to return a chunk without reasoning_content, then verify our
+        # override injects it.
+        base_msg = AIMessageChunk(content="", additional_kwargs={})
+        base_chunk = ChatGenerationChunk(message=base_msg)
+
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        # Bind the real method to our mock instance
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=base_chunk,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        assert result is not None
+        assert result.message.additional_kwargs["reasoning_content"] == "Let me think..."
+
+    def test_convert_chunk_no_reasoning_leaves_kwargs_clean(self):
+        """Streaming: when delta has no reasoning_content, additional_kwargs
+        is not polluted."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        raw_chunk = {
+            "choices": [
+                {
+                    "delta": {"role": "assistant", "content": "hi"},
+                    "finish_reason": None,
+                }
+            ],
+        }
+
+        base_msg = AIMessageChunk(content="hi", additional_kwargs={})
+        base_chunk = ChatGenerationChunk(message=base_msg)
+
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=base_chunk,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        assert result is not None
+        assert "reasoning_content" not in result.message.additional_kwargs
+
+    def test_reasoning_content_accumulates_across_chunks(self):
+        """Streaming: reasoning_content from multiple chunks concatenates
+        via AIMessageChunk.__add__ (merge_dicts)."""
+        from langchain_core.messages import AIMessageChunk
+
+        c1 = AIMessageChunk(content="", additional_kwargs={"reasoning_content": "Let me "})
+        c2 = AIMessageChunk(content="", additional_kwargs={"reasoning_content": "think..."})
+        c3 = AIMessageChunk(content="Hello!", additional_kwargs={})
+
+        merged = c1 + c2 + c3
+        assert merged.additional_kwargs["reasoning_content"] == "Let me think..."
+        assert merged.content == "Hello!"
+
+    def test_get_request_payload_injects_reasoning_content(self):
+        """Outbound: _get_request_payload injects reasoning_content from
+        AIMessage.additional_kwargs into serialized assistant message dicts."""
+        from unittest.mock import patch
+
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        messages = [
+            HumanMessage(content="hi"),
+            AIMessage(
+                content="hello",
+                additional_kwargs={"reasoning_content": "thinking..."},
+            ),
+        ]
+
+        # Mock super()._get_request_payload to return a payload without reasoning_content
+        mock_payload = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+            "model": "deepseek/deepseek-v4-pro",
+        }
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_get_request_payload",
+            return_value=mock_payload,
+        ):
+            instance = object.__new__(_DeepSeekThinkingChatOpenAI)
+            payload = instance._get_request_payload(messages)
+
+        assert payload["messages"][1]["reasoning_content"] == "thinking..."
+        assert "reasoning_content" not in payload["messages"][0]
+        assert payload["extra_body"]["thinking"] == {"type": "enabled"}
+        assert payload["reasoning_effort"] == "high"
+
+    def test_convert_chunk_empty_reasoning_content_ignored(self):
+        """Streaming: empty string reasoning_content in delta is ignored."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        raw_chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "content": "hi",
+                        "reasoning_content": "",
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+
+        base_msg = AIMessageChunk(content="hi", additional_kwargs={})
+        base_chunk = ChatGenerationChunk(message=base_msg)
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=base_chunk,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        # Empty string is falsy — should not pollute additional_kwargs
+        assert "reasoning_content" not in result.message.additional_kwargs
+
+    def test_convert_chunk_none_delta_no_crash(self):
+        """Streaming: None delta in choices does not crash."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        raw_chunk = {
+            "choices": [
+                {
+                    "delta": None,
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        base_msg = AIMessageChunk(content="", additional_kwargs={})
+        base_chunk = ChatGenerationChunk(message=base_msg)
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=base_chunk,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        assert result is not None
+        assert "reasoning_content" not in result.message.additional_kwargs
+
+    def test_convert_chunk_empty_choices_no_crash(self):
+        """Streaming: empty choices array does not crash."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        raw_chunk = {"choices": []}
+
+        base_msg = AIMessageChunk(content="", additional_kwargs={})
+        base_chunk = ChatGenerationChunk(message=base_msg)
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=base_chunk,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        assert result is not None
+        assert "reasoning_content" not in result.message.additional_kwargs
+
+    def test_convert_chunk_parent_returns_none(self):
+        """Streaming: when parent returns None, we return None too."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        raw_chunk = {"type": "content.delta"}  # parent returns None for these
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=None,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        assert result is None
+
+    def test_convert_chunk_beta_stream_format(self):
+        """Streaming: handles beta.chat.completions.stream nested chunk format."""
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        # Some LangChain versions nest under "chunk" key
+        raw_chunk = {
+            "chunk": {
+                "choices": [
+                    {
+                        "delta": {
+                            "role": "assistant",
+                            "content": "",
+                            "reasoning_content": "Thinking via beta format...",
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+        }
+
+        base_msg = AIMessageChunk(content="", additional_kwargs={})
+        base_chunk = ChatGenerationChunk(message=base_msg)
+        instance = MagicMock(spec=_DeepSeekThinkingChatOpenAI)
+        method = _DeepSeekThinkingChatOpenAI._convert_chunk_to_generation_chunk
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_convert_chunk_to_generation_chunk",
+            return_value=base_chunk,
+        ):
+            result = method(instance, raw_chunk, AIMessageChunk, None)
+
+        assert (
+            result.message.additional_kwargs["reasoning_content"] == "Thinking via beta format..."
+        )
+
+    def test_get_request_payload_multiple_assistant_messages(self):
+        """Outbound: each assistant message gets its own reasoning_content."""
+        from unittest.mock import patch
+
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from decepticon.llm.factory import _DeepSeekThinkingChatOpenAI
+
+        messages = [
+            HumanMessage(content="q1"),
+            AIMessage(content="a1", additional_kwargs={"reasoning_content": "thought1"}),
+            HumanMessage(content="q2"),
+            AIMessage(content="a2", additional_kwargs={"reasoning_content": "thought2"}),
+        ]
+
+        mock_payload = {
+            "messages": [
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a1"},
+                {"role": "user", "content": "q2"},
+                {"role": "assistant", "content": "a2"},
+            ],
+            "model": "deepseek/deepseek-v4-pro",
+        }
+
+        with patch.object(
+            _DeepSeekThinkingChatOpenAI.__bases__[0],
+            "_get_request_payload",
+            return_value=mock_payload,
+        ):
+            instance = object.__new__(_DeepSeekThinkingChatOpenAI)
+            payload = instance._get_request_payload(messages)
+
+        assert payload["messages"][1]["reasoning_content"] == "thought1"
+        assert payload["messages"][3]["reasoning_content"] == "thought2"
+        assert "reasoning_content" not in payload["messages"][0]
+        assert "reasoning_content" not in payload["messages"][2]
+
+    def test_model_detection(self):
+        """Factory routes deepseek-v4-pro through the thinking subclass."""
+        from decepticon.llm.factory import _model_is_deepseek_thinking
+
+        assert _model_is_deepseek_thinking("deepseek/deepseek-v4-pro") is True
+        assert _model_is_deepseek_thinking("deepseek/deepseek-reasoner") is True
+        assert _model_is_deepseek_thinking("deepseek/deepseek-v4-flash") is False
+        assert _model_is_deepseek_thinking("deepseek/deepseek-chat") is False
+        assert _model_is_deepseek_thinking("openai/gpt-5.5") is False


### PR DESCRIPTION
## Summary

Three fixes addressing user-reported issues:

### 1. DeepSeek V4 Pro `reasoning_content` passthrough (streaming + non-streaming)

**Bug:** PR #121 only handled `_generate`/`_agenerate` (non-streaming). LangGraph uses both paths — the streaming path never captured `reasoning_content`, and the non-streaming path searched `generation_info`/`response_metadata` where LangChain never puts the field. Result: 400 error on every multi-turn tool call with DeepSeek V4 Pro thinking mode.

**Fix:**
- **Streaming:** Override `_convert_chunk_to_generation_chunk` to capture `reasoning_content` from `choices[0].delta` in each SSE chunk → injected into `AIMessageChunk.additional_kwargs` → accumulated via `merge_dicts`
- **Non-streaming:** Override `_create_chat_result` to extract `reasoning_content` from the OpenAI SDK's parsed `ChatCompletion.model_extra` (the SDK preserves it, but LangChain's `_convert_dict_to_message` drops it)
- **Outbound:** `_get_request_payload` injects `reasoning_content` back into serialized assistant message dicts
- **Cleanup:** Removed dead `_create_message_dicts` that called a nonexistent `super()` method

**Verified live:** Soundwave → 5 tool calls → multi-turn follow-up on `deepseek-v4-pro` thinking mode. No 400.

### 2. Conditional subscription OAuth route registration

**Bug:** `chatgpt/*`, `gemini-sub/*`, `copilot/*`, `grok-sub/*`, `pplx-sub/*` routes were statically registered in `litellm.yaml`. LiteLLM's native providers attempt OAuth handshakes at startup when they see their routes — regardless of `DECEPTICON_AUTH_*=false`. The ChatGPT provider blocks ~370s on device-code auth, times out, makes the container unhealthy.

**Fix:** Moved 13 subscription routes + 5 fallback entries to conditional registration in `litellm_dynamic_config.py`, gated on `DECEPTICON_AUTH_*` flags. Default (false) = zero subscription routes registered.

### 3. CLI: `/file` command + larger UserMessage display

- `/file <path>` (alias `/f`) — reads a file and submits as a message. For long VDP/engagement prompts.
- `UserMessage` truncation raised from 5000 → 10000 chars so typical engagement briefs display fully.

## Files Changed

| File | Change |
|------|--------|
| `decepticon/llm/factory.py` | `_convert_chunk_to_generation_chunk` + `_create_chat_result` overrides, removed dead code |
| `config/litellm.yaml` | Removed 13 static subscription OAuth routes |
| `config/litellm_dynamic_config.py` | Conditional subscription route injection gated on `DECEPTICON_AUTH_*` |
| `tests/unit/llm/test_factory.py` | 13 new tests covering streaming, non-streaming, edge cases |
| `clients/cli/src/commands/file.ts` | New `/file` slash command |
| `clients/cli/src/commands/registry.ts` | Register `/file` command |
| `clients/cli/src/components/messages/UserMessage.tsx` | Increased truncation limit |

## Testing

- 761 unit tests passing (0 failures)
- Ruff lint: 0 errors
- Ruff format: clean
- basedpyright: 0 errors
- CLI typecheck: clean
- Live E2E: Soundwave multi-turn with tool calls on `deepseek-v4-pro` ✓
- Live E2E: LiteLLM starts without ChatGPT OAuth prompt when `DECEPTICON_AUTH_CHATGPT=false` ✓