### PR TITLE
feat(litellm): per-model cost tracking + benchmark cost surfacing

### DIFF
--- a/benchmark/harness.py
+++ b/benchmark/harness.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
@@ -103,6 +104,67 @@ class Harness:
     def __init__(self, provider: BaseBenchmarkProvider, config: BenchmarkConfig) -> None:
         self.provider = provider
         self.config = config
+
+    @property
+    def _litellm_url(self) -> str:
+        """Derive the LiteLLM URL from the configured LangGraph URL.
+
+        Both services are exposed on localhost when the harness runs on
+        the host (default in ``make benchmark``). The :2024 → :4000 swap
+        matches ``_ensure_services_healthy``; keeping the derivation in
+        one place avoids drift if the port mapping changes.
+        """
+        return self.config.langgraph_url.replace(":2024", ":4000")
+
+    @staticmethod
+    def _utc_iso() -> str:
+        """RFC 3339 timestamp matching LiteLLM's spend_logs.startTime format."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    async def _query_cost(self, start_iso: str, end_iso: str) -> float | None:
+        """Sum spend from LiteLLM's /spend/logs for a time window.
+
+        Returns the USD total (sum of the ``spend`` field across every
+        row whose ``startTime`` falls inside ``[start_iso, end_iso]``)
+        or ``None`` if LiteLLM is unreachable, returns a non-200, or
+        emits a payload we can't parse. ``None`` is distinct from
+        ``0.0`` — the former means "we don't know," the latter means
+        "this window had no LLM calls (or all rows had spend=0)."
+
+        Uses the master key for read-only spend access; this is the
+        same path /spend/logs already serves to the LiteLLM admin UI.
+        Single attempt (no retry loop) so a slow proxy doesn't double
+        the harness's per-challenge teardown latency.
+        """
+        master_key = os.getenv("LITELLM_MASTER_KEY", "sk-decepticon-master")
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                r = await client.get(
+                    f"{self._litellm_url}/spend/logs",
+                    headers={"Authorization": f"Bearer {master_key}"},
+                    params={"start_date": start_iso, "end_date": end_iso},
+                )
+        except Exception as exc:
+            log.warning("harness.cost: /spend/logs unreachable: %s", exc)
+            return None
+        if r.status_code != 200:
+            log.warning("harness.cost: /spend/logs HTTP %s — %s", r.status_code, r.text[:200])
+            return None
+        try:
+            rows = r.json()
+        except Exception as exc:
+            log.warning("harness.cost: /spend/logs payload not JSON: %s", exc)
+            return None
+        if not isinstance(rows, list):
+            log.warning("harness.cost: /spend/logs returned non-list payload type=%s", type(rows))
+            return None
+        total = 0.0
+        for row in rows:
+            if isinstance(row, dict):
+                spend = row.get("spend")
+                if isinstance(spend, (int, float)):
+                    total += float(spend)
+        return round(total, 6)
 
     async def _cancel_active_runs(self, active: _ActiveRun) -> None:
         """Fire-and-forget cancel of the in-flight LangGraph run for ``active``.
@@ -454,6 +516,12 @@ class Harness:
 
         run_start = time.time()
         agent_start: float | None = None
+        # ISO timestamp captured right before the LangGraph run is
+        # submitted, so /spend/logs filtering covers the full agent
+        # window without including provider.setup() / sandbox-restart
+        # noise. ``None`` until set, signaling "no agent ran yet —
+        # don't attempt a cost query" on early-return paths.
+        cost_start_iso: str | None = None
         try:
             setup_result = self.provider.setup(challenge)
             if not setup_result.success:
@@ -472,6 +540,7 @@ class Harness:
             # Agent creates its own OPPLAN based on challenge info
             extra_ports = setup_result.extra_ports
             agent_start = time.time()
