### PR TITLE
fix(tmux): recover from 'can't find pane: main' during parallel execution

### DIFF
--- a/decepticon/backends/docker_sandbox.py
+++ b/decepticon/backends/docker_sandbox.py
@@ -118,7 +118,11 @@ class TmuxSessionManager:
         if result.returncode != 0:
             error_msg = result.stderr or result.stdout
             # Detect tmux server death and invalidate session cache
-            if "no server running" in error_msg or "server exited" in error_msg:
+            if (
+                "no server running" in error_msg
+                or "server exited" in error_msg
+                or "can't find pane" in error_msg
+            ):
                 log.warning("tmux server died — invalidating all session caches")
                 with TmuxSessionManager._init_lock:
                     TmuxSessionManager._initialized.clear()
@@ -157,7 +161,18 @@ class TmuxSessionManager:
         """Create session if needed and inject PS1 marker (once per session)."""
         with TmuxSessionManager._init_lock:
             if self.session in TmuxSessionManager._initialized:
-                return
+                # Stale-cache guard: the tmux server may have been killed
+                # externally (e.g. benchmark harness cleanup) since we last
+                # created this session.
+                try:
+                    self._docker_tmux(["has-session", "-t", self.session], timeout=5)
+                    return
+                except RuntimeError:
+                    log.warning(
+                        "Session '%s' was in init cache but tmux says it is gone — recreating",
+                        self.session,
+                    )
+                    TmuxSessionManager._initialized.discard(self.session)
 
         session_exists = False
         try:
@@ -231,7 +246,11 @@ class TmuxSessionManager:
             baseline = self._capture()
         except RuntimeError as e:
             error_msg = str(e)
-            if "no server running" in error_msg or "session not found" in error_msg:
+            if (
+                "no server running" in error_msg
+                or "session not found" in error_msg
+                or "can't find pane" in error_msg
+            ):
                 log.warning("Session '%s' is dead — attempting recovery", self.session)
                 with TmuxSessionManager._init_lock:
                     TmuxSessionManager._initialized.discard(self.session)
@@ -273,7 +292,7 @@ class TmuxSessionManager:
             try:
                 screen = self._capture()
             except RuntimeError as poll_err:
