### PR TITLE
feat(llm): native llama.cpp / llama-server backend (issue #151)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,16 @@ GITHUB_TOKEN=your-github-token-here
 # LMSTUDIO_MODEL=qwen2.5-coder-7b-instruct
 # LMSTUDIO_API_KEY=lm-studio  # accepts any string; sentinel for the shim
 
+# --- llama.cpp (local OpenAI-compatible) ---
+# llama.cpp's `llama-server` exposes an OpenAI-compatible REST API
+# (default http://localhost:8080/v1). Run a GGUF model with:
+#   llama-server -m /path/to/model.gguf --port 8080
+# The route prefix is `llamacpp/` and remaps to LiteLLM's openai-
+# compatible path with LLAMACPP_API_BASE. See issue #151.
+# LLAMACPP_API_BASE=http://host.docker.internal:8080/v1
+# LLAMACPP_MODEL=qwen2.5-coder-7b-instruct-q4_k_m
+# LLAMACPP_API_KEY=llama-cpp  # accepts any string; sentinel for the shim
+
 # --- Custom OpenAI-compatible Endpoint ---
 # Bring-your-own gateway (vLLM, internal LiteLLM, third-party hub, etc.).
 # CUSTOM_OPENAI_API_BASE=https://gateway.example.com/v1

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -85,6 +85,7 @@ ALLOWED_DYNAMIC_PROVIDERS = frozenset(
         "grok_sub",
         "pplx_sub",
         "custom",
+        "llamacpp",
     }
 )
 # ``_provider_prefix`` normalizes ``vertex-ai`` → ``vertex_ai`` already,
@@ -290,6 +291,19 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
             "model": model_name,
             "api_base": "os.environ/LMSTUDIO_API_BASE",
             "api_key": "os.environ/LMSTUDIO_API_KEY",
+        }
+    elif provider == "llamacpp":
+        # llama.cpp's llama-server is OpenAI-compatible but is not a
+        # native LiteLLM provider, so we remap the route to ``openai/<m>``
+        # and point LiteLLM at LLAMACPP_API_BASE. Symmetric to the
+        # ``custom/`` branch above; kept as its own provider so a user
+        # can have a generic custom OpenAI gateway AND llama.cpp wired
+        # at the same time. Issue #151.
+        actual_model = model_name.split("/", 1)[1]
+        params = {
+            "model": f"openai/{actual_model}",
+            "api_key": "os.environ/LLAMACPP_API_KEY",
+            "api_base": "os.environ/LLAMACPP_API_BASE",
         }
     else:
         params = {"model": model_name}

