### PR TITLE
fix(ad): fix _build_bh_index returning dict[Any|None, Node]

### DIFF
--- a/decepticon/tools/ad/bloodhound.py
+++ b/decepticon/tools/ad/bloodhound.py
@@ -121,7 +121,12 @@ def _upsert_bh_object(graph: KnowledgeGraph, obj: dict[str, Any], type_name: str
 
 def _build_bh_index(graph: KnowledgeGraph) -> dict[str, Node]:
     """Build a bh_id → Node lookup for O(1) principal resolution."""
-    return {n.props.get("bh_id"): n for n in graph.nodes.values() if n.props.get("bh_id")}
+    result: dict[str, Node] = {}
+    for n in graph.nodes.values():
+        bh_id = n.props.get("bh_id")
+        if bh_id is not None:
+            result[str(bh_id)] = n
+    return result
 
 
 def _ingest_aces(


### PR DESCRIPTION
## Summary

Closes #166

`_build_bh_index` in `decepticon/tools/ad/bloodhound.py` used a dict comprehension keyed on `n.props.get("bh_id")`, which returns `Any | None`. This produces a `dict[Any | None, Node]` at runtime despite the declared return type of `dict[str, Node]`, and the truthiness guard silently drops any node whose `bh_id` is `0` (falsy but a valid integer ID).

### Changes

Replace the comprehension with an explicit loop that:
- Uses an `is not None` guard instead of truthiness — preserves nodes with `bh_id = 0`
- Casts the key to `str` — satisfies the declared return type and ensures consistent lookup behaviour for callers

## Test plan

- [x] `uv run ruff check decepticon/tools/ad/bloodhound.py` — passes
- [x] `uv run basedpyright decepticon/tools/ad/bloodhound.py` — 0 errors
- [x] `uv run pytest tests/unit/ad/` — 15/15 passed