### PR TITLE
ci(release): add manual release recovery workflow

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -1,0 +1,71 @@
+name: Release Recovery
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without the leading v, e.g. 1.0.20"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  finalize:
+    name: Verify images & promote release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Verify all version-tagged images exist on GHCR
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          images=(
+            decepticon-litellm
+            decepticon-langgraph
+            decepticon-sandbox
+            decepticon-cli
+            decepticon-c2-sliver
+            decepticon-web
+          )
+          for img in "${images[@]}"; do
+            ref="ghcr.io/purpleailab/${img}:${VERSION}"
+            echo "Verifying ${ref}"
+            docker buildx imagetools inspect "${ref}" >/dev/null
+          done
+
+      - name: Promote :<version> to :latest
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          images=(
+            decepticon-litellm
+            decepticon-langgraph
+            decepticon-sandbox
+            decepticon-cli
+            decepticon-c2-sliver
+            decepticon-web
+          )
+          for img in "${images[@]}"; do
+            src="ghcr.io/purpleailab/${img}:${VERSION}"
+            dst="ghcr.io/purpleailab/${img}:latest"
+            echo "Promoting ${src} -> ${dst}"
+            docker buildx imagetools create --tag "${dst}" "${src}"
+          done
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: gh release edit "v${VERSION}" --draft=false --prerelease=false


### PR DESCRIPTION
Adds a manual Release Recovery workflow for cases where the release build artifacts and GHCR version tags exist, but the final publish step is skipped after a transient GoReleaser/GitHub asset upload failure.\n\nThis is needed to recover v1.0.20: the release assets and version-tagged images exist, but :latest promotion was skipped because GoReleaser failed on an uploads.github.com 502 followed by an already_exists retry.