### PR TITLE
fix(middleware): resolve /workspace correctly under launcher mode

### DIFF
--- a/decepticon/middleware/filesystem.py
+++ b/decepticon/middleware/filesystem.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import replace
 from typing import Any
 
@@ -30,8 +31,18 @@ NO_WORKSPACE_ERROR = (
 
 
 def _normalize_engagement_workspace(workspace_path: str | None) -> str | None:
-    normalized = DockerSandbox._normalize_workspace_path(workspace_path)
-    return None if normalized == WORKSPACE else normalized
+    path = (workspace_path or "").strip()
+    if not path:
+        return None
+    if path == WORKSPACE:
+        return WORKSPACE
+    if not path.startswith(f"{WORKSPACE}/"):
+        return None
+    expected = path.rstrip("/")
+    if os.path.normpath(expected) != expected:
+        return None
+    normalized = DockerSandbox._normalize_workspace_path(path)
+    return normalized if normalized == expected else None
 
 
 class EngagementFilesystemBackend(BackendProtocol):

--- a/tests/unit/middleware/test_filesystem.py
+++ b/tests/unit/middleware/test_filesystem.py
@@ -144,9 +144,48 @@ def test_missing_engagement_workspace_fails_closed() -> None:
     assert backend.calls == []
 
 
-def test_root_workspace_fails_closed() -> None:
+def test_root_workspace_accepted_as_engagement_root() -> None:
     backend = RecordingBackend()
     scoped = EngagementFilesystemBackend(backend, "/workspace")
 
-    assert scoped.ls("/workspace").error is not None
+    result = scoped.ls("/workspace")
+    assert result.error is None
+    assert backend.calls == [("ls_info", "/workspace")]
+
+
+def test_root_workspace_no_prefix_doubling() -> None:
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace")
+
+    scoped.read("/workspace/plan/roe.json")
+
+    assert backend.calls[-1] == ("read", ("/workspace/plan/roe.json", 0, 2000))
+
+
+def test_root_workspace_glob_scoped_to_root() -> None:
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace")
+
+    scoped.glob("**/*.json")
+
+    # Non-/-prefixed patterns pass through _glob unchanged; root is /workspace
+    assert backend.calls[-1] == ("glob_info", ("**/*.json", "/workspace"))
+
+
+def test_root_workspace_trailing_slash_accepted() -> None:
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace/test/")
+
+    scoped.read("/workspace/plan/roe.json")
+
+    assert backend.calls[-1] == ("read", ("/workspace/test/plan/roe.json", 0, 2000))
+
+
+def test_invalid_workspace_paths_fail_closed() -> None:
+    backend = RecordingBackend()
+
+    for bad_path in ("/tmp/foo", "/etc/passwd", "/workspace/../etc", "relative/path", ""):
+        scoped = EngagementFilesystemBackend(backend, bad_path)
+        assert scoped.ls("/workspace").error is not None, f"expected error for {bad_path!r}"
+
     assert backend.calls == []


### PR DESCRIPTION
## Summary

- `_normalize_engagement_workspace()` was collapsing `workspace_path="/workspace"` to `None`, causing every filesystem tool (`ls`, `read`, `write`, `edit`, `grep`, `glob`, `download_files`) to return `"No engagement workspace is set..."` even when an engagement is active.
- The bug: the function conflated "path resolved to the literal `/workspace`" with "no engagement configured", which is only true in raw `make dev` mode. In launcher mode the Docker bind-mount already scopes `/workspace` to the engagement, so `/workspace` IS the correct engagement root.
- Fix: rewrite the normalizer to accept `/workspace` explicitly, accept `/workspace/<safe-slug>` (unchanged), and fail closed for `None`/empty/traversal/invalid paths. Invalid paths are not silently coerced into `/workspace`.

Prerequisite: #180 (slug propagation) must be merged first — this PR fixes the second half of the chain.

## What changed

**`decepticon/middleware/filesystem.py`**: Rewrote `_normalize_engagement_workspace` with a strict 4-case contract: empty→`None`, `/workspace`→`/workspace`, `/workspace/<slug>`→normalized (only if `_normalize_workspace_path` did not silently coerce), anything else (including traversal like `/workspace/../etc`)→`None`. Added `os.path.normpath` guard to catch `..`-based traversal that the slug regex would otherwise accept. Added `import os`.

**`tests/unit/middleware/test_filesystem.py`**: Flipped `test_root_workspace_fails_closed` → `test_root_workspace_accepted_as_engagement_root`. Added: no-prefix-doubling under `/workspace` root, glob scoping, trailing-slash acceptance, explicit negative regression that invalid paths fail closed and do NOT coerce to `/workspace`.

## Test plan

- [x] `pytest tests/unit/middleware/test_filesystem.py -v` — 11/11 pass
- [x] `make test-local` — 726 passed, 1 skipped (pre-existing skip), 0 failures
- [x] `ruff check` + `ruff format --check` on changed files — clean
- [x] `basedpyright decepticon/middleware/filesystem.py` — 0 errors
- [ ] Manual smoke (launcher mode `ls /workspace` from an active engagement) requires the LangGraph + Docker stack and is out of scope for CI

## Notes

- `DECEPTICON_ENGAGEMENT_WORKSPACE` env fallback was considered and intentionally excluded: the variable is used by compose for host-side bind interpolation and is not currently propagated into the LangGraph container environment. A follow-up PR adding compose/launcher env propagation would be needed to make that fallback reliable.
- This PR addresses the filesystem failure reported in #175. It does not address that issue's separate LangGraph DB-init claim.

Closes #152
Closes #173
Addresses the filesystem failure reported in #175