### PR TITLE
fix(web): prevent duplicate keystrokes on WebSocket reconnection

### DIFF
--- a/clients/web/src/components/terminal/web-terminal.tsx
+++ b/clients/web/src/components/terminal/web-terminal.tsx
@@ -63,6 +63,8 @@ export function WebTerminal({
   const reconnectMsgShownRef = useRef(false);
   // Track the onData listener for manual retry so we can dispose it
   const retryListenerRef = useRef<{ dispose: () => void } | null>(null);
+  // Track the main onData listener so we can dispose it on reconnect
+  const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
 
   const cleanup = useCallback(() => {
     disposedRef.current = true;
@@ -165,8 +167,9 @@ export function WebTerminal({
       setConnState("reconnecting");
     };
 
-    // Forward input
-    term.onData((data: string) => {
+    // Forward input — dispose previous listener to prevent duplicates on reconnect
+    onDataDisposableRef.current?.dispose();
+    onDataDisposableRef.current = term.onData((data: string) => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(data);
       }


### PR DESCRIPTION
## Summary

Fixes duplicate character input in the web terminal (`xterm.js`) embedded in the engagement dashboard. Each keystroke or paste was repeated N times, where N is the number of WebSocket reconnections that occurred during the session.

## Environment

- **Component**: `clients/web/src/components/terminal/web-terminal.tsx`
- **Trigger**: Tab visibility change, network recovery, or WebSocket reconnect
- **Version**: 1.0.24 (present on `main`)

## Root Cause

In `connectWs()`, a new `term.onData()` listener was registered every time the function was called, but the previous listener was never disposed. Since `connectWs()` runs on:
1. Initial mount
2. Every WebSocket reconnection (`scheduleReconnect` → `connectWs`)
3. Tab becoming visible (`visibilitychange` → `connectWs`)
4. Browser coming back online (`online` → `connectWs`)

...after N reconnection events, each keystroke was forwarded N times to the PTY via the WebSocket, producing duplicate characters.

## Fix

Added `onDataDisposableRef` to store the disposable returned by `term.onData()`. Before registering a new listener in `connectWs()`, the previous disposable is called via `onDataDisposableRef.current?.dispose()`. This follows the same pattern already used by `retryListenerRef` for the manual-retry handlers.

## Testing

- Applied the fix to a running Decepticon instance (v1.0.24) by patching the source, rebuilding (`next build`), and restarting the web container
- Verified no more duplicate characters after multiple WS reconnections (tab background/foreground cycling, network toggle)
- Confirmed `onDataDisposableRef` appears in the compiled client bundle
- Web dashboard returns HTTP 200, terminal loads and functions normally
- Existing `retryListenerRef` pattern (same dispose pattern) remains unchanged