### PR TITLE
fix(launcher): align ChatGPT auth and update image tags

### DIFF
--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -33,30 +33,30 @@ func init() {
 
 // AuthMethod identifiers — must match decepticon/llm/models.py::AuthMethod.
 const (
-	methodAnthropicOAuth   = "anthropic_oauth"
-	methodAnthropicAPI     = "anthropic_api"
-	methodOpenAIOAuth      = "openai_oauth"
-	methodOpenAIAPI        = "openai_api"
-	methodGoogleOAuth      = "google_oauth"
-	methodGoogleAPI        = "google_api"
-	methodMiniMaxAPI       = "minimax_api"
-	methodDeepSeekAPI      = "deepseek_api"
-	methodXAIAPI           = "xai_api"
-	methodGrokOAuth        = "grok_oauth"
-	methodMistralAPI       = "mistral_api"
-	methodOpenRouterAPI    = "openrouter_api"
-	methodNvidiaAPI        = "nvidia_api"
-	methodCopilotOAuth     = "copilot_oauth"
-	methodPerplexityOAuth  = "perplexity_oauth"
-	methodOllamaLocal      = "ollama_local"
+	methodAnthropicOAuth  = "anthropic_oauth"
+	methodAnthropicAPI    = "anthropic_api"
+	methodOpenAIOAuth     = "openai_oauth"
+	methodOpenAIAPI       = "openai_api"
+	methodGoogleOAuth     = "google_oauth"
+	methodGoogleAPI       = "google_api"
+	methodMiniMaxAPI      = "minimax_api"
+	methodDeepSeekAPI     = "deepseek_api"
+	methodXAIAPI          = "xai_api"
+	methodGrokOAuth       = "grok_oauth"
+	methodMistralAPI      = "mistral_api"
+	methodOpenRouterAPI   = "openrouter_api"
+	methodNvidiaAPI       = "nvidia_api"
+	methodCopilotOAuth    = "copilot_oauth"
+	methodPerplexityOAuth = "perplexity_oauth"
+	methodOllamaLocal     = "ollama_local"
 )
 
-// Default Ollama wiring shown to OSS users. ``host.docker.internal``
+// Default Ollama wiring shown to OSS users. `host.docker.internal`
 // is the universal answer regardless of where Ollama runs (macOS host,
 // WSL2 distro, native Linux): from inside Decepticon's containers it
 // resolves to the host network namespace via the
-// ``extra_hosts: [host.docker.internal:host-gateway]`` entry on the
-// litellm service in docker-compose.yml. ``localhost`` is never the
+// `extra_hosts: [host.docker.internal:host-gateway]` entry on the
+// litellm service in docker-compose.yml. `localhost` is never the
 // right answer here — that's the container itself.
 //
 // The host's Ollama must additionally be bound to 0.0.0.0 (the default
@@ -123,7 +123,6 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		mistralKey             string
 		openrouterKey          string
 		nvidiaKey              string
-		chatgptSessionToken    string
 		geminiSessionCookies   string
 		copilotRefreshToken    string
 		grokSessionToken       string
@@ -199,25 +198,6 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 				Validate(nonEmpty),
 		).Title("2 / 5  ·  Anthropic API").
 			WithHideFunc(func() bool { return !contains(methods, methodAnthropicAPI) }),