--- a/decepticon/llm/factory.py
+++ b/decepticon/llm/factory.py
@@ -75,6 +75,7 @@ _DEFAULT_AUTH_PRIORITY: tuple[AuthMethod, ...] = (
     AuthMethod.VERTEX_API,
     AuthMethod.AZURE_API,
     AuthMethod.LMSTUDIO_LOCAL,
+    AuthMethod.LLAMACPP_LOCAL,
     AuthMethod.CUSTOM_OPENAI_API,
     AuthMethod.OLLAMA_LOCAL,
     AuthMethod.OLLAMA_CLOUD,
@@ -209,6 +210,21 @@ def _lmstudio_local_configured() -> bool:
     """Return True when the user has wired up local LM Studio."""
     return bool(
         os.getenv("LMSTUDIO_API_BASE", "").strip() or os.getenv("LMSTUDIO_MODEL", "").strip()
+    )
+
+
+def _llamacpp_local_configured() -> bool:
+    """Return True when the user has wired up local llama.cpp llama-server.
+
+    Either ``LLAMACPP_API_BASE`` (preferred — explicit endpoint, e.g.
+    ``http://localhost:8080/v1``) or ``LLAMACPP_MODEL`` (a logical model
+    name) is enough to opt in. ``LLAMACPP_API_KEY`` is *not* required —
+    llama-server accepts any string by default and an unset key resolves
+    to a literal placeholder via LiteLLM's env interpolation, which the
+    server happily accepts. See issue #151.
+    """
+    return bool(
+        os.getenv("LLAMACPP_API_BASE", "").strip() or os.getenv("LLAMACPP_MODEL", "").strip()
     )
 
 
@@ -360,6 +376,9 @@ def _resolve_credentials() -> Credentials:
         elif method == AuthMethod.LMSTUDIO_LOCAL:
             if _lmstudio_local_configured():
                 methods.append(method)
+        elif method == AuthMethod.LLAMACPP_LOCAL:
+            if _llamacpp_local_configured():
+                methods.append(method)
         elif method == AuthMethod.CUSTOM_OPENAI_API:
             if _custom_openai_configured():
                 methods.append(method)
@@ -382,6 +401,9 @@ def _resolve_credentials() -> Credentials:
         if _lmstudio_local_configured():
             log.info("Only LMSTUDIO_API_BASE/LMSTUDIO_MODEL detected; using LM Studio")
             return Credentials(methods=[AuthMethod.LMSTUDIO_LOCAL])
+        if _llamacpp_local_configured():
+            log.info("Only LLAMACPP_API_BASE/LLAMACPP_MODEL detected; using llama.cpp")
+            return Credentials(methods=[AuthMethod.LLAMACPP_LOCAL])
         if _custom_openai_configured():
             log.info("Only CUSTOM_OPENAI_* detected; using custom OpenAI-compatible endpoint")
             return Credentials(methods=[AuthMethod.CUSTOM_OPENAI_API])

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -110,6 +110,7 @@ class AuthMethod(StrEnum):
     DASHSCOPE_API = "dashscope_api"  # Alibaba DashScope (Qwen)
     GITHUB_MODELS_API = "github_models_api"  # GitHub Models (PAT auth)
     LMSTUDIO_LOCAL = "lmstudio_local"  # Local LM Studio (OpenAI-compatible)
+    LLAMACPP_LOCAL = "llamacpp_local"  # Local llama.cpp llama-server (OpenAI-compatible)
     CUSTOM_OPENAI_API = "custom_openai_api"  # Custom OpenAI-compatible endpoint
 
 
@@ -315,6 +316,19 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.MID: "lm_studio/__LMSTUDIO_MODEL__",
         Tier.LOW: "lm_studio/__LMSTUDIO_MODEL__",
     },
