### PR TITLE
feat(launcher): interactive update prompt at start + re-exec

### DIFF
--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -115,10 +115,19 @@ func runStart(cmd *cobra.Command, args []string) error {
 		_ = os.Setenv("CODEX_AUTH_VOLUME", "/dev/null")
 	}
 
-	// 2.5. Update notice. Applying updates is intentionally explicit via
-	// `decepticon update` because it can replace the binary, compose files,
-	// LiteLLM config, and Docker images.
-	updater.NotifyIfUpdateAvailable(version)
+	// 2.5. Update prompt. When a newer release is available and stdin is
+	// a TTY, ask the operator interactively whether to apply it. On
+	// confirmation the launcher applies the update (config sync + image
+	// pull + binary replace) and re-execs itself so the rest of this
+	// ``start`` flow runs against the just-installed version — matches
+	// the Claude Code / Codex CLI "update available, restarting" UX.
+	// Non-interactive shells (CI, piped) fall back to the passive notice
+	// path inside ``PromptIfUpdateAvailable``.
+	if _, err := updater.PromptIfUpdateAvailable(version); err != nil {
+		// Non-fatal — surface as a warning and continue with the
+		// current launcher rather than aborting the start.
+		ui.Warning("Update check: " + err.Error())
+	}
 
 	// 3. Engagement picker — must run BEFORE compose Up so the sandbox
 	// container starts with /workspace bound to the chosen engagement

--- a/clients/launcher/cmd/update.go
+++ b/clients/launcher/cmd/update.go
@@ -33,8 +33,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	hasUpdate := updater.CompareVersions(version, release.TagName)
-	if !hasUpdate {
+	if !hasUpdate && !forceUpdate {
 		ui.Success(fmt.Sprintf("Already up to date (%s)", version))
+		return nil
 	}
 
 	if hasUpdate {
@@ -53,26 +54,25 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		ref = branch
 	}
 
-	// Sync config files
-	ui.Info("Syncing configuration files...")
-	if err := updater.SyncConfigFiles(ref); err != nil {
-		ui.Warning("Config sync: " + err.Error())
-	}
-
-	// Pull new images
-	c := compose.New()
-	targetVersion := strings.TrimPrefix(release.TagName, "v")
-	ui.Info("Pulling Docker images (" + targetVersion + ")...")
-	if err := c.Pull(targetVersion); err != nil {
-		ui.Warning("Image pull: " + err.Error())
-	}
-
-	// Self-update binary
 	if hasUpdate {
-		if err := updater.SelfUpdate(release); err != nil {
-			ui.Warning("Binary update: " + err.Error())
+		// Full upgrade flow — shared with the launch-time interactive
+		// prompt so behavior stays consistent between the two paths.
+		if err := updater.ApplyUpdate(release, ref); err != nil {
+			ui.Warning(err.Error())
 		}
-		_ = updater.WriteVersion(release.TagName)
+	} else {
+		// --force: re-sync config + re-pull images without bumping the
+		// binary (already on release.TagName).
+		ui.Info("Syncing configuration files...")
+		if err := updater.SyncConfigFiles(ref); err != nil {
+			ui.Warning("Config sync: " + err.Error())
+		}
+		c := compose.New()
+		targetVersion := strings.TrimPrefix(release.TagName, "v")
+		ui.Info("Pulling Docker images (" + targetVersion + ")...")
+		if err := c.Pull(targetVersion); err != nil {
+			ui.Warning("Image pull: " + err.Error())
+		}
 	}
 
 	ui.Success("Update complete")

--- a/clients/launcher/internal/updater/reexec_unix.go
+++ b/clients/launcher/internal/updater/reexec_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// reexecSelf replaces the current process with a fresh exec of the
+// launcher binary, preserving argv and the environment. Used after a
+// successful in-place self-update so the rest of the user's command
+// runs against the just-installed binary instead of the in-memory copy
+// of the previous version.
+//
+// On POSIX this is a true exec — control never returns on success,
+// callers should treat the function as no-return. A non-nil error means
+// the exec syscall itself failed (rare: missing executable, EACCES on
+// the new binary, kernel ENOMEM); the caller should surface a "rerun
+// manually" message and exit.
+func reexecSelf() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("get executable path: %w", err)
+	}
+	// ``syscall.Exec`` discards file descriptors with FD_CLOEXEC and
+	// inherits the rest. stdin/stdout/stderr stay connected to the
+	// parent terminal, which is exactly what the operator expects.
+	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+		return fmt.Errorf("exec %s: %w", exe, err)
+	}
+	return nil // unreachable on success
+}

