### PR TITLE
chore: PR review NIT cleanup

### DIFF
--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -25,6 +25,11 @@ const (
 	RawBaseURL = "https://raw.githubusercontent.com/" + Repo
 )
 
+// executableFn is a var so tests can redirect binary writes to a temp dir
+// instead of overwriting the test binary itself. Matches the isWSLFn /
+// wslHostIPFn pattern used in cmd/start.go.
+var executableFn = os.Executable
+
 // Release represents a GitHub release.
 type Release struct {
 	TagName string  `json:"tag_name"`
@@ -347,11 +352,6 @@ func PromptIfUpdateAvailable(currentVersion string) (bool, error) {
 	// child, so this is also unreachable on Windows. Kept for symmetry.
 	return true, nil
 }
-
-// executableFn is a var so tests can redirect binary writes to a temp dir
-// instead of overwriting the test binary itself. Matches the isWSLFn /
-// wslHostIPFn pattern used in cmd/start.go.
-var executableFn = os.Executable
 
 // isInteractiveStdin returns true when the launcher's stdin is connected
 // to a real terminal. Piped / redirected stdin (CI, log shippers,

--- a/clients/web/src/components/terminal/web-terminal.tsx
+++ b/clients/web/src/components/terminal/web-terminal.tsx
@@ -71,6 +71,9 @@ export function WebTerminal({
     if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
     if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
     retryListenerRef.current?.dispose();
+    retryListenerRef.current = null;
+    onDataDisposableRef.current?.dispose();
+    onDataDisposableRef.current = null;
     resizeObserverRef.current?.disconnect();
     wsRef.current?.close();
     termRef.current?.dispose();


### PR DESCRIPTION
## Summary

Two narrow cleanups surfaced during the recent PR review round. Both are stylistic / latent-pattern hygiene — no production behaviour change.

## Changes

### 1. \`clients/launcher/internal/updater/updater.go\` — move \`executableFn\` to top

Move \`var executableFn = os.Executable\` from line 354 (sitting between \`PromptIfUpdateAvailable\` and \`isInteractiveStdin\`) to the top of the file right after the \`const\` block. Matches the \`isWSLFn\` / \`wslHostIPFn\` convention at \`clients/launcher/cmd/start.go:25-28\`.

This var was added in PR #193 to make \`SelfUpdate\` test-injectable. The placement mid-file was a NIT noted in the review — the launcher's other DI injection vars live at the top.

### 2. \`clients/web/src/components/terminal/web-terminal.tsx\` — \`cleanup\` symmetry

In the \`cleanup\` callback (lines 69-83 after the change):
- Add \`onDataDisposableRef.current?.dispose()\` (previously relied on \`term.dispose()\`'s cascade).
- Null both \`retryListenerRef.current = null\` and \`onDataDisposableRef.current = null\` after disposing.

Pre-fix, \`cleanup\` disposed \`retryListenerRef.current\` but did not null its ref, and did not touch \`onDataDisposableRef\` at all. xterm.js disposables are idempotent so this was never crashy in practice. The symmetry makes intent explicit and removes a latent footgun under React Strict Mode dev re-mounts where the same ref could briefly point at a disposable belonging to a destroyed terminal.

This was a NIT noted in the PR #206 review — the \`retryListenerRef\` pattern already had the same latent issue; this PR fixes both at once.

## Rationale for the third NIT (intentionally omitted)

The PR #206 review also flagged dispose-ordering asymmetry inside \`connectWs\` itself — \`retryListenerRef\` is disposed at the top of \`connectWs\` (lines 88-89), while \`onDataDisposableRef\` is disposed at the bottom (right before re-registering the listener at lines 171-172). On closer analysis the asymmetry has a real reason: moving the \`onDataDisposableRef\` dispose to the top would create a window where the \`term.onData\` listener is gone before the new WebSocket is wired up, potentially dropping keystrokes during ~100ms WebSocket setup. Current placement (dispose-then-re-register atomically) is the right pattern; \`retryListenerRef\` is fundamentally different (a one-shot "press Enter to reconnect" listener that should NOT survive into the reconnect itself).

## Verification

- \`go vet ./...\` clean
- \`cd clients/launcher && go test ./internal/updater/...\` passes (10 tests, 8.5s)
- TypeScript types on the changed file are valid (\`retryListenerRef\` and \`onDataDisposableRef\` both have type \`{ dispose: () => void } | null\`, so \`?.dispose()\` and \`= null\` are both valid).

## Test plan

- [x] \`go vet ./...\` from \`clients/launcher/\`
- [x] \`go test ./internal/updater/...\` from \`clients/launcher/\`
- [x] Manual review of diff (8 insertions, 5 deletions across 2 files)
- [ ] CI: Launcher (ubuntu + macos), Web (lint + build), Docker build (web)

## Refs

- NIT 1 surfaced in #193 review
- NIT 2 surfaced in #206 review