+            cost_start_iso = self._utc_iso()
             agent_resp = await asyncio.wait_for(
                 self._invoke_agent(challenge, setup_result.target_url, extra_ports, active=active),
                 timeout=self.config.timeout,
@@ -513,6 +582,8 @@ class Harness:
             # completion. Safe to teardown immediately.
             result.cancel_outcome = "clean"
             result.terminal_status_at_teardown = "success"
+            if cost_start_iso is not None:
+                result.cost_usd = await self._query_cost(cost_start_iso, self._utc_iso())
             self.provider.teardown(challenge)
             return result
 
@@ -551,10 +622,17 @@ class Harness:
                 result.agent_summary = agent_summary
                 result.trace_id = trace_id
                 result.token_count = token_count
+                if cost_start_iso is not None:
+                    result.cost_usd = await self._query_cost(cost_start_iso, self._utc_iso())
                 self.provider.teardown(challenge)
                 return result
 
             now = time.time()
+            cost_usd = (
+                await self._query_cost(cost_start_iso, self._utc_iso())
+                if cost_start_iso is not None
+                else None
+            )
             self.provider.teardown(challenge)
             return ChallengeResult(
                 challenge_id=challenge.id,
@@ -570,6 +648,7 @@ class Harness:
                 agent_summary=agent_summary,
                 trace_id=trace_id,
                 token_count=token_count,
+                cost_usd=cost_usd,
             )
         except Exception as exc:
             # Unexpected exception path — same discipline: cancel + verify
@@ -580,6 +659,11 @@ class Harness:
             )
             agent_summary, trace_id, token_count = postmortem
             now = time.time()
+            cost_usd = (
+                await self._query_cost(cost_start_iso, self._utc_iso())
+                if cost_start_iso is not None
+                else None
+            )
             self.provider.teardown(challenge)
             return ChallengeResult(
                 challenge_id=challenge.id,
@@ -595,6 +679,7 @@ class Harness:
                 agent_summary=agent_summary,
                 trace_id=trace_id,
                 token_count=token_count,
+                cost_usd=cost_usd,
             )
         finally:
             # Workspace cleanup is safe in unconditional finally — it doesn't

--- a/benchmark/reporter.py
+++ b/benchmark/reporter.py
@@ -73,6 +73,14 @@ class Reporter:
         lines.append(f"| Failed | {report.failed} |")
         lines.append(f"| Pass Rate | {report.pass_rate:.1%} |")
         lines.append(f"| Duration | {report.duration_seconds:.1f}s |")
+        # Cost is rendered with 4-decimal precision (≈ tenths of a cent),
+        # matching LiteLLM's /spend/logs precision. ``n/a`` is reserved
+        # for the "no challenge captured cost" state — distinct from an
+        # all-zero capture (e.g. only OAuth routes with $0 model_info).
+        if report.total_cost_usd is not None:
+            lines.append(f"| Total Cost (USD) | ${report.total_cost_usd:.4f} |")
+        else:
+            lines.append("| Total Cost (USD) | n/a |")
         lines.append("")
         lines.append("## Results by Level")
         lines.append("")
@@ -96,14 +104,17 @@ class Reporter:
         lines.append("")
         lines.append("## Individual Results")
         lines.append("")
-        lines.append("| ID | Name | Level | Result | Duration | Error |")
-        lines.append("|----|------|-------|--------|----------|-------|")
+        lines.append("| ID | Name | Level | Result | Duration | Cost (USD) | Tokens | Error |")
+        lines.append("|----|------|-------|--------|----------|------------|--------|-------|")
         for r in report.results:
             result_str = "PASS" if r.passed else "FAIL"
             error_str = r.error or ""
+            cost_str = f"${r.cost_usd:.4f}" if r.cost_usd is not None else "n/a"
+            tokens_str = f"{r.token_count:,}" if r.token_count is not None else "n/a"
             lines.append(
                 f"| {r.challenge_id} | {r.challenge_name} | {r.level} "
-                f"| {result_str} | {r.duration_seconds:.1f}s | {error_str} |"
+                f"| {result_str} | {r.duration_seconds:.1f}s | {cost_str} "
+                f"| {tokens_str} | {error_str} |"
             )
         lines.append("")
 
@@ -205,6 +216,8 @@ class Reporter:
             lines.append(f"**Trace ID:** `{result.trace_id}`")
         if result.token_count is not None:
             lines.append(f"**Tokens:** {result.token_count:,}")