-                if "no server running" in str(poll_err):
+                if "no server running" in str(poll_err) or "can't find pane" in str(poll_err):
                     with TmuxSessionManager._init_lock:
                         TmuxSessionManager._initialized.discard(self.session)
                     return (
@@ -390,7 +409,11 @@ class TmuxSessionManager:
             baseline = await asyncio.to_thread(self._capture)
         except RuntimeError as e:
             error_msg = str(e)
-            if "no server running" in error_msg or "session not found" in error_msg:
+            if (
+                "no server running" in error_msg
+                or "session not found" in error_msg
+                or "can't find pane" in error_msg
+            ):
                 log.warning("Session '%s' is dead — attempting recovery", self.session)
                 with TmuxSessionManager._init_lock:
                     TmuxSessionManager._initialized.discard(self.session)
@@ -434,7 +457,7 @@ class TmuxSessionManager:
             try:
                 screen = await asyncio.to_thread(self._capture)
             except RuntimeError as poll_err:
-                if "no server running" in str(poll_err):
+                if "no server running" in str(poll_err) or "can't find pane" in str(poll_err):
                     with TmuxSessionManager._init_lock:
                         TmuxSessionManager._initialized.discard(self.session)
                     return (

--- a/tests/unit/backends/test_session_log.py
+++ b/tests/unit/backends/test_session_log.py
@@ -369,3 +369,110 @@ def test_poll_loop_capture_errors_dont_falsely_trigger_stall_detection():
     # And not [TIMEOUT] either — the loop should have detected completion.
     assert "[TIMEOUT]" not in result, f"Should have completed: {result!r}"
     assert "[ERROR]" not in result, f"Should not have errored: {result!r}"
+
+
+def test_initialize_recreate_when_stale_cache():
+    """If _initialized contains the session but tmux has no such session,
+    initialize() must detect the stale cache and recreate the session."""
+    mgr = TmuxSessionManager("stale", "decepticon-sandbox")
+    TmuxSessionManager._initialized.add("stale")
+
+    with (
+        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run,
+        patch("time.sleep"),
+    ):
+        mock_tmux.side_effect = [
+            RuntimeError("can't find pane: stale"),  # has-session inside cache check
+            "",  # has-session after cache discard
+            "",  # new-session
+            "",  # send-keys ps1_cmd
+            "",  # send-keys Enter
+            "",  # send-keys C-l
+            "",  # clear-history
+            "",  # pipe-pane
+        ]
+        mock_run.return_value.returncode = 0
+        mgr.initialize()
+
+    # Should have called has-session, detected failure, discarded cache, then recreated
+    assert "stale" in TmuxSessionManager._initialized
+
+
+def test_execute_recovers_from_cant_find_pane():
+    """execute() must treat 'can't find pane' as a recoverable session-death
+    error, same as 'no server running' and 'session not found'."""
+    mgr = TmuxSessionManager("pane-test", "decepticon-sandbox")
+    TmuxSessionManager._initialized.add("pane-test")
+
+    side_effects = [
+        RuntimeError("can't find pane: pane-test"),  # first _capture fails
+        "",  # has-session in recovery
+        "",  # new-session in recovery
+        "[DCPTN:0:/workspace] ",  # recovery _capture baseline
+        "",  # _send command
+        "[DCPTN:0:/workspace] ls\nfile.txt\n[DCPTN:0:/workspace] ",  # poll _capture
+        "",  # _clear_screen
+    ]
+
+    with (
+        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch("time.sleep"),
+    ):
+        mock_tmux.side_effect = side_effects
+        result = mgr.execute(command="ls", is_input=False, timeout=2)
+
+    assert "[ERROR]" not in result
+    assert "file.txt" in result
+
+
+def test_execute_async_recovers_from_cant_find_pane():
+    """execute_async() must treat 'can't find pane' as a recoverable
+    session-death error."""
+    import asyncio
+
+    mgr = TmuxSessionManager("async-pane", "decepticon-sandbox")
+    TmuxSessionManager._initialized.add("async-pane")
+
+    side_effects = [
+        RuntimeError("can't find pane: async-pane"),  # first _capture fails
+        "",  # has-session in recovery
+        "",  # new-session in recovery
+        "[DCPTN:0:/workspace] ",  # recovery _capture baseline
+        "",  # _send command
+        "[DCPTN:0:/workspace] ls\nfile.txt\n[DCPTN:0:/workspace] ",  # poll _capture
+        "",  # _clear_screen
+    ]
+
+    with (
+        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch("asyncio.sleep", return_value=None),
+        patch("time.sleep"),
+    ):
+        mock_tmux.side_effect = side_effects
+        result = asyncio.run(
+            mgr.execute_async(command="ls", is_input=False, timeout=2)
+        )
+
+    assert "[ERROR]" not in result
+    assert "file.txt" in result
+
+
+def test_docker_tmux_invalidates_cache_on_cant_find_pane():
+    """_docker_tmux() must clear _initialized when tmux reports 'can't find pane',
+    because that means the server (or at least the session) is gone."""
+    mgr = TmuxSessionManager("die", "decepticon-sandbox")
+    TmuxSessionManager._initialized.add("die")
+    TmuxSessionManager._initialized.add("other")
+
+    import subprocess
+
+    with patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "can't find pane: die"
+        mock_run.return_value.stdout = ""
+        with pytest.raises(RuntimeError, match="can't find pane"):
+            mgr._docker_tmux(["send-keys", "-t", "die", "ls"])
+
+    assert "die" not in TmuxSessionManager._initialized
+    assert "other" not in TmuxSessionManager._initialized


### PR DESCRIPTION
## Problem

When launching parallel objectives, Decepticon throws:

```
error> can't find pane: main
```

This blocks parallel execution and leaves the orchestrator unable to dispatch sub-agents.

## Root Cause

`TmuxSessionManager._initialized` is a class-level cache. When `initialize()` is called:

1. If the session name is in `_initialized`, it returns immediately without verifying the session still exists in tmux.
2. If the tmux server was killed externally (e.g. benchmark harness cleanup runs `tmux kill-server`), the session is gone but `_initialized` still contains the name.
3. Subsequent `_capture()` / `_send()` calls fail with `can't find pane: main` because tmux cannot resolve the target.
4. The recovery logic only caught `"no server running"` and `"session not found"`, not `"can't find pane"`.

## Changes

### `decepticon/backends/docker_sandbox.py`

- **`initialize()`**: When the session is in `_initialized`, verify it still exists via `has-session` before returning. If the session is gone, remove it from the cache and proceed with creation.
- **`execute()` / `execute_async()`**: Added `"can't find pane"` to the recoverable error conditions.
- **Poll loops**: Detect `"can't find pane"` as session-death and invalidate the cache.
- **`_docker_tmux()`**: Detect `"can't find pane"` as server death and clear all session caches.

### `tests/unit/backends/test_session_log.py`

- `test_initialize_recreate_when_stale_cache`
- `test_execute_recovers_from_cant_find_pane`
- `test_execute_async_recovers_from_cant_find_pane`
- `test_docker_tmux_invalidates_cache_on_cant_find_pane`

## Verification

- Syntax checks pass for both modified files.
- New tests cover the stale-cache and recovery paths.

## Fixes

Fixes #124