+    # llama.cpp llama-server — local OpenAI-compatible server (GGUF
+    # models). Issue #151. Tiers collapse to a single model resolved at
+    # chain-build time from LLAMACPP_MODEL because llama-server runs one
+    # GGUF at a time. The route prefix is ``llamacpp/`` (not a native
+    # LiteLLM provider — remapped to ``openai/<model>`` plus a custom
+    # api_base by ``litellm_dynamic_config.build_model_entry``); kept
+    # distinct from ``custom/`` so users can have BOTH a generic
+    # OpenAI-compatible gateway AND llama.cpp wired up at the same time.
+    AuthMethod.LLAMACPP_LOCAL: {
+        Tier.HIGH: "llamacpp/__LLAMACPP_MODEL__",
+        Tier.MID: "llamacpp/__LLAMACPP_MODEL__",
+        Tier.LOW: "llamacpp/__LLAMACPP_MODEL__",
+    },
     # Custom OpenAI-compatible endpoint — collapses tiers, model id from
     # CUSTOM_OPENAI_MODEL, base URL from CUSTOM_OPENAI_API_BASE.
     AuthMethod.CUSTOM_OPENAI_API: {
@@ -431,6 +445,7 @@ class Credentials(BaseModel):
 _OLLAMA_DEFAULT_MODEL = "llama3.2"
 _OLLAMA_CLOUD_DEFAULT_MODEL = "llama3.2"
 _LMSTUDIO_DEFAULT_MODEL = "qwen2.5-coder-7b-instruct"
+_LLAMACPP_DEFAULT_MODEL = "qwen2.5-coder-7b-instruct-q4_k_m"
 _CUSTOM_OPENAI_DEFAULT_MODEL = "gpt-4o-mini"
 
 
@@ -493,6 +508,33 @@ def _resolve_lmstudio_model() -> str | None:
     return f"lm_studio/{model}"
 
 
+def _resolve_llamacpp_model() -> str | None:
+    """Return the LiteLLM model id for the user's llama.cpp server, or None.
+
+    llama.cpp's ``llama-server`` exposes an OpenAI-compatible REST API
+    (default ``http://localhost:8080/v1``). The route prefix is
+    ``llamacpp/`` and the actual model name comes from ``LLAMACPP_MODEL``
+    — typically the GGUF file's logical name (e.g. ``qwen2.5-coder-7b-
+    instruct-q4_k_m``). The model name is mostly cosmetic at the server
+    side because ``llama-server`` runs one GGUF at a time, but it shows
+    up in LiteLLM logs and dashboards so a meaningful name helps.
+
+    Returns None when neither ``LLAMACPP_API_BASE`` nor ``LLAMACPP_MODEL``
+    is set so resolve_chain skips the method without leaking the
+    placeholder ``llamacpp/__LLAMACPP_MODEL__`` into the chain. When
+    only the base URL is set, ``_LLAMACPP_DEFAULT_MODEL`` provides a
+    sensible default — same fail-soft policy as the Ollama / LM Studio
+    resolvers.
+    """
+    base = os.getenv("LLAMACPP_API_BASE", "").strip()
+    model = os.getenv("LLAMACPP_MODEL", "").strip()
+    if not base and not model:
+        return None
+    if not model:
+        model = _LLAMACPP_DEFAULT_MODEL
+    return f"llamacpp/{model}"
+
+
 def _resolve_custom_openai_model() -> str | None:
     """Return the LiteLLM model id for the user's custom endpoint, or None.
 
@@ -542,6 +584,11 @@ def resolve_chain(tier: Tier, credentials: Credentials) -> list[str]:
             lmstudio_model = _resolve_lmstudio_model()
             if lmstudio_model is not None:
                 chain.append(lmstudio_model)
+            continue
+        if method == AuthMethod.LLAMACPP_LOCAL:
+            llamacpp_model = _resolve_llamacpp_model()
+            if llamacpp_model is not None:
+                chain.append(llamacpp_model)
             continue
         if method == AuthMethod.CUSTOM_OPENAI_API:
             custom_model = _resolve_custom_openai_model()

--- a/docs/models.md
+++ b/docs/models.md
@@ -223,6 +223,42 @@ Local model handles routine work; when the local model fails (OOM,
 context overflow, hardware fault), Anthropic takes over for that
 request only.
 
+
+### Local llama.cpp (GGUF) only
+
+```
+DECEPTICON_AUTH_PRIORITY=llamacpp_local
+LLAMACPP_API_BASE=http://host.docker.internal:8080/v1
+LLAMACPP_MODEL=qwen2.5-coder-7b-instruct-q4_k_m
+```
+
+| Agent (tier)     | Primary                                                  | Fallback |
+|------------------|----------------------------------------------------------|----------|
+| decepticon (HIGH)| `llamacpp/qwen2.5-coder-7b-instruct-q4_k_m`              | —        |
+| exploit (MID)    | `llamacpp/qwen2.5-coder-7b-instruct-q4_k_m`              | —        |
+| recon (LOW)      | `llamacpp/qwen2.5-coder-7b-instruct-q4_k_m`              | —        |
+
+Run a GGUF model with llama.cpp's OpenAI-compatible server:
+
+```bash
+llama-server -m /path/to/qwen2.5-coder-7b-instruct-q4_k_m.gguf --port 8080
+# server listens on http://localhost:8080/v1
+```
+
+Like Ollama, the model collapses across tiers — `llama-server` runs one
+GGUF at a time. The `llamacpp/<model>` route remaps to LiteLLM's
+`openai/` provider (since llama.cpp does not have a dedicated LiteLLM
+provider) plus a custom `api_base` pointed at `LLAMACPP_API_BASE`. This
+is the integration the maintainer recommended on issue #151 — it reuses
+the existing LiteLLM provider machinery and avoids vendoring
+`llama-cpp-python` as a runtime dependency.
+
+Tool calling works as long as the GGUF was trained or fine-tuned with
+function-calling support (Qwen 2.5 Coder, Llama 3.1 Instruct, Mistral
+Small Instruct all qualify). The `llama-server` request format is
+identical to OpenAI's; LiteLLM translates the agent's tool calls
+through unchanged.
+
 ### MiniMax-only (LOW gap)
 
 ```

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -7,6 +7,7 @@ import pytest
 from decepticon.llm.factory import (
     LLMFactory,
     _is_real_key,
+    _llamacpp_local_configured,
     _oauth_credentials_present,
     _resolve_credentials,
 )
@@ -932,3 +933,123 @@ class TestDeepSeekReasoningContent:
         assert _model_is_deepseek_thinking("deepseek/deepseek-v4-flash") is False
         assert _model_is_deepseek_thinking("deepseek/deepseek-chat") is False
         assert _model_is_deepseek_thinking("openai/gpt-5.5") is False
+
+
+# ── LLAMACPP_LOCAL credential detection (issue #151) ────────────────────
+
+
+_LLAMACPP_RELATED_ENV = (
+    "LLAMACPP_API_BASE",
+    "LLAMACPP_MODEL",
+    "LLAMACPP_API_KEY",
+)
+
+
+def _scrub_other_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Delete any env that would be detected as another credential.
+
+    The credential-detection tests below need to assert "only LLAMACPP
+    is detected"; without this scrub, a developer's exported
+    ``ANTHROPIC_API_KEY`` would creep in and the assertion would fail
+    locally only.
+    """
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "MINIMAX_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "XAI_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "NVIDIA_API_KEY",
+        "GROQ_API_KEY",
+        "TOGETHER_API_KEY",
+        "FIREWORKS_API_KEY",
+        "COHERE_API_KEY",
+        "MOONSHOT_API_KEY",
+        "ZAI_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "GITHUB_API_KEY",
+        "OLLAMA_API_BASE",
+        "OLLAMA_MODEL",
+        "OLLAMA_CLOUD_API_BASE",
+        "OLLAMA_CLOUD_MODEL",
+        "LMSTUDIO_API_BASE",
+        "LMSTUDIO_MODEL",
+        "CUSTOM_OPENAI_API_BASE",
+        "CUSTOM_OPENAI_API_KEY",
+        "DECEPTICON_AUTH_PRIORITY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    for flag in (
+        "DECEPTICON_AUTH_CLAUDE_CODE",
+        "DECEPTICON_AUTH_CHATGPT",
+        "DECEPTICON_AUTH_COPILOT",
+        "DECEPTICON_AUTH_GEMINI",
+        "DECEPTICON_AUTH_GROK",
+        "DECEPTICON_AUTH_PERPLEXITY",
+    ):
+        monkeypatch.delenv(flag, raising=False)
+
+
+class TestLlamacppLocalConfigured:
+    """``_llamacpp_local_configured`` is the gate for adding
+    ``LLAMACPP_LOCAL`` to the credentials chain. Either env var being
+    set is enough — neither requires the other, mirroring the
+    LM Studio / Ollama detection contract.
+    """
+
+    def test_returns_false_when_neither_env_set(self, monkeypatch):
+        for var in _LLAMACPP_RELATED_ENV:
+            monkeypatch.delenv(var, raising=False)
+        assert _llamacpp_local_configured() is False
+
+    def test_returns_true_when_only_base_set(self, monkeypatch):
+        for var in _LLAMACPP_RELATED_ENV:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://localhost:8080/v1")
+        assert _llamacpp_local_configured() is True
+
+    def test_returns_true_when_only_model_set(self, monkeypatch):
+        for var in _LLAMACPP_RELATED_ENV:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("LLAMACPP_MODEL", "qwen2.5-coder-7b-instruct-q4_k_m")
+        assert _llamacpp_local_configured() is True
+
+    def test_whitespace_does_not_count_as_set(self, monkeypatch):
+        """Stray ``LLAMACPP_API_BASE=`` lines in .env must not silently
+        opt the user in — same fail-soft as the Ollama detector."""
+        monkeypatch.setenv("LLAMACPP_API_BASE", "   ")
+        monkeypatch.setenv("LLAMACPP_MODEL", "")
+        assert _llamacpp_local_configured() is False
+
+
+class TestResolveCredentialsForLlamacpp:
+    """End-to-end check that ``_resolve_credentials`` picks up the
+    user's llama.cpp config — both the explicit-priority path and the
+    "only LLAMACPP_* detected" auto-fallback at the bottom of
+    ``_resolve_credentials``.
+    """
+
+    def test_only_llamacpp_detected_returns_llamacpp_only_chain(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _scrub_other_credentials(monkeypatch)
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://localhost:8080/v1")
+        monkeypatch.setenv("LLAMACPP_MODEL", "qwen2.5-coder-7b-instruct-q4_k_m")
+
+        creds = _resolve_credentials()
+        assert creds.methods == [AuthMethod.LLAMACPP_LOCAL]
+
+    def test_priority_list_with_llamacpp_picks_it_up(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """User wrote an explicit DECEPTICON_AUTH_PRIORITY listing
+        llamacpp_local — the resolver must respect that ordering."""
+        _scrub_other_credentials(monkeypatch)
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://localhost:8080/v1")
+        monkeypatch.setenv("LLAMACPP_MODEL", "qwen-coder")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-realtokenfortestingauthrouting12345")
+        monkeypatch.setenv("DECEPTICON_AUTH_PRIORITY", "llamacpp_local,anthropic_api")
+
+        creds = _resolve_credentials()
+        assert creds.methods == [AuthMethod.LLAMACPP_LOCAL, AuthMethod.ANTHROPIC_API]

--- a/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/tests/unit/llm/test_litellm_dynamic_config.py
@@ -193,3 +193,42 @@ def test_merge_dynamic_models_registers_only_supported_chatgpt_oauth_routes() ->
         {"auth/gpt-5.5": ["auth/gpt-5.4"]},
         {"auth/gpt-5.4": ["auth/gpt-5.4-mini"]},
     ]
+
+
+# ── llama.cpp OpenAI-compatible backend (issue #151) ────────────────────
+
+
+def test_build_model_entry_routes_llamacpp_to_openai_with_custom_base() -> None:
+    """``llamacpp/<model>`` routes through LiteLLM's openai-compatible
+    path with ``LLAMACPP_API_BASE`` and ``LLAMACPP_API_KEY``. Symmetric
+    to the ``custom/`` branch but kept distinct so users can have BOTH
+    a generic custom OpenAI gateway AND llama.cpp configured.
+    """
+    entry = build_model_entry("llamacpp/qwen2.5-coder-7b-instruct-q4_k_m")
+
+    assert entry["model_name"] == "llamacpp/qwen2.5-coder-7b-instruct-q4_k_m", (
+        "model_name must be the agent-facing alias unchanged — per-role "
+        "DECEPTICON_MODEL_<ROLE> overrides depend on this passthrough"
+    )
+    assert entry["litellm_params"] == {
+        "model": "openai/qwen2.5-coder-7b-instruct-q4_k_m",
+        "api_key": "os.environ/LLAMACPP_API_KEY",
+        "api_base": "os.environ/LLAMACPP_API_BASE",
+    }
+
+
+def test_validate_model_name_accepts_llamacpp_prefix() -> None:
+    """``llamacpp/`` is in ``ALLOWED_DYNAMIC_PROVIDERS`` so the validator
+    must let it through. Pre-fix this would raise the
+    ``unsupported model provider`` error.
+    """
+    # Should not raise.
+    validate_model_name("llamacpp/qwen2.5-coder-7b-instruct-q4_k_m")
+
+
+def test_validate_model_name_rejects_llamacpp_without_model_slug() -> None:
+    """Bare ``llamacpp`` (no slash, no model) is still invalid — the
+    validator's first check is the provider/model format gate.
+    """
+    with pytest.raises(ValueError, match="provider/model"):
+        validate_model_name("llamacpp")

--- a/tests/unit/llm/test_models.py
+++ b/tests/unit/llm/test_models.py
@@ -269,6 +269,91 @@ class TestOllamaLocalChain:
         assert chain == ["ollama_chat/qwen3-coder:30b", "openai/gpt-5.5"]
 
 
+# ── LLAMACPP_LOCAL dynamic resolution (issue #151) ──────────────────────
+
+
+class TestLlamacppLocalChain:
+    """LLAMACPP_LOCAL is OpenAI-compatible (llama-server) and collapses
+    across tiers like OLLAMA_LOCAL — llama-server runs one GGUF at a
+    time. Chain must read the live env value, not a static placeholder.
+    """
+
+    def test_llamacpp_resolves_user_chosen_model_at_high(self, monkeypatch):
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://host.docker.internal:8080/v1")
+        monkeypatch.setenv("LLAMACPP_MODEL", "qwen2.5-coder-7b-instruct-q4_k_m")
+        creds = Credentials(methods=[AuthMethod.LLAMACPP_LOCAL])
+        chain = resolve_chain(Tier.HIGH, creds)
+        assert chain == ["llamacpp/qwen2.5-coder-7b-instruct-q4_k_m"]
+
+    def test_llamacpp_collapses_across_tiers(self, monkeypatch):
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://host.docker.internal:8080/v1")
+        monkeypatch.setenv("LLAMACPP_MODEL", "llama-3.3-70b-instruct-q5_k_m")
+        creds = Credentials(methods=[AuthMethod.LLAMACPP_LOCAL])
+        for tier in (Tier.HIGH, Tier.MID, Tier.LOW):
+            assert resolve_chain(tier, creds) == ["llamacpp/llama-3.3-70b-instruct-q5_k_m"]
+
+    def test_llamacpp_skipped_when_env_unset(self, monkeypatch):
+        """LLAMACPP_LOCAL listed but not configured — chain must drop it
+        rather than emit ``llamacpp/__LLAMACPP_MODEL__`` placeholder."""
+        monkeypatch.delenv("LLAMACPP_API_BASE", raising=False)
+        monkeypatch.delenv("LLAMACPP_MODEL", raising=False)
+        creds = Credentials(methods=[AuthMethod.LLAMACPP_LOCAL, AuthMethod.OPENAI_API])
+        chain = resolve_chain(Tier.HIGH, creds)
+        assert chain == ["openai/gpt-5.5"]
+
+    def test_llamacpp_default_when_only_base_set(self, monkeypatch):
+        """User opted in via base URL but didn't pick a model — fall
+        back to the documented default rather than failing."""
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://host.docker.internal:8080/v1")
+        monkeypatch.delenv("LLAMACPP_MODEL", raising=False)
+        creds = Credentials(methods=[AuthMethod.LLAMACPP_LOCAL])
+        chain = resolve_chain(Tier.HIGH, creds)
+        # The default lives in models._LLAMACPP_DEFAULT_MODEL — assert
+        # on the prefix + the format rather than the exact tag so a
+        # future bump doesn't churn this test.
+        assert len(chain) == 1
+        assert chain[0].startswith("llamacpp/")
+        assert chain[0] != "llamacpp/__LLAMACPP_MODEL__"
+
+    def test_llamacpp_mixed_with_api_chain_priority_wins(self, monkeypatch):
+        """User has llama.cpp primary + OpenAI fallback — chain leads
+        with llama.cpp."""
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://host.docker.internal:8080/v1")
+        monkeypatch.setenv("LLAMACPP_MODEL", "qwen2.5-coder-7b-instruct-q4_k_m")
+        creds = Credentials(methods=[AuthMethod.LLAMACPP_LOCAL, AuthMethod.OPENAI_API])
+        chain = resolve_chain(Tier.HIGH, creds)
+        assert chain == [
+            "llamacpp/qwen2.5-coder-7b-instruct-q4_k_m",
+            "openai/gpt-5.5",
+        ]
+
+    def test_llamacpp_coexists_with_lmstudio_and_custom_openai(self, monkeypatch):
+        """All three OpenAI-compatible local-ish methods configured at
+        once — each picks up its own env namespace and the chain holds
+        all three in priority order. Pins that the new ``llamacpp/``
+        prefix does not collide with ``custom/`` or ``lm_studio/``.
+        """
+        monkeypatch.setenv("LLAMACPP_API_BASE", "http://host.docker.internal:8080/v1")
+        monkeypatch.setenv("LLAMACPP_MODEL", "model-llamacpp")
+        monkeypatch.setenv("LMSTUDIO_API_BASE", "http://host.docker.internal:1234/v1")
+        monkeypatch.setenv("LMSTUDIO_MODEL", "model-lmstudio")
+        monkeypatch.setenv("CUSTOM_OPENAI_API_BASE", "https://gateway.example/v1")
+        monkeypatch.setenv("CUSTOM_OPENAI_MODEL", "model-custom")
+        creds = Credentials(
+            methods=[
+                AuthMethod.LLAMACPP_LOCAL,
+                AuthMethod.LMSTUDIO_LOCAL,
+                AuthMethod.CUSTOM_OPENAI_API,
+            ]
+        )
+        chain = resolve_chain(Tier.HIGH, creds)
+        assert chain == [
+            "llamacpp/model-llamacpp",
+            "lm_studio/model-lmstudio",
+            "custom/model-custom",
+        ]
+
+
 # ── ModelAssignment ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #151. Adds first-class support for llama.cpp's OpenAI-compatible `llama-server` mode as a credentials-tier backend, alongside the existing `OLLAMA_LOCAL` / `LMSTUDIO_LOCAL` / `CUSTOM_OPENAI_API` entries.

This implements the route the maintainer recommended on the issue thread:

> **Likely path:**
> - Short term: improve Ollama support…
> - Longer term: evaluate whether direct `llama-cpp-python` or the OpenAI-compatible mode of `llama-server` is the better integration point. The OpenAI-compatible route reuses our existing LiteLLM provider machinery and avoids vendoring a native dependency.

That's exactly the route this PR takes. **No new runtime dependency.** The `llamacpp/<model>` provider prefix remaps to LiteLLM's `openai/<model>` path with a custom `api_base` derived from `LLAMACPP_API_BASE`, mirroring the `custom/` branch but kept distinct so users can have BOTH a generic OpenAI-compatible gateway AND llama.cpp wired at the same time.

## User-facing config

```bash
# .env
LLAMACPP_API_BASE=http://host.docker.internal:8080/v1
LLAMACPP_MODEL=qwen2.5-coder-7b-instruct-q4_k_m
# LLAMACPP_API_KEY=llama-cpp   # optional sentinel; llama-server accepts any string
```

```bash
# Run llama.cpp in OpenAI-compat mode:
llama-server -m /path/to/model.gguf --port 8080
```

## Changes

- **`decepticon/llm/models.py`**
  - New `AuthMethod.LLAMACPP_LOCAL` enum value
  - `METHOD_MODELS` placeholder `llamacpp/__LLAMACPP_MODEL__` resolved dynamically at chain-build time (same pattern as `OLLAMA_LOCAL` / `LMSTUDIO_LOCAL`)
  - `_LLAMACPP_DEFAULT_MODEL` fallback when only the base URL is set
  - `_resolve_llamacpp_model()` reads env, collapses tiers, returns `None` when unwired (so `resolve_chain` skips without leaking the placeholder)
  - `resolve_chain` branch routes the method through the resolver

- **`decepticon/llm/factory.py`**
  - `LLAMACPP_LOCAL` added to `_DEFAULT_AUTH_PRIORITY` (alongside the other local methods, before `CUSTOM_OPENAI_API`)
  - `_llamacpp_local_configured()` detector — fail-soft on whitespace, opt-in via either `LLAMACPP_API_BASE` or `LLAMACPP_MODEL`
  - `_resolve_credentials()` picks up `LLAMACPP_LOCAL` through the explicit-priority path AND the "only LLAMACPP_* detected" auto-fallback

- **`config/litellm_dynamic_config.py`**
  - `'llamacpp'` added to `ALLOWED_DYNAMIC_PROVIDERS`
  - `build_model_entry()` branches on `llamacpp/<m>` and emits `{model: openai/<m>, api_base: LLAMACPP_API_BASE, api_key: LLAMACPP_API_KEY}`

- **`.env.example`** — new `LLAMACPP_*` section with run instructions
- **`docs/models.md`** — new "Local llama.cpp (GGUF) only" worked example with config, table, and a note linking the maintainer's guidance

## Testing

- [x] `make quality` Python lane passes.
  - Pytest: 793 → 808 (15 new tests). 0 ruff issues. 0 basedpyright errors.
- [ ] `make smoke` not run — Docker stack unavailable on this dev machine. The integration is unit-testable end-to-end via the existing `test_litellm_dynamic_config.py` machinery (it imports the config module by file path and exercises `build_model_entry` against the real builder).
- [x] Manual end-to-end: with `LLAMACPP_API_BASE=http://localhost:8080/v1` and `LLAMACPP_MODEL=qwen2.5-coder-7b-instruct-q4_k_m` set:
  - `_resolve_llamacpp_model()` returns `llamacpp/qwen2.5-coder-7b-instruct-q4_k_m`
  - `resolve_chain(Tier.HIGH, Credentials([LLAMACPP_LOCAL]))` returns `["llamacpp/qwen2.5-coder-7b-instruct-q4_k_m"]`
  - `_resolve_credentials()` returns `Credentials(methods=[LLAMACPP_LOCAL])` when no other env is set
  - `build_model_entry("llamacpp/qwen2.5-coder-7b-instruct-q4_k_m")` returns `{"model_name": "llamacpp/qwen2.5-coder-7b-instruct-q4_k_m", "litellm_params": {"model": "openai/qwen2.5-coder-7b-instruct-q4_k_m", "api_key": "os.environ/LLAMACPP_API_KEY", "api_base": "os.environ/LLAMACPP_API_BASE"}}`

### New tests (15)

- `tests/unit/llm/test_models.py::TestLlamacppLocalChain` (6) — chain resolution, tier collapse, skip-when-unset, default-when-only-base, primary+cloud fallback, coexistence with LM Studio + custom OpenAI without prefix collision
- `tests/unit/llm/test_factory.py::TestLlamacppLocalConfigured` (4) — detector behaviour
- `tests/unit/llm/test_factory.py::TestResolveCredentialsForLlamacpp` (2) — end-to-end credential pickup
- `tests/unit/llm/test_litellm_dynamic_config.py` (3) — `build_model_entry` routes correctly, `validate_model_name` accepts the new prefix and still rejects bare `llamacpp`

## Related Issues

Closes #151.
