### PR TITLE
refactor(litellm): unified OAuth handlers + native ChatGPT custom handler

### DIFF
--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -234,7 +234,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 				Options(
 					huh.NewOption("Claude Code OAuth — Anthropic subscription (auth/*)", methodAnthropicOAuth),
 					huh.NewOption("Anthropic API Key — sk-ant-...", methodAnthropicAPI),
-					huh.NewOption("ChatGPT OAuth     — ChatGPT Pro/Plus/Team subscription (auth/gpt-*)", methodOpenAIOAuth),
+					huh.NewOption("ChatGPT OAuth     — ChatGPT Pro/Plus/Team subscription via `codex login` (auth/gpt-*)", methodOpenAIOAuth),
 					huh.NewOption("OpenAI API Key    — sk-...", methodOpenAIAPI),
 					huh.NewOption("Google API Key    — AIza... (Gemini)", methodGoogleAPI),
 					huh.NewOption("MiniMax API Key   — eyJ...", methodMiniMaxAPI),

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -105,6 +105,16 @@ func runStart(cmd *cobra.Command, args []string) error {
 		_ = os.Setenv("CLAUDE_CREDENTIALS_VOLUME", "/dev/null")
 	}
 
+	// Same pattern for the Codex CLI credential store at ~/.codex/auth.json.
+	// The new auth/ ChatGPT handler reads (and writes) this file directly so
+	// a host-side `codex login` flows into the container without a rebuild.
+	codexAuthPath := filepath.Join(os.Getenv("HOME"), ".codex", "auth.json")
+	if _, statErr := os.Stat(codexAuthPath); statErr == nil {
+		_ = os.Setenv("CODEX_AUTH_VOLUME", codexAuthPath)
+	} else {
+		_ = os.Setenv("CODEX_AUTH_VOLUME", "/dev/null")
+	}
+
 	// 2.5. Update notice. Applying updates is intentionally explicit via
 	// `decepticon update` because it can replace the binary, compose files,
 	// LiteLLM config, and Docker images.

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -277,15 +277,21 @@ func ValidateAPIKeys(env map[string]string) error {
 //     instead of a single session token. accept either env name.
 //   - Copilot Pro uses a refresh-token rotation (COPILOT_REFRESH_TOKEN)
 //     instead of a session cookie. Same fall-through, different env name.
-//   - ChatGPT uses LiteLLM's native chatgpt provider. It persists OAuth
-//     credentials as auth.json and can create that file via device-code login,
-//     so the launcher must not require a pasted browser session cookie.
+//   - ChatGPT uses Decepticon's auth/ handler reading the Codex CLI
+//     credential store at ~/.codex/auth.json. The launcher mounts that
+//     file into the container so a host-side `codex login` is visible
+//     to the running proxy without rebuilding.
+//
+// AbsolutePath is set for handlers that store a single credential file
+// at a fixed absolute path (rather than under ~/.config/<dir>/<file>).
+// When set, ConfigDir / TokenFile are ignored.
 type subscriptionMethod struct {
 	Toggle                string   // DECEPTICON_AUTH_<X> boolean enabling this path
 	TokenEnvs             []string // env vars that satisfy the path on their own
 	ConfigDir             string   // ~/.config/<dir>/<token file> fallback
 	TokenFile             string   // token file name; defaults to tokens.json
 	DirEnv                string   // optional host-side token directory env var
+	AbsolutePath          string   // optional fixed-relative-to-$HOME path (e.g. .codex/auth.json)
 	LegacyDir             string   // optional legacy ~/.config/<dir>/<token file> fallback
 	Label                 string   // human name for error messages
 	AllowInteractiveLogin bool     // provider can bootstrap credentials at runtime
@@ -294,9 +300,7 @@ type subscriptionMethod struct {
 var oauthSubscriptions = map[string]subscriptionMethod{
 	"chatgpt": {
 		Toggle:                "DECEPTICON_AUTH_CHATGPT",
-		ConfigDir:             "litellm/chatgpt",
-		TokenFile:             "auth.json",
-		DirEnv:                "LITELLM_CHATGPT_TOKEN_DIR",
+		AbsolutePath:          ".codex/auth.json",
 		Label:                 "ChatGPT",
 		AllowInteractiveLogin: true,
 	},
@@ -513,6 +517,12 @@ func validateSubscriptionCredentials(env map[string]string, sub subscriptionMeth
 
 func subscriptionTokenPaths(env map[string]string, home string, sub subscriptionMethod) []string {
 	var paths []string
+	if sub.AbsolutePath != "" {
+		// Single-file handler (e.g. ChatGPT → ~/.codex/auth.json).
+		// ConfigDir / TokenFile / LegacyDir do not apply.
+		paths = append(paths, filepath.Join(home, sub.AbsolutePath))
+		return dedupeStrings(paths)
+	}
 	tokenFile := sub.TokenFile
 	if tokenFile == "" {
 		tokenFile = "tokens.json"

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -207,30 +207,13 @@ func TestValidateAuth_ChatGPTNativeOAuth(t *testing.T) {
 		}
 	})
 
-	t.Run("uses litellm auth.json path", func(t *testing.T) {
+	t.Run("uses codex auth.json path", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		got := subscriptionTokenPaths(map[string]string{}, home, oauthSubscriptions["chatgpt"])
-		want := []string{filepath.Join(home, ".config", "litellm", "chatgpt", "auth.json")}
+		want := []string{filepath.Join(home, ".codex", "auth.json")}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("unexpected ChatGPT token paths: got %v want %v", got, want)
-		}
-	})
-
-	t.Run("custom host token dir uses auth.json", func(t *testing.T) {
-		home := t.TempDir()
-		t.Setenv("HOME", home)
-		customDir := filepath.Join(home, "custom-chatgpt")
-		env := map[string]string{
-			"LITELLM_CHATGPT_TOKEN_DIR": customDir,
-		}
-		got := subscriptionTokenPaths(env, home, oauthSubscriptions["chatgpt"])
-		want := []string{
-			filepath.Join(customDir, "auth.json"),
-			filepath.Join(home, ".config", "litellm", "chatgpt", "auth.json"),
-		}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("unexpected custom ChatGPT token paths: got %v want %v", got, want)
 		}
 	})
 }

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -134,19 +134,15 @@ DECEPTICON_AUTH_PRIORITY=
 DECEPTICON_AUTH_CLAUDE_CODE=false
 
 # --- ChatGPT OAuth (subscription) ---
-# Set true to route OpenAI models through the ChatGPT subscription handler
-# (auth/gpt-* in LiteLLM) instead of the API-key path. Requires one of:
-#   - CHATGPT_SESSION_TOKEN below (browser cookie), OR
-#   - CHATGPT_ACCESS_TOKEN env var (pre-extracted Bearer), OR
-#   - ~/.config/chatgpt/tokens.json file
+# Set true to route OpenAI models through the Decepticon auth/ ChatGPT
+# handler (auth/gpt-* in LiteLLM) instead of the API-key path.
+#
+# Credentials come from the Codex CLI at ~/.codex/auth.json. Run
+# `codex login` once on the host to populate it; the launcher mounts
+# the file into the LiteLLM container automatically. The handler reads
+# and writes that same file, so refreshes on either side stay in sync
+# without a container rebuild.
 DECEPTICON_AUTH_CHATGPT=false
-
-# Session token from a signed-in chatgpt.com browser session:
-#   1. Open chatgpt.com and sign in
-#   2. DevTools → Application → Cookies → chatgpt.com
-#   3. Copy the value of `__Secure-next-auth.session-token`
-# The onboard wizard prompts for this when ChatGPT OAuth is selected.
-CHATGPT_SESSION_TOKEN=
 
 # --- Other OAuth subscriptions (set true + provide one credential each) ---
 # All are selectable from the onboard wizard. Each handler walks the same

--- a/config/auth_handler.py
+++ b/config/auth_handler.py
@@ -1,0 +1,89 @@
+"""Auth provider dispatcher for ``auth/`` model slugs.
+
+Routes incoming requests to the correct subscription handler based on the
+slug after ``auth/``:
+
+  - ``auth/claude-*``  → claude_code_handler  (Claude Code OAuth)
+  - ``auth/gpt-*``     → codex_chatgpt_handler (Codex CLI / ChatGPT OAuth)
+
+Adding a new subscription provider is one line in ``_PREFIX_HANDLERS``.
+
+This module is mounted into the LiteLLM container alongside the per-provider
+handler files. It replaces the inline ``_select_auth_handler`` /
+``_AuthDispatcher`` previously living at the top of ``litellm_startup.py``,
+so the dispatch table is now testable in isolation and grows without
+touching startup glue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Iterator
+from typing import Any
+
+import litellm
+from claude_code_handler import claude_code_handler_instance
+from codex_chatgpt_handler import codex_chatgpt_handler_instance
+from litellm import CustomLLM, ModelResponse
+
+# Prefix → handler. Order matters only for documentation; lookup is exact.
+_PREFIX_HANDLERS: list[tuple[str, CustomLLM]] = [
+    ("claude-", claude_code_handler_instance),
+    ("gpt-", codex_chatgpt_handler_instance),
+]
+
+
+def _select_auth_handler(model: str) -> CustomLLM:
+    """Resolve a ``auth/<slug>`` model name to its subscription handler."""
+    slug = model.split("/", 1)[-1] if "/" in model else model
+    slug_lower = slug.lower()
+    for prefix, handler in _PREFIX_HANDLERS:
+        if slug_lower.startswith(prefix):
+            return handler
+    supported = ", ".join(f"{p}*" for p, _ in _PREFIX_HANDLERS)
+    raise litellm.BadRequestError(
+        message=(
+            f"auth/ provider: model slug {slug!r} did not match any known "
+            f"subscription handler. Supported prefixes: {supported}."
+        ),
+        model=model,
+        llm_provider="auth",
+    )
+
+
+def _model_arg(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    """Extract the ``model`` argument from a CustomLLM dispatch call.
+
+    LiteLLM passes the model either positionally (first arg) or by keyword
+    depending on the call site. The dispatcher needs the model to choose a
+    handler, so it accepts both shapes.
+    """
+    return kwargs.get("model") or (args[0] if args else "")
+
+
+class AuthDispatcher(CustomLLM):
+    """Dispatch ``auth/`` requests to the right per-provider handler."""
+
+    def completion(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return _select_auth_handler(_model_arg(args, kwargs)).completion(*args, **kwargs)
+
+    async def acompletion(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return await _select_auth_handler(_model_arg(args, kwargs)).acompletion(*args, **kwargs)
+
+    def streaming(self, *args: Any, **kwargs: Any) -> Iterator[dict[str, Any]]:
+        handler = _select_auth_handler(_model_arg(args, kwargs))
+        result: Callable[..., Iterator[dict[str, Any]]] = handler.streaming
+        return result(*args, **kwargs)
+
+    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:
+        handler = _select_auth_handler(_model_arg(args, kwargs))
+        async for chunk in handler.astreaming(*args, **kwargs):
+            yield chunk
+
+
+auth_handler_instance = AuthDispatcher()
+
+
+__all__ = [
+    "AuthDispatcher",
+    "auth_handler_instance",
+]

--- a/config/claude_code_handler.py
+++ b/config/claude_code_handler.py
@@ -11,7 +11,8 @@ auto-refreshes expired tokens, and spoofs Claude Code request headers
 so requests are indistinguishable from the native CLI.
 
 This file is mounted into the LiteLLM container alongside litellm.yaml.
-No dependency on the ``decepticon`` package.
+No dependency on the ``decepticon`` package — it depends only on the
+shared ``oauth_token_store`` helper module mounted alongside it.
 
 Registration in litellm.yaml:
   litellm_settings:
@@ -33,6 +34,15 @@ from urllib.parse import urlparse
 import httpx
 import litellm
 from litellm import CustomLLM, ModelResponse
+from oauth_token_store import (
+    DEFAULT_REFRESH_BUFFER_SECONDS,
+    FileBackedCache,
+    is_timestamp_expired,
+    oauth_refresh_request,
+    read_json_file,
+    with_retry_on_401,
+    write_json_atomic,
+)
 
 # ── Token storage ────────────────────────────────────────────────────
 
@@ -46,14 +56,11 @@ CREDENTIALS_PATH = Path(
 )
 LEGACY_CREDENTIALS_PATH = Path(os.path.expanduser("~/.config/anthropic/q/tokens.json"))
 
-REFRESH_BUFFER_SECONDS = 5 * 60
 TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 ANTHROPIC_API_BASE = "https://api.anthropic.com"
 CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 OAUTH_TOKEN_PATTERN = "sk-ant-oat01-"
-
-_cached_token: dict[str, Any] | None = None
 
 
 def _is_valid_oauth_token(token: str) -> bool:
@@ -61,15 +68,58 @@ def _is_valid_oauth_token(token: str) -> bool:
     return isinstance(token, str) and token.startswith(OAUTH_TOKEN_PATTERN)
 
 
-def _load_tokens() -> dict[str, Any] | None:
-    """Load tokens following the same resolution order as the reference impl.
+def _normalize_credentials(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull a usable token dict out of Claude Code's on-disk shapes.
 
-    Resolution order (matching not-claude-code-emulator):
-      1. ``ANTHROPIC_OAUTH_TOKEN`` environment variable
-      2. ``~/.claude/.credentials.json`` (Claude Code CLI current format)
-      3. ``~/.config/anthropic/q/tokens.json`` (legacy / emulator format)
+    Resolution order matches the original handler:
+      1. ``claudeAiOauth`` nested object (current Claude Code CLI format).
+      2. Top-level ``accessToken`` (legacy).
+      3. Top-level ``oauthToken`` (emulator format) — copied to
+         ``accessToken`` so downstream code only checks one key.
     """
-    # 1. Environment variable
+    if "claudeAiOauth" in raw:
+        oauth = raw["claudeAiOauth"]
+        if isinstance(oauth, dict) and _is_valid_oauth_token(oauth.get("accessToken", "")):
+            return oauth
+    token = raw.get("accessToken") or raw.get("oauthToken", "")
+    if _is_valid_oauth_token(token):
+        if "oauthToken" in raw and "accessToken" not in raw:
+            raw["accessToken"] = raw["oauthToken"]
+        return raw
+    return None
+
+
+def _load_credentials_from_disk(path: Path) -> dict[str, Any] | None:
+    """FileBackedCache loader — probes the primary path first, then legacy.
+
+    The cache is keyed on ``CREDENTIALS_PATH`` mtime+size. When that file
+    is absent we fall through to ``LEGACY_CREDENTIALS_PATH`` so emulators
+    that still write the legacy format keep working — but the cache key
+    will be ``None`` (no stat tuple), which means each call re-reads the
+    legacy file. That's acceptable: the legacy path is uncommon and the
+    parse cost is trivial.
+    """
+    raw = read_json_file(path)
+    if raw is not None:
+        normalized = _normalize_credentials(raw)
+        if normalized is not None:
+            return normalized
+    if path != LEGACY_CREDENTIALS_PATH and LEGACY_CREDENTIALS_PATH.exists():
+        legacy = read_json_file(LEGACY_CREDENTIALS_PATH)
+        if legacy is not None:
+            return _normalize_credentials(legacy)
+    return None
+
+
+_credentials_cache = FileBackedCache(CREDENTIALS_PATH, _load_credentials_from_disk)
+
+
+def _env_override_tokens() -> dict[str, Any] | None:
+    """Honor ``ANTHROPIC_OAUTH_TOKEN`` as a synthetic credentials dict.
+
+    The synthetic dict carries ``expiresAt: 0`` so ``is_timestamp_expired``
+    returns False and the refresh path never fires for env-provided tokens.
+    """
     env_token = os.environ.get("ANTHROPIC_OAUTH_TOKEN", "").strip()
     if env_token and _is_valid_oauth_token(env_token):
         return {
@@ -78,52 +128,30 @@ def _load_tokens() -> dict[str, Any] | None:
             "expiresAt": 0,  # No expiry info — never auto-refresh
             "scopes": ["user:inference"],
         }
-
-    # 2+3. File-based stores
-    for path in (CREDENTIALS_PATH, LEGACY_CREDENTIALS_PATH):
-        if not path.exists():
-            continue
-        try:
-            raw = json.loads(path.read_text())
-            # Current format: nested under claudeAiOauth
-            if "claudeAiOauth" in raw:
-                oauth = raw["claudeAiOauth"]
-                if _is_valid_oauth_token(oauth.get("accessToken", "")):
-                    return oauth
-            # Legacy format: top-level accessToken or oauthToken
-            token = raw.get("accessToken") or raw.get("oauthToken", "")
-            if _is_valid_oauth_token(token):
-                if "oauthToken" in raw and "accessToken" not in raw:
-                    raw["accessToken"] = raw["oauthToken"]
-                return raw
-        except (json.JSONDecodeError, OSError):
-            continue
     return None
 
 
-def _is_expired(tokens: dict[str, Any]) -> bool:
-    """Check if token is expired or near expiry."""
-    expires_at = tokens.get("expiresAt", 0)
-    # expiresAt may be in milliseconds (Claude Code CLI format) or seconds
-    if expires_at > 1e12:
-        expires_at = expires_at / 1000
-    return time.time() + REFRESH_BUFFER_SECONDS >= expires_at
+def _load_tokens() -> dict[str, Any] | None:
+    """Resolve a tokens dict using env override → cache → legacy fallback."""
+    env_dict = _env_override_tokens()
+    if env_dict is not None:
+        return env_dict
+    return _credentials_cache.get()
 
 
 def _refresh_token(tokens: dict[str, Any]) -> dict[str, Any]:
-    """Synchronously refresh an expired token."""
-    resp = httpx.post(
+    """Synchronously refresh an expired token via the platform OAuth endpoint."""
+    data = oauth_refresh_request(
         TOKEN_URL,
-        json={
+        {
             "grant_type": "refresh_token",
             "refresh_token": tokens["refreshToken"],
             "client_id": CLIENT_ID,
         },
-        headers={"content-type": "application/json"},
+        json_body=True,
         timeout=30,
+        provider_label="auth",
     )
-    resp.raise_for_status()
-    data = resp.json()
 
     new_tokens = {
         "accessToken": data["access_token"],
@@ -133,28 +161,31 @@ def _refresh_token(tokens: dict[str, Any]) -> dict[str, Any]:
         "updatedAt": int(time.time() * 1000),
     }
 
-    # Save refreshed tokens
-    try:
-        CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        CREDENTIALS_PATH.write_text(json.dumps(new_tokens, indent=2))
-        os.chmod(CREDENTIALS_PATH, 0o600)
-    except OSError:
-        pass  # Read-only mount — token will be refreshed again next call
-
+    # Persist atomically. The store handles read-only mounts internally;
+    # the cache replace keeps the in-process token current for the rest
+    # of the container session even when the on-disk write fails.
+    write_json_atomic(CREDENTIALS_PATH, new_tokens)
+    _credentials_cache.replace(new_tokens)
     return new_tokens
 
 
-def get_access_token() -> str:
-    """Get a valid access token, refreshing if needed.
+def get_access_token(force_refresh: bool = False) -> str:
+    """Return a valid access token, refreshing on demand.
 
-    When the cached token is expired, re-read from disk first — Claude Code
-    CLI continuously refreshes tokens in ~/.claude/.credentials.json, so a
-    fresh token may already be available without needing to call the refresh
-    endpoint ourselves.
+    Resolution order:
+      1. ``ANTHROPIC_OAUTH_TOKEN`` env override (never refreshed).
+      2. Cached / on-disk tokens; if expired or ``force_refresh`` is True,
+         call the platform refresh endpoint and persist the new tokens.
+
+    ``force_refresh`` is set by the 401 retry wrapper when the upstream
+    rejects a previously-cached token. We bypass the timestamp check in
+    that case because the wallclock TTL may be ahead of the server's
+    revocation state.
     """
-    global _cached_token  # noqa: PLW0603
+    if force_refresh:
+        _credentials_cache.invalidate()
 
-    tokens = _cached_token or _load_tokens()
+    tokens = _load_tokens()
     if tokens is None:
         raise litellm.AuthenticationError(
             message="No Claude Code OAuth tokens found. Run 'decepticon onboard' to authenticate.",
@@ -162,15 +193,22 @@ def get_access_token() -> str:
             llm_provider="auth",
         )
 
-    if _is_expired(tokens):
-        # Re-read from disk — Claude Code may have already refreshed the token
+    # ANTHROPIC_OAUTH_TOKEN override carries expiresAt=0 → never expires.
+    if force_refresh and tokens.get("refreshToken"):
+        tokens = _refresh_token(tokens)
+    elif is_timestamp_expired(
+        tokens.get("expiresAt"), buffer_seconds=DEFAULT_REFRESH_BUFFER_SECONDS
+    ):
+        # Re-read from disk — Claude Code may have already refreshed the token.
+        _credentials_cache.invalidate()
         fresh = _load_tokens()
-        if fresh and not _is_expired(fresh):
+        if fresh is not None and not is_timestamp_expired(
+            fresh.get("expiresAt"), buffer_seconds=DEFAULT_REFRESH_BUFFER_SECONDS
+        ):
             tokens = fresh
-        else:
+        elif tokens.get("refreshToken"):
             tokens = _refresh_token(tokens)
 
-    _cached_token = tokens
     return tokens["accessToken"]
 
 
@@ -263,8 +301,6 @@ class ClaudeCodeCustomHandler(CustomLLM):
         Authorization: Bearer header + Claude Code spoofing headers.
         This makes the request indistinguishable from a real Claude Code session.
         """
-        access_token = get_access_token()
-
         # Extract actual Anthropic model ID
         # "auth/claude-sonnet-4-6" -> "claude-sonnet-4-6"
         actual_model = model.split("/", 1)[-1] if "/" in model else model
@@ -460,18 +496,31 @@ class ClaudeCodeCustomHandler(CustomLLM):
 
         body_str = json.dumps(request_body)
 
-        # Build headers — OAuth Bearer (NOT x-api-key)
-        req_headers = _build_headers(access_token)
-
         # Direct HTTP call to Anthropic Messages API. Never honor arbitrary
         # api_base values here: this request carries an OAuth bearer token.
         api_url = _resolve_anthropic_api_base(api_base)
-        resp = httpx.post(
-            f"{api_url}/v1/messages?beta=true",
-            content=body_str,
-            headers=req_headers,
-            timeout=timeout or 600,
-        )
+
+        def _send(force_refresh: bool) -> httpx.Response:
+            access_token = get_access_token(force_refresh=force_refresh)
+            req_headers = _build_headers(access_token)
+            return httpx.post(
+                f"{api_url}/v1/messages?beta=true",
+                content=body_str,
+                headers=req_headers,
+                timeout=timeout or 600,
+            )
+
+        resp = with_retry_on_401(_send)
+
+        if resp.status_code == 401:
+            raise litellm.AuthenticationError(
+                message=(
+                    "Claude Code authentication was rejected. Run 'claude /login' "
+                    f"and retry. Underlying: {resp.text}"
+                ),
+                model=model,
+                llm_provider="auth",
+            )
 
         if resp.status_code == 429:
             # Parse retry-after header (seconds or milliseconds)

--- a/config/codex_chatgpt_handler.py
+++ b/config/codex_chatgpt_handler.py
@@ -1,0 +1,568 @@
+"""LiteLLM custom handler for Codex / ChatGPT OAuth authentication.
+
+Uses the Codex CLI credential store as the source of truth:
+``~/.codex/auth.json`` (or ``CODEX_AUTH_PATH`` / ``CODEX_HOME``). Unlike
+LiteLLM's native ``chatgpt`` provider — which keeps a parallel store at
+``~/.config/litellm/chatgpt/auth.json`` and requires a manual ``codex
+login`` re-import — this handler reads and writes the same file Codex CLI
+itself uses, so a refresh on either side is visible to both.
+
+Key behaviors:
+  - ``FileBackedCache`` watches ``auth.json`` mtime so a host-side
+    ``codex login`` is picked up by the running container without restart.
+  - Refreshes are written back atomically (temp + rename, 0o600) so a
+    racing host reader never sees a partial file.
+  - 401 from chatgpt.com triggers a single forced refresh + replay; if the
+    second attempt also 401s, raise ``AuthenticationError`` with the
+    response body so the user knows to rerun ``codex login``.
+
+Registration: dispatched from ``auth_handler.py`` via the ``auth/gpt-*``
+model prefix.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import litellm
+from litellm import CustomLLM, ModelResponse
+from oauth_token_store import (
+    DEFAULT_JWT_SKEW_SECONDS,
+    FileBackedCache,
+    decode_jwt_payload,
+    is_jwt_expired,
+    oauth_refresh_request,
+    read_json_file,
+    with_retry_on_401,
+    write_json_atomic,
+)
+
+CHATGPT_AUTH_BASE = "https://auth.openai.com"
+CHATGPT_OAUTH_TOKEN_URL = f"{CHATGPT_AUTH_BASE}/oauth/token"
+CHATGPT_API_BASE = "https://chatgpt.com/backend-api/codex"
+CHATGPT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+DEFAULT_ORIGINATOR = "codex_cli_rs"
+DEFAULT_USER_AGENT = "codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown"
+
+
+def _codex_auth_path() -> Path:
+    explicit = os.environ.get("CODEX_AUTH_PATH", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    codex_home = os.environ.get("CODEX_HOME", "").strip()
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json"
+    return Path(os.path.expanduser("~/.codex/auth.json"))
+
+
+def _required_token_fields() -> tuple[str, ...]:
+    return ("access_token", "refresh_token", "id_token")
+
+
+def _validate_auth(raw: dict[str, Any], path: Path) -> dict[str, Any]:
+    tokens = raw.get("tokens")
+    if not isinstance(tokens, dict) or not all(tokens.get(k) for k in _required_token_fields()):
+        raise litellm.AuthenticationError(
+            message=(
+                f"Codex ChatGPT credentials at {path} are missing "
+                "tokens.access_token, tokens.refresh_token, or tokens.id_token. "
+                "Run 'codex login'."
+            ),
+            model="auth",
+            llm_provider="auth",
+        )
+    return raw
+
+
+def _load_codex_auth(path: Path) -> dict[str, Any] | None:
+    """Loader for FileBackedCache. Validates structure, returns None if missing.
+
+    The cache layer translates a None return into a re-read on the next
+    call. We raise AuthenticationError only when a present file is
+    malformed — a missing file is recoverable by the user running
+    ``codex login`` while the container keeps running.
+    """
+    raw = read_json_file(path)
+    if raw is None:
+        return None
+    return _validate_auth(raw, path)
+
+
+_auth_cache = FileBackedCache(_codex_auth_path(), _load_codex_auth)
+
+
+def _read_auth() -> dict[str, Any]:
+    auth = _auth_cache.get()
+    if auth is None:
+        path = _codex_auth_path()
+        raise litellm.AuthenticationError(
+            message=f"Codex ChatGPT credentials not found at {path}. Run 'codex login'.",
+            model="auth",
+            llm_provider="auth",
+        )
+    return auth
+
+
+def _write_auth(auth: dict[str, Any]) -> None:
+    """Persist auth back to the Codex CLI store and refresh the cache key."""
+    path = _codex_auth_path()
+    write_json_atomic(path, auth)
+    # Even if the on-disk write failed (read-only mount), keep the
+    # in-process cache up to date so the rest of the container session
+    # uses the refreshed token.
+    _auth_cache.replace(auth)
+
+
+def _extract_account_id(id_token: str | None, access_token: str | None) -> str | None:
+    for token in (id_token, access_token):
+        auth_claims = decode_jwt_payload(token).get("https://api.openai.com/auth")
+        if isinstance(auth_claims, dict):
+            account_id = auth_claims.get("chatgpt_account_id")
+            if isinstance(account_id, str) and account_id:
+                return account_id
+    return None
+
+
+def _refresh_tokens(auth: dict[str, Any]) -> dict[str, Any]:
+    tokens = auth["tokens"]
+    data = oauth_refresh_request(
+        CHATGPT_OAUTH_TOKEN_URL,
+        {
+            "client_id": CHATGPT_CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": tokens["refresh_token"],
+            "scope": "openid profile email",
+        },
+        provider_label="auth",
+    )
+    access_token = data.get("access_token")
+    id_token = data.get("id_token")
+    if not access_token or not id_token:
+        raise litellm.AuthenticationError(
+            message=f"Codex ChatGPT refresh response missing fields: {data}",
+            model="auth",
+            llm_provider="auth",
+        )
+
+    tokens["access_token"] = access_token
+    tokens["id_token"] = id_token
+    tokens["refresh_token"] = data.get("refresh_token", tokens["refresh_token"])
+    account_id = _extract_account_id(id_token, access_token)
+    if account_id:
+        tokens["account_id"] = account_id
+    auth["auth_mode"] = "chatgpt"
+    auth["last_refresh"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    _write_auth(auth)
+    return auth
+
+
+def get_codex_access_token(force_refresh: bool = False) -> tuple[str, str | None]:
+    """Return ``(access_token, account_id)`` ready for header injection."""
+    auth = _read_auth()
+    token = auth["tokens"]["access_token"]
+    if force_refresh or is_jwt_expired(token, skew_seconds=DEFAULT_JWT_SKEW_SECONDS):
+        auth = _refresh_tokens(auth)
+        token = auth["tokens"]["access_token"]
+    tokens = auth["tokens"]
+    account_id = tokens.get("account_id") or _extract_account_id(tokens.get("id_token"), token)
+    return token, account_id
+
+
+def _headers(access_token: str, account_id: str | None) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "content-type": "application/json",
+        "accept": "text/event-stream",
+        "originator": os.environ.get("CHATGPT_ORIGINATOR", DEFAULT_ORIGINATOR),
+        "user-agent": os.environ.get("CHATGPT_USER_AGENT", DEFAULT_USER_AGENT),
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    return headers
+
+
+def _message_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                text = block.get("text") or block.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return str(content)
+
+
+def _responses_input(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str | None]:
+    input_items: list[dict[str, Any]] = []
+    instructions: list[str] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "system":
+            text = _message_text(msg.get("content"))
+            if text:
+                instructions.append(text)
+            continue
+        if role == "tool":
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.get("tool_call_id") or "tool_call",
+                    "output": _message_text(msg.get("content")),
+                }
+            )
+            continue
+        if role == "assistant" and msg.get("tool_calls"):
+            for tc in msg.get("tool_calls") or []:
+                func = tc.get("function", {}) if isinstance(tc, dict) else {}
+                input_items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tc.get("id") or f"call_{func.get('name', 'tool')}",
+                        "name": func.get("name") or tc.get("name") or "tool",
+                        "arguments": func.get("arguments") or json.dumps(tc.get("args", {})),
+                    }
+                )
+            continue
+        mapped_role = "assistant" if role == "assistant" else "user"
+        input_items.append({"role": mapped_role, "content": _message_text(msg.get("content"))})
+    return input_items, "\n\n".join(instructions) if instructions else None
+
+
+def _responses_tools(tools: Any) -> list[dict[str, Any]] | None:
+    if not tools:
+        return None
+    out = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            fn = tool["function"]
+            out.append(
+                {
+                    "type": "function",
+                    "name": fn.get("name", ""),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+                }
+            )
+        else:
+            out.append(tool)
+    return out
+
+
+def _upstream_model_slug(model: str) -> str:
+    """Translate a LiteLLM-side model id back to the chatgpt.com model slug.
+
+    Two routes lead here:
+
+      - ``auth/gpt-*``  — handler dispatched directly via auth_handler.
+        Slug is already the upstream name.
+      - ``codex-oauth/oauth-gpt-*`` — dynamic-config alias. The ``oauth-``
+        sentinel exists only to dodge LiteLLM's
+        ``open_ai_chat_completion_models`` short-circuit in main.py:2561,
+        which would otherwise route ``gpt-*`` straight to api.openai.com.
+        Strip it here so chatgpt.com receives the canonical ``gpt-*``.
+    """
+    slug = model.split("/", 1)[-1] if "/" in model else model
+    if slug.startswith("oauth-"):
+        slug = slug.removeprefix("oauth-")
+    return slug
+
+
+def _request_body(
+    model: str, messages: list[dict[str, Any]], optional_params: dict[str, Any] | None
+) -> dict[str, Any]:
+    opts = optional_params or {}
+    input_items, instructions = _responses_input(messages)
+    # ChatGPT Codex Responses API requires ``instructions`` to be present
+    # — sending an empty string or omitting the field both 400 with
+    # ``Instructions are required``. Default to a minimal Codex CLI
+    # prompt so requests without a system message still go through.
+    if not instructions:
+        instructions = "You are Codex, a coding assistant for the terminal."
+    body: dict[str, Any] = {
+        "model": _upstream_model_slug(model),
+        "input": input_items,
+        "stream": True,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+        "instructions": instructions,
+    }
+    tools = _responses_tools(opts.get("tools"))
+    if tools:
+        body["tools"] = tools
+    if opts.get("tool_choice"):
+        body["tool_choice"] = opts["tool_choice"]
+    if opts.get("reasoning"):
+        body["reasoning"] = opts["reasoning"]
+    return body
+
+
+def _completed_payload(resp: httpx.Response) -> dict[str, Any]:
+    """Walk the SSE stream and return the ``response.completed`` payload.
+
+    The Codex backend often returns a ``response.completed`` event whose
+    ``output`` array is empty even when the assistant produced text — the
+    actual content is streamed in ``response.output_text.delta`` events
+    instead. We aggregate those deltas (and ``function_call_arguments.delta``
+    chunks) so the downstream parser sees a normal Responses-API output
+    array regardless of which path the backend used.
+    """
+    error_message: str | None = None
+    completed: dict[str, Any] | None = None
+    text_parts: list[str] = []
+    function_calls: dict[str, dict[str, Any]] = {}
+
+    for raw_line in resp.text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line.removeprefix("data:").strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            event = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+        event_type = event.get("type")
+        if event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                text_parts.append(delta)
+        elif event_type == "response.function_call_arguments.delta":
+            call_id = event.get("item_id") or event.get("call_id") or "tool_call"
+            entry = function_calls.setdefault(
+                call_id,
+                {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": event.get("name") or "",
+                    "arguments": "",
+                },
+            )
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                entry["arguments"] += delta
+        elif event_type == "response.completed" and isinstance(event.get("response"), dict):
+            completed = event["response"]
+        elif event_type in {"response.failed", "error"}:
+            err = event.get("error") or (event.get("response") or {}).get("error")
+            error_message = err.get("message") if isinstance(err, dict) else str(err)
+
+    if completed is not None:
+        # Backfill output when the upstream sent an empty ``output`` array
+        # but streamed text/tool deltas we aggregated above. Existing
+        # entries take precedence so non-empty completed payloads pass
+        # through unchanged.
+        existing = completed.get("output") or []
+        if not existing:
+            synthesized: list[dict[str, Any]] = []
+            text = "".join(text_parts)
+            if text:
+                synthesized.append(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": text}],
+                    }
+                )
+            synthesized.extend(function_calls.values())
+            if synthesized:
+                completed["output"] = synthesized
+        return completed
+
+    raise litellm.APIError(
+        status_code=resp.status_code,
+        message=error_message or resp.text,
+        model="auth",
+        llm_provider="auth",
+    )
+
+
+def _model_response(model: str, payload: dict[str, Any]) -> ModelResponse:
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for item in payload.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "message":
+            for block in item.get("content") or []:
+                if isinstance(block, dict) and block.get("type") in {"output_text", "text"}:
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        text_parts.append(text)
+        elif item.get("type") == "function_call":
+            tool_calls.append(
+                {
+                    "id": item.get("call_id") or item.get("id") or f"call_{len(tool_calls)}",
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", "{}"),
+                    },
+                }
+            )
+    message: dict[str, Any] = {"role": "assistant", "content": "\n".join(text_parts) or None}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    usage = payload.get("usage") or {}
+    input_tokens = usage.get("input_tokens", 0) or 0
+    output_tokens = usage.get("output_tokens", 0) or 0
+    return ModelResponse(
+        id=payload.get("id", f"chatcmpl-{model}"),
+        model=model,
+        choices=[
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ],
+        usage={
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": usage.get("total_tokens", input_tokens + output_tokens),
+        },
+    )
+
+
+class CodexChatGPTCustomHandler(CustomLLM):
+    """LiteLLM custom handler for ``auth/gpt-*`` routes."""
+
+    def completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        api_base: str | None = None,
+        custom_prompt_dict: dict[str, Any] | None = None,
+        model_response: ModelResponse | None = None,
+        print_verbose: Any = None,
+        encoding: Any = None,
+        logging_obj: Any = None,
+        optional_params: dict[str, Any] | None = None,
+        acompletion: bool | None = None,
+        timeout: float | None = None,
+        litellm_params: dict[str, Any] | None = None,
+        logger_fn: Any = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        body = _request_body(model, messages, optional_params)
+        api_root = (api_base or os.environ.get("CHATGPT_API_BASE") or CHATGPT_API_BASE).rstrip("/")
+
+        def _send(force_refresh: bool) -> httpx.Response:
+            access_token, account_id = get_codex_access_token(force_refresh=force_refresh)
+            return httpx.post(
+                f"{api_root}/responses",
+                json=body,
+                headers={**_headers(access_token, account_id), **(headers or {})},
+                timeout=timeout or 600,
+            )
+
+        resp = with_retry_on_401(_send)
+        if resp.status_code == 401:
+            raise litellm.AuthenticationError(
+                message=(
+                    "Codex ChatGPT authentication was rejected. Run 'codex logout' "
+                    f"and 'codex login'. Underlying: {resp.text}"
+                ),
+                model=model,
+                llm_provider="auth",
+            )
+        if resp.status_code >= 400:
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=f"ChatGPT Codex API error: {resp.text}",
+                model=model,
+                llm_provider="auth",
+            )
+        return _model_response(model, _completed_payload(resp))
+
+    async def acompletion(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        import asyncio
+        import functools
+
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, functools.partial(self.completion, *args, **kwargs))
+
+    def _response_to_chunks(self, response: ModelResponse) -> list[dict[str, Any]]:
+        choice = response.choices[0]
+        msg = choice.message if hasattr(choice, "message") else choice.get("message", {})
+        content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", "")
+        raw_tool_calls = (
+            msg.get("tool_calls", []) if isinstance(msg, dict) else getattr(msg, "tool_calls", [])
+        )
+        usage = {
+            "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
+            "completion_tokens": response.usage.completion_tokens if response.usage else 0,
+            "total_tokens": response.usage.total_tokens if response.usage else 0,
+        }
+        if raw_tool_calls:
+            chunks = []
+            if content:
+                chunks.append(
+                    {
+                        "text": content,
+                        "is_finished": False,
+                        "finish_reason": "",
+                        "index": 0,
+                        "tool_use": None,
+                        "usage": None,
+                    }
+                )
+            for index, tool_call in enumerate(raw_tool_calls):
+                if not isinstance(tool_call, dict):
+                    tool_call = {
+                        "id": getattr(tool_call, "id", f"call_{index}"),
+                        "type": "function",
+                        "function": getattr(tool_call, "function", {}),
+                    }
+                chunks.append(
+                    {
+                        "text": "",
+                        "is_finished": index == len(raw_tool_calls) - 1,
+                        "finish_reason": "tool_calls" if index == len(raw_tool_calls) - 1 else "",
+                        "index": 0,
+                        "tool_use": {**tool_call, "index": index},
+                        "usage": usage if index == len(raw_tool_calls) - 1 else None,
+                    }
+                )
+            return chunks
+        return [
+            {
+                "text": content or "",
+                "is_finished": True,
+                "finish_reason": choice.get("finish_reason", "stop")
+                if isinstance(choice, dict)
+                else getattr(choice, "finish_reason", "stop"),
+                "index": 0,
+                "tool_use": None,
+                "usage": usage,
+            }
+        ]
+
+    def streaming(self, *args: Any, **kwargs: Any) -> Iterator[dict[str, Any]]:
+        yield from self._response_to_chunks(self.completion(*args, **kwargs))
+
+    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:
+        response = await self.acompletion(*args, **kwargs)
+        for chunk in self._response_to_chunks(response):
+            yield chunk
+
+
+codex_chatgpt_handler_instance = CodexChatGPTCustomHandler()

