### PR TITLE
feat(launcher): require explicit updates

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -7,6 +7,11 @@ on:
         description: "Release version without the leading v, e.g. 1.0.20"
         required: true
         type: string
+      promote_latest:
+        description: "Promote this version to :latest. Use false for pre-releases."
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -45,6 +50,7 @@ jobs:
           done
 
       - name: Promote :<version> to :latest
+        if: inputs.promote_latest
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -69,4 +75,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
-        run: gh release edit "v${VERSION}" --draft=false --prerelease=false
+        run: |
+          prerelease=false
+          if [[ "${VERSION}" == *-* ]]; then
+            prerelease=true
+          fi
+          gh release edit "v${VERSION}" --draft=false --prerelease="${prerelease}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,14 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [[ "${version}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -500,7 +507,7 @@ jobs:
   # then promotes :<version> → :latest and flips the GitHub release from
   # draft → published. Until this job succeeds:
   #   - GitHub `releases/latest` keeps returning the previous version, so
-  #     the launcher's auto-update never points users at images that are
+  #     the launcher's update notice never points users at images that are
   #     still mid-push.
   #   - The :latest tag is not moved, so `${DECEPTICON_VERSION:-latest}`
   #     fallbacks keep resolving to the previous (working) release.
@@ -521,7 +528,14 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [[ "${version}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Verify all version-tagged images exist on GHCR
         env:
@@ -543,6 +557,7 @@ jobs:
           done
 
       - name: Promote :<version> → :latest
+        if: steps.version.outputs.prerelease != 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -566,4 +581,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit "v${{ steps.version.outputs.version }}" --draft=false
+          gh release edit "v${{ steps.version.outputs.version }}" \
+            --draft=false \
+            --prerelease=${{ steps.version.outputs.prerelease }}

--- a/clients/launcher/.goreleaser.yml
+++ b/clients/launcher/.goreleaser.yml
@@ -36,8 +36,8 @@ release:
     owner: PurpleAILAB
     name: Decepticon
   # Publish as draft so the GitHub `releases/latest` endpoint (used by the
-  # launcher's auto-update) does NOT see this version until every Docker
-  # image is verified on GHCR. The publish-release job in
+  # launcher's update notice and explicit `decepticon update`) does NOT see
+  # this version until every Docker image is verified on GHCR. The publish-release job in
   # .github/workflows/release.yml flips draft → published once all images
   # exist, closing the release-atomicity gap that previously let the
   # launcher pull a tag whose images were still mid-push.

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/compose"
@@ -106,11 +105,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 		_ = os.Setenv("CLAUDE_CREDENTIALS_VOLUME", "/dev/null")
 	}
 
-	// 2.5. Auto-update check
-	if updater.CheckAndUpdate(version, env) {
-		ui.Info("Restarting with updated binary...")
-		return restartSelf()
-	}
+	// 2.5. Update notice. Applying updates is intentionally explicit via
+	// `decepticon update` because it can replace the binary, compose files,
+	// LiteLLM config, and Docker images.
+	updater.NotifyIfUpdateAvailable(version)
 
 	// 3. Engagement picker — must run BEFORE compose Up so the sandbox
 	// container starts with /workspace bound to the chosen engagement
@@ -171,7 +169,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 }
 
 // probeOllamaIfSelected does a best-effort GET on /api/tags to verify the
-// user's Ollama server is reachable when ``ollama_local`` is configured.
+// user's Ollama server is reachable when `ollama_local` is configured.
 // Failures don't block startup — the user might be about to launch
 // Ollama, or running on an unusual setup we can't introspect. We just
 // surface a hint so they aren't surprised by a 'model not found' on the
