### PR TITLE
fix(factory): log diagnostic when explicit AUTH_PRIORITY has no detectable credentials

### DIFF
--- a/decepticon/llm/factory.py
+++ b/decepticon/llm/factory.py
@@ -323,7 +323,8 @@ def _resolve_credentials() -> Credentials:
     surface for that misconfiguration.
     """
     priority_raw = os.getenv("DECEPTICON_AUTH_PRIORITY", "")
-    if priority_raw.strip():
+    priority_explicit = bool(priority_raw.strip())
+    if priority_explicit:
         priority: list[AuthMethod] = []
         for token in priority_raw.split(","):
             token = token.strip().lower()
@@ -385,10 +386,34 @@ def _resolve_credentials() -> Credentials:
         if _custom_openai_configured():
             log.info("Only CUSTOM_OPENAI_* detected; using custom OpenAI-compatible endpoint")
             return Credentials(methods=[AuthMethod.CUSTOM_OPENAI_API])
-        log.info(
-            "No credentials detected in environment; using all-API-methods "
-            "fallback so module-level agent constructors stay importable"
-        )
+        if priority_explicit:
+            # User expressed clear intent (set DECEPTICON_AUTH_PRIORITY) but
+            # every listed method failed detection. Surface the root cause
+            # at ERROR level — otherwise the silent fallback to
+            # all_api_methods() runs through providers the user doesn't
+            # have, producing a confusing 401 cascade (often masked as a
+            # downstream "rate limit (429)" once the routed-to provider
+            # cools down). Return behavior preserved so module imports
+            # stay green; real model calls still surface a remediation
+            # hint via _reraise_with_actionable_message.
+            log.error(
+                "DECEPTICON_AUTH_PRIORITY=%r set but no listed method has "
+                "detectable credentials. Verify: (1) API keys are "
+                "non-placeholder (e.g. ANTHROPIC_API_KEY starts with "
+                "'sk-ant-'), (2) OAuth flag matches credential file "
+                "(e.g. DECEPTICON_AUTH_CLAUDE_CODE=true requires "
+                "~/.claude/.credentials.json to exist and contain a valid "
+                "JSON object — a /dev/null mount fails this check). "
+                "Falling back to all-API-methods so module imports "
+                "remain importable; every model call will 401 until "
+                "the priority chain is fixed.",
+                priority_raw,
+            )
+        else:
+            log.info(
+                "No credentials detected in environment; using all-API-methods "
+                "fallback so module-level agent constructors stay importable"
+            )
         return Credentials.all_api_methods()
 
     return Credentials(methods=methods)

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -1,6 +1,7 @@
 """Unit tests for decepticon.llm.factory."""
 
 import asyncio
+import logging
 
 import pytest
 
@@ -363,6 +364,122 @@ class TestResolveCredentials:
             AuthMethod.OPENROUTER_API,
             AuthMethod.NVIDIA_API,
         ]
+
+    def test_explicit_priority_no_creds_logs_error(self, monkeypatch, tmp_path, caplog):
+        """An explicit ``DECEPTICON_AUTH_PRIORITY`` whose every listed
+        method fails detection (typical of a broken OAuth credentials
+        mount — e.g. ``CLAUDE_CREDENTIALS_VOLUME`` unset and the
+        compose file bound ``/dev/null`` into the container) must
+        surface the root cause at ERROR level.
+
+        Otherwise the silent fallback to ``all_api_methods()`` runs
+        through nine unrelated providers and the operator only sees a
+        downstream 401-cascade — confusingly masked as a 429 once the
+        routed-to provider (e.g. NVIDIA NIM) cools down. Backward
+        compat is preserved: the resolver still returns
+        ``all_api_methods()`` so module imports remain green; the
+        real model call surfaces a separate, actionable error via
+        ``_reraise_with_actionable_message``.
+        """
+        # Point the OAuth credential path at a file we never create so
+        # detection fails the same way ``/dev/null`` does at runtime.
+        missing = tmp_path / "missing.json"
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CODE_CREDENTIALS_PATH", str(missing))
+        monkeypatch.setenv("DECEPTICON_AUTH_PRIORITY", "anthropic_oauth")
+        monkeypatch.setenv("DECEPTICON_AUTH_CLAUDE_CODE", "true")
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "MINIMAX_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "XAI_API_KEY",
+            "MISTRAL_API_KEY",
+            "OPENROUTER_API_KEY",
+            "NVIDIA_API_KEY",
+            "OLLAMA_API_BASE",
+            "OLLAMA_MODEL",
+            "OLLAMA_CLOUD_API_BASE",
+            "OLLAMA_CLOUD_MODEL",
+            "LMSTUDIO_API_BASE",
+            "LMSTUDIO_MODEL",
+            "CUSTOM_OPENAI_API_BASE",
+            "CUSTOM_OPENAI_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        for flag in (
+            "DECEPTICON_AUTH_CHATGPT",
+            "DECEPTICON_AUTH_COPILOT",
+            "DECEPTICON_AUTH_GEMINI",
+            "DECEPTICON_AUTH_GROK",
+            "DECEPTICON_AUTH_PERPLEXITY",
+        ):
+            monkeypatch.delenv(flag, raising=False)
+
+        # ``decepticon.core.logging`` sets the parent decepticon logger
+        # to ``propagate=False`` so library output doesn't double up in
+        # apps that own their root handler. caplog hooks the root logger,
+        # so without re-enabling propagation our ERROR record never
+        # reaches pytest's capture buffer. Re-enable for the duration of
+        # the call and let monkeypatch restore on teardown.
+        decepticon_log = logging.getLogger("decepticon")
+        monkeypatch.setattr(decepticon_log, "propagate", True)
+
+        with caplog.at_level(logging.ERROR):
+            creds = _resolve_credentials()
+
+        # Backward compat: still returns the all-API-methods fallback.
+        assert creds.methods == Credentials.all_api_methods().methods
+
+        # ERROR diagnostic must mention the env var name so an operator
+        # scanning ``decepticon logs langgraph`` knows where to look.
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert any("DECEPTICON_AUTH_PRIORITY" in r.getMessage() for r in error_records), (
+            f"No ERROR log mentioned DECEPTICON_AUTH_PRIORITY. "
+            f"Got: {[r.getMessage() for r in error_records]}"
+        )
+
+    def test_implicit_priority_no_creds_stays_info_level(self, monkeypatch, caplog):
+        """Implicit priority (no DECEPTICON_AUTH_PRIORITY set) with no
+        detectable credentials is the import-friendly CI/test path:
+        we keep the existing INFO log and ``all_api_methods()`` return
+        so module imports work without keys present. Only **explicit**
+        priority with no matches gets escalated to ERROR.
+        """
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "MINIMAX_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "XAI_API_KEY",
+            "MISTRAL_API_KEY",
+            "OPENROUTER_API_KEY",
+            "NVIDIA_API_KEY",
+            "OLLAMA_API_BASE",
+            "OLLAMA_MODEL",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv("DECEPTICON_AUTH_PRIORITY", raising=False)
+        monkeypatch.delenv("DECEPTICON_AUTH_CLAUDE_CODE", raising=False)
+
+        # Match the explicit-priority test's pattern so caplog sees the
+        # records — the decepticon parent logger defaults to
+        # ``propagate=False`` per ``decepticon.core.logging``.
+        decepticon_log = logging.getLogger("decepticon")
+        monkeypatch.setattr(decepticon_log, "propagate", True)
+
+        with caplog.at_level(logging.DEBUG):
+            creds = _resolve_credentials()
+
+        assert creds.methods == Credentials.all_api_methods().methods
+        # No ERROR records — this case stays informational.
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert not error_records, (
+            f"Unexpected ERROR logs in implicit-priority path: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
 
     def test_ollama_local_only_returns_ollama_chain(self, monkeypatch):
         """Issue #106: a user with only OLLAMA_API_BASE / OLLAMA_MODEL set


