### PR TITLE
fix(middleware,core): remove nonexistent method call and guard None tool-call id

### DIFF
--- a/decepticon/core/subagent_streaming.py
+++ b/decepticon/core/subagent_streaming.py
@@ -137,7 +137,7 @@ class StreamingRunnable:
     def _process_messages(
         self,
         new_messages: list,
-        active_tool_calls: dict[str, dict],
+        active_tool_calls: dict[str, Any],
         renderer: Any,
         has_renderer: bool,
         writer: Callable | None,
@@ -166,7 +166,9 @@ class StreamingRunnable:
 
                 if hasattr(msg, "tool_calls") and msg.tool_calls:
                     for tc in msg.tool_calls:
-                        active_tool_calls[tc["id"]] = tc
+                        tc_id: str | None = tc.get("id")
+                        if tc_id is not None:
+                            active_tool_calls[tc_id] = tc
                         tc_args = {
                             k: str(v) if not isinstance(v, (str, int, float, bool)) else v
                             for k, v in tc["args"].items()
@@ -228,7 +230,7 @@ class StreamingRunnable:
         start = time.monotonic()
         last_state = None
         last_count = 0
-        active_tool_calls: dict[str, dict] = {}
+        active_tool_calls: dict[str, Any] = {}
 
         try:
             for state in self._runnable.stream(
@@ -310,7 +312,7 @@ class StreamingRunnable:
         start = time.monotonic()
         last_state = None
         last_count = 0
-        active_tool_calls: dict[str, dict] = {}
+        active_tool_calls: dict[str, Any] = {}
 
         try:
             async for state in self._runnable.astream(

--- a/decepticon/middleware/filesystem.py
+++ b/decepticon/middleware/filesystem.py
@@ -20,8 +20,6 @@ from deepagents.backends.protocol import (
 from deepagents.backends.utils import validate_path
 from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesystemMiddleware
 
-from decepticon.backends.docker_sandbox import DockerSandbox
-
 WORKSPACE = "/workspace"
 NO_WORKSPACE_ERROR = (
     "No engagement workspace is set. Filesystem tools are scoped to the active "
@@ -30,8 +28,12 @@ NO_WORKSPACE_ERROR = (
 
 
 def _normalize_engagement_workspace(workspace_path: str | None) -> str | None:
-    normalized = DockerSandbox._normalize_workspace_path(workspace_path)
-    return None if normalized == WORKSPACE else normalized
+    if workspace_path is None:
+        return None
+    path = workspace_path.strip()
+    if not path or path == WORKSPACE:
+        return None
+    return path
 
 
 class EngagementFilesystemBackend(BackendProtocol):


### PR DESCRIPTION
## Summary

Two independent defensive fixes bundled into one PR.

---

### Fix 1 — `middleware/filesystem.py` (Closes #155)

`_normalize_engagement_workspace` called `DockerSandbox._normalize_workspace_path()` — a method that has never existed in `DockerSandbox` or any class in its MRO. The call was hidden by a short-circuit (the `/workspace` root path always returned `None` first), but any change to that function's control flow would immediately surface an `AttributeError`.

**Changes:**
- Replace the nonexistent method call with inline normalization that preserves the original semantics: return `None` for `None` input, empty string, or the bare `/workspace` root
- Remove the now-unused `DockerSandbox` import

---

### Fix 2 — `core/subagent_streaming.py` (Closes #161)

`active_tool_calls[tc["id"]] = tc` keyed the lookup dict directly on `tc["id"]`. LangChain's `ToolCall` type declares `id` as `str | None`, so a `None` id stored under a `None` key. The subsequent lookup `active_tool_calls.get(msg.tool_call_id)` then silently missed the entry, causing tool results to be dropped from the streaming pipeline for any subagent that emits a tool call without an id (valid per the LangChain spec).

**Changes:**
- Guard the store with `if tc_id is not None` so `None`-id tool calls are skipped rather than mis-keyed
- Narrow `active_tool_calls` type annotation from `dict[str, dict]` → `dict[str, Any]` to match the actual `ToolCall` value type (3 sites)

---

## Test plan

- [x] `uv run ruff check decepticon/middleware/filesystem.py decepticon/core/subagent_streaming.py` — passes
- [x] `uv run basedpyright decepticon/middleware/filesystem.py decepticon/core/subagent_streaming.py` — 0 errors
- [x] `uv run pytest tests/unit/middleware/test_filesystem.py tests/unit/core/test_subagent_streaming.py` — 11/11 passed