### PR TITLE
Refactor middleware tools and harden OPPLAN persistence

### DIFF
--- a/decepticon/agents/decepticon.py
+++ b/decepticon/agents/decepticon.py
@@ -24,8 +24,8 @@ The orchestrator has tools=[] — all offensive work goes through task()
 delegation to specialist sub-agents. SandboxNotificationMiddleware lives
 on each sub-agent (where bash actually runs), not here.
 
-OPPLAN replaces TodoListMiddleware with domain-specific objective tracking:
-  - 5 CRUD tools following Claude Code's V2 Task tool patterns
+OPPLAN provides domain-specific objective tracking:
+  - CRUD tools for engagement objectives and child task trees
   - Dynamic state injection: every LLM call sees OPPLAN progress table
   - State transition validation with dependency checking
 
@@ -64,7 +64,7 @@ def create_decepticon_agent():
     Context engineering decisions:
       - Explicit middleware stack instead of create_deep_agent() defaults
       - SubAgentMiddleware: task() tool for delegating to specialist sub-agents
-      - OPPLANMiddleware: 5 CRUD tools for objective tracking (Claude Code V2 Task pattern)
+      - OPPLANMiddleware: CRUD tools for objective tracking
       - ModelFallbackMiddleware: primary → fallback chain built from the user's Credentials inventory
     Returns a compiled LangGraph agent ready for invocation.
     """
@@ -214,7 +214,7 @@ def create_decepticon_agent():
         ),
         FilesystemMiddleware(backend=backend),
         SubAgentMiddleware(backend=backend, subagents=subagents),
-        OPPLANMiddleware(),
+        OPPLANMiddleware(backend=backend),
         ModelOverrideMiddleware(),
     ]
     if fallback_models:

--- a/decepticon/agents/exploit.py
+++ b/decepticon/agents/exploit.py
@@ -54,7 +54,7 @@ def create_exploit_agent():
 
     Context engineering decisions:      - Bash tool for running exploit frameworks (sqlmap, Impacket, Certipy, etc.)
       - ModelFallbackMiddleware: sonnet 4.6 primary → gpt-4.1 fallback on failure
-      - No TodoListMiddleware: opplan.json handles task tracking
+      - OPPLAN is owned by the orchestrator; this specialist writes evidence only
       - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation
     """
     config = load_config()

--- a/decepticon/agents/postexploit.py
+++ b/decepticon/agents/postexploit.py
@@ -54,7 +54,7 @@ def create_postexploit_agent():
 
     Context engineering decisions:      - Bash tool for running post-exploitation tools (Mimikatz, Impacket, Evil-WinRM, etc.)
       - ModelFallbackMiddleware: sonnet 4.6 primary → gpt-4.1 fallback on failure
-      - No TodoListMiddleware: opplan.json handles task tracking
+      - OPPLAN is owned by the orchestrator; this specialist writes evidence only
       - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation
     """
     config = load_config()

--- a/decepticon/agents/prompts/soundwave.md
+++ b/decepticon/agents/prompts/soundwave.md
@@ -18,7 +18,7 @@ These rules override all other instructions:
 3. **Document Order**: RoE → CONOPS → Deconfliction Plan. Never generate a later document without its prerequisites.
 4. **User Confirmation**: Present each document for user review before proceeding to the next. Never auto-generate the full bundle without checkpoints.
 5. **Real Dates Only**: Always use absolute dates (2026-03-15), never relative (next Monday).
-6. **No OPPLAN**: You generate RoE, CONOPS, and Deconfliction Plan only. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your CONOPS kill chain and builds the OPPLAN via `add_objective` tools, then persists it with `save_opplan`.
+6. **No OPPLAN**: You generate RoE, CONOPS, and Deconfliction Plan only. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your CONOPS kill chain and builds the OPPLAN via `add_objective` tools — every objective is auto-persisted to `plan/opplan.json`, no separate save step.
 7. **EXACTLY ONE question per turn**: Never bundle multiple questions in one reply. Wait for the operator's answer before moving to the next dimension. Bundling = scope drift.
 8. **EVERY operator-facing question MUST go through `ask_user_question`**: there is no "use the tool for taxonomy and prose for narrative" split. Every time you collect input from the operator, use the tool. Provide 2–5 best-guess options that cover the most common shapes for the dimension, and **always set `allow_other=true`** so the operator can type a custom answer when the predefined options do not fit. Plain prose is reserved for statements, summaries, and document drafts — never for soliciting input.
 9. **Never re-ask for the engagement slug**: the launcher chose it before you started. The slug arrives via the engagement-context block injected into your system prompt — read it there.
@@ -113,8 +113,9 @@ not re-ask the same dimension.
 5. Save all documents to engagement directory
 
 Note: After soundwave completes, the orchestrator reads all three documents
-(`roe.json`, `conops.json`, `deconfliction.json`), maps the kill chain phases
-to objectives via `add_objective`, and persists the plan with `save_opplan`.
+(`roe.json`, `conops.json`, `deconfliction.json`) and maps the kill chain
+phases to objectives via `add_objective`. The OPPLAN persists to
+`plan/opplan.json` automatically on every mutation — no save step required.
 </WORKFLOW>
 
 <INTERVIEW_STYLE>

--- a/decepticon/agents/recon.py
+++ b/decepticon/agents/recon.py
@@ -59,7 +59,7 @@ def create_recon_agent():
 
     Context engineering decisions:      - InMemoryStore: cross-thread memory for persisting findings across sessions
       - ModelFallbackMiddleware: haiku 4.5 primary → gemini 2.5 flash fallback on failure
-      - No TodoListMiddleware: opplan.json handles task tracking
+      - OPPLAN is owned by the orchestrator; this specialist writes evidence only
       - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation
     """
     config = load_config()

--- a/decepticon/agents/soundwave.py
+++ b/decepticon/agents/soundwave.py
@@ -2,7 +2,7 @@
 
 Generates RoE, CONOPS, and Deconfliction Plan documents that frame the
 red team engagement. Does NOT generate OPPLAN — the orchestrator owns
-OPPLAN directly via OPPLANMiddleware (Claude Code V2 Task pattern).
+OPPLAN directly via OPPLANMiddleware.
 
 Named after the Decepticon intelligence officer who intercepts, processes,
 and organizes strategic information for Megatron's operations.

--- a/decepticon/agents/vulnresearch.py
+++ b/decepticon/agents/vulnresearch.py
@@ -134,7 +134,7 @@ def create_vulnresearch_agent():
         ),
         FilesystemMiddleware(backend=backend),
         SubAgentMiddleware(backend=backend, subagents=subagents),
-        OPPLANMiddleware(),
+        OPPLANMiddleware(backend=backend),
     ]
     if fallback_models:
         middleware.append(ModelFallbackMiddleware(*fallback_models))

--- a/decepticon/middleware/filesystem.py
+++ b/decepticon/middleware/filesystem.py
@@ -22,6 +22,7 @@ from deepagents.backends.utils import validate_path
 from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesystemMiddleware
 
 from decepticon.backends.docker_sandbox import DockerSandbox
