### PR TITLE
fix(sandbox): verify tmux session existence before reusing cached handle (#133)

### DIFF
--- a/decepticon/backends/docker_sandbox.py
+++ b/decepticon/backends/docker_sandbox.py
@@ -157,7 +157,23 @@ class TmuxSessionManager:
         """Create session if needed and inject PS1 marker (once per session)."""
         with TmuxSessionManager._init_lock:
             if self.session in TmuxSessionManager._initialized:
-                return
+                # Double-check the tmux session still exists — the cache can
+                # become stale when a previous command killed the shell (e.g.
+                # "exit", "reboot", or a rogue SIGKILL). Without this check,
+                # every subsequent bash call for this session would fail with
+                # "can't find pane: <session>" because initialize() skips
+                # creation, then _capture() / _send() hit a dead session.
+                try:
+                    self._docker_tmux(["has-session", "-t", self.session], timeout=5)
+                    return  # Session exists, cache is valid.
+                except RuntimeError:
+                    # Session was destroyed since the cache was populated.
+                    # Discard and fall through to re-initialize below.
+                    log.warning(
+                        "Session '%s' is cached but dead — reinitializing",
+                        self.session,
+                    )
+                    TmuxSessionManager._initialized.discard(self.session)
 
         session_exists = False
         try:


### PR DESCRIPTION
## Problem

`TmuxSessionManager.initialize()` uses a process-wide `_initialized` class-level cache to avoid redundant tmux session creation. When a session is killed (e.g., `exit` command, `reboot`, or SIGKILL), the cached entry is never invalidated. Every subsequent `bash(session="<name>", ...)` call skips initialization and fails with:

```
error> can't find pane: native
```

The error recovery in `execute()` already handles `_capture()` failures for "can't find pane", but `_send()` errors propagate unhandled, leaving the agent stuck in an unrecoverable error loop.

Fixes #133

## Solution

Added a `tmux has-session` verification inside the cache-hit fast-path of `initialize()`. When the cache says the session is initialized, we double-check the session actually exists by calling `tmux has-session -t <name>` inside the Docker sandbox. If the check fails, the stale cache entry is discarded and initialization falls through to normal session creation.

## Testing

1. Created a tmux session, sent commands, confirmed working
2. Sent `exit` to kill the bash shell (which destroys the tmux session)
3. `has-session` correctly returned non-zero
4. After discarding cache, re-created session with same name
5. New session accepted commands normally -- full recovery cycle verified

## Impact

Zero behavioral change for sessions that are alive (the `has-session` check succeeds in <50ms). Fix only activates when the cache is stale, which is the exact failure mode reported.
