### PR TITLE
fix(middleware): add reducer for workspace_path to allow concurrent updates

### DIFF
--- a/decepticon/middleware/engagement.py
+++ b/decepticon/middleware/engagement.py
@@ -34,7 +34,7 @@ from langgraph.config import get_config
 from langgraph.types import Command
 from typing_extensions import override
 
-from decepticon.middleware.opplan import _reduce_engagement_name
+from decepticon.middleware.opplan import _reduce_engagement_name, _reduce_workspace_path
 from decepticon.tools.bash.bash import bash_workspace
 
 
@@ -44,7 +44,9 @@ class EngagementContextState(AgentState):
     engagement_name: NotRequired[
         Annotated[str, "Workspace slug set by the launcher.", _reduce_engagement_name]
     ]
-    workspace_path: NotRequired[Annotated[str, "Sandbox root for this engagement."]]
+    workspace_path: NotRequired[
+        Annotated[str, "Sandbox root for this engagement.", _reduce_workspace_path]
+    ]
     # Benchmark / CTF challenge context — populated by the benchmark harness.
     target_url: NotRequired[Annotated[str, "CTF challenge target URL."]]
     target_extra_ports: NotRequired[

--- a/decepticon/middleware/opplan.py
+++ b/decepticon/middleware/opplan.py
@@ -48,6 +48,18 @@ def _reduce_engagement_name(current: str | None, update: str | None) -> str | No
     return update if update is not None else current
 
 
+def _reduce_workspace_path(current: str | None, update: str | None) -> str | None:
+    """Merge concurrent writes to the active workspace path.
+
+    Without a reducer, LangGraph rejects parallel state updates to the
+    same key with INVALID_CONCURRENT_GRAPH_UPDATE. The launcher is the
+    single source of truth, so every concurrent writer agrees on the
+    same value — last-write-wins on non-None is sufficient and matches
+    ``_reduce_engagement_name`` semantics. Closes #153.
+    """
+    return update if update is not None else current
+
+
 # ── State Schema ──────────────────────────────────────────────────────
 
 
@@ -71,7 +83,7 @@ class OPPLANState(AgentState):
     objective_counter: Annotated[NotRequired[int], OmitFromInput]
     """Auto-increment counter for objective IDs (like Claude Code high water mark)."""
 
-    workspace_path: Annotated[NotRequired[str], OmitFromInput]
+    workspace_path: Annotated[NotRequired[str], OmitFromInput, _reduce_workspace_path]
     """Engagement workspace root path — set by save_opplan/load_opplan."""
 
 

--- a/tests/unit/middleware/test_engagement.py
+++ b/tests/unit/middleware/test_engagement.py
@@ -112,6 +112,37 @@ def test_engagement_name_reducer_handles_concurrent_updates(schema) -> None:
     assert result["engagement_name"] == "demo-engagement"
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        OPPLANState,
+        EngagementContextState,
+        _resolve_schemas({AgentState, OPPLANState, EngagementContextState})[0],
+    ],
+)
+def test_workspace_path_reducer_handles_concurrent_updates(schema) -> None:
+    """Regression for #153 — parallel objectives must not trigger
+    INVALID_CONCURRENT_GRAPH_UPDATE on workspace_path."""
+
+    def set_workspace(_state):
+        return {"workspace_path": "/workspace"}
+
+    def keep_workspace(_state):
+        return {"workspace_path": None}
+
+    graph = StateGraph(schema)
+    graph.add_node("set_workspace", set_workspace)
+    graph.add_node("keep_workspace", keep_workspace)
+    graph.add_edge(START, "set_workspace")
+    graph.add_edge(START, "keep_workspace")
+    graph.add_edge("set_workspace", END)
+    graph.add_edge("keep_workspace", END)
+
+    result = graph.compile().invoke({"messages": []})
+
+    assert result["workspace_path"] == "/workspace"
+
+
 # ── inject paths ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a reducer for `workspace_path` so parallel objective dispatch no longer trips `INVALID_CONCURRENT_GRAPH_UPDATE`.

When the orchestrator dispatches 3+ independent objectives in parallel via `task()`, both `EngagementContextState.workspace_path` and `OPPLANState.workspace_path` receive concurrent writes. Without a reducer, LangGraph rejects them with:

```
At key 'workspace_path': Can receive only one value per step. Use an Annotated key to handle multiple values.
```

`engagement_name` already had `_reduce_engagement_name`; `workspace_path` was missed.

## Changes

- `decepticon/middleware/opplan.py`:
  - Add `_reduce_workspace_path` next to `_reduce_engagement_name` — last-write-wins on non-None, identical semantics. The launcher is the single source of truth, so all concurrent writers carry the same value; the reducer just satisfies LangGraph's contract for parallel updates.
  - Wire it into `OPPLANState.workspace_path` annotation.
- `decepticon/middleware/engagement.py`:
  - Import `_reduce_workspace_path` and wire it into `EngagementContextState.workspace_path`.
- `tests/unit/middleware/test_engagement.py`:
  - Add a parametrized regression test that mirrors the existing `test_engagement_name_reducer_handles_concurrent_updates` — two parallel nodes write to `workspace_path`, graph converges without raising. Runs against `OPPLANState`, `EngagementContextState`, and the merged schema.

## Verification

```bash
uv run ruff check .                                  # clean
uv run ruff format --check .                         # clean
uv run basedpyright --level error                    # 0 errors
uv run pytest -n auto -q -m "not slow"               # 730 passed, 0 failed
```

The new test currently fails on main (raises `InvalidUpdateError`) and passes with this change.

## Closes

Closes #153.

## Test plan

- [x] Python lint + typecheck + full unit test suite locally.
- [ ] End-to-end: orchestrator dispatching 3+ parallel objectives via `task()` no longer raises `INVALID_CONCURRENT_GRAPH_UPDATE` (requires the full LangGraph stack — appropriate for the dogfood gate).