### PR TITLE
refactor(litellm): centralize auth dispatcher, modernize subscription models, register Codex variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,11 @@ export DECEPTICON_HOME ?= $(HOME)/.decepticon
 
 # Mirror the launcher's start.go credential mount logic so `make dev` (and any
 # other target that calls `docker compose`) populates the litellm container's
-# Claude Code OAuth token without requiring users to run `decepticon onboard`.
-# Existence check at make-time: real file when host has tokens, /dev/null
-# otherwise so docker doesn't synthesize a bind directory.
+# Claude Code + Codex CLI OAuth tokens without requiring users to run
+# `decepticon onboard`. Existence check at make-time: real file when host has
+# tokens, /dev/null otherwise so docker doesn't synthesize a bind directory.
 export CLAUDE_CREDENTIALS_VOLUME ?= $(shell test -f $(HOME)/.claude/.credentials.json && echo $(HOME)/.claude/.credentials.json || echo /dev/null)
+export CODEX_AUTH_VOLUME ?= $(shell test -f $(HOME)/.codex/auth.json && echo $(HOME)/.codex/auth.json || echo /dev/null)
 
 .PHONY: help \
         dogfood launcher smoke \

--- a/clients/cli/src/commands/model.ts
+++ b/clients/cli/src/commands/model.ts
@@ -36,8 +36,18 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
     "auth/claude-haiku-4-5",
   ],
   // Cloud OpenAI
