### PR TITLE
fix(llm): remove unsupported ChatGPT nano route

### DIFF
--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -251,7 +251,6 @@ _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
     "DECEPTICON_AUTH_CHATGPT": [
         {"model_name": "auth/gpt-5.5", "litellm_params": {"model": "chatgpt/gpt-5.5"}},
         {"model_name": "auth/gpt-5.4", "litellm_params": {"model": "chatgpt/gpt-5.4"}},
-        {"model_name": "auth/gpt-5-nano", "litellm_params": {"model": "chatgpt/gpt-5-nano"}},
     ],
     "DECEPTICON_AUTH_GEMINI": [
         {

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -37,6 +37,7 @@ Tier × AuthMethod matrix
   anthropic_api    claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
   anthropic_oauth  auth/claude-opus-4-7          auth/claude-sonnet-4-6         auth/claude-haiku-4-5
   openai_api       gpt-5.5                       gpt-5.4                        gpt-5-nano
+  openai_oauth     auth/gpt-5.5                  auth/gpt-5.4                   auth/gpt-5.4
   google_api       gemini-2.5-pro                gemini-2.5-flash               gemini-2.5-flash-lite
   minimax_api      MiniMax-M2.5                  MiniMax-M2.5-lightning         — (falls through)
   openrouter_api   claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
@@ -131,7 +132,10 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
     AuthMethod.OPENAI_OAUTH: {
         Tier.HIGH: "auth/gpt-5.5",
         Tier.MID: "auth/gpt-5.4",
-        Tier.LOW: "auth/gpt-5-nano",
+        # LiteLLM's native ChatGPT provider does not expose gpt-5-nano for
+        # ChatGPT subscriptions. Keep LOW on 5.4 so low-tier roles and the
+        # test profile never route to an invalid upstream model.
+        Tier.LOW: "auth/gpt-5.4",
     },
     AuthMethod.GOOGLE_OAUTH: {
         Tier.HIGH: "gemini-sub/gemini-2.5-pro",

--- a/docs/models.md
+++ b/docs/models.md
@@ -25,7 +25,7 @@ For each agent, Decepticon resolves a tier (from the profile) and walks your Aut
 | `anthropic_api`       | `anthropic/claude-opus-4-7`               | `anthropic/claude-sonnet-4-6`                 | `anthropic/claude-haiku-4-5`                  |
 | `anthropic_oauth`     | `auth/claude-opus-4-7`                    | `auth/claude-sonnet-4-6`                      | `auth/claude-haiku-4-5`                       |
 | `openai_api`          | `openai/gpt-5.5`                          | `openai/gpt-5.4`                              | `openai/gpt-5-nano`                           |
-| `openai_oauth`        | `auth/gpt-5.5`                            | `auth/gpt-5.4`                                | `auth/gpt-5-nano`                             |
+| `openai_oauth`        | `auth/gpt-5.5`                            | `auth/gpt-5.4`                                | `auth/gpt-5.4`                                |
 | `google_api`          | `gemini/gemini-2.5-pro`                   | `gemini/gemini-2.5-flash`                     | `gemini/gemini-2.5-flash-lite`                |
 | `google_oauth`        | `gemini-sub/gemini-2.5-pro`               | `gemini-sub/gemini-2.5-flash`                 | — *(falls through)*                           |
 | `minimax_api`         | `minimax/MiniMax-M2.5`                    | `minimax/MiniMax-M2.5-lightning`              | — *(falls through)*                           |
@@ -297,7 +297,7 @@ Use monthly subscriptions instead of per-token API billing. ChatGPT uses LiteLLM
 | Subscription | AuthMethod | Models | Handler |
 |---|---|---|---|
 | Claude Max/Pro/Team | `anthropic_oauth` | auth/claude-opus, sonnet, haiku | `claude_code_handler.py` |
-| ChatGPT Pro/Plus/Team | `openai_oauth` | auth/gpt-5.5, gpt-5.4, gpt-5-nano | LiteLLM native `chatgpt` provider |
+| ChatGPT Pro/Plus/Team | `openai_oauth` | auth/gpt-5.5, gpt-5.4 | LiteLLM native `chatgpt` provider |
 | Gemini Advanced | `google_oauth` | gemini-sub/gemini-2.5-pro, flash | `gemini_handler.py` |
 | Copilot Pro | `copilot_oauth` | copilot/gpt-4o, o1, o3-mini | `copilot_handler.py` |
 | SuperGrok | `grok_oauth` | grok-sub/grok-3, grok-3-mini | `grok_handler.py` |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -320,9 +320,9 @@ Use your ChatGPT Pro, Plus, or Team subscription instead of OpenAI API billing.
 
 | Tier | Models Available (via `auth/gpt-5.x` route) |
 |------|--------------------------------------------|
-| ChatGPT Plus ($20/mo) | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` |
-| ChatGPT Pro ($200/mo) | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` |
-| ChatGPT Team | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` + admin controls |
+| ChatGPT Plus ($20/mo) | `auth/gpt-5.5`, `auth/gpt-5.4` |
+| ChatGPT Pro ($200/mo) | `auth/gpt-5.5`, `auth/gpt-5.4` |
+| ChatGPT Team | `auth/gpt-5.5`, `auth/gpt-5.4` + admin controls |
 
 **Setup:**
 
@@ -348,8 +348,8 @@ decepticon
 
 **How it works:**
 
-- Decepticon exposes ChatGPT subscription models as `auth/gpt-5.5`,
-  `auth/gpt-5.4`, and `auth/gpt-5-nano`.
+- Decepticon exposes ChatGPT subscription models as `auth/gpt-5.5`
+  and `auth/gpt-5.4`.
 - LiteLLM dynamic config maps those aliases to LiteLLM's native
   `chatgpt/gpt-*` provider routes only when `DECEPTICON_AUTH_CHATGPT=true`.
 - `docker-compose.yml` mounts the host token directory into the LiteLLM
@@ -457,7 +457,7 @@ Complete list of all supported LLM providers and their pre-configured models:
 |----------|--------|-----------|------|
 | **Subscriptions (OAuth — no API billing)** | | | |
 | Claude Max/Pro/Team | Opus, Sonnet, Haiku | OAuth | $20–$100/mo |
-| ChatGPT Pro/Plus/Team | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5-nano` | OAuth | $20–$200/mo |
+| ChatGPT Pro/Plus/Team | `auth/gpt-5.5`, `auth/gpt-5.4` | OAuth | $20–$200/mo |
 | Gemini Advanced | Gemini 2.5 Pro/Flash | OAuth | $20/mo |
 | Copilot Pro | `copilot/gpt-4o`, `copilot/o1`, `copilot/o3-mini` | OAuth | $20/mo |
 | SuperGrok | Grok-3, Grok-3 Mini | OAuth | X Premium+ |

--- a/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/tests/unit/llm/test_litellm_dynamic_config.py
@@ -137,3 +137,20 @@ def test_merge_dynamic_models_keeps_existing_entries_and_appends_missing() -> No
         "openai/gpt-4.1",
         "mistral/mistral-large-latest",
     ]
+
+
+def test_merge_dynamic_models_registers_only_supported_chatgpt_oauth_routes() -> None:
+    merged = merge_dynamic_models(
+        {"model_list": [], "litellm_settings": {"fallbacks": []}},
+        {"DECEPTICON_AUTH_CHATGPT": "true"},
+    )
+
+    routes = {
+        entry["model_name"]: entry["litellm_params"]["model"] for entry in merged["model_list"]
+    }
+    assert routes == {
+        "auth/gpt-5.5": "chatgpt/gpt-5.5",
+        "auth/gpt-5.4": "chatgpt/gpt-5.4",
+    }
+    assert "auth/gpt-5-nano" not in routes
+    assert merged["litellm_settings"]["fallbacks"] == [{"auth/gpt-5.5": ["auth/gpt-5.4"]}]

--- a/tests/unit/llm/test_models.py
+++ b/tests/unit/llm/test_models.py
@@ -70,6 +70,13 @@ class TestMethodModels:
         assert m[Tier.MID] == "openai/gpt-5.4"
         assert m[Tier.LOW] == "openai/gpt-5-nano"
 
+    def test_chatgpt_oauth_uses_only_supported_subscription_models(self):
+        m = METHOD_MODELS[AuthMethod.OPENAI_OAUTH]
+        assert m[Tier.HIGH] == "auth/gpt-5.5"
+        assert m[Tier.MID] == "auth/gpt-5.4"
+        assert m[Tier.LOW] == "auth/gpt-5.4"
+        assert "auth/gpt-5-nano" not in m.values()
+
     def test_google_full_tier_coverage(self):
         m = METHOD_MODELS[AuthMethod.GOOGLE_API]
         assert m[Tier.HIGH] == "gemini/gemini-2.5-pro"
@@ -186,6 +193,11 @@ class TestResolveChain:
         creds = Credentials(methods=[AuthMethod.MINIMAX_API])
         chain = resolve_chain(Tier.LOW, creds)
         assert chain == []
+
+    def test_chatgpt_oauth_low_falls_back_to_gpt_5_4(self):
+        creds = Credentials(methods=[AuthMethod.OPENAI_OAUTH])
+        chain = resolve_chain(Tier.LOW, creds)
+        assert chain == ["auth/gpt-5.4"]
 
     def test_empty_credentials_returns_empty(self):
         assert resolve_chain(Tier.HIGH, Credentials()) == []


### PR DESCRIPTION
## Summary
- remove `auth/gpt-5-nano -> chatgpt/gpt-5-nano` from dynamic LiteLLM ChatGPT OAuth routes
- keep ChatGPT OAuth LOW tier on `auth/gpt-5.4`, so low-tier roles and the test profile only use `auth/gpt-5.5` / `auth/gpt-5.4`
- update ChatGPT OAuth docs to list only supported subscription aliases
- add regression tests proving ChatGPT OAuth does not emit the nano alias

## Root Cause
`auth/gpt-5-nano` was a Decepticon alias that mapped to LiteLLM native `chatgpt/gpt-5-nano`. The native ChatGPT provider rejects that upstream model name, so LOW-tier ChatGPT OAuth requests failed with `Invalid model name passed in model=auth/gpt-5-nano`.

## Verification
- `uv run pytest tests/unit/llm/test_models.py tests/unit/llm/test_litellm_dynamic_config.py`
- `python3 -m py_compile config/litellm_dynamic_config.py decepticon/llm/models.py`
- `git diff --check`

## Note
`auth/*` remains the Decepticon-facing alias namespace. The real LiteLLM provider remains `chatgpt/*`; dynamic config maps `auth/gpt-5.5` and `auth/gpt-5.4` to `chatgpt/gpt-5.5` and `chatgpt/gpt-5.4`.