@@ -229,11 +227,11 @@ func probeOllamaIfSelected(env map[string]string) {
 // verify host-side Ollama reachability. The returned list is ordered
 // best-first so the loop short-circuits on the most likely candidate.
 //
-// For URLs that don't reference ``host.docker.internal`` the list is
+// For URLs that don't reference `host.docker.internal` the list is
 // just the URL itself — the user wired up an explicit address (real
 // IP, DNS name) and we trust it.
 //
-// For ``host.docker.internal`` the resolution depends on platform:
+// For `host.docker.internal` the resolution depends on platform:
 //
 //   - Always try the URL verbatim first. Docker Desktop on macOS,
 //     Windows, and WSL2 typically populates /etc/hosts with this name.
@@ -242,7 +240,7 @@ func probeOllamaIfSelected(env map[string]string) {
 //     hosts entry, but the Windows host is always the WSL2 default
 //     nameserver, so this catches the "Ollama on Windows" case.
 //   - Always fall back to 127.0.0.1. Native Linux Docker reaches the
-//     host loopback via the ``extra_hosts: host-gateway`` mapping,
+//     host loopback via the `extra_hosts: host-gateway` mapping,
 //     which on the host is just localhost. On WSL this also catches
 //     the "Ollama running inside the WSL distro" case.
 func candidateProbeURLs(raw string) []string {
@@ -283,13 +281,4 @@ func candidateProbeURLs(raw string) []string {
 	}
 	add("127.0.0.1")
 	return candidates
-}
-
-// restartSelf re-execs the current binary after a self-update.
-func restartSelf() error {
-	execPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("get executable: %w", err)
-	}
-	return syscall.Exec(execPath, os.Args, os.Environ())
 }

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -52,7 +52,7 @@ func (c *Compose) baseArgs() []string {
 
 // readVersion returns the installed version from $DECEPTICON_HOME/.version,
 // or an empty string if the file is missing or unreadable. The launcher
-// (install + auto-update) is the single writer; compose falls back to :latest
+// (install + explicit update) is the single writer; compose falls back to :latest
 // when the marker is absent.
 func (c *Compose) readVersion() string {
 	data, err := os.ReadFile(filepath.Join(c.Home, ".version"))

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -128,6 +128,4 @@ COMPOSE_PROFILES=c2-sliver
 # DECEPTICON_HOME=/home/youruser/.decepticon
 
 # --- Advanced (optional) ---
-# Disable automatic self-update checks on startup
-# AUTO_UPDATE=false
 # DECEPTICON_DEBUG=true

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -58,7 +58,7 @@ func CompareVersions(current, latest string) bool {
 	current = strings.TrimPrefix(current, "v")
 	latest = strings.TrimPrefix(latest, "v")
 	if current == "dev" || current == "" {
-		return false // Don't auto-update dev builds
+		return false // Dev builds do not track published releases.
 	}
 	return compareSemver(current, latest) < 0
 }
@@ -89,8 +89,8 @@ func compareSemver(a, b string) int {
 func SyncConfigFiles(branch string) error {
 	home := config.DecepticonHome()
 	files := map[string]string{
-		"docker-compose.yml":   filepath.Join(home, "docker-compose.yml"),
-		"config/litellm.yaml":  filepath.Join(home, "config", "litellm.yaml"),
+		"docker-compose.yml":  filepath.Join(home, "docker-compose.yml"),
+		"config/litellm.yaml": filepath.Join(home, "config", "litellm.yaml"),
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
@@ -189,45 +189,28 @@ func WriteVersion(version string) error {
 	return os.WriteFile(versionFile, []byte(strings.TrimPrefix(version, "v")), 0o644)
 }
 
-// CheckAndUpdate performs auto-update check. Returns true if update was applied.
-//
-// Update order is binary-first, then config files. If the binary update fails
-// we abort entirely so we never end up with new compose/litellm files driving
-// an old launcher (which has caused breakage in past releases when image
-// tags or compose schema changed). If config sync fails after a successful
-// binary update we keep the new binary and leave .version unwritten so the
-// next launch retries config sync.
-func CheckAndUpdate(currentVersion string, env map[string]string) bool {
-	if config.Get(env, "AUTO_UPDATE", "true") == "false" {
-		return false
-	}
-
+// NotifyIfUpdateAvailable checks GitHub releases and prints a non-blocking
+// update notice. It never mutates the binary, config files, or Docker images;
+// users apply updates explicitly with `decepticon update`.
+func NotifyIfUpdateAvailable(currentVersion string) bool {
 	release, err := FetchLatestRelease()
 	if err != nil {
-		return false // Silent fail for auto-update
+		return false // Silent fail; startup should not depend on GitHub.
 	}
 
 	if !CompareVersions(currentVersion, release.TagName) {
 		return false
 	}
 
-	ui.Info(fmt.Sprintf("Update available: %s → %s", currentVersion, release.TagName))
-
-	if err := SelfUpdate(release); err != nil {
-		ui.Warning("Self-update failed: " + err.Error())
-		return false
-	}
-
-	// Use release tag for config files to avoid main branch drift
-	ref := release.TagName // e.g., "v1.0.7"
-	if err := SyncConfigFiles(ref); err != nil {
-		ui.Warning("Binary updated but config sync failed: " + err.Error())
-		ui.Warning("Run 'decepticon update' to retry config sync.")
-		// Do not WriteVersion — leaving .version stale lets the next run
-		// retry the sync via this same code path.
-		return true
-	}
-
-	_ = WriteVersion(release.TagName)
+	ui.Info(fmt.Sprintf("Update available: %s -> %s", displayVersion(currentVersion), release.TagName))
+	ui.DimText("Run `decepticon update` to upgrade.")
 	return true
+}
+
+func displayVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" || version == "dev" || strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
 }

--- a/clients/launcher/internal/updater/updater_test.go
+++ b/clients/launcher/internal/updater/updater_test.go
@@ -32,6 +32,20 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
+func TestDisplayVersion(t *testing.T) {
+	tests := map[string]string{
+		"1.0.22":  "v1.0.22",
+		"v1.0.22": "v1.0.22",
+		"dev":     "dev",
+		"":        "",
+	}
+	for input, want := range tests {
+		if got := displayVersion(input); got != want {
+			t.Errorf("displayVersion(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func TestFetchLatestRelease_Mock(t *testing.T) {
 	release := Release{
 		TagName: "v1.2.0",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,7 +11,7 @@
 | `decepticon status` | Show service status |
 | `decepticon logs [service]` | Follow service logs (default: `langgraph`) |
 | `decepticon kg-health` | Diagnose the Neo4j knowledge graph |
-| `decepticon update` | Check for updates and apply them |
+| `decepticon update` | Explicitly refresh config files, Docker images, and the launcher binary when a release is available |
 | `decepticon remove` | Uninstall Decepticon completely |
 | `decepticon --version` | Show installed version |
 

--- a/docs/makefile-reference.md
+++ b/docs/makefile-reference.md
@@ -14,7 +14,7 @@ The primary purpose of this Makefile. Run these before tagging a release.
 |--------|-------------|
 | `make dogfood` | Full OSS UX on local code: builds the Go launcher + every service image (`:dev` tag), wires up an isolated `$DECEPTICON_HOME` under `.dogfood/`, then runs the launcher. The onboard wizard, engagement picker, `compose up`, health checks, and CLI all execute exactly as a `curl \| bash` install. |
 | `make smoke` | Compose-only smoke (no launcher, no onboard wizard) — fastest possible release-shape check. Replicates only the launcher's `compose up` step: clean → build images locally → `up -d --no-build --wait` → health checks. Use when you only changed the compose stack. |
-| `make launcher` | Build the Go launcher binary at `clients/launcher/bin/decepticon`. Embedded version is `dev`, which gates auto-update + config-sync inside the launcher. Invoked automatically by `make dogfood`. |
+| `make launcher` | Build the Go launcher binary at `clients/launcher/bin/decepticon`. Embedded version is `dev`, which skips release update notices and versioned config sync inside the launcher. Invoked automatically by `make dogfood`. |
 
 `make dogfood` runs against an isolated `.dogfood/` directory so the user's real `~/.decepticon` is never touched. `make clean` purges both the compose volumes and `.dogfood/` when you want a fresh onboard.
 
@@ -105,6 +105,14 @@ To regenerate just the Prisma client (without a full build): `cd clients/web && 
 ## Versioning (no manual step)
 
 There is no `make sync-version` or pre-tag commit. Source-tree version fields carry a `"0.0.0"` sentinel in `pyproject.toml`, `clients/cli/package.json`, and `clients/web/package.json`. The release workflow stamps the real tag into the images at Docker build time via `--build-arg VERSION=<tag>`. The Go launcher is similarly stamped via GoReleaser ldflags.
+
+Release channel policy:
+
+- `vX.Y.Z` Git tags are the source of truth for stable releases.
+- GHCR version tags (`X.Y.Z`) are immutable release artifacts and should be used by installed deployments.
+- GHCR `latest` is a moving pointer to the newest fully verified stable release only. It is promoted after all version-tagged images exist and the GitHub release is undrafted.
+- Pre-releases should use SemVer suffixes such as `v1.1.0-rc.1`, stay marked as GitHub pre-releases, and should not move `latest`.
+- Bug fixes ship as new patch releases. Do not rebuild or rewrite an existing version tag.
 
 To cut a release:
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -560,7 +560,7 @@ decepticon onboard --reset  # Re-run setup from scratch
 decepticon stop             # Stop all services, keep data
 decepticon status           # Show running services
 decepticon logs [service]   # Follow service logs
-decepticon update           # Check for and apply updates
+decepticon update           # Explicitly refresh config/images and upgrade when available
 decepticon remove           # Uninstall Decepticon completely
 decepticon --version        # Show installed version
 ```


### PR DESCRIPTION
## Summary
- replace startup auto-update with a non-mutating update notice
- remove `AUTO_UPDATE` from the environment template and docs
- keep `decepticon update` as the explicit path for binary/config/image refresh
- document release channel policy for stable, versioned GHCR tags, `latest`, and pre-releases
- prevent pre-release tags like `v1.1.0-rc.1` from moving GHCR `latest`

## Verification
- `go test ./...` from `clients/launcher`
- `git diff --check`

## Release Policy
Stable releases use `vX.Y.Z` Git tags and immutable `X.Y.Z` GHCR image tags. `latest` only moves after all stable images are verified and the GitHub release is published. Pre-releases keep their version tags and GitHub prerelease marker but do not move `latest`.