### PR TITLE
fix(research): fix AttributeError in suggest_objectives_from_chains

### DIFF
--- a/decepticon/tools/research/tools.py
+++ b/decepticon/tools/research/tools.py
@@ -1627,29 +1627,19 @@ def suggest_objectives_from_chains(
 
     for idx, chain in enumerate(ranked[:top_k], start=1):
         chain_score = critical_path_score(chain)
-        mitre: list[str] = []
-        highest = Severity.INFO
-
-        for step in chain.steps:
-            step_mitre = step.node.props.get("mitre")
-            if isinstance(step_mitre, list):
-                mitre.extend([m for m in step_mitre if isinstance(m, str)])
-            sev = _severity_from_string(step.node.props.get("severity"))
-            if sev in {Severity.CRITICAL, Severity.HIGH}:
-                highest = sev
 
         phase = "initial-access"
-        if any(step.node.kind in {NodeKind.CREDENTIAL, NodeKind.SECRET} for step in chain.steps):
+        if any(step.node_kind in {NodeKind.CREDENTIAL, NodeKind.SECRET} for step in chain.steps):
             phase = "post-exploit"
         elif (
-            "admin" in chain.crown_jewel.label.lower()
-            or "domain" in chain.crown_jewel.label.lower()
+            "admin" in chain.crown_jewel_label.lower()
+            or "domain" in chain.crown_jewel_label.lower()
         ):
             phase = "post-exploit"
 
-        title = f"Exploit chain {idx}: {chain.entrypoint.label} -> {chain.crown_jewel.label}"
+        title = f"Exploit chain {idx}: {chain.entrypoint_label} -> {chain.crown_jewel_label}"
         acceptance = [
-            f"Demonstrate path from {chain.entrypoint.label} to {chain.crown_jewel.label}.",
+            f"Demonstrate path from {chain.entrypoint_label} to {chain.crown_jewel_label}.",
             "Capture evidence for each hop (commands, outputs, and impacted asset IDs).",
             "Validate the highest-risk step with PoC evidence or explain why blocked.",
         ]
@@ -1660,8 +1650,8 @@ def suggest_objectives_from_chains(
                 "title": title,
                 "description": chain.summary(),
                 "acceptance_criteria": acceptance,
-                "mitre": sorted(set(mitre)),
-                "opsec": "careful" if highest in {Severity.HIGH, Severity.CRITICAL} else "standard",
+                "mitre": [],
+                "opsec": "standard",
                 "notes": {
                     "chain_total_cost": chain.total_cost,
                     "chain_score": chain_score,


### PR DESCRIPTION
## Summary

Closes #165

`suggest_objectives_from_chains` crashes with `AttributeError` any time `plan_chains()` returns chains with steps, because the function accessed members that don't exist on the `ChainStep` and `Chain` dataclasses:

| Broken access | Actual field |
|---|---|
| `step.node.props.get("mitre")` | not on `ChainStep` — no `.node` attribute |
| `step.node.props.get("severity")` | not on `ChainStep` |
| `step.node.kind` | `step.node_kind` (flat `str`) |
| `chain.crown_jewel.label` | `chain.crown_jewel_label` (flat `str`) |
| `chain.entrypoint.label` | `chain.entrypoint_label` (flat `str`) |

`ChainStep` stores flat string fields (`node_id`, `node_label`, `node_kind`, `edge_kind`, `hop_cost`). `Chain` stores `crown_jewel_label` and `entrypoint_label` as flat strings — not objects with a `.label` attribute.

### Changes

- Replace all five broken attribute accesses with the correct flat-string fields
- Remove the mitre/severity enrichment loop — neither field is carried by `ChainStep`; `mitre` defaults to `[]` and `opsec` to `"standard"` (these can be enriched in a follow-up if `Chain` is extended to carry full `Node.props`)

## Test plan

- [x] `uv run ruff check decepticon/tools/research/tools.py` — passes
- [x] `uv run basedpyright decepticon/tools/research/tools.py` — 0 errors
- [x] `uv run pytest tests/unit/research/test_tools.py` — 10/10 passed