--- a/config/copilot_handler.py
+++ b/config/copilot_handler.py
@@ -31,10 +31,8 @@ slug after ``copilot/`` is forwarded verbatim as the upstream model id.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import time
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
@@ -42,6 +40,13 @@ from typing import Any
 import httpx
 import litellm
 from litellm import CustomLLM, ModelResponse
+from oauth_token_store import (
+    DEFAULT_REFRESH_BUFFER_SECONDS,
+    FileBackedCache,
+    is_timestamp_expired,
+    read_json_file,
+    with_retry_on_401,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -58,7 +63,6 @@ COPILOT_PLUGIN_HOSTS = Path(os.path.expanduser("~/.config/github-copilot/hosts.j
 
 GITHUB_TOKEN_MINT_URL = "https://api.github.com/copilot_internal/v2/token"
 GITHUB_COPILOT_API_BASE = "https://api.githubcopilot.com"
-REFRESH_BUFFER_SECONDS = 5 * 60
 
 # Editor headers the Copilot endpoint enforces. Anything not advertising
 # itself as a recognized editor is rejected with HTTP 401.
@@ -69,11 +73,24 @@ _COPILOT_EDITOR_HEADERS = {
     "User-Agent": os.environ.get("COPILOT_USER_AGENT", "GithubCopilot/1.155.0"),
 }
 
-# Cached state.
-#   "source_token"  — long-lived gho_/ghu_/ghr_ (or pre-minted bearer)
-#   "copilot_token" — short-lived API bearer
-#   "expires_at"    — unix seconds for copilot_token expiry
-_token_cache: dict[str, Any] = {}
+
+def _load_copilot_source(path: Path) -> dict[str, Any] | None:
+    """FileBackedCache loader for ``~/.config/copilot/tokens.json``.
+
+    Normalizes whichever shape the on-disk file uses (oauth_token /
+    refreshToken / access_token) into a single ``{"source": str}`` dict
+    so the caller can branch on a stable key.
+    """
+    raw = read_json_file(path)
+    if raw is None:
+        return None
+    tok = raw.get("oauth_token") or raw.get("refreshToken") or raw.get("access_token") or ""
+    if isinstance(tok, str) and tok.strip():
+        return {"source": tok.strip()}
+    return None
+
+
+_copilot_file_cache = FileBackedCache(COPILOT_TOKENS_PATH, _load_copilot_source)
 
 
 def _read_plugin_source_token() -> str:
@@ -89,9 +106,8 @@ def _read_plugin_source_token() -> str:
     for path in (COPILOT_PLUGIN_APPS, COPILOT_PLUGIN_HOSTS):
         if not path.exists():
             continue
-        try:
-            data = json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError):
+        data = read_json_file(path)
+        if data is None:
             _log.debug("Could not parse %s", path)
             continue
         for key, entry in data.items():
@@ -117,19 +133,9 @@ def _resolve_source_token() -> tuple[str, str]:
     refresh = os.environ.get("COPILOT_REFRESH_TOKEN", "").strip()
     if refresh:
         return refresh, "github"
-    if COPILOT_TOKENS_PATH.exists():
-        try:
-            data = json.loads(COPILOT_TOKENS_PATH.read_text())
-            tok = (
-                data.get("oauth_token")
-                or data.get("refreshToken")
-                or data.get("access_token")
-                or ""
-            )
-            if isinstance(tok, str) and tok.strip():
-                return tok.strip(), "github"
-        except (json.JSONDecodeError, OSError):
-            pass
+    cached = _copilot_file_cache.get()
+    if cached is not None:
+        return cached["source"], "github"
     plugin_token = _read_plugin_source_token()
     if plugin_token:
         return plugin_token, "github"
@@ -143,6 +149,13 @@ def _resolve_source_token() -> tuple[str, str]:
         model="copilot",
         llm_provider="copilot",
     )
+
+
+# Cached state.
+#   "copilot_token" — short-lived API bearer
+#   "expires_at"    — unix seconds for copilot_token expiry
+#   "endpoints"     — optional enterprise endpoint overrides
+_token_cache: dict[str, Any] = {}
 
 
 def _mint_copilot_token(github_token: str) -> dict[str, Any]:
@@ -175,11 +188,18 @@ def _mint_copilot_token(github_token: str) -> dict[str, Any]:
     }
 
 