--- a/clients/launcher/internal/updater/reexec_windows.go
+++ b/clients/launcher/internal/updater/reexec_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// reexecSelf re-runs the launcher binary as a child process and exits
+// with its status code. Windows has no ``execve`` equivalent that
+// replaces the running process, so the parent stays alive only long
+// enough to wait for the child and propagate the exit code.
+//
+// stdin / stdout / stderr are inherited from the parent so the user's
+// terminal session is uninterrupted. If the child cannot be spawned,
+// the caller surfaces the error and falls back to a manual-restart
+// message.
+func reexecSelf() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("get executable path: %w", err)
+	}
+	cmd := exec.Command(exe, os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		// ``cmd.Run`` returns the child's non-zero exit code wrapped in
+		// *exec.ExitError — propagate that as our own exit so the user
+		// sees the same status the new launcher returned.
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		return fmt.Errorf("spawn %s: %w", exe, err)
+	}
+	os.Exit(0)
+	return nil // unreachable
+}

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"charm.land/huh/v2"
+	"golang.org/x/term"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/compose"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
 )
@@ -192,6 +196,9 @@ func WriteVersion(version string) error {
 // NotifyIfUpdateAvailable checks GitHub releases and prints a non-blocking
 // update notice. It never mutates the binary, config files, or Docker images;
 // users apply updates explicitly with `decepticon update`.
+//
+// Used as the fallback path when ``PromptIfUpdateAvailable`` cannot present
+// an interactive prompt (e.g. stdin is not a TTY in CI / piped invocation).
 func NotifyIfUpdateAvailable(currentVersion string) bool {
 	release, err := FetchLatestRelease()
 	if err != nil {
@@ -205,6 +212,149 @@ func NotifyIfUpdateAvailable(currentVersion string) bool {
 	ui.Info(fmt.Sprintf("Update available: %s -> %s", displayVersion(currentVersion), release.TagName))
 	ui.DimText("Run `decepticon update` to upgrade.")
 	return true
+}
+
+// ApplyUpdate runs the full upgrade flow: SyncConfigFiles, Docker image
+// pull, SelfUpdate (binary), WriteVersion. Shared between the
+// ``decepticon update`` command and the interactive launch-time prompt.
+//
+// ``ref`` is the git ref used for ``SyncConfigFiles`` — ``release.TagName``
+// for tagged releases, or a branch name for development tracking.
+//
+// Errors from individual steps are surfaced as warnings via ui rather
+// than propagated, so a transient image-pull failure does not abort the
+// otherwise-completed binary update. The caller is responsible for
+// surfacing the final state.
+func ApplyUpdate(release *Release, ref string) error {
+	if release == nil {
+		return fmt.Errorf("nil release")
+	}
+
+	ui.Info("Syncing configuration files...")
+	if err := SyncConfigFiles(ref); err != nil {
+		ui.Warning("Config sync: " + err.Error())
+	}
+
+	c := compose.New()
+	targetVersion := strings.TrimPrefix(release.TagName, "v")
+	ui.Info("Pulling Docker images (" + targetVersion + ")...")
+	if err := c.Pull(targetVersion); err != nil {
+		ui.Warning("Image pull: " + err.Error())
+	}
+
+	if err := SelfUpdate(release); err != nil {
+		return fmt.Errorf("binary update: %w", err)
+	}
+	if err := WriteVersion(release.TagName); err != nil {
+		ui.Warning("Write version stamp: " + err.Error())
+	}
+	return nil
+}
+
+// PromptIfUpdateAvailable presents an interactive y/n confirmation when a
+// newer release exists. On approval, applies the update and re-execs the
+// running launcher with the freshly installed binary so the rest of the
+// caller's flow runs against the new version (matches the Claude Code /
+// Codex CLI behavior of "update applied, restarting").
+//
+// Returns ``true`` only when the user approved AND ApplyUpdate succeeded
+// AND re-exec was issued. On POSIX the re-exec replaces the process via
+// ``syscall.Exec``, so a true return is effectively unreachable; the
+// helper still returns the value for tests and Windows callers, where
+// re-exec spawns a child + ``os.Exit`` from the parent.
+//
+// Skips silently (returns false, nil) when:
+//   - ``currentVersion`` is empty / "dev" — local build, no published release to track.
+//   - ``FetchLatestRelease`` fails — offline or GitHub unavailable.
+//   - the latest release is not newer than ``currentVersion``.
+//   - stdin is not a TTY — CI / piped invocations fall back to
+//     ``NotifyIfUpdateAvailable`` so the user still sees the notice.
+func PromptIfUpdateAvailable(currentVersion string) (bool, error) {
+	if currentVersion == "" || currentVersion == "dev" {
+		return false, nil
+	}
+	if !isInteractiveStdin() {
+		NotifyIfUpdateAvailable(currentVersion)
+		return false, nil
+	}
+
+	release, err := FetchLatestRelease()
+	if err != nil {
+		return false, nil // Silent skip — startup must not depend on GitHub.
+	}
+	if !CompareVersions(currentVersion, release.TagName) {
+		return false, nil
+	}
+
+	ui.Info(fmt.Sprintf(
+		"Update available: %s → %s",
+		displayVersion(currentVersion),
+		release.TagName,
+	))
+
+	var confirmed bool
+	if err := huh.NewConfirm().
+		Title(fmt.Sprintf("Install %s now?", release.TagName)).
+		Description(
+			"Updates the launcher binary, docker-compose config, and pulls\n"+
+				"the matching Docker images. Decepticon will restart with\n"+
+				"the new version once the update finishes.",
+		).
+		Affirmative("Yes, update").
+		Negative("Skip").
+		Value(&confirmed).
+		Run(); err != nil {
+		// Prompt failure (e.g. tty closed mid-render) — fall through to
+		// the passive notice rather than crashing the launch.
+		ui.Warning("Update prompt failed: " + err.Error())
+		return false, nil
+	}
+	if !confirmed {
+		ui.DimText(
+			"Continuing with " + displayVersion(currentVersion) +
+				". Run `decepticon update` later to upgrade.",
+		)
+		return false, nil
+	}
+
+	// Determine the ref — same logic as ``decepticon update``: prefer
+	// the explicit branch override in .env, fall back to the release tag.
+	ref := release.TagName
+	if config.EnvExists() {
+		if env, lerr := config.LoadEnv(config.EnvPath()); lerr == nil {
+			if branch := strings.TrimSpace(env["DECEPTICON_BRANCH"]); branch != "" {
+				ref = branch
+			}
+		}
+	}
+
+	if err := ApplyUpdate(release, ref); err != nil {
+		ui.Warning("Update failed: " + err.Error())
+		ui.DimText("Continuing with " + displayVersion(currentVersion) + ".")
+		return false, nil
+	}
+
+	ui.Success("Update complete — restarting with " + release.TagName + "...")
+	if err := reexecSelf(); err != nil {
+		// Re-exec failed: tell the user to restart manually rather than
+		// silently keep running the old in-memory image.
+		ui.Warning("Re-exec failed: " + err.Error())
+		ui.DimText("Run `decepticon` again to use the new version.")
+		os.Exit(0)
+	}
+	// POSIX exec replaces the process — control never reaches here. The
+	// Windows path inside reexecSelf calls os.Exit after spawning the
+	// child, so this is also unreachable on Windows. Kept for symmetry.
+	return true, nil
+}
+
+// isInteractiveStdin returns true when the launcher's stdin is connected
+// to a real terminal. Piped / redirected stdin (CI, log shippers,
+// supervisor pipelines) returns false so the launch flow falls back to
+// the passive update notice instead of blocking on a prompt that nobody
+// can answer.
+func isInteractiveStdin() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func displayVersion(version string) string {

--- a/clients/launcher/internal/updater/updater_test.go
+++ b/clients/launcher/internal/updater/updater_test.go
@@ -79,3 +79,38 @@ func TestFetchLatestRelease_Mock(t *testing.T) {
 		t.Errorf("Assets = %v", got.Assets)
 	}
 }
+
+func TestPromptIfUpdateAvailable_SkipsDevBuilds(t *testing.T) {
+	// "dev" / empty version means a local build that does not track
+	// published releases — no prompt, no GitHub round-trip.
+	for _, v := range []string{"dev", ""} {
+		applied, err := PromptIfUpdateAvailable(v)
+		if err != nil {
+			t.Errorf("PromptIfUpdateAvailable(%q) err = %v", v, err)
+		}
+		if applied {
+			t.Errorf("PromptIfUpdateAvailable(%q) applied=true, want false", v)
+		}
+	}
+}
+
+func TestPromptIfUpdateAvailable_SkipsNonInteractive(t *testing.T) {
+	// Test runs are always non-interactive (stdin is the test harness
+	// pipe), so PromptIfUpdateAvailable must fall straight through
+	// without ever calling huh.Run. A non-zero version that would
+	// otherwise fail the "is dev?" gate is safe — the function returns
+	// silently on the TTY check before fetching anything.
+	applied, err := PromptIfUpdateAvailable("0.0.0")
+	if err != nil {
+		t.Errorf("PromptIfUpdateAvailable err = %v", err)
+	}
+	if applied {
+		t.Errorf("PromptIfUpdateAvailable applied=true, want false (no TTY)")
+	}
+}
+
+func TestApplyUpdate_NilRelease(t *testing.T) {
+	if err := ApplyUpdate(nil, "main"); err == nil {
+		t.Error("ApplyUpdate(nil, ...) err = nil, want non-nil")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the passive *"Run \`decepticon update\` to upgrade"* notice that fired at every launch with an interactive y/n prompt. When the operator approves, the launcher applies the full upgrade (config sync + image pull + binary replace) and re-execs itself so the rest of the current \`decepticon\` command runs against the just-installed version — matches the Claude Code / Codex CLI *"update available, restarting"* UX.

## Behavior

| Stdin TTY | Newer release | Outcome |
|---|---|---|
| Yes | Yes | huh confirm prompt → on approval, apply + re-exec |
| Yes | No | silent |
| No (CI / piped) | Yes | falls back to passive \`NotifyIfUpdateAvailable\` notice |
| Any | offline / GitHub down | silent |
| version == \"dev\" | any | silent (local build) |

## Architecture

### \`updater\` package
- \`ApplyUpdate(release, ref)\`: extracts the shared upgrade flow (\`SyncConfigFiles\` + \`compose.Pull\` + \`SelfUpdate\` + \`WriteVersion\`) so both the launch-time prompt and the explicit \`decepticon update\` command run identical logic. Per-step errors degrade to \`ui.Warning\` rather than aborting — a transient image pull failure shouldn't undo a completed binary update.
- \`PromptIfUpdateAvailable(currentVersion)\`: fetch + compare + huh confirm; on approval calls \`ApplyUpdate\` then \`reexecSelf\`. Skips silently when current is \`dev\` / empty, GitHub fails, latest ≤ current, or stdin is not a TTY.
- \`isInteractiveStdin\` via \`golang.org/x/term\` (already a direct dep).
- \`reexec_unix.go\`: \`syscall.Exec\` replaces the running process. argv + env preserved, fds with \`FD_CLOEXEC\` discarded, stdin/stdout/stderr stay attached to the parent terminal.
- \`reexec_windows.go\`: spawn child + \`os.Exit\` with its code (Windows has no \`execve\` equivalent).

### \`decepticon update\` command
- Now delegates the upgrade flow to \`ApplyUpdate\` so the two paths share identical behavior.
- Honors the existing-but-dead \`--force\` flag: when the binary is already on latest, \`--force\` still re-syncs config + pulls images; without it the command short-circuits with *\"already up to date\"*.

### \`start.go\`
- Calls \`PromptIfUpdateAvailable\` instead of \`NotifyIfUpdateAvailable\`.
- Errors from the prompt itself degrade to \`ui.Warning\` so a transient GitHub or huh failure does not abort engagement startup.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all packages OK (3 new tests, 6 total in updater)
- [x] Smoke build via \`go build ./...\`
- [x] Test cases:
  - dev-build / empty version short-circuits before GitHub round-trip
  - non-TTY stdin falls through to the passive notice without calling huh.Run
  - nil-release guard on \`ApplyUpdate\`
- Manual verification (would require a tagged release newer than the local build to trigger the prompt path interactively).