### PR TITLE
fix(agent): stabilize local model flow and workspace scoping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
           load: true
           tags: decepticon-${{ matrix.image }}:ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=${{ github.event_name == 'push' && 'max' || 'min' }}
       - name: Trivy image scan
         uses: aquasecurity/trivy-action@0.35.0
         with:

--- a/clients/launcher/cmd/stop.go
+++ b/clients/launcher/cmd/stop.go
@@ -13,9 +13,8 @@ var stopCmd = &cobra.Command{
 		c := compose.New()
 		ui.Info("Stopping Decepticon services...")
 		c.RemoveOrphanedCLI()
-		// Clear bash-tool scratch buffers before tearing the stack down so
-		// /workspace/.scratch does not accumulate across engagements. Must run
-		// while the sandbox is still up; CleanScratch is a no-op otherwise.
+		// Clear legacy root-level scratch/session buffers before tearing the
+		// stack down. Current runs keep these under engagement workspaces.
 		c.CleanScratch()
 		if err := c.Down(); err != nil {
 			return err

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -207,12 +207,20 @@ func (c *Compose) RunInteractive(profiles []string, service string, env map[stri
 	return nil
 }
 
-// CleanScratch removes /workspace/.scratch inside the running sandbox.
-// Best-effort: silently no-ops when the sandbox is not running so a stale
-// scratch directory can be retired without forcing the user to bring the
-// stack up just for cleanup.
+// CleanScratch removes legacy root-level scratch/session directories inside
+// the running sandbox. Current bash tooling writes these directories under
+// each engagement workspace; this cleanup only retires leftovers from older
+// versions.
 func (c *Compose) CleanScratch() {
-	cmd := exec.Command("docker", "exec", "decepticon-sandbox", "rm", "-rf", "/workspace/.scratch")
+	cmd := exec.Command(
+		"docker",
+		"exec",
+		"decepticon-sandbox",
+		"rm",
+		"-rf",
+		"/workspace/.scratch",
+		"/workspace/.sessions",
+	)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	_ = cmd.Run()

--- a/clients/launcher/internal/engagement/picker.go
+++ b/clients/launcher/internal/engagement/picker.go
@@ -16,9 +16,9 @@ import (
 	"sort"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 
@@ -80,6 +80,9 @@ func ScanEngagements(home string) ([]engagementEntry, error) {
 			continue
 		}
 		slug := e.Name()
+		if strings.HasPrefix(slug, ".") {
+			continue
+		}
 		entry := engagementEntry{Slug: slug, Ready: isReady(home, slug)}
 		if entry.Ready {
 			if st, err := os.Stat(filepath.Join(root, slug, "plan", "roe.json")); err == nil {
@@ -343,9 +346,9 @@ func (m pickerModel) refresh() pickerModel {
 
 var (
 	confirmStyle = lipgloss.NewStyle().
-		Padding(0, 1).
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#ef4444"))
+			Padding(0, 1).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#ef4444"))
 	confirmTextStyle = lipgloss.NewStyle().Bold(true)
 	confirmHintStyle = lipgloss.NewStyle().Faint(true)
 )

--- a/clients/launcher/internal/engagement/picker_test.go
+++ b/clients/launcher/internal/engagement/picker_test.go
@@ -67,6 +67,24 @@ func TestScanEngagements_ReadyAndInProgress(t *testing.T) {
 	}
 }
 
+func TestScanEngagements_IgnoresHiddenWorkspaceDirs(t *testing.T) {
+	home := t.TempDir()
+	mkBareDir(t, home, "visible-engagement")
+	mkBareDir(t, home, ".sessions")
+	mkBareDir(t, home, ".scratch")
+
+	got, err := ScanEngagements(home)
+	if err != nil {
+		t.Fatalf("ScanEngagements: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 visible engagement, got %d (%v)", len(got), got)
+	}
+	if got[0].Slug != "visible-engagement" {
+		t.Fatalf("expected visible-engagement, got %q", got[0].Slug)
+	}
+}
+
 func TestScanEngagements_ReadyEngagementsBubbleUp(t *testing.T) {
 	home := t.TempDir()
 	now := time.Now()

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -42,8 +42,10 @@
     "neo4j-driver": "^6.0.1",
     "next": "16.2.3",
     "next-themes": "^0.4.6",
+    "node-pty": "^1.1.0",
 
     "pg": "^8.20.0",
+    "prisma": "^7.7.0",
 
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -53,8 +55,10 @@
     "remark-gfm": "^4.0.1",
 
     "shadcn": "^4.2.0",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "tsx": "^4.19.0",
 
     "ws": "^8.20.0",
     "xterm": "^5.3.0"
@@ -63,7 +67,6 @@
   "devDependencies": {
     "@types/d3-force": "^3.0.10",
     "@types/ws": "^8.18.1",
-    "node-pty": "^1.1.0",
 
     "@tailwindcss/postcss": "^4",
 
@@ -75,7 +78,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.3",
 
-    "sharp": "^0.34.5",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/clients/web/src/app/api/engagements/route.ts
+++ b/clients/web/src/app/api/engagements/route.ts
@@ -13,19 +13,25 @@ const WORKSPACE_SUBDIRS = ["plan"];
 // from either side surface in the other's picker without quoting/encoding hacks.
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/;
 
+function isEngagementWorkspaceDir(name: string) {
+  return SLUG_RE.test(name) && !name.startsWith(".");
+}
+
 export async function GET() {
   try {
     const { userId } = await requireAuth();
 
-    const engagements = await prisma.engagement.findMany({
+    const engagements = (await prisma.engagement.findMany({
       where: { userId },
       orderBy: { createdAt: "desc" },
-    });
+    })).filter((eng) => isEngagementWorkspaceDir(eng.name));
 
     // Auto-import workspace dirs created by CLI that are not yet in DB
     try {
       const entries = await fs.readdir(WORKSPACE, { withFileTypes: true });
-      const wsDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+      const wsDirs = entries
+        .filter((e) => e.isDirectory() && isEngagementWorkspaceDir(e.name))
+        .map((e) => e.name);
       const knownNames = new Set(engagements.map((e) => e.name));
 
       for (const dir of wsDirs) {

--- a/containers/web.Dockerfile
+++ b/containers/web.Dockerfile
@@ -1,8 +1,8 @@
 # ----------------------
-# build-base — Node 22 LTS + native build toolchain.
+# build-base — Node 24 + native build toolchain.
 # Used only by stages that compile native addons (node-pty, sharp).
 # ----------------------
-FROM node:22-slim AS build-base
+FROM node:24-slim AS build-base
 
 WORKDIR /app
 
@@ -55,12 +55,15 @@ WORKDIR /app/clients/web
 RUN npx prisma generate
 RUN npm run build
 
+WORKDIR /app
+RUN npm prune --omit=dev --no-audit --no-fund
+
 # ----------------------
-# runtime — minimal node:22-slim, NO build toolchain.
+# runtime — minimal node:24-slim, NO build toolchain.
 # Native addons compiled in `build` are copied as prebuilt .node binaries;
 # python3/make/g++ are not needed at runtime and would add ~1GB of bloat.
 # ----------------------
-FROM node:22-slim AS runner
+FROM node:24-slim AS runner
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl \
@@ -91,10 +94,8 @@ COPY --from=build --chown=nextjs:nodejs /app/clients/cli/src ./clients/cli/src
 COPY --from=build --chown=nextjs:nodejs /app/clients/cli/package.json ./clients/cli/package.json
 # Shared streaming library
 COPY --from=build --chown=nextjs:nodejs /app/clients/shared ./clients/shared
-# node_modules carries the compiled native addons (node-pty, sharp) plus
-# tsx for running the terminal server. Production-only installs would drop
-# tsx (devDep), so we keep the full tree but rely on the `runner` stage
-# omitting build tools to keep the image lean.
+# Production workspace dependencies: external Next packages, Prisma CLI,
+# node-pty, sharp, and tsx for the current embedded terminal/CLI bridge.
 COPY --from=build --chown=nextjs:nodejs /app/node_modules ./node_modules
 
 WORKDIR /app/clients/web

--- a/decepticon/agents/prompts/decepticon.md
+++ b/decepticon/agents/prompts/decepticon.md
@@ -22,22 +22,28 @@ Violating any of these is a critical failure that compromises the engagement.
 4. **Context Handoff**: ALWAYS include workspace path, scope, prior findings, and
    lessons learned in every `task()` delegation. Sub-agents start with zero context.
    NEVER use double-nested paths like `/workspace/workspace/`.
-5. **State Persistence**: After EVERY sub-agent completion, use `update_objective`
+5. **Remote Targets Are Not Files**: URLs, domains, IP ranges, and hostnames are
+   remote targets, not workspace paths or grep patterns. NEVER call `grep`,
+   `glob`, `ls`, or `read_file` with a target URL/domain to perform recon.
+   Use filesystem tools only for existing engagement artifacts under the
+   workspace; delegate remote reconnaissance to `task()` with the recon or
+   vulnresearch sub-agent.
+6. **State Persistence**: After EVERY sub-agent completion, use `update_objective`
    to record status. Sub-agents record individual findings to `findings/FIND-{NNN}.md`.
    Verify findings were recorded after each delegation.
-6. **Kill Chain Order**: ALWAYS check `blocked_by` dependencies via `get_objective`
+7. **Kill Chain Order**: ALWAYS check `blocked_by` dependencies via `get_objective`
    before starting any objective. Premature execution wastes context windows.
-7. **OPPLAN Discipline**: ALWAYS call `get_objective` before `update_objective`.
+8. **OPPLAN Discipline**: ALWAYS call `get_objective` before `update_objective`.
    NEVER call `update_objective` multiple times in parallel. NEVER mark an objective
    PASSED without evidence in notes. NEVER mark BLOCKED without documenting what was attempted.
-8. **Startup Required**: NEVER skip the `engagement-startup` skill on session start.
-9. **Final Report**: When ALL objectives are completed/blocked, load `final-report` skill
+9. **Startup Required**: NEVER skip the `engagement-startup` skill on session start.
+10. **Final Report**: When ALL objectives are completed/blocked, load `final-report` skill
    and generate `report/executive-summary.md` + `report/technical-report.md` from the
    accumulated findings, attack paths, and timeline.
-10. **Markdown Only**: ALL deliverable documents MUST be Markdown. JSON is only for
+11. **Markdown Only**: ALL deliverable documents MUST be Markdown. JSON is only for
     operational data files (opplan.json, shells.json, etc.).
-11. **C2 Framework**: NEVER install or use Metasploit — the C2 framework is Sliver.
-12. **Sub-Agent Infra-Failure Retry**: When a `task()` call returns an error containing
+12. **C2 Framework**: NEVER install or use Metasploit — the C2 framework is Sliver.
+13. **Sub-Agent Infra-Failure Retry**: When a `task()` call returns an error containing
     `TimeoutExpired`, `tmux capture-pane`, `docker exec`, `connection reset`, `broken pipe`,
     or `sandbox unavailable`, treat it as an INFRA fault (not a reasoning fault). Retry
     the SAME sub-agent ONCE with the SAME prompt — apply symmetrically to recon, exploit,

--- a/decepticon/agents/prompts/soundwave.md
+++ b/decepticon/agents/prompts/soundwave.md
@@ -22,6 +22,10 @@ These rules override all other instructions:
 7. **EXACTLY ONE question per turn**: Never bundle multiple questions in one reply. Wait for the operator's answer before moving to the next dimension. Bundling = scope drift.
 8. **EVERY operator-facing question MUST go through `ask_user_question`**: there is no "use the tool for taxonomy and prose for narrative" split. Every time you collect input from the operator, use the tool. Provide 2–5 best-guess options that cover the most common shapes for the dimension, and **always set `allow_other=true`** so the operator can type a custom answer when the predefined options do not fit. Plain prose is reserved for statements, summaries, and document drafts — never for soliciting input.
 9. **Never re-ask for the engagement slug**: the launcher chose it before you started. The slug arrives via the engagement-context block injected into your system prompt — read it there.
+10. **Remote Targets Are Not Files**: URLs, domains, IP ranges, and hostnames
+   are scope answers, not workspace paths or grep patterns. NEVER call `grep`,
+   `glob`, `ls`, or `read_file` with a target URL/domain. Record targets in
+   the planning documents and leave reconnaissance to the operations agent.
 </CRITICAL_RULES>
 
 <ENVIRONMENT>

--- a/decepticon/backends/docker_sandbox.py
+++ b/decepticon/backends/docker_sandbox.py
@@ -261,7 +261,7 @@ class TmuxSessionManager:
         self._clear_screen()
         time.sleep(0.2)
 
-        if not session_exists:
+        if not session_exists and self._workspace_path != "/workspace":
             log_path = f"{self._workspace_path}/.sessions/{self._log_name}.log"
             try:
                 # Idempotent — the directory is bind-mounted to the host so

--- a/decepticon/middleware/engagement.py
+++ b/decepticon/middleware/engagement.py
@@ -31,13 +31,16 @@ from langchain_core.messages import SystemMessage, ToolMessage
 from langgraph.types import Command
 from typing_extensions import override
 
+from decepticon.middleware.opplan import _reduce_engagement_name
 from decepticon.tools.bash.bash import bash_workspace
 
 
 class EngagementContextState(AgentState):
     """State extension carrying launcher- and harness-decided context."""
 
-    engagement_name: NotRequired[Annotated[str, "Workspace slug set by the launcher."]]
+    engagement_name: NotRequired[
+        Annotated[str, "Workspace slug set by the launcher.", _reduce_engagement_name]
+    ]
     workspace_path: NotRequired[Annotated[str, "Sandbox root for this engagement."]]
     # Benchmark / CTF challenge context — populated by the benchmark harness.
     target_url: NotRequired[Annotated[str, "CTF challenge target URL."]]

--- a/decepticon/middleware/filesystem.py
+++ b/decepticon/middleware/filesystem.py
@@ -10,7 +10,10 @@ from deepagents.backends.protocol import (
     EditResult,
     FileDownloadResponse,
     FileInfo,
+    GlobResult,
     GrepMatch,
+    GrepResult,
+    LsResult,
     ReadResult,
     WriteResult,
 )
@@ -20,18 +23,27 @@ from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesys
 from decepticon.backends.docker_sandbox import DockerSandbox
 
 WORKSPACE = "/workspace"
+NO_WORKSPACE_ERROR = (
+    "No engagement workspace is set. Filesystem tools are scoped to the active "
+    "engagement and cannot access the shared /workspace root."
+)
+
+
+def _normalize_engagement_workspace(workspace_path: str | None) -> str | None:
+    normalized = DockerSandbox._normalize_workspace_path(workspace_path)
+    return None if normalized == WORKSPACE else normalized
 
 
 class EngagementFilesystemBackend(BackendProtocol):
     """Map virtual /workspace paths to /workspace/<engagement> internally."""
 
-    def __init__(self, backend: BackendProtocol, workspace_path: str) -> None:
+    def __init__(self, backend: BackendProtocol, workspace_path: str | None) -> None:
         self._backend = backend
-        self._root = DockerSandbox._normalize_workspace_path(workspace_path)
+        self._root = _normalize_engagement_workspace(workspace_path)
 
     def _real(self, path: str | None) -> str:
-        if self._root == WORKSPACE:
-            return validate_path(path or WORKSPACE)
+        if self._root is None:
+            raise ValueError(NO_WORKSPACE_ERROR)
         virtual = validate_path(path or WORKSPACE)
         if virtual in {"/", WORKSPACE}:
             return self._root
@@ -39,8 +51,8 @@ class EngagementFilesystemBackend(BackendProtocol):
         return f"{self._root}/{rel}" if rel else self._root
 
     def _virtual(self, path: str) -> str | None:
-        if self._root == WORKSPACE:
-            return path
+        if self._root is None:
+            return None
         normalized = path.replace("\\", "/").rstrip("/")
         if normalized and not normalized.startswith("/"):
             normalized = f"{self._root}/{normalized}"
@@ -51,6 +63,8 @@ class EngagementFilesystemBackend(BackendProtocol):
         return None
 
     def _glob(self, pattern: str) -> str:
+        if self._root is None:
+            raise ValueError(NO_WORKSPACE_ERROR)
         if not pattern.startswith("/"):
             return pattern
         virtual = validate_path(pattern)
@@ -62,18 +76,33 @@ class EngagementFilesystemBackend(BackendProtocol):
         path = self._virtual(info.get("path", ""))
         return {**info, "path": path} if path else None
 
+    def ls(self, path: str) -> LsResult:
+        try:
+            real_path = self._real(path)
+        except ValueError as e:
+            return LsResult(error=str(e))
+        result = self._backend.ls(real_path)
+        if result.error:
+            return result
+        return LsResult(
+            entries=[mapped for item in result.entries or [] if (mapped := self._info(item))]
+        )
+
     def ls_info(self, path: str) -> list[FileInfo]:
-        return [
-            mapped
-            for item in self._backend.ls_info(self._real(path))
-            if (mapped := self._info(item))
-        ]
+        result = self.ls(path)
+        return result.entries or []
 
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
-        return self._backend.read(self._real(file_path), offset=offset, limit=limit)
+        try:
+            return self._backend.read(self._real(file_path), offset=offset, limit=limit)
+        except ValueError as e:
+            return ReadResult(error=str(e))
 
     def write(self, file_path: str, content: str) -> WriteResult:
-        result = self._backend.write(self._real(file_path), content)
+        try:
+            result = self._backend.write(self._real(file_path), content)
+        except ValueError as e:
+            return WriteResult(error=str(e))
         path = self._virtual(result.path or "") if result.path else None
         return replace(result, path=path) if path else result
 
@@ -84,9 +113,28 @@ class EngagementFilesystemBackend(BackendProtocol):
         new_string: str,
         replace_all: bool = False,
     ) -> EditResult:
-        result = self._backend.edit(self._real(file_path), old_string, new_string, replace_all)
+        try:
+            result = self._backend.edit(self._real(file_path), old_string, new_string, replace_all)
+        except ValueError as e:
+            return EditResult(error=str(e))
         path = self._virtual(result.path or "") if result.path else None
         return replace(result, path=path) if path else result
+
+    def grep(self, pattern: str, path: str | None = None, glob: str | None = None) -> GrepResult:
+        try:
+            real_path = self._real(path)
+        except ValueError as e:
+            return GrepResult(error=str(e))
+        result = self._backend.grep(pattern, path=real_path, glob=glob)
+        if result.error:
+            return result
+        return GrepResult(
+            matches=[
+                {**match, "path": mapped}
+                for match in result.matches or []
+                if (mapped := self._virtual(match.get("path", "")))
+            ]
+        )
 
     def grep_raw(
         self,
@@ -94,40 +142,49 @@ class EngagementFilesystemBackend(BackendProtocol):
         path: str | None = None,
         glob: str | None = None,
     ) -> list[GrepMatch] | str:
-        result = self._backend.grep_raw(pattern, path=self._real(path), glob=glob)
-        if isinstance(result, str):
+        result = self.grep(pattern, path=path, glob=glob)
+        return result.error if result.error else result.matches or []
+
+    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        try:
+            real_pattern = self._glob(pattern)
+            real_path = self._real(path)
+        except ValueError as e:
+            return GlobResult(error=str(e))
+        result = self._backend.glob(real_pattern, path=real_path)
+        if result.error:
             return result
-        return [
-            {**match, "path": mapped}
-            for match in result
-            if (mapped := self._virtual(match.get("path", "")))
-        ]
+        return GlobResult(
+            matches=[mapped for item in result.matches or [] if (mapped := self._info(item))]
+        )
 
     def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
-        return [
-            mapped
-            for item in self._backend.glob_info(self._glob(pattern), path=self._real(path))
-            if (mapped := self._info(item))
-        ]
+        result = self.glob(pattern, path=path)
+        return result.matches or []
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        result = self._backend.download_files([self._real(path) for path in paths])
+        try:
+            real_paths = [self._real(path) for path in paths]
+        except ValueError:
+            return [
+                FileDownloadResponse(path=path, content=None, error="invalid_path")
+                for path in paths
+            ]
+        result = self._backend.download_files(real_paths)
         return [
             FileDownloadResponse(path=paths[i], content=response.content, error=response.error)
             for i, response in enumerate(result)
         ]
 
 
-def _workspace_from_runtime(runtime: Any) -> str:
+def _workspace_from_runtime(runtime: Any) -> str | None:
     state = getattr(runtime, "state", {}) or {}
     if hasattr(state, "get") and state.get("workspace_path"):
         return str(state["workspace_path"])
     configurable = (getattr(runtime, "config", {}) or {}).get("configurable", {})
-    return (
-        str(configurable.get("workspace_path", WORKSPACE))
-        if isinstance(configurable, dict)
-        else WORKSPACE
-    )
+    if isinstance(configurable, dict) and configurable.get("workspace_path"):
+        return str(configurable["workspace_path"])
+    return None
 
 
 class FilesystemMiddleware(BaseFilesystemMiddleware):

--- a/decepticon/middleware/opplan.py
+++ b/decepticon/middleware/opplan.py
@@ -42,6 +42,12 @@ from decepticon.core.schemas import (
     OpsecLevel,
 )
 
+
+def _reduce_engagement_name(current: str | None, update: str | None) -> str | None:
+    """Merge concurrent launcher/tool writes to the stable engagement slug."""
+    return update if update is not None else current
+
+
 # ── State Schema ──────────────────────────────────────────────────────
 
 
@@ -56,7 +62,7 @@ class OPPLANState(AgentState):
     objectives: Annotated[NotRequired[list[dict]], OmitFromInput]
     """List of OPPLAN objectives in dict form (serialized Objective models)."""
 
-    engagement_name: Annotated[NotRequired[str], OmitFromInput]
+    engagement_name: NotRequired[Annotated[str, OmitFromInput, _reduce_engagement_name]]
     """Current engagement name for context."""
 
     threat_profile: Annotated[NotRequired[str], OmitFromInput]

--- a/decepticon/tools/bash/bash.py
+++ b/decepticon/tools/bash/bash.py
@@ -26,6 +26,7 @@ import contextlib
 import contextvars
 import hashlib
 import logging
+import os
 import re
 import time
 
@@ -140,7 +141,22 @@ def _workspace_path_from_config(config: RunnableConfig | None) -> str:
     configurable = (config or {}).get("configurable", {})
     workspace = configurable.get("workspace_path") if isinstance(configurable, dict) else None
     if isinstance(workspace, str) and workspace.startswith("/workspace"):
-        return DockerSandbox._normalize_workspace_path(workspace)
+        normalized = DockerSandbox._normalize_workspace_path(workspace)
+        if normalized != "/workspace":
+            return normalized
+
+    env_workspace = os.environ.get("DECEPTICON_WORKSPACE_PATH")
+    if env_workspace:
+        normalized = DockerSandbox._normalize_workspace_path(env_workspace)
+        if normalized != "/workspace":
+            return normalized
+
+    env_slug = os.environ.get("DECEPTICON_ENGAGEMENT")
+    if env_slug:
+        normalized = DockerSandbox._normalize_workspace_path(f"/workspace/{env_slug}")
+        if normalized != "/workspace":
+            return normalized
+
     return _current_workspace_path.get()
 
 
@@ -168,7 +184,7 @@ async def _prune_old_scratch(workspace_path: str = "/workspace") -> None:
     path pays for cleanup at most every ~10 minutes per process. Best-effort:
     a failure here must never block the agent's command.
     """
-    if _sandbox is None:
+    if _sandbox is None or workspace_path == "/workspace":
         return
     now = time.monotonic()
     if now - _scratch_prune_state.get(workspace_path, 0.0) < SCRATCH_PRUNE_INTERVAL:
@@ -199,6 +215,19 @@ async def _offload_large_output(
     - Agent can use read_file or grep to access specific parts later
     """
     assert _sandbox is not None
+
+    if workspace_path == "/workspace":
+        head_preview = output[:2000].strip()
+        tail_preview = output[-1000:].strip()
+        line_count = output.count("\n") + 1
+        char_count = len(output)
+        return (
+            f"{head_preview}\n\n"
+            f"[... {line_count} lines / {char_count} chars truncated. "
+            "No engagement workspace was available, so output was not written "
+            "to the root scratch directory. ...]\n\n"
+            f"...{tail_preview}"
+        )
 
     # Generate unique filename
     ts = int(time.time())

--- a/decepticon/tools/interaction/ask_user.py
+++ b/decepticon/tools/interaction/ask_user.py
@@ -15,12 +15,53 @@ after resume.
 
 from __future__ import annotations
 
+import ast
+import json
 from typing import Annotated, Any
 
 from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.config import get_stream_writer
 from langgraph.types import interrupt
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+HEADER_MAX_CHARS = 60
+
+
+def _coerce_options_list(value: Any) -> list[Any]:
+    """Normalize common local-model shapes for ``options``."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        return [value]
+    if not isinstance(value, str):
+        return []
+
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(value)
+        except (json.JSONDecodeError, ValueError, SyntaxError, TypeError, MemoryError):
+            continue
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, dict):
+            return [parsed]
+
+    try:
+        cleaned = value.replace("\r\n", "\\n").replace("\r", "\\n").replace("\n", "\\n")
+        parsed = json.loads(cleaned)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if isinstance(parsed, list):
+        return parsed
+    if isinstance(parsed, dict):
+        return [parsed]
+    return []
+
+
+def _truncate_header(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > HEADER_MAX_CHARS:
+        return value[:HEADER_MAX_CHARS]
+    return value
 
 
 class QuestionOption(BaseModel):
@@ -51,13 +92,15 @@ def ask_user_question(
     question: str,
     header: Annotated[
         str,
+        BeforeValidator(_truncate_header),
         Field(
-            max_length=60,
+            max_length=HEADER_MAX_CHARS,
             description="Short label (≤60 chars) shown as the picker's compact chrome label.",
         ),
     ],
     options: Annotated[
         list[QuestionOption],
+        BeforeValidator(_coerce_options_list),
         Field(
             max_length=5,
             description=(
@@ -85,7 +128,7 @@ def ask_user_question(
 
     Args:
         question: The full question text shown to the operator.
-        header: ≤12-char label for the picker chrome.
+        header: ≤60-char label for the picker chrome.
         options: 2–5 entries, each ``{label, description}``.
         multi_select: If True, the operator may pick multiple options and the
             return value is ``list[str]``.

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,14 +106,18 @@
         "neo4j-driver": "^6.0.1",
         "next": "16.2.3",
         "next-themes": "^0.4.6",
+        "node-pty": "^1.1.0",
         "pg": "^8.20.0",
+        "prisma": "^7.7.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.2.0",
+        "sharp": "^0.34.5",
         "tailwind-merge": "^3.5.0",
+        "tsx": "^4.19.0",
         "tw-animate-css": "^1.4.0",
         "ws": "^8.20.0",
         "xterm": "^5.3.0"
@@ -128,8 +132,6 @@
         "dotenv": "^17.4.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.3",
-        "node-pty": "^1.1.0",
-        "sharp": "^0.34.5",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -962,7 +964,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -987,7 +988,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1004,7 +1004,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,7 +1020,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,7 +1036,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1055,7 +1052,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,7 +1068,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1089,7 +1084,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1106,7 +1100,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1123,7 +1116,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1140,7 +1132,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1157,7 +1148,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,7 +1164,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,7 +1180,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1208,7 +1196,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1225,7 +1212,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1242,7 +1228,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1259,7 +1244,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1276,7 +1260,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1293,7 +1276,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,7 +1292,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1327,7 +1308,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,7 +1324,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1361,7 +1340,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1378,7 +1356,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1395,7 +1372,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1412,7 +1388,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1672,7 +1647,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1685,7 +1659,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1708,7 +1681,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1731,7 +1703,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1748,7 +1719,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1765,7 +1735,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1782,7 +1751,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1799,7 +1767,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1816,7 +1783,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1833,7 +1799,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1850,7 +1815,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1867,7 +1831,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1884,7 +1847,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1901,7 +1863,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1924,7 +1885,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1947,7 +1907,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1970,7 +1929,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1993,7 +1951,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2016,7 +1973,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2039,7 +1995,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2062,7 +2017,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2085,7 +2039,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2105,7 +2058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2125,7 +2077,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2145,7 +2096,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8062,7 +8012,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8478,7 +8427,6 @@
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9557,7 +9505,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9765,7 +9712,6 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -13433,7 +13379,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-domexception": {
@@ -13518,7 +13463,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
       "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -15397,7 +15341,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -15909,7 +15852,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15954,7 +15896,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -16827,7 +16768,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",

--- a/tests/unit/backends/test_session_log.py
+++ b/tests/unit/backends/test_session_log.py
@@ -1,4 +1,4 @@
-"""Pipe-pane log moved to /workspace/.sessions/, manager dict is lock-protected."""
+"""Pipe-pane logs are engagement-scoped and manager dict is lock-protected."""
 
 import logging
 import subprocess as _sp
@@ -15,7 +15,7 @@ from decepticon.backends.docker_sandbox import (
 )
 
 
-def test_initialize_pipes_pane_to_workspace_sessions_log():
+def test_initialize_does_not_create_root_workspace_sessions_log():
     mgr = TmuxSessionManager("scan-1", "decepticon-sandbox")
     TmuxSessionManager._initialized.discard("scan-1")
 
@@ -36,10 +36,8 @@ def test_initialize_pipes_pane_to_workspace_sessions_log():
         mock_run.return_value.returncode = 0
         mgr.initialize()
 
-    pipe_pane_call = next(c for c in mock_tmux.call_args_list if c.args[0][0] == "pipe-pane")
-    args = pipe_pane_call.args[0]
-    cmd_arg = args[args.index("-o") + 1]
-    assert cmd_arg == "cat >> /workspace/.sessions/scan-1.log"
+    assert not any(c.args[0][0] == "pipe-pane" for c in mock_tmux.call_args_list)
+    assert not any("mkdir" in (c.args[0] if c.args else []) for c in mock_run.call_args_list)
 
 
 def test_initialize_pipes_pane_to_engagement_scoped_sessions_log():
@@ -78,9 +76,14 @@ def test_initialize_pipes_pane_to_engagement_scoped_sessions_log():
     assert cmd_arg == "cat >> /workspace/test/.sessions/main.log"
 
 
-def test_initialize_creates_sessions_directory_inside_container():
-    mgr = TmuxSessionManager("scan-2", "decepticon-sandbox")
-    TmuxSessionManager._initialized.discard("scan-2")
+def test_initialize_creates_sessions_directory_inside_engagement_workspace():
+    mgr = TmuxSessionManager(
+        "dcptn_test-scan-2",
+        "decepticon-sandbox",
+        workspace_path="/workspace/test",
+        log_name="scan-2",
+    )
+    TmuxSessionManager._initialized.discard("dcptn_test-scan-2")
 
     with (
         patch.object(mgr, "_docker_tmux") as mock_tmux,
@@ -91,15 +94,25 @@ def test_initialize_creates_sessions_directory_inside_container():
         mock_run.return_value.returncode = 0
         mgr.initialize()
 
-    mkdir_calls = [c for c in mock_run.call_args_list if "mkdir" in (c.args[0] if c.args else [])]
+    mkdir_calls = [
+        c
+        for c in mock_run.call_args_list
+        if "mkdir" in (c.args[0] if c.args else [])
+        and "/workspace/test/.sessions" in (c.args[0] if c.args else [])
+    ]
     assert mkdir_calls, "Expected a docker exec mkdir call"
     cmd = mkdir_calls[0].args[0]
-    assert "/workspace/.sessions" in cmd
+    assert "/workspace/test/.sessions" in cmd
 
 
 def test_initialize_warns_when_mkdir_fails(caplog):
-    mgr = TmuxSessionManager("scan-3", "decepticon-sandbox")
-    TmuxSessionManager._initialized.discard("scan-3")
+    mgr = TmuxSessionManager(
+        "dcptn_test-scan-3",
+        "decepticon-sandbox",
+        workspace_path="/workspace/test",
+        log_name="scan-3",
+    )
+    TmuxSessionManager._initialized.discard("dcptn_test-scan-3")
 
     decepticon_logger = logging.getLogger("decepticon")
     original_propagate = decepticon_logger.propagate
@@ -111,7 +124,7 @@ def test_initialize_warns_when_mkdir_fails(caplog):
             patch("time.sleep"),
         ):
             mock_tmux.side_effect = [RuntimeError("session not found"), "", "", "", "", "", ""]
-            mock_run.side_effect = CalledProcessError(1, ["docker", "exec"])
+            mock_run.side_effect = [None, CalledProcessError(1, ["docker", "exec"])]
             with caplog.at_level(logging.WARNING):
                 mgr.initialize()
     finally:

--- a/tests/unit/middleware/test_engagement.py
+++ b/tests/unit/middleware/test_engagement.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from langchain.agents import AgentState
+from langchain.agents.factory import _resolve_schemas
 from langchain_core.messages import SystemMessage
+from langgraph.graph import END, START, StateGraph
 
 from decepticon.middleware.engagement import (
     EngagementContextMiddleware,
+    EngagementContextState,
     _benchmark_mode_active,
 )
+from decepticon.middleware.opplan import OPPLANState
 
 
 class _FakeRequest:
@@ -75,6 +80,34 @@ def test_benchmark_mode_active_falsy(monkeypatch: pytest.MonkeyPatch, value: str
 def test_benchmark_mode_active_unset() -> None:
     # autouse fixture deletes the env; must be False.
     assert _benchmark_mode_active() is False
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        OPPLANState,
+        EngagementContextState,
+        _resolve_schemas({AgentState, OPPLANState, EngagementContextState})[0],
+    ],
+)
+def test_engagement_name_reducer_handles_concurrent_updates(schema) -> None:
+    def set_name(_state):
+        return {"engagement_name": "demo-engagement"}
+
+    def keep_name(_state):
+        return {"engagement_name": None}
+
+    graph = StateGraph(schema)
+    graph.add_node("set_name", set_name)
+    graph.add_node("keep_name", keep_name)
+    graph.add_edge(START, "set_name")
+    graph.add_edge(START, "keep_name")
+    graph.add_edge("set_name", END)
+    graph.add_edge("keep_name", END)
+
+    result = graph.compile().invoke({"messages": []})
+
+    assert result["engagement_name"] == "demo-engagement"
 
 
 # ── inject paths ───────────────────────────────────────────────────────

--- a/tests/unit/middleware/test_filesystem.py
+++ b/tests/unit/middleware/test_filesystem.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
-from deepagents.backends.protocol import FileDownloadResponse, FileInfo, ReadResult, WriteResult
+from deepagents.backends.protocol import (
+    FileDownloadResponse,
+    FileInfo,
+    GlobResult,
+    GrepResult,
+    LsResult,
+    ReadResult,
+    WriteResult,
+)
+from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesystemMiddleware
 
-from decepticon.middleware.filesystem import EngagementFilesystemBackend
+from decepticon.middleware.filesystem import EngagementFilesystemBackend, FilesystemMiddleware
 
 
 class RecordingBackend:
@@ -12,6 +21,9 @@ class RecordingBackend:
     def ls_info(self, path: str) -> list[FileInfo]:
         self.calls.append(("ls_info", path))
         return [{"path": f"{path}/plan/roe.json", "is_dir": False}]
+
+    def ls(self, path: str) -> LsResult:
+        return LsResult(entries=self.ls_info(path))
 
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
         self.calls.append(("read", (file_path, offset, limit)))
@@ -25,9 +37,16 @@ class RecordingBackend:
         self.calls.append(("glob_info", (pattern, path)))
         return [{"path": "plan/roe.json", "is_dir": False}]
 
+    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        return GlobResult(matches=self.glob_info(pattern, path))
+
     def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
         self.calls.append(("grep_raw", (pattern, path, glob)))
-        return [{"path": f"{path}/plan/roe.json", "line": 1, "text": "target"}]
+        suffix = "roe.json" if (path or "").endswith("/plan") else "plan/roe.json"
+        return [{"path": f"{path}/{suffix}", "line": 1, "text": "target"}]
+
+    def grep(self, pattern: str, path: str | None = None, glob: str | None = None) -> GrepResult:
+        return GrepResult(matches=self.grep_raw(pattern, path, glob))
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
         self.calls.append(("download_files", paths))
@@ -51,7 +70,9 @@ def test_returns_virtual_paths_to_agent() -> None:
     backend = RecordingBackend()
     scoped = EngagementFilesystemBackend(backend, "/workspace/test")
 
-    assert scoped.ls_info("/workspace") == [{"path": "/workspace/plan/roe.json", "is_dir": False}]
+    assert scoped.ls("/workspace").entries == [
+        {"path": "/workspace/plan/roe.json", "is_dir": False}
+    ]
     write_result = scoped.write("/workspace/findings/FIND-001.md", "x")
 
     assert write_result.path == "/workspace/findings/FIND-001.md"
@@ -61,12 +82,43 @@ def test_scopes_glob_and_grep_without_exposing_real_engagement_path() -> None:
     backend = RecordingBackend()
     scoped = EngagementFilesystemBackend(backend, "/workspace/test")
 
-    assert scoped.glob_info("/workspace/**/*.json") == [
+    assert scoped.glob("/workspace/**/*.json").matches == [
         {"path": "/workspace/plan/roe.json", "is_dir": False}
     ]
     assert backend.calls[-1] == ("glob_info", ("**/*.json", "/workspace/test"))
 
-    assert scoped.grep_raw("target", path="/workspace") == [
+    assert scoped.grep("target", path="/workspace").matches == [
         {"path": "/workspace/plan/roe.json", "line": 1, "text": "target"}
     ]
     assert backend.calls[-1] == ("grep_raw", ("target", "/workspace/test", None))
+
+
+def test_filesystem_middleware_removes_execute_without_rewriting_descriptions() -> None:
+    base = BaseFilesystemMiddleware(backend=RecordingBackend())
+    middleware = FilesystemMiddleware(backend=RecordingBackend())
+    base_descriptions = {tool.name: tool.description for tool in base.tools}
+    descriptions = {tool.name: tool.description for tool in middleware.tools}
+
+    assert "execute" not in descriptions
+    assert descriptions == {
+        name: description for name, description in base_descriptions.items() if name != "execute"
+    }
+
+
+def test_missing_engagement_workspace_fails_closed() -> None:
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, None)
+
+    assert scoped.ls("/workspace").error is not None
+    assert scoped.read("/workspace/plan/roe.json").error is not None
+    assert scoped.glob("**/*.json").error is not None
+    assert scoped.grep("target", path="/workspace").error is not None
+    assert backend.calls == []
+
+
+def test_root_workspace_fails_closed() -> None:
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace")
+
+    assert scoped.ls("/workspace").error is not None
+    assert backend.calls == []

--- a/tests/unit/tools/bash/test_bash_output.py
+++ b/tests/unit/tools/bash/test_bash_output.py
@@ -1,7 +1,7 @@
 """bash_output / bash_kill / bash_status tool unit tests."""
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from decepticon.backends.docker_sandbox import BackgroundJobTracker
 from decepticon.tools.bash.bash import (
@@ -89,7 +89,8 @@ def test_bash_status_lists_running_and_done_jobs():
 def test_bash_status_empty_returns_empty_marker():
     sandbox = _fake_sandbox()
     set_sandbox(sandbox)
-    result = asyncio.run(bash_status.ainvoke({}))
+    with bash_workspace("/workspace/test"):
+        result = asyncio.run(bash_status.ainvoke({}))
     assert "[EMPTY]" in result
 
 
@@ -116,3 +117,40 @@ def test_bash_background_uses_engagement_workspace_context():
         workspace_path="/workspace/test",
     )
     assert "[BACKGROUND]" in result
+
+
+def test_bash_uses_engagement_workspace_from_environment(monkeypatch):
+    sandbox = _fake_sandbox()
+    sandbox.execute = MagicMock()
+    sandbox.execute_tmux_async = AsyncMock(return_value="ok")
+    set_sandbox(sandbox)
+    monkeypatch.setenv("DECEPTICON_ENGAGEMENT", "env-engagement")
+
+    result = asyncio.run(bash.ainvoke({"command": "pwd"}))
+
+    sandbox.execute_tmux_async.assert_called_once_with(
+        command="pwd",
+        session="main",
+        timeout=120,
+        is_input=False,
+        workspace_path="/workspace/env-engagement",
+    )
+    assert result == "ok"
+
+
+def test_large_output_without_engagement_workspace_does_not_create_root_scratch():
+    sandbox = _fake_sandbox()
+    sandbox.execute = MagicMock()
+    sandbox.execute_tmux_async = AsyncMock(return_value="x" * 15_001)
+    set_sandbox(sandbox)
+
+    result = asyncio.run(
+        bash.ainvoke(
+            {"command": "big"},
+            config={"configurable": {"workspace_path": "/workspace"}},
+        )
+    )
+
+    assert "/workspace/.scratch" not in result
+    assert "not written" in result
+    sandbox.execute.assert_not_called()

--- a/tests/unit/tools/test_ask_user_question.py
+++ b/tests/unit/tools/test_ask_user_question.py
@@ -147,14 +147,63 @@ def test_skips_writer_when_outside_graph_context():
         assert _invoke() == "Yes"
 
 
-def test_rejects_header_longer_than_max():
-    too_long = "X" * (HEADER_MAX_CHARS + 1)
-    with patch(
-        "decepticon.tools.interaction.ask_user.interrupt",
-        return_value="Yes",
+def test_truncates_header_longer_than_max():
+    captured: list[dict] = []
+    too_long = "X" * (HEADER_MAX_CHARS + 10)
+
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda event: captured.append(event),
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value="Yes",
+        ),
     ):
-        with pytest.raises(ValidationError):
-            _invoke(header=too_long)
+        assert _invoke(header=too_long) == "Yes"
+
+    assert captured[0]["header"] == "X" * HEADER_MAX_CHARS
+
+
+def test_coerces_options_json_string_from_local_models():
+    options = '[{"label":"External Web (Recommended)","description":"Public website"}]'
+    captured: list[dict] = []
+
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda event: captured.append(event),
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value="External Web (Recommended)",
+        ),
+    ):
+        assert _invoke(options=options) == "External Web (Recommended)"
+
+    assert captured[0]["options"] == [
+        {"label": "External Web (Recommended)", "description": "Public website"}
+    ]
+
+
+def test_coerces_options_python_literal_string_from_local_models():
+    options = "[{'label': 'Recon', 'description': 'Surface level\\nonly'}]"
+    captured: list[dict] = []
+
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda event: captured.append(event),
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value="Recon",
+        ),
+    ):
+        assert _invoke(options=options) == "Recon"
+
+    assert captured[0]["options"] == [{"label": "Recon", "description": "Surface level\nonly"}]
 
 
 def test_accepts_empty_options():


### PR DESCRIPTION
## Summary

This PR replaces #139 and resolves the remaining local-model engagement flow issues tracked in #140 and #141.

- Adds a LangGraph reducer for `engagement_name` in both OPPLAN and engagement context state, with the reducer placed as the final `Annotated` metadata so LangGraph actually recognizes it.
- Keeps PR #139's local-model resilience for `ask_user_question` by coercing malformed `options` values and truncating overlong headers.
- Scopes Deep Agents filesystem tools to the active engagement workspace, removes the filesystem `execute` tool in favor of Decepticon's `bash`, and preserves Deep Agents' default filesystem tool descriptions.
- Prevents internal `.scratch` and `.sessions` runtime directories from appearing as engagements and keeps new scratch/session artifacts under the active engagement workspace.

Closes #140.
Closes #141.
Supersedes #139.

## Validation

- `uv run pytest tests/unit/tools/test_ask_user_question.py tests/unit/middleware/test_engagement.py tests/unit/middleware/test_filesystem.py tests/unit/tools/bash/test_bash_output.py tests/unit/backends/test_session_log.py -q`
- `uv run ruff check decepticon/middleware/opplan.py decepticon/middleware/engagement.py decepticon/middleware/filesystem.py decepticon/tools/interaction/ask_user.py decepticon/tools/bash/bash.py decepticon/backends/docker_sandbox.py tests/unit/middleware/test_engagement.py tests/unit/middleware/test_filesystem.py tests/unit/tools/test_ask_user_question.py tests/unit/tools/bash/test_bash_output.py tests/unit/backends/test_session_log.py`
- `go test ./internal/engagement ./internal/compose ./cmd`
- `npm run lint --workspace=web`