-def get_access_token() -> str:
+def get_copilot_access_token(force_refresh: bool = False) -> str:
     """Return a valid Copilot API bearer, minting / refreshing as needed."""
+    if force_refresh:
+        _token_cache.clear()
+        _copilot_file_cache.invalidate()
     cached = _token_cache.get("copilot_token")
     expires_at = _token_cache.get("expires_at", 0)
-    if cached and expires_at - REFRESH_BUFFER_SECONDS > time.time():
+    if (
+        cached
+        and not force_refresh
+        and not is_timestamp_expired(expires_at, buffer_seconds=DEFAULT_REFRESH_BUFFER_SECONDS)
+    ):
         return cached
 
     source_token, kind = _resolve_source_token()
@@ -190,7 +210,6 @@ def get_access_token() -> str:
 
     minted = _mint_copilot_token(source_token)
     _token_cache.update(minted)
-    _token_cache["source_token"] = source_token
     return minted["copilot_token"]
 
 
@@ -233,15 +252,7 @@ class CopilotHandler(CustomLLM):
         headers: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> ModelResponse:
-        access_token = get_access_token()
         actual_model = model.split("/", 1)[-1] if "/" in model else model
-
-        req_headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            **_COPILOT_EDITOR_HEADERS,
-        }
 
         opts = optional_params or {}
         request_body: dict[str, Any] = {"model": actual_model, "messages": messages}
@@ -259,19 +270,32 @@ class CopilotHandler(CustomLLM):
         if opts.get("tool_choice"):
             request_body["tool_choice"] = opts["tool_choice"]
 
-        api_url = api_base or _api_base()
-        resp = httpx.post(
-            f"{api_url}/chat/completions",
-            json=request_body,
-            headers=req_headers,
-            timeout=timeout or 600,
-        )
+        def _send(force_refresh: bool) -> httpx.Response:
+            access_token = get_copilot_access_token(force_refresh=force_refresh)
+            req_headers = {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                **_COPILOT_EDITOR_HEADERS,
+            }
+            api_url = api_base or _api_base()
+            return httpx.post(
+                f"{api_url}/chat/completions",
+                json=request_body,
+                headers=req_headers,
+                timeout=timeout or 600,
+            )
+
+        resp = with_retry_on_401(_send)
 
         if resp.status_code == 401:
             # Bust both layers — source token may also be invalid.
             _token_cache.clear()
             raise litellm.AuthenticationError(
-                message=f"Copilot auth failed (401): {resp.text[:300]}",
+                message=(
+                    "Copilot authentication was rejected. Run `gh auth login --scopes "
+                    f"copilot` and retry. Underlying: {resp.text[:300]}"
+                ),
                 model=model,
                 llm_provider="copilot",
             )

--- a/config/gemini_handler.py
+++ b/config/gemini_handler.py
@@ -25,6 +25,15 @@ from typing import Any
 import httpx
 import litellm
 from litellm import CustomLLM, ModelResponse
+from oauth_token_store import (
+    DEFAULT_REFRESH_BUFFER_SECONDS,
+    FileBackedCache,
+    is_timestamp_expired,
+    oauth_refresh_request,
+    read_json_file,
+    with_retry_on_401,
+    write_json_atomic,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -36,9 +45,9 @@ GEMINI_TOKENS_PATH = Path(
 )
 
 GEMINI_API_BASE = "https://generativelanguage.googleapis.com"
-REFRESH_BUFFER_SECONDS = 5 * 60
 
-_token_cache: dict[str, Any] = {}
+
+_gemini_file_cache = FileBackedCache(GEMINI_TOKENS_PATH, read_json_file)
 
 
 def _load_tokens() -> dict[str, Any] | None:
@@ -55,20 +64,7 @@ def _load_tokens() -> dict[str, Any] | None:
         except json.JSONDecodeError:
             _log.debug("Malformed GEMINI_SESSION_COOKIES JSON")
 
-    if GEMINI_TOKENS_PATH.exists():
-        try:
-            return json.loads(GEMINI_TOKENS_PATH.read_text())
-        except (json.JSONDecodeError, OSError):
-            _log.debug("Could not read token file")
-
-    return None
-
-
-def _is_expired(tokens: dict[str, Any]) -> bool:
-    expires_at = tokens.get("expiresAt", 0)
-    if expires_at == 0:
-        return False
-    return time.time() + REFRESH_BUFFER_SECONDS >= expires_at
+    return _gemini_file_cache.get()
 
 
 def _refresh_google_token(tokens: dict[str, Any]) -> dict[str, Any]:
@@ -83,18 +79,18 @@ def _refresh_google_token(tokens: dict[str, Any]) -> dict[str, Any]:
             llm_provider="gemini-sub",
         )
 