+from decepticon.tools.filesystem import filesystem_tools_without_execute
 
 WORKSPACE = "/workspace"
 NO_WORKSPACE_ERROR = (
@@ -223,7 +224,7 @@ class FilesystemMiddleware(BaseFilesystemMiddleware):
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)  # type: ignore[arg-type]
-        self.tools = [tool for tool in self.tools if tool.name != "execute"]
+        self.tools = filesystem_tools_without_execute(self.tools)
 
     def _get_backend(self, runtime) -> BackendProtocol:
         return EngagementFilesystemBackend(

--- a/decepticon/middleware/notifications.py
+++ b/decepticon/middleware/notifications.py
@@ -12,12 +12,22 @@ on its very next inference even if it didn't poll bash_output.
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
+from collections import OrderedDict
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
 
 from decepticon.backends.docker_sandbox import DockerSandbox
+
+log = logging.getLogger(__name__)
+
+# Cap on how many job keys we track to avoid unbounded memory growth in
+# long-lived agent sessions. We hold an ``OrderedDict`` keyed by job.key
+# and evict in FIFO order — duplicate notifications for evicted keys are
+# acceptable (the alternative is uncapped growth).
+_NOTIFIED_KEYS_MAX = 4096
 
 
 class SandboxNotificationMiddleware(AgentMiddleware):
@@ -26,45 +36,97 @@ class SandboxNotificationMiddleware(AgentMiddleware):
     def __init__(self, sandbox: DockerSandbox) -> None:
         super().__init__()
         self._sandbox = sandbox
-        self._notified: set[str] = set()
+        # OrderedDict-as-set so we can both check membership and evict in
+        # insertion order. Values are unused; we keep ``True`` to make the
+        # intent explicit at call sites.
+        self._notified: OrderedDict[str, bool] = OrderedDict()
         self._lock = threading.Lock()
+
+    def _jobs_view(self):
+        """Defensive accessor for the sandbox's job registry.
+
+        ``DockerSandbox`` exposes ``_jobs`` as an internal attribute. Going
+        through ``getattr`` lets us survive a backend that has not yet
+        attached the registry (e.g. a partially constructed sandbox in a
+        test fixture) without crashing the middleware.
+        """
+        return getattr(self._sandbox, "_jobs", None)
+
+    def _record_notified(self, keys) -> None:
+        """Insert keys into the bounded notified-set, evicting oldest first."""
+        for key in keys:
+            self._notified[key] = True
+        while len(self._notified) > _NOTIFIED_KEYS_MAX:
+            self._notified.popitem(last=False)
 
     def _build_message(self) -> dict | None:
         """Build the system-reminder message dict, or None if nothing new."""
+        jobs = self._jobs_view()
+        if jobs is None:
+            return None
+        try:
+            pending = list(jobs.pending_completions())
+        except Exception as e:  # noqa: BLE001 — best-effort middleware
+            log.warning("Failed to read pending completions from sandbox: %s", e)
+            return None
+
         with self._lock:
-            new = [
-                j for j in self._sandbox._jobs.pending_completions() if j.key not in self._notified
-            ]
+            new = [j for j in pending if j.key not in self._notified]
             if not new:
                 return None
-            for job in new:
-                self._notified.add(job.key)
+            self._record_notified(j.key for j in new)
 
         lines = ["<system-reminder>", "Background sandbox session updates:"]
         for job in new:
+            command = (job.command or "")[:80]
             lines.append(
                 f"- {job.session}: completed exit {job.exit_code} "
-                f"({job.elapsed:.0f}s) — command={job.command[:80]}"
+                f"({job.elapsed:.0f}s) — command={command}"
             )
         lines.append("Use bash_output(session) to retrieve full results.")
         lines.append("</system-reminder>")
         return {"messages": [HumanMessage(content="\n".join(lines))]}
 
-    def before_model(self, state, runtime):  # type: ignore[override]
-        # Refresh status of still-running jobs (sync subprocess calls).
-        for job in list(self._sandbox._jobs.all_jobs()):
-            if job.status == "running":
+    def _refresh_running_jobs(self) -> None:
+        """Sync poll for still-running jobs; swallow per-job subprocess errors."""
+        jobs = self._jobs_view()
+        if jobs is None:
+            return
+        try:
+            running = [j for j in jobs.all_jobs() if j.status == "running"]
+        except Exception as e:  # noqa: BLE001
+            log.warning("Failed to enumerate sandbox jobs: %s", e)
+            return
+        for job in running:
+            try:
                 self._sandbox.poll_completion(job.session, workspace_path=job.workspace_path)
-        return self._build_message()
+            except Exception as e:  # noqa: BLE001
+                log.warning("poll_completion failed for session=%s: %s", job.session, e)
 
-    async def abefore_model(self, state, runtime):  # type: ignore[override]
-        # Async path: offload blocking subprocess polls to a thread so we
-        # do not stall the LangGraph event loop.
-        for job in list(self._sandbox._jobs.all_jobs()):
-            if job.status == "running":
+    async def _arefresh_running_jobs(self) -> None:
+        """Async sibling of ``_refresh_running_jobs`` — same error semantics."""
+        jobs = self._jobs_view()
+        if jobs is None:
+            return
+        try:
+            running = [j for j in jobs.all_jobs() if j.status == "running"]
+        except Exception as e:  # noqa: BLE001
+            log.warning("Failed to enumerate sandbox jobs: %s", e)
+            return
+        for job in running:
+            try:
                 await asyncio.to_thread(
                     self._sandbox.poll_completion,
                     job.session,
                     workspace_path=job.workspace_path,
                 )
+            except Exception as e:  # noqa: BLE001
+                log.warning("poll_completion failed for session=%s: %s", job.session, e)
+
+    def before_model(self, state, runtime):  # type: ignore[override]
+        self._refresh_running_jobs()
+        return self._build_message()
+
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        await self._arefresh_running_jobs()
         return self._build_message()

--- a/decepticon/middleware/opplan.py
+++ b/decepticon/middleware/opplan.py
@@ -1,46 +1,44 @@
-"""OPPLANMiddleware — domain-specific task tracking for red team engagements.
+"""OPPLANMiddleware — domain-specific objective tracking for red team engagements.
 
-Follows the TodoListMiddleware pattern: OPPLAN CRUD tools execute their logic
-directly via InjectedState, appearing as proper `tool` type runs in LangSmith.
-No middleware tool-call interception needed.
+This middleware injects OPPLAN instructions and live objective status into the
+model prompt, registers OPPLAN tools from ``decepticon.tools.opplan``, and
+enforces one OPPLAN tool call per model step.
 
-4 tools (Claude Code mapping):
-  add_objective    — add single objective           (TaskCreate)
-  get_objective    — read single objective detail   (TaskGet)
-  list_objectives  — list all + progress summary    (TaskList)
-  update_objective — update status/notes/owner      (TaskUpdate)
+OPPLAN persistence uses the same configured backend as the engagement
+filesystem tools. In production that backend is DockerSandbox, scoped through
+EngagementFilesystemBackend, so reads/writes target the sandbox's active
+engagement workspace rather than the LangGraph host filesystem.
 
-Key differences from Claude Code:
-  - Domain: Task → Objective, project → engagement, coding → kill chain
+Tools:
+  add_objective      — add single objective
+  get_objective      — read single objective detail
+  list_objectives    — list all objectives with progress summary
+  update_objective   — update status, notes, owner, or dependencies
+  objective_expand   — add child objectives
+  objective_collapse — cancel descendant objectives
+  load_opplan      — hydrate state from backend file
+
+Design notes:
+  - Domain model is engagement objective tracking for kill-chain execution
   - Enum-typed parameters (ObjectivePhase, OpsecLevel, C2Tier)
   - Kill chain dependencies (blocked_by) with execution-time validation
   - Dynamic OPPLAN status injection every LLM call (battle tracker)
   - Parallel mutation prevention (sequential counter-based IDs)
+  - Backend-mediated OPPLAN persistence at /workspace/plan/opplan.json
 """
 
 from __future__ import annotations
 
-import json
 import os
-from pathlib import Path
 from typing import Annotated, Any, NotRequired, cast, override
 
+from deepagents.backends.protocol import BackendProtocol
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import OmitFromInput
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
-from langchain_core.tools import InjectedToolCallId, tool
-from langgraph.prebuilt import InjectedState
-from langgraph.types import Command
 
-from decepticon.core.schemas import (
-    OPPLAN,
-    C2Tier,
-    Objective,
-    ObjectivePhase,
-    ObjectiveStatus,
-    OpsecLevel,
-)
+from decepticon.tools.opplan import OPPLAN_TOOL_NAMES, build_opplan_tools
 
 
 def _reduce_engagement_name(current: str | None, update: str | None) -> str | None:
@@ -81,10 +79,10 @@ class OPPLANState(AgentState):
     """Threat actor profile for context injection."""
 
     objective_counter: Annotated[NotRequired[int], OmitFromInput]
-    """Auto-increment counter for objective IDs (like Claude Code high water mark)."""
+    """Auto-increment counter for objective IDs."""
 
     workspace_path: Annotated[NotRequired[str], OmitFromInput, _reduce_workspace_path]
-    """Engagement workspace root path — set by save_opplan/load_opplan."""
+    """Engagement workspace root path — set by launcher config/load_opplan."""
 
 
 # ── System Prompt ─────────────────────────────────────────────────────
@@ -95,6 +93,16 @@ OPPLAN_SYSTEM_PROMPT = """\
 You have OPPLAN tools to manage red team engagement objectives.
 These are always available — no mode switching needed.
 
+### Persistence model
+
+The launcher binds the engagement workspace at `/workspace`. Every mutation
+through these tools (`add_objective`, `update_objective`, `objective_expand`,
+`objective_collapse`) is **automatically persisted through the configured
+filesystem/sandbox backend to `/workspace/plan/opplan.json`** — there is no
+separate save step and no direct host-filesystem write. The persisted file is
+a stable, sorted, human-readable JSON document with a `schema_version`, a
+`saved_at` timestamp, and a `summary` block alongside the objectives list.
+
 ### Objective CRUD Tools
 
 - **`add_objective`** — Add a single objective (auto-ID: OBJ-001, OBJ-002, ...).
@@ -102,13 +110,13 @@ These are always available — no mode switching needed.
   Set `engagement_name` and `threat_profile` on the first call to initialize context.
 
 - **`get_objective`** — Read a single objective's full details.
-  ALWAYS call this before update_objective (read-before-write, staleness prevention).
+  ALWAYS call this before `update_objective` (read-before-write, staleness prevention).
 
 - **`list_objectives`** — List all objectives with progress summary.
-  Use when: Selecting the next objective, reviewing progress, situational awareness.
+  Use when: selecting the next objective, reviewing progress, situational awareness.
 
 - **`update_objective`** — Update status, notes, or owner.
-  ALWAYS call get_objective first. NEVER call multiple times in parallel.
+  ALWAYS call `get_objective` first.
 
 - **`objective_expand`** — Break a parent objective into N child sub-tasks.
   Use when an objective is broad or when discovered work reveals sub-tasks —
@@ -120,16 +128,20 @@ These are always available — no mode switching needed.
   Use when abandoning a hierarchical task so the parent can then be moved
   to COMPLETED or CANCELLED itself.
 
-- **`save_opplan`** — Persist the current OPPLAN state to `plan/opplan.json`.
-  Call after the user approves the plan and after any major re-planning.
-  Validates all objectives against the Pydantic schema before writing.
-
 - **`load_opplan`** — Hydrate agent state from an existing `plan/opplan.json`.
   Call on session startup if the engagement already has an OPPLAN file.
 
+### Concurrency rule
+
+OPPLAN tools must be called **strictly one at a time** — never two OPPLAN
+tools in the same model step. The middleware will reject parallel
+OPPLAN calls with an error so each call observes the previous result
+before issuing the next. This applies to read tools (`get_objective`,
+`list_objectives`) as well as mutating tools.
+
 ### Workflow
 ```
-add_objective(×N, engagement_name=...) → [user approval] → save_opplan → Ralph Loop
+add_objective(×N, engagement_name=...) → Ralph Loop
           ↓
 objective_expand(parent_id, children=[...])   # split broad work on demand
 ```
@@ -146,24 +158,13 @@ blocked → in-progress                 (retry with different approach)
 
 ### Rules — NEVER Violate
 - NEVER execute objectives without user-approved OPPLAN
-- NEVER call update_objective without calling get_objective first
-- NEVER call update_objective multiple times in parallel
+- NEVER call `update_objective` without calling `get_objective` first
+- NEVER call OPPLAN tools in parallel (one tool per model step)
 - ALWAYS include evidence when marking COMPLETED
 - ALWAYS include failure reason and attempts when marking BLOCKED
 - ALWAYS set owner to the sub-agent name before delegating (recon/exploit/postexploit)
 - ALWAYS respect blocked_by dependencies and kill chain phase order
 """
-
-
-# ── State Transition Rules ────────────────────────────────────────────
-
-_VALID_TRANSITIONS: dict[str, set[str]] = {
-    "pending": {"in-progress", "cancelled"},
-    "in-progress": {"completed", "blocked", "cancelled"},
-    "blocked": {"in-progress", "completed", "cancelled"},  # retry, abandon, drop
-    # completed is terminal
-    # cancelled is terminal
-}
 
 
 # ── Formatting Helpers ────────────────────────────────────────────────
@@ -295,9 +296,15 @@ def _format_opplan_status(
                 lines.append(f"    - [ ] {c}")
     else:
         lines.append("")
-        all_done = all(o.get("status") == "completed" for o in objectives)
+        # Guard against the empty-objectives case: ``all([])`` is vacuously
+        # True, which previously rendered "ALL OBJECTIVES COMPLETE" for an
+        # engagement that had zero objectives ever defined. Treat zero as
+        # "no plan yet" rather than "all done".
+        all_done = bool(objectives) and all(o.get("status") == "completed" for o in objectives)
         if all_done:
             lines.append("**ALL OBJECTIVES COMPLETE** — Generate final engagement report.")
+        elif not objectives:
+            lines.append("**No objectives defined** — Add objectives to begin the engagement.")
         else:
             lines.append("**No actionable objectives** — Review blocked items for retry.")
 
@@ -305,887 +312,6 @@ def _format_opplan_status(
     return "\n".join(lines)
 
 
-def _format_opplan_for_agent(
-    objectives: list[dict],
-    engagement_name: str,
-    threat_profile: str,
-) -> str:
-    """Format OPPLAN for list_objectives response (detailed overview).
-
-    When any objective has ``parent_id`` set, the output includes an
-    indented tree view after the flat table so the agent can see the
-    hierarchy at a glance.
-    """
-    total = len(objectives)
-    completed = sum(1 for o in objectives if o.get("status") == "completed")
-    blocked = sum(1 for o in objectives if o.get("status") == "blocked")
-
-    has_tree = any(o.get("parent_id") for o in objectives)
-
-    lines = [
-        f"# OPPLAN: {engagement_name}",
-        f"Threat Profile: {threat_profile}",
-        f"Progress: {completed}/{total} completed, {blocked} blocked",
-        "",
-        "| ID | Phase | Title | Status | Priority | Owner | Blocked By |",
-        "|---|---|---|---|---|---|---|",
-    ]
-
-    for o in sorted(objectives, key=lambda x: x.get("priority", 999)):
-        status = o.get("status", "pending")
-        blocked_by = ", ".join(o.get("blocked_by", [])) or "-"
-        title = o.get("title", "?")
-        if o.get("parent_id"):
-            title = f"↳ {title}"
-        lines.append(
-            f"| {o.get('id', '?')} | {o.get('phase', '?')} | "
-            f"{title} | {status} | "
-            f"{o.get('priority', '?')} | {o.get('owner') or '-'} | "
-            f"{blocked_by} |"
-        )
-
-    lines.append("")
-
-    if has_tree:
-        lines.append("## Task Tree")
-
-        def _render(parent_id: str | None, depth: int) -> None:
-            kids = sorted(
-                [o for o in objectives if o.get("parent_id") == parent_id],
-                key=lambda x: x.get("priority", 999),
-            )
-            for o in kids:
-                indent = "  " * depth
-                status = o.get("status", "pending")
-                marker = {
-                    "completed": "[x]",
-                    "blocked": "[!]",
-                    "cancelled": "[-]",
-                    "in-progress": "[~]",
-                }.get(status, "[ ]")
-                lines.append(
-                    f"{indent}- {marker} {o.get('id', '?')} {o.get('title', '?')} ({status})"
-                )
-                _render(o["id"], depth + 1)
-
-        _render(None, 0)
-        lines.append("")
-
-    # Next objective recommendation
-    actionable = [o for o in objectives if o.get("status") in ("pending", "in-progress")]
-    actionable.sort(key=lambda o: o.get("priority", 999))
-    if actionable:
-        nxt = actionable[0]
-        lines.append(
-            f"Next: {nxt.get('id')} — {nxt.get('title')} "
-            f"(phase: {nxt.get('phase')}, priority: {nxt.get('priority')})"
-        )
-    else:
-        all_done = all(o.get("status") == "completed" for o in objectives)
-        if all_done:
-            lines.append("ALL OBJECTIVES COMPLETE — Generate final engagement report.")
-        else:
-            lines.append("No actionable objectives — review blocked items for retry.")
-
-    return "\n".join(lines)
-
-
-# ── Tool Definitions ──────────────────────────────────────────────────
-
-
-def _make_tools() -> list:
-    """Create OPPLAN tools with InjectedState for direct state access.
-
-    Follows TodoListMiddleware pattern: tool bodies execute CRUD logic directly,
-    returning Command for state mutations. No middleware interception needed —
-    tools appear as proper `tool` type runs in LangSmith.
-    """
-
-    @tool(
-        description=(
-            "Add a single objective to the OPPLAN. Auto-generates an ID "
-            "(OBJ-001, OBJ-002, ...). Each objective must be completable in "
-            "ONE sub-agent context window. Use blocked_by to set kill chain dependencies. "
-            "Set engagement_name and threat_profile on the first call to initialize context."
-        )
-    )
-    def add_objective(
-        title: str,
-        phase: ObjectivePhase,
-        description: str,
-        acceptance_criteria: list[str],
-        priority: int,
-        state: Annotated[dict, InjectedState],
-        engagement_name: str | None = None,
-        threat_profile: str | None = None,
-        mitre: list[str] | None = None,
-        opsec: OpsecLevel = OpsecLevel.STANDARD,
-        opsec_notes: str = "",
-        c2_tier: C2Tier = C2Tier.INTERACTIVE,
-        concessions: list[str] | None = None,
-        blocked_by: list[str] | None = None,
-        parent_id: str | None = None,
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Add one objective with auto-ID generation."""
-        counter = state.get("objective_counter", 0) + 1
-        obj_id = f"OBJ-{counter:03d}"
-
-        # Validate parent_id if supplied
-        if parent_id:
-            existing_ids = {o.get("id") for o in state.get("objectives", [])}
-            if parent_id not in existing_ids:
-                return Command(
-                    update={
-                        "messages": [
-                            ToolMessage(
-                                content=(
-                                    f"Parent objective '{parent_id}' not found. "
-                                    f"Existing: {', '.join(sorted(i for i in existing_ids if i))}"
-                                ),
-                                tool_call_id=tool_call_id,
-                                status="error",
-                            )
-                        ],
-                    }
-                )
-
-        obj_dict = {
-            "id": obj_id,
-            "title": title,
-            "phase": phase,
-            "description": description,
-            "acceptance_criteria": acceptance_criteria,
-            "priority": priority,
-            "status": "pending",
-            "mitre": mitre or [],
-            "opsec": opsec,
-            "opsec_notes": opsec_notes,
-            "c2_tier": c2_tier,
-            "concessions": concessions or [],
-            "blocked_by": blocked_by or [],
-            "owner": "",
-            "notes": "",
-            "parent_id": parent_id,
-        }
-
-        # Pydantic validation
-        try:
-            Objective(**obj_dict)
-        except Exception as e:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Validation failed for objective: {e}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-
-        objectives = list(state.get("objectives", []))
-        objectives.append(obj_dict)
-
-        # Build state update — always include objectives + counter
-        update: dict[str, Any] = {
-            "objectives": objectives,
-            "objective_counter": counter,
-            "messages": [
-                ToolMessage(
-                    content=(
-                        f"Added {obj_id}: {obj_dict['title']} "
-                        f"(phase: {obj_dict['phase']}, priority: {obj_dict['priority']})"
-                    ),
-                    tool_call_id=tool_call_id,
-                )
-            ],
-        }
-
-        # Set engagement metadata if provided (typically on first call)
-        if engagement_name:
-            update["engagement_name"] = engagement_name
-        if threat_profile:
-            update["threat_profile"] = threat_profile
-
-        return Command(update=update)
-
-    @tool(
-        description=(
-            "Read a single objective's full details by ID. "
-            "ALWAYS call this before update_objective to prevent staleness. "
-            "Returns: status, description, acceptance criteria, dependencies, notes."
-        )
-    )
-    def get_objective(
-        objective_id: str,
-        state: Annotated[dict, InjectedState],
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Read one objective detail from state."""
-        objectives = state.get("objectives", [])
-        target = next((o for o in objectives if o.get("id") == objective_id), None)
-
-        if not target:
-            available = ", ".join(o.get("id", "?") for o in objectives)
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=(
-                                f"Objective '{objective_id}' not found. "
-                                f"Available: {available or 'none (use add_objective first)'}"
-                            ),
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-
-        obj_status = target.get("status", "pending")
-        mitre_ids = target.get("mitre") or []
-        mitre_str = ", ".join(mitre_ids) if mitre_ids else "n/a"
-        lines = [
-            f"## {target['id']} [{obj_status.upper()}]",
-            f"Title: {target.get('title', '')}",
-            f"Phase: {target.get('phase', '')} | Priority: {target.get('priority', '')}",
-            f"MITRE: {mitre_str}",
-            f"OPSEC: {target.get('opsec', 'standard')} | C2: {target.get('c2_tier', 'interactive')}",
-            f"Description: {target.get('description', '')}",
-        ]
-
-        criteria = target.get("acceptance_criteria", [])
-        if criteria:
-            check = "x" if obj_status == "completed" else " "
-            lines.append("Acceptance Criteria:")
-            for c in criteria:
-                lines.append(f"  - [{check}] {c}")
-
-        blocked_by_ids = target.get("blocked_by", [])
-        if blocked_by_ids:
-            lines.append(f"Blocked By: {', '.join(blocked_by_ids)}")
-
-        owner = target.get("owner", "")
-        if owner:
-            lines.append(f"Owner: {owner}")
-
-        obj_opsec_notes = target.get("opsec_notes", "")
-        if obj_opsec_notes:
-            lines.append(f"OPSEC Notes: {obj_opsec_notes}")
-
-        obj_concessions = target.get("concessions") or []
-        if obj_concessions:
-            lines.append("Concessions:")
-            for c in obj_concessions:
-                lines.append(f"  - {c}")
-
-        notes = target.get("notes", "")
-        if notes:
-            lines.append(f"Notes: {notes}")
-
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content="\n".join(lines),
-                        tool_call_id=tool_call_id,
-                    )
-                ],
-            }
-        )
-
-    @tool(
-        description=(
-            "List all OPPLAN objectives with progress summary. "
-            "Returns: engagement overview, objective table with status, "
-            "and next recommended objective."
-        )
-    )
-    def list_objectives(
-        state: Annotated[dict, InjectedState],
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """List all objectives with progress summary."""
-        objectives = state.get("objectives", [])
-        engagement = state.get("engagement_name", "")
-        threat = state.get("threat_profile", "")
-
-        if not objectives:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content="No objectives defined yet. Use `add_objective` to create objectives.",
-                            tool_call_id=tool_call_id,
-                        )
-                    ],
-                }
-            )
-
-        content = _format_opplan_for_agent(objectives, engagement, threat)
-        return Command(
-            update={
-                "messages": [ToolMessage(content=content, tool_call_id=tool_call_id)],
-            }
-        )
-
-    @tool(
-        description=(
-            "Update a single objective. MUST call get_objective first. "
-            "Can change: status, notes, owner, add_blocked_by. "
-            "Valid transitions: pending→in-progress, in-progress→completed/blocked, "
-            "blocked→in-progress (retry) or completed (abandon). "
-            "Include evidence when marking completed, failure reason when marking blocked."
-        )
-    )
-    def update_objective(
-        objective_id: str,
-        state: Annotated[dict, InjectedState],
-        status: str | None = None,
-        notes: str | None = None,
-        owner: str | None = None,
-        add_blocked_by: list[str] | None = None,
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Update one objective with state transition validation."""
-        # Deep copy objectives to avoid mutating state
-        objectives = [dict(o) for o in state.get("objectives", [])]
-        target = next((o for o in objectives if o.get("id") == objective_id), None)
-
-        if not target:
-            available = ", ".join(o.get("id", "?") for o in objectives)
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Objective '{objective_id}' not found. Available: {available}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-
-        updated_fields: list[str] = []
-
-        # ── Status change with transition + dependency validation ─────
-        if status is not None:
-            # Validate status value
-            try:
-                ObjectiveStatus(status)
-            except ValueError:
-                valid = ", ".join(s.value for s in ObjectiveStatus)
-                return Command(
-                    update={
-                        "messages": [
-                            ToolMessage(
-                                content=f"Invalid status '{status}'. Valid: {valid}",
-                                tool_call_id=tool_call_id,
-                                status="error",
-                            )
-                        ],
-                    }
-                )
-
-            current = target.get("status", "pending")
-            if not _is_valid_transition(current, status):
-                return Command(
-                    update={
-                        "messages": [
-                            ToolMessage(
-                                content=(
-                                    f"Invalid transition: {current} → {status}. "
-                                    f"Valid from '{current}': {_valid_next(current)}"
-                                ),
-                                tool_call_id=tool_call_id,
-                                status="error",
-                            )
-                        ],
-                    }
-                )
-
-            # Check blocked_by dependencies when starting execution
-            if status == "in-progress":
-                blocked_by_ids = target.get("blocked_by", [])
-                unresolved = [
-                    bid
-                    for bid in blocked_by_ids
-                    if any(
-                        o.get("id") == bid and o.get("status") != "completed" for o in objectives
-                    )
-                ]
-                if unresolved:
-                    return Command(
-                        update={
-                            "messages": [
-                                ToolMessage(
-                                    content=(
-                                        f"Cannot start {objective_id}: "
-                                        f"blocked by unresolved objectives: {', '.join(unresolved)}"
-                                    ),
-                                    tool_call_id=tool_call_id,
-                                    status="error",
-                                )
-                            ],
-                        }
-                    )
-
-            # Parents cannot complete until every child is done.
-            if status == "completed":
-                children = [o for o in objectives if o.get("parent_id") == objective_id]
-                if children:
-                    unresolved_kids = [
-                        c["id"]
-                        for c in children
-                        if c.get("status") not in {"completed", "cancelled"}
-                    ]
-                    if unresolved_kids:
-                        return Command(
-                            update={
-                                "messages": [
-                                    ToolMessage(
-                                        content=(
-                                            f"Cannot complete {objective_id}: "
-                                            f"children still open: {', '.join(unresolved_kids)}. "
-                                            f"Complete or cancel each child first, or call "
-                                            f"objective_collapse({objective_id})."
-                                        ),
-                                        tool_call_id=tool_call_id,
-                                        status="error",
-                                    )
-                                ],
-                            }
-                        )
-
-            target["status"] = status
-            updated_fields.append(f"status → {status}")
-
-        # ── Notes ─────────────────────────────────────────────────────
-        if notes is not None:
-            target["notes"] = notes
-            updated_fields.append("notes")
-
-        # ── Owner (which sub-agent is executing) ─────────────────────
-        if owner is not None:
-            target["owner"] = owner
-            updated_fields.append("owner")
-
-        # ── Add blocked_by dependencies ──────────────────────────────
-        if add_blocked_by:
-            existing_blocked = set(target.get("blocked_by", []))
-            all_ids = {o.get("id") for o in objectives}
-            invalid = [bid for bid in add_blocked_by if bid not in all_ids]
-            if invalid:
-                return Command(
-                    update={
-                        "messages": [
-                            ToolMessage(
-                                content=f"Invalid blocked_by references: {', '.join(invalid)}",
-                                tool_call_id=tool_call_id,
-                                status="error",
-                            )
-                        ],
-                    }
-                )
-            for bid in add_blocked_by:
-                existing_blocked.add(bid)
-            target["blocked_by"] = sorted(existing_blocked)
-            updated_fields.append("blocked_by")
-
-        if not updated_fields:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"No changes specified for {objective_id}.",
-                            tool_call_id=tool_call_id,
-                        )
-                    ],
-                }
-            )
-
-        total = len(objectives)
-        completed_count = sum(1 for o in objectives if o.get("status") == "completed")
-
-        return Command(
-            update={
-                "objectives": objectives,
-                "messages": [
-                    ToolMessage(
-                        content=(
-                            f"Updated {objective_id}: {', '.join(updated_fields)}. "
-                            f"Progress: {completed_count}/{total} completed."
-                        ),
-                        tool_call_id=tool_call_id,
-                    )
-                ],
-            }
-        )
-
-    @tool(
-        description=(
-            "Expand a parent objective into one or more child sub-tasks. "
-            "Each child inherits the parent's phase by default but can override it. "
-            "Children auto-receive IDs (OBJ-NNN) and are added with status 'pending'. "
-            "The parent cannot move to COMPLETED until every child is COMPLETED or CANCELLED. "
-            "Use this when an objective is broad or when recon reveals sub-tasks — it is "
-            "the Pentesting Task Tree (PTT) pattern. Keep children small enough to complete "
-            "in one sub-agent iteration."
-        )
-    )
-    def objective_expand(
-        parent_id: str,
-        children: list[dict],
-        state: Annotated[dict, InjectedState],
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Create ``len(children)`` child objectives under ``parent_id``.
-
-        Each child dict must have: ``title`` (str), ``description`` (str),
-        ``acceptance_criteria`` (list[str]). Optional: ``phase``
-        (ObjectivePhase value, default inherited from parent),
-        ``priority`` (int, default parent.priority + N), ``mitre``,
-        ``blocked_by``.
-        """
-        objectives = [dict(o) for o in state.get("objectives", [])]
-        parent = next((o for o in objectives if o.get("id") == parent_id), None)
-        if parent is None:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Parent objective '{parent_id}' not found.",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-        if parent.get("status") in {"completed", "cancelled"}:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=(
-                                f"Cannot expand {parent_id}: status is "
-                                f"{parent.get('status')}. Expand open parents only."
-                            ),
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-        if not children:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content="children list is empty — nothing to expand.",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-
-        counter = state.get("objective_counter", 0)
-        created_ids: list[str] = []
-        parent_phase = parent.get("phase")
-        try:
-            parent_priority = int(parent.get("priority", 100))
-        except (ValueError, TypeError):
-            parent_priority = 100
-        for idx, child in enumerate(children, start=1):
-            counter += 1
-            obj_id = f"OBJ-{counter:03d}"
-            title = str(child.get("title", "")).strip()
-            description = str(child.get("description", "")).strip()
-            acceptance = child.get("acceptance_criteria") or []
-            if not title or not description or not acceptance:
-                return Command(
-                    update={
-                        "messages": [
-                            ToolMessage(
-                                content=(
-                                    f"Child #{idx} missing required fields "
-                                    "(title, description, acceptance_criteria)."
-                                ),
-                                tool_call_id=tool_call_id,
-                                status="error",
-                            )
-                        ],
-                    }
-                )
-            phase = child.get("phase", parent_phase)
-            try:
-                priority = int(child.get("priority", parent_priority + idx))
-            except (ValueError, TypeError):
-                priority = parent_priority + idx
-            child_dict = {
-                "id": obj_id,
-                "title": title,
-                "phase": phase,
-                "description": description,
-                "acceptance_criteria": list(acceptance),
-                "priority": priority,
-                "status": "pending",
-                "mitre": list(child.get("mitre") or []),
-                "opsec": parent.get("opsec", "standard"),
-                "opsec_notes": "",
-                "c2_tier": parent.get("c2_tier", "interactive"),
-                "concessions": [],
-                "blocked_by": list(child.get("blocked_by") or []),
-                "owner": "",
-                "notes": "",
-                "parent_id": parent_id,
-            }
-            try:
-                Objective(**child_dict)
-            except Exception as e:
-                return Command(
-                    update={
-                        "messages": [
-                            ToolMessage(
-                                content=f"Child #{idx} validation failed: {e}",
-                                tool_call_id=tool_call_id,
-                                status="error",
-                            )
-                        ],
-                    }
-                )
-            objectives.append(child_dict)
-            created_ids.append(obj_id)
-
-        return Command(
-            update={
-                "objectives": objectives,
-                "objective_counter": counter,
-                "messages": [
-                    ToolMessage(
-                        content=(
-                            f"Expanded {parent_id} into {len(created_ids)} children: "
-                            f"{', '.join(created_ids)}"
-                        ),
-                        tool_call_id=tool_call_id,
-                    )
-                ],
-            }
-        )
-
-    @tool(
-        description=(
-            "Cancel every descendant of a parent objective. Use when abandoning a "
-            "hierarchical task — sets each child's status to 'cancelled' so the "
-            "parent can then be moved to COMPLETED or CANCELLED itself. "
-            "Only pending / in-progress / blocked children are touched; already-done "
-            "children are left as-is."
-        )
-    )
-    def objective_collapse(
-        parent_id: str,
-        state: Annotated[dict, InjectedState],
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Mark every descendant of ``parent_id`` as cancelled."""
-        objectives = [dict(o) for o in state.get("objectives", [])]
-        if not any(o.get("id") == parent_id for o in objectives):
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Parent objective '{parent_id}' not found.",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ],
-                }
-            )
-
-        # Walk descendants depth-first
-        stack = [parent_id]
-        descendants: list[dict[str, Any]] = []
-        while stack:
-            current = stack.pop()
-            for o in objectives:
-                if o.get("parent_id") == current:
-                    descendants.append(o)
-                    stack.append(o["id"])
-
-        cancelled: list[str] = []
-        for o in descendants:
-            if o.get("status") in {"pending", "in-progress", "blocked"}:
-                o["status"] = "cancelled"
-                cancelled.append(o["id"])
-
-        return Command(
-            update={
-                "objectives": objectives,
-                "messages": [
-                    ToolMessage(
-                        content=(
-                            f"Cancelled {len(cancelled)} descendants of {parent_id}"
-                            + (f": {', '.join(cancelled)}" if cancelled else "")
-                        ),
-                        tool_call_id=tool_call_id,
-                    )
-                ],
-            }
-        )
-
-    @tool(
-        description=(
-            "Persist the current OPPLAN to plan/opplan.json in the engagement workspace. "
-            "Validates all objectives against the Pydantic schema before writing. "
-            "Call after the user approves the plan and after any major re-planning. "
-            "Sets workspace_path in state for subsequent calls."
-        )
-    )
-    def save_opplan(
-        workspace_path: str,
-        state: Annotated[dict, InjectedState],
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Serialize state objectives → OPPLAN schema → plan/opplan.json."""
-        objectives_raw = state.get("objectives", [])
-        engagement_name = state.get("engagement_name", "")
-        threat_profile = state.get("threat_profile", "")
-
-        try:
-            objectives = [Objective(**o) for o in objectives_raw]
-        except Exception as e:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"OPPLAN validation failed: {e}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ]
-                }
-            )
-
-        opplan = OPPLAN(
-            engagement_name=engagement_name,
-            threat_profile=threat_profile,
-            objectives=objectives,
-        )
-
-        plan_dir = Path(workspace_path) / "plan"
-        plan_dir.mkdir(parents=True, exist_ok=True)
-        out_path = plan_dir / "opplan.json"
-        out_path.write_text(
-            json.dumps(opplan.model_dump(), indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
-
-        return Command(
-            update={
-                "workspace_path": workspace_path,
-                "messages": [
-                    ToolMessage(
-                        content=(
-                            f"OPPLAN saved to {out_path} "
-                            f"({len(objectives)} objectives, engagement: {engagement_name})"
-                        ),
-                        tool_call_id=tool_call_id,
-                    )
-                ],
-            }
-        )
-
-    @tool(
-        description=(
-            "Load an existing plan/opplan.json into agent state to resume an engagement. "
-            "Call on session startup when plan/opplan.json already exists — "
-            "this hydrates objectives, engagement_name, and threat_profile into state "
-            "so OPPLAN tools and the status tracker work immediately."
-        )
-    )
-    def load_opplan(
-        workspace_path: str,
-        state: Annotated[dict, InjectedState],
-        tool_call_id: Annotated[str, InjectedToolCallId] = "",
-    ) -> Command[Any]:
-        """Read plan/opplan.json and hydrate agent state."""
-        path = Path(workspace_path) / "plan" / "opplan.json"
-        if not path.exists():
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=(
-                                f"No opplan.json found at {path}. "
-                                "Use add_objective to create a new OPPLAN."
-                            ),
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ]
-                }
-            )
-
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            opplan = OPPLAN(**data)
-        except Exception as e:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Failed to load opplan.json: {e}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ]
-                }
-            )
-
-        objectives_raw = [o.model_dump() for o in opplan.objectives]
-
-        # Derive counter from highest existing ID so new objectives don't collide
-        counter = 0
-        for o in opplan.objectives:
-            try:
-                n = int(o.id.replace("OBJ-", ""))
-                if n > counter:
-                    counter = n
-            except (ValueError, AttributeError):
-                pass
-
-        return Command(
-            update={
-                "objectives": objectives_raw,
-                "engagement_name": opplan.engagement_name,
-                "threat_profile": opplan.threat_profile,
-                "objective_counter": counter,
-                "workspace_path": workspace_path,
-                "messages": [
-                    ToolMessage(
-                        content=(
-                            f"Loaded {len(objectives_raw)} objectives from {path}. "
-                            f"Engagement: {opplan.engagement_name} | "
-                            f"Counter at OBJ-{counter:03d}"
-                        ),
-                        tool_call_id=tool_call_id,
-                    )
-                ],
-            }
-        )
-
-    return [
-        add_objective,
-        get_objective,
-        list_objectives,
-        update_objective,
-        objective_expand,
-        objective_collapse,
-        save_opplan,
-        load_opplan,
-    ]
 
 
 # ── Middleware Class ──────────────────────────────────────────────────
@@ -1194,10 +320,10 @@ def _make_tools() -> list:
 class OPPLANMiddleware(AgentMiddleware):
     """Domain-specific OPPLAN tracking for red team engagements.
 
-    Follows TodoListMiddleware pattern: tools execute CRUD logic directly
-    via InjectedState, appearing as proper `tool` type runs in LangSmith.
+    Tools execute CRUD logic directly via InjectedState, appearing as proper
+    `tool` type runs in LangSmith.
 
-    - __init__: creates 4 CRUD tools
+    - __init__: creates OPPLAN CRUD tools
     - wrap_model_call: injects dynamic OPPLAN progress into system message
     - after_model: validates no parallel state-mutating calls
 
@@ -1206,9 +332,10 @@ class OPPLANMiddleware(AgentMiddleware):
 
     state_schema = OPPLANState
 
-    def __init__(self) -> None:
+    def __init__(self, backend: BackendProtocol | None = None) -> None:
         super().__init__()
-        self.tools = _make_tools()
+        self._backend = backend
+        self.tools = build_opplan_tools(backend)
 
     # ── wrap_model_call: inject OPPLAN context ────────────────────────
 
@@ -1254,11 +381,14 @@ class OPPLANMiddleware(AgentMiddleware):
 
     @override
     def after_model(self, state, runtime):
-        """Validate: no parallel state-mutating OPPLAN calls.
+        """Reject parallel OPPLAN tool calls in the same model step.
 
-        add_objective and update_objective both write to the objectives list.
-        Parallel calls read the same stale state, causing concurrent update
-        errors. Force sequential execution like Claude Code's Task tools.
+        Mutating tools (add/update/expand/collapse/load_opplan) race on
+        ``state.objectives`` because the field has no merge reducer; reads
+        (get/list) gain nothing from parallelism but mixing them with writes
+        muddies the contract. Apply one rule: at most one OPPLAN tool per
+        LLM step. Each call gets a separate ToolMessage error so the LLM
+        can re-issue them sequentially.
         """
         messages = state.get("messages", [])
         if not messages:
@@ -1271,24 +401,21 @@ class OPPLANMiddleware(AgentMiddleware):
         if not last_ai or not last_ai.tool_calls:
             return None
 
-        # Block parallel state-mutating calls (add + update both write objectives)
-        mutating_calls = [
-            tc for tc in last_ai.tool_calls if tc["name"] in ("add_objective", "update_objective")
-        ]
-        if len(mutating_calls) > 1:
+        opplan_calls = [tc for tc in last_ai.tool_calls if tc["name"] in OPPLAN_TOOL_NAMES]
+        if len(opplan_calls) > 1:
+            names = ", ".join(sorted({tc["name"] for tc in opplan_calls}))
             return {
                 "messages": [
                     ToolMessage(
                         content=(
-                            "Error: OPPLAN state-mutating tools (add_objective, update_objective) "
-                            "must be called one at a time, not in parallel. Each call needs "
-                            "the updated objectives list. Call one, wait for the result, "
-                            "then call the next."
+                            f"Error: OPPLAN tools ({names}) must be called sequentially, "
+                            "one per model step. Each tool needs to observe the result of "
+                            "the previous one before the next call. Re-issue them one at a time."
                         ),
                         tool_call_id=tc["id"],
                         status="error",
                     )
-                    for tc in mutating_calls
+                    for tc in opplan_calls
                 ]
             }
 
@@ -1298,16 +425,3 @@ class OPPLANMiddleware(AgentMiddleware):
     async def aafter_model(self, state, runtime):
         """Async variant delegates to sync."""
         return self.after_model(state, runtime)
-
-
-# ── Module-level helpers ──────────────────────────────────────────────
-
-
-def _is_valid_transition(current: str, new: str) -> bool:
-    """Check if a status transition is allowed."""
-    return new in _VALID_TRANSITIONS.get(current, set())
-
-
-def _valid_next(current: str) -> str:
-    """Return comma-separated valid next statuses."""
-    return ", ".join(sorted(_VALID_TRANSITIONS.get(current, set())))

--- a/decepticon/middleware/opplan.py
+++ b/decepticon/middleware/opplan.py
@@ -312,8 +312,6 @@ def _format_opplan_status(
     return "\n".join(lines)
 
 
-
-
 # ── Middleware Class ──────────────────────────────────────────────────
 
 

--- a/decepticon/middleware/skills.py
+++ b/decepticon/middleware/skills.py
@@ -51,8 +51,6 @@ if TYPE_CHECKING:
     from deepagents.middleware.skills import SkillMetadata
 
 
-
-
 # ── Decepticon skill system prompt template ──────────────────────────────────
 # Replaces both the old shared skill prompt fragment and the base middleware's
 # generic SKILLS_SYSTEM_PROMPT. Placeholders:
@@ -325,8 +323,6 @@ def _parse_comma_field(value: str | list | None) -> list[str]:
     if isinstance(value, list):
         return [str(v).strip() for v in value if str(v).strip()]
     return [t.strip() for t in str(value).replace(",", " ").split() if t.strip()]
-
-
 
 
 __all__ = ["SkillsMiddleware"]

--- a/decepticon/middleware/skills.py
+++ b/decepticon/middleware/skills.py
@@ -36,34 +36,21 @@ Usage:
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.skills import SkillsMiddleware as BaseSkillsMiddleware
-from langchain_core.tools import tool
+
+from decepticon.tools.skills import build_load_skill_tool
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from deepagents.middleware.skills import SkillMetadata
 
 
-def _unwrap_backend(backend: Any) -> Any:
-    """Strip EngagementFilesystemBackend wrapping from a backend.
-
-    EngagementFilesystemBackend._real() maps /workspace paths to
-    /workspace/<slug>/..., which mangles /skills/ paths to
-    /workspace/<slug>/skills/... — a path that does not exist in the
-    sandbox container. Skill reads must bypass this wrapper and go
-    directly to the raw DockerSandbox which can reach /skills/ via
-    docker cp / execute().
-    """
-    # Import here to avoid circular import (filesystem.py imports from skills.py
-    # indirectly via middleware/__init__.py)
-    from decepticon.middleware.filesystem import EngagementFilesystemBackend  # noqa: PLC0415
-
-    while isinstance(backend, EngagementFilesystemBackend):
-        backend = backend._backend
-    return backend
 
 
 # ── Decepticon skill system prompt template ──────────────────────────────────
@@ -164,7 +151,7 @@ class SkillsMiddleware(BaseSkillsMiddleware):
     def __init__(self, *, backend: Any, sources: list[str]) -> None:
         super().__init__(backend=backend, sources=sources)
         self.system_prompt_template = DECEPTICON_SKILLS_PROMPT
-        self.tools = [_build_load_skill_tool(backend, self.sources)]
+        self.tools = [build_load_skill_tool(backend, self.sources)]
 
     # ── workflow.md auto-load ────────────────────────────────────────────────
 
@@ -178,7 +165,10 @@ class SkillsMiddleware(BaseSkillsMiddleware):
         if getattr(res, "error", None):
             return None
         data = getattr(res, "file_data", None)
-        if not data:
+        # Truthy-but-not-a-dict (e.g. a backend returning a raw string in
+        # error paths) would crash on ``.get``; isinstance gate is the
+        # explicit contract check.
+        if not isinstance(data, dict):
             return None
         content = data.get("content", "")
         if isinstance(content, list):  # legacy v1 (line-split) format
@@ -195,7 +185,7 @@ class SkillsMiddleware(BaseSkillsMiddleware):
         if getattr(res, "error", None):
             return None
         data = getattr(res, "file_data", None)
-        if not data:
+        if not isinstance(data, dict):
             return None
         content = data.get("content", "")
         if isinstance(content, list):
@@ -255,11 +245,23 @@ class SkillsMiddleware(BaseSkillsMiddleware):
         workflow_blob = request.state.get("workflow_content", "")
         skills_locations = self._format_skills_locations()
         skills_list = self._format_skills_list(skills_metadata)
-        skills_section = self.system_prompt_template.format(
-            skills_locations=skills_locations,
-            workflow=workflow_blob,
-            skills_list=skills_list,
-        )
+        # The template can be edited at runtime by subclasses; missing or
+        # extra placeholders should not raise from a hot model-call path.
+        # On mismatch, log once and fall through to the original system
+        # message rather than failing the whole agent step.
+        try:
+            skills_section = self.system_prompt_template.format(
+                skills_locations=skills_locations,
+                workflow=workflow_blob,
+                skills_list=skills_list,
+            )
+        except (KeyError, IndexError) as e:
+            log.warning(
+                "skills system_prompt_template format failed (%s); "
+                "skipping skills injection for this call",
+                e,
+            )
+            return request
         new_system_message = append_to_system_message(request.system_message, skills_section)
         return request.override(system_message=new_system_message)
 
@@ -325,182 +327,6 @@ def _parse_comma_field(value: str | list | None) -> list[str]:
     return [t.strip() for t in str(value).replace(",", " ").split() if t.strip()]
 
 
-# ── load_skill tool ──────────────────────────────────────────────────────────
-# A Decepticon-specific replacement for `load_skill("/skills/...")` that
-# returns the full skill body without the deepagents 100-line limit, plus a
-# base-directory header and an index of references/* in the same directory.
-
-_SKILL_PATH_PREFIX = "/skills/"
-
-
-def _strip_frontmatter(text: str) -> tuple[str, dict[str, str]]:
-    """Strip a leading YAML frontmatter block (``---\\n...\\n---``) from text.
-
-    Returns ``(body, frontmatter_dict)``. Only flat ``key: value`` pairs are
-    parsed — nested YAML is ignored. If no frontmatter is present the original
-    text is returned with an empty dict.
-    """
-    if not text.startswith("---\n"):
-        return text, {}
-    end = text.find("\n---\n", 4)
-    if end == -1:
-        return text, {}
-    fm_text = text[4:end]
-    body = text[end + 5 :]
-    fm: dict[str, str] = {}
-    for line in fm_text.splitlines():
-        if ":" not in line:
-            continue
-        key, _, value = line.partition(":")
-        fm[key.strip()] = value.strip().strip('"').strip("'")
-    return body, fm
-
-
-def _read_via_backend(backend: Any, skill_path: str) -> tuple[str | None, str | None]:
-    """Read a file via the deepagents backend protocol.
-
-    Returns ``(content, error)``: exactly one of the two is non-None. The
-    backend abstraction is what gives ``load_skill`` access to the sandbox
-    container's filesystem (where ``/skills/`` is baked into the image) instead
-    of the langgraph container's local fs (where ``/skills/`` does not exist).
-    """
-    try:
-        res = backend.read(skill_path)
-    except Exception as exc:
-        return None, f"backend read failed: {exc}"
-    if getattr(res, "error", None):
-        return None, str(res.error)
-    data = getattr(res, "file_data", None)
-    if not data:
-        return None, "empty backend response"
-    content = data.get("content", "")
-    if isinstance(content, list):  # legacy v1 (line-split) format
-        content = "\n".join(content)
-    if not isinstance(content, str):
-        return None, "backend returned non-string content"
-    return content, None
-
-
-def _list_dir_via_backend(backend: Any, dir_path: str) -> list[str]:
-    """List ``.md`` files under ``dir_path`` via backend, sorted.
-
-    Best-effort: returns an empty list on any backend failure rather than
-    raising, so the references/siblings index degrades gracefully when a
-    skill directory has none.
-    """
-    try:
-        res = backend.ls(dir_path)
-    except Exception:
-        return []
-    if getattr(res, "error", None):
-        return []
-    names: list[str] = []
-    for attr in ("entries", "files", "items"):
-        candidate = getattr(res, attr, None)
-        if isinstance(candidate, list):
-            names = [str(n) for n in candidate]
-            break
-    if not names:
-        data = getattr(res, "file_data", None)
-        if isinstance(data, dict):
-            names = [str(n) for n in data.get("entries", [])]
-    return sorted(n for n in names if n.endswith(".md"))
-
-
-def _build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-untyped-def]
-    """Construct the ``load_skill`` LangChain tool.
-
-    Returns a closure-bound ``@tool``-decorated function that reads a skill
-    markdown file via the deepagents backend (same path used by ``read_file``,
-    so it sees the sandbox container's ``/skills/`` mount instead of the
-    langgraph container's local fs). Path is restricted to ``/skills/*`` to
-    keep this tool's intent distinct from the general ``read_file``.
-
-    Strips any EngagementFilesystemBackend wrapping — /skills/ paths must
-    reach the raw sandbox directly; the engagement wrapper mangles them to
-    /workspace/<slug>/skills/... which does not exist in the container.
-    """
-    backend = _unwrap_backend(backend)
-
-    @tool
-    def load_skill(skill_path: str, include_siblings: bool = False) -> str:
-        """Load a Decepticon skill file (full body, no line-limit truncation).
-
-        Use this for ANY ``/skills/*.md`` file instead of ``read_file``. It
-        returns the entire skill body (frontmatter stripped) prepended with a
-        base directory header, followed by an index of any ``references/`` files
-        in the same directory so you know what additional templates / cheat
-        sheets exist for this skill.
-
-        Args:
-            skill_path: Absolute path under ``/skills/``, e.g.
-                ``/skills/exploit/web/crypto.md``.
-            include_siblings: If True, also list sibling ``.md`` files in the
-                same directory (useful when the skill is a category index).
-                Default False to avoid duplicating the catalog already in the
-                system prompt.
-
-        Returns:
-            The skill body with a header + references index. Errors are
-            returned as ``[load_skill error] ...`` strings (never raised).
-        """
-        if not isinstance(skill_path, str) or not skill_path:
-            return "[load_skill error] skill_path must be a non-empty string."
-        if not skill_path.startswith(_SKILL_PATH_PREFIX):
-            return (
-                "[load_skill error] Path must start with /skills/. "
-                "For non-skill files use read_file. "
-                f"Got: {skill_path!r}"
-            )
-        if not skill_path.endswith(".md"):
-            return f"[load_skill error] Skill files must be markdown (.md). Got: {skill_path!r}"
-        # Reject path traversal — disallow ".." segments
-        if ".." in skill_path.split("/"):
-            return f"[load_skill error] Path traversal not allowed: {skill_path!r}"
-        # Enforce agent's skill source allowlist
-        if sources and not any(skill_path.startswith(src.rstrip("/")) for src in sources):
-            allowed = ", ".join(sources)
-            return (
-                f"[load_skill error] This agent may only load skills from: {allowed}. "
-                f"Got: {skill_path!r}"
-            )
-
-        raw, err = _read_via_backend(backend, skill_path)
-        if raw is None:
-            return f"[load_skill error] Skill not found: {skill_path} ({err})"
-
-        body, frontmatter = _strip_frontmatter(raw)
-
-        path_parts = skill_path.rsplit("/", 1)
-        base_dir = path_parts[0] if len(path_parts) == 2 else "/"
-        stem = path_parts[-1].rsplit(".", 1)[0]
-        header_lines = [f"Base directory for this skill: {base_dir}"]
-        name = frontmatter.get("name") or stem
-        description = frontmatter.get("description", "").strip()
-        header_lines.append(f"Skill: {name}" + (f" — {description}" if description else ""))
-        header = "\n".join(header_lines)
-
-        sections: list[str] = [header, "", body.rstrip(), ""]
-
-        refs_dir = base_dir.rstrip("/") + "/references"
-        refs = _list_dir_via_backend(backend, refs_dir)
-        if refs:
-            sections.append("---")
-            sections.append("References (load with `load_skill` or `read_file`):")
-            sections.extend(f"- {refs_dir}/{r}" for r in refs)
-            sections.append("")
-
-        if include_siblings:
-            sibs = [s for s in _list_dir_via_backend(backend, base_dir) if s != path_parts[-1]]
-            if sibs:
-                sections.append("---")
-                sections.append("Related sub-skills in this directory (load with `load_skill`):")
-                sections.extend(f"- {base_dir.rstrip('/')}/{s}" for s in sibs)
-                sections.append("")
-
-        return "\n".join(sections).rstrip() + "\n"
-
-    return load_skill
 
 
 __all__ = ["SkillsMiddleware"]

--- a/decepticon/tools/filesystem.py
+++ b/decepticon/tools/filesystem.py
@@ -1,0 +1,20 @@
+"""Filesystem tool-surface helpers for Decepticon middleware."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def filesystem_tools_without_execute(tools: Sequence[Any]) -> list[Any]:
+    """Return filesystem tools with the generic execute tool removed.
+
+    Decepticon routes command execution through its dedicated bash tools, while
+    Deep Agents' filesystem middleware owns file operations. Keeping this
+    selection helper in ``decepticon.tools`` makes the public tool surface
+    explicit and keeps middleware focused on backend scoping.
+    """
+    return [tool for tool in tools if getattr(tool, "name", None) != "execute"]
+
+
+__all__ = ["filesystem_tools_without_execute"]

--- a/decepticon/tools/opplan.py
+++ b/decepticon/tools/opplan.py
@@ -120,7 +120,9 @@ def _scoped_opplan_backend(
     return EngagementFilesystemBackend(backend, workspace_path)
 
 
-def _read_text_from_backend(backend: BackendProtocol, file_path: str) -> tuple[str | None, str | None]:
+def _read_text_from_backend(
+    backend: BackendProtocol, file_path: str
+) -> tuple[str | None, str | None]:
     result = backend.read(file_path, offset=0, limit=1_000_000)
     if result.error:
         return None, result.error
@@ -193,7 +195,6 @@ def _persist_opplan_to_backend(
             log.warning("OPPLAN persistence failed for workspace=%s: %s", workspace_path, error)
     except Exception as e:  # noqa: BLE001 — best-effort persistence
         log.warning("OPPLAN persistence failed for workspace=%s: %s", workspace_path, e)
-
 
 
 def _format_opplan_for_agent(
@@ -1020,9 +1021,9 @@ def build_opplan_tools(backend: BackendProtocol | None = None) -> list:
 
         raw, read_error = _read_text_from_backend(scoped_backend, OPPLAN_VIRTUAL_PATH)
         if raw is None:
-            not_found = "file_not_found" in (read_error or "") or "not found" in (
-                read_error or ""
-            ).lower()
+            not_found = (
+                "file_not_found" in (read_error or "") or "not found" in (read_error or "").lower()
+            )
             content = (
                 f"No opplan.json found at {OPPLAN_VIRTUAL_PATH}. "
                 "Use add_objective to create a new OPPLAN."

--- a/decepticon/tools/opplan.py
+++ b/decepticon/tools/opplan.py
@@ -1,0 +1,1124 @@
+"""OPPLAN tools and backend persistence helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from deepagents.backends.protocol import BackendProtocol
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import InjectedToolCallId, tool
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from decepticon.core.schemas import (
+    OPPLAN,
+    C2Tier,
+    Objective,
+    ObjectivePhase,
+    ObjectiveStatus,
+    OpsecLevel,
+)
+
+log = logging.getLogger(__name__)
+
+OPPLAN_FILE_SCHEMA_VERSION = "1"
+OPPLAN_VIRTUAL_PATH = "/workspace/plan/opplan.json"
+
+# All OPPLAN tools — used by ``OPPLANMiddleware.after_model`` to enforce
+# strictly sequential calls (one OPPLAN tool per LLM step). Parallel calls
+# would either race on ``state.objectives`` (mutations) or just waste a
+# round-trip (reads), so the same rule applies uniformly.
+OPPLAN_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "add_objective",
+        "update_objective",
+        "get_objective",
+        "list_objectives",
+        "objective_expand",
+        "objective_collapse",
+        "load_opplan",
+    }
+)
+
+_VALID_TRANSITIONS: dict[str, set[str]] = {
+    "pending": {"in-progress", "cancelled"},
+    "in-progress": {"completed", "blocked", "cancelled"},
+    "blocked": {"in-progress", "completed", "cancelled"},  # retry, abandon, drop
+    # completed is terminal
+    # cancelled is terminal
+}
+
+
+def _build_opplan_payload(opplan: OPPLAN) -> dict[str, Any]:
+    """Render an OPPLAN as a stable, human-readable JSON document.
+
+    Format ``v1``::
+
+        {
+          "schema_version": "1",
+          "saved_at": "2026-05-09T09:30:00+00:00",
+          "engagement_name": "<slug>",
+          "threat_profile": "<text>",
+          "summary": {
+              "total": 5,
+              "completed": 2,
+              "in_progress": 1,
+              "blocked": 1,
+              "cancelled": 0,
+              "pending": 1
+          },
+          "objectives": [ {Objective json}, ... ]   # sorted by id
+        }
+
+    Objectives are sorted by ``id`` so consecutive saves diff cleanly under
+    git, and a top-level ``summary`` block lets a human or ops tool read
+    progress without parsing the full list. The persisted schema is a
+    *superset* of the runtime ``OPPLAN`` model — the wrapper fields
+    (schema_version, saved_at, summary) are dropped silently by
+    ``OPPLAN(**data)`` thanks to Pydantic's default extra-field policy.
+    """
+    objectives_json = [
+        obj.model_dump(mode="json") for obj in sorted(opplan.objectives, key=lambda o: o.id)
+    ]
+    summary: dict[str, int] = {"total": len(objectives_json)}
+    for status_value in (
+        ObjectiveStatus.PENDING,
+        ObjectiveStatus.IN_PROGRESS,
+        ObjectiveStatus.COMPLETED,
+        ObjectiveStatus.BLOCKED,
+        ObjectiveStatus.CANCELLED,
+    ):
+        key = status_value.value.replace("-", "_")
+        summary[key] = sum(1 for o in objectives_json if o.get("status") == status_value.value)
+    return {
+        "schema_version": OPPLAN_FILE_SCHEMA_VERSION,
+        "saved_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "engagement_name": opplan.engagement_name,
+        "threat_profile": opplan.threat_profile,
+        "summary": summary,
+        "objectives": objectives_json,
+    }
+
+
+def _scoped_opplan_backend(
+    backend: BackendProtocol | None,
+    workspace_path: str | None,
+) -> BackendProtocol | None:
+    """Return a backend scoped to the active engagement workspace."""
+    if backend is None:
+        return None
+    if not workspace_path:
+        return None
+
+    # Local import avoids a module cycle: filesystem.py imports the OPPLAN
+    # reducers for its state schema.
+    from decepticon.middleware.filesystem import EngagementFilesystemBackend
+
+    return EngagementFilesystemBackend(backend, workspace_path)
+
+
+def _read_text_from_backend(backend: BackendProtocol, file_path: str) -> tuple[str | None, str | None]:
+    result = backend.read(file_path, offset=0, limit=1_000_000)
+    if result.error:
+        return None, result.error
+    data = result.file_data
+    if not isinstance(data, dict):
+        return None, f"File '{file_path}': backend returned no file data"
+    if data.get("encoding", "utf-8") != "utf-8":
+        return None, f"File '{file_path}': expected utf-8 text, got {data.get('encoding')}"
+    content = data.get("content", "")
+    if not isinstance(content, str):
+        return None, f"File '{file_path}': backend returned non-text content"
+    return content, None
+
+
+def _write_text_to_backend(backend: BackendProtocol, file_path: str, content: str) -> str | None:
+    """Create or overwrite a text file through the configured backend."""
+    old_content, read_error = _read_text_from_backend(backend, file_path)
+    if old_content is None:
+        write_result = backend.write(file_path, content)
+        if write_result.error:
+            return (
+                f"read failed: {read_error}; write failed: {write_result.error}"
+                if read_error
+                else write_result.error
+            )
+        return None
+
+    if old_content == content:
+        return None
+
+    edit_result = backend.edit(file_path, old_content, content)
+    return edit_result.error
+
+
+def _persist_opplan_to_backend(
+    backend: BackendProtocol | None,
+    workspace_path: str | None,
+    objectives: list[dict],
+    engagement_name: str,
+    threat_profile: str,
+) -> None:
+    """Write the current OPPLAN to ``/workspace/plan/opplan.json`` via backend.
+
+    Best-effort: a missing backend/workspace_path (e.g. a unit-level tool
+    call before agent wiring) skips with a debug log, and any backend /
+    serialization error is logged rather than raised. The caller has already
+    mutated agent state by the time this runs; raising here would put the LLM
+    in a retry loop while state and the backend file diverge. The next
+    mutation retries.
+
+    The persisted JSON is wrapped with metadata (schema_version, saved_at,
+    summary) for human/ops readability; see :func:`_build_opplan_payload`.
+    """
+    scoped_backend = _scoped_opplan_backend(backend, workspace_path)
+    if scoped_backend is None:
+        log.debug("OPPLAN persistence skipped: backend or workspace_path missing")
+        return
+    try:
+        opplan = OPPLAN(
+            engagement_name=engagement_name or "",
+            threat_profile=threat_profile or "",
+            objectives=[Objective(**o) for o in objectives],
+        )
+        error = _write_text_to_backend(
+            scoped_backend,
+            OPPLAN_VIRTUAL_PATH,
+            json.dumps(_build_opplan_payload(opplan), indent=2, ensure_ascii=False),
+        )
+        if error:
+            log.warning("OPPLAN persistence failed for workspace=%s: %s", workspace_path, error)
+    except Exception as e:  # noqa: BLE001 — best-effort persistence
+        log.warning("OPPLAN persistence failed for workspace=%s: %s", workspace_path, e)
+
+
+
+def _format_opplan_for_agent(
+    objectives: list[dict],
+    engagement_name: str,
+    threat_profile: str,
+) -> str:
+    """Format OPPLAN for list_objectives response (detailed overview).
+
+    When any objective has ``parent_id`` set, the output includes an
+    indented tree view after the flat table so the agent can see the
+    hierarchy at a glance.
+    """
+    total = len(objectives)
+    completed = sum(1 for o in objectives if o.get("status") == "completed")
+    blocked = sum(1 for o in objectives if o.get("status") == "blocked")
+
+    has_tree = any(o.get("parent_id") for o in objectives)
+
+    lines = [
+        f"# OPPLAN: {engagement_name}",
+        f"Threat Profile: {threat_profile}",
+        f"Progress: {completed}/{total} completed, {blocked} blocked",
+        "",
+        "| ID | Phase | Title | Status | Priority | Owner | Blocked By |",
+        "|---|---|---|---|---|---|---|",
+    ]
+
+    for o in sorted(objectives, key=lambda x: x.get("priority", 999)):
+        status = o.get("status", "pending")
+        blocked_by = ", ".join(o.get("blocked_by", [])) or "-"
+        title = o.get("title", "?")
+        if o.get("parent_id"):
+            title = f"↳ {title}"
+        lines.append(
+            f"| {o.get('id', '?')} | {o.get('phase', '?')} | "
+            f"{title} | {status} | "
+            f"{o.get('priority', '?')} | {o.get('owner') or '-'} | "
+            f"{blocked_by} |"
+        )
+
+    lines.append("")
+
+    if has_tree:
+        lines.append("## Task Tree")
+
+        # ``visited`` guards against parent_id cycles so a malformed plan
+        # cannot hang the agent in unbounded recursion when list_objectives
+        # or any prompt-injection path renders the tree.
+        visited: set[str] = set()
+
+        def _render(parent_id: str | None, depth: int) -> None:
+            kids = sorted(
+                [o for o in objectives if o.get("parent_id") == parent_id],
+                key=lambda x: x.get("priority", 999),
+            )
+            for o in kids:
+                obj_id = o.get("id")
+                if not obj_id or obj_id in visited:
+                    continue
+                visited.add(obj_id)
+                indent = "  " * depth
+                status = o.get("status", "pending")
+                marker = {
+                    "completed": "[x]",
+                    "blocked": "[!]",
+                    "cancelled": "[-]",
+                    "in-progress": "[~]",
+                }.get(status, "[ ]")
+                lines.append(f"{indent}- {marker} {obj_id} {o.get('title', '?')} ({status})")
+                _render(obj_id, depth + 1)
+
+        _render(None, 0)
+        lines.append("")
+
+    # Next objective recommendation
+    actionable = [o for o in objectives if o.get("status") in ("pending", "in-progress")]
+    actionable.sort(key=lambda o: o.get("priority", 999))
+    if actionable:
+        nxt = actionable[0]
+        lines.append(
+            f"Next: {nxt.get('id')} — {nxt.get('title')} "
+            f"(phase: {nxt.get('phase')}, priority: {nxt.get('priority')})"
+        )
+    else:
+        all_done = all(o.get("status") == "completed" for o in objectives)
+        if all_done:
+            lines.append("ALL OBJECTIVES COMPLETE — Generate final engagement report.")
+        else:
+            lines.append("No actionable objectives — review blocked items for retry.")
+
+    return "\n".join(lines)
+
+
+# ── Tool Definitions ──────────────────────────────────────────────────
+
+
+def build_opplan_tools(backend: BackendProtocol | None = None) -> list:
+    """Create OPPLAN tools with InjectedState for direct state access.
+
+    Tool bodies execute CRUD logic directly, returning Command for state
+    mutations. No middleware interception is needed; tools appear as proper
+    `tool` type runs in LangSmith.
+    """
+
+    @tool(
+        description=(
+            "Add a single objective to the OPPLAN. Auto-generates an ID "
+            "(OBJ-001, OBJ-002, ...). Each objective must be completable in "
+            "ONE sub-agent context window. Use blocked_by to set kill chain dependencies. "
+            "Set engagement_name and threat_profile on the first call to initialize context. "
+            "Auto-persists the OPPLAN through the engagement filesystem backend "
+            "to /workspace/plan/opplan.json on success. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def add_objective(
+        title: str,
+        phase: ObjectivePhase,
+        description: str,
+        acceptance_criteria: list[str],
+        priority: int,
+        state: Annotated[dict, InjectedState],
+        engagement_name: str | None = None,
+        threat_profile: str | None = None,
+        mitre: list[str] | None = None,
+        opsec: OpsecLevel = OpsecLevel.STANDARD,
+        opsec_notes: str = "",
+        c2_tier: C2Tier = C2Tier.INTERACTIVE,
+        concessions: list[str] | None = None,
+        blocked_by: list[str] | None = None,
+        parent_id: str | None = None,
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Add one objective with auto-ID generation."""
+        counter = state.get("objective_counter", 0) + 1
+        obj_id = f"OBJ-{counter:03d}"
+
+        # Validate parent_id if supplied
+        if parent_id:
+            existing_ids = {o.get("id") for o in state.get("objectives", [])}
+            if parent_id not in existing_ids:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=(
+                                    f"Parent objective '{parent_id}' not found. "
+                                    f"Existing: {', '.join(sorted(i for i in existing_ids if i))}"
+                                ),
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ],
+                    }
+                )
+
+        obj_dict = {
+            "id": obj_id,
+            "title": title,
+            "phase": phase,
+            "description": description,
+            "acceptance_criteria": acceptance_criteria,
+            "priority": priority,
+            "status": "pending",
+            "mitre": mitre or [],
+            "opsec": opsec,
+            "opsec_notes": opsec_notes,
+            "c2_tier": c2_tier,
+            "concessions": concessions or [],
+            "blocked_by": blocked_by or [],
+            "owner": "",
+            "notes": "",
+            "parent_id": parent_id,
+        }
+
+        # Pydantic validation
+        try:
+            Objective(**obj_dict)
+        except Exception as e:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Validation failed for objective: {e}",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+
+        objectives = list(state.get("objectives", []))
+        objectives.append(obj_dict)
+
+        # Build state update — always include objectives + counter
+        update: dict[str, Any] = {
+            "objectives": objectives,
+            "objective_counter": counter,
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Added {obj_id}: {obj_dict['title']} "
+                        f"(phase: {obj_dict['phase']}, priority: {obj_dict['priority']})"
+                    ),
+                    tool_call_id=tool_call_id,
+                )
+            ],
+        }
+
+        # Set engagement metadata if provided (typically on first call)
+        if engagement_name:
+            update["engagement_name"] = engagement_name
+        if threat_profile:
+            update["threat_profile"] = threat_profile
+
+        _persist_opplan_to_backend(
+            backend,
+            state.get("workspace_path"),
+            objectives,
+            engagement_name or state.get("engagement_name", ""),
+            threat_profile or state.get("threat_profile", ""),
+        )
+
+        return Command(update=update)
+
+    @tool(
+        description=(
+            "Read a single objective's full details by ID. "
+            "ALWAYS call this before update_objective to prevent staleness. "
+            "Returns: status, description, acceptance criteria, dependencies, notes. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def get_objective(
+        objective_id: str,
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Read one objective detail from state."""
+        objectives = state.get("objectives", [])
+        target = next((o for o in objectives if o.get("id") == objective_id), None)
+
+        if not target:
+            available = ", ".join(o.get("id", "?") for o in objectives)
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=(
+                                f"Objective '{objective_id}' not found. "
+                                f"Available: {available or 'none (use add_objective first)'}"
+                            ),
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+
+        obj_status = target.get("status", "pending")
+        mitre_ids = target.get("mitre") or []
+        mitre_str = ", ".join(mitre_ids) if mitre_ids else "n/a"
+        lines = [
+            f"## {target['id']} [{obj_status.upper()}]",
+            f"Title: {target.get('title', '')}",
+            f"Phase: {target.get('phase', '')} | Priority: {target.get('priority', '')}",
+            f"MITRE: {mitre_str}",
+            f"OPSEC: {target.get('opsec', 'standard')} | C2: {target.get('c2_tier', 'interactive')}",
+            f"Description: {target.get('description', '')}",
+        ]
+
+        criteria = target.get("acceptance_criteria", [])
+        if criteria:
+            check = "x" if obj_status == "completed" else " "
+            lines.append("Acceptance Criteria:")
+            for c in criteria:
+                lines.append(f"  - [{check}] {c}")
+
+        blocked_by_ids = target.get("blocked_by", [])
+        if blocked_by_ids:
+            lines.append(f"Blocked By: {', '.join(blocked_by_ids)}")
+
+        owner = target.get("owner", "")
+        if owner:
+            lines.append(f"Owner: {owner}")
+
+        obj_opsec_notes = target.get("opsec_notes", "")
+        if obj_opsec_notes:
+            lines.append(f"OPSEC Notes: {obj_opsec_notes}")
+
+        obj_concessions = target.get("concessions") or []
+        if obj_concessions:
+            lines.append("Concessions:")
+            for c in obj_concessions:
+                lines.append(f"  - {c}")
+
+        notes = target.get("notes", "")
+        if notes:
+            lines.append(f"Notes: {notes}")
+
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content="\n".join(lines),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    @tool(
+        description=(
+            "List all OPPLAN objectives with progress summary. "
+            "Returns: engagement overview, objective table with status, "
+            "and next recommended objective. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def list_objectives(
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """List all objectives with progress summary."""
+        objectives = state.get("objectives", [])
+        engagement = state.get("engagement_name", "")
+        threat = state.get("threat_profile", "")
+
+        if not objectives:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content="No objectives defined yet. Use `add_objective` to create objectives.",
+                            tool_call_id=tool_call_id,
+                        )
+                    ],
+                }
+            )
+
+        content = _format_opplan_for_agent(objectives, engagement, threat)
+        return Command(
+            update={
+                "messages": [ToolMessage(content=content, tool_call_id=tool_call_id)],
+            }
+        )
+
+    @tool(
+        description=(
+            "Update a single objective. MUST call get_objective first. "
+            "Can change: status, notes, owner, add_blocked_by. "
+            "Valid transitions: pending→in-progress, in-progress→completed/blocked, "
+            "blocked→in-progress (retry) or completed (abandon). "
+            "Include evidence when marking completed, failure reason when marking blocked. "
+            "Auto-persists the OPPLAN through the engagement filesystem backend "
+            "to /workspace/plan/opplan.json on success. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def update_objective(
+        objective_id: str,
+        state: Annotated[dict, InjectedState],
+        status: str | None = None,
+        notes: str | None = None,
+        owner: str | None = None,
+        add_blocked_by: list[str] | None = None,
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Update one objective with state transition validation."""
+        # Deep copy objectives to avoid mutating state
+        objectives = [dict(o) for o in state.get("objectives", [])]
+        target = next((o for o in objectives if o.get("id") == objective_id), None)
+
+        if not target:
+            available = ", ".join(o.get("id", "?") for o in objectives)
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Objective '{objective_id}' not found. Available: {available}",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+
+        updated_fields: list[str] = []
+
+        # ── Status change with transition + dependency validation ─────
+        if status is not None:
+            # Validate status value
+            try:
+                ObjectiveStatus(status)
+            except ValueError:
+                valid = ", ".join(s.value for s in ObjectiveStatus)
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=f"Invalid status '{status}'. Valid: {valid}",
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ],
+                    }
+                )
+
+            current = target.get("status", "pending")
+            if not _is_valid_transition(current, status):
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=(
+                                    f"Invalid transition: {current} → {status}. "
+                                    f"Valid from '{current}': {_valid_next(current)}"
+                                ),
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ],
+                    }
+                )
+
+            # Check blocked_by dependencies when starting execution
+            if status == "in-progress":
+                blocked_by_ids = target.get("blocked_by", [])
+                unresolved = [
+                    bid
+                    for bid in blocked_by_ids
+                    if any(
+                        o.get("id") == bid and o.get("status") != "completed" for o in objectives
+                    )
+                ]
+                if unresolved:
+                    return Command(
+                        update={
+                            "messages": [
+                                ToolMessage(
+                                    content=(
+                                        f"Cannot start {objective_id}: "
+                                        f"blocked by unresolved objectives: {', '.join(unresolved)}"
+                                    ),
+                                    tool_call_id=tool_call_id,
+                                    status="error",
+                                )
+                            ],
+                        }
+                    )
+
+            # Parents cannot complete until every child is done.
+            if status == "completed":
+                children = [o for o in objectives if o.get("parent_id") == objective_id]
+                if children:
+                    unresolved_kids = [
+                        c["id"]
+                        for c in children
+                        if c.get("status") not in {"completed", "cancelled"}
+                    ]
+                    if unresolved_kids:
+                        return Command(
+                            update={
+                                "messages": [
+                                    ToolMessage(
+                                        content=(
+                                            f"Cannot complete {objective_id}: "
+                                            f"children still open: {', '.join(unresolved_kids)}. "
+                                            f"Complete or cancel each child first, or call "
+                                            f"objective_collapse({objective_id})."
+                                        ),
+                                        tool_call_id=tool_call_id,
+                                        status="error",
+                                    )
+                                ],
+                            }
+                        )
+
+            target["status"] = status
+            updated_fields.append(f"status → {status}")
+
+        # ── Notes ─────────────────────────────────────────────────────
+        if notes is not None:
+            target["notes"] = notes
+            updated_fields.append("notes")
+
+        # ── Owner (which sub-agent is executing) ─────────────────────
+        if owner is not None:
+            target["owner"] = owner
+            updated_fields.append("owner")
+
+        # ── Add blocked_by dependencies ──────────────────────────────
+        if add_blocked_by:
+            existing_blocked = set(target.get("blocked_by", []))
+            all_ids = {o.get("id") for o in objectives}
+            invalid = [bid for bid in add_blocked_by if bid not in all_ids]
+            if invalid:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=f"Invalid blocked_by references: {', '.join(invalid)}",
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ],
+                    }
+                )
+            for bid in add_blocked_by:
+                existing_blocked.add(bid)
+            target["blocked_by"] = sorted(existing_blocked)
+            updated_fields.append("blocked_by")
+
+        if not updated_fields:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"No changes specified for {objective_id}.",
+                            tool_call_id=tool_call_id,
+                        )
+                    ],
+                }
+            )
+
+        total = len(objectives)
+        completed_count = sum(1 for o in objectives if o.get("status") == "completed")
+
+        _persist_opplan_to_backend(
+            backend,
+            state.get("workspace_path"),
+            objectives,
+            state.get("engagement_name", ""),
+            state.get("threat_profile", ""),
+        )
+
+        return Command(
+            update={
+                "objectives": objectives,
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"Updated {objective_id}: {', '.join(updated_fields)}. "
+                            f"Progress: {completed_count}/{total} completed."
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    @tool(
+        description=(
+            "Expand a parent objective into one or more child sub-tasks. "
+            "Each child inherits the parent's phase by default but can override it. "
+            "Children auto-receive IDs (OBJ-NNN) and are added with status 'pending'. "
+            "The parent cannot move to COMPLETED until every child is COMPLETED or CANCELLED. "
+            "Use this when an objective is broad or when recon reveals sub-tasks — it is "
+            "the Pentesting Task Tree (PTT) pattern. Keep children small enough to complete "
+            "in one sub-agent iteration. "
+            "Auto-persists the OPPLAN through the engagement filesystem backend "
+            "to /workspace/plan/opplan.json on success. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def objective_expand(
+        parent_id: str,
+        children: list[dict],
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Create ``len(children)`` child objectives under ``parent_id``.
+
+        Each child dict must have: ``title`` (str), ``description`` (str),
+        ``acceptance_criteria`` (list[str]). Optional: ``phase``
+        (ObjectivePhase value, default inherited from parent),
+        ``priority`` (int, default parent.priority + N), ``mitre``,
+        ``blocked_by``.
+        """
+        objectives = [dict(o) for o in state.get("objectives", [])]
+        parent = next((o for o in objectives if o.get("id") == parent_id), None)
+        if parent is None:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Parent objective '{parent_id}' not found.",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+        if parent.get("status") in {"completed", "cancelled"}:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=(
+                                f"Cannot expand {parent_id}: status is "
+                                f"{parent.get('status')}. Expand open parents only."
+                            ),
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+        if not children:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content="children list is empty — nothing to expand.",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+
+        counter = state.get("objective_counter", 0)
+        created_ids: list[str] = []
+        parent_phase = parent.get("phase")
+        try:
+            parent_priority = int(parent.get("priority", 100))
+        except (ValueError, TypeError):
+            parent_priority = 100
+        for idx, child in enumerate(children, start=1):
+            counter += 1
+            obj_id = f"OBJ-{counter:03d}"
+            title = str(child.get("title", "")).strip()
+            description = str(child.get("description", "")).strip()
+            acceptance = child.get("acceptance_criteria") or []
+            if not title or not description or not acceptance:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=(
+                                    f"Child #{idx} missing required fields "
+                                    "(title, description, acceptance_criteria)."
+                                ),
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ],
+                    }
+                )
+            phase = child.get("phase", parent_phase)
+            try:
+                priority = int(child.get("priority", parent_priority + idx))
+            except (ValueError, TypeError):
+                priority = parent_priority + idx
+            child_dict = {
+                "id": obj_id,
+                "title": title,
+                "phase": phase,
+                "description": description,
+                "acceptance_criteria": list(acceptance),
+                "priority": priority,
+                "status": "pending",
+                "mitre": list(child.get("mitre") or []),
+                "opsec": parent.get("opsec", "standard"),
+                "opsec_notes": "",
+                "c2_tier": parent.get("c2_tier", "interactive"),
+                "concessions": [],
+                "blocked_by": list(child.get("blocked_by") or []),
+                "owner": "",
+                "notes": "",
+                "parent_id": parent_id,
+            }
+            try:
+                Objective(**child_dict)
+            except Exception as e:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=f"Child #{idx} validation failed: {e}",
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ],
+                    }
+                )
+            objectives.append(child_dict)
+            created_ids.append(obj_id)
+
+        _persist_opplan_to_backend(
+            backend,
+            state.get("workspace_path"),
+            objectives,
+            state.get("engagement_name", ""),
+            state.get("threat_profile", ""),
+        )
+
+        return Command(
+            update={
+                "objectives": objectives,
+                "objective_counter": counter,
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"Expanded {parent_id} into {len(created_ids)} children: "
+                            f"{', '.join(created_ids)}"
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    @tool(
+        description=(
+            "Cancel every descendant of a parent objective. Use when abandoning a "
+            "hierarchical task — sets each child's status to 'cancelled' so the "
+            "parent can then be moved to COMPLETED or CANCELLED itself. "
+            "Only pending / in-progress / blocked children are touched; already-done "
+            "children are left as-is. "
+            "Auto-persists the OPPLAN through the engagement filesystem backend "
+            "to /workspace/plan/opplan.json on success. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def objective_collapse(
+        parent_id: str,
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Mark every descendant of ``parent_id`` as cancelled."""
+        objectives = [dict(o) for o in state.get("objectives", [])]
+        if not any(o.get("id") == parent_id for o in objectives):
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Parent objective '{parent_id}' not found.",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ],
+                }
+            )
+
+        # Walk descendants depth-first. ``visited`` guards against cycles in
+        # parent_id references (which the schema does not formally rule out)
+        # so a malformed plan does not hang the agent in an infinite loop.
+        stack = [parent_id]
+        visited: set[str] = {parent_id}
+        descendants: list[dict[str, Any]] = []
+        while stack:
+            current = stack.pop()
+            for o in objectives:
+                if o.get("parent_id") == current:
+                    obj_id = o.get("id")
+                    if not obj_id or obj_id in visited:
+                        continue
+                    visited.add(obj_id)
+                    descendants.append(o)
+                    stack.append(obj_id)
+
+        cancelled: list[str] = []
+        for o in descendants:
+            if o.get("status") in {"pending", "in-progress", "blocked"}:
+                o["status"] = "cancelled"
+                cancelled.append(o["id"])
+
+        _persist_opplan_to_backend(
+            backend,
+            state.get("workspace_path"),
+            objectives,
+            state.get("engagement_name", ""),
+            state.get("threat_profile", ""),
+        )
+
+        return Command(
+            update={
+                "objectives": objectives,
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"Cancelled {len(cancelled)} descendants of {parent_id}"
+                            + (f": {', '.join(cancelled)}" if cancelled else "")
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    @tool(
+        description=(
+            "Load an existing plan/opplan.json into agent state to resume an engagement. "
+            "Call on session startup when plan/opplan.json already exists — "
+            "this hydrates objectives, engagement_name, and threat_profile into state "
+            "so OPPLAN tools and the status tracker work immediately. "
+            "Call OPPLAN tools sequentially — never in parallel with other OPPLAN tools."
+        )
+    )
+    def load_opplan(
+        workspace_path: str,
+        state: Annotated[dict, InjectedState],
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> Command[Any]:
+        """Read plan/opplan.json and hydrate agent state."""
+        scoped_backend = _scoped_opplan_backend(backend, workspace_path)
+        if scoped_backend is None:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=(
+                                "No engagement workspace backend is configured. "
+                                "Use add_objective after the launcher provides workspace_path."
+                            ),
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        raw, read_error = _read_text_from_backend(scoped_backend, OPPLAN_VIRTUAL_PATH)
+        if raw is None:
+            not_found = "file_not_found" in (read_error or "") or "not found" in (
+                read_error or ""
+            ).lower()
+            content = (
+                f"No opplan.json found at {OPPLAN_VIRTUAL_PATH}. "
+                "Use add_objective to create a new OPPLAN."
+                if not_found
+                else f"Failed to load opplan.json: {read_error}"
+            )
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=content,
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        try:
+            data = json.loads(raw)
+            opplan = OPPLAN(**data)
+        except Exception as e:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Failed to load opplan.json: {e}",
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        objectives_raw = [o.model_dump() for o in opplan.objectives]
+
+        # Derive counter from highest existing ID so new objectives don't collide
+        counter = 0
+        for o in opplan.objectives:
+            try:
+                n = int(o.id.replace("OBJ-", ""))
+                if n > counter:
+                    counter = n
+            except (ValueError, AttributeError):
+                pass
+
+        return Command(
+            update={
+                "objectives": objectives_raw,
+                "engagement_name": opplan.engagement_name,
+                "threat_profile": opplan.threat_profile,
+                "objective_counter": counter,
+                "workspace_path": workspace_path,
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"Loaded {len(objectives_raw)} objectives from {OPPLAN_VIRTUAL_PATH}. "
+                            f"Engagement: {opplan.engagement_name} | "
+                            f"Counter at OBJ-{counter:03d}"
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    return [
+        add_objective,
+        get_objective,
+        list_objectives,
+        update_objective,
+        objective_expand,
+        objective_collapse,
+        load_opplan,
+    ]
+
+
+# ── State transition helpers ──────────────────────────────────────────
+
+
+def _is_valid_transition(current: str, new: str) -> bool:
+    """Check if a status transition is allowed."""
+    return new in _VALID_TRANSITIONS.get(current, set())
+
+
+def _valid_next(current: str) -> str:
+    """Return comma-separated valid next statuses."""
+    return ", ".join(sorted(_VALID_TRANSITIONS.get(current, set())))
+
+
+__all__ = [
+    "OPPLAN_FILE_SCHEMA_VERSION",
+    "OPPLAN_TOOL_NAMES",
+    "OPPLAN_VIRTUAL_PATH",
+    "build_opplan_tools",
+    "_build_opplan_payload",
+    "_format_opplan_for_agent",
+    "_persist_opplan_to_backend",
+]

--- a/decepticon/tools/skills.py
+++ b/decepticon/tools/skills.py
@@ -1,0 +1,207 @@
+"""Skill loading tools for Decepticon agents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import tool
+
+
+def _unwrap_backend(backend: Any) -> Any:
+    """Strip EngagementFilesystemBackend wrapping from a backend.
+
+    EngagementFilesystemBackend._real() maps /workspace paths to
+    /workspace/<slug>/..., which mangles /skills/ paths to
+    /workspace/<slug>/skills/... — a path that does not exist in the
+    sandbox container. Skill reads must bypass this wrapper and go
+    directly to the raw DockerSandbox which can reach /skills/ via
+    docker cp / execute().
+    """
+    # Import here to avoid circular import (filesystem.py imports from skills.py
+    # indirectly via middleware/__init__.py)
+    from decepticon.middleware.filesystem import EngagementFilesystemBackend  # noqa: PLC0415
+
+    while isinstance(backend, EngagementFilesystemBackend):
+        backend = backend._backend
+    return backend
+
+
+# ── load_skill tool ──────────────────────────────────────────────────────────
+# A Decepticon-specific replacement for `load_skill("/skills/...")` that
+# returns the full skill body without the deepagents 100-line limit, plus a
+# base-directory header and an index of references/* in the same directory.
+
+_SKILL_PATH_PREFIX = "/skills/"
+
+
+def _strip_frontmatter(text: str) -> tuple[str, dict[str, str]]:
+    """Strip a leading YAML frontmatter block (``---\\n...\\n---``) from text.
+
+    Returns ``(body, frontmatter_dict)``. Only flat ``key: value`` pairs are
+    parsed — nested YAML is ignored. If no frontmatter is present the original
+    text is returned with an empty dict.
+    """
+    if not text.startswith("---\n"):
+        return text, {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return text, {}
+    fm_text = text[4:end]
+    body = text[end + 5 :]
+    fm: dict[str, str] = {}
+    for line in fm_text.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        fm[key.strip()] = value.strip().strip('"').strip("'")
+    return body, fm
+
+
+def _read_via_backend(backend: Any, skill_path: str) -> tuple[str | None, str | None]:
+    """Read a file via the deepagents backend protocol.
+
+    Returns ``(content, error)``: exactly one of the two is non-None. The
+    backend abstraction is what gives ``load_skill`` access to the sandbox
+    container's filesystem (where ``/skills/`` is baked into the image) instead
+    of the langgraph container's local fs (where ``/skills/`` does not exist).
+    """
+    try:
+        res = backend.read(skill_path)
+    except Exception as exc:
+        return None, f"backend read failed: {exc}"
+    if getattr(res, "error", None):
+        return None, str(res.error)
+    data = getattr(res, "file_data", None)
+    if not data:
+        return None, "empty backend response"
+    content = data.get("content", "")
+    if isinstance(content, list):  # legacy v1 (line-split) format
+        content = "\n".join(content)
+    if not isinstance(content, str):
+        return None, "backend returned non-string content"
+    return content, None
+
+
+def _list_dir_via_backend(backend: Any, dir_path: str) -> list[str]:
+    """List ``.md`` files under ``dir_path`` via backend, sorted.
+
+    Best-effort: returns an empty list on any backend failure rather than
+    raising, so the references/siblings index degrades gracefully when a
+    skill directory has none.
+    """
+    try:
+        res = backend.ls(dir_path)
+    except Exception:
+        return []
+    if getattr(res, "error", None):
+        return []
+    names: list[str] = []
+    for attr in ("entries", "files", "items"):
+        candidate = getattr(res, attr, None)
+        if isinstance(candidate, list):
+            names = [str(n) for n in candidate]
+            break
+    if not names:
+        data = getattr(res, "file_data", None)
+        if isinstance(data, dict):
+            names = [str(n) for n in data.get("entries", [])]
+    return sorted(n for n in names if n.endswith(".md"))
+
+
+def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-untyped-def]
+    """Construct the ``load_skill`` LangChain tool.
+
+    Returns a closure-bound ``@tool``-decorated function that reads a skill
+    markdown file via the deepagents backend (same path used by ``read_file``,
+    so it sees the sandbox container's ``/skills/`` mount instead of the
+    langgraph container's local fs). Path is restricted to ``/skills/*`` to
+    keep this tool's intent distinct from the general ``read_file``.
+
+    Strips any EngagementFilesystemBackend wrapping — /skills/ paths must
+    reach the raw sandbox directly; the engagement wrapper mangles them to
+    /workspace/<slug>/skills/... which does not exist in the container.
+    """
+    backend = _unwrap_backend(backend)
+
+    @tool
+    def load_skill(skill_path: str, include_siblings: bool = False) -> str:
+        """Load a Decepticon skill file (full body, no line-limit truncation).
+
+        Use this for ANY ``/skills/*.md`` file instead of ``read_file``. It
+        returns the entire skill body (frontmatter stripped) prepended with a
+        base directory header, followed by an index of any ``references/`` files
+        in the same directory so you know what additional templates / cheat
+        sheets exist for this skill.
+
+        Args:
+            skill_path: Absolute path under ``/skills/``, e.g.
+                ``/skills/exploit/web/crypto.md``.
+            include_siblings: If True, also list sibling ``.md`` files in the
+                same directory (useful when the skill is a category index).
+                Default False to avoid duplicating the catalog already in the
+                system prompt.
+
+        Returns:
+            The skill body with a header + references index. Errors are
+            returned as ``[load_skill error] ...`` strings (never raised).
+        """
+        if not isinstance(skill_path, str) or not skill_path:
+            return "[load_skill error] skill_path must be a non-empty string."
+        if not skill_path.startswith(_SKILL_PATH_PREFIX):
+            return (
+                "[load_skill error] Path must start with /skills/. "
+                "For non-skill files use read_file. "
+                f"Got: {skill_path!r}"
+            )
+        if not skill_path.endswith(".md"):
+            return f"[load_skill error] Skill files must be markdown (.md). Got: {skill_path!r}"
+        # Reject path traversal — disallow ".." segments
+        if ".." in skill_path.split("/"):
+            return f"[load_skill error] Path traversal not allowed: {skill_path!r}"
+        # Enforce agent's skill source allowlist
+        if sources and not any(skill_path.startswith(src.rstrip("/")) for src in sources):
+            allowed = ", ".join(sources)
+            return (
+                f"[load_skill error] This agent may only load skills from: {allowed}. "
+                f"Got: {skill_path!r}"
+            )
+
+        raw, err = _read_via_backend(backend, skill_path)
+        if raw is None:
+            return f"[load_skill error] Skill not found: {skill_path} ({err})"
+
+        body, frontmatter = _strip_frontmatter(raw)
+
+        path_parts = skill_path.rsplit("/", 1)
+        base_dir = path_parts[0] if len(path_parts) == 2 else "/"
+        stem = path_parts[-1].rsplit(".", 1)[0]
+        header_lines = [f"Base directory for this skill: {base_dir}"]
+        name = frontmatter.get("name") or stem
+        description = frontmatter.get("description", "").strip()
+        header_lines.append(f"Skill: {name}" + (f" — {description}" if description else ""))
+        header = "\n".join(header_lines)
+
+        sections: list[str] = [header, "", body.rstrip(), ""]
+
+        refs_dir = base_dir.rstrip("/") + "/references"
+        refs = _list_dir_via_backend(backend, refs_dir)
+        if refs:
+            sections.append("---")
+            sections.append("References (load with `load_skill` or `read_file`):")
+            sections.extend(f"- {refs_dir}/{r}" for r in refs)
+            sections.append("")
+
+        if include_siblings:
+            sibs = [s for s in _list_dir_via_backend(backend, base_dir) if s != path_parts[-1]]
+            if sibs:
+                sections.append("---")
+                sections.append("Related sub-skills in this directory (load with `load_skill`):")
+                sections.extend(f"- {base_dir.rstrip('/')}/{s}" for s in sibs)
+                sections.append("")
+
+        return "\n".join(sections).rstrip() + "\n"
+
+    return load_skill
+
+
+__all__ = ["build_load_skill_tool"]

--- a/tests/unit/middleware/test_opplan_hierarchy.py
+++ b/tests/unit/middleware/test_opplan_hierarchy.py
@@ -13,7 +13,7 @@ from decepticon.core.schemas import (
     ObjectivePhase,
     ObjectiveStatus,
 )
-from decepticon.middleware import opplan as opplan_mod
+from decepticon.tools.opplan import build_opplan_tools
 
 
 def _objective(
@@ -139,10 +139,10 @@ class TestSchemaHierarchy:
 
 
 class _ToolBag:
-    """Convenience accessor over the tuple returned by ``_make_tools()``."""
+    """Convenience accessor over the OPPLAN tool list."""
 
     def __init__(self) -> None:
-        self.tools = opplan_mod._make_tools()
+        self.tools = build_opplan_tools()
         by_name = {getattr(t, "name", None) or t.__name__: t for t in self.tools}
         self.add = by_name["add_objective"]
         self.update = by_name["update_objective"]

--- a/tests/unit/middleware/test_opplan_persistence.py
+++ b/tests/unit/middleware/test_opplan_persistence.py
@@ -1,0 +1,410 @@
+"""Tests for OPPLAN backend persistence, structured JSON, cycle guards, and the
+strict-sequential ``after_model`` rule.
+
+Covers the slice of the OPPLAN middleware that this PR introduced:
+
+- ``_persist_opplan_to_backend`` writes a v1-shaped JSON document.
+- Each mutating tool (add/update/expand/collapse) writes through the backend.
+- ``_render`` and ``objective_collapse`` survive cycles in ``parent_id``.
+- ``after_model`` rejects two OPPLAN tool calls in the same model step.
+- ``list_objectives`` does not announce "ALL OBJECTIVES COMPLETE" for an
+  empty plan.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from deepagents.backends.filesystem import FilesystemBackend
+from langchain_core.messages import AIMessage, ToolMessage
+
+from decepticon.core.schemas import OPPLAN, Objective, ObjectivePhase
+from decepticon.middleware import opplan as opplan_mod
+from decepticon.middleware.opplan import OPPLANMiddleware
+from decepticon.tools.opplan import (
+    OPPLAN_FILE_SCHEMA_VERSION,
+    OPPLAN_TOOL_NAMES,
+    OPPLAN_VIRTUAL_PATH,
+    _build_opplan_payload,
+    _format_opplan_for_agent,
+    _persist_opplan_to_backend,
+)
+
+
+def _obj_dict(obj_id: str, **overrides: Any) -> dict:
+    base = {
+        "id": obj_id,
+        "title": f"objective {obj_id}",
+        "phase": "recon",
+        "description": "…",
+        "acceptance_criteria": ["criterion"],
+        "priority": 1,
+        "status": "pending",
+        "mitre": [],
+        "opsec": "standard",
+        "opsec_notes": "",
+        "c2_tier": "interactive",
+        "concessions": [],
+        "blocked_by": [],
+        "owner": "",
+        "notes": "",
+        "parent_id": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ── _build_opplan_payload / _persist_opplan_to_backend ─────────────────
+
+
+def _backend(tmp_path: Path) -> FilesystemBackend:
+    return FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+
+def _opplan_path(tmp_path: Path, workspace_path: str = "/workspace") -> Path:
+    rel = workspace_path.removeprefix("/").rstrip("/")
+    return tmp_path / rel / "plan" / "opplan.json"
+
+
+def test_build_opplan_payload_emits_versioned_envelope() -> None:
+    opplan = OPPLAN(
+        engagement_name="demo",
+        threat_profile="apt-x",
+        objectives=[
+            Objective(
+                id="OBJ-002",
+                phase=ObjectivePhase.RECON,
+                title="b",
+                description="…",
+                acceptance_criteria=["x"],
+                priority=2,
+            ),
+            Objective(
+                id="OBJ-001",
+                phase=ObjectivePhase.RECON,
+                title="a",
+                description="…",
+                acceptance_criteria=["x"],
+                priority=1,
+                status="completed",  # type: ignore[arg-type]
+            ),
+        ],
+    )
+
+    payload = _build_opplan_payload(opplan)
+
+    assert payload["schema_version"] == OPPLAN_FILE_SCHEMA_VERSION
+    assert payload["engagement_name"] == "demo"
+    assert payload["threat_profile"] == "apt-x"
+    # Objectives sorted by id for stable diffs.
+    assert [o["id"] for o in payload["objectives"]] == ["OBJ-001", "OBJ-002"]
+    # Summary aggregates by status.
+    assert payload["summary"]["total"] == 2
+    assert payload["summary"]["completed"] == 1
+    assert payload["summary"]["pending"] == 1
+
+
+def test_persist_writes_payload_under_workspace_plan(tmp_path: Path) -> None:
+    _persist_opplan_to_backend(
+        _backend(tmp_path),
+        "/workspace",
+        [_obj_dict("OBJ-001", title="t")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+
+    out = _opplan_path(tmp_path)
+    assert out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["schema_version"] == OPPLAN_FILE_SCHEMA_VERSION
+    assert data["engagement_name"] == "demo"
+    assert [o["id"] for o in data["objectives"]] == ["OBJ-001"]
+
+
+def test_persist_overwrites_existing_opplan_through_backend(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    _persist_opplan_to_backend(
+        backend,
+        "/workspace",
+        [_obj_dict("OBJ-001", status="pending")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+    _persist_opplan_to_backend(
+        backend,
+        "/workspace",
+        [_obj_dict("OBJ-001", status="completed", notes="evidence saved")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+
+    data = json.loads(_opplan_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["objectives"][0]["status"] == "completed"
+    assert data["objectives"][0]["notes"] == "evidence saved"
+
+
+def test_persist_skips_when_workspace_path_missing(tmp_path: Path) -> None:
+    # Should not raise; nothing should be written.
+    _persist_opplan_to_backend(
+        _backend(tmp_path),
+        None,
+        [_obj_dict("OBJ-001")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+    _persist_opplan_to_backend(
+        _backend(tmp_path),
+        "",
+        [_obj_dict("OBJ-001")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_persist_swallows_filesystem_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An OSError must become a log warning, not an exception."""
+
+    def boom(self: Path, *a: Any, **kw: Any) -> None:
+        raise PermissionError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    # No assertion — just must not raise.
+    _persist_opplan_to_backend(
+        _backend(tmp_path),
+        "/workspace",
+        [_obj_dict("OBJ-001")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+
+
+def test_loaded_opplan_ignores_persistence_metadata(tmp_path: Path) -> None:
+    """``OPPLAN(**data)`` must drop the wrapper fields silently (Pydantic
+    default extra-field policy) so ``load_opplan`` can read what we wrote."""
+    _persist_opplan_to_backend(
+        _backend(tmp_path),
+        "/workspace",
+        [_obj_dict("OBJ-001")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+    data = json.loads(_opplan_path(tmp_path).read_text(encoding="utf-8"))
+    # Sanity: the wrapper fields ARE present in the persisted file.
+    assert {"schema_version", "saved_at", "summary"} <= set(data.keys())
+    # And OPPLAN(**data) must round-trip without raising.
+    opplan = OPPLAN(**data)
+    assert opplan.engagement_name == "demo"
+    assert [o.id for o in opplan.objectives] == ["OBJ-001"]
+
+
+def test_load_opplan_reads_through_backend(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    _persist_opplan_to_backend(
+        backend,
+        "/workspace",
+        [_obj_dict("OBJ-001")],
+        engagement_name="demo",
+        threat_profile="apt-x",
+    )
+
+    cmd = _call(
+        "load_opplan",
+        {"workspace_path": "/workspace"},
+        state={},
+        backend=backend,
+    )
+
+    assert cmd.update["engagement_name"] == "demo"
+    assert cmd.update["workspace_path"] == "/workspace"
+    assert cmd.update["objectives"][0]["id"] == "OBJ-001"
+    assert OPPLAN_VIRTUAL_PATH in cmd.update["messages"][0].content
+
+
+# ── auto-persist on each mutating tool ─────────────────────────────────
+
+
+def _tool(name: str, backend=None):
+    """Look up an OPPLAN tool by name from a fresh middleware instance."""
+    tools = OPPLANMiddleware(backend=backend).tools
+    return next(t for t in tools if t.name == name)
+
+
+def _call(name: str, args: dict, state: dict, backend=None):
+    """Invoke an OPPLAN tool with the LangChain ToolCall envelope.
+
+    The tools declare ``tool_call_id: Annotated[str, InjectedToolCallId]``
+    so they cannot be invoked with a plain kwargs dict — InjectedToolCallId
+    must be injected through the ``{"type": "tool_call", "id": ...}`` shape.
+    """
+    payload = {
+        "name": name,
+        "type": "tool_call",
+        "id": "test-call-id",
+        "args": {**args, "state": state},
+    }
+    return _tool(name, backend=backend).invoke(payload)
+
+
+def test_add_objective_auto_persists(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    cmd = _call(
+        "add_objective",
+        {
+            "title": "scan",
+            "phase": "recon",
+            "description": "…",
+            "acceptance_criteria": ["nmap output saved"],
+            "priority": 1,
+            "engagement_name": "demo",
+            "threat_profile": "apt-x",
+        },
+        state={"workspace_path": "/workspace"},
+        backend=backend,
+    )
+    assert _opplan_path(tmp_path).exists()
+    assert cmd.update["objectives"][0]["title"] == "scan"
+
+
+def test_update_objective_auto_persists(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    state = {
+        "objectives": [_obj_dict("OBJ-001", status="pending")],
+        "engagement_name": "demo",
+        "threat_profile": "apt-x",
+        "workspace_path": "/workspace",
+    }
+    _call(
+        "update_objective",
+        {"objective_id": "OBJ-001", "status": "in-progress"},
+        state=state,
+        backend=backend,
+    )
+    out = _opplan_path(tmp_path)
+    assert out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["objectives"][0]["status"] == "in-progress"
+
+
+def test_objective_collapse_auto_persists(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    state = {
+        "objectives": [
+            _obj_dict("OBJ-001"),
+            _obj_dict("OBJ-002", parent_id="OBJ-001"),
+            _obj_dict("OBJ-003", parent_id="OBJ-002"),
+        ],
+        "engagement_name": "demo",
+        "threat_profile": "apt-x",
+        "workspace_path": "/workspace",
+    }
+    _call("objective_collapse", {"parent_id": "OBJ-001"}, state=state, backend=backend)
+    out = _opplan_path(tmp_path)
+    assert out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    statuses = {o["id"]: o["status"] for o in data["objectives"]}
+    assert statuses["OBJ-002"] == "cancelled"
+    assert statuses["OBJ-003"] == "cancelled"
+
+
+# ── cycle protection ───────────────────────────────────────────────────
+
+
+def test_objective_collapse_survives_parent_id_cycle() -> None:
+    # OBJ-A.parent_id = OBJ-B, OBJ-B.parent_id = OBJ-A → cycle
+    state = {
+        "objectives": [
+            _obj_dict("OBJ-A", parent_id="OBJ-B"),
+            _obj_dict("OBJ-B", parent_id="OBJ-A"),
+        ],
+        "engagement_name": "demo",
+        "threat_profile": "apt-x",
+        "workspace_path": None,  # skip persistence
+    }
+    # Must terminate (no RecursionError, no hang).
+    cmd = _call("objective_collapse", {"parent_id": "OBJ-A"}, state=state)
+    cancelled = {o["id"] for o in cmd.update["objectives"] if o["status"] == "cancelled"}
+    # OBJ-B is the descendant of OBJ-A; OBJ-A is itself the parent target.
+    assert "OBJ-B" in cancelled
+
+
+def test_format_opplan_for_agent_survives_parent_id_cycle() -> None:
+    objectives = [
+        _obj_dict("OBJ-A", parent_id="OBJ-B"),
+        _obj_dict("OBJ-B", parent_id="OBJ-A"),
+    ]
+    # Must not infinite-recurse — the call returns in finite time.
+    out = _format_opplan_for_agent(objectives, "demo", "apt-x")
+    assert "## Task Tree" in out
+    # The tree section appears once (we don't double-render the cycle).
+    tree_section = out.split("## Task Tree", 1)[1]
+    # Tree-line markers like "[ ]" should appear at most twice (once per node)
+    # and never more — without the visited-set guard this would be unbounded.
+    assert tree_section.count("[ ]") <= 2
+
+
+# ── after_model strict-sequential ──────────────────────────────────────
+
+
+def test_after_model_blocks_two_opplan_tools_in_same_step() -> None:
+    middleware = OPPLANMiddleware()
+    # Read tools must be blocked too (per the unified rule).
+    last_ai = AIMessage(
+        content="",
+        tool_calls=[
+            {"id": "tc-x", "name": "list_objectives", "args": {}, "type": "tool_call"},
+            {
+                "id": "tc-y",
+                "name": "get_objective",
+                "args": {"objective_id": "OBJ-1"},
+                "type": "tool_call",
+            },
+        ],
+    )
+    update = middleware.after_model({"messages": [last_ai]}, runtime=None)
+    assert update is not None
+    msgs = update["messages"]
+    assert len(msgs) == 2
+    assert all(isinstance(m, ToolMessage) and m.status == "error" for m in msgs)
+    assert all("sequentially" in str(m.content) for m in msgs)
+
+
+def test_after_model_allows_single_opplan_tool() -> None:
+    middleware = OPPLANMiddleware()
+    last_ai = AIMessage(
+        content="",
+        tool_calls=[
+            {"id": "tc-z", "name": "add_objective", "args": {}, "type": "tool_call"},
+        ],
+    )
+    assert middleware.after_model({"messages": [last_ai]}, runtime=None) is None
+
+
+def test_after_model_allows_opplan_alongside_non_opplan_tool() -> None:
+    """One OPPLAN call plus an unrelated tool (e.g. bash) is fine."""
+    middleware = OPPLANMiddleware()
+    last_ai = AIMessage(
+        content="",
+        tool_calls=[
+            {"id": "tc-1", "name": "add_objective", "args": {}, "type": "tool_call"},
+            {"id": "tc-2", "name": "bash", "args": {"command": "ls"}, "type": "tool_call"},
+        ],
+    )
+    assert middleware.after_model({"messages": [last_ai]}, runtime=None) is None
+
+
+def test_opplan_tool_names_constant_matches_registered_tools() -> None:
+    registered = {t.name for t in OPPLANMiddleware().tools}
+    assert registered == set(OPPLAN_TOOL_NAMES)
+
+
+# ── empty objectives renders correctly ─────────────────────────────────
+
+
+def test_format_opplan_status_empty_does_not_say_all_complete() -> None:
+    out = opplan_mod._format_opplan_status([], "demo", "apt-x")
+    assert "ALL OBJECTIVES COMPLETE" not in out
+    assert "No objectives defined" in out


### PR DESCRIPTION
## Summary
- Move OPPLAN, skill-loading, and filesystem tool-surface logic into decepticon/tools modules while keeping middleware focused on state, prompt injection, backend scoping, and hooks.
- Persist and load OPPLAN through the configured engagement filesystem/sandbox backend instead of direct host filesystem access.
- Harden sandbox notification middleware against backend/job-registry errors and cap notified job tracking.
- Update OPPLAN prompts/docstrings to match backend persistence and remove external tool-mapping terminology.

## Related issues
- Related to #153
- Builds on #183

## Tests
- uv run ruff check decepticon/middleware/opplan.py decepticon/tools/opplan.py decepticon/middleware/skills.py decepticon/tools/skills.py decepticon/middleware/filesystem.py decepticon/tools/filesystem.py tests/unit/middleware/test_opplan_persistence.py tests/unit/middleware/test_opplan_hierarchy.py
- uv run pytest tests/unit/middleware/test_opplan_persistence.py tests/unit/middleware/test_opplan_hierarchy.py tests/unit/middleware/test_filesystem.py -q

Note: full tests/unit was attempted but was stopped after a long-running section; targeted middleware coverage passed.