### PR TITLE
feat(middleware): per-run language override via config.configurable

### DIFF
--- a/decepticon/agents/prompts/__init__.py
+++ b/decepticon/agents/prompts/__init__.py
@@ -239,6 +239,135 @@ class PromptBuilder:
         return "\n\n".join(parts)
 
 
+# Country-code aliases → ISO 639-1 language codes. Users naturally type
+# "dk" (Denmark), "se" (Sweden), "jp" (Japan), "cn" (China) instead of
+# the ISO 639-1 "da", "sv", "ja", "zh". Shared between the env-based
+# prompt-time path (CLI) and the runtime config path (web SaaS).
+_COUNTRY_TO_LANG = {
+    "dk": "da",
+    "se": "sv",
+    "jp": "ja",
+    "cn": "zh",
+    "br": "pt-br",
+    "tw": "zh-tw",
+}
+
+_LANG_NAMES = {
+    # East Asian
+    "ko": "Korean",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "zh-cn": "Simplified Chinese",
+    "zh-tw": "Traditional Chinese",
+    # Nordic / Scandinavian
+    "no": "Norwegian",
+    "nb": "Norwegian Bokmål",
+    "nn": "Norwegian Nynorsk",
+    "sv": "Swedish",
+    "da": "Danish",
+    "fi": "Finnish",
+    "is": "Icelandic",
+    # Western European
+    "de": "German",
+    "fr": "French",
+    "es": "Spanish",
+    "pt": "Portuguese",
+    "pt-br": "Brazilian Portuguese",
+    "it": "Italian",
+    "nl": "Dutch",
+    "ca": "Catalan",
+    # Eastern European / Slavic
+    "ru": "Russian",
+    "pl": "Polish",
+    "cs": "Czech",
+    "sk": "Slovak",
+    "uk": "Ukrainian",
+    "bg": "Bulgarian",
+    "hr": "Croatian",
+    "sr": "Serbian",
+    "sl": "Slovenian",
+    "ro": "Romanian",
+    # South / Southeast Asian
+    "hi": "Hindi",
+    "bn": "Bengali",
+    "ta": "Tamil",
+    "te": "Telugu",
+    "th": "Thai",
+    "vi": "Vietnamese",
+    "id": "Indonesian",
+    "ms": "Malay",
+    "tl": "Filipino",
+    # Middle Eastern
+    "ar": "Arabic",
+    "fa": "Persian",
+    "he": "Hebrew",
+    "tr": "Turkish",
+    # Other
+    "el": "Greek",
+    "hu": "Hungarian",
+    "et": "Estonian",
+    "lv": "Latvian",
+    "lt": "Lithuanian",
+    "sw": "Swahili",
+    "af": "Afrikaans",
+}
+
+
+def build_language_policy(language: str) -> str | None:
+    """Build the LANGUAGE_POLICY block for a given ISO 639-1 code.
+
+    Returns the policy text, or None when the code is empty / English (no
+    override needed — the prompt's default language.md fragment applies).
+    Shared between the prompt builder (env-based) and the
+    EngagementContextMiddleware runtime path (config-based).
+    """
+    lang = (language or "").strip()
+    if not lang or lang.lower() == "en":
+        return None
+
+    resolved = _COUNTRY_TO_LANG.get(lang.lower(), lang.lower())
+
+    if resolved == "wenyan":
+        return (
+            "<LANGUAGE_POLICY>\n"
+            "You MUST respond in 文言文 (wenyan-full) — Classical Chinese literary\n"
+            "prose with English technical terms preserved verbatim.\n"
+            "\n"
+            "Rules:\n"
+            "- Maximum classical terseness. 80-90% character reduction vs normal prose.\n"
+            "- Classical sentence patterns: verbs precede objects, subjects often omitted,\n"
+            "  use classical particles (之/乃/為/其/則/而/以/故).\n"
+            "- ALL technical terms stay in English exactly as-is: function names, API names,\n"
+            "  code symbols, error strings, file paths, command flags, tool names, config\n"
+            "  keys, variable names. NEVER transliterate these into Chinese.\n"
+            "- Code blocks, tool calls, JSON, structured payloads: completely unchanged.\n"
+            "- Mix freely: Classical Chinese for explanation, English for technical nouns.\n"
+            "\n"
+            "Examples:\n"
+            "- '物出新參照，致重繪。useMemo Wrap之。'\n"
+            "- '池reuse open connection。不每req新開。skip handshake overhead。'\n"
+            "- 'Bug在auth middleware。Token expiry check用 `<` 非 `<=`。Fix:'\n"
+            "\n"
+            "Drop caveman for: security warnings, irreversible action confirmations,\n"
+            "cases where compression creates technical ambiguity. Resume after.\n"
+            "</LANGUAGE_POLICY>"
+        )
+
+    lang_name = _LANG_NAMES.get(resolved, lang)
+    return (
+        "<LANGUAGE_POLICY>\n"
+        f"You MUST respond in {lang_name} for all operator-facing prose.\n"
+        f"\n"
+        f"- All operator-facing prose (interview questions, menu options, explanations,\n"
+        f"  summaries, status updates, error messages) MUST be in {lang_name}.\n"
+        f"- Tool calls, tool arguments, and structured payloads (JSON fields, code\n"
+        f"  blocks, file paths, command output) stay in their original technical\n"
+        f"  form — do not translate identifiers, file names, command flags, or\n"
+        f"  schema field names.\n"
+        f"</LANGUAGE_POLICY>"
+    )
+
+
 def load_prompt(name: str, *, shared: list[str] | None = None) -> str:
     """Load an agent system prompt with structured assembly.
 
@@ -279,126 +408,13 @@ def load_prompt(name: str, *, shared: list[str] | None = None) -> str:
 
     # Runtime language pin: when DECEPTICON_LANGUAGE is set, replace the
     # default English policy with a pinned-language directive so every agent
-    # replies in the configured locale regardless of input language.
+    # replies in the configured locale regardless of input language. The
+    # env-based path is the CLI / single-tenant convention; multi-tenant
+    # launchers (SaaS web) override per-run via config.configurable.language
+    # which EngagementContextMiddleware injects as a later SystemMessage.
     pinned_lang = os.environ.get("DECEPTICON_LANGUAGE", "").strip()
-    if pinned_lang and pinned_lang.lower() != "en":
-        # Country-code aliases → ISO 639-1 language codes. Users naturally
-        # type "dk" (Denmark), "se" (Sweden), "jp" (Japan), "cn" (China)
-        # instead of the ISO 639-1 "da", "sv", "ja", "zh".
-        _COUNTRY_TO_LANG = {
-            "dk": "da",
-            "se": "sv",
-            "jp": "ja",
-            "cn": "zh",
-            "br": "pt-br",
-            "tw": "zh-tw",
-        }
-        _LANG_NAMES = {
-            # East Asian
-            "ko": "Korean",
-            "ja": "Japanese",
-            "zh": "Chinese",
-            "zh-cn": "Simplified Chinese",
-            "zh-tw": "Traditional Chinese",
-            # Nordic / Scandinavian
-            "no": "Norwegian",
-            "nb": "Norwegian Bokmål",
-            "nn": "Norwegian Nynorsk",
-            "sv": "Swedish",
-            "da": "Danish",
-            "fi": "Finnish",
-            "is": "Icelandic",
-            # Western European
-            "de": "German",
-            "fr": "French",
-            "es": "Spanish",
-            "pt": "Portuguese",
-            "pt-br": "Brazilian Portuguese",
-            "it": "Italian",
-            "nl": "Dutch",
-            "ca": "Catalan",
-            # Eastern European / Slavic
-            "ru": "Russian",
-            "pl": "Polish",
-            "cs": "Czech",
-            "sk": "Slovak",
-            "uk": "Ukrainian",
-            "bg": "Bulgarian",
-            "hr": "Croatian",
-            "sr": "Serbian",
-            "sl": "Slovenian",
-            "ro": "Romanian",
-            # South / Southeast Asian
-            "hi": "Hindi",
-            "bn": "Bengali",
-            "ta": "Tamil",
-            "te": "Telugu",
-            "th": "Thai",
-            "vi": "Vietnamese",
-            "id": "Indonesian",
-            "ms": "Malay",
-            "tl": "Filipino",
-            # Middle Eastern
-            "ar": "Arabic",
-            "fa": "Persian",
-            "he": "Hebrew",
-            "tr": "Turkish",
-            # Other
-            "el": "Greek",
-            "hu": "Hungarian",
-            "et": "Estonian",
-            "lv": "Latvian",
-            "lt": "Lithuanian",
-            "sw": "Swahili",
-            "af": "Afrikaans",
-        }
-
-        resolved = _COUNTRY_TO_LANG.get(pinned_lang.lower(), pinned_lang.lower())
-
-        # Special mode: Wenyan (文言文) — Classical Chinese literary compression
-        # matching caveman's wenyan-full intensity level.
-        # See: github.com/JuliusBrussee/caveman
-        if resolved == "wenyan":
-            override = (
-                "<LANGUAGE_POLICY>\n"
-                "You MUST respond in 文言文 (wenyan-full) — Classical Chinese literary\n"
-                "prose with English technical terms preserved verbatim.\n"
-                "\n"
-                "Rules:\n"
-                "- Maximum classical terseness. 80-90% character reduction vs normal prose.\n"
-                "- Classical sentence patterns: verbs precede objects, subjects often omitted,\n"
-                "  use classical particles (之/乃/為/其/則/而/以/故).\n"
-                "- ALL technical terms stay in English exactly as-is: function names, API names,\n"
-                "  code symbols, error strings, file paths, command flags, tool names, config\n"
-                "  keys, variable names. NEVER transliterate these into Chinese.\n"
-                "- Code blocks, tool calls, JSON, structured payloads: completely unchanged.\n"
-                "- Mix freely: Classical Chinese for explanation, English for technical nouns.\n"
-                "\n"
-                "Examples:\n"
-                "- '物出新參照，致重繪。useMemo Wrap之。'\n"
-                "- '池reuse open connection。不每req新開。skip handshake overhead。'\n"
-                "- 'Bug在auth middleware。Token expiry check用 `<` 非 `<=`。Fix:'\n"
-                "\n"
-                "Drop caveman for: security warnings, irreversible action confirmations,\n"
-                "cases where compression creates technical ambiguity. Resume after.\n"
-                "</LANGUAGE_POLICY>"
-            )
-        else:
-            lang_name = _LANG_NAMES.get(resolved, pinned_lang)
-            override = (
-                "<LANGUAGE_POLICY>\n"
-                f"You MUST respond in {lang_name} for all operator-facing prose.\n"
-                f"\n"
-                f"- All operator-facing prose (interview questions, menu options, explanations,\n"
-                f"  summaries, status updates, error messages) MUST be in {lang_name}.\n"
-                f"- Tool calls, tool arguments, and structured payloads (JSON fields, code\n"
-                f"  blocks, file paths, command output) stay in their original technical\n"
-                f"  form — do not translate identifiers, file names, command flags, or\n"
-                f"  schema field names.\n"
-                f"</LANGUAGE_POLICY>"
-            )
-
-        # Replace the existing policy block
+    override = build_language_policy(pinned_lang)
+    if override is not None:
         import re
 
         prompt = re.sub(

--- a/decepticon/middleware/engagement.py
+++ b/decepticon/middleware/engagement.py
@@ -47,6 +47,12 @@ class EngagementContextState(AgentState):
     workspace_path: NotRequired[
         Annotated[str, "Sandbox root for this engagement.", _reduce_workspace_path]
     ]
+    # Per-run language override. When set via config.configurable.language,
+    # the middleware appends a LANGUAGE_POLICY SystemMessage that supersedes
+    # the prompt-time DECEPTICON_LANGUAGE env policy. Multi-tenant launchers
+    # (SaaS) need different orgs to receive different language outputs from
+    # the same container, which the env-based path cannot deliver.
+    language: NotRequired[Annotated[str, "Per-run output language (ISO 639-1)."]]
     # Benchmark / CTF challenge context — populated by the benchmark harness.
     target_url: NotRequired[Annotated[str, "CTF challenge target URL."]]
     target_extra_ports: NotRequired[
@@ -107,6 +113,11 @@ def _hydrate_engagement_state(state: Any) -> dict[str, Any] | None:
         cfg_workspace = configurable.get("workspace_path")
         if isinstance(cfg_workspace, str) and cfg_workspace:
             updates["workspace_path"] = cfg_workspace
+
+    if not get("language"):
+        cfg_lang = configurable.get("language")
+        if isinstance(cfg_lang, str) and cfg_lang:
+            updates["language"] = cfg_lang
 
     return updates or None
 
@@ -245,6 +256,7 @@ class EngagementContextMiddleware(AgentMiddleware):
 
         slug = get("engagement_name", "") or ""
         workspace = get("workspace_path", "/workspace") or "/workspace"
+        language = get("language", "") or ""
 
         sections: list[str] = []
         if slug:
@@ -259,6 +271,23 @@ class EngagementContextMiddleware(AgentMiddleware):
                     brief=get("mission_brief", "") or "",
                 )
             )
+
+        # Per-run language override. Multi-tenant launchers (SaaS web) inject
+        # the org's selected language via config.configurable.language; we
+        # append the same LANGUAGE_POLICY block the prompt builder would have
+        # produced if DECEPTICON_LANGUAGE were set, but per-run rather than
+        # per-container. Because this is a later SystemMessage, it supersedes
+        # the prompt-time policy without needing to reach into the cached
+        # static prompt.
+        #
+        # Lazy import to avoid a circular: agents.__init__ pulls in agents
+        # which pull in middleware which would otherwise pull back into
+        # agents.prompts before that package is fully initialized.
+        from decepticon.agents.prompts import build_language_policy
+
+        language_policy = build_language_policy(language)
+        if language_policy:
+            sections.append("\n\n" + language_policy)
 
         if not sections:
             return request

--- a/tests/unit/middleware/test_engagement.py
+++ b/tests/unit/middleware/test_engagement.py
@@ -436,3 +436,92 @@ def test_benchmark_with_missing_optional_fields(
     assert "**Vulnerability tags:**" not in text
     assert "**Flag format:**" not in text
     assert "**Mission brief:**" not in text
+
+
+# ── Per-run language override ─────────────────────────────────────────────
+
+
+def test_hydrate_pulls_language_from_configurable_when_state_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SaaS launcher path: config.configurable.language flows into state."""
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"language": "ko"},
+    )
+
+    updates = _hydrate_engagement_state({})
+
+    assert updates == {"language": "ko"}
+
+
+def test_hydrate_does_not_overwrite_existing_language(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """State-set language wins over a different value in configurable."""
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {"language": "en"},
+    )
+
+    updates = _hydrate_engagement_state({"language": "ko"})
+
+    assert updates is None
+
+
+def test_inject_appends_language_policy_when_state_carries_language(
+    middleware: EngagementContextMiddleware,
+) -> None:
+    """A run with state.language=ko produces a LANGUAGE_POLICY system block."""
+    req = _FakeRequest(state={"language": "ko"})
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "<LANGUAGE_POLICY>" in text
+    assert "Korean" in text
+
+
+def test_inject_skips_language_policy_for_english_or_empty(
+    middleware: EngagementContextMiddleware,
+) -> None:
+    """en / empty → no override block; default prompt policy applies."""
+    req_en = _FakeRequest(state={"language": "en"})
+    assert middleware._inject(req_en).system_message is None
+
+    req_empty = _FakeRequest(state={"language": ""})
+    assert middleware._inject(req_empty).system_message is None
+
+
+def test_inject_combines_engagement_slug_and_language_in_one_message(
+    middleware: EngagementContextMiddleware,
+) -> None:
+    """Both injections compose into a single SystemMessage in order."""
+    req = _FakeRequest(state={"engagement_name": "acme", "language": "ja"})
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "Workspace slug: acme" in text
+    assert "<LANGUAGE_POLICY>" in text
+    assert "Japanese" in text
+
+
+def test_build_language_policy_helper_handles_aliases_and_no_op_cases() -> None:
+    """The shared helper is the single source of truth for both paths."""
+    from decepticon.agents.prompts import build_language_policy
+
+    # No-op codes
+    assert build_language_policy("") is None
+    assert build_language_policy("en") is None
+    assert build_language_policy("EN") is None
+
+    # ISO code → full name
+    policy_ko = build_language_policy("ko")
+    assert policy_ko is not None and "Korean" in policy_ko
+
+    # Country-code alias resolved (jp → ja → Japanese)
+    policy_jp = build_language_policy("jp")
+    assert policy_jp is not None and "Japanese" in policy_jp
+
+    # Wenyan special mode
+    policy_wenyan = build_language_policy("wenyan")
+    assert policy_wenyan is not None and "文言文" in policy_wenyan