### PR DESCRIPTION
## Summary

When \`DECEPTICON_AUTH_PRIORITY\` lists methods whose credentials all fail detection (typical of a broken OAuth credentials mount — e.g. \`CLAUDE_CREDENTIALS_VOLUME\` unset and compose binds \`/dev/null\` into the container), \`_resolve_credentials()\` silently fell back to \`Credentials.all_api_methods()\`. That chain includes NVIDIA_API which most users do not have, so the agent's first model call produces a **confusing 401 cascade — masked as a downstream "rate limit (429)"** once the routed-to provider cools down. The real misconfiguration root cause was never surfaced.

This PR distinguishes the explicit-priority case (user expressed clear intent via env) from the implicit case (default chain in CI/dev imports) and **emits an ERROR with the exact misconfiguration** when explicit intent fails. Return behavior is unchanged so module-level graph constructors stay importable; real model calls still surface a remediation hint via \`_reraise_with_actionable_message\`.

## Real-world surface

Encountered today while preparing benchmark cycle 1. A manual \`docker compose up -d --force-recreate langgraph\` bypassed the Makefile's \`CLAUDE_CREDENTIALS_VOLUME\` export so \`/root/.claude/.credentials.json\` was mounted as \`/dev/null\` (a char device that reads as empty). The container then logged:

> Model 'nvidia_nim/meta/llama-3.3-70b-instruct' hit the provider's rate limit (429)

instead of pointing at the actual credential mount issue. The first \`log.info(\"No credentials detected...\")\` message was easy to miss against the rest of langgraph's INFO log volume.

With this PR, the same misconfiguration now emits:

> ERROR: DECEPTICON_AUTH_PRIORITY='anthropic_oauth' set but no listed method has detectable credentials. Verify: (1) API keys are non-placeholder (e.g. ANTHROPIC_API_KEY starts with 'sk-ant-'), (2) OAuth flag matches credential file (e.g. DECEPTICON_AUTH_CLAUDE_CODE=true requires ~/.claude/.credentials.json to exist and contain a valid JSON object — a /dev/null mount fails this check). Falling back to all-API-methods so module imports remain importable; every model call will 401 until the priority chain is fixed.

## Scope (deliberately tight)

In scope:
- \`factory._resolve_credentials()\` — distinguish explicit vs implicit priority; log.error on explicit-with-no-creds.
- Two new tests: \`test_explicit_priority_no_creds_logs_error\`, \`test_implicit_priority_no_creds_stays_info_level\`.

Out of scope (separate consideration):
- Removing NVIDIA_API from \`Credentials.all_api_methods()\` — broader behavior change.
- Reconciling \`_DEFAULT_AUTH_PRIORITY\` (26 methods) vs \`all_api_methods()\` (9 methods) inconsistency.
- Docker-compose level \`/dev/null\` mount detection.

## Test plan

- [x] \`uv run pytest tests/unit/llm/\` → **190 passed**
- [x] \`uv run ruff check .\` → All checks passed
- [x] \`uv run ruff format --check .\` → All files already formatted
- [x] \`uv run basedpyright --level error\` → 0 errors, 0 warnings
- [x] Backward compat: existing \`test_placeholder_falls_back_to_all_api_methods\` still passes (implicit-priority fallback unchanged)