### PR TITLE
chore: remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,0 @@
-# Security updates only — version bumps disabled to avoid breaking changes.
-# GitHub automatically creates PRs for known vulnerabilities (GHSA advisories).
-# Manual dependency updates should be done intentionally with testing.
-version: 2
-updates: []


### PR DESCRIPTION
## Summary

Removes `.github/dependabot.yml` entirely. Dependency upgrades will be handled intentionally with explicit breaking-change review.

## Why

- Repo-level **vulnerability alerts** and **automated security fixes** are already disabled (`gh api .../vulnerability-alerts` → 404; `.../automated-security-fixes` → `enabled: false`).
- The config previously held `updates: []`, which already disabled version updates, but left a dangling file that implied Dependabot was a supported mechanism.
- A stray Dependabot PR (#195, ink 6.8.0 → 7.0.2) slipped through earlier and would have broken the CLI (Ink 7 requires Node 22 + React 19.2 and changes \`key.backspace\` / \`key.meta\` semantics). Closed alongside this PR.

## Effect

Dependabot will no longer create any PRs against this repository.

## Test plan

- [x] No workflow references \`dependabot\` (\`grep -rn dependabot .github/workflows/\` → empty)
- [x] PR #195 closed, remote branch \`dependabot/npm_and_yarn/clients/cli/ink-7.0.2\` deleted