### PR TITLE
test(middleware): pin defensive paths against regression (issue #157)

### DIFF
--- a/tests/unit/middleware/test_notifications.py
+++ b/tests/unit/middleware/test_notifications.py
@@ -135,3 +135,102 @@ def test_concurrent_before_model_calls_each_session_notified_once():
 
     emitted = [r for r in results if r is not None]
     assert len(emitted) == 1, f"Expected exactly one emission, got {len(emitted)}"
+
+
+# ── Issue #157 regressions: defensive error-handling paths ──────────────
+# Each test pins a fix that landed in current main so a future refactor
+# cannot silently regress to the original crashy behaviour. Cross-ref
+# the audit table in issue #157.
+
+
+def test_poll_completion_exception_does_not_crash_middleware() -> None:
+    """HIGH #1: ``poll_completion`` runs subprocess (docker exec) and can
+    raise on container disconnect, invalid session, or timeout. The
+    middleware must catch and log so a transient sandbox blip does not
+    take down the whole agent step.
+    """
+    sandbox = _sandbox_with_tracker()
+    sandbox._jobs.register("scan", command="nmap target", initial_markers=1)
+    # Note: do NOT mark_complete — leave the job running so the
+    # poll_completion path is exercised on enumerate.
+    sandbox.poll_completion = MagicMock(side_effect=RuntimeError("docker exec disconnected"))
+
+    mw = SandboxNotificationMiddleware(sandbox=sandbox)
+
+    # Must not raise — the middleware is best-effort and a poll error
+    # cannot crash the model step.
+    update = mw.before_model(_state(HumanMessage(content="hi")), runtime=None)
+
+    # Nothing completed, nothing to notify.
+    assert update is None or not update.get("messages")
+    sandbox.poll_completion.assert_called()
+
+
+def test_poll_completion_exception_does_not_crash_async_middleware() -> None:
+    """HIGH #1 async sibling — same contract for ``abefore_model``."""
+    sandbox = _sandbox_with_tracker()
+    sandbox._jobs.register("scan", command="nmap", initial_markers=1)
+    sandbox.poll_completion = MagicMock(side_effect=RuntimeError("session lost"))
+
+    mw = SandboxNotificationMiddleware(sandbox=sandbox)
+
+    update = asyncio.run(mw.abefore_model(_state(HumanMessage(content="hi")), runtime=None))
+    assert update is None or not update.get("messages")
+
+
+def test_sandbox_without_jobs_attribute_returns_none() -> None:
+    """MED #5: ``self._sandbox._jobs`` is accessed via ``getattr`` so a
+    partially-constructed sandbox (e.g. test fixture, early init) does
+    not raise ``AttributeError`` from the middleware. Pin that contract.
+    """
+    sandbox = MagicMock(spec=[])  # spec=[] → no attributes whatsoever
+    mw = SandboxNotificationMiddleware(sandbox=sandbox)
+
+    update = mw.before_model(_state(HumanMessage(content="hi")), runtime=None)
+    assert update is None
+
+
+def test_command_none_does_not_crash_message_builder() -> None:
+    """MED #6: ``job.command`` can be None on jobs registered without an
+    explicit command. Slicing ``None[:80]`` would raise TypeError; the
+    fix uses ``(job.command or "")[:80]``. Pin it.
+    """
+    sandbox = _sandbox_with_tracker()
+    # Register with no command — BackgroundJobTracker accepts command=""
+    # and we patch the resulting job's ``command`` attribute to None to
+    # simulate the legacy/edge case the audit flagged.
+    sandbox._jobs.register("scan", command="", initial_markers=1)
+    sandbox._jobs.mark_complete("scan", exit_code=0)
+    for job in sandbox._jobs.all_jobs():
+        job.command = None  # type: ignore[assignment]
+
+    mw = SandboxNotificationMiddleware(sandbox=sandbox)
+    update = mw.before_model(_state(HumanMessage(content="hi")), runtime=None)
+
+    assert update is not None
+    msg = update["messages"][0]
+    # Empty command renders as ``command=`` (no value); no crash.
+    assert "command=" in msg.content
+
+
+def test_notified_set_evicts_oldest_when_capped() -> None:
+    """LOW #9: ``_notified`` was unbounded; the fix caps at
+    ``_NOTIFIED_KEYS_MAX`` and evicts FIFO. Verify the cap is enforced
+    so a long-running agent session cannot leak memory through this set.
+    """
+    from decepticon.middleware.notifications import _NOTIFIED_KEYS_MAX
+
+    sandbox = _sandbox_with_tracker()
+    mw = SandboxNotificationMiddleware(sandbox=sandbox)
+
+    # Insert one beyond the cap; the oldest must have been evicted.
+    keys = [f"k{i}" for i in range(_NOTIFIED_KEYS_MAX + 5)]
+    mw._record_notified(keys)
+
+    assert len(mw._notified) == _NOTIFIED_KEYS_MAX
+    # FIFO eviction: the first 5 keys are the ones evicted.
+    for evicted in keys[:5]:
+        assert evicted not in mw._notified
+    # Keys past the eviction window are retained.
+    for kept in keys[5:]:
+        assert kept in mw._notified

--- a/tests/unit/middleware/test_skills.py
+++ b/tests/unit/middleware/test_skills.py
@@ -1,0 +1,287 @@
+"""Tests for SkillsMiddleware defensive paths (issue #157 regressions).
+
+The base ``SkillsMiddleware`` is exercised through deepagents' own tests,
+but the decepticon subclass adds workflow-loading, a custom prompt
+template, and isinstance gates on backend results that aren't covered
+by the base test surface. This file pins those defensive paths so the
+fixes that landed for the audit findings cannot silently regress.
+
+Findings covered:
+  - MED #7: ``data.get("content", "")`` is gated by ``isinstance(data, dict)``
+    in both ``_read_workflow_for_source`` and ``_aread_workflow_for_source``.
+    Pre-fix, a backend returning a truthy non-dict (e.g. a raw string in
+    error paths) crashed the middleware on ``.get``.
+  - MED #8: ``self.system_prompt_template.format(...)`` is wrapped in
+    ``except (KeyError, IndexError)``. Pre-fix, a template edit that
+    introduced a placeholder mismatch would crash every model step from
+    that point on; the fix logs and falls through to the original system
+    message instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from langchain_core.messages import SystemMessage
+
+from decepticon.middleware.skills import SkillsMiddleware
+
+# ── Backend stand-ins ───────────────────────────────────────────────────
+
+
+class _BackendResult:
+    """Minimal duck-typed stand-in for backend read results.
+
+    Real backend results expose ``.error`` (str | None) and ``.file_data``
+    (dict | None). We construct edge-case shapes (non-dict file_data) on
+    purpose to exercise the isinstance gate.
+    """
+
+    def __init__(self, *, error: str | None = None, file_data: Any = None) -> None:
+        self.error = error
+        self.file_data = file_data
+
+
+class _StringFileDataBackend:
+    """Backend whose ``read``/``aread`` return a result whose
+    ``file_data`` is a raw string instead of a dict.
+
+    Pre-fix this triggered ``AttributeError: 'str' object has no attribute 'get'``
+    inside ``_read_workflow_for_source``; the fix gates on
+    ``isinstance(data, dict)`` and returns None.
+    """
+
+    def __init__(self, file_data: Any) -> None:
+        self._file_data = file_data
+
+    def read(self, _path: str) -> _BackendResult:
+        return _BackendResult(error=None, file_data=self._file_data)
+
+    async def aread(self, _path: str) -> _BackendResult:
+        return _BackendResult(error=None, file_data=self._file_data)
+
+
+class _DictFileDataBackend:
+    """Backend that returns a properly-shaped dict for the happy path."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def read(self, _path: str) -> _BackendResult:
+        return _BackendResult(file_data={"content": self._content})
+
+    async def aread(self, _path: str) -> _BackendResult:
+        return _BackendResult(file_data={"content": self._content})
+
+
+class _RaisingBackend:
+    """Backend whose ``read`` raises — exercises the outer try/except in
+    ``_read_workflow_for_source``."""
+
+    def read(self, _path: str) -> _BackendResult:
+        raise RuntimeError("backend not connected")
+
+    async def aread(self, _path: str) -> _BackendResult:
+        raise RuntimeError("backend not connected")
+
+
+# ── Request stand-in ────────────────────────────────────────────────────
+
+
+class _FakeRequest:
+    """Minimal duck-typed request — same pattern as test_engagement.py."""
+
+    def __init__(
+        self,
+        state: dict[str, Any] | None = None,
+        system_message: SystemMessage | None = None,
+    ) -> None:
+        self.state = state or {}
+        self.system_message = system_message
+
+    def override(self, system_message: SystemMessage) -> "_FakeRequest":
+        new = _FakeRequest(state=self.state, system_message=system_message)
+        return new
+
+
+def _make_middleware(backend: Any) -> SkillsMiddleware:
+    """Build a SkillsMiddleware against a stub backend with one source."""
+    return SkillsMiddleware(backend=backend, sources=["/skills/recon/"])
+
+
+# ── MED #7 — isinstance gate on backend result ─────────────────────────
+
+
+class TestWorkflowLoaderRejectsNonDictFileData:
+    """``_read_workflow_for_source`` and its async sibling must return
+    None when the backend hands back a non-dict ``file_data``. The
+    isinstance gate at line 169/186 of skills.py is the explicit
+    contract — pre-fix this crashed on ``.get``.
+    """
+
+    def test_string_file_data_returns_none(self) -> None:
+        backend = _StringFileDataBackend(file_data="raw text not a dict")
+        mw = _make_middleware(backend)
+
+        result = mw._read_workflow_for_source(backend, "/skills/recon/")
+
+        assert result is None, (
+            "non-dict file_data must short-circuit to None — see issue #157 MED #7"
+        )
+
+    def test_list_file_data_returns_none(self) -> None:
+        backend = _StringFileDataBackend(file_data=["line1", "line2"])
+        mw = _make_middleware(backend)
+
+        assert mw._read_workflow_for_source(backend, "/skills/recon/") is None
+
+    def test_none_file_data_returns_none(self) -> None:
+        backend = _StringFileDataBackend(file_data=None)
+        mw = _make_middleware(backend)
+
+        assert mw._read_workflow_for_source(backend, "/skills/recon/") is None
+
+    def test_dict_with_content_returns_string(self) -> None:
+        """Happy-path positive control: a properly-shaped dict still works."""
+        backend = _DictFileDataBackend(content="# Recon Workflow\nDo this then that.")
+        mw = _make_middleware(backend)
+
+        result = mw._read_workflow_for_source(backend, "/skills/recon/")
+        assert result == "# Recon Workflow\nDo this then that."
+
+    def test_backend_read_exception_returns_none(self) -> None:
+        """Outer try/except catches arbitrary backend errors."""
+        backend = _RaisingBackend()
+        mw = _make_middleware(backend)
+
+        assert mw._read_workflow_for_source(backend, "/skills/recon/") is None
+
+    # ── async siblings ──────────────────────────────────────────────────
+
+    def test_async_string_file_data_returns_none(self) -> None:
+        backend = _StringFileDataBackend(file_data="raw text not a dict")
+        mw = _make_middleware(backend)
+
+        result = asyncio.run(mw._aread_workflow_for_source(backend, "/skills/recon/"))
+        assert result is None
+
+    def test_async_dict_with_content_returns_string(self) -> None:
+        backend = _DictFileDataBackend(content="# Recon Workflow")
+        mw = _make_middleware(backend)
+
+        result = asyncio.run(mw._aread_workflow_for_source(backend, "/skills/recon/"))
+        assert result == "# Recon Workflow"
+
+    def test_async_backend_read_exception_returns_none(self) -> None:
+        backend = _RaisingBackend()
+        mw = _make_middleware(backend)
+
+        result = asyncio.run(mw._aread_workflow_for_source(backend, "/skills/recon/"))
+        assert result is None
+
+    def test_empty_string_content_returns_none(self) -> None:
+        """Empty content collapses to None — keeps the prompt clean.
+
+        Implementation detail of the helper, but pinning it here so a
+        future refactor that emits an empty string banner does not
+        accidentally inject visible whitespace into the system prompt.
+        """
+        backend = _DictFileDataBackend(content="   ")
+        mw = _make_middleware(backend)
+
+        assert mw._read_workflow_for_source(backend, "/skills/recon/") is None
+
+
+# ── MED #8 — template format failures are swallowed ────────────────────
+
+
+class TestModifyRequestTemplateFormatFailures:
+    """``modify_request`` wraps ``self.system_prompt_template.format(...)``
+    in ``except (KeyError, IndexError)``. A user/subclass that overrides
+    the template with a bad placeholder must not crash every model step.
+    """
+
+    def test_keyerror_falls_through_to_original_request(self) -> None:
+        """Template referencing an unknown placeholder must not raise.
+
+        The contract: log a warning, return the original request
+        untouched, so the agent step continues with the baked-in system
+        message rather than failing the whole inference.
+        """
+        backend = _DictFileDataBackend(content="x")
+        mw = _make_middleware(backend)
+        # Inject a bad template — references a placeholder we never pass.
+        mw.system_prompt_template = "broken {nonexistent_placeholder}"
+
+        original_msg = SystemMessage(content="original system msg")
+        request = _FakeRequest(
+            state={"skills_metadata": [], "workflow_content": ""},
+            system_message=original_msg,
+        )
+
+        out = mw.modify_request(request)
+
+        # On format failure, the contract is to return the request as-is.
+        # ``out is request`` is the literal "untouched" guarantee.
+        assert out is request, (
+            "format failure must return request unchanged — see issue #157 MED #8"
+        )
+
+    def test_indexerror_also_caught(self) -> None:
+        """Positional placeholder ``{0}`` is also a format-bomb path —
+        Python raises IndexError here, not KeyError, so the except clause
+        must cover both.
+        """
+        backend = _DictFileDataBackend(content="x")
+        mw = _make_middleware(backend)
+        mw.system_prompt_template = "broken {0}"
+
+        original_msg = SystemMessage(content="original")
+        request = _FakeRequest(
+            state={"skills_metadata": [], "workflow_content": ""},
+            system_message=original_msg,
+        )
+
+        out = mw.modify_request(request)
+        assert out is request
+
+    def test_valid_template_still_overrides_system_message(self) -> None:
+        """Positive control: a working template still does its job —
+        otherwise the swallow-on-error contract would mask all failures.
+        """
+        backend = _DictFileDataBackend(content="x")
+        mw = _make_middleware(backend)
+        # Use a minimal template that only references the standard placeholders.
+        mw.system_prompt_template = (
+            "skills_locations={skills_locations}|workflow={workflow}|skills_list={skills_list}"
+        )
+
+        request = _FakeRequest(
+            state={
+                "skills_metadata": [],
+                "workflow_content": "WORKFLOW_BODY",
+            },
+            system_message=SystemMessage(content="original"),
+        )
+
+        out = mw.modify_request(request)
+
+        # The override path was taken: out is a *new* request with a
+        # different system_message that includes our marker.
+        assert out is not request
+        # Narrow the type for the type checker — the override path always
+        # populates system_message; the Optional shape is only there for
+        # callers that pass system_message=None on input.
+        assert out.system_message is not None
+        # The new system message contains our marker, proving format() ran.
+        content = out.system_message.content
+        flattened = (
+            content
+            if isinstance(content, str)
+            else "".join(
+                block.get("text", "") if isinstance(block, dict) else str(block)
+                for block in content
+            )
+        )
+        assert "WORKFLOW_BODY" in flattened


### PR DESCRIPTION
## Summary

Refs #157. The audit catalogued 13 individual findings across `notifications.py`, `opplan.py`, and `skills.py` (the three middleware modules that wrap external I/O most aggressively). Walking the current `main` against each finding, **every named issue is already fixed in code** — the audit landed mostly post-hoc to recent refactors. Coverage was uneven though: opplan had explicit cycle/persistence tests, notifications had partial coverage, and `skills.py` had no test file at all.

This PR is **regression-test pinning only** — no production-code changes. It locks every defensive path the audit raised so a future refactor cannot silently regress them.

Per the maintainer's note on the issue ("HIGH-severity items deserve targeted PRs that add the right exception boundaries — not a blanket try/except: pass"), I am **not** posting a code patch here; the targeted boundaries already exist and are unchanged. If any specific finding turns out to need a different boundary than the one currently in `main`, that's a separate targeted PR.

## Audit walkthrough vs. current `main`

| # | Severity | Issue claim | Where it lives now |
|---|----------|------------|--------------------|
| 1 | HIGH | notifications.py:148 `poll_completion` unhandled | `try/except Exception` wrapping `poll_completion` at L102 + L119 (sync + async) |
| 2 | HIGH | opplan.py:1059 `save_opplan` file I/O | moved to `tools/opplan.py:_persist_opplan_to_backend`; full backend path wrapped in `try/except` (L183–197) |
| 3 | HIGH | opplan.py:334 `_render` recursive cycle | moved to `tools/opplan.py:_format_opplan_for_agent._render`; explicit `visited: set[str]` guard at L247 |
| 4 | HIGH | opplan.py:990 `objective_collapse` walker | moved to `tools/opplan.py:objective_collapse`; explicit `visited: set[str] = {parent_id}` at L948 |
| 5 | MED | notifications.py:143 `_jobs` direct access | `getattr(self._sandbox, "_jobs", None)` at L53 |
| 6 | MED | notifications.py:139 None slice on `job.command` | `(job.command or "")[:80]` at L81 |
| 7 | MED | skills.py multiple `.get()` on non-dict | `if not isinstance(data, dict): return None` at L169 + L186 |
| 8 | MED | skills.py:239 template format `KeyError` | `try/except (KeyError, IndexError)` at L256, returns request unchanged |
| 9 | LOW | notifications.py:120 unbounded `_notified` | `OrderedDict` + `_NOTIFIED_KEYS_MAX = 4096` cap + FIFO eviction at L59–63 |
| 10 | LOW | opplan.py:280 vacuous `all([])` | `bool(objectives) and all(...)` at L303 |

## Changes

- `tests/unit/middleware/test_notifications.py` — appended 5 regression tests:
  - `poll_completion` raising `RuntimeError` does not crash sync middleware (HIGH #1)
  - `poll_completion` raising in async middleware (HIGH #1 async)
  - Sandbox stub without `_jobs` attribute returns None gracefully (MED #5)
  - `command=None` does not crash the message builder (MED #6)
  - `_notified` evicts in FIFO order at `_NOTIFIED_KEYS_MAX` (LOW #9)
- `tests/unit/middleware/test_skills.py` — new file (this module had no test coverage at all):
  - 9 tests for `_read_workflow_for_source` / `_aread_workflow_for_source` covering non-dict `file_data`, raising backends, empty content, plus the happy path positive control (MED #7)
  - 3 tests for `modify_request` template-format errors — `KeyError`, `IndexError`, valid-template positive control (MED #8)

The opplan defensive paths already had explicit coverage in `test_opplan_persistence.py` (cycle survival for both `_render` and `objective_collapse`, vacuous-empty guard for `_format_opplan_status`, persistence-failure swallowing). No changes needed there.

## Testing

- [x] `make quality` Python lane passes.
  - Pytest: 793 → 810 (17 new tests). 0 ruff issues. 0 basedpyright errors.
- [ ] `make smoke` not run — Docker stack unavailable on this dev machine. All defensive paths are unit-testable in isolation against the production helpers.
- [x] Manual: re-read each cited line in current `main` to confirm the fix is in place before pinning it; cross-checked the test suite catches the regression by verifying each test fails against a reverted version of its target.

## Related Issues

Refs #157.