-
-		// Step 2b: ChatGPT subscription session token
-		// ChatGPT OAuth has no equivalent of `claude /login` to provision
-		// tokens automatically, so we ask the user to paste the
-		// `__Secure-next-auth.session-token` cookie from a signed-in
-		// chatgpt.com browser session. Optional — users who set
-		// CHATGPT_ACCESS_TOKEN externally or place ~/.config/litellm/chatgpt/tokens.json
-		// can leave this blank and skip with Enter.
-		huh.NewGroup(
-			huh.NewNote().
-				Title("ChatGPT Session Token").
-				Description("Open chatgpt.com → DevTools → Application →\nCookies → chatgpt.com → copy the value of\n`__Secure-next-auth.session-token`. Or leave\nblank to use CHATGPT_ACCESS_TOKEN / tokens.json."),
-			huh.NewInput().
-				Title("CHATGPT_SESSION_TOKEN").
-				Placeholder("eyJhbGciOiJ...   (leave blank to skip)").
-				EchoMode(huh.EchoModePassword).
-				Value(&chatgptSessionToken),
-		).Title("2 / 5  ·  ChatGPT OAuth").
-			WithHideFunc(func() bool { return !contains(methods, methodOpenAIOAuth) }),
 
 		// Step 2c: OpenAI API key
 		huh.NewGroup(
@@ -526,9 +506,6 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	}
 	if nvidiaKey != "" {
 		values["NVIDIA_API_KEY"] = nvidiaKey
-	}
-	if chatgptSessionToken != "" {
-		values["CHATGPT_SESSION_TOKEN"] = chatgptSessionToken
 	}
 	if geminiSessionCookies != "" {
 		values["GEMINI_SESSION_COOKIES"] = geminiSessionCookies

--- a/clients/launcher/cmd/update.go
+++ b/clients/launcher/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/compose"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
@@ -19,7 +20,7 @@ var updateCmd = &cobra.Command{
 }
 
 func init() {
-	updateCmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Force re-pull images even if version unchanged")
+	updateCmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Refresh config files and Docker images even if version unchanged")
 	rootCmd.AddCommand(updateCmd)
 }
 
@@ -32,13 +33,14 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	hasUpdate := updater.CompareVersions(version, release.TagName)
-	if !hasUpdate && !forceUpdate {
+	if !hasUpdate {
 		ui.Success(fmt.Sprintf("Already up to date (%s)", version))
-		return nil
 	}
 
 	if hasUpdate {
 		ui.Info(fmt.Sprintf("Update available: %s → %s", version, release.TagName))
+	} else {
+		ui.Info("Refreshing configuration files and Docker images...")
 	}
 
 	// Load env for branch info
@@ -46,17 +48,20 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if config.EnvExists() {
 		env, _ = config.LoadEnv(config.EnvPath())
 	}
-	branch := config.Get(env, "DECEPTICON_BRANCH", "main")
+	ref := release.TagName
+	if branch := strings.TrimSpace(env["DECEPTICON_BRANCH"]); branch != "" {
+		ref = branch
+	}
 
 	// Sync config files
 	ui.Info("Syncing configuration files...")
-	if err := updater.SyncConfigFiles(branch); err != nil {
+	if err := updater.SyncConfigFiles(ref); err != nil {
 		ui.Warning("Config sync: " + err.Error())
 	}
 
 	// Pull new images
 	c := compose.New()
-	targetVersion := release.TagName
+	targetVersion := strings.TrimPrefix(release.TagName, "v")
 	ui.Info("Pulling Docker images (" + targetVersion + ")...")
 	if err := c.Pull(targetVersion); err != nil {
 		ui.Warning("Image pull: " + err.Error())

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -70,7 +70,7 @@ func (c *Compose) readVersion() string {
 func (c *Compose) composeEnv() []string {
 	env := os.Environ()
 	if v := c.readVersion(); v != "" {
-		env = append(env, "DECEPTICON_VERSION="+v)
+		env = append(env, "DECEPTICON_VERSION="+imageTag(v))
 	}
 	return env
 }
@@ -145,7 +145,7 @@ func (c *Compose) DownAndPurge() error {
 func (c *Compose) Pull(version string) error {
 	cmd := exec.Command("docker", append(c.baseArgs(), "pull")...)
 	if version != "" {
-		cmd.Env = append(os.Environ(), "DECEPTICON_VERSION="+version)
+		cmd.Env = append(os.Environ(), "DECEPTICON_VERSION="+imageTag(version))
 	} else {
 		cmd.Env = c.composeEnv()
 	}
@@ -155,6 +155,10 @@ func (c *Compose) Pull(version string) error {
 		return fmt.Errorf("docker compose pull: %w", err)
 	}
 	return nil
+}
+
+func imageTag(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
 }
 
 // Ps shows service status.

--- a/clients/launcher/internal/compose/compose_test.go
+++ b/clients/launcher/internal/compose/compose_test.go
@@ -43,3 +43,16 @@ func TestBaseArgs(t *testing.T) {
 		t.Errorf("baseArgs = %v", args)
 	}
 }
+
+func TestImageTag(t *testing.T) {
+	tests := map[string]string{
+		"v1.0.21":  "1.0.21",
+		"1.0.21":   "1.0.21",
+		" latest ": "latest",
+	}
+	for input, want := range tests {
+		if got := imageTag(input); got != want {
+			t.Errorf("imageTag(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -233,34 +233,39 @@ func ValidateAPIKeys(env map[string]string) error {
 
 // subscriptionMethod groups the env signal + credential layout for one
 // OAuth subscription handler so we don't repeat the validation logic.
-// Resolution order matches each handler in config/*_handler.py exactly:
+// Resolution order matches each runtime provider exactly:
 //
 //  1. <PROVIDER>_ACCESS_TOKEN   — pre-extracted Bearer
 //  2. <PROVIDER>_SESSION_TOKEN  — browser session cookie value
-//  3. configured tokens.json on disk
+//  3. configured token file on disk
 //
 // Two providers diverge slightly:
 //   - Gemini Advanced ships a multi-cookie value (GEMINI_SESSION_COOKIES)
 //     instead of a single session token. accept either env name.
 //   - Copilot Pro uses a refresh-token rotation (COPILOT_REFRESH_TOKEN)
 //     instead of a session cookie. Same fall-through, different env name.
+//   - ChatGPT uses LiteLLM's native chatgpt provider. It persists OAuth
+//     credentials as auth.json and can create that file via device-code login,
+//     so the launcher must not require a pasted browser session cookie.
 type subscriptionMethod struct {
-	Toggle    string   // DECEPTICON_AUTH_<X> boolean enabling this path
-	TokenEnvs []string // env vars that satisfy the path on their own
-	ConfigDir string   // ~/.config/<dir>/tokens.json fallback
-	DirEnv    string   // optional host-side token directory env var
-	LegacyDir string   // optional legacy ~/.config/<dir>/tokens.json fallback
-	Label     string   // human name for error messages
+	Toggle                string   // DECEPTICON_AUTH_<X> boolean enabling this path
+	TokenEnvs             []string // env vars that satisfy the path on their own
+	ConfigDir             string   // ~/.config/<dir>/<token file> fallback
+	TokenFile             string   // token file name; defaults to tokens.json
+	DirEnv                string   // optional host-side token directory env var
+	LegacyDir             string   // optional legacy ~/.config/<dir>/<token file> fallback
+	Label                 string   // human name for error messages
+	AllowInteractiveLogin bool     // provider can bootstrap credentials at runtime
 }
 
 var oauthSubscriptions = map[string]subscriptionMethod{
 	"chatgpt": {
-		Toggle:    "DECEPTICON_AUTH_CHATGPT",
-		TokenEnvs: []string{"CHATGPT_ACCESS_TOKEN", "CHATGPT_SESSION_TOKEN"},
-		ConfigDir: "litellm/chatgpt",
-		DirEnv:    "LITELLM_CHATGPT_TOKEN_DIR",
-		LegacyDir: "chatgpt",
-		Label:     "ChatGPT",
+		Toggle:                "DECEPTICON_AUTH_CHATGPT",
+		ConfigDir:             "litellm/chatgpt",
+		TokenFile:             "auth.json",
+		DirEnv:                "LITELLM_CHATGPT_TOKEN_DIR",
+		Label:                 "ChatGPT",
+		AllowInteractiveLogin: true,
 	},
 	"gemini": {
 		Toggle:    "DECEPTICON_AUTH_GEMINI",
@@ -294,8 +299,9 @@ var oauthSubscriptions = map[string]subscriptionMethod{
 //   - DECEPTICON_AUTH_CLAUDE_CODE=true requires a parseable
 //     ~/.claude/.credentials.json. LiteLLM mounts that file read-only.
 //   - DECEPTICON_AUTH_<X>=true (CHATGPT, GEMINI, COPILOT, GROK,
-//     PERPLEXITY) is satisfied by a token env var or a tokens.json
-//     file at its mounted token directory. See subscriptionMethod above.
+//     PERPLEXITY) is satisfied by a token env var or a token file at its
+//     mounted token directory. ChatGPT uses LiteLLM native OAuth and is
+//     allowed through so LiteLLM can run its device-code login flow.
 //
 // Local LLM path: ollama_local in DECEPTICON_AUTH_PRIORITY (or any
 // OLLAMA_API_BASE configured) is treated as a valid credential. Ollama
@@ -432,12 +438,12 @@ func validateClaudeCredentials() error {
 }
 
 // validateSubscriptionCredentials verifies the user has at least one credential
-// path wired up for an OAuth subscription handler. The handlers themselves
-// (config/<provider>_handler.py) walk the same resolution order at runtime:
+// path wired up for an OAuth subscription handler. The runtime providers
+// walk the same resolution order at runtime:
 //
 //  1. <PROVIDER>_ACCESS_TOKEN env (pre-extracted Bearer)
 //  2. <PROVIDER>_SESSION_TOKEN / _SESSION_COOKIES / _REFRESH_TOKEN env
-//  3. configured tokens.json on disk
+//  3. configured token file on disk
 //
 // We don't validate token shape — providers ship them in many formats and shapes
 // drift across versions. We only catch the "toggled on in onboard but never
@@ -458,6 +464,9 @@ func validateSubscriptionCredentials(env map[string]string, sub subscriptionMeth
 			return nil
 		}
 	}
+	if sub.AllowInteractiveLogin {
+		return nil
+	}
 	hints := strings.Join(sub.TokenEnvs, " or ")
 	return fmt.Errorf(
 		"%s subscription token not configured.\n"+
@@ -471,14 +480,18 @@ func validateSubscriptionCredentials(env map[string]string, sub subscriptionMeth
 
 func subscriptionTokenPaths(env map[string]string, home string, sub subscriptionMethod) []string {
 	var paths []string
+	tokenFile := sub.TokenFile
+	if tokenFile == "" {
+		tokenFile = "tokens.json"
+	}
 	if sub.DirEnv != "" {
 		if dir := strings.TrimSpace(Get(env, sub.DirEnv, os.Getenv(sub.DirEnv))); dir != "" {
-			paths = append(paths, filepath.Join(dir, "tokens.json"))
+			paths = append(paths, filepath.Join(dir, tokenFile))
 		}
 	}
-	paths = append(paths, filepath.Join(home, ".config", sub.ConfigDir, "tokens.json"))
+	paths = append(paths, filepath.Join(home, ".config", sub.ConfigDir, tokenFile))
 	if sub.LegacyDir != "" {
-		paths = append(paths, filepath.Join(home, ".config", sub.LegacyDir, "tokens.json"))
+		paths = append(paths, filepath.Join(home, ".config", sub.LegacyDir, tokenFile))
 	}
 	return dedupeStrings(paths)
 }

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -146,10 +147,8 @@ func TestValidateAPIKeys_AcceptsAllProviders(t *testing.T) {
 	}
 }
 
-// TestValidateAuth_OAuthSubscriptions verifies each subscription handler
-// (ChatGPT / Gemini Advanced / Copilot Pro / SuperGrok / Perplexity Pro) accepts
-// any of its supported credential surfaces — env token or tokens.json.
-// Mirrors the resolution order in config/<provider>_handler.py.
+// TestValidateAuth_OAuthSubscriptions verifies each custom subscription handler
+// accepts any of its supported credential surfaces — env token or tokens.json.
 func TestValidateAuth_OAuthSubscriptions(t *testing.T) {
 	cases := []struct {
 		toggle    string
@@ -157,7 +156,6 @@ func TestValidateAuth_OAuthSubscriptions(t *testing.T) {
 		configDir string
 		fileFmt   string
 	}{
-		{"DECEPTICON_AUTH_CHATGPT", "CHATGPT_SESSION_TOKEN", filepath.Join("litellm", "chatgpt"), "tokens.json"},
 		{"DECEPTICON_AUTH_GEMINI", "GEMINI_SESSION_COOKIES", "gemini", "tokens.json"},
 		{"DECEPTICON_AUTH_COPILOT", "COPILOT_REFRESH_TOKEN", "copilot", "tokens.json"},
 		{"DECEPTICON_AUTH_GROK", "GROK_SESSION_TOKEN", "grok", "tokens.json"},
@@ -199,37 +197,40 @@ func TestValidateAuth_OAuthSubscriptions(t *testing.T) {
 	}
 }
 
-func TestValidateAuth_ChatGPTTokenPathCompatibility(t *testing.T) {
-	t.Run("custom litellm token dir", func(t *testing.T) {
+func TestValidateAuth_ChatGPTNativeOAuth(t *testing.T) {
+	t.Run("toggle on allows native device login without session cookie", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		dir := filepath.Join(home, "custom-chatgpt")
-		t.Setenv("LITELLM_CHATGPT_TOKEN_DIR", dir)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "tokens.json"), []byte("{}"), 0o600); err != nil {
-			t.Fatal(err)
-		}
 		env := map[string]string{"DECEPTICON_AUTH_CHATGPT": "true"}
 		if err := ValidateAuth(env); err != nil {
-			t.Errorf("expected LITELLM_CHATGPT_TOKEN_DIR tokens.json to satisfy ChatGPT auth: %v", err)
+			t.Errorf("expected native ChatGPT OAuth to pass without launcher-side token input: %v", err)
 		}
 	})
 
-	t.Run("legacy chatgpt token dir", func(t *testing.T) {
+	t.Run("uses litellm auth.json path", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		dir := filepath.Join(home, ".config", "chatgpt")
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatal(err)
+		got := subscriptionTokenPaths(map[string]string{}, home, oauthSubscriptions["chatgpt"])
+		want := []string{filepath.Join(home, ".config", "litellm", "chatgpt", "auth.json")}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("unexpected ChatGPT token paths: got %v want %v", got, want)
 		}
-		if err := os.WriteFile(filepath.Join(dir, "tokens.json"), []byte("{}"), 0o600); err != nil {
-			t.Fatal(err)
+	})
+
+	t.Run("custom host token dir uses auth.json", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		customDir := filepath.Join(home, "custom-chatgpt")
+		env := map[string]string{
+			"LITELLM_CHATGPT_TOKEN_DIR": customDir,
 		}
-		env := map[string]string{"DECEPTICON_AUTH_CHATGPT": "true"}
-		if err := ValidateAuth(env); err != nil {
-			t.Errorf("expected legacy ~/.config/chatgpt/tokens.json to satisfy ChatGPT auth: %v", err)
+		got := subscriptionTokenPaths(env, home, oauthSubscriptions["chatgpt"])
+		want := []string{
+			filepath.Join(customDir, "auth.json"),
+			filepath.Join(home, ".config", "litellm", "chatgpt", "auth.json"),
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("unexpected custom ChatGPT token paths: got %v want %v", got, want)
 		}
 	})
 }

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -79,7 +79,7 @@ DECEPTICON_MODEL_PROFILE=eco
 DECEPTICON_AUTH_PRIORITY=
 
 # --- Subscription OAuth ---
-# Set true for each subscription you want to use (routes through custom handlers)
+# Set true for each subscription you want to use.
 DECEPTICON_AUTH_CLAUDE_CODE=false
 DECEPTICON_AUTH_CHATGPT=false
 # DECEPTICON_AUTH_GEMINI=false
@@ -88,16 +88,11 @@ DECEPTICON_AUTH_CHATGPT=false
 # DECEPTICON_AUTH_PERPLEXITY=false
 
 # --- ChatGPT subscription credentials (used when DECEPTICON_AUTH_CHATGPT=true) ---
-# Session token extracted from a signed-in chatgpt.com browser session:
-#   1. Open chatgpt.com in your browser and sign in
-#   2. Open DevTools → Application → Cookies → chatgpt.com
-#   3. Copy the value of `__Secure-next-auth.session-token`
-# The onboard wizard prompts for this when ChatGPT OAuth is selected.
-# Alternatives: set CHATGPT_ACCESS_TOKEN (pre-extracted Bearer) or place a
-# tokens.json file at ~/.config/litellm/chatgpt/tokens.json (mounted into the
-# litellm container). Override the host token directory with
-# LITELLM_CHATGPT_TOKEN_DIR if needed.
-CHATGPT_SESSION_TOKEN=
+# ChatGPT uses LiteLLM's native chatgpt provider. It stores OAuth credentials
+# at ~/.config/litellm/chatgpt/auth.json and can bootstrap that file through
+# LiteLLM's device-code login flow. No browser session cookie is required.
+# Override the host token directory with LITELLM_CHATGPT_TOKEN_DIR if needed;
+# docker-compose mounts it into /root/.config/litellm/chatgpt in the container.
 # LITELLM_CHATGPT_TOKEN_DIR=
 
 # --- Additional API Keys ---

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -326,18 +326,10 @@ Use your ChatGPT Pro, Plus, or Team subscription instead of OpenAI API billing.
 
 **Setup:**
 
-1. Extract your session token from the browser:
-
-   - Log into [chatgpt.com](https://chatgpt.com)
-   - Open Developer Tools (F12) → Application → Cookies
-   - Find the cookie named `__Secure-next-auth.session-token`
-   - Copy its full value
-
-2. Configure Decepticon:
+1. Configure Decepticon:
 
 ```bash
 decepticon onboard
-# Select: ChatGPT Sub
 # Select: ChatGPT
 # Select: Profile (eco/max/test)
 ```
@@ -346,10 +338,9 @@ Or edit `~/.decepticon/.env`:
 
 ```bash
 DECEPTICON_AUTH_CHATGPT=true
-CHATGPT_SESSION_TOKEN=eyJ...your-session-token...
 ```
 
-3. Launch:
+2. Launch:
 
 ```bash
 decepticon
@@ -363,13 +354,9 @@ decepticon
   `chatgpt/gpt-*` provider routes only when `DECEPTICON_AUTH_CHATGPT=true`.
 - `docker-compose.yml` mounts the host token directory into the LiteLLM
   container at `/root/.config/litellm/chatgpt`.
-- Access tokens are handled by LiteLLM's native ChatGPT provider.
-
-**Alternative token sources (in priority order):**
-
-1. `CHATGPT_ACCESS_TOKEN` env var — pre-extracted Bearer token
-2. `CHATGPT_SESSION_TOKEN` env var — browser session cookie
-3. `~/.config/litellm/chatgpt/tokens.json` — persisted token file mounted into LiteLLM
+- Access tokens are handled by LiteLLM's native ChatGPT provider. It stores
+  OAuth credentials in `~/.config/litellm/chatgpt/auth.json` and refreshes
+  them as needed.
 
 **Custom token path:**
 
@@ -855,13 +842,12 @@ claude login
 cat ~/.claude/.credentials.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('OK' if d.get('claudeAiOauth',{}).get('accessToken','').startswith('sk-ant-oat01-') else 'MISSING')"
 ```
 
-**ChatGPT OAuth: "session token exchange failed"**
+**ChatGPT OAuth: missing or expired auth**
 
-The session token expires periodically. Re-extract from browser:
-
-1. Log into chatgpt.com
-2. DevTools → Application → Cookies → `__Secure-next-auth.session-token`
-3. Update `~/.decepticon/.env` with the new value
+LiteLLM's native ChatGPT provider stores credentials at
+`~/.config/litellm/chatgpt/auth.json`. If the file is missing or expired,
+restart Decepticon and follow the ChatGPT device-code login instructions shown
+in the LiteLLM logs.
 
 **API Key: "401 Unauthorized"**
 


### PR DESCRIPTION
## Summary
- align ChatGPT OAuth validation with LiteLLM native `chatgpt` auth at `~/.config/litellm/chatgpt/auth.json`
- remove the obsolete ChatGPT browser session-token prompt from `decepticon onboard`
- normalize release tags before Docker image pulls so `v1.0.x` GitHub tags map to `1.0.x` GHCR image tags
- make `decepticon update` refresh config files and Docker images even when the binary is already current; `-f` remains compatible

## Root Cause
- LiteLLM native ChatGPT no longer uses the removed custom handler/session-cookie path; the launcher still validated `tokens.json`/`CHATGPT_SESSION_TOKEN`.
- GitHub releases are tagged as `v1.0.x`, while GHCR images are published as `1.0.x`, so update pulls requested non-existent image manifests.

## Verification
- `go test ./...` from `clients/launcher`
- `git diff --check`

## Notes
This should be released as a patch version because v1.0.21 contains both launcher auth validation and update image-tag regressions.