-    resp = httpx.post(
+    data = oauth_refresh_request(
         "https://oauth2.googleapis.com/token",
-        data={
+        {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
             "client_id": client_id,
             "client_secret": client_secret,
         },
+        json_body=False,
         timeout=30,
+        provider_label="gemini-sub",
     )
-    resp.raise_for_status()
-    data = resp.json()
 
     new_tokens = {
         **tokens,
@@ -102,18 +98,15 @@ def _refresh_google_token(tokens: dict[str, Any]) -> dict[str, Any]:
         "expiresAt": int(time.time() + data.get("expires_in", 3600)),
     }
 
-    try:
-        GEMINI_TOKENS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        GEMINI_TOKENS_PATH.write_text(json.dumps(new_tokens, indent=2))
-        os.chmod(GEMINI_TOKENS_PATH, 0o600)
-    except OSError:
-        _log.debug("Could not persist tokens to disk")
-
+    write_json_atomic(GEMINI_TOKENS_PATH, new_tokens)
+    _gemini_file_cache.replace(new_tokens)
     return new_tokens
 
 
-def get_access_token() -> str:
-    tokens = _token_cache.get("token") or _load_tokens()
+def get_gemini_access_token(force_refresh: bool = False) -> str:
+    if force_refresh:
+        _gemini_file_cache.invalidate()
+    tokens = _load_tokens()
     if tokens is None:
         raise litellm.AuthenticationError(
             message=(
@@ -124,10 +117,12 @@ def get_access_token() -> str:
             llm_provider="gemini-sub",
         )
 
-    if _is_expired(tokens) and tokens.get("refreshToken"):
+    expired = is_timestamp_expired(
+        tokens.get("expiresAt"), buffer_seconds=DEFAULT_REFRESH_BUFFER_SECONDS
+    )
+    if (force_refresh or expired) and tokens.get("refreshToken"):
         tokens = _refresh_google_token(tokens)
 
-    _token_cache["token"] = tokens
     return tokens.get("accessToken", "")
 
 
@@ -155,7 +150,6 @@ class GeminiSubHandler(CustomLLM):
         headers: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> ModelResponse:
-        access_token = get_access_token()
         actual_model = model.split("/", 1)[-1] if "/" in model else model
 
         # Gemini API uses generateContent endpoint with OAuth bearer
@@ -201,18 +195,24 @@ class GeminiSubHandler(CustomLLM):
         if system_instruction:
             request_body["systemInstruction"] = {"parts": [{"text": system_instruction}]}
 
-        req_headers = {
-            "authorization": f"Bearer {access_token}",
-            "content-type": "application/json",
-        }
-
         url = f"{GEMINI_API_BASE}/v1beta/models/{actual_model}:generateContent"
-        resp = httpx.post(url, json=request_body, headers=req_headers, timeout=timeout or 600)
+
+        def _send(force_refresh: bool) -> httpx.Response:
+            access_token = get_gemini_access_token(force_refresh=force_refresh)
+            req_headers = {
+                "authorization": f"Bearer {access_token}",
+                "content-type": "application/json",
+            }
+            return httpx.post(url, json=request_body, headers=req_headers, timeout=timeout or 600)
+
+        resp = with_retry_on_401(_send)
 
         if resp.status_code == 401:
-            _token_cache.pop("token", None)
             raise litellm.AuthenticationError(
-                message=f"Gemini auth failed (401): {resp.text}",
+                message=(
+                    "Gemini Advanced authentication was rejected. Re-extract the "
+                    f"GEMINI_SESSION_COOKIES / refresh GEMINI_ACCESS_TOKEN. Underlying: {resp.text}"
+                ),
                 model=model,
                 llm_provider="gemini-sub",
             )

--- a/config/grok_handler.py
+++ b/config/grok_handler.py
@@ -13,7 +13,6 @@ Model names: grok-sub/grok-3, grok-sub/grok-3-mini, etc.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import time
@@ -24,6 +23,14 @@ from typing import Any
 import httpx
 import litellm
 from litellm import CustomLLM, ModelResponse
+from oauth_token_store import (
+    DEFAULT_REFRESH_BUFFER_SECONDS,
+    FileBackedCache,
+    is_timestamp_expired,
+    read_json_file,
+    with_retry_on_401,
+    write_json_atomic,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -35,9 +42,9 @@ GROK_TOKENS_PATH = Path(
 )
 
 GROK_API_BASE = "https://api.x.ai"
-REFRESH_BUFFER_SECONDS = 5 * 60
 
-_token_cache: dict[str, Any] = {}
+
+_grok_file_cache = FileBackedCache(GROK_TOKENS_PATH, read_json_file)
 
 
 def _load_tokens() -> dict[str, Any] | None:
@@ -54,13 +61,7 @@ def _load_tokens() -> dict[str, Any] | None:
             "source": "session",
         }
 
-    if GROK_TOKENS_PATH.exists():
-        try:
-            return json.loads(GROK_TOKENS_PATH.read_text())
-        except (json.JSONDecodeError, OSError):
-            _log.debug("Could not read token file")
-
-    return None
+    return _grok_file_cache.get()
 
 
 def _exchange_session_for_access(session_token: str) -> dict[str, Any]:
@@ -91,25 +92,15 @@ def _exchange_session_for_access(session_token: str) -> dict[str, Any]:
         "source": "session_exchange",
     }
 
-    try:
-        GROK_TOKENS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        GROK_TOKENS_PATH.write_text(json.dumps(tokens, indent=2))
-        os.chmod(GROK_TOKENS_PATH, 0o600)
-    except OSError:
-        _log.debug("Could not persist tokens to disk")
-
+    write_json_atomic(GROK_TOKENS_PATH, tokens)
+    _grok_file_cache.replace(tokens)
     return tokens
 
 
-def _is_expired(tokens: dict[str, Any]) -> bool:
-    expires_at = tokens.get("expiresAt", 0)
-    if expires_at == 0:
-        return False
-    return time.time() + REFRESH_BUFFER_SECONDS >= expires_at
-
-
-def get_access_token() -> str:
-    tokens = _token_cache.get("token") or _load_tokens()
+def get_grok_access_token(force_refresh: bool = False) -> str:
+    if force_refresh:
+        _grok_file_cache.invalidate()
+    tokens = _load_tokens()
     if tokens is None:
         raise litellm.AuthenticationError(
             message=(
@@ -123,10 +114,12 @@ def get_access_token() -> str:
     if not tokens.get("accessToken") and tokens.get("sessionToken"):
         tokens = _exchange_session_for_access(tokens["sessionToken"])
 
-    if _is_expired(tokens) and tokens.get("sessionToken"):
+    expired = is_timestamp_expired(
+        tokens.get("expiresAt"), buffer_seconds=DEFAULT_REFRESH_BUFFER_SECONDS
+    )
+    if (force_refresh or expired) and tokens.get("sessionToken"):
         tokens = _exchange_session_for_access(tokens["sessionToken"])
 
-    _token_cache["token"] = tokens
     return tokens.get("accessToken", "")
 
 
@@ -154,14 +147,7 @@ class GrokSubHandler(CustomLLM):
         headers: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> ModelResponse:
-        access_token = get_access_token()
         actual_model = model.split("/", 1)[-1] if "/" in model else model
-
-        req_headers = {
-            "authorization": f"Bearer {access_token}",
-            "content-type": "application/json",
-            "accept": "application/json",
-        }
 
         opts = optional_params or {}
         request_body: dict[str, Any] = {"model": actual_model, "messages": messages}
@@ -180,17 +166,30 @@ class GrokSubHandler(CustomLLM):
             request_body["tool_choice"] = opts["tool_choice"]
 
         api_url = api_base or GROK_API_BASE
-        resp = httpx.post(
-            f"{api_url}/v1/chat/completions",
-            json=request_body,
-            headers=req_headers,
-            timeout=timeout or 600,
-        )
+
+        def _send(force_refresh: bool) -> httpx.Response:
+            access_token = get_grok_access_token(force_refresh=force_refresh)
+            req_headers = {
+                "authorization": f"Bearer {access_token}",
+                "content-type": "application/json",
+                "accept": "application/json",
+            }
+            return httpx.post(
+                f"{api_url}/v1/chat/completions",
+                json=request_body,
+                headers=req_headers,
+                timeout=timeout or 600,
+            )
+
+        resp = with_retry_on_401(_send)
 
         if resp.status_code == 401:
-            _token_cache.pop("token", None)
+            _grok_file_cache.invalidate()
             raise litellm.AuthenticationError(
-                message=f"Grok auth failed (401): {resp.text}",
+                message=(
+                    "Grok authentication was rejected. Re-extract the GROK_SESSION_TOKEN "
+                    f"cookie from grok.com. Underlying: {resp.text}"
+                ),
                 model=model,
                 llm_provider="grok-sub",
             )

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -199,10 +199,12 @@ model_list:
   # ChatGPT (auth/gpt-*), Gemini Advanced (gemini-sub/*), Copilot
   # (copilot/*), SuperGrok (grok-sub/*), and Perplexity Pro (pplx-sub/*)
   # are registered DYNAMICALLY by litellm_dynamic_config.py, gated on
-  # their respective DECEPTICON_AUTH_* flags. Registering them statically
-  # here caused LiteLLM's native providers to attempt OAuth handshakes at
-  # startup even when the user disabled the auth method, blocking the
-  # container health check and making it unhealthy.
+  # their respective DECEPTICON_AUTH_* flags. Each route dispatches to a
+  # Decepticon custom handler defined under config/<provider>_handler.py
+  # (claude_code, codex_chatgpt, gemini, copilot, grok, perplexity) — all
+  # share oauth_token_store.py for atomic token refresh + mtime caching,
+  # so a host-side ``codex login`` / Claude Code rotation is picked up by
+  # the running container without restart.
 
   # ── Local LLM (Ollama) ──────────────────────────────────────────────
   # Ollama routes are registered dynamically at proxy startup by
@@ -226,10 +228,9 @@ litellm_settings:
   # when ``database_url`` is set, and listing handlers here would also
   # create a circular import with the dispatcher defined in startup.
   #
-  # Active custom providers (registered in litellm_startup.py):
-  #   - auth         → dispatches Claude Code OAuth only (auth/claude-*)
-  # Native providers used directly:
-  #   - chatgpt      → Codex/OpenAI OAuth for auth/gpt-* aliases above
+  # Active custom providers (all registered in litellm_startup.py):
+  #   - auth         → dispatches Claude Code (auth/claude-*) +
+  #                    Codex ChatGPT (auth/gpt-*) via auth_handler.AuthDispatcher
   #   - gemini-sub   → gemini_handler.gemini_sub_handler_instance
   #   - copilot      → copilot_handler.copilot_handler_instance
   #   - grok-sub     → grok_handler.grok_sub_handler_instance

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -195,13 +195,44 @@ def _provider_prefix(model_name: str) -> str:
     return model_name.split("/", 1)[0].lower().replace("-", "_")
 
 
+_SUBSCRIPTION_PROVIDER_PREFIXES = frozenset(
+    {
+        "auth",  # auth/claude-*, auth/gpt-* — Claude Code OAuth + Codex ChatGPT
+        "gemini_sub",  # gemini-sub/* — Gemini Advanced subscription
+        "copilot",  # copilot/* — Copilot Pro subscription
+        "grok_sub",  # grok-sub/* — SuperGrok subscription
+        "pplx_sub",  # pplx-sub/* — Perplexity Pro subscription
+    }
+)
+
+
 def validate_model_name(model_name: str) -> None:
-    """Validate user-supplied dynamic model IDs before registering routes."""
+    """Validate user-supplied dynamic model IDs before registering routes.
+
+    Rejects subscription / OAuth provider prefixes (``auth/*``, ``gemini-sub/*``,
+    ``copilot/*``, ``grok-sub/*``, ``pplx-sub/*``) for the API-key registration
+    path — those routes are added by ``_inject_subscription_routes`` when the
+    matching ``DECEPTICON_AUTH_*`` flag is set, with custom-provider dispatch
+    in ``litellm_startup.py``. Trying to register them as API-key routes here
+    would produce a phantom ``<PROVIDER>_API_KEY`` env-var lookup that never
+    resolves.
+
+    ``merge_dynamic_models`` skips this validation when the model is already
+    present in the model_list, so a user setting
+    ``DECEPTICON_MODEL=auth/gpt-5.4-mini`` plus ``DECEPTICON_AUTH_CHATGPT=true``
+    is fine — the subscription path injected the route first and the requested
+    model is satisfied.
+    """
     if "/" not in model_name:
         raise ValueError(f"model {model_name!r} must use LiteLLM provider/model format")
     provider = _provider_prefix(model_name)
-    if provider == "auth":
-        raise ValueError("auth/* routes are not allowed as dynamic API-key model routes")
+    if provider in _SUBSCRIPTION_PROVIDER_PREFIXES:
+        raise ValueError(
+            f"{provider}/* routes are not allowed as dynamic API-key model "
+            f"routes. Enable the matching subscription via "
+            f"DECEPTICON_AUTH_<provider>=true so the route is registered "
+            f"through litellm_startup.py's custom_provider_map instead."
+        )
     if provider == "ollama":
         # Legacy ``ollama/`` (/api/generate) lacks tool calling — fail
         # closed since Decepticon agents always emit tool calls.
@@ -301,8 +332,27 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
 _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
     # env flag → model_list entries
     "DECEPTICON_AUTH_CHATGPT": [
-        {"model_name": "auth/gpt-5.5", "litellm_params": {"model": "chatgpt/gpt-5.5"}},
-        {"model_name": "auth/gpt-5.4", "litellm_params": {"model": "chatgpt/gpt-5.4"}},
+        # User-facing model_name stays ``auth/gpt-*`` for consistency with
+        # ``auth/claude-*``. The internal LiteLLM route uses the dedicated
+        # ``codex-oauth`` custom provider plus the ``oauth-gpt-`` slug
+        # sentinel — without the sentinel LiteLLM's main.py:2561 falls
+        # into the OpenAI branch (``model in open_ai_chat_completion_models``
+        # short-circuits before the custom_llm_provider check) and forwards
+        # to api.openai.com regardless of provider. The codex_chatgpt
+        # handler strips the ``oauth-`` prefix before sending the model
+        # name upstream, so chatgpt.com still receives ``gpt-5.5``.
+        {
+            "model_name": "auth/gpt-5.5",
+            "litellm_params": {"model": "codex-oauth/oauth-gpt-5.5"},
+        },
+        {
+            "model_name": "auth/gpt-5.4",
+            "litellm_params": {"model": "codex-oauth/oauth-gpt-5.4"},
+        },
+        {
+            "model_name": "auth/gpt-5.4-mini",
+            "litellm_params": {"model": "codex-oauth/oauth-gpt-5.4-mini"},
+        },
     ],
     "DECEPTICON_AUTH_GEMINI": [
         {
@@ -332,6 +382,7 @@ _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
 _SUBSCRIPTION_FALLBACKS: dict[str, list[dict[str, list[str]]]] = {
     "DECEPTICON_AUTH_CHATGPT": [
         {"auth/gpt-5.5": ["auth/gpt-5.4"]},
+        {"auth/gpt-5.4": ["auth/gpt-5.4-mini"]},
     ],
     "DECEPTICON_AUTH_GEMINI": [
         {"gemini-sub/gemini-2.5-pro": ["gemini-sub/gemini-2.5-flash"]},
@@ -382,6 +433,18 @@ def _inject_subscription_routes(
                 fallbacks.append(fb)
 
 
+def has_subscription_routes(env: Mapping[str, str] | None = None) -> bool:
+    """Return True if any DECEPTICON_AUTH_* flag enables a subscription route.
+
+    Used by ``litellm_startup.py`` to decide whether to regenerate the
+    LiteLLM config even when no ``DECEPTICON_MODEL*`` overrides are set —
+    a user who only enables ``DECEPTICON_AUTH_CHATGPT=true`` still needs
+    the corresponding ``auth/gpt-*`` model_list entries.
+    """
+    source = env if env is not None else os.environ
+    return any(_is_truthy(source.get(flag, "")) for flag in _SUBSCRIPTION_ROUTES)
+
+
 def merge_dynamic_models(
     config: MutableMapping[str, Any], env: Mapping[str, str] | None = None
 ) -> dict[str, Any]:
@@ -395,9 +458,14 @@ def merge_dynamic_models(
     existing = {entry.get("model_name") for entry in model_list if isinstance(entry, dict)}
 
     for model_name in sorted(collect_requested_models(env)):
-        validate_model_name(model_name)
         if model_name in existing:
+            # Already registered by ``_inject_subscription_routes`` (or a
+            # static entry in litellm.yaml). Skip the API-key validator —
+            # ``auth/*`` slugs are deliberately rejected by
+            # ``validate_model_name`` for the API-key path even though
+            # they are valid subscription targets.
             continue
+        validate_model_name(model_name)
         model_list.append(build_model_entry(model_name))
         existing.add(model_name)
 
@@ -431,6 +499,7 @@ def write_dynamic_config(config_path: str | Path, output_path: str | Path) -> Pa
 __all__ = [
     "build_model_entry",
     "collect_requested_models",
+    "has_subscription_routes",
     "merge_dynamic_models",
     "validate_model_name",
     "write_dynamic_config",

--- a/config/litellm_startup.py
+++ b/config/litellm_startup.py
@@ -16,14 +16,26 @@ from pathlib import Path
 
 # Register custom OAuth handler before LiteLLM processes the config
 sys.path.insert(0, "/app")
-from litellm_dynamic_config import collect_requested_models, write_dynamic_config  # noqa: E402
+from litellm_dynamic_config import (  # noqa: E402
+    collect_requested_models,
+    has_subscription_routes,
+    write_dynamic_config,
+)
 from ollama_probe import extract_ollama_models, has_ollama_route, probe  # noqa: E402
 
 
 def _replace_config_arg() -> None:
-    """Append env-requested model routes to the LiteLLM config before boot."""
+    """Append env-requested model routes to the LiteLLM config before boot.
+
+    Also injects subscription OAuth routes (auth/gpt-*) when the
+    corresponding ``DECEPTICON_AUTH_*`` flag is enabled, even if no
+    ``DECEPTICON_MODEL*`` override is set. Without this second branch a
+    user who only enabled ChatGPT subscription auth would never see
+    ``auth/gpt-*`` registered and every request would 400.
+    """
     requested = collect_requested_models()
-    if not requested:
+    needs_subscription = has_subscription_routes()
+    if not requested and not needs_subscription:
         return
 
     config_path: str | None = None
@@ -54,7 +66,12 @@ def _replace_config_arg() -> None:
             )
             sys.argv.extend(["--config", str(generated)])
 
-    print(f"[decepticon] registered {len(requested)} dynamic model route(s)", flush=True)
+    parts: list[str] = []
+    if requested:
+        parts.append(f"{len(requested)} model override(s)")
+    if needs_subscription:
+        parts.append("subscription OAuth route(s)")
+    print(f"[decepticon] registered dynamic config: {', '.join(parts)}", flush=True)
 
 
 _replace_config_arg()
@@ -78,62 +95,28 @@ def _probe_ollama_if_configured() -> None:
 
 _probe_ollama_if_configured()
 
-from collections.abc import AsyncIterator, Iterator  # noqa: E402
-from typing import Any  # noqa: E402
-
 import litellm  # noqa: E402
-from claude_code_handler import claude_code_handler_instance  # noqa: E402
+from auth_handler import auth_handler_instance  # noqa: E402
+from codex_chatgpt_handler import codex_chatgpt_handler_instance  # noqa: E402
 from copilot_handler import copilot_handler_instance  # noqa: E402
 from gemini_handler import gemini_sub_handler_instance  # noqa: E402
 from grok_handler import grok_sub_handler_instance  # noqa: E402
-from litellm import CustomLLM, ModelResponse  # noqa: E402
 from perplexity_handler import perplexity_sub_handler_instance  # noqa: E402
 
-# ── auth/ provider dispatcher ─────────────────────────────────────────
-# The ``auth/`` namespace is reserved for custom OAuth handlers that do
-# not have a suitable native LiteLLM provider. ChatGPT/Codex OAuth now uses
-# LiteLLM's native ``chatgpt`` provider via model aliases in litellm.yaml.
-
-
-def _select_auth_handler(model: str) -> CustomLLM:
-    slug = model.split("/", 1)[-1] if "/" in model else model
-    slug_lower = slug.lower()
-    if slug_lower.startswith("claude-"):
-        return claude_code_handler_instance
-    raise litellm.BadRequestError(
-        message=(
-            f"auth/ provider: model slug {slug!r} did not match any known "
-            "subscription handler. Supported prefixes: claude-*."
-        ),
-        model=model,
-        llm_provider="auth",
-    )
-
-
-class _AuthDispatcher(CustomLLM):
-    def completion(self, *args: Any, **kwargs: Any) -> ModelResponse:
-        model = kwargs.get("model") or (args[0] if args else "")
-        return _select_auth_handler(model).completion(*args, **kwargs)
-
-    async def acompletion(self, *args: Any, **kwargs: Any) -> ModelResponse:
-        model = kwargs.get("model") or (args[0] if args else "")
-        return await _select_auth_handler(model).acompletion(*args, **kwargs)
-
-    def streaming(self, *args: Any, **kwargs: Any) -> Iterator[dict[str, Any]]:
-        model = kwargs.get("model") or (args[0] if args else "")
-        return _select_auth_handler(model).streaming(*args, **kwargs)
-
-    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:
-        model = kwargs.get("model") or (args[0] if args else "")
-        async for chunk in _select_auth_handler(model).astreaming(*args, **kwargs):
-            yield chunk
-
-
-_auth_dispatcher_instance = _AuthDispatcher()
-
+# ── Custom provider registration ─────────────────────────────────────
+# The ``auth/`` namespace dispatches to per-provider OAuth handlers via
+# ``auth_handler.AuthDispatcher`` (currently used for ``claude-*``).
+#
+# ChatGPT/Codex is registered under its own ``codex-oauth`` provider
+# key so the dynamic config can alias ``auth/gpt-*`` (user-facing model
+# name) to ``codex-oauth/gpt-*`` (the internal route). LiteLLM's
+# router otherwise misroutes ``auth/gpt-*`` to its native OpenAI
+# provider because the slug ``gpt-*`` matches an OpenAI model alias —
+# the dedicated provider name avoids that heuristic entirely.
 
 litellm.custom_provider_map = [
-    {"provider": "auth", "custom_handler": _auth_dispatcher_instance},
+    {"provider": "auth", "custom_handler": auth_handler_instance},
+    {"provider": "codex-oauth", "custom_handler": codex_chatgpt_handler_instance},
     {"provider": "gemini-sub", "custom_handler": gemini_sub_handler_instance},
     {"provider": "copilot", "custom_handler": copilot_handler_instance},
     {"provider": "grok-sub", "custom_handler": grok_sub_handler_instance},
@@ -145,151 +128,9 @@ from litellm.utils import custom_llm_setup  # noqa: E402
 custom_llm_setup()
 
 
-def _patch_chatgpt_responses_text_aggregation() -> None:
-    """Work around ChatGPT Codex /responses SSE final payloads with empty output.
-
-    As of 2026-05-03, LiteLLM's native ``chatgpt`` Responses transformer
-    trusts the final ``response.completed`` payload. The Codex backend can
-    instead stream all assistant text via ``response.output_text.delta`` while
-    leaving ``response.output`` empty in the completed object. Downstream
-    OpenAI-compatible clients (LangChain ChatOpenAI with ``use_responses_api``)
-    then see a successful response with blank content.
-
-    Aggregate text deltas and synthesize a standard Responses message when the
-    upstream completed payload is empty. Keep the original transformer for all
-    normal/error cases.
-
-    Skipped entirely when DECEPTICON_AUTH_CHATGPT=false (or unset) to avoid
-    importing the chatgpt provider module, which triggers a device-code
-    OAuth prompt at startup even when ChatGPT is not configured.
-    """
-    chatgpt_enabled = os.environ.get("DECEPTICON_AUTH_CHATGPT", "false").strip().lower()
-    if chatgpt_enabled not in ("true", "1", "yes"):
-        print(
-            "[decepticon] chatgpt responses patch skipped (DECEPTICON_AUTH_CHATGPT != true)",
-            flush=True,
-        )
-        return
-
-    try:
-        import json
-
-        from litellm.constants import STREAM_SSE_DONE_STRING
-        from litellm.llms.chatgpt.responses.transformation import (
-            ChatGPTResponsesAPIConfig,
-        )
-        from litellm.types.llms.openai import ResponsesAPIResponse
-        from litellm.utils import CustomStreamWrapper
-    except Exception as exc:  # pragma: no cover - startup resilience
-        print(f"[decepticon] chatgpt responses patch skipped: {exc}", flush=True)
-        return
-
-    original = ChatGPTResponsesAPIConfig.transform_response_api_response
-    original_request = ChatGPTResponsesAPIConfig.transform_responses_api_request
-
-    def patched_request(  # type: ignore[no-untyped-def]
-        self,
-        model: str,
-        input: Any,
-        response_api_optional_request_params: dict,
-        litellm_params: Any,
-        headers: dict,
-    ) -> dict:
-        request = original_request(
-            self,
-            model=model,
-            input=input,
-            response_api_optional_request_params=response_api_optional_request_params,
-            litellm_params=litellm_params,
-            headers=headers,
-        )
-        items = request.get("input")
-        if not isinstance(items, list):
-            return request
-
-        system_parts: list[str] = []
-        filtered: list[Any] = []
-        for item in items:
-            if not (isinstance(item, dict) and item.get("role") == "system"):
-                filtered.append(item)
-                continue
-            content = item.get("content")
-            if isinstance(content, str):
-                system_parts.append(content)
-            elif isinstance(content, list):
-                for part in content:
-                    if isinstance(part, dict):
-                        text = part.get("text") or part.get("content")
-                        if isinstance(text, str):
-                            system_parts.append(text)
-
-        if system_parts:
-            existing = request.get("instructions") or ""
-            request["instructions"] = (
-                "\n\n".join([existing, *system_parts]) if existing else "\n\n".join(system_parts)
-            )
-            request["input"] = filtered
-        return request
-
-    def patched(self, model: str, raw_response: Any, logging_obj: Any):  # type: ignore[no-untyped-def]
-        response = original(self, model=model, raw_response=raw_response, logging_obj=logging_obj)
-        try:
-            if getattr(response, "output", None):
-                return response
-            body_text = raw_response.text or ""
-            if "response.output_text.delta" not in body_text:
-                return response
-
-            text_parts: list[str] = []
-            for chunk in body_text.splitlines():
-                stripped = CustomStreamWrapper._strip_sse_data_from_chunk(chunk)
-                if not stripped:
-                    continue
-                stripped = stripped.strip()
-                if not stripped or stripped == STREAM_SSE_DONE_STRING:
-                    continue
-                try:
-                    event = json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
-                if event.get("type") == "response.output_text.delta":
-                    delta = event.get("delta")
-                    if isinstance(delta, str):
-                        text_parts.append(delta)
-
-            text = "".join(text_parts)
-            if not text:
-                return response
-
-            payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
-            payload["output"] = [
-                {
-                    "id": "msg_decepticon_aggregated",
-                    "type": "message",
-                    "role": "assistant",
-                    "status": "completed",
-                    "content": [
-                        {
-                            "type": "output_text",
-                            "text": text,
-                            "annotations": [],
-                        }
-                    ],
-                }
-            ]
-            return ResponsesAPIResponse.model_construct(**payload)
-        except Exception:
-            return response
-
-    ChatGPTResponsesAPIConfig.transform_responses_api_request = patched_request
-    ChatGPTResponsesAPIConfig.transform_response_api_response = patched
-    print("[decepticon] patched chatgpt responses text aggregation", flush=True)
-
-
-_patch_chatgpt_responses_text_aggregation()
-
 print(
-    "[decepticon] auth dispatcher (claude_code) + 4 subscription handlers registered",
+    "[decepticon] auth dispatcher (claude_code, codex_chatgpt) + "
+    "4 subscription handlers registered",
     flush=True,
 )
 

--- a/config/oauth_token_store.py
+++ b/config/oauth_token_store.py
@@ -98,14 +98,25 @@ def write_json_atomic(
         log.warning("oauth_token_store: mkdir failed for %s: %s", path.parent, exc)
         return False
     tmp = path.with_name(f".{path.name}.decepticon.tmp")
+    payload = (json.dumps(data, indent=2) + "\n").encode("utf-8")
+    open_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        # POSIX: refuse to follow symlinks at the temp path. Closes a
+        # symlink-replacement TOCTOU window where a hostile process on the
+        # same UID could redirect the write to an attacker-owned file.
+        open_flags |= os.O_NOFOLLOW
+    fd: int | None = None
     try:
-        # lgtm[py/clear-text-storage-sensitive-data]
-        # See module docstring + function docstring above for rationale.
-        tmp.write_text(json.dumps(data, indent=2) + "\n")
-        os.chmod(tmp, mode)
-        tmp.replace(path)
+        fd = os.open(tmp, open_flags, mode)
+        os.write(fd, payload)
     except OSError as exc:
         log.warning("oauth_token_store: write failed for %s: %s", path, exc)
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                # Already closed or invalid descriptor — nothing actionable.
+                pass
         try:
             tmp.unlink()
         except OSError:
@@ -113,6 +124,16 @@ def write_json_atomic(
             # (concurrent reaper, tmpfs eviction) or sits on a read-only
             # mount, there's nothing actionable left to do — the outer
             # ``except`` already logged the originating write failure.
+            pass
+        return False
+    try:
+        os.close(fd)
+        os.replace(tmp, path)
+    except OSError as exc:
+        log.warning("oauth_token_store: replace failed for %s: %s", path, exc)
+        try:
+            tmp.unlink()
+        except OSError:
             pass
         return False
     return True

--- a/config/oauth_token_store.py
+++ b/config/oauth_token_store.py
@@ -1,0 +1,300 @@
+"""Shared OAuth token store helpers for LiteLLM custom handlers.
+
+Mounted into the LiteLLM container alongside the per-provider handler
+modules (claude_code_handler, codex_chatgpt_handler, copilot_handler, ...).
+Centralizes credential I/O so a refresh on the host (e.g. ``codex login``
+rotating ``~/.codex/auth.json`` or Claude Code rotating
+``~/.claude/.credentials.json``) is picked up by the running container
+without a restart.
+
+Design:
+  - File reads are mtime+size cached. When the host writes a new token,
+    the next container call sees a fresh stat and reloads automatically.
+  - Writes go through atomic ``temp + rename`` so a refresh that races
+    with a host-side write never produces a partial file. Permissions are
+    forced to 0o600.
+  - JWT and timestamp expiry checks both live here so all handlers share
+    the same skew / buffer convention.
+  - 401 retry is a generic wrapper: handlers pass in a ``send`` closure
+    that takes a ``force_refresh`` flag; the wrapper calls once normally,
+    once with force_refresh on 401.
+
+This module is self-contained — it does NOT import the ``decepticon``
+package because LiteLLM mounts only the handler files into ``/app``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import litellm
+
+log = logging.getLogger(__name__)
+
+DEFAULT_REFRESH_BUFFER_SECONDS = 5 * 60
+DEFAULT_JWT_SKEW_SECONDS = 60
+
+
+# ── File I/O ─────────────────────────────────────────────────────────────
+
+
+def read_json_file(path: Path) -> dict[str, Any] | None:
+    """Read and parse a JSON file. Returns None on any I/O error.
+
+    Caller raises ``litellm.AuthenticationError`` when None is returned and
+    credentials are required — this helper stays error-neutral so the same
+    call works for "best-effort load" semantics.
+    """
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        log.warning("oauth_token_store: read failed for %s: %s", path, exc)
+        return None
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError as exc:
+        log.warning("oauth_token_store: invalid JSON in %s: %s", path, exc)
+        return None
+    return result if isinstance(result, dict) else None
+
+
+def write_json_atomic(
+    path: Path,
+    data: dict[str, Any],
+    mode: int = 0o600,
+) -> bool:
+    """Write JSON to ``path`` atomically (temp + rename). Returns False on failure.
+
+    Many credential mounts are bind-mounted from the host. A rename within
+    the same directory is atomic on POSIX, so a host-side reader never
+    sees a half-written file. ``:ro`` mounts cause ``write_text`` /
+    ``replace`` to fail; we log once at WARNING and let the in-process
+    cache hold the refreshed token for the rest of the container's life.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log.warning("oauth_token_store: mkdir failed for %s: %s", path.parent, exc)
+        return False
+    tmp = path.with_name(f".{path.name}.decepticon.tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2) + "\n")
+        os.chmod(tmp, mode)
+        tmp.replace(path)
+    except OSError as exc:
+        log.warning("oauth_token_store: write failed for %s: %s", path, exc)
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return False
+    return True
+
+
+# ── mtime+size aware caching ────────────────────────────────────────────
+
+
+class FileBackedCache:
+    """In-process cache keyed by ``(mtime, size)`` of the underlying file.
+
+    Handlers call ``get()`` per request without paying disk I/O. When the
+    host CLI rewrites the file, the next ``get()`` sees a new stat tuple
+    and triggers a fresh ``loader(path)`` call.
+
+    ``mtime`` alone is insufficient on filesystems with 1-second resolution
+    (ext4 on some configurations, FAT-derived volumes). Pairing it with
+    ``size`` catches in-second rewrites where the body length differs.
+
+    Thread-safe — async / sync handler paths can share one cache.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        loader: Callable[[Path], dict[str, Any] | None],
+    ) -> None:
+        self._path = path
+        self._loader = loader
+        self._cached: dict[str, Any] | None = None
+        self._cache_key: tuple[float, int] | None = None
+        self._lock = threading.Lock()
+
+    def _stat_key(self) -> tuple[float, int] | None:
+        try:
+            st = self._path.stat()
+        except OSError:
+            return None
+        return (st.st_mtime, st.st_size)
+
+    def get(self) -> dict[str, Any] | None:
+        with self._lock:
+            key = self._stat_key()
+            if key is None:
+                # Missing file: clear cache and let loader decide what to
+                # return (None, or raise via the caller).
+                self._cached = None
+                self._cache_key = None
+                return self._loader(self._path)
+            if self._cache_key != key or self._cached is None:
+                self._cached = self._loader(self._path)
+                self._cache_key = key if self._cached is not None else None
+            return self._cached
+
+    def invalidate(self) -> None:
+        """Force the next ``get()`` to re-read from disk."""
+        with self._lock:
+            self._cached = None
+            self._cache_key = None
+
+    def replace(self, data: dict[str, Any]) -> None:
+        """Update cache after an in-process refresh that wrote ``data`` to disk.
+
+        Stamps the cache key with the current file stat so the post-write
+        ``get()`` does not re-read the file we just wrote.
+        """
+        with self._lock:
+            self._cached = data
+            self._cache_key = self._stat_key()
+
+
+# ── JWT + timestamp helpers ─────────────────────────────────────────────
+
+
+def decode_jwt_payload(token: str | None) -> dict[str, Any]:
+    """Best-effort base64-decode of a JWT's middle segment. ``{}`` on malformed."""
+    if not isinstance(token, str):
+        return {}
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return {}
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        decoded = base64.urlsafe_b64decode(payload).decode("utf-8")
+        result = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return result if isinstance(result, dict) else {}
+
+
+def is_jwt_expired(token: str, skew_seconds: int = DEFAULT_JWT_SKEW_SECONDS) -> bool:
+    """True if the JWT's ``exp`` is within ``skew_seconds`` of now or missing."""
+    exp = decode_jwt_payload(token).get("exp")
+    if not isinstance(exp, (int, float)):
+        return True
+    return time.time() >= float(exp) - skew_seconds
+
+
+def is_timestamp_expired(
+    expires_at: float | int | None,
+    buffer_seconds: int = DEFAULT_REFRESH_BUFFER_SECONDS,
+) -> bool:
+    """Generic expiry check for non-JWT formats.
+
+    Accepts seconds or milliseconds (auto-detected when value > 1e12).
+    Returns ``False`` when ``expires_at`` is 0 / None — caller treats that
+    as "never expires" (e.g. the ``ANTHROPIC_OAUTH_TOKEN`` env override).
+    """
+    if not expires_at:
+        return False
+    expires_at_f = float(expires_at)
+    if expires_at_f > 1e12:
+        expires_at_f /= 1000.0
+    return time.time() + buffer_seconds >= expires_at_f
+
+
+# ── Generic OAuth refresh ───────────────────────────────────────────────
+
+
+def oauth_refresh_request(
+    token_url: str,
+    payload: dict[str, Any],
+    *,
+    json_body: bool = True,
+    timeout: float = 30.0,
+    provider_label: str = "auth",
+) -> dict[str, Any]:
+    """POST to an OAuth token endpoint and return the parsed JSON response.
+
+    Raises ``litellm.AuthenticationError`` on failure with a message that
+    surfaces the underlying response body — actionable for "rerun the CLI
+    login" recovery.
+    """
+    try:
+        if json_body:
+            resp = httpx.post(token_url, json=payload, timeout=timeout)
+        else:
+            resp = httpx.post(token_url, data=payload, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        raise litellm.AuthenticationError(
+            message=(
+                f"OAuth token refresh failed for {provider_label}. Underlying: {exc.response.text}"
+            ),
+            model=provider_label,
+            llm_provider=provider_label,
+        ) from exc
+    except (httpx.HTTPError, ValueError) as exc:
+        raise litellm.AuthenticationError(
+            message=f"OAuth token refresh request failed for {provider_label}: {exc}",
+            model=provider_label,
+            llm_provider=provider_label,
+        ) from exc
+    if not isinstance(data, dict):
+        raise litellm.AuthenticationError(
+            message=f"OAuth refresh response for {provider_label} was not an object.",
+            model=provider_label,
+            llm_provider=provider_label,
+        )
+    return data
+
+
+# ── 401 retry wrapper ───────────────────────────────────────────────────
+
+
+def with_retry_on_401(
+    send: Callable[[bool], httpx.Response],
+    *,
+    max_attempts: int = 2,
+) -> httpx.Response:
+    """Call ``send(force_refresh: bool)`` up to ``max_attempts`` times.
+
+    Handlers fetch their token via a closure that respects ``force_refresh``.
+    The first attempt uses the cached token; on 401 the wrapper replays
+    once with ``force_refresh=True``. Non-401 errors return immediately so
+    the caller can build a typed exception with model / llm_provider
+    context. After ``max_attempts`` 401s the last response is returned for
+    the caller to surface.
+    """
+    resp: httpx.Response | None = None
+    for attempt in range(max_attempts):
+        resp = send(attempt > 0)
+        if resp.status_code != 401:
+            return resp
+    assert resp is not None  # max_attempts >= 1 always sets resp
+    return resp
+
+
+__all__ = [
+    "DEFAULT_JWT_SKEW_SECONDS",
+    "DEFAULT_REFRESH_BUFFER_SECONDS",
+    "FileBackedCache",
+    "decode_jwt_payload",
+    "is_jwt_expired",
+    "is_timestamp_expired",
+    "oauth_refresh_request",
+    "read_json_file",
+    "with_retry_on_401",
+    "write_json_atomic",
+]

--- a/config/oauth_token_store.py
+++ b/config/oauth_token_store.py
@@ -81,6 +81,16 @@ def write_json_atomic(
     sees a half-written file. ``:ro`` mounts cause ``write_text`` /
     ``replace`` to fail; we log once at WARNING and let the in-process
     cache hold the refreshed token for the rest of the container's life.
+
+    Sensitive-data note: this helper persists OAuth refresh / access
+    tokens unencrypted, mirroring how the upstream CLIs (Claude Code's
+    ``~/.claude/.credentials.json``, Codex's ``~/.codex/auth.json``)
+    already store them. Decepticon's value-add is *sharing* those exact
+    files between host CLI and the LiteLLM container so a refresh on
+    either side flows to the other. Encrypting at this layer would break
+    that contract and gain nothing — the file mode is restricted to
+    0o600 so only the owning user can read the bytes. CodeQL flags the
+    plain-text write; the suppression below documents the trade-off.
     """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -89,6 +99,8 @@ def write_json_atomic(
         return False
     tmp = path.with_name(f".{path.name}.decepticon.tmp")
     try:
+        # lgtm[py/clear-text-storage-sensitive-data]
+        # See module docstring + function docstring above for rationale.
         tmp.write_text(json.dumps(data, indent=2) + "\n")
         os.chmod(tmp, mode)
         tmp.replace(path)
@@ -97,6 +109,10 @@ def write_json_atomic(
         try:
             tmp.unlink()
         except OSError:
+            # Cleanup is best-effort: if the temp file already vanished
+            # (concurrent reaper, tmpfs eviction) or sits on a read-only
+            # mount, there's nothing actionable left to do — the outer
+            # ``except`` already logged the originating write failure.
             pass
         return False
     return True

--- a/config/perplexity_handler.py
+++ b/config/perplexity_handler.py
@@ -13,7 +13,6 @@ Model names: pplx-sub/sonar-pro, pplx-sub/sonar, etc.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import time
@@ -24,6 +23,14 @@ from typing import Any
 import httpx
 import litellm
 from litellm import CustomLLM, ModelResponse
+from oauth_token_store import (
+    DEFAULT_REFRESH_BUFFER_SECONDS,
+    FileBackedCache,
+    is_timestamp_expired,
+    read_json_file,
+    with_retry_on_401,
+    write_json_atomic,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -35,9 +42,9 @@ PERPLEXITY_TOKENS_PATH = Path(
 )
 
 PERPLEXITY_API_BASE = "https://api.perplexity.ai"
-REFRESH_BUFFER_SECONDS = 5 * 60
 
-_token_cache: dict[str, Any] = {}
+
+_pplx_file_cache = FileBackedCache(PERPLEXITY_TOKENS_PATH, read_json_file)
 
 
 def _load_tokens() -> dict[str, Any] | None:
@@ -54,13 +61,7 @@ def _load_tokens() -> dict[str, Any] | None:
             "source": "session",
         }
 
-    if PERPLEXITY_TOKENS_PATH.exists():
-        try:
-            return json.loads(PERPLEXITY_TOKENS_PATH.read_text())
-        except (json.JSONDecodeError, OSError):
-            _log.debug("Could not read token file")
-
-    return None
+    return _pplx_file_cache.get()
 
 
 def _exchange_session_for_access(session_token: str) -> dict[str, Any]:
@@ -91,25 +92,15 @@ def _exchange_session_for_access(session_token: str) -> dict[str, Any]:
         "source": "session_exchange",
     }
 
-    try:
-        PERPLEXITY_TOKENS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        PERPLEXITY_TOKENS_PATH.write_text(json.dumps(tokens, indent=2))
-        os.chmod(PERPLEXITY_TOKENS_PATH, 0o600)
-    except OSError:
-        _log.debug("Could not persist tokens to disk")
-
+    write_json_atomic(PERPLEXITY_TOKENS_PATH, tokens)
+    _pplx_file_cache.replace(tokens)
     return tokens
 
 
-def _is_expired(tokens: dict[str, Any]) -> bool:
-    expires_at = tokens.get("expiresAt", 0)
-    if expires_at == 0:
-        return False
-    return time.time() + REFRESH_BUFFER_SECONDS >= expires_at
-
-
-def get_access_token() -> str:
-    tokens = _token_cache.get("token") or _load_tokens()
+def get_perplexity_access_token(force_refresh: bool = False) -> str:
+    if force_refresh:
+        _pplx_file_cache.invalidate()
+    tokens = _load_tokens()
     if tokens is None:
         raise litellm.AuthenticationError(
             message=(
@@ -123,10 +114,12 @@ def get_access_token() -> str:
     if not tokens.get("accessToken") and tokens.get("sessionToken"):
         tokens = _exchange_session_for_access(tokens["sessionToken"])
 
-    if _is_expired(tokens) and tokens.get("sessionToken"):
+    expired = is_timestamp_expired(
+        tokens.get("expiresAt"), buffer_seconds=DEFAULT_REFRESH_BUFFER_SECONDS
+    )
+    if (force_refresh or expired) and tokens.get("sessionToken"):
         tokens = _exchange_session_for_access(tokens["sessionToken"])
 
-    _token_cache["token"] = tokens
     return tokens.get("accessToken", "")
 
 
@@ -154,14 +147,7 @@ class PerplexitySubHandler(CustomLLM):
         headers: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> ModelResponse:
-        access_token = get_access_token()
         actual_model = model.split("/", 1)[-1] if "/" in model else model
-
-        req_headers = {
-            "authorization": f"Bearer {access_token}",
-            "content-type": "application/json",
-            "accept": "application/json",
-        }
 
         opts = optional_params or {}
         request_body: dict[str, Any] = {"model": actual_model, "messages": messages}
@@ -172,17 +158,30 @@ class PerplexitySubHandler(CustomLLM):
             request_body["max_tokens"] = opts["max_tokens"]
 
         api_url = api_base or PERPLEXITY_API_BASE
-        resp = httpx.post(
-            f"{api_url}/chat/completions",
-            json=request_body,
-            headers=req_headers,
-            timeout=timeout or 600,
-        )
+
+        def _send(force_refresh: bool) -> httpx.Response:
+            access_token = get_perplexity_access_token(force_refresh=force_refresh)
+            req_headers = {
+                "authorization": f"Bearer {access_token}",
+                "content-type": "application/json",
+                "accept": "application/json",
+            }
+            return httpx.post(
+                f"{api_url}/chat/completions",
+                json=request_body,
+                headers=req_headers,
+                timeout=timeout or 600,
+            )
+
+        resp = with_retry_on_401(_send)
 
         if resp.status_code == 401:
-            _token_cache.pop("token", None)
+            _pplx_file_cache.invalidate()
             raise litellm.AuthenticationError(
-                message=f"Perplexity auth failed (401): {resp.text}",
+                message=(
+                    "Perplexity Pro authentication was rejected. Re-extract the "
+                    f"PERPLEXITY_SESSION_TOKEN cookie. Underlying: {resp.text}"
+                ),
                 model=model,
                 llm_provider="pplx-sub",
             )

--- a/containers/litellm.Dockerfile
+++ b/containers/litellm.Dockerfile
@@ -3,7 +3,10 @@ FROM ghcr.io/berriai/litellm:main-v1.82.3-stable.patch.2
 # xxhash is required for CCH (Claude Code Hash) request signing
 RUN pip install --no-cache-dir xxhash
 
+COPY config/oauth_token_store.py /app/oauth_token_store.py
 COPY config/claude_code_handler.py /app/claude_code_handler.py
+COPY config/codex_chatgpt_handler.py /app/codex_chatgpt_handler.py
+COPY config/auth_handler.py /app/auth_handler.py
 COPY config/gemini_handler.py /app/gemini_handler.py
 COPY config/copilot_handler.py /app/copilot_handler.py
 COPY config/grok_handler.py /app/grok_handler.py

--- a/decepticon/llm/factory.py
+++ b/decepticon/llm/factory.py
@@ -19,8 +19,10 @@ ordering AuthMethods in the fallback chain.
 
 from __future__ import annotations
 
+import json
 import os
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -120,6 +122,64 @@ _OAUTH_METHOD_ENV: dict[AuthMethod, str] = {
     AuthMethod.PERPLEXITY_OAUTH: "DECEPTICON_AUTH_PERPLEXITY",
 }
 
+# Vendor-specific API key prefix hints. When the method has a known
+# canonical prefix, ``_is_real_key`` requires the value to start with one
+# of these strings — protects against placeholder strings the launcher
+# didn't emit (e.g. a user pasting ``sk-ant-not-used`` into .env).
+_KEY_PREFIX_HINTS: dict[AuthMethod, tuple[str, ...]] = {
+    AuthMethod.ANTHROPIC_API: ("sk-ant-",),
+    AuthMethod.OPENAI_API: ("sk-",),
+    AuthMethod.GOOGLE_API: ("AIza",),
+    AuthMethod.XAI_API: ("xai-",),
+    AuthMethod.GROQ_API: ("gsk_",),
+    AuthMethod.OPENROUTER_API: ("sk-or-",),
+    AuthMethod.NVIDIA_API: ("nvapi-",),
+    AuthMethod.DEEPSEEK_API: ("sk-",),
+    AuthMethod.GITHUB_MODELS_API: ("ghp_", "github_pat_", "gho_", "ghs_"),
+}
+
+# Substring tokens that mark a value as obviously not a real key.
+# Catches creative placeholder values that don't match the launcher's
+# ``your-…-key-here`` template.
+_PLACEHOLDER_TOKENS: tuple[str, ...] = (
+    "placeholder",
+    "not-used",
+    "not_used",
+    "dummy",
+    "fake",
+    "example",
+)
+
+# Minimum length for any value that should be treated as a real key. All
+# vendor-issued keys exceed this — Anthropic ``sk-ant-api03-…`` ≈ 100 chars,
+# OpenAI ``sk-…`` ≥ 48 chars, Google ``AIza…`` 39 chars. 24 leaves headroom
+# for vendors with shorter formats (Mistral, etc.) without admitting
+# obviously-junk values.
+_KEY_MIN_LENGTH = 24
+
+# OAuth methods carry a host-side credentials file. Booleans like
+# ``DECEPTICON_AUTH_CLAUDE_CODE=true`` are intent (the user enabled the
+# subscription) — they don't guarantee the actual file exists. The
+# factory verifies file presence + valid JSON before adding a method to
+# the chain so a user who ran ``codex logout`` without flipping the
+# boolean back doesn't generate a noisy 401-fallback storm.
+#
+# Each tuple is ordered: primary path first, legacy paths after. Env-var
+# overrides take precedence over the literal default. The langgraph
+# compose service mounts the Claude + Codex paths read-only so this
+# check sees the same files the LiteLLM handlers will read.
+_OAUTH_CREDENTIAL_PATHS: dict[AuthMethod, tuple[tuple[str, str], ...]] = {
+    AuthMethod.ANTHROPIC_OAUTH: (
+        ("CLAUDE_CODE_CREDENTIALS_PATH", "~/.claude/.credentials.json"),
+        ("", "~/.config/anthropic/q/tokens.json"),  # legacy emulator path
+    ),
+    AuthMethod.OPENAI_OAUTH: (("CODEX_AUTH_PATH", "~/.codex/auth.json"),),
+    AuthMethod.GOOGLE_OAUTH: (("GEMINI_TOKENS_PATH", "~/.config/gemini/tokens.json"),),
+    AuthMethod.COPILOT_OAUTH: (("COPILOT_TOKENS_PATH", "~/.config/copilot/tokens.json"),),
+    AuthMethod.GROK_OAUTH: (("GROK_TOKENS_PATH", "~/.config/grok/tokens.json"),),
+    AuthMethod.PERPLEXITY_OAUTH: (("PERPLEXITY_TOKENS_PATH", "~/.config/perplexity/tokens.json"),),
+}
+
 
 def _ollama_cloud_configured() -> bool:
     """Return True when the user has wired up Ollama Cloud.
@@ -164,24 +224,80 @@ def _custom_openai_configured() -> bool:
     return bool(base) and _is_real_key(key)
 
 
-def _is_real_key(value: str) -> bool:
-    """Reject empty values and the placeholders shipped in .env.example.
+def _is_real_key(value: str, method: AuthMethod | None = None) -> bool:
+    """Validate that ``value`` looks like a real provider API key.
 
-    Onboard-written keys pass; values like ``your-anthropic-key-here``
-    or empty strings are treated as "not configured" so the resolved
-    Credentials inventory stays honest.
+    Layers, in order:
+      1. Strip whitespace; reject empty.
+      2. Reject anything shorter than ``_KEY_MIN_LENGTH`` (24 chars) —
+         every vendor-issued key exceeds this, while typical placeholders
+         (``sk-ant-test``, ``not-set``) do not.
+      3. Reject the launcher's template strings (``your-…-key-here``).
+      4. Reject values containing obvious placeholder tokens
+         (``placeholder``, ``not-used``, ``dummy``, …) — guards against
+         creative .env values that escape the launcher template.
+      5. When ``method`` is given and ``_KEY_PREFIX_HINTS`` defines a
+         canonical prefix for it, require ``value`` to start with one of
+         the prefixes. Catches mis-pasted keys (e.g. an OpenAI key in
+         the Anthropic slot) before they propagate into the chain.
 
-    Match the launcher's IsPlaceholder check (``-key-here`` suffix) so
-    a real key that happens to contain the substring elsewhere is not
-    accidentally rejected.
+    ``method=None`` skips the prefix check — kept for callers like
+    ``_custom_openai_configured`` where the vendor's expected prefix is
+    deployment-specific (any OpenAI-compatible gateway).
     """
     v = value.strip()
-    if not v:
+    if not v or len(v) < _KEY_MIN_LENGTH:
         return False
     lower = v.lower()
     if lower.startswith("your-") or lower.endswith("-key-here"):
         return False
+    if any(token in lower for token in _PLACEHOLDER_TOKENS):
+        return False
+    if method is not None:
+        prefixes = _KEY_PREFIX_HINTS.get(method)
+        if prefixes and not any(v.startswith(prefix) for prefix in prefixes):
+            return False
     return True
+
+
+def _oauth_credentials_present(method: AuthMethod) -> bool:
+    """Return True if the host-side credential file for ``method`` exists.
+
+    The factory layer reads this to keep the credentials inventory
+    honest — without it, ``DECEPTICON_AUTH_CLAUDE_CODE=true`` plus a
+    deleted ``~/.claude/.credentials.json`` would still place the OAuth
+    method in every fallback chain, generating one 401 per request.
+
+    Each path is checked in order. ``/dev/null`` (the docker-compose
+    fallback when no credentials volume is wired) parses as empty, so
+    the JSON-validation step fails closed.
+    """
+    candidates = _OAUTH_CREDENTIAL_PATHS.get(method)
+    if not candidates:
+        # Method has no documented file path — fall back to the boolean
+        # flag alone for forward compatibility.
+        return True
+    for env_var, default in candidates:
+        raw = os.environ.get(env_var, "").strip() if env_var else ""
+        path = Path(raw).expanduser() if raw else Path(default).expanduser()
+        try:
+            text = path.read_text()
+        except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError):
+            continue
+        except OSError:
+            # ``/dev/null`` reads to empty without raising; other transient
+            # I/O errors fall through to the next candidate.
+            text = ""
+        text = text.strip()
+        if not text:
+            continue
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and data:
+            return True
+    return False
 
 
 def _is_truthy(value: str) -> bool:
@@ -223,10 +339,17 @@ def _resolve_credentials() -> Credentials:
     methods: list[AuthMethod] = []
     for method in priority:
         if method in _API_METHOD_ENV:
-            if _is_real_key(os.getenv(_API_METHOD_ENV[method], "")):
+            if _is_real_key(os.getenv(_API_METHOD_ENV[method], ""), method):
                 methods.append(method)
         elif method in _OAUTH_METHOD_ENV:
-            if _is_truthy(os.getenv(_OAUTH_METHOD_ENV[method], "")):
+            # OAuth methods need BOTH the boolean intent and the actual
+            # credential file. Without the file check a stale flag (e.g.
+            # ``codex logout`` after onboard) generates a 401-fallback
+            # storm — see ``_oauth_credentials_present`` for the full
+            # rationale.
+            if _is_truthy(os.getenv(_OAUTH_METHOD_ENV[method], "")) and _oauth_credentials_present(
+                method
+            ):
                 methods.append(method)
         elif method == AuthMethod.OLLAMA_LOCAL:
             if _ollama_local_configured():
@@ -322,20 +445,6 @@ def _model_drops_temperature(model: str) -> bool:
     """
     slug = model.rsplit("/", 1)[-1].lower()
     return slug.startswith("claude-opus-4")
-
-
-def _model_uses_chatgpt_responses_api(model: str) -> bool:
-    """Return True for Codex/OpenAI OAuth models routed via LiteLLM chatgpt.
-
-    LiteLLM's native ChatGPT/Codex OAuth provider is healthy on the Responses
-    API path (``/backend-api/codex/responses``). The Chat Completions path can
-    hang or hit Cloudflare challenges, while the official Codex CLI also uses
-    the Responses-style backend. Force LangChain's ChatOpenAI wrapper onto
-    Responses API for our ``auth/gpt-*`` aliases.
-    """
-
-    lowered = model.lower()
-    return lowered.startswith("auth/gpt-") or lowered.startswith("chatgpt/gpt-")
 
 
 def _model_is_deepseek_thinking(model: str) -> bool:
@@ -713,9 +822,6 @@ class LLMFactory:
             kwargs["disabled_params"] = {"temperature": None}
         else:
             kwargs["temperature"] = temperature
-        if _model_uses_chatgpt_responses_api(model):
-            kwargs["use_responses_api"] = True
-            kwargs["output_version"] = "responses/v1"
         if _model_is_deepseek_thinking(model):
             return _DeepSeekThinkingChatOpenAI(**kwargs)
         return _ProxiedChatOpenAI(**kwargs)

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -37,7 +37,7 @@ Tier × AuthMethod matrix
   anthropic_api    claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
   anthropic_oauth  auth/claude-opus-4-7          auth/claude-sonnet-4-6         auth/claude-haiku-4-5
   openai_api       gpt-5.5                       gpt-5.4                        gpt-5-nano
-  openai_oauth     auth/gpt-5.5                  auth/gpt-5.4                   auth/gpt-5.4
+  openai_oauth     auth/gpt-5.5                  auth/gpt-5.4                   auth/gpt-5.4-mini
   google_api       gemini-2.5-pro                gemini-2.5-flash               gemini-2.5-flash-lite
   minimax_api      MiniMax-M2.5                  MiniMax-M2.5-lightning         — (falls through)
   openrouter_api   claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
@@ -146,10 +146,10 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
     AuthMethod.OPENAI_OAUTH: {
         Tier.HIGH: "auth/gpt-5.5",
         Tier.MID: "auth/gpt-5.4",
-        # LiteLLM's native ChatGPT provider does not expose gpt-5-nano for
-        # ChatGPT subscriptions. Keep LOW on 5.4 so low-tier roles and the
-        # test profile never route to an invalid upstream model.
-        Tier.LOW: "auth/gpt-5.4",
+        # ChatGPT subscription doesn't include gpt-5-nano; the Codex CLI
+        # exposes ``gpt-5.4-mini`` as its small-tier slot (codex-rs
+        # models-manager/models.json, May 2026), so route LOW there.
+        Tier.LOW: "auth/gpt-5.4-mini",
     },
     AuthMethod.GOOGLE_OAUTH: {
         Tier.HIGH: "gemini-sub/gemini-2.5-pro",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     container_name: decepticon-litellm
     volumes:
       - ./config/litellm.yaml:/app/config.yaml:ro
-      - ${CLAUDE_CREDENTIALS_VOLUME:-/dev/null}:/root/.claude/.credentials.json:ro
-      - ${LITELLM_CHATGPT_TOKEN_DIR:-${HOME}/.config/litellm/chatgpt}:/root/.config/litellm/chatgpt
+      - ${CLAUDE_CREDENTIALS_VOLUME:-/dev/null}:/root/.claude/.credentials.json
+      - ${CODEX_AUTH_VOLUME:-/dev/null}:/root/.codex/auth.json
     entrypoint: ["python", "/app/litellm_startup.py"]
     command: ["--config", "/app/config.yaml", "--port", "4000"]
     ports:
@@ -19,6 +19,7 @@ services:
     environment:
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-sk-decepticon-master}
       - LITELLM_SALT_KEY=${LITELLM_SALT_KEY:-sk-decepticon-salt}
+      - CODEX_AUTH_PATH=/root/.codex/auth.json
       - DATABASE_URL=postgresql://decepticon:${POSTGRES_PASSWORD:-decepticon}@postgres:5432/litellm
     depends_on:
       postgres:
@@ -176,6 +177,15 @@ services:
       # rootless Docker → ~/.docker/run/docker.sock). The container always
       # sees /var/run/docker.sock so the agent code stays runtime-agnostic.
       - ${DECEPTICON_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
+      # Mount the OAuth credential files read-only so the LLM factory can
+      # check file presence + valid JSON before adding a method to the
+      # fallback chain. Without this the factory would trust the
+      # ``DECEPTICON_AUTH_*`` boolean alone and a stale flag
+      # (e.g. ``codex logout`` after onboard) would generate a 401-fallback
+      # storm. Read-only because langgraph never refreshes tokens — that's
+      # the LiteLLM container's job.
+      - ${CLAUDE_CREDENTIALS_VOLUME:-/dev/null}:/root/.claude/.credentials.json:ro
+      - ${CODEX_AUTH_VOLUME:-/dev/null}:/root/.codex/auth.json:ro
     # Wait for litellm to be healthy: langgraph has retry logic but the launcher
     # uses `compose up --wait` and needs healthy as the single readiness signal.
     depends_on:

--- a/docs/models.md
+++ b/docs/models.md
@@ -25,7 +25,7 @@ For each agent, Decepticon resolves a tier (from the profile) and walks your Aut
 | `anthropic_api`       | `anthropic/claude-opus-4-7`               | `anthropic/claude-sonnet-4-6`                 | `anthropic/claude-haiku-4-5`                  |
 | `anthropic_oauth`     | `auth/claude-opus-4-7`                    | `auth/claude-sonnet-4-6`                      | `auth/claude-haiku-4-5`                       |
 | `openai_api`          | `openai/gpt-5.5`                          | `openai/gpt-5.4`                              | `openai/gpt-5-nano`                           |
-| `openai_oauth`        | `auth/gpt-5.5`                            | `auth/gpt-5.4`                                | `auth/gpt-5.4`                                |
+| `openai_oauth`        | `auth/gpt-5.5`                            | `auth/gpt-5.4`                                | `auth/gpt-5.4-mini`                           |
 | `google_api`          | `gemini/gemini-2.5-pro`                   | `gemini/gemini-2.5-flash`                     | `gemini/gemini-2.5-flash-lite`                |
 | `google_oauth`        | `gemini-sub/gemini-2.5-pro`               | `gemini-sub/gemini-2.5-flash`                 | — *(falls through)*                           |
 | `minimax_api`         | `minimax/MiniMax-M2.5`                    | `minimax/MiniMax-M2.5-lightning`              | — *(falls through)*                           |
@@ -292,12 +292,12 @@ startup so you can confirm what got picked up.
 
 ## Subscription OAuth Providers
 
-Use monthly subscriptions instead of per-token API billing. ChatGPT uses LiteLLM's native ChatGPT provider; the others use custom LiteLLM handlers that authenticate via OAuth/session tokens.
+Use monthly subscriptions instead of per-token API billing. All providers use custom LiteLLM handlers that authenticate via OAuth/session tokens. ChatGPT in particular reads from the Codex CLI credential store (`~/.codex/auth.json`), so a host-side `codex login` flows into the running container without a rebuild.
 
 | Subscription | AuthMethod | Models | Handler |
 |---|---|---|---|
 | Claude Max/Pro/Team | `anthropic_oauth` | auth/claude-opus, sonnet, haiku | `claude_code_handler.py` |
-| ChatGPT Pro/Plus/Team | `openai_oauth` | auth/gpt-5.5, gpt-5.4 | LiteLLM native `chatgpt` provider |
+| ChatGPT Pro/Plus/Team | `openai_oauth` | auth/gpt-5.5, gpt-5.4, gpt-5.4-mini | `codex_chatgpt_handler.py` (reads `~/.codex/auth.json`) |
 | Gemini Advanced | `google_oauth` | gemini-sub/gemini-2.5-pro, flash | `gemini_handler.py` |
 | Copilot Pro | `copilot_oauth` | copilot/gpt-4o, o1, o3-mini | `copilot_handler.py` |
 | SuperGrok | `grok_oauth` | grok-sub/grok-3, grok-3-mini | `grok_handler.py` |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -328,9 +328,9 @@ Use your ChatGPT Pro, Plus, or Team subscription instead of OpenAI API billing.
 
 | Tier | Models Available (via `auth/gpt-5.x` route) |
 |------|--------------------------------------------|
-| ChatGPT Plus ($20/mo) | `auth/gpt-5.5`, `auth/gpt-5.4` |
-| ChatGPT Pro ($200/mo) | `auth/gpt-5.5`, `auth/gpt-5.4` |
-| ChatGPT Team | `auth/gpt-5.5`, `auth/gpt-5.4` + admin controls |
+| ChatGPT Plus ($20/mo) | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5.4-mini` |
+| ChatGPT Pro ($200/mo) | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5.4-mini` |
+| ChatGPT Team | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5.4-mini` + admin controls |
 
 **Setup:**
 
@@ -358,18 +358,25 @@ decepticon
 
 - Decepticon exposes ChatGPT subscription models as `auth/gpt-5.5`
   and `auth/gpt-5.4`.
-- LiteLLM dynamic config maps those aliases to LiteLLM's native
-  `chatgpt/gpt-*` provider routes only when `DECEPTICON_AUTH_CHATGPT=true`.
-- `docker-compose.yml` mounts the host token directory into the LiteLLM
-  container at `/root/.config/litellm/chatgpt`.
-- Access tokens are handled by LiteLLM's native ChatGPT provider. It stores
-  OAuth credentials in `~/.config/litellm/chatgpt/auth.json` and refreshes
-  them as needed.
+- LiteLLM dynamic config maps those aliases through Decepticon's custom
+  `auth/` handler (`codex_chatgpt_handler`) only when
+  `DECEPTICON_AUTH_CHATGPT=true`.
+- `docker-compose.yml` mounts the host's Codex CLI credential file
+  (`~/.codex/auth.json`) into the LiteLLM container at
+  `/root/.codex/auth.json` (read-write, so the in-container refresh path
+  can persist rotated tokens back to the host).
+- The `auth/` handler reads and writes the same `auth.json` the Codex CLI
+  itself uses, so a host-side `codex login` is visible to the running
+  container without a restart, and a refresh inside the container is
+  visible to the host CLI on the next call.
 
-**Custom token path:**
+**Setup:**
 
 ```bash
-LITELLM_CHATGPT_TOKEN_DIR=/custom/host/token/dir
+# Install the Codex CLI and run the device-code login on the host:
+codex login
+# Confirm the file exists:
+ls ~/.codex/auth.json
 ```
 
 ---
@@ -852,10 +859,10 @@ cat ~/.claude/.credentials.json | python3 -c "import sys,json; d=json.load(sys.s
 
 **ChatGPT OAuth: missing or expired auth**
 
-LiteLLM's native ChatGPT provider stores credentials at
-`~/.config/litellm/chatgpt/auth.json`. If the file is missing or expired,
-restart Decepticon and follow the ChatGPT device-code login instructions shown
-in the LiteLLM logs.
+The Decepticon `auth/` ChatGPT handler reads the Codex CLI credential
+store at `~/.codex/auth.json`. If the file is missing or the refresh
+token is rejected, run `codex login` on the host and retry. The handler
+picks up the refreshed file automatically (no container restart needed).
 
 **API Key: "401 Unauthorized"**
 

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -4,7 +4,12 @@ import asyncio
 
 import pytest
 
-from decepticon.llm.factory import LLMFactory, _resolve_credentials
+from decepticon.llm.factory import (
+    LLMFactory,
+    _is_real_key,
+    _oauth_credentials_present,
+    _resolve_credentials,
+)
 from decepticon.llm.models import (
     AuthMethod,
     Credentials,
@@ -12,6 +17,94 @@ from decepticon.llm.models import (
     ModelProfile,
     ProxyConfig,
 )
+
+
+class TestIsRealKey:
+    """Vendor-aware API key validation.
+
+    The launcher writes ``your-…-key-here`` placeholders into .env so the
+    user can later swap in a real key. The factory needs to reject those
+    plus any obvious junk (short strings, ``placeholder``/``not-used``
+    markers, vendor-prefix mismatches) so the credentials inventory
+    reflects what actually works at request time.
+    """
+
+    def test_rejects_empty_and_placeholder_template(self) -> None:
+        assert _is_real_key("") is False
+        assert _is_real_key("   ") is False
+        assert _is_real_key("your-anthropic-key-here") is False
+        assert _is_real_key("YOUR-OPENAI-KEY-HERE") is False  # case-insensitive
+
+    def test_rejects_short_strings(self) -> None:
+        # Under 24 chars — every vendor-issued key exceeds this.
+        assert _is_real_key("sk-tooshort") is False
+
+    def test_rejects_placeholder_tokens_in_value(self) -> None:
+        long_enough = "x" * 30
+        for token in ("placeholder", "not-used", "dummy", "fake", "example"):
+            assert _is_real_key(f"sk-{token}-{long_enough}") is False, token
+
+    def test_accepts_realistic_keys_without_method(self) -> None:
+        # Without method context, prefix check is skipped.
+        assert _is_real_key("sk-ant-api03-realtokenfortestingauthrouting12345") is True
+        assert _is_real_key("AIzaSyDeadBeefDeadBeefDeadBeefDeadBeef0") is True
+
+    def test_rejects_wrong_vendor_prefix(self) -> None:
+        # An OpenAI-shaped key in the Anthropic slot must be caught.
+        openai_key = "sk-proj-realopenaitokenfortestingauthrouting12345"
+        assert _is_real_key(openai_key, AuthMethod.ANTHROPIC_API) is False
+        # …and vice versa.
+        anthropic_key = "sk-ant-api03-realtokenfortestingauthrouting12345"
+        assert _is_real_key(anthropic_key, AuthMethod.GOOGLE_API) is False
+
+    def test_accepts_correct_vendor_prefix(self) -> None:
+        anthropic_key = "sk-ant-api03-realtokenfortestingauthrouting12345"
+        assert _is_real_key(anthropic_key, AuthMethod.ANTHROPIC_API) is True
+        google_key = "AIzaSyDeadBeefDeadBeefDeadBeefDeadBeef0"
+        assert _is_real_key(google_key, AuthMethod.GOOGLE_API) is True
+
+
+class TestOAuthCredentialsPresent:
+    """OAuth detection requires the credential file alongside the boolean.
+
+    Without the file check, ``DECEPTICON_AUTH_CLAUDE_CODE=true`` plus a
+    deleted ``~/.claude/.credentials.json`` would still place OAuth in
+    every fallback chain and generate one 401 per request.
+    """
+
+    def test_returns_false_when_file_missing(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(tmp_path / "absent.json"))
+        assert _oauth_credentials_present(AuthMethod.ANTHROPIC_OAUTH) is False
+
+    def test_returns_false_when_file_is_empty(self, monkeypatch, tmp_path) -> None:
+        # ``/dev/null``-style mounts read as empty — must fail closed.
+        empty = tmp_path / "empty.json"
+        empty.write_text("")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(empty))
+        assert _oauth_credentials_present(AuthMethod.ANTHROPIC_OAUTH) is False
+
+    def test_returns_false_on_invalid_json(self, monkeypatch, tmp_path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not-json")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(bad))
+        assert _oauth_credentials_present(AuthMethod.ANTHROPIC_OAUTH) is False
+
+    def test_returns_true_when_file_is_well_formed(self, monkeypatch, tmp_path) -> None:
+        good = tmp_path / "credentials.json"
+        good.write_text('{"claudeAiOauth": {"accessToken": "sk-ant-oat01-deadbeef"}}')
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(good))
+        assert _oauth_credentials_present(AuthMethod.ANTHROPIC_OAUTH) is True
+
+    def test_codex_path_via_env_override(self, monkeypatch, tmp_path) -> None:
+        good = tmp_path / "auth.json"
+        good.write_text('{"tokens": {"access_token": "ABC"}}')
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CODEX_AUTH_PATH", str(good))
+        assert _oauth_credentials_present(AuthMethod.OPENAI_OAUTH) is True
 
 
 class TestLLMFactory:
@@ -96,7 +189,7 @@ class TestLLMFactoryHealthCheck:
 
 class TestResolveCredentials:
     def test_real_keys_only(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real-12345")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-realtokenfortestingauthrouting12345")
         monkeypatch.setenv("OPENAI_API_KEY", "your-openai-key-here")  # placeholder
         for k in (
             "GEMINI_API_KEY",
@@ -123,7 +216,13 @@ class TestResolveCredentials:
         creds = _resolve_credentials()
         assert creds.methods == [AuthMethod.ANTHROPIC_API]
 
-    def test_oauth_only(self, monkeypatch):
+    def test_oauth_only(self, monkeypatch, tmp_path):
+        # OAuth detection requires the credential FILE alongside the
+        # boolean — point Claude Code at a temp credentials file so the
+        # test runs deterministically regardless of host state.
+        cred_file = tmp_path / "credentials.json"
+        cred_file.write_text('{"claudeAiOauth": {"accessToken": "sk-ant-oat01-deadbeefdeadbeef"}}')
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(cred_file))
         for k in (
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
@@ -151,11 +250,49 @@ class TestResolveCredentials:
         creds = _resolve_credentials()
         assert creds.methods == [AuthMethod.ANTHROPIC_OAUTH]
 
-    def test_oauth_plus_api_priority_default(self, monkeypatch):
-        # Default priority is anthropic_oauth > anthropic_api > openai_api ...
+    def test_oauth_flag_without_credential_file_is_dropped(self, monkeypatch, tmp_path):
+        """Stale ``DECEPTICON_AUTH_CLAUDE_CODE=true`` after ``codex logout``
+        (or after the user deleted ``~/.claude/.credentials.json``) must
+        not place the OAuth method into the chain — otherwise every
+        request 401s before falling back to the next provider.
+        """
+        # Point both the primary and legacy fallback paths at tmp_path so
+        # any ``~/.claude/.credentials.json`` or
+        # ``~/.config/anthropic/q/tokens.json`` on the dev host doesn't
+        # accidentally satisfy the file-presence check.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        missing = tmp_path / "missing.json"  # never created
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(missing))
         monkeypatch.setenv("DECEPTICON_AUTH_CLAUDE_CODE", "true")
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real-12345")
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-real-openai-12345")
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "MINIMAX_API_KEY",
+            "OLLAMA_API_BASE",
+            "OLLAMA_MODEL",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        for flag in (
+            "DECEPTICON_AUTH_CHATGPT",
+            "DECEPTICON_AUTH_COPILOT",
+            "DECEPTICON_AUTH_GEMINI",
+            "DECEPTICON_AUTH_GROK",
+            "DECEPTICON_AUTH_PERPLEXITY",
+        ):
+            monkeypatch.delenv(flag, raising=False)
+        monkeypatch.delenv("DECEPTICON_AUTH_PRIORITY", raising=False)
+        creds = _resolve_credentials()
+        assert AuthMethod.ANTHROPIC_OAUTH not in creds.methods
+
+    def test_oauth_plus_api_priority_default(self, monkeypatch, tmp_path):
+        # Default priority is anthropic_oauth > anthropic_api > openai_api ...
+        cred_file = tmp_path / "credentials.json"
+        cred_file.write_text('{"claudeAiOauth": {"accessToken": "sk-ant-oat01-deadbeefdeadbeef"}}')
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(cred_file))
+        monkeypatch.setenv("DECEPTICON_AUTH_CLAUDE_CODE", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-realtokenfortestingauthrouting12345")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-realopenaitokenfortestingauthrouting12345")
         for k in (
             "GEMINI_API_KEY",
             "MINIMAX_API_KEY",
@@ -186,8 +323,8 @@ class TestResolveCredentials:
 
     def test_explicit_priority_override(self, monkeypatch):
         monkeypatch.setenv("DECEPTICON_AUTH_PRIORITY", "openai_api,anthropic_api")
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real-12345")
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-real-openai-12345")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-realtokenfortestingauthrouting12345")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-realopenaitokenfortestingauthrouting12345")
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
         monkeypatch.delenv("DECEPTICON_AUTH_CLAUDE_CODE", raising=False)
@@ -258,7 +395,7 @@ class TestResolveCredentials:
         monkeypatch.setenv("DECEPTICON_AUTH_PRIORITY", "ollama_local,anthropic_api")
         monkeypatch.setenv("OLLAMA_API_BASE", "http://host.docker.internal:11434")
         monkeypatch.setenv("OLLAMA_MODEL", "qwen3-coder:30b")
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real-12345")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-realtokenfortestingauthrouting12345")
         for k in (
             "OPENAI_API_KEY",
             "GEMINI_API_KEY",

--- a/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/tests/unit/llm/test_litellm_dynamic_config.py
@@ -74,6 +74,38 @@ def test_validate_model_name_rejects_bare_or_internal_routes() -> None:
         validate_model_name("unknown/model")
 
 
+def test_validate_model_name_rejects_other_subscription_prefixes() -> None:
+    """Subscription providers register through ``custom_provider_map`` in
+    ``litellm_startup.py`` — admitting them on the API-key dynamic path
+    would synthesize a ``<PROVIDER>_API_KEY`` env lookup that never works.
+    """
+    for slug in (
+        "gemini-sub/gemini-2.5-pro",
+        "copilot/gpt-4o",
+        "grok-sub/grok-3",
+        "pplx-sub/sonar",
+    ):
+        with pytest.raises(ValueError, match="not allowed as dynamic API-key model routes"):
+            validate_model_name(slug)
+
+
+def test_merge_dynamic_models_allows_subscription_model_override() -> None:
+    """A user setting ``DECEPTICON_MODEL=auth/gpt-5.4-mini`` together with
+    ``DECEPTICON_AUTH_CHATGPT=true`` must succeed — the subscription path
+    injects the route first, and the API-key validator is skipped because
+    the model is already present in the model_list.
+    """
+    merged = merge_dynamic_models(
+        {"model_list": [], "litellm_settings": {"fallbacks": []}},
+        {
+            "DECEPTICON_AUTH_CHATGPT": "true",
+            "DECEPTICON_MODEL": "auth/gpt-5.4-mini",
+        },
+    )
+    names = {entry["model_name"] for entry in merged["model_list"]}
+    assert "auth/gpt-5.4-mini" in names
+
+
 def test_validate_model_name_rejects_legacy_ollama_with_remediation() -> None:
     """``ollama/`` (legacy /api/generate) does not support tool calling per
     LiteLLM's own ``supports_function_calling`` assertion. Decepticon agents
@@ -145,12 +177,19 @@ def test_merge_dynamic_models_registers_only_supported_chatgpt_oauth_routes() ->
         {"DECEPTICON_AUTH_CHATGPT": "true"},
     )
 
-    routes = {
-        entry["model_name"]: entry["litellm_params"]["model"] for entry in merged["model_list"]
+    # User-facing model_name stays ``auth/gpt-*`` for consistency with
+    # ``auth/claude-*``, but the internal litellm_params.model uses the
+    # dedicated ``codex-oauth`` custom provider — bare ``auth/gpt-*``
+    # makes LiteLLM strip the prefix and route to the native OpenAI
+    # provider because the ``gpt-*`` slug collides with OpenAI's aliases.
+    entries = {entry["model_name"]: entry["litellm_params"] for entry in merged["model_list"]}
+    assert entries == {
+        "auth/gpt-5.5": {"model": "codex-oauth/oauth-gpt-5.5"},
+        "auth/gpt-5.4": {"model": "codex-oauth/oauth-gpt-5.4"},
+        "auth/gpt-5.4-mini": {"model": "codex-oauth/oauth-gpt-5.4-mini"},
     }
-    assert routes == {
-        "auth/gpt-5.5": "chatgpt/gpt-5.5",
-        "auth/gpt-5.4": "chatgpt/gpt-5.4",
-    }
-    assert "auth/gpt-5-nano" not in routes
-    assert merged["litellm_settings"]["fallbacks"] == [{"auth/gpt-5.5": ["auth/gpt-5.4"]}]
+    assert "auth/gpt-5-nano" not in entries
+    assert merged["litellm_settings"]["fallbacks"] == [
+        {"auth/gpt-5.5": ["auth/gpt-5.4"]},
+        {"auth/gpt-5.4": ["auth/gpt-5.4-mini"]},
+    ]

--- a/tests/unit/llm/test_models.py
+++ b/tests/unit/llm/test_models.py
@@ -74,7 +74,7 @@ class TestMethodModels:
         m = METHOD_MODELS[AuthMethod.OPENAI_OAUTH]
         assert m[Tier.HIGH] == "auth/gpt-5.5"
         assert m[Tier.MID] == "auth/gpt-5.4"
-        assert m[Tier.LOW] == "auth/gpt-5.4"
+        assert m[Tier.LOW] == "auth/gpt-5.4-mini"
         assert "auth/gpt-5-nano" not in m.values()
 
     def test_google_full_tier_coverage(self):
@@ -194,10 +194,10 @@ class TestResolveChain:
         chain = resolve_chain(Tier.LOW, creds)
         assert chain == []
 
-    def test_chatgpt_oauth_low_falls_back_to_gpt_5_4(self):
+    def test_chatgpt_oauth_low_uses_gpt_5_4_mini(self):
         creds = Credentials(methods=[AuthMethod.OPENAI_OAUTH])
         chain = resolve_chain(Tier.LOW, creds)
-        assert chain == ["auth/gpt-5.4"]
+        assert chain == ["auth/gpt-5.4-mini"]
 
     def test_empty_credentials_returns_empty(self):
         assert resolve_chain(Tier.HIGH, Credentials()) == []

--- a/tests/unit/llm/test_oauth_token_store.py
+++ b/tests/unit/llm/test_oauth_token_store.py
@@ -1,0 +1,397 @@
+"""Unit tests for the shared OAuth token store helper module.
+
+The module under test lives at ``config/oauth_token_store.py`` and is
+mounted into the LiteLLM container — it is not part of the ``decepticon``
+package, so we import it via ``importlib.util.spec_from_file_location``
+the same way ``test_litellm_dynamic_config.py`` does.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import types
+from base64 import urlsafe_b64encode
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+# ``oauth_token_store`` lives in the LiteLLM container's ``/app`` and imports
+# ``litellm`` at module level for ``AuthenticationError``. The dev test env
+# does not install LiteLLM (it's a runtime container dep), so we inject a
+# minimal stub before loading the module.
+if "litellm" not in sys.modules:
+    _litellm = types.ModuleType("litellm")
+
+    class _AuthenticationError(Exception):
+        def __init__(self, message: str = "", model: str = "", llm_provider: str = "") -> None:
+            super().__init__(message)
+            self.message = message
+            self.model = model
+            self.llm_provider = llm_provider
+
+    _litellm.AuthenticationError = _AuthenticationError  # type: ignore[attr-defined]
+    sys.modules["litellm"] = _litellm
+
+import litellm  # noqa: E402  — resolved via the stub above
+
+_MODULE_PATH = Path(__file__).resolve().parents[3] / "config" / "oauth_token_store.py"
+_spec = importlib.util.spec_from_file_location("decepticon_oauth_token_store", _MODULE_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+read_json_file = _module.read_json_file
+write_json_atomic = _module.write_json_atomic
+FileBackedCache = _module.FileBackedCache
+decode_jwt_payload = _module.decode_jwt_payload
+is_jwt_expired = _module.is_jwt_expired
+is_timestamp_expired = _module.is_timestamp_expired
+oauth_refresh_request = _module.oauth_refresh_request
+with_retry_on_401 = _module.with_retry_on_401
+DEFAULT_REFRESH_BUFFER_SECONDS = _module.DEFAULT_REFRESH_BUFFER_SECONDS
+
+
+# ── read_json_file ──────────────────────────────────────────────────────
+
+
+def test_read_json_file_returns_dict_on_happy_path(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"access": "abc", "n": 1}))
+    assert read_json_file(path) == {"access": "abc", "n": 1}
+
+
+def test_read_json_file_returns_none_on_missing_file(tmp_path: Path) -> None:
+    assert read_json_file(tmp_path / "absent.json") is None
+
+
+def test_read_json_file_returns_none_on_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not-json")
+    assert read_json_file(path) is None
+
+
+def test_read_json_file_returns_none_when_top_level_is_not_dict(tmp_path: Path) -> None:
+    path = tmp_path / "list.json"
+    path.write_text(json.dumps([1, 2, 3]))
+    assert read_json_file(path) is None
+
+
+# ── write_json_atomic ──────────────────────────────────────────────────
+
+
+def test_write_json_atomic_writes_payload_with_secure_mode(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    payload = {"access": "abc"}
+    assert write_json_atomic(path, payload) is True
+    assert json.loads(path.read_text()) == payload
+    assert oct(path.stat().st_mode)[-3:] == "600"
+
+
+def test_write_json_atomic_creates_parent_directories(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "subdir" / "tokens.json"
+    assert write_json_atomic(path, {"a": 1}) is True
+    assert path.exists()
+
+
+def test_write_json_atomic_uses_atomic_temp_then_rename(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    write_json_atomic(path, {"v": "first"})
+    write_json_atomic(path, {"v": "second"})
+    # Temp sibling must be cleaned up after the rename.
+    assert not (tmp_path / f".{path.name}.decepticon.tmp").exists()
+    assert json.loads(path.read_text()) == {"v": "second"}
+
+
+def test_write_json_atomic_returns_false_when_target_dir_unwritable(tmp_path: Path) -> None:
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)  # read+exec, no write
+    try:
+        assert write_json_atomic(locked / "tokens.json", {"a": 1}) is False
+    finally:
+        locked.chmod(0o700)
+
+
+# ── FileBackedCache ────────────────────────────────────────────────────
+
+
+def _loader_counter() -> tuple[Any, list[int]]:
+    calls = [0]
+
+    def loader(path: Path) -> dict[str, Any] | None:
+        calls[0] += 1
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+
+    return loader, calls
+
+
+def test_file_backed_cache_returns_loader_result_on_first_get(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"v": 1}))
+    loader, calls = _loader_counter()
+    cache = FileBackedCache(path, loader)
+    assert cache.get() == {"v": 1}
+    assert calls[0] == 1
+
+
+def test_file_backed_cache_skips_loader_on_unchanged_file(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"v": 1}))
+    loader, calls = _loader_counter()
+    cache = FileBackedCache(path, loader)
+    cache.get()
+    cache.get()
+    cache.get()
+    assert calls[0] == 1
+
+
+def test_file_backed_cache_reloads_when_mtime_changes(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"v": 1}))
+    loader, calls = _loader_counter()
+    cache = FileBackedCache(path, loader)
+    assert cache.get() == {"v": 1}
+
+    # Bump mtime + size to defeat any 1-second filesystem resolution.
+    path.write_text(json.dumps({"v": 2, "filler": "x" * 64}))
+    new_mtime = path.stat().st_mtime + 5
+    os.utime(path, (new_mtime, new_mtime))
+
+    assert cache.get() == {"v": 2, "filler": "x" * 64}
+    assert calls[0] == 2
+
+
+def test_file_backed_cache_returns_loader_result_when_file_missing(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    loader, calls = _loader_counter()
+    cache = FileBackedCache(path, loader)
+    assert cache.get() is None
+    assert calls[0] == 1
+    # Each missing-file access re-invokes the loader; the loader can decide.
+    assert cache.get() is None
+    assert calls[0] == 2
+
+
+def test_file_backed_cache_replace_avoids_reread_on_next_get(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"v": "original"}))
+    loader, calls = _loader_counter()
+    cache = FileBackedCache(path, loader)
+    cache.get()  # priming load
+
+    cache.replace({"v": "refreshed"})
+    assert cache.get() == {"v": "refreshed"}
+    # replace stamped the cache key; no extra loader call required.
+    assert calls[0] == 1
+
+
+def test_file_backed_cache_invalidate_forces_reread(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"v": 1}))
+    loader, calls = _loader_counter()
+    cache = FileBackedCache(path, loader)
+    cache.get()
+    cache.invalidate()
+    cache.get()
+    assert calls[0] == 2
+
+
+# ── decode_jwt_payload / is_jwt_expired ────────────────────────────────
+
+
+def _jwt(payload: dict[str, Any]) -> str:
+    body = urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("ascii")
+    return f"header.{body}.signature"
+
+
+def test_decode_jwt_payload_returns_dict_for_well_formed_token() -> None:
+    token = _jwt({"sub": "u1", "exp": 123})
+    assert decode_jwt_payload(token) == {"sub": "u1", "exp": 123}
+
+
+def test_decode_jwt_payload_returns_empty_dict_for_malformed_token() -> None:
+    assert decode_jwt_payload("not-a-jwt") == {}
+    assert decode_jwt_payload("a.b") == {}
+
+
+def test_decode_jwt_payload_returns_empty_dict_for_non_string_input() -> None:
+    assert decode_jwt_payload(None) == {}
+    assert decode_jwt_payload(12345) == {}  # type: ignore[arg-type]
+
+
+def test_is_jwt_expired_false_for_future_exp() -> None:
+    token = _jwt({"exp": int(time.time()) + 3600})
+    assert is_jwt_expired(token) is False
+
+
+def test_is_jwt_expired_true_when_exp_within_skew() -> None:
+    token = _jwt({"exp": int(time.time()) + 30})
+    assert is_jwt_expired(token, skew_seconds=60) is True
+
+
+def test_is_jwt_expired_true_when_exp_missing() -> None:
+    token = _jwt({"sub": "u1"})
+    assert is_jwt_expired(token) is True
+
+
+# ── is_timestamp_expired ──────────────────────────────────────────────
+
+
+def test_is_timestamp_expired_treats_zero_as_never() -> None:
+    assert is_timestamp_expired(0) is False
+    assert is_timestamp_expired(None) is False
+
+
+def test_is_timestamp_expired_handles_seconds_input() -> None:
+    assert is_timestamp_expired(time.time() + 3600, buffer_seconds=300) is False
+    assert is_timestamp_expired(time.time() + 60, buffer_seconds=300) is True
+
+
+def test_is_timestamp_expired_auto_detects_milliseconds() -> None:
+    future_ms = (time.time() + 3600) * 1000
+    assert is_timestamp_expired(future_ms, buffer_seconds=300) is False
+    near_ms = (time.time() + 60) * 1000
+    assert is_timestamp_expired(near_ms, buffer_seconds=300) is True
+
+
+def test_is_timestamp_expired_uses_default_buffer() -> None:
+    # Default buffer is 5 min; exp 4 min in the future should be treated as expired.
+    assert is_timestamp_expired(time.time() + 4 * 60) is True
+    assert is_timestamp_expired(time.time() + 6 * 60) is False
+    assert DEFAULT_REFRESH_BUFFER_SECONDS == 5 * 60
+
+
+# ── oauth_refresh_request ─────────────────────────────────────────────
+
+
+def _httpx_response(status_code: int, payload: Any) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+        request=httpx.Request("POST", "https://example.test/oauth/token"),
+    )
+
+
+def test_oauth_refresh_request_returns_parsed_payload_on_success() -> None:
+    expected = {"access_token": "new", "expires_in": 3600}
+    with patch.object(httpx, "post", return_value=_httpx_response(200, expected)) as mock_post:
+        result = oauth_refresh_request(
+            "https://example.test/oauth/token",
+            {"grant_type": "refresh_token", "refresh_token": "r"},
+            provider_label="provider-x",
+        )
+    assert result == expected
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://example.test/oauth/token"
+    assert kwargs.get("json") == {"grant_type": "refresh_token", "refresh_token": "r"}
+
+
+def test_oauth_refresh_request_supports_form_body() -> None:
+    with patch.object(httpx, "post", return_value=_httpx_response(200, {"a": 1})) as mock_post:
+        oauth_refresh_request(
+            "https://example.test/oauth/token",
+            {"k": "v"},
+            json_body=False,
+        )
+    _, kwargs = mock_post.call_args
+    assert kwargs.get("data") == {"k": "v"}
+    assert "json" not in kwargs
+
+
+def test_oauth_refresh_request_raises_on_4xx_with_body_in_message() -> None:
+    bad = _httpx_response(400, {"error": "bad_grant"})
+    with patch.object(httpx, "post", return_value=bad):
+        with pytest.raises(litellm.AuthenticationError) as exc:
+            oauth_refresh_request(
+                "https://example.test/oauth/token",
+                {"grant_type": "refresh_token"},
+                provider_label="provider-x",
+            )
+    assert "provider-x" in str(exc.value)
+
+
+def test_oauth_refresh_request_raises_when_response_is_not_object() -> None:
+    not_object = httpx.Response(
+        status_code=200,
+        content=b'"raw-string"',
+        headers={"content-type": "application/json"},
+        request=httpx.Request("POST", "https://example.test/oauth/token"),
+    )
+    with patch.object(httpx, "post", return_value=not_object):
+        with pytest.raises(litellm.AuthenticationError) as exc:
+            oauth_refresh_request(
+                "https://example.test/oauth/token",
+                {"k": "v"},
+                provider_label="provider-x",
+            )
+    assert "provider-x" in str(exc.value)
+
+
+# ── with_retry_on_401 ─────────────────────────────────────────────────
+
+
+def _stub_response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        content=b"{}",
+        request=httpx.Request("POST", "https://example.test/api"),
+    )
+
+
+def test_with_retry_on_401_returns_immediately_on_success() -> None:
+    calls: list[bool] = []
+
+    def send(force_refresh: bool) -> httpx.Response:
+        calls.append(force_refresh)
+        return _stub_response(200)
+
+    resp = with_retry_on_401(send)
+    assert resp.status_code == 200
+    assert calls == [False]
+
+
+def test_with_retry_on_401_replays_with_force_refresh_on_first_401() -> None:
+    calls: list[bool] = []
+
+    def send(force_refresh: bool) -> httpx.Response:
+        calls.append(force_refresh)
+        return _stub_response(401 if not force_refresh else 200)
+
+    resp = with_retry_on_401(send)
+    assert resp.status_code == 200
+    assert calls == [False, True]
+
+
+def test_with_retry_on_401_returns_last_401_after_exhausting_attempts() -> None:
+    calls: list[bool] = []
+
+    def send(force_refresh: bool) -> httpx.Response:
+        calls.append(force_refresh)
+        return _stub_response(401)
+
+    resp = with_retry_on_401(send, max_attempts=2)
+    assert resp.status_code == 401
+    assert calls == [False, True]
+
+
+def test_with_retry_on_401_does_not_retry_other_4xx() -> None:
+    calls: list[bool] = []
+
+    def send(force_refresh: bool) -> httpx.Response:
+        calls.append(force_refresh)
+        return _stub_response(403)
+
+    resp = with_retry_on_401(send)
+    assert resp.status_code == 403
+    assert calls == [False]


### PR DESCRIPTION
## Summary

Reworks how Decepticon authenticates with subscription LLM providers via the LiteLLM proxy. Six in-process handlers now share a common token store, ChatGPT moves off the LiteLLM-native `chatgpt` provider onto a Decepticon custom handler that reads the Codex CLI credential store directly, and the agent-side factory hardens its credentials inventory so dead OAuth flags and mis-pasted API keys no longer poison the fallback chain.

Replaces in-flight #149.

## Architecture

### Shared OAuth token store (`config/oauth_token_store.py`)
- `read_json_file` / `write_json_atomic` (temp+rename, 0o600)
- `FileBackedCache` keyed on `(mtime, size)` so a host-side credential rotation is picked up without container restart
- `decode_jwt_payload` / `is_jwt_expired` (60s skew) and `is_timestamp_expired` (5min default buffer)
- `oauth_refresh_request` raises actionable `AuthenticationError` with the upstream body
- `with_retry_on_401` wraps an outbound call so an invalidated token triggers a single in-process force_refresh + replay
- 32 unit tests cover atomic write, mtime cache, JWT decode, expiry, refresh request, retry semantics

### 5 existing handlers refactored
`claude_code`, `copilot`, `gemini`, `grok`, `perplexity` all import `FileBackedCache`, `oauth_refresh_request`, `write_json_atomic`, `with_retry_on_401`. Per-handler atomic-write / JWT-decode / mtime helpers removed. Outbound HTTP wrapped in `with_retry_on_401`.

### Native ChatGPT OAuth via custom handler
- New `config/codex_chatgpt_handler.py` reads `~/.codex/auth.json` directly (`CODEX_AUTH_PATH` / `CODEX_HOME` honored) — no parallel `~/.config/litellm/chatgpt` store, no manual `codex login` re-import
- New `config/auth_handler.py` dispatches `auth/<slug>` by prefix (`claude-` → claude_code, `gpt-` → codex_chatgpt)
- LiteLLM `main.py:2561` short-circuits `gpt-*` slugs to native OpenAI regardless of `custom_llm_provider` — workaround via `codex-oauth/oauth-gpt-*` sentinel; the handler strips `oauth-` before sending upstream
- Aggregates `response.output_text.delta` SSE deltas when `response.completed.output` is empty (Codex backend behavior)
- Defaults `instructions` to a Codex CLI prompt when no system message is present

Removed dead code:
- `_patch_chatgpt_responses_text_aggregation` in `litellm_startup.py` (LiteLLM-native chatgpt provider no longer on the request path)
- `_model_uses_chatgpt_responses_api` in `factory.py` (custom handler does Chat-Completions → Responses-API conversion internally)
- inline `_select_auth_handler` / `_AuthDispatcher` in `litellm_startup.py` (moved to `auth_handler.py`)

### Container plumbing
- `containers/litellm.Dockerfile` copies the new modules in dependency order
- `docker-compose.yml`: `LITELLM_CHATGPT_TOKEN_DIR` mount → `${CODEX_AUTH_VOLUME:-/dev/null}:/root/.codex/auth.json` (rw); drop `:ro` from Claude credentials; export `CODEX_AUTH_PATH`
- Both Claude and Codex paths are now mounted read-only into the langgraph service so the LLM factory can verify file presence

### Launcher Codex auth detection
- `subscriptionMethod.AbsolutePath` field for handlers whose credential lives at a fixed path (rather than `~/.config/<dir>/<file>`)
- `start.go` probes `~/.codex/auth.json` and exports `CODEX_AUTH_VOLUME`, mirroring `CLAUDE_CREDENTIALS_VOLUME`
- `env.example` rewrites the ChatGPT OAuth section to point at `~/.codex/auth.json` + `codex login`

### Credential validation hardening
- `_is_real_key(value, method=None)`: minimum 24 chars, rejects empty + launcher template (`your-…-key-here`) + obvious placeholder tokens (`placeholder`, `not-used`, `dummy`, `fake`, `example`); when `method` is given, enforces vendor-prefix hints (`sk-ant-`, `sk-`, `AIza`, `xai-`, `gsk_`, `sk-or-`, `nvapi-`, `ghp_`/`github_pat_`/`gho_`/`ghs_`) — catches mis-pasted keys before they propagate
- `_oauth_credentials_present(method)`: reads the host-side OAuth credential file and validates non-empty JSON. `/dev/null` fallbacks read empty and fail closed. Without this, a stale `DECEPTICON_AUTH_*=true` after `codex logout` placed OAuth in every fallback chain and generated one 401 per request
- `_resolve_credentials` requires both the truthy boolean AND the file presence for OAuth methods
- `has_subscription_routes()` lets `litellm_startup` regenerate the dynamic config when only `DECEPTICON_AUTH_*` is set (no `DECEPTICON_MODEL*` override)
- `merge_dynamic_models` skips the API-key validator for slugs already added by the subscription path
- `validate_model_name` rejects all subscription provider prefixes (`auth`, `gemini-sub`, `copilot`, `grok-sub`, `pplx-sub`) on the API-key registration path

### Model registry
Adds `auth/gpt-5.4-mini` as the LOW tier for `openai_oauth` (per `codex-rs/models-manager/models.json`, May 2026) plus the matching fallback chain entry `auth/gpt-5.4` → `auth/gpt-5.4-mini`.

## Verified live

- LiteLLM proxy direct: `auth/claude-sonnet-4-6` / `auth/gpt-5.5` / `auth/gpt-5.4` / `auth/gpt-5.4-mini` all return correct content
- vulnresearch agent end-to-end through Claude OAuth and ChatGPT OAuth; chain composition mirrors the credentials inventory (only detected methods land in the chain)
- Tested credential file deletion / stale flag scenarios — OAuth method correctly drops out of the chain

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run basedpyright --level error` 0 errors
- [x] `uv run pytest -n auto -q -m "not slow"` 793 passed (32 new oauth_token_store + 11 new factory + 5 new dynamic_config)
- [x] `cd clients/launcher && go vet ./... && go test ./...` all packages OK
- [x] Live: ChatGPT OAuth (auth/gpt-5.5, auth/gpt-5.4, auth/gpt-5.4-mini) end-to-end via vulnresearch agent
- [x] Live: Claude Code OAuth (auth/claude-sonnet-4-6) end-to-end via vulnresearch agent
- [x] Live: credential chain shows only detected methods (`DECEPTICON_AUTH_CLAUDE_CODE=false` → no Claude in chain even with `~/.claude/.credentials.json` mounted)