-  "OpenAI API": ["openai/gpt-5.5", "openai/gpt-5.4", "openai/gpt-5-nano"],
-  "ChatGPT OAuth": ["auth/gpt-5.5", "auth/gpt-5.4"],
+  "OpenAI API": [
+    "openai/gpt-5.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5-nano",
+    "openai/gpt-5.3-codex",
+  ],
+  "ChatGPT OAuth": [
+    "auth/gpt-5.5",
+    "auth/gpt-5.4",
+    "auth/gpt-5.4-mini",
+    "auth/gpt-5.3-codex",
+  ],
   // Cloud Google
   "Google API": [
     "gemini/gemini-2.5-pro",
@@ -51,8 +61,8 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
   // Other vendors
   "MiniMax": ["minimax/MiniMax-M2.5", "minimax/MiniMax-M2.5-lightning"],
   "DeepSeek": ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash"],
-  "xAI Grok API": ["xai/grok-3", "xai/grok-3-mini"],
-  "SuperGrok OAuth": ["grok-sub/grok-3", "grok-sub/grok-3-mini"],
+  "xAI Grok API": ["xai/grok-4.3", "xai/grok-4-1-fast-reasoning"],
+  "SuperGrok OAuth": ["grok-sub/grok-4.3", "grok-sub/grok-4-1-fast-reasoning"],
   "Mistral": ["mistral/mistral-large-latest", "mistral/codestral-latest"],
   "OpenRouter": [
     "openrouter/anthropic/claude-opus-4-7",
@@ -65,7 +75,12 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
     "nvidia_nim/meta/llama-3.2-3b-instruct",
   ],
   // Subscription OAuth
-  "GitHub Copilot Pro (OAuth)": ["copilot/gpt-4o", "copilot/o1", "copilot/o3-mini"],
+  "GitHub Copilot Pro (OAuth)": [
+    "copilot/gpt-5.5",
+    "copilot/claude-sonnet-4-6",
+    "copilot/gpt-5.4-mini",
+    "copilot/gpt-5.3-codex",
+  ],
   "Perplexity Pro (OAuth)": ["pplx-sub/sonar-pro", "pplx-sub/sonar"],
   // Cloud gateways (added in OpenClaude provider migration)
   "AWS Bedrock": [

--- a/config/auth_handler.py
+++ b/config/auth_handler.py
@@ -4,9 +4,17 @@ Routes incoming requests to the correct subscription handler based on the
 slug after ``auth/``:
 
   - ``auth/claude-*``  → claude_code_handler  (Claude Code OAuth)
-  - ``auth/gpt-*``     → codex_chatgpt_handler (Codex CLI / ChatGPT OAuth)
 
-Adding a new subscription provider is one line in ``_PREFIX_HANDLERS``.
+Adding a new ``auth/<prefix>-*`` subscription is one line in
+``_PREFIX_HANDLERS``.
+
+Note: ChatGPT Codex (user-facing ``auth/gpt-*``) does NOT go through this
+dispatcher. ``litellm_dynamic_config.py`` aliases it to the dedicated
+``codex-oauth/oauth-gpt-*`` route — the ``oauth-`` sentinel is required to
+dodge LiteLLM's ``main.py:2561`` ``open_ai_chat_completion_models``
+short-circuit, which would otherwise route bare ``gpt-*`` slugs to
+api.openai.com. The dispatcher remains the multiplex point for any future
+``auth/<prefix>-*`` namespace whose slugs do not collide.
 
 This module is mounted into the LiteLLM container alongside the per-provider
 handler files. It replaces the inline ``_select_auth_handler`` /
@@ -22,13 +30,11 @@ from typing import Any
 
 import litellm
 from claude_code_handler import claude_code_handler_instance
-from codex_chatgpt_handler import codex_chatgpt_handler_instance
 from litellm import CustomLLM, ModelResponse
 
 # Prefix → handler. Order matters only for documentation; lookup is exact.
 _PREFIX_HANDLERS: list[tuple[str, CustomLLM]] = [
     ("claude-", claude_code_handler_instance),
-    ("gpt-", codex_chatgpt_handler_instance),
 ]
 
 

--- a/config/copilot_handler.py
+++ b/config/copilot_handler.py
@@ -25,8 +25,20 @@ Source-token resolution order (first match wins):
   5. ``~/.config/github-copilot/hosts.json`` (legacy format used by
      older versions of the Copilot CLI).
 
-Model names: copilot/gpt-4o, copilot/o1, copilot/o3-mini, etc. The
-slug after ``copilot/`` is forwarded verbatim as the upstream model id.
+User-facing model names: ``copilot/gpt-5.5``, ``copilot/claude-sonnet-4-6``,
+``copilot/gpt-5.4-mini``, ``copilot/gpt-5.3-codex``, etc. The exact lineup
+follows GitHub Copilot's model picker (gpt-4o / o1 / o3-mini were retired
+on 2025-10-23 and have been replaced by the GPT-5 family).
+
+Slugs that collide with ``litellm.open_ai_chat_completion_models``
+(currently ``gpt-5.3-codex`` among Copilot's lineup; the default tier
+picks above avoid this set) are aliased in ``litellm_dynamic_config.py``
+to an internal ``copilot/oauth-<slug>`` form. The ``oauth-`` sentinel
+dodges LiteLLM's ``main.py:2561`` short-circuit, which would otherwise
+route the bare slug straight to api.openai.com regardless of provider.
+This handler strips the sentinel via ``_upstream_model_slug`` before
+forwarding to api.githubcopilot.com, so Copilot receives the canonical
+name.
 """
 
 from __future__ import annotations
@@ -228,10 +240,31 @@ def _api_base() -> str:
     return GITHUB_COPILOT_API_BASE
 
 
+def _upstream_model_slug(model: str) -> str:
+    """Translate a LiteLLM-side model id back to the Copilot model slug.
+
+    Routes that reach this handler:
+
+      - ``copilot/<slug>`` — passthrough for slugs that don't collide with
+        LiteLLM's ``open_ai_chat_completion_models``.
+      - ``copilot/oauth-<slug>`` — dynamic-config alias for slugs that
+        would otherwise bypass to api.openai.com via main.py:2561. The
+        ``oauth-`` sentinel is stripped here so api.githubcopilot.com
+        receives the canonical model id.
+    """
+    slug = model.split("/", 1)[-1] if "/" in model else model
+    if slug.startswith("oauth-"):
+        slug = slug.removeprefix("oauth-")
+    return slug
+
+
 class CopilotHandler(CustomLLM):
     """Routes through GitHub Copilot subscription.
 
-    Model names: copilot/gpt-4o, copilot/o1, copilot/o3-mini, etc.
+    Model names: copilot/gpt-5.5, copilot/claude-sonnet-4-6,
+    copilot/gpt-5.4-mini, copilot/gpt-5.3-codex, etc. The slug after
+    ``copilot/`` is forwarded verbatim to api.githubcopilot.com after
+    the ``oauth-`` sentinel (if present) is stripped.
     """
 
     def completion(
@@ -252,7 +285,7 @@ class CopilotHandler(CustomLLM):
         headers: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> ModelResponse:
-        actual_model = model.split("/", 1)[-1] if "/" in model else model
+        actual_model = _upstream_model_slug(model)
 
         opts = optional_params or {}
         request_body: dict[str, Any] = {"model": actual_model, "messages": messages}

--- a/config/grok_handler.py
+++ b/config/grok_handler.py
@@ -1,14 +1,16 @@
 """LiteLLM custom handler for xAI SuperGrok subscription.
 
-Routes requests through Grok's API using X Premium+ subscription tokens.
-Enables Grok-3/Grok-3-mini access without xAI API billing.
+Routes requests through Grok's API using X Premium+ / SuperGrok
+subscription tokens. Enables Grok 4.x access without xAI API billing.
 
 Token sources (checked in order):
   1. GROK_ACCESS_TOKEN env var
   2. GROK_SESSION_TOKEN env var (X.com auth cookie)
   3. ~/.config/grok/tokens.json
 
-Model names: grok-sub/grok-3, grok-sub/grok-3-mini, etc.
+Model names: grok-sub/grok-4.3, grok-sub/grok-4-1-fast-reasoning, etc.
+The slug after ``grok-sub/`` is forwarded verbatim as the upstream
+model id; xAI retired grok-3 / grok-3-mini on 2026-05-15.
 """
 
 from __future__ import annotations
@@ -126,7 +128,7 @@ def get_grok_access_token(force_refresh: bool = False) -> str:
 class GrokSubHandler(CustomLLM):
     """Routes through xAI SuperGrok subscription.
 
-    Model names: grok-sub/grok-3, grok-sub/grok-3-mini
+    Model names: grok-sub/grok-4.3, grok-sub/grok-4-1-fast-reasoning, etc.
     """
 
     def completion(

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -63,6 +63,16 @@ model_list:
       model: openai/gpt-5-nano
       api_key: os.environ/OPENAI_API_KEY
 
+  # Code-heavy override — opt-in via DECEPTICON_MODEL_<ROLE> for roles
+  # like patcher, exploiter, contract_auditor that benefit from OpenAI's
+  # agentic coding specialization. Not a default tier pick (gpt-5.5 stays
+  # HIGH for general agent balance); this route exists so per-agent env
+  # overrides don't require a yaml edit.
+  - model_name: openai/gpt-5.3-codex
+    litellm_params:
+      model: openai/gpt-5.3-codex
+      api_key: os.environ/OPENAI_API_KEY
+
   # ── Google ───────────────────────────────────────────────────────────
   # HIGH tier
   - model_name: gemini/gemini-2.5-pro
@@ -139,14 +149,18 @@ model_list:
       api_key: os.environ/DEEPSEEK_API_KEY
 
   # ── xAI (Grok) ──────────────────────────────────────────────────────
-  - model_name: xai/grok-3
+  # grok-3 / grok-3-mini retired by xAI on 2026-05-15 (12pm PT). The 4.x
+  # family below is the current production lineup; grok-4.3 is xAI's
+  # general flagship and grok-4-1-fast-reasoning is the cost-efficient
+  # MID tier with comparable tool-call quality.
+  - model_name: xai/grok-4.3
     litellm_params:
-      model: xai/grok-3
+      model: xai/grok-4.3
       api_key: os.environ/XAI_API_KEY
 
-  - model_name: xai/grok-3-mini
+  - model_name: xai/grok-4-1-fast-reasoning
     litellm_params:
-      model: xai/grok-3-mini
+      model: xai/grok-4-1-fast-reasoning
       api_key: os.environ/XAI_API_KEY
 
   # ── Mistral ──────────────────────────────────────────────────────────
@@ -272,7 +286,7 @@ litellm_settings:
     # DeepSeek
     - {"deepseek/deepseek-v4-pro": ["deepseek/deepseek-v4-flash"]}
     # xAI direct API
-    - {"xai/grok-3": ["xai/grok-3-mini"]}
+    - {"xai/grok-4.3": ["xai/grok-4-1-fast-reasoning"]}
     # Mistral (no LOW tier)
     - {"mistral/mistral-large-latest": ["mistral/codestral-latest"]}
     # Nvidia NIM

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -353,6 +353,16 @@ _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
             "model_name": "auth/gpt-5.4-mini",
             "litellm_params": {"model": "codex-oauth/oauth-gpt-5.4-mini"},
         },
+        # Code-heavy override (option α). gpt-5.3-codex is OpenAI's
+        # agentic-coding specialized model (Codex + GPT-5 training
+        # stack); register the route here so per-agent env overrides
+        # like ``DECEPTICON_MODEL_PATCHER=auth/gpt-5.3-codex`` work
+        # without yaml edits. Slug ``gpt-5.3-codex`` IS in
+        # open_ai_chat_completion_models, so the sentinel is required.
+        {
+            "model_name": "auth/gpt-5.3-codex",
+            "litellm_params": {"model": "codex-oauth/oauth-gpt-5.3-codex"},
+        },
     ],
     "DECEPTICON_AUTH_GEMINI": [
         {
@@ -365,12 +375,56 @@ _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
         },
     ],
     "DECEPTICON_AUTH_COPILOT": [
-        {"model_name": "copilot/gpt-4o", "litellm_params": {"model": "copilot/gpt-4o"}},
-        {"model_name": "copilot/o1", "litellm_params": {"model": "copilot/o1"}},
+        # GitHub Copilot retired gpt-4o / o1 / o3-mini on 2025-10-23.
+        # Current Copilot model picker exposes (as of 2026-05-14):
+        #   OpenAI:   gpt-5 mini, gpt-5.2, gpt-5.2-Codex, gpt-5.3-Codex,
+        #             gpt-5.4, gpt-5.4 mini, gpt-5.4 nano, gpt-5.5
+        #   Anthropic: Haiku 4.5, Opus 4.5/4.6/4.7, Sonnet 4.5/4.6
+        #   Google:    Gemini 2.5 Pro, Gemini 3 Flash (preview)
+        #   xAI:       Grok Code Fast 1
+        # Default tier picks below avoid the LiteLLM main.py:2561
+        # short-circuit by choosing slugs NOT in
+        # ``open_ai_chat_completion_models`` — no sentinel needed.
+        # ``claude-sonnet-4-6`` is in ``anthropic_models`` but main.py
+        # does not early-check that list (only openai's), so it routes
+        # cleanly through the ``copilot`` custom provider.
+        {
+            "model_name": "copilot/gpt-5.5",
+            "litellm_params": {"model": "copilot/gpt-5.5"},
+        },
+        {
+            "model_name": "copilot/claude-sonnet-4-6",
+            "litellm_params": {"model": "copilot/claude-sonnet-4-6"},
+        },
+        {
+            "model_name": "copilot/gpt-5.4-mini",
+            "litellm_params": {"model": "copilot/gpt-5.4-mini"},
+        },
+        # Code-heavy override (option α). gpt-5.3-codex is in
+        # ``open_ai_chat_completion_models``, so the ``oauth-`` slug
+        # sentinel is required to dodge the main.py:2561 short-circuit.
+        # copilot_handler._upstream_model_slug strips ``oauth-`` before
+        # posting to api.githubcopilot.com. Pick via
+        # ``DECEPTICON_MODEL_<ROLE>=copilot/gpt-5.3-codex`` for
+        # patcher / exploiter / contract_auditor.
+        {
+            "model_name": "copilot/gpt-5.3-codex",
+            "litellm_params": {"model": "copilot/oauth-gpt-5.3-codex"},
+        },
     ],
     "DECEPTICON_AUTH_GROK": [
-        {"model_name": "grok-sub/grok-3", "litellm_params": {"model": "grok-sub/grok-3"}},
-        {"model_name": "grok-sub/grok-3-mini", "litellm_params": {"model": "grok-sub/grok-3-mini"}},
+        # grok-3 / grok-3-mini retired by xAI on 2026-05-15. Replaced
+        # with the current production lineup: grok-4.3 (flagship) and
+        # grok-4-1-fast-reasoning (cost-efficient MID). Both slugs are
+        # NOT in ``open_ai_chat_completion_models`` so no sentinel needed.
+        {
+            "model_name": "grok-sub/grok-4.3",
+            "litellm_params": {"model": "grok-sub/grok-4.3"},
+        },
+        {
+            "model_name": "grok-sub/grok-4-1-fast-reasoning",
+            "litellm_params": {"model": "grok-sub/grok-4-1-fast-reasoning"},
+        },
     ],
     "DECEPTICON_AUTH_PERPLEXITY": [
         {"model_name": "pplx-sub/sonar-pro", "litellm_params": {"model": "pplx-sub/sonar-pro"}},
@@ -388,10 +442,11 @@ _SUBSCRIPTION_FALLBACKS: dict[str, list[dict[str, list[str]]]] = {
         {"gemini-sub/gemini-2.5-pro": ["gemini-sub/gemini-2.5-flash"]},
     ],
     "DECEPTICON_AUTH_COPILOT": [
-        {"copilot/gpt-4o": ["copilot/o1"]},
+        {"copilot/gpt-5.5": ["copilot/claude-sonnet-4-6"]},
+        {"copilot/claude-sonnet-4-6": ["copilot/gpt-5.4-mini"]},
     ],
     "DECEPTICON_AUTH_GROK": [
-        {"grok-sub/grok-3": ["grok-sub/grok-3-mini"]},
+        {"grok-sub/grok-4.3": ["grok-sub/grok-4-1-fast-reasoning"]},
     ],
     "DECEPTICON_AUTH_PERPLEXITY": [
         {"pplx-sub/sonar-pro": ["pplx-sub/sonar"]},

--- a/config/litellm_startup.py
+++ b/config/litellm_startup.py
@@ -105,14 +105,23 @@ from perplexity_handler import perplexity_sub_handler_instance  # noqa: E402
 
 # ── Custom provider registration ─────────────────────────────────────
 # The ``auth/`` namespace dispatches to per-provider OAuth handlers via
-# ``auth_handler.AuthDispatcher`` (currently used for ``claude-*``).
+# ``auth_handler.AuthDispatcher`` (currently used for ``claude-*`` only).
 #
-# ChatGPT/Codex is registered under its own ``codex-oauth`` provider
-# key so the dynamic config can alias ``auth/gpt-*`` (user-facing model
-# name) to ``codex-oauth/gpt-*`` (the internal route). LiteLLM's
-# router otherwise misroutes ``auth/gpt-*`` to its native OpenAI
-# provider because the slug ``gpt-*`` matches an OpenAI model alias —
-# the dedicated provider name avoids that heuristic entirely.
+# Slug-collision rule: whenever a subscription slug matches a name in
+# ``litellm.open_ai_chat_completion_models``, ``litellm_dynamic_config``
+# aliases the internal model id with an ``oauth-`` sentinel and the
+# matching handler strips it before forwarding upstream. Without the
+# sentinel LiteLLM's ``main.py:2561`` short-circuit (``model in
+# open_ai_chat_completion_models``) fires BEFORE the custom-provider
+# dispatch and forwards to api.openai.com regardless of provider name.
+# Currently affected:
+#   - ChatGPT Codex (auth/gpt-5.5/5.4/5.4-mini/5.3-codex) →
+#       codex-oauth/oauth-gpt-<slug>
+#   - Copilot opt-in (copilot/gpt-5.3-codex) → copilot/oauth-gpt-5.3-codex
+# Default Copilot tier picks (gpt-5.5, claude-sonnet-4-6, gpt-5.4-mini)
+# and all other subscription routes (claude-*, gemini-2.5-*, grok-4.*,
+# sonar*) use slugs that do NOT collide with open_ai_chat_completion_models
+# and pass through their providers directly with no aliasing.
 
 litellm.custom_provider_map = [
     {"provider": "auth", "custom_handler": auth_handler_instance},

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -42,6 +42,21 @@ Tier × AuthMethod matrix
   minimax_api      MiniMax-M2.5                  MiniMax-M2.5-lightning         — (falls through)
   openrouter_api   claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
   nvidia_api       llama-3.3-70b-instruct        nemotron-70b-instruct          llama-3.2-3b-instruct
+  xai_api          grok-4.3                      grok-4-1-fast-reasoning        — (falls through)
+  copilot_oauth    copilot/gpt-5.5               copilot/claude-sonnet-4-6      copilot/gpt-5.4-mini
+  grok_oauth       grok-sub/grok-4.3             grok-sub/grok-4-1-fast-reasoning — (falls through)
+  pplx_oauth       pplx-sub/sonar-pro            pplx-sub/sonar                 — (falls through)
+
+Code-heavy override
+-------------------
+For roles that benefit from OpenAI's agentic coding specialization (patcher,
+exploiter, contract_auditor, reverser, verifier), set
+``DECEPTICON_MODEL_<ROLE>`` to one of the registered Codex variant routes:
+  - ``openai/gpt-5.3-codex``       (paid API key)
+  - ``auth/gpt-5.3-codex``         (ChatGPT subscription via Codex backend)
+  - ``copilot/gpt-5.3-codex``      (GitHub Copilot subscription)
+These are NOT default tier picks — gpt-5.5 stays HIGH for general agent
+balance — but are registered so per-role overrides work without yaml edits.
 
 Profiles
 --------
@@ -49,7 +64,7 @@ Profiles
   max   every agent on HIGH (high-value targets)
   test  every agent on LOW (development / CI)
 
-Model identifiers verified against provider docs as of 2026-04-28.
+Model identifiers verified against provider docs as of 2026-05-14.
 """
 
 from __future__ import annotations
@@ -161,8 +176,12 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.LOW: "deepseek/deepseek-v4-flash",
     },
     AuthMethod.XAI_API: {
-        Tier.HIGH: "xai/grok-3",
-        Tier.MID: "xai/grok-3-mini",
+        # grok-3 / grok-3-mini retired by xAI on 2026-05-15 (12pm PT).
+        # grok-4.3 is xAI's current general-purpose flagship; the 4-1-fast
+        # reasoning variant gives a cheaper second-best with comparable
+        # tool-call quality for the MID tier.
+        Tier.HIGH: "xai/grok-4.3",
+        Tier.MID: "xai/grok-4-1-fast-reasoning",
     },
     AuthMethod.MISTRAL_API: {
         Tier.HIGH: "mistral/mistral-large-latest",
@@ -202,13 +221,27 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.LOW: "ollama_chat/__OLLAMA_CLOUD_MODEL__",
     },
     AuthMethod.COPILOT_OAUTH: {
-        Tier.HIGH: "copilot/gpt-4o",
-        Tier.MID: "copilot/o1",
-        Tier.LOW: "copilot/o3-mini",
+        # gpt-4o / o1 / o3-mini retired from GitHub Copilot on 2025-10-23.
+        # Current Copilot OpenAI lineup: gpt-5 mini, gpt-5.2, gpt-5.2-Codex,
+        # gpt-5.3-Codex, gpt-5.4, gpt-5.4 mini, gpt-5.4 nano, gpt-5.5.
+        # Claude lineup: Haiku 4.5, Opus 4.5/4.6/4.7, Sonnet 4.5/4.6.
+        # Picks below avoid the LiteLLM main.py:2561 short-circuit by using
+        # slugs that are NOT in ``open_ai_chat_completion_models``:
+        #   - gpt-5.5            (general HIGH)
+        #   - claude-sonnet-4-6  (cyber MID per Cybench, cross-vendor via Copilot)
+        #   - gpt-5.4-mini       (cost-effective LOW)
+        # For code-heavy roles (patcher, exploiter, contract_auditor), the
+        # ``copilot/gpt-5.3-codex`` route is registered as an alternative in
+        # ``litellm_dynamic_config`` (sentinel-aliased to dodge bypass) and
+        # can be selected per-agent via ``DECEPTICON_MODEL_<ROLE>``.
+        Tier.HIGH: "copilot/gpt-5.5",
+        Tier.MID: "copilot/claude-sonnet-4-6",
+        Tier.LOW: "copilot/gpt-5.4-mini",
     },
     AuthMethod.GROK_OAUTH: {
-        Tier.HIGH: "grok-sub/grok-3",
-        Tier.MID: "grok-sub/grok-3-mini",
+        # grok-3 / grok-3-mini retired by xAI on 2026-05-15.
+        Tier.HIGH: "grok-sub/grok-4.3",
+        Tier.MID: "grok-sub/grok-4-1-fast-reasoning",
     },
     AuthMethod.PERPLEXITY_OAUTH: {
         Tier.HIGH: "pplx-sub/sonar-pro",

--- a/docs/models.md
+++ b/docs/models.md
@@ -30,12 +30,12 @@ For each agent, Decepticon resolves a tier (from the profile) and walks your Aut
 | `google_oauth`        | `gemini-sub/gemini-2.5-pro`               | `gemini-sub/gemini-2.5-flash`                 | — *(falls through)*                           |
 | `minimax_api`         | `minimax/MiniMax-M2.5`                    | `minimax/MiniMax-M2.5-lightning`              | — *(falls through)*                           |
 | `deepseek_api`        | `deepseek/deepseek-v4-pro`                | `deepseek/deepseek-v4-flash`                   | `deepseek/deepseek-v4-flash`                   |
-| `xai_api`             | `xai/grok-3`                              | `xai/grok-3-mini`                             | — *(falls through)*                           |
-| `grok_oauth`          | `grok-sub/grok-3`                         | `grok-sub/grok-3-mini`                        | — *(falls through)*                           |
+| `xai_api`             | `xai/grok-4.3`                            | `xai/grok-4-1-fast-reasoning`                 | — *(falls through)*                           |
+| `grok_oauth`          | `grok-sub/grok-4.3`                       | `grok-sub/grok-4-1-fast-reasoning`            | — *(falls through)*                           |
 | `mistral_api`         | `mistral/mistral-large-latest`            | `mistral/codestral-latest`                    | — *(falls through)*                           |
 | `openrouter_api`      | `openrouter/anthropic/claude-opus-4-7`    | `openrouter/anthropic/claude-sonnet-4-6`      | `openrouter/anthropic/claude-haiku-4-5`       |
 | `nvidia_api`          | `nvidia_nim/meta/llama-3.3-70b-instruct`  | `nvidia_nim/nvidia/llama-3.1-nemotron-70b-instruct` | `nvidia_nim/meta/llama-3.2-3b-instruct` |
-| `copilot_oauth`       | `copilot/gpt-4o`                          | `copilot/o1`                                  | `copilot/o3-mini`                             |
+| `copilot_oauth`       | `copilot/gpt-5.5`                         | `copilot/claude-sonnet-4-6`                   | `copilot/gpt-5.4-mini`                        |
 | `perplexity_oauth`    | `pplx-sub/sonar-pro`                      | `pplx-sub/sonar`                              | — *(falls through)*                           |
 | `ollama_local`        | `ollama_chat/<OLLAMA_MODEL>`              | `ollama_chat/<OLLAMA_MODEL>`                  | `ollama_chat/<OLLAMA_MODEL>`                  |
 
@@ -297,10 +297,10 @@ Use monthly subscriptions instead of per-token API billing. All providers use cu
 | Subscription | AuthMethod | Models | Handler |
 |---|---|---|---|
 | Claude Max/Pro/Team | `anthropic_oauth` | auth/claude-opus, sonnet, haiku | `claude_code_handler.py` |
-| ChatGPT Pro/Plus/Team | `openai_oauth` | auth/gpt-5.5, gpt-5.4, gpt-5.4-mini | `codex_chatgpt_handler.py` (reads `~/.codex/auth.json`) |
+| ChatGPT Pro/Plus/Team | `openai_oauth` | auth/gpt-5.5, gpt-5.4, gpt-5.4-mini (+ gpt-5.3-codex for code roles) | `codex_chatgpt_handler.py` (reads `~/.codex/auth.json`) |
 | Gemini Advanced | `google_oauth` | gemini-sub/gemini-2.5-pro, flash | `gemini_handler.py` |
-| Copilot Pro | `copilot_oauth` | copilot/gpt-4o, o1, o3-mini | `copilot_handler.py` |
-| SuperGrok | `grok_oauth` | grok-sub/grok-3, grok-3-mini | `grok_handler.py` |
+| Copilot Pro | `copilot_oauth` | copilot/gpt-5.5, claude-sonnet-4-6, gpt-5.4-mini (+ gpt-5.3-codex) | `copilot_handler.py` |
+| SuperGrok | `grok_oauth` | grok-sub/grok-4.3, grok-4-1-fast-reasoning | `grok_handler.py` |
 | Perplexity Pro | `perplexity_oauth` | pplx-sub/sonar-pro, sonar | `perplexity_handler.py` |
 
 Enable in `.env`:

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -472,17 +472,17 @@ Complete list of all supported LLM providers and their pre-configured models:
 |----------|--------|-----------|------|
 | **Subscriptions (OAuth — no API billing)** | | | |
 | Claude Max/Pro/Team | Opus, Sonnet, Haiku | OAuth | $20–$100/mo |
-| ChatGPT Pro/Plus/Team | `auth/gpt-5.5`, `auth/gpt-5.4` | OAuth | $20–$200/mo |
+| ChatGPT Pro/Plus/Team | `auth/gpt-5.5`, `auth/gpt-5.4`, `auth/gpt-5.4-mini` (+ `auth/gpt-5.3-codex` for code agents) | OAuth | $20–$200/mo |
 | Gemini Advanced | Gemini 2.5 Pro/Flash | OAuth | $20/mo |
-| Copilot Pro | `copilot/gpt-4o`, `copilot/o1`, `copilot/o3-mini` | OAuth | $20/mo |
-| SuperGrok | Grok-3, Grok-3 Mini | OAuth | X Premium+ |
+| Copilot Pro | `copilot/gpt-5.5`, `copilot/claude-sonnet-4-6`, `copilot/gpt-5.4-mini` (+ `copilot/gpt-5.3-codex`) | OAuth | $20/mo |
+| SuperGrok | Grok 4.3, Grok 4-1 Fast Reasoning | OAuth | X Premium+ |
 | Perplexity Pro | Sonar Pro, Sonar | OAuth | $20/mo |
 | **API Key Providers (pay-per-token)** | | | |
 | Anthropic | Claude Opus 4.7, Sonnet 4.6, Haiku 4.5 | API key | Per token |
-| OpenAI | GPT-5.5, GPT-5.4, GPT-5-nano | API key | Per token |
+| OpenAI | GPT-5.5, GPT-5.4, GPT-5-nano (+ GPT-5.3-Codex for code agents) | API key | Per token |
 | DeepSeek | DeepSeek Chat, DeepSeek Reasoner | API key | Per token |
 | Google | Gemini 2.5 Flash, Gemini 2.5 Pro | API key | Per token |
-| xAI | Grok-3, Grok-3 Mini | API key | Per token |
+| xAI | Grok 4.3, Grok 4-1 Fast Reasoning | API key | Per token |
 | Mistral | Mistral Large, Codestral | API key | Per token |
 | Cohere | Command R+, Command R | API key | Per token |
 | Groq | Llama 3.3 70B, Llama 3.1 8B | API key | Per token |

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -160,7 +160,7 @@ class TestLLMFactory:
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M2.5",
             "deepseek/deepseek-v4-pro",
-            "xai/grok-3",
+            "xai/grok-4.3",
             "mistral/mistral-large-latest",
             "openrouter/anthropic/claude-opus-4-7",
             "nvidia_nim/meta/llama-3.3-70b-instruct",

--- a/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/tests/unit/llm/test_litellm_dynamic_config.py
@@ -81,8 +81,8 @@ def test_validate_model_name_rejects_other_subscription_prefixes() -> None:
     """
     for slug in (
         "gemini-sub/gemini-2.5-pro",
-        "copilot/gpt-4o",
-        "grok-sub/grok-3",
+        "copilot/gpt-5.5",
+        "grok-sub/grok-4.3",
         "pplx-sub/sonar",
     ):
         with pytest.raises(ValueError, match="not allowed as dynamic API-key model routes"):
@@ -187,6 +187,12 @@ def test_merge_dynamic_models_registers_only_supported_chatgpt_oauth_routes() ->
         "auth/gpt-5.5": {"model": "codex-oauth/oauth-gpt-5.5"},
         "auth/gpt-5.4": {"model": "codex-oauth/oauth-gpt-5.4"},
         "auth/gpt-5.4-mini": {"model": "codex-oauth/oauth-gpt-5.4-mini"},
+        # Code-heavy override route. Registered alongside the tier
+        # defaults so per-agent env overrides like
+        # ``DECEPTICON_MODEL_PATCHER=auth/gpt-5.3-codex`` work without a
+        # yaml edit. The ``oauth-`` slug sentinel is required because
+        # ``gpt-5.3-codex`` is in ``open_ai_chat_completion_models``.
+        "auth/gpt-5.3-codex": {"model": "codex-oauth/oauth-gpt-5.3-codex"},
     }
     assert "auth/gpt-5-nano" not in entries
     assert merged["litellm_settings"]["fallbacks"] == [

--- a/tests/unit/llm/test_models.py
+++ b/tests/unit/llm/test_models.py
@@ -397,7 +397,7 @@ class TestLLMModelMapping:
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M2.5",
             "deepseek/deepseek-v4-pro",
-            "xai/grok-3",
+            "xai/grok-4.3",
             "mistral/mistral-large-latest",
             "openrouter/anthropic/claude-opus-4-7",
             "nvidia_nim/meta/llama-3.3-70b-instruct",

--- a/tests/unit/llm/test_router.py
+++ b/tests/unit/llm/test_router.py
@@ -44,7 +44,7 @@ class TestModelRouter:
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M2.5",
             "deepseek/deepseek-v4-pro",
-            "xai/grok-3",
+            "xai/grok-4.3",
             "mistral/mistral-large-latest",
             "openrouter/anthropic/claude-opus-4-7",
             "nvidia_nim/meta/llama-3.3-70b-instruct",


### PR DESCRIPTION
## Summary

Two-commit refactor of the LiteLLM auth dispatcher, verified live (2026-05-14) against ChatGPT/Anthropic OAuth backends and one end-to-end LangGraph agent invocation.

### \`fix(make): export CODEX_AUTH_VOLUME for compose mount parity\`

Pre-existing bug uncovered while validating this PR: ``make dev`` / ``make infra`` exported ``CLAUDE_CREDENTIALS_VOLUME`` but not ``CODEX_AUTH_VOLUME``, so the LiteLLM container always bound ``/dev/null`` to ``/root/.codex/auth.json`` regardless of host login state. The launcher (``clients/launcher/cmd/start.go``) already does both — this restores Makefile parity.

### \`refactor(litellm): modernize subscription models + register Codex variants\`

Three coordinated changes (one commit because they share files):

**(1) Modernize deprecated subscription model IDs**
- xAI / SuperGrok: \`grok-3*\` → \`grok-4.3\` + \`grok-4-1-fast-reasoning\` (xAI retired 3-series at 12pm PT today)
- Copilot: \`gpt-4o\` / \`o1\` / \`o3-mini\` (retired 2025-10-23) → \`gpt-5.5\` / \`claude-sonnet-4-6\` / \`gpt-5.4-mini\`. New picks avoid \`open_ai_chat_completion_models\` so no \`oauth-\` sentinel is needed on the default tier.

**(2) Register opt-in \`gpt-5.3-codex\` routes (option α)**

OpenAI's agentic-coding specialized model (Codex + GPT-5 training stack) is registered on the \`auth/\`, \`openai/\`, and \`copilot/\` paths so per-agent overrides like \`DECEPTICON_MODEL_PATCHER=auth/gpt-5.3-codex\` work without yaml edits. Default tier picks stay \`gpt-5.5\` for general agent balance. Slug \`gpt-5.3-codex\` IS in \`open_ai_chat_completion_models\`, so the custom-provider routes alias through the existing \`oauth-\` slug sentinel.

**(3) Clean up AuthDispatcher dead code**

The \`gpt-\` entry in \`auth_handler._PREFIX_HANDLERS\` was unreachable — \`auth/gpt-*\` is aliased to \`codex-oauth/oauth-gpt-*\` in dynamic config, so the dispatcher only ever sees \`claude-*\` slugs. Dropped + documented the slug-collision rule once at the startup.py registration site.

### Cybersecurity benchmark validation (May 2026)

Tier matrix preserved (HIGH=Opus 4.7 / MID=Sonnet 4.6 / LOW=Haiku 4.5 for the Anthropic path). Cybench, XBOW, SmartBugs, and Penligent's workflow-based article all support the current HIGH/MID/LOW assignment for the 16 specialist agents — most notably patcher (Opus 4.7 = patch review sweet spot per Penligent) and contract_auditor (Opus 4.7 recall leader on SmartBugs). \`postexploit\` / \`ad_operator\` were considered for HIGH promotion but external research confirms autonomous post-exploit/lateral movement is unsuitable for any current model regardless of tier; MID with human gating remains defensible.

## Test plan

- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run ruff format --check .\` — 213 files already formatted
- [x] \`uv run basedpyright --level error\` — 0 errors, 0 warnings
- [x] \`uv run pytest -n auto -q -m "not slow"\` — 809 passed
- [x] \`cd clients/cli && npm run typecheck\` — exit 0
- [x] Live curl tests against running infra:
  - \`auth/claude-haiku-4-5\` (Claude OAuth) → 200 "ok"
  - \`auth/gpt-5.4-mini\` (ChatGPT OAuth via Codex) → 200 "ok"
  - \`auth/gpt-5.3-codex\` (new sentinel route) → 200 "ok"
- [x] End-to-end agent invocation: LangGraph \`soundwave\` agent with "hi" input → tier-correct \`auth/claude-haiku-4-5\` selection, tool call + multi-turn cycle complete