### PR TITLE
fix(llm): use Any instead of object for kwargs type in _build_litellm_model

### DIFF
--- a/decepticon/llm/factory.py
+++ b/decepticon/llm/factory.py
@@ -699,7 +699,7 @@ class LLMFactory:
         belt-and-suspenders for any future client that bypasses this
         factory.
         """
-        kwargs: dict[str, object] = {
+        kwargs: dict[str, Any] = {
             "model": model,
             "base_url": self._proxy.url,
             "api_key": SecretStr(self._proxy.api_key),


### PR DESCRIPTION
## Summary

- Fixes `dict[str, object]` → `dict[str, Any]` for the `kwargs` accumulator in `LLMFactory._build_litellm_model()` (`decepticon/llm/factory.py:702`)
- `Any` is already imported; this is a one-line change
- Resolves ~80 spurious pyright warnings of the form `Argument of type "object" cannot be assigned to parameter "model" of type "str"` that were drowning out real type errors in the factory module

## Test plan

- [ ] `make lint` passes on the changed file (`ruff check` + `ruff format`)
- [ ] `make test-local` passes (no behavioural change — this is a type annotation only)
- [ ] Verify pyright/basedpyright no longer emits the ~80 `object` → constructor-param warnings in `factory.py`

Closes #162