### PR TITLE
fix(deps): bump deepagents to >=0.5.0 and lock Dockerfile install via uv.lock

### DIFF
--- a/containers/langgraph.Dockerfile
+++ b/containers/langgraph.Dockerfile
@@ -15,8 +15,8 @@ WORKDIR /app
 # Install uv for fast dependency resolution
 COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /usr/local/bin/uv
 
-# Copy project files
-COPY pyproject.toml langgraph.json README.md ./
+# Copy project files (uv.lock included so the install is reproducible)
+COPY pyproject.toml langgraph.json README.md uv.lock ./
 COPY decepticon/ decepticon/
 COPY skills/ skills/
 
@@ -26,10 +26,14 @@ COPY skills/ skills/
 ARG VERSION=0.0.0
 RUN sed -i 's/^version = "[^"]*"/version = "'"$VERSION"'"/' pyproject.toml
 
-# Install Python dependencies (editable — synced source changes via docker compose watch
-# are immediately reflected without reinstall)
-RUN uv pip install --system -e "." && \
-    uv pip install --system "langgraph-cli[inmem]>=0.2.0"
+# Install Python dependencies. uv export --frozen derives the exact set from
+# uv.lock (ignoring pyproject.toml's loose constraints), so the container
+# always gets the same versions that were locked at commit time. The editable
+# install uses --no-deps because all dependencies are already installed; source
+# changes via docker compose watch are still reflected without reinstall.
+RUN uv export --no-dev --frozen -o /tmp/requirements.txt && \
+    uv pip install --system -r /tmp/requirements.txt && \
+    uv pip install --system -e "." --no-deps
 
 EXPOSE 2024
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "langgraph-sdk>=0.1.0",
     # HTTP
     "httpx>=0.27.0",
-    "deepagents>=0.4.4",
+    "deepagents>=0.5.0",
     # CLI
     "typer[all]>=0.9.0",
     "xxhash>=3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -394,7 +394,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepagents", specifier = ">=0.4.4" },
+    { name = "deepagents", specifier = ">=0.5.0" },
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain-anthropic", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Problem

After pulling the L2-12→L2-19 commits, `make dogfood` fails because the `decepticon-langgraph` container exits unhealthy immediately on startup:

```
ImportError: cannot import name 'GlobResult' from 'deepagents.backends.protocol'
```

`GlobResult` was introduced in `deepagents 0.5.0`. The L2-19 commits used it in `decepticon/middleware/filesystem.py`, but `pyproject.toml` still declared `deepagents>=0.4.4`, so the container was resolving `0.4.12`.

The constraint alone isn't the full story. `langgraph.Dockerfile` didn't copy `uv.lock`, so `uv pip install` resolved dependencies live from the loose `pyproject.toml` constraints — ignoring the fact that `uv.lock` already pins `deepagents` to `0.5.6`. Any future commit that uses a newer `deepagents` symbol would hit the same class of bug unless the constraint was also manually bumped.

## Fix

Two changes:

**1. `pyproject.toml`** — tighten the constraint:
```diff
-    "deepagents>=0.4.4",
+    "deepagents>=0.5.0",
```

**2. `containers/langgraph.Dockerfile`** — wire `uv.lock` into the build so the installed set is always reproducible:
```diff
-COPY pyproject.toml langgraph.json README.md ./
+COPY pyproject.toml langgraph.json README.md uv.lock ./

-RUN uv pip install --system -e "." && \
-    uv pip install --system "langgraph-cli[inmem]>=0.2.0"
+RUN uv export --no-dev --frozen -o /tmp/requirements.txt && \
+    uv pip install --system -r /tmp/requirements.txt && \
+    uv pip install --system -e "." --no-deps
```

`uv export --frozen` derives the exact package set from `uv.lock`, not from the loose constraints. The editable install uses `--no-deps` because all transitive deps are already installed; the `docker compose watch` live-reload behaviour is unchanged.

## Test plan

- [ ] `docker buildx prune --filter type=exec.cachemount --force`
- [ ] `make dogfood` — langgraph container reaches healthy, Soundwave CLI launches
- [ ] `docker run --rm <langgraph-image> pip show deepagents` → `Version: 0.5.x`

Fixes #199