### PR DESCRIPTION
## Summary

Teach `EngagementContextMiddleware` to pick up `language` from `config.configurable` and surface it as a runtime `SystemMessage` override. This makes the pinned-output-language feature work for **multi-tenant launchers** (Decepticon Cloud) where different orgs share one LangGraph container and need different output languages per invocation — something the env-based `DECEPTICON_LANGUAGE` path could never deliver.

The CLI / single-tenant path stays unchanged: `DECEPTICON_LANGUAGE` continues to bake a `LANGUAGE_POLICY` into the static cached prompt at build time.

## Why

`load_prompt()` reads `DECEPTICON_LANGUAGE` env once at prompt-assembly time. In Decepticon Cloud one container will serve many orgs — each with its own preferred output language — so env-based pinning can't follow the run. LangGraph's native channel for per-invocation context is `config.configurable`, which the middleware can read via `get_config()` and propagate as state on `before_agent`.

## What

- `EngagementContextState.language` slot. `before_agent` hydrates it from `config.configurable.language` on the first step of each thread, mirroring the existing `engagement_name` / `workspace_path` flow.
- `_inject` (the `wrap_model_call` hook) appends a `LANGUAGE_POLICY` block to the assembled `SystemMessage` whenever `state.language` resolves to a non-English code. Because this is a later system message, it supersedes the prompt-time policy without needing to reach into the cached static prompt.
- The policy-text generator is extracted out of `load_prompt()` into a module-level `build_language_policy()` so the env path (CLI) and runtime path (web launcher) produce **byte-identical** policy blocks for the same language code. Country-code alias table (`jp` → `ja`, etc.) and language-name table move out of the function body to module scope where both paths reference them.
- Lazy import inside the middleware avoids a circular between `decepticon.agents.__init__` → `middleware` → `agents.prompts`.

## Tests

Six new regression tests in `tests/unit/middleware/test_engagement.py`:

- `test_hydrate_pulls_language_from_configurable_when_state_empty`
- `test_hydrate_does_not_overwrite_existing_language`
- `test_inject_appends_language_policy_when_state_carries_language`
- `test_inject_skips_language_policy_for_english_or_empty`
- `test_inject_combines_engagement_slug_and_language_in_one_message`
- `test_build_language_policy_helper_handles_aliases_and_no_op_cases`

All 43 tests in the file pass (37 existing + 6 new).

## Backward compatibility

- CLI behavior is unchanged. `DECEPTICON_LANGUAGE` env still drives the policy on prompt build.
- Existing thread state with no `language` field gets the default English policy from `language.md`.
- The env path and the runtime path share `build_language_policy()`, so any future change to the policy text applies uniformly to both surfaces.

## Test plan

- [x] `pytest tests/unit/middleware/test_engagement.py` — 43 passed
- [ ] Smoke test in Decepticon Cloud: workspace with `defaultLanguage="ko"` triggers Korean Soundwave responses without env vars
- [ ] CLI regression: `DECEPTICON_LANGUAGE=ja deceptioncli` still pins Japanese as before