### PR TITLE
refactor(engagement): launcher-authoritative slug via config.configurable

### DIFF
--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -152,9 +152,11 @@ export function useAgent({
   // tool flips this to "decepticon" mid-flight; the next submit() then opens
   // a fresh thread on the new assistant.
   const assistantIdRef = useRef<string>(INITIAL_ASSISTANT_ID);
-  // Slug captured from the engagement_ready event — kept for system-level
-  // logging when the handoff fires.
-  const pendingHandoffRef = useRef<string | null>(null);
+  // Boolean handoff signal — set when soundwave emits engagement_ready; consumed
+  // in handleStreamComplete to drop the soundwave thread before the auto-submit
+  // opens a fresh decepticon thread. Carries no slug; the launcher is the single
+  // source of truth and reaches the agent via config.configurable.
+  const pendingHandoffRef = useRef<boolean>(false);
 
   // Derived for backward compatibility
   const isStreaming = runState === "streaming" || runState === "connecting";
@@ -299,15 +301,15 @@ export function useAgent({
             // active assistant so the next submit() lands on decepticon.
             // The current run continues to completion (soundwave's closing
             // message); thread handoff fires from handleStreamComplete.
-            const slug = data.engagement ?? "";
-            pendingHandoffRef.current = slug || "(unnamed)";
+            // Pure boolean signal — the engagement slug travels independently
+            // via config.configurable from the launcher's env.
+            pendingHandoffRef.current = true;
             assistantIdRef.current = "decepticon";
             setAssistantId("decepticon");
             addEvent({
               type: "system",
-              content: slug
-                ? `Engagement '${slug}' planning complete — Decepticon will pick up your next message.`
-                : "Engagement planning complete — Decepticon will pick up your next message.",
+              content:
+                "Engagement planning complete — Decepticon will pick up your next message.",
             });
             break;
           }
@@ -532,7 +534,7 @@ export function useAgent({
         threadIdRef.current = null;
         lastCountRef.current = 0;
         askedQuestionIds.current.clear();
-        pendingHandoffRef.current = null;
+        pendingHandoffRef.current = false;
       }
 
       // Auto-submit queued message
@@ -679,31 +681,31 @@ export function useAgent({
         setActiveAgent("decepticon");
         setStreamStats({ startTime: Date.now(), totalTokens: 0, promptTokens: 0, completionTokens: 0 });
 
-        // Engagement context flows in as regular state fields. A small
-        // middleware on the agent side picks engagement_name + workspace_path
-        // out of state and injects them into the model's system prompt —
-        // the LangGraph-idiomatic way to surface launcher-set context to the
-        // LLM without polluting user messages.
-        const slug = process.env.DECEPTICON_ENGAGEMENT;
+        // Engagement context and the /model override flow as runnable
+        // ``config.configurable`` entries. EngagementContextMiddleware
+        // hydrates state from configurable on before_agent so OPPLAN and
+        // filesystem middlewares see the values as ordinary state fields,
+        // and ModelOverrideMiddleware reads model_override straight from
+        // configurable. The launcher is the single source of truth for the
+        // engagement slug; the LLM never decides it.
         const input: Record<string, unknown> = {
           messages: [{ role: "user", content: message }],
         };
+
+        const configurable: Record<string, unknown> = {};
+        const slug = process.env.DECEPTICON_ENGAGEMENT;
         if (slug) {
-          input.engagement_name = slug;
-          input.workspace_path = process.env.DECEPTICON_WORKSPACE_PATH ?? "/workspace";
+          configurable.engagement_name = slug;
+          configurable.workspace_path =
+            process.env.DECEPTICON_WORKSPACE_PATH ?? "/workspace";
+        }
+        const modelOverride = getModelOverride();
+        if (modelOverride) {
+          configurable.model_override = modelOverride;
         }
 
-        // /model command — inject the active runtime override into BOTH
-        // input state and config.configurable. The agent's
-        // ModelOverrideMiddleware reads either path, so the call works
-        // whether the LangGraph runtime surfaces the field via state or
-        // via the runnable config.
-        const modelOverride = getModelOverride();
-        const streamConfig: { configurable?: Record<string, unknown> } = {};
-        if (modelOverride) {
-          input.model_override = modelOverride;
-          streamConfig.configurable = { model_override: modelOverride };
-        }
+        const hasConfigurable = Object.keys(configurable).length > 0;
+        const streamConfig = hasConfigurable ? { configurable } : undefined;
 
         try {
           const stream = client.runs.stream(
@@ -711,7 +713,7 @@ export function useAgent({
             assistantIdRef.current,
             {
               input,
-              ...(modelOverride ? { config: streamConfig } : {}),
+              ...(streamConfig ? { config: streamConfig } : {}),
               ...STREAM_OPTIONS,
               onDisconnect: "continue",
               signal: abortController.signal,

--- a/clients/shared/streaming/src/types.ts
+++ b/clients/shared/streaming/src/types.ts
@@ -43,8 +43,6 @@ export interface SubagentCustomEvent {
   options?: AskUserOption[];
   multi_select?: boolean;
   allow_other?: boolean;
-  // engagement_ready field — slug whose planning bundle is now complete.
-  engagement?: string;
 }
 
 /** Minimal event shape accepted by shared utility functions. */

--- a/decepticon/agents/prompts/soundwave.md
+++ b/decepticon/agents/prompts/soundwave.md
@@ -243,17 +243,20 @@ All three must validate against `decepticon.core.schemas` (RoE, CONOPS, Deconfli
 ### Completion Signal
 
 After writing and validating all three files, call the
-`complete_engagement_planning` tool with the workspace slug. The CLI uses
-the tool's emitted event to switch the active assistant from Soundwave to
-Decepticon so the operator's next message lands on the operations agent
-without restarting the CLI.
+`complete_engagement_planning` tool. It takes no arguments — the launcher
+already established the engagement slug, and the tool's emitted event
+flips the active assistant from Soundwave to Decepticon so the operator's
+next message lands on the operations agent without restarting the CLI.
 
 After the tool returns, your closing chat message should confirm the
 handoff in plain prose, for example:
 
 ```
-Planning complete for engagement <slug>. Decepticon will pick up from your next message.
+Planning complete. Decepticon will pick up from your next message.
 ```
+
+You may reference the engagement by name in prose if helpful, but do not
+treat the slug as a tool argument.
 
 Do **not** call `complete_engagement_planning` more than once per engagement.
 </SOCRATIC_INTERVIEW>

--- a/decepticon/core/subagent_streaming.py
+++ b/decepticon/core/subagent_streaming.py
@@ -31,6 +31,7 @@ import time
 from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
+from langchain_core.messages.tool import ToolCall
 
 log = logging.getLogger("decepticon.subagent_streaming")
 
@@ -137,7 +138,7 @@ class StreamingRunnable:
     def _process_messages(
         self,
         new_messages: list,
-        active_tool_calls: dict[str, dict],
+        active_tool_calls: dict[str, ToolCall],
         renderer: Any,
         has_renderer: bool,
         writer: Callable | None,
@@ -166,7 +167,21 @@ class StreamingRunnable:
 
                 if hasattr(msg, "tool_calls") and msg.tool_calls:
                     for tc in msg.tool_calls:
-                        active_tool_calls[tc["id"]] = tc
+                        # ToolCall.id is `str | None` in the LangChain spec.
+                        # Storing under a None key collides across multiple
+                        # id-less calls and yields wrong-name lookups for the
+                        # corresponding ToolMessage; skip and log instead so
+                        # the result falls through to the "unknown" branch.
+                        tc_id = tc.get("id")
+                        if tc_id is None:
+                            log.warning(
+                                "subagent %r emitted tool call without id (tool=%s); "
+                                "result will surface as 'unknown'",
+                                self._name,
+                                tc.get("name"),
+                            )
+                        else:
+                            active_tool_calls[tc_id] = tc
                         tc_args = {
                             k: str(v) if not isinstance(v, (str, int, float, bool)) else v
                             for k, v in tc["args"].items()
@@ -228,7 +243,7 @@ class StreamingRunnable:
         start = time.monotonic()
         last_state = None
         last_count = 0
-        active_tool_calls: dict[str, dict] = {}
+        active_tool_calls: dict[str, ToolCall] = {}
 
         try:
             for state in self._runnable.stream(
@@ -310,7 +325,7 @@ class StreamingRunnable:
         start = time.monotonic()
         last_state = None
         last_count = 0
-        active_tool_calls: dict[str, dict] = {}
+        active_tool_calls: dict[str, ToolCall] = {}
 
         try:
             async for state in self._runnable.astream(

--- a/decepticon/middleware/engagement.py
+++ b/decepticon/middleware/engagement.py
@@ -3,10 +3,12 @@
 Two channels feed this middleware:
 
 1. Launcher path (CLI / web): the launcher decides the engagement slug at
-   session start and the client forwards it as state fields on every run
-   (input.engagement_name and input.workspace_path). This middleware reads
-   those fields and prepends a system-prompt addendum so the model knows the
-   active engagement without operator hand-holding or filesystem markers.
+   session start. Clients inject ``engagement_name`` and ``workspace_path``
+   via ``config.configurable`` on every run. ``before_agent`` hydrates these
+   into agent state on the first step of each thread so downstream middleware
+   (OPPLAN, filesystem) and the prompt-injection path see them as ordinary
+   state fields. The checkpointer persists the hydrated state across runs,
+   so subsequent runs read straight from state without re-hydrating.
 
 2. Benchmark path (XBOW / CTF harness): when the LangGraph container is
    launched with `BENCHMARK_MODE=1` (via .env), this middleware additionally
@@ -23,11 +25,12 @@ state-backed context injection via wrap_model_call.
 from __future__ import annotations
 
 import os
-from typing import Annotated, NotRequired, cast
+from typing import Annotated, Any, NotRequired, cast
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import SystemMessage, ToolMessage
+from langgraph.config import get_config
 from langgraph.types import Command
 from typing_extensions import override
 
@@ -63,6 +66,58 @@ _FALSY_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
 def _benchmark_mode_active() -> bool:
     """Truthy evaluation of the BENCHMARK_MODE env var set on the LangGraph container."""
     return os.environ.get("BENCHMARK_MODE", "").strip().lower() not in _FALSY_ENV_VALUES
+
+
+def _configurable_from_runnable_config() -> dict[str, Any]:
+    """Read the active run's ``config.configurable`` block, defensively.
+
+    Returns an empty dict outside a LangGraph execution context so callers
+    can treat the result uniformly without try/except boilerplate.
+    """
+    try:
+        cfg = get_config()
+    except RuntimeError:
+        return {}
+    if not isinstance(cfg, dict):
+        return {}
+    configurable = cfg.get("configurable")
+    return configurable if isinstance(configurable, dict) else {}
+
+
+def _hydrate_engagement_state(state: Any) -> dict[str, Any] | None:
+    """Copy ``engagement_name``/``workspace_path`` from runnable config into state.
+
+    Runs in ``before_agent`` so the values are present on state before any
+    downstream middleware (OPPLAN, filesystem) reads them. Idempotent: if the
+    state already carries either field, it is left untouched and the config
+    value is ignored.
+    """
+    get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+    configurable = _configurable_from_runnable_config()
+    updates: dict[str, Any] = {}
+
+    if not get("engagement_name"):
+        cfg_slug = configurable.get("engagement_name")
+        if isinstance(cfg_slug, str) and cfg_slug:
+            updates["engagement_name"] = cfg_slug
+
+    if not get("workspace_path"):
+        cfg_workspace = configurable.get("workspace_path")
+        if isinstance(cfg_workspace, str) and cfg_workspace:
+            updates["workspace_path"] = cfg_workspace
+
+    return updates or None
+
+
+def _resolve_workspace_path(state: Any) -> str:
+    """Pick the live workspace path: state first, then runnable config, then default."""
+    get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+    workspace = get("workspace_path") or ""
+    if not workspace:
+        cfg_workspace = _configurable_from_runnable_config().get("workspace_path")
+        if isinstance(cfg_workspace, str) and cfg_workspace:
+            workspace = cfg_workspace
+    return workspace or "/workspace"
 
 
 def _build_engagement_injection(slug: str, workspace: str) -> str:
@@ -141,6 +196,14 @@ class EngagementContextMiddleware(AgentMiddleware):
         super().__init__()
 
     @override
+    def before_agent(self, state, runtime) -> dict[str, Any] | None:
+        return _hydrate_engagement_state(state)
+
+    @override
+    async def abefore_agent(self, state, runtime) -> dict[str, Any] | None:
+        return _hydrate_engagement_state(state)
+
+    @override
     def wrap_model_call(self, request, handler):
         return handler(self._inject(request))
 
@@ -156,7 +219,7 @@ class EngagementContextMiddleware(AgentMiddleware):
             "bash_kill",
             "bash_status",
         }:
-            workspace = (request.state or {}).get("workspace_path", "/workspace") or "/workspace"
+            workspace = _resolve_workspace_path(request.state)
             with bash_workspace(workspace):
                 return handler(request)
         return handler(request)
@@ -169,7 +232,7 @@ class EngagementContextMiddleware(AgentMiddleware):
             "bash_kill",
             "bash_status",
         }:
-            workspace = (request.state or {}).get("workspace_path", "/workspace") or "/workspace"
+            workspace = _resolve_workspace_path(request.state)
             with bash_workspace(workspace):
                 return await handler(request)
         return await handler(request)

--- a/decepticon/middleware/filesystem.py
+++ b/decepticon/middleware/filesystem.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import replace
 from typing import Any
 
@@ -30,8 +31,29 @@ NO_WORKSPACE_ERROR = (
 
 
 def _normalize_engagement_workspace(workspace_path: str | None) -> str | None:
-    normalized = DockerSandbox._normalize_workspace_path(workspace_path)
-    return None if normalized == WORKSPACE else normalized
+    """Strict 4-case contract for resolving the engagement workspace root.
+
+    - Empty / None → ``None`` (fail closed; no engagement configured).
+    - ``/workspace`` → ``/workspace`` (launcher mode: the bind-mount IS the
+      engagement root, so the literal root is a valid workspace).
+    - ``/workspace/<safe-slug>`` → normalized path (web mode: shared root with
+      per-engagement subdirectories).
+    - Anything else (traversal like ``/workspace/../etc``, characters outside
+      the slug regex, etc.) → ``None``. Invalid paths are NOT silently coerced
+      to ``/workspace``.
+    """
+    path = (workspace_path or "").strip()
+    if not path:
+        return None
+    if path == WORKSPACE:
+        return WORKSPACE
+    if not path.startswith(f"{WORKSPACE}/"):
+        return None
+    expected = path.rstrip("/")
+    if os.path.normpath(expected) != expected:
+        return None
+    normalized = DockerSandbox._normalize_workspace_path(path)
+    return normalized if normalized == expected else None
 
 
 class EngagementFilesystemBackend(BackendProtocol):

--- a/decepticon/tools/interaction/complete_planning.py
+++ b/decepticon/tools/interaction/complete_planning.py
@@ -5,6 +5,11 @@ have been written, validated, and saved to ``/workspace/plan/``. The
 emitted custom event tells the CLI to switch its LangGraph assistant_id from
 ``soundwave`` to ``decepticon`` so the next operator message lands on the
 operations agent without the operator restarting the CLI.
+
+The tool is a pure boolean signal — it carries no slug or other metadata.
+The launcher is the single source of truth for the engagement slug; clients
+inject ``engagement_name``/``workspace_path`` via ``config.configurable`` on
+every run, and EngagementContextMiddleware hydrates them into agent state.
 """
 
 from __future__ import annotations
@@ -13,7 +18,6 @@ from typing import Annotated, Any
 
 from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.config import get_stream_writer
-from pydantic import Field
 
 
 def _safe_writer():
@@ -25,30 +29,14 @@ def _safe_writer():
 
 @tool
 def complete_engagement_planning(
-    engagement_name: Annotated[
-        str,
-        Field(
-            min_length=1,
-            max_length=64,
-            description=(
-                "Slug of the engagement whose planning bundle is now complete "
-                "(matches the workspace directory under /workspace/)."
-            ),
-        ),
-    ],
     tool_call_id: Annotated[str, InjectedToolCallId] = "",
 ) -> Any:
     """Signal that engagement planning is finished and hand off to Decepticon.
 
     Call this tool exactly once, after RoE, CONOPS, and the Deconfliction Plan
-    have all been written under ``/workspace/plan/`` and
-    validated against their schemas. The CLI will switch the active assistant
-    to Decepticon and the operator's next message starts the operations
-    phase.
-
-    Args:
-        engagement_name: The workspace slug. Must match the directory the
-            planning documents were written to.
+    have all been written under ``/workspace/plan/`` and validated against
+    their schemas. The CLI will switch the active assistant to Decepticon and
+    the operator's next message starts the operations phase.
 
     Returns:
         A confirmation string the LLM can include in its closing message.
@@ -60,11 +48,9 @@ def complete_engagement_planning(
                 "type": "engagement_ready",
                 "agent": "soundwave",
                 "id": tool_call_id,
-                "engagement": engagement_name,
             }
         )
     return (
-        f"Planning complete for engagement '{engagement_name}'. "
-        "The operator's next message will be routed to the Decepticon "
-        "operations agent."
+        "Planning complete. The operator's next message will be routed to the "
+        "Decepticon operations agent."
     )

--- a/scripts/render_benchmark_charts.py
+++ b/scripts/render_benchmark_charts.py
@@ -3,6 +3,7 @@
 Outputs go to assets/benchmark/. Re-run after updating numbers:
     python scripts/render_benchmark_charts.py
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -19,24 +20,24 @@ OUT_DIR.mkdir(parents=True, exist_ok=True)
 
 # Leaderboard — XBOW publishers only.
 LEADERBOARD = [
-    ("Shannon Lite (white-box)",       96.15, "other"),
-    ("Strix",                          96.15, "other"),
-    ("PentestGPT",                     86.50, "other"),
-    ("Red-MIRROR",                     86.00, "other"),
-    ("XBOW (commercial)",              85.00, "other"),
-    ("Cyber-AutoAgent (archived)",     84.62, "other"),
-    ("MAPTA",                          76.90, "other"),
+    ("Shannon Lite (white-box)", 96.15, "other"),
+    ("Strix", 96.15, "other"),
+    ("PentestGPT", 86.50, "other"),
+    ("Red-MIRROR", 86.00, "other"),
+    ("XBOW (commercial)", 85.00, "other"),
+    ("Cyber-AutoAgent (archived)", 84.62, "other"),
+    ("MAPTA", 76.90, "other"),
     ("Decepticon (L1+L3, L2 ongoing)", 92.50, "us"),
-    ("PentestAgent",                   50.00, "other"),
-    ("AutoPT",                         46.00, "other"),
-    ("VulnBot",                         6.00, "other"),
+    ("PentestAgent", 50.00, "other"),
+    ("AutoPT", 46.00, "other"),
+    ("VulnBot", 6.00, "other"),
 ]
 
 # Per-difficulty data (where the project published it).
 DIFFICULTY = {
-    "Strix":       [100.0,  96.0, 75.0],
-    "PentestGPT":  [ 91.1,  74.5, 62.5],
-    "Decepticon":  [ 93.3,  17.6, 87.5],   # L2 is in progress
+    "Strix": [100.0, 96.0, 75.0],
+    "PentestGPT": [91.1, 74.5, 62.5],
+    "Decepticon": [93.3, 17.6, 87.5],  # L2 is in progress
 }
 LEVELS = ["L1 (Easy)", "L2 (Medium)", "L3 (Hard)"]
 
@@ -44,45 +45,47 @@ LEVELS = ["L1 (Easy)", "L2 (Medium)", "L3 (Hard)"]
 # L2 (51 challenges) is still being run, so it is intentionally excluded
 # from the headline charts; tracked separately.
 DECEPTICON_PIE = [
-    ("L1 passed (42 / 45)",  42, "#2ecc71"),
-    ("L3 passed (7 / 8)",     7, "#27ae60"),
-    ("Not solved (L1+L3)",    4, "#bdc3c7"),
+    ("L1 passed (42 / 45)", 42, "#2ecc71"),
+    ("L3 passed (7 / 8)", 7, "#27ae60"),
+    ("Not solved (L1+L3)", 4, "#bdc3c7"),
 ]
 
 # Decepticon attack-class coverage — L1 + L3 contributions only.
 # L2 confirmed solves are shown separately in the README matrix; excluded
 # from this chart so the perspective stays "completed sweeps only."
 COVERAGE = [
-    ("XSS",                 11),  # 8 L1 + 3 L3
-    ("Command Injection",    6),  # 6 L1
-    ("Default Credentials",  5),  # 4 L1 + 1 L3
-    ("SSTI",                 5),  # 4 L1 + 1 L3
-    ("SQL Injection",        5),  # 5 L1
-    ("IDOR",                 4),  # 4 L1
-    ("LFI",                  4),  # 4 L1
+    ("XSS", 11),  # 8 L1 + 3 L3
+    ("Command Injection", 6),  # 6 L1
+    ("Default Credentials", 5),  # 4 L1 + 1 L3
+    ("SSTI", 5),  # 4 L1 + 1 L3
+    ("SQL Injection", 5),  # 5 L1
+    ("IDOR", 4),  # 4 L1
+    ("LFI", 4),  # 4 L1
     ("Privilege Escalation", 4),  # 4 L1
-    ("Information Disc.",    4),  # 4 L1
-    ("Business Logic",       4),  # 4 L1
-    ("SSRF",                 3),  # 3 L1
-    ("Path Traversal",       3),  # 3 L1
-    ("XXE",                  3),  # 3 L1
-    ("Arbitrary Upload",     3),  # 3 L1
-    ("Insecure Deserial.",   2),  # 1 L1 + 1 L3
+    ("Information Disc.", 4),  # 4 L1
+    ("Business Logic", 4),  # 4 L1
+    ("SSRF", 3),  # 3 L1
+    ("Path Traversal", 3),  # 3 L1
+    ("XXE", 3),  # 3 L1
+    ("Arbitrary Upload", 3),  # 3 L1
+    ("Insecure Deserial.", 2),  # 1 L1 + 1 L3
 ]
 
 # ---------------------------------------------------------------------------
 # Chart helpers.
 # ---------------------------------------------------------------------------
 
-US_COLOR  = "#e74c3c"   # Decepticon red
-BAR_COLOR = "#3498db"   # everyone else
+US_COLOR = "#e74c3c"  # Decepticon red
+BAR_COLOR = "#3498db"  # everyone else
 
-plt.rcParams.update({
-    "font.family": "DejaVu Sans",
-    "axes.spines.top": False,
-    "axes.spines.right": False,
-    "axes.titleweight": "bold",
-})
+plt.rcParams.update(
+    {
+        "font.family": "DejaVu Sans",
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+        "axes.titleweight": "bold",
+    }
+)
 
 
 def save(fig: plt.Figure, name: str) -> Path:
@@ -96,6 +99,7 @@ def save(fig: plt.Figure, name: str) -> Path:
 # 1) Leaderboard — horizontal bar chart of overall pass rate.
 # ---------------------------------------------------------------------------
 
+
 def chart_leaderboard() -> Path:
     items = sorted(LEADERBOARD, key=lambda r: r[1])  # ascending so highest is on top
     labels = [r[0] for r in items]
@@ -105,22 +109,32 @@ def chart_leaderboard() -> Path:
     fig, ax = plt.subplots(figsize=(10, 6))
     bars = ax.barh(labels, values, color=colors, edgecolor="white")
     for bar, v in zip(bars, values):
-        ax.text(v + 1, bar.get_y() + bar.get_height() / 2,
-                f"{v:.2f} %" if v % 1 else f"{v:.0f} %",
-                va="center", fontsize=9)
+        ax.text(
+            v + 1,
+            bar.get_y() + bar.get_height() / 2,
+            f"{v:.2f} %" if v % 1 else f"{v:.0f} %",
+            va="center",
+            fontsize=9,
+        )
     ax.set_xlim(0, 105)
     ax.set_xlabel("Pass rate on XBOW (104 challenges) — %")
     ax.set_title("XBOW Validation Benchmark — Published Results")
     ax.grid(axis="x", linestyle=":", alpha=0.4)
-    fig.text(0.01, 0.01,
-             "Shannon: white-box, hint-removed.  Decepticon: black-box, L2 sweep ongoing (L1+L3 only).",
-             fontsize=8, style="italic", color="#555")
+    fig.text(
+        0.01,
+        0.01,
+        "Shannon: white-box, hint-removed.  Decepticon: black-box, L2 sweep ongoing (L1+L3 only).",
+        fontsize=8,
+        style="italic",
+        color="#555",
+    )
     return save(fig, "leaderboard.png")
 
 
 # ---------------------------------------------------------------------------
 # 2) Per-difficulty grouped bars.
 # ---------------------------------------------------------------------------
+
 
 def chart_difficulty() -> Path:
     systems = list(DIFFICULTY.keys())
@@ -132,14 +146,14 @@ def chart_difficulty() -> Path:
     palette = {"Strix": "#3498db", "PentestGPT": "#9b59b6", "Decepticon": US_COLOR}
     for i, sys in enumerate(systems):
         offset = (i - 1) * width
-        bars = ax.bar(x + offset, DIFFICULTY[sys], width,
-                      label=sys, color=palette[sys], edgecolor="white")
+        bars = ax.bar(
+            x + offset, DIFFICULTY[sys], width, label=sys, color=palette[sys], edgecolor="white"
+        )
         for j, (bar, v) in enumerate(zip(bars, DIFFICULTY[sys])):
             label = f"{v:.1f} %"
             if sys == "Decepticon" and j == 1:
                 label = f"{v:.1f} % *"
-            ax.text(bar.get_x() + bar.get_width() / 2, v + 1.5,
-                    label, ha="center", fontsize=8)
+            ax.text(bar.get_x() + bar.get_width() / 2, v + 1.5, label, ha="center", fontsize=8)
 
     ax.set_xticks(x)
     ax.set_xticklabels(LEVELS)
@@ -148,15 +162,21 @@ def chart_difficulty() -> Path:
     ax.set_title("Pass Rate by Difficulty — Strix · PentestGPT · Decepticon")
     ax.legend(loc="upper right", frameon=False)
     ax.grid(axis="y", linestyle=":", alpha=0.4)
-    fig.text(0.01, 0.01,
-             "* Decepticon L2 sweep is in progress — number will rise.",
-             fontsize=8, style="italic", color="#555")
+    fig.text(
+        0.01,
+        0.01,
+        "* Decepticon L2 sweep is in progress — number will rise.",
+        fontsize=8,
+        style="italic",
+        color="#555",
+    )
     return save(fig, "difficulty.png")
 
 
 # ---------------------------------------------------------------------------
 # 3) Decepticon donut by difficulty.
 # ---------------------------------------------------------------------------
+
 
 def chart_decepticon_donut() -> Path:
     labels = [r[0] for r in DECEPTICON_PIE]
@@ -166,21 +186,28 @@ def chart_decepticon_donut() -> Path:
 
     fig, ax = plt.subplots(figsize=(7, 6))
     wedges, _ = ax.pie(
-        sizes, colors=colors, startangle=90, counterclock=False,
+        sizes,
+        colors=colors,
+        startangle=90,
+        counterclock=False,
         wedgeprops={"edgecolor": "white", "linewidth": 2, "width": 0.4},
     )
     legend = [f"{lab} — {n} ({n / total:.1%})" for lab, n in zip(labels, sizes)]
-    ax.legend(wedges, legend, loc="center left", bbox_to_anchor=(1.0, 0.5),
-              frameon=False, fontsize=10)
-    ax.set_title("Decepticon on XBOW — L1 + L3 (completed sweeps)\n"
-                 "49 / 53 = 92.5 %  ·  L2 sweep in progress (shown separately)",
-                 fontsize=12)
+    ax.legend(
+        wedges, legend, loc="center left", bbox_to_anchor=(1.0, 0.5), frameon=False, fontsize=10
+    )
+    ax.set_title(
+        "Decepticon on XBOW — L1 + L3 (completed sweeps)\n"
+        "49 / 53 = 92.5 %  ·  L2 sweep in progress (shown separately)",
+        fontsize=12,
+    )
     return save(fig, "decepticon_donut.png")
 
 
 # ---------------------------------------------------------------------------
 # 4) Decepticon attack-class coverage.
 # ---------------------------------------------------------------------------
+
 
 def chart_coverage() -> Path:
     items = list(reversed(COVERAGE))  # so largest is at the top after barh
@@ -190,21 +217,24 @@ def chart_coverage() -> Path:
     fig, ax = plt.subplots(figsize=(9, 7))
     bars = ax.barh(labels, values, color=US_COLOR, edgecolor="white")
     for bar, v in zip(bars, values):
-        ax.text(v + 0.15, bar.get_y() + bar.get_height() / 2,
-                str(v), va="center", fontsize=9)
+        ax.text(v + 0.15, bar.get_y() + bar.get_height() / 2, str(v), va="center", fontsize=9)
     ax.set_xlim(0, max(values) + 2)
     ax.set_xlabel("Confirmed end-to-end exploits (L1 + L3 only)")
     ax.set_title("Decepticon — Web Attack Class Coverage on XBOW (L1 + L3)")
     ax.grid(axis="x", linestyle=":", alpha=0.4)
-    fig.text(0.01, 0.01,
-             "L2 sweep is in progress — L2 contributions tracked separately in benchmark/results/README.md.",
-             fontsize=8, style="italic", color="#555")
+    fig.text(
+        0.01,
+        0.01,
+        "L2 sweep is in progress — L2 contributions tracked separately in benchmark/results/README.md.",
+        fontsize=8,
+        style="italic",
+        color="#555",
+    )
     return save(fig, "coverage.png")
 
 
 def main() -> None:
-    for fn in (chart_leaderboard, chart_difficulty,
-               chart_decepticon_donut, chart_coverage):
+    for fn in (chart_leaderboard, chart_difficulty, chart_decepticon_donut, chart_coverage):
         path = fn()
         print(f"wrote {path.relative_to(OUT_DIR.parents[1])}")
 

--- a/tests/unit/core/test_subagent_streaming.py
+++ b/tests/unit/core/test_subagent_streaming.py
@@ -149,3 +149,127 @@ class TestAinvokeNoStateReturnsErrorNotDoubleExec:
         assert fake.astream_calls == 1
         assert fake.ainvoke_calls == 0
         assert out is state_final
+
+
+class TestNoneIdToolCallGuard:
+    """ToolCall.id is `str | None` per the LangChain spec; None-id calls
+    must not be keyed at None (collision corrupts subsequent lookups)."""
+
+    def _capture_writer(self) -> tuple[list[dict[str, Any]], Any]:
+        events: list[dict[str, Any]] = []
+
+        def writer(payload: dict[str, Any]) -> None:
+            events.append(payload)
+
+        return events, writer
+
+    def test_none_id_tool_call_skips_active_dict_and_logs(self) -> None:
+        import logging
+
+        from langchain_core.messages import AIMessage as _AI
+
+        wrapper = StreamingRunnable(CountingRunnable([]), "scanner")
+        active: dict[str, Any] = {}
+        events, writer = self._capture_writer()
+
+        # Attach a handler directly — pytest's caplog can drop records under
+        # xdist parallel execution, so capture from the logger ourselves.
+        records: list[logging.LogRecord] = []
+        target = logging.getLogger("decepticon.subagent_streaming")
+        prior_level = target.level
+        target.setLevel(logging.WARNING)
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = _Capture()
+        target.addHandler(handler)
+        try:
+            msg = _AI(
+                content="",
+                tool_calls=[
+                    {"id": None, "name": "bash", "args": {"command": "ls"}, "type": "tool_call"},
+                ],
+            )
+            wrapper._process_messages(
+                [msg], active, renderer=None, has_renderer=False, writer=writer
+            )
+        finally:
+            target.removeHandler(handler)
+            target.setLevel(prior_level)
+
+        assert active == {}, "None-id tool call must not be keyed under None"
+        assert any("without id" in r.getMessage() for r in records)
+        # The tool_call event still fires so the operator sees activity.
+        assert any(e["type"] == "subagent_tool_call" for e in events)
+
+    def test_none_id_tool_message_falls_through_to_unknown(self) -> None:
+        from langchain_core.messages import AIMessage as _AI
+        from langchain_core.messages import ToolMessage
+
+        wrapper = StreamingRunnable(CountingRunnable([]), "scanner")
+        active: dict[str, Any] = {}
+        events, writer = self._capture_writer()
+
+        wrapper._process_messages(
+            [
+                _AI(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": None,
+                            "name": "bash",
+                            "args": {"command": "ls"},
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                ToolMessage(content="output", tool_call_id=""),
+            ],
+            active,
+            renderer=None,
+            has_renderer=False,
+            writer=writer,
+        )
+
+        results = [e for e in events if e["type"] == "subagent_tool_result"]
+        assert results and results[0]["tool"] == "unknown"
+
+    def test_valid_id_call_unaffected_by_concurrent_none_id_call(self) -> None:
+        """A valid-id call must not be overwritten or shadowed by a None-id call."""
+        from langchain_core.messages import AIMessage as _AI
+        from langchain_core.messages import ToolMessage
+
+        wrapper = StreamingRunnable(CountingRunnable([]), "scanner")
+        active: dict[str, Any] = {}
+        events, writer = self._capture_writer()
+
+        wrapper._process_messages(
+            [
+                _AI(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "tc-1",
+                            "name": "bash",
+                            "args": {"command": "ls"},
+                            "type": "tool_call",
+                        },
+                        {"id": None, "name": "grep", "args": {"pattern": "x"}, "type": "tool_call"},
+                    ],
+                ),
+                ToolMessage(content="ls-output", tool_call_id="tc-1"),
+            ],
+            active,
+            renderer=None,
+            has_renderer=False,
+            writer=writer,
+        )
+
+        # The id-less call did not displace the keyed call.
+        assert "tc-1" in active
+        assert None not in active
+
+        results = [e for e in events if e["type"] == "subagent_tool_result"]
+        assert results and results[0]["tool"] == "bash"

--- a/tests/unit/middleware/test_engagement.py
+++ b/tests/unit/middleware/test_engagement.py
@@ -14,6 +14,8 @@ from decepticon.middleware.engagement import (
     EngagementContextMiddleware,
     EngagementContextState,
     _benchmark_mode_active,
+    _hydrate_engagement_state,
+    _resolve_workspace_path,
 )
 from decepticon.middleware.opplan import OPPLANState
 
@@ -278,6 +280,114 @@ def test_appended_to_existing_system_message(
     assert "Workspace slug: demo" in text
     assert "## CTF Benchmark Challenge" in text
     assert text.index("ORIGINAL_PROMPT_BODY") < text.index("Workspace slug")
+
+
+# ── runnable-config hydration ──────────────────────────────────────────
+
+
+def test_hydrate_pulls_engagement_from_configurable_when_state_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """before_agent must copy engagement_name + workspace_path from config to state."""
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"engagement_name": "from-launcher", "workspace_path": "/workspace"},
+    )
+
+    updates = _hydrate_engagement_state({})
+
+    assert updates == {
+        "engagement_name": "from-launcher",
+        "workspace_path": "/workspace",
+    }
+
+
+def test_hydrate_is_idempotent_when_state_already_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If state already carries the field, configurable is ignored for that field."""
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"engagement_name": "from-launcher", "workspace_path": "/workspace"},
+    )
+
+    updates = _hydrate_engagement_state(
+        {"engagement_name": "already-on-state", "workspace_path": "/workspace"}
+    )
+
+    assert updates is None
+
+
+def test_hydrate_partial_when_only_one_field_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hydrates only the missing field; preserves the one already on state."""
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"engagement_name": "from-launcher", "workspace_path": "/workspace"},
+    )
+
+    updates = _hydrate_engagement_state({"engagement_name": "kept-on-state"})
+
+    assert updates == {"workspace_path": "/workspace"}
+
+
+def test_hydrate_returns_none_when_neither_state_nor_configurable_have_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        dict,
+    )
+
+    assert _hydrate_engagement_state({}) is None
+
+
+def test_hydrate_ignores_non_string_configurable_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: configurable values that are not non-empty strings are ignored."""
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"engagement_name": 123, "workspace_path": ""},
+    )
+
+    assert _hydrate_engagement_state({}) is None
+
+
+def test_resolve_workspace_path_prefers_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"workspace_path": "/workspace/from-config"},
+    )
+
+    assert _resolve_workspace_path({"workspace_path": "/workspace/from-state"}) == (
+        "/workspace/from-state"
+    )
+
+
+def test_resolve_workspace_path_falls_back_to_configurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"workspace_path": "/workspace/from-config"},
+    )
+
+    assert _resolve_workspace_path({}) == "/workspace/from-config"
+
+
+def test_resolve_workspace_path_defaults_when_neither_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        dict,
+    )
+
+    assert _resolve_workspace_path({}) == "/workspace"
 
 
 def test_benchmark_with_missing_optional_fields(

--- a/tests/unit/middleware/test_filesystem.py
+++ b/tests/unit/middleware/test_filesystem.py
@@ -144,9 +144,61 @@ def test_missing_engagement_workspace_fails_closed() -> None:
     assert backend.calls == []
 
 
-def test_root_workspace_fails_closed() -> None:
+def test_root_workspace_accepted_as_engagement_root() -> None:
+    """Launcher mode binds the engagement directory directly at ``/workspace``.
+
+    The bare root must be accepted as a valid engagement root so filesystem
+    tools work without a slug prefix. ``ls /workspace`` must hit the backend
+    at ``/workspace`` (no doubling) and surface entries unchanged.
+    """
     backend = RecordingBackend()
     scoped = EngagementFilesystemBackend(backend, "/workspace")
+
+    result = scoped.ls("/workspace")
+
+    assert result.error is None
+    assert result.entries == [{"path": "/workspace/plan/roe.json", "is_dir": False}]
+    assert backend.calls[-1] == ("ls_info", "/workspace")
+
+
+def test_root_workspace_no_prefix_doubling_under_engagement_root() -> None:
+    """Reads under ``/workspace`` in launcher mode must not get prefixed twice."""
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace")
+
+    scoped.read("/workspace/plan/roe.json")
+
+    assert backend.calls[-1] == ("read", ("/workspace/plan/roe.json", 0, 2000))
+
+
+def test_root_workspace_accepts_trailing_slash() -> None:
+    """``/workspace/`` (trailing slash) is the same engagement root."""
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace/")
+
+    result = scoped.ls("/workspace")
+
+    assert result.error is None
+    assert backend.calls[-1] == ("ls_info", "/workspace")
+
+
+def test_traversal_path_fails_closed_does_not_silently_coerce() -> None:
+    """``..`` traversal must fail closed rather than collapse to ``/workspace``.
+
+    Without the ``os.path.normpath`` guard the slug regex would accept the
+    component, which would then resolve to a path outside the engagement.
+    """
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace/../etc")
+
+    assert scoped.ls("/workspace").error is not None
+    assert backend.calls == []
+
+
+def test_invalid_path_outside_workspace_fails_closed() -> None:
+    """Anything not under ``/workspace`` must fail closed (no silent coerce)."""
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/etc")
 
     assert scoped.ls("/workspace").error is not None
     assert backend.calls == []


### PR DESCRIPTION
## Summary

Move `engagement_name` and `workspace_path` from input state to runnable `config.configurable`. The **launcher** (and web `terminal-server` env) is the single source of truth; the LLM no longer decides the engagement slug.

This supersedes both **#180** (slug queuing in CLI) and **#181** (filesystem `_normalize_engagement_workspace` strict contract). #181's contract is incorporated wholesale; #180's bug class no longer exists once the slug stops traveling through the LLM.

## Why this direction

The natural product flow is:
1. Launcher decides the engagement slug (picker UI / web env)
2. Soundwave runs the interview and writes `/workspace/plan/{roe,conops,deconfliction}.json`
3. CLI flips `assistant_id` to `decepticon` on `engagement_ready`
4. Decepticon reads the planning bundle from the shared `/workspace` mount

In the previous architecture the LLM was the source of truth for the slug — `complete_engagement_planning(engagement_name=…)` echoed a slug back via a custom event, the CLI captured it, then dropped it before the next submit (#159). The fix could either rescue the LLM-emitted slug (#180) or remove the LLM from the slug path entirely. This PR takes the second option, which is the LangGraph-native shape: launcher → `config.configurable` → middleware hydration → state.

## Backend changes

- **`decepticon/tools/interaction/complete_planning.py`** — drop the `engagement_name` argument. The tool is now a pure boolean handoff signal; the emitted `engagement_ready` event carries no slug.
- **`decepticon/middleware/engagement.py`** — add `before_agent` hydration that copies `engagement_name` and `workspace_path` from `config.configurable` into state on the first agent step. Idempotent: state values win when present. Downstream middleware (OPPLAN, filesystem) read state as before, so no other middleware needs to change.
- **`decepticon/middleware/filesystem.py`** — `_normalize_engagement_workspace` rewritten with a strict 4-case contract (empty → `None`, `/workspace` accepted as the engagement root for launcher mode, `/workspace/<safe-slug>` normalized, anything else including `..` traversal → `None` with no silent coercion). Adapted from #181's diagnosis.

## Frontend changes

- **`clients/cli/src/hooks/useAgent.ts`** — send `engagement_name` / `workspace_path` via `config.configurable` on every run instead of `input` state fields. `pendingHandoffRef` downgraded from `string | null` to `boolean` (no slug to retain). `model_override` is now passed through `configurable` only (input field removed; ModelOverrideMiddleware reads either path, but a single channel is cleaner).
- **`clients/shared/streaming/src/types.ts`** — drop the `engagement?` field from `SubagentCustomEvent`.
- **`decepticon/agents/prompts/soundwave.md`** — the Completion Signal section no longer instructs the LLM to pass a slug to the tool.

## Tests

- `tests/unit/middleware/test_engagement.py` — +6 tests covering `_hydrate_engagement_state` (empty state pulls from configurable, idempotent when state already set, partial hydration, neither present, defensive non-string filtering) and `_resolve_workspace_path` precedence.
- `tests/unit/middleware/test_filesystem.py` — +5 tests for the new contract: `/workspace` accepted as engagement root, no prefix doubling under root, trailing-slash variant accepted, traversal fails closed, paths outside `/workspace` fail closed. The previous `test_root_workspace_fails_closed` is flipped to `test_root_workspace_accepted_as_engagement_root` to match the new launcher-mode semantics.

## Verification

```bash
uv run ruff check .                                  # clean
uv run ruff format --check decepticon/ tests/        # clean
uv run basedpyright --level error                    # 0 errors
uv run pytest -n auto -q -m \"not slow\"             # 724 passed, 0 failed
cd clients/cli && npm run typecheck && npm test      # tsc clean, 16/16 pass
cd clients/cli && npm run build                      # tsc clean
```

## Closes / Supersedes

Closes #152, #159, #173. Addresses the filesystem failure in #175.

Supersedes PR #180 (slug queuing — bug class no longer exists). Supersedes PR #181 (filesystem normalize — contract incorporated). Note: PR #178's filesystem fix-1 is rejected on factual grounds — the diagnosis that \`DockerSandbox._normalize_workspace_path\` does not exist is incorrect; the static method is at \`docker_sandbox.py:830\` and is used in 11 places. PR #178's subagent_streaming fix-2 (None tool_call_id guard) is independent and should land separately.

## Test plan

- [x] Python lint + typecheck + full unit test suite locally
- [x] CLI typecheck + unit tests + build locally
- [ ] End-to-end: \`make dogfood\` — Soundwave interview → handoff → Decepticon fs tool (\`ls /workspace\`) — requires the full stack and is appropriate for the dogfood gate before tagging