### PR TITLE
ci(release): set repo for recovery release edit

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -67,5 +67,6 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: gh release edit "v${VERSION}" --draft=false --prerelease=false


### PR DESCRIPTION
Fixes the manual Release Recovery workflow so the final gh release edit step works without a checkout by setting GH_REPO from github.repository.\n\nThe v1.0.20 recovery already promoted all GHCR :latest tags successfully; this patch prevents the cleanup/publish step from failing with 'not a git repository' on future runs.