+        if result.cost_usd is not None:
+            lines.append(f"**Cost (USD):** ${result.cost_usd:.4f}")
         if result.cancel_outcome:
             lines.append(f"**Cancel outcome:** {result.cancel_outcome}")
         if result.terminal_status_at_teardown:

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -83,6 +83,8 @@ def run(
     typer.echo("")
     typer.echo(f"Results: {report.passed}/{report.total} passed ({report.pass_rate:.1%})")
     typer.echo(f"Duration: {report.duration_seconds:.1f}s")
+    if report.total_cost_usd is not None:
+        typer.echo(f"Cost (USD): ${report.total_cost_usd:.4f}")
     typer.echo(f"JSON report: {json_path}")
     typer.echo(f"Markdown report: {md_path}")
     typer.echo(f"Evidence: {evidence_dir}")

--- a/benchmark/schemas.py
+++ b/benchmark/schemas.py
@@ -73,6 +73,15 @@ class ChallengeResult(BaseModel):
     # Excludes agent execution — captures docker start + provider.setup() cost
     # so duration_seconds reflects only agent wall-clock budget.
     setup_seconds: float | None = None
+    # Per-challenge USD cost from LiteLLM /spend/logs (sum of spend
+    # field for rows whose startTime falls inside this run's agent
+    # window). ``None`` when LiteLLM was unreachable or returned no
+    # rows. For subscription routes (auth/*, gemini-sub/*, copilot/*,
+    # grok-sub/*, pplx-sub/*) this is shadow cost: what the same
+    # request would have cost on the equivalent paid API. Reliable
+    # only for sequential runs (parallel=1) — concurrent challenges
+    # share the time window and cost cannot be cleanly attributed.
+    cost_usd: float | None = None
 
 
 class BenchmarkReport(BaseModel):
@@ -93,6 +102,12 @@ class BenchmarkReport(BaseModel):
     started_at: datetime
     completed_at: datetime
     duration_seconds: float
+    # Sum of ChallengeResult.cost_usd across results with a non-None
+    # value. ``None`` only when EVERY challenge missed cost capture
+    # (LiteLLM unreachable, or the /spend/logs window was empty); a
+    # partial set rolls up to the available subtotal so reports never
+    # silently lose cost data for the runs that did capture it.
+    total_cost_usd: float | None = None
 
 
 class FilterConfig(BaseModel):

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -40,6 +40,13 @@ class Scorer:
 
         duration_seconds = (completed_at - started_at).total_seconds()
 
+        # Roll up per-challenge cost into a batch total. None when no
+        # challenge captured cost (LiteLLM unreachable across the
+        # board); otherwise sum the available subtotals so a partial
+        # capture still surfaces in the report.
+        costs = [r.cost_usd for r in results if r.cost_usd is not None]
+        total_cost_usd = sum(costs) if costs else None
+
         return BenchmarkReport(
             provider_name=provider_name,
             total=total,
@@ -52,4 +59,5 @@ class Scorer:
             started_at=started_at,
             completed_at=completed_at,
             duration_seconds=duration_seconds,
+            total_cost_usd=total_cost_usd,
         )

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -28,40 +28,72 @@ model_list:
   # it's a *request validation* error, not a model-failure signal. Dropping
   # the param at the proxy keeps the request well-formed regardless of which
   # client hit us.
+  # Per-1M USD as of 2026-05-14 (Anthropic API):
+  #   opus-4-7   $5.00 / $25.00
+  #   sonnet-4-6 $3.00 / $15.00
+  #   haiku-4-5  $1.00 /  $5.00
+  # LiteLLM's built-in cost map ships sonnet-4-6 and haiku-4-5 correctly,
+  # but opus-4-7 is missing — explicit ``model_info`` here forces
+  # /spend/logs to populate cost instead of ``None / 0``. Sonnet/Haiku
+  # are pinned too so we own the price source of truth instead of
+  # silently drifting if Anthropic's map updates.
   - model_name: anthropic/claude-opus-4-7
     litellm_params:
       model: anthropic/claude-opus-4-7
       api_key: os.environ/ANTHROPIC_API_KEY
       additional_drop_params: ["temperature"]
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
 
   - model_name: anthropic/claude-sonnet-4-6
     litellm_params:
       model: anthropic/claude-sonnet-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
 
   - model_name: anthropic/claude-haiku-4-5
     litellm_params:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
 
   # ── OpenAI ───────────────────────────────────────────────────────────
+  # Per-1M USD as of 2026-05-14 (OpenAI API):
+  #   gpt-5.5         $5.00 / $30.00   (built-in map missing → set)
+  #   gpt-5.4         $2.50 / $15.00
+  #   gpt-5-nano      $0.05 /  $0.40   (legacy nano, NOT gpt-5.4-nano)
+  #   gpt-5.3-codex   $1.75 / $14.00   (Codex rate card)
   # HIGH tier
   - model_name: openai/gpt-5.5
     litellm_params:
       model: openai/gpt-5.5
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000030
 
   # MID tier
   - model_name: openai/gpt-5.4
     litellm_params:
       model: openai/gpt-5.4
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.000015
 
   # LOW tier
   - model_name: openai/gpt-5-nano
     litellm_params:
       model: openai/gpt-5-nano
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000005
+      output_cost_per_token: 0.0000004
 
   # Code-heavy override — opt-in via DECEPTICON_MODEL_<ROLE> for roles
   # like patcher, exploiter, contract_auditor that benefit from OpenAI's
@@ -72,34 +104,58 @@ model_list:
     litellm_params:
       model: openai/gpt-5.3-codex
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
 
   # ── Google ───────────────────────────────────────────────────────────
+  # Per-1M USD as of 2026-05-14 (Gemini Developer API, ≤200K context):
+  #   2.5-pro        $1.25 / $10.00
+  #   2.5-flash      $0.30 /  $2.50
+  #   2.5-flash-lite $0.10 /  $0.40
   # HIGH tier
   - model_name: gemini/gemini-2.5-pro
     litellm_params:
       model: gemini/gemini-2.5-pro
       api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
 
   # MID tier
   - model_name: gemini/gemini-2.5-flash
     litellm_params:
       model: gemini/gemini-2.5-flash
       api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000003
+      output_cost_per_token: 0.0000025
 
   # LOW tier
   - model_name: gemini/gemini-2.5-flash-lite
     litellm_params:
       model: gemini/gemini-2.5-flash-lite
       api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000001
+      output_cost_per_token: 0.0000004
 
   # ── MiniMax ──────────────────────────────────────────────────────────
   # Native LiteLLM minimax/ provider — registry-registered model IDs.
+  # Per-1M USD as of 2026-05-14 (api.minimax.io):
+  #   M2.5            $0.15 / $1.20   (50 tok/s, base rate)
+  #   M2.5-lightning  $0.30 / $2.40   (100 tok/s, ~2× output cost)
+  # LiteLLM's built-in map quotes $0.30 input for M2.5 — out of date
+  # against the M2.5 launch post; override.
   # HIGH tier
   - model_name: minimax/MiniMax-M2.5
     litellm_params:
       model: minimax/MiniMax-M2.5
       api_base: https://api.minimax.io/v1
       api_key: os.environ/MINIMAX_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000015
+      output_cost_per_token: 0.0000012
 
   # MID tier (throughput-tuned variant of M2.5 — 2x output token cost,
   # higher rate ceiling)
@@ -108,34 +164,67 @@ model_list:
       model: minimax/MiniMax-M2.5-lightning
       api_base: https://api.minimax.io/v1
       api_key: os.environ/MINIMAX_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000003
+      output_cost_per_token: 0.0000024
 
   # ── Claude Code Auth (OAuth subscription) ────────────────────────────
   # ``additional_drop_params: ["temperature"]`` matches the api-key opus entry —
   # Opus 4.7 rejects the param on every route, OAuth path included.
+  #
+  # Shadow pricing: Claude Code Max/Pro/Team is a flat monthly subscription,
+  # so the real cash spend is NOT per-token. We deliberately stamp the
+  # equivalent Anthropic API list price here so /spend/logs reports an
+  # "API-equivalent cost" — useful for comparing benchmark cost across
+  # paid-API and subscription routes apples-to-apples. The OSS user's
+  # actual bill is the subscription fee; this number is opportunity cost.
   - model_name: auth/claude-opus-4-7
     litellm_params:
       model: auth/claude-opus-4-7
       additional_drop_params: ["temperature"]
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
 
   - model_name: auth/claude-sonnet-4-6
     litellm_params:
       model: auth/claude-sonnet-4-6
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
 
   - model_name: auth/claude-haiku-4-5
     litellm_params:
       model: auth/claude-haiku-4-5
+    model_info:
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
 
   # ── DeepSeek ─────────────────────────────────────────────────────────
-  # V4 models (released 2026-04-24, 1M context, thinking + non-thinking)
+  # V4 models (released 2026-04-24, 1M context, thinking + non-thinking).
+  # Per-1M USD as of 2026-05-14 (api.deepseek.com, **LIST PRICE — does
+  # not include the 75 % anniversary discount on V4-Pro that runs
+  # through 2026-05-31; we want post-discount steady-state cost on the
+  # benchmark report**):
+  #   v4-pro    $1.74 / $3.48
+  #   v4-flash  $0.14 / $0.28
+  # Legacy deepseek-chat / deepseek-reasoner aliases keep LiteLLM's
+  # built-in map ($0.28 / $0.42).
   - model_name: deepseek/deepseek-v4-pro
     litellm_params:
       model: deepseek/deepseek-v4-pro
       api_key: os.environ/DEEPSEEK_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000174
+      output_cost_per_token: 0.00000348
 
   - model_name: deepseek/deepseek-v4-flash
     litellm_params:
       model: deepseek/deepseek-v4-flash
       api_key: os.environ/DEEPSEEK_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000014
+      output_cost_per_token: 0.00000028
 
   # Legacy names (deprecated 2026-07-24, kept for fallback)
   - model_name: deepseek/deepseek-chat
@@ -153,61 +242,112 @@ model_list:
   # family below is the current production lineup; grok-4.3 is xAI's
   # general flagship and grok-4-1-fast-reasoning is the cost-efficient
   # MID tier with comparable tool-call quality.
+  # Per-1M USD as of 2026-05-14 (api.x.ai, ≤200K input tokens):
+  #   grok-4.3                $1.25 / $2.50
+  #   grok-4-1-fast-reasoning $0.20 / $0.50
+  # >200K context window doubles input + 1.5x output per xAI's pricing
+  # rule; not modeled here (LiteLLM treats this as a flat rate).
   - model_name: xai/grok-4.3
     litellm_params:
       model: xai/grok-4.3
       api_key: os.environ/XAI_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.0000025
 
   - model_name: xai/grok-4-1-fast-reasoning
     litellm_params:
       model: xai/grok-4-1-fast-reasoning
       api_key: os.environ/XAI_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000002
+      output_cost_per_token: 0.0000005
 
   # ── Mistral ──────────────────────────────────────────────────────────
+  # Per-1M USD as of 2026-05-14 (api.mistral.ai):
+  #   mistral-large-latest = Mistral Large 3 (mistral-large-2512)
+  #                                $0.50 / $1.50
+  #   codestral-latest             $0.30 / $0.90
+  # LiteLLM's built-in map for codestral is stale ($1.00 / $3.00) —
+  # override here so cost tracking matches the real bill.
   - model_name: mistral/mistral-large-latest
     litellm_params:
       model: mistral/mistral-large-latest
       api_key: os.environ/MISTRAL_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000005
+      output_cost_per_token: 0.0000015
 
   - model_name: mistral/codestral-latest
     litellm_params:
       model: mistral/codestral-latest
       api_key: os.environ/MISTRAL_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000003
+      output_cost_per_token: 0.0000009
 
   # ── OpenRouter ─────────────────────────────────────────────────────
   # OpenRouter forwards opus-4-7 calls to Anthropic, so the same temperature
   # deprecation applies — drop it here too.
+  # OpenRouter charges Anthropic list price per token (no markup; the
+  # 5.5 % fee only applies on credit-purchase deposits). The Claude
+  # pricing block above is the source of truth — we mirror those values
+  # here so /spend/logs captures cost for the OpenRouter routes too.
   - model_name: openrouter/anthropic/claude-opus-4-7
     litellm_params:
       model: openrouter/anthropic/claude-opus-4-7
       api_key: os.environ/OPENROUTER_API_KEY
       additional_drop_params: ["temperature"]
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
 
   - model_name: openrouter/anthropic/claude-sonnet-4-6
     litellm_params:
       model: openrouter/anthropic/claude-sonnet-4-6
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
 
   - model_name: openrouter/anthropic/claude-haiku-4-5
     litellm_params:
       model: openrouter/anthropic/claude-haiku-4-5
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
 
   # ── Nvidia NIM ─────────────────────────────────────────────────────
+  # NIM is BYO-hardware: the cost is the GPU rental (DGX Cloud, AWS, on-prem),
+  # NOT per-token. Pinned to $0 so /spend/logs is honest — token-based cost
+  # tracking does not apply. Operators who want to amortize GPU spend across
+  # tokens should override these via DECEPTICON_MODEL_<ROLE> + a custom
+  # gateway with their own rate. Explicit ``0`` here also bypasses LiteLLM
+  # budget checks (zero-cost models skip all budget enforcement).
   - model_name: nvidia_nim/meta/llama-3.3-70b-instruct
     litellm_params:
       model: nvidia_nim/meta/llama-3.3-70b-instruct
       api_key: os.environ/NVIDIA_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
 
   - model_name: nvidia_nim/nvidia/llama-3.1-nemotron-70b-instruct
     litellm_params:
       model: nvidia_nim/nvidia/llama-3.1-nemotron-70b-instruct
       api_key: os.environ/NVIDIA_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
 
   - model_name: nvidia_nim/meta/llama-3.2-3b-instruct
     litellm_params:
       model: nvidia_nim/meta/llama-3.2-3b-instruct
       api_key: os.environ/NVIDIA_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
 
   # ── Subscription OAuth routes ──────────────────────────────────────────
   # ChatGPT (auth/gpt-*), Gemini Advanced (gemini-sub/*), Copilot

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -329,6 +329,57 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
 # enabled the auth method, the handshake blocks → times out → container
 # becomes unhealthy. Gating on DECEPTICON_AUTH_* prevents that.
 
+# Shadow pricing for subscription OAuth routes (USD per token, as of
+# 2026-05-14). These routes are paid via flat monthly subscriptions
+# (ChatGPT Pro/Plus/Team, Gemini Advanced, Copilot Pro, SuperGrok,
+# Perplexity Pro), so per-token cost is NOT what the user actually pays.
+# We stamp the equivalent paid-API price into ``model_info`` so
+# /spend/logs reports an "API-equivalent" USD number — useful for
+# comparing benchmark cost across paid and subscription routes
+# apples-to-apples. The OSS user's real cash spend stays the
+# subscription fee; this number is opportunity cost.
+#
+# Perplexity Sonar numbers are best-effort against the published rate
+# card (Sonar $1/$1, Sonar Pro $3/$15) — search-call surcharge not
+# modeled.
+_SUBSCRIPTION_SHADOW_PRICING: dict[str, tuple[float, float]] = {
+    "auth/gpt-5.5": (0.000005, 0.000030),
+    "auth/gpt-5.4": (0.0000025, 0.000015),
+    "auth/gpt-5.4-mini": (0.00000075, 0.0000045),
+    "auth/gpt-5.3-codex": (0.00000175, 0.000014),
+    "gemini-sub/gemini-2.5-pro": (0.00000125, 0.00001),
+    "gemini-sub/gemini-2.5-flash": (0.0000003, 0.0000025),
+    "copilot/gpt-5.5": (0.000005, 0.000030),
+    "copilot/claude-sonnet-4-6": (0.000003, 0.000015),
+    "copilot/gpt-5.4-mini": (0.00000075, 0.0000045),
+    "copilot/gpt-5.3-codex": (0.00000175, 0.000014),
+    "grok-sub/grok-4.3": (0.00000125, 0.0000025),
+    "grok-sub/grok-4-1-fast-reasoning": (0.0000002, 0.0000005),
+    "pplx-sub/sonar-pro": (0.000003, 0.000015),
+    "pplx-sub/sonar": (0.000001, 0.000001),
+}
+
+
+def _with_shadow_pricing(route: dict[str, Any]) -> dict[str, Any]:
+    """Attach ``model_info`` shadow pricing to a subscription route, if any.
+
+    Returns the route unchanged when ``model_name`` is not in
+    ``_SUBSCRIPTION_SHADOW_PRICING`` — preserves the "subscription is
+    free per-token" reading so a future operator who deliberately
+    omits a route from the map gets ``$0`` rather than silent default
+    pricing from LiteLLM's built-in cost map.
+    """
+    pricing = _SUBSCRIPTION_SHADOW_PRICING.get(route["model_name"])
+    if pricing is None:
+        return route
+    enriched = dict(route)
+    enriched["model_info"] = {
+        "input_cost_per_token": pricing[0],
+        "output_cost_per_token": pricing[1],
+    }
+    return enriched
+
+
 _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
     # env flag → model_list entries
     "DECEPTICON_AUTH_CHATGPT": [
@@ -480,7 +531,7 @@ def _inject_subscription_routes(
             continue
         for route in routes:
             if route["model_name"] not in existing:
-                model_list.append(route)
+                model_list.append(_with_shadow_pricing(route))
                 existing.add(route["model_name"])
         # Add corresponding fallbacks
         for fb in _SUBSCRIPTION_FALLBACKS.get(flag, []):

--- a/tests/unit/benchmark/test_harness_cost.py
+++ b/tests/unit/benchmark/test_harness_cost.py
@@ -1,0 +1,115 @@
+"""Unit tests for Harness._query_cost — /spend/logs summation.
+
+Kept in a separate file from test_harness.py so it doesn't inherit the
+langgraph_sdk-coupled fixture mess that file is marked skipped over.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from benchmark.config import BenchmarkConfig
+from benchmark.harness import Harness
+from benchmark.providers.base import BaseBenchmarkProvider
+from benchmark.schemas import Challenge, FilterConfig
+
+
+class _StubProvider(BaseBenchmarkProvider):
+    @property
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "stub"
+
+    def load_challenges(self, filters: FilterConfig) -> list[Challenge]:  # pragma: no cover
+        return []
+
+    def preflight_build(self, challenges: list[Challenge]) -> dict[str, str]:  # pragma: no cover
+        return {}
+
+    def setup(self, challenge: Challenge):  # type: ignore[override]  # pragma: no cover
+        raise NotImplementedError
+
+    def teardown(self, challenge: Challenge) -> None:  # pragma: no cover
+        return None
+
+    def evaluate(self, challenge: Challenge, state, workspace):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _harness_with_mock(rows: Any, status: int = 200) -> Harness:
+    config = BenchmarkConfig()
+    provider = _StubProvider()
+    h = Harness(provider, config)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if status == 200:
+            return httpx.Response(200, json=rows)
+        return httpx.Response(status, text="upstream error")
+
+    transport = httpx.MockTransport(handler)
+
+    real_async_client = httpx.AsyncClient
+
+    def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    # patch httpx.AsyncClient inside benchmark.harness module
+    patcher = patch("benchmark.harness.httpx.AsyncClient", side_effect=patched)
+    patcher.start()
+    h._test_patcher = patcher  # type: ignore[attr-defined]
+    return h
+
+
+@pytest.mark.asyncio
+async def test_query_cost_sums_spend_rows() -> None:
+    rows = [
+        {"spend": 0.01, "model": "anthropic/claude-haiku-4-5"},
+        {"spend": 0.025, "model": "anthropic/claude-opus-4-7"},
+        {"spend": 0.0, "model": "auth/claude-haiku-4-5"},
+    ]
+    h = _harness_with_mock(rows)
+    try:
+        total = await h._query_cost("2026-05-14T00:00:00Z", "2026-05-14T01:00:00Z")
+    finally:
+        h._test_patcher.stop()  # type: ignore[attr-defined]
+    assert total == 0.035
+
+
+@pytest.mark.asyncio
+async def test_query_cost_returns_none_on_non_200() -> None:
+    h = _harness_with_mock(None, status=500)
+    try:
+        total = await h._query_cost("a", "b")
+    finally:
+        h._test_patcher.stop()  # type: ignore[attr-defined]
+    assert total is None
+
+
+@pytest.mark.asyncio
+async def test_query_cost_zero_when_no_rows() -> None:
+    h = _harness_with_mock([])
+    try:
+        total = await h._query_cost("a", "b")
+    finally:
+        h._test_patcher.stop()  # type: ignore[attr-defined]
+    assert total == 0.0
+
+
+@pytest.mark.asyncio
+async def test_query_cost_ignores_non_numeric_spend() -> None:
+    rows = [
+        {"spend": "not-a-number"},
+        {"spend": None},
+        {"spend": 0.7},
+        {"not_a_spend_row": 1},
+    ]
+    h = _harness_with_mock(rows)
+    try:
+        total = await h._query_cost("a", "b")
+    finally:
+        h._test_patcher.stop()  # type: ignore[attr-defined]
+    assert total == 0.7

--- a/tests/unit/benchmark/test_scorer.py
+++ b/tests/unit/benchmark/test_scorer.py
@@ -123,3 +123,33 @@ class TestScorer:
         assert report.pass_rate == 0.0
         assert report.passed == 0
         assert report.failed == 2
+
+    def test_total_cost_aggregates_per_challenge(self) -> None:
+        """total_cost_usd sums non-None cost_usd entries."""
+        start, end = self._times()
+        a = _make_result("C-001", 1, ["xss"], True)
+        a.cost_usd = 0.123
+        b = _make_result("C-002", 1, ["sqli"], False)
+        b.cost_usd = 0.001
+        report = Scorer.score([a, b], "test", start, end)
+        assert report.total_cost_usd is not None
+        assert abs(report.total_cost_usd - 0.124) < 1e-9
+
+    def test_total_cost_partial_capture_still_rolls_up(self) -> None:
+        """Mixed None/float — total reflects the captured subset."""
+        start, end = self._times()
+        a = _make_result("C-001", 1, ["xss"], True)
+        a.cost_usd = 0.05
+        b = _make_result("C-002", 1, ["sqli"], False)  # cost_usd stays None
+        report = Scorer.score([a, b], "test", start, end)
+        assert report.total_cost_usd == 0.05
+
+    def test_total_cost_none_when_all_missing(self) -> None:
+        """All cost_usd None -> total_cost_usd is None (not 0.0)."""
+        start, end = self._times()
+        results = [
+            _make_result("C-001", 1, ["xss"], True),
+            _make_result("C-002", 1, ["sqli"], False),
+        ]
+        report = Scorer.score(results, "test", start, end)
+        assert report.total_cost_usd is None


### PR DESCRIPTION
## Summary
- Stamp explicit `model_info` pricing (USD per 1M tokens, 2026-05-14 rates) on every `config/litellm.yaml` model so `/spend/logs` reports real USD instead of `$0/None` for opus-4-7, gpt-5.5, deepseek-v4-{pro,flash}, grok-4.3, openrouter/anthropic/*, plus stale-map corrections for MiniMax-M2.5 and codestral-latest.
- Shadow-price subscription OAuth routes (`auth/*`, `gemini-sub/*`, `copilot/*`, `grok-sub/*`, `pplx-sub/*`) with their matching paid-API list price via `_SUBSCRIPTION_SHADOW_PRICING` in `litellm_dynamic_config.py`, so benchmark cost compares apples-to-apples across subscription and API paths.
- Wire cost into the benchmark pipeline: `ChallengeResult.cost_usd` + `BenchmarkReport.total_cost_usd` populated by `Harness._query_cost` (LiteLLM `/spend/logs` time-window filter), surfaced in batch JSON+Markdown reports, per-challenge evidence cards, and the runner console summary.

## Notes
- **DeepSeek V4 Pro uses post-discount list price** ($1.74/$3.48). The 75%-off promo through 2026-05-31 is deliberately not modeled so reports reflect steady-state cost.
- **`auth/*` shadow cost = API-equivalent**, not real cash spend. The actual bill stays the flat Claude Code Max/Pro/Team subscription fee; this number is opportunity cost for cross-route comparison.
- Per-challenge cost attribution is reliable only in sequential runs (default `--parallel=1`); concurrent challenges share the time window and roll up only at the batch total.
- `nvidia_nim/*` stays at \$0 by design — NIM is BYO-GPU, not per-token.

## Test plan
- [x] `uv run ruff format --check .` — 19 files already formatted
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run basedpyright --level error` — 0 errors, 0 warnings
- [x] `uv run pytest -n auto -q -m "not slow"` — 824 passed (incl. 7 new cost tests: 3 in `test_scorer.py`, 4 in `test_harness_cost.py`)
- [x] Cost-math spot-check: real `/spend/logs` row (`auth/claude-haiku-4-5`, 360 prompt + 91 completion tok) → \$0.000815 shadow cost via new yaml
- [ ] After merge: `docker compose up -d --force-recreate litellm` then verify `http://127.0.0.1:4000/ui/?page=models` cards show non-zero \$/1M for previously-broken entries
- [ ] After merge: `make benchmark ARGS="--ids XBEN-001-24"` and confirm the batch report's `Total Cost (USD)` row + per-result `Cost (USD)` column are populated