### PR TITLE
feat(launcher): one-time GitHub star prompt on onboard + first start

### DIFF
--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/huh/v2"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/starprompt"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -922,6 +923,13 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	fmt.Println(ui.Dim.Render("  │  ") + ui.Dim.Render(config.EnvPath()))
 	fmt.Println(ui.Dim.Render("  └──────────────────────────────────┘"))
 	fmt.Println()
+
+	// One-time GitHub star ask — the natural post-onboarding moment.
+	// Suppressed on subsequent runs by the ack file at
+	// $DECEPTICON_HOME/.starred, so a re-run of `decepticon onboard
+	// --reset` does not re-prompt.
+	starprompt.PromptIfNotStarred()
+
 	ui.DimText("  Run 'decepticon' to start the platform")
 	return nil
 }

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/engagement"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/health"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/platform"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/starprompt"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/updater"
 	"github.com/spf13/cobra"
@@ -128,6 +129,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// current launcher rather than aborting the start.
 		ui.Warning("Update check: " + err.Error())
 	}
+
+	// 2.6. One-time GitHub star ask. Idempotent across launches — the
+	// ack file at $DECEPTICON_HOME/.starred suppresses the prompt
+	// after the user has been through it once. Silent no-op on
+	// non-interactive stdin, so CI / piped invocations are untouched.
+	starprompt.PromptIfNotStarred()
 
 	// 3. Engagement picker — must run BEFORE compose Up so the sandbox
 	// container starts with /workspace bound to the chosen engagement

--- a/clients/launcher/internal/starprompt/browser.go
+++ b/clients/launcher/internal/starprompt/browser.go
@@ -1,0 +1,42 @@
+package starprompt
+
+import (
+	"os/exec"
+	"runtime"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/platform"
+)
+
+// platformIsWSLFn is overridable for tests — production wires it to
+// platform.IsWSL, the same detector cmd/start.go uses for its Ollama
+// host-IP probe.
+var platformIsWSLFn = platform.IsWSL
+
+// openBrowserToRepo opens RepoURL in the host's default browser.
+// Supported targets are macOS and WSL; native Linux is a best-effort
+// fallback that lets a launcher built on a native Linux dev box still
+// work.
+//
+//   - macOS                : `open <url>`
+//   - WSL with wslview     : `wslview <url>` (purpose-built; from wslu)
+//   - WSL without wslview  : `cmd.exe /c start <url>` (WSL2 interop)
+//   - Native Linux         : `xdg-open <url>` (not a primary target)
+//
+// A non-nil error tells the caller to surface the URL as text instead
+// — used when the host has no usable opener (headless SSH, WSL2 with
+// interop disabled, etc.).
+func openBrowserToRepo() error {
+	if runtime.GOOS == "darwin" {
+		return exec.Command("open", RepoURL).Start()
+	}
+	if platformIsWSLFn() {
+		if _, err := exec.LookPath("wslview"); err == nil {
+			return exec.Command("wslview", RepoURL).Start()
+		}
+		// WSL2 with Windows interop guarantees cmd.exe on PATH at
+		// /mnt/c/Windows/System32/cmd.exe. If interop is disabled the
+		// caller's fallback prints the URL.
+		return exec.Command("cmd.exe", "/c", "start", RepoURL).Start()
+	}
+	return exec.Command("xdg-open", RepoURL).Start()
+}

--- a/clients/launcher/internal/starprompt/gh.go
+++ b/clients/launcher/internal/starprompt/gh.go
@@ -1,0 +1,75 @@
+package starprompt
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"time"
+)
+
+// ghCallTimeout bounds every subprocess call against the gh CLI.
+// The launcher's start flow must never block on a stalled gh process.
+const ghCallTimeout = 3 * time.Second
+
+type starStatus int
+
+const (
+	statusUnknown starStatus = iota
+	statusStarred
+	statusNotStarred
+)
+
+// ghReady reports whether the `gh` binary is on PATH AND the user is
+// authenticated specifically to github.com. Authentication only to a
+// non-github.com host (e.g. an Enterprise instance) is intentionally
+// not enough — the star endpoint lives on github.com.
+func ghReady() bool {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), ghCallTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "auth", "status",
+		"--hostname", "github.com")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
+}
+
+// checkStarStatus runs `gh api /user/starred/<slug>`. The endpoint
+// returns 204 when the user has starred the repo and 404 otherwise;
+// gh maps the 204 to a clean exit and the 404 to exit code 1. Any
+// other failure (network, scope, timeout) returns statusUnknown so
+// the caller falls back to the browser path.
+func checkStarStatus() starStatus {
+	ctx, cancel := context.WithTimeout(context.Background(), ghCallTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "api",
+		"/user/starred/"+RepoSlug, "--silent")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	if err == nil {
+		return statusStarred
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return statusNotStarred
+	}
+	return statusUnknown
+}
+
+// starViaGh issues PUT /user/starred/<slug> through the gh CLI. Any
+// non-nil error means the caller should fall back to opening a
+// browser — we never re-attempt the PUT to avoid double-starring or
+// looping on a permanent error like a missing scope.
+func starViaGh() error {
+	ctx, cancel := context.WithTimeout(context.Background(), ghCallTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "PUT",
+		"/user/starred/"+RepoSlug, "--silent")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run()
+}

--- a/clients/launcher/internal/starprompt/starprompt.go
+++ b/clients/launcher/internal/starprompt/starprompt.go
@@ -1,0 +1,177 @@
+// Package starprompt presents a one-time GitHub star ask at the natural
+// post-onboarding moment and again at the first interactive launch
+// (before the engagement picker). Idempotent — a sentinel file at
+// ${DECEPTICON_HOME}/.starred suppresses the prompt permanently after
+// the first outcome (Yes / Skip / already-starred).
+//
+// Behaviour:
+//   - Non-interactive stdin (CI, pipes) is a silent no-op. No ack is
+//     written; the next interactive launch reconsiders.
+//   - When `gh` is present and authenticated to github.com, the prompt
+//     status-checks the repo and either stars in-place (PUT to
+//     /user/starred/<repo>) or silently writes the ack when the user
+//     has already starred.
+//   - When `gh` is absent, unauthenticated, or any call errors/times
+//     out, the prompt opens a browser (macOS `open`; WSL `wslview`
+//     then `cmd.exe /c start`) and writes the ack regardless of the
+//     browser's success.
+//   - Every `gh` subprocess carries a 3-second deadline. The launcher
+//     start flow can never be blocked by a hung `gh` process.
+package starprompt
+
+import (
+	"os"
+	"path/filepath"
+
+	"charm.land/huh/v2"
+	"golang.org/x/term"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
+)
+
+const (
+	// AckFileName is the zero-byte sentinel inside DECEPTICON_HOME.
+	// Presence alone is the signal — contents are intentionally empty
+	// so an operator can suppress the prompt forever with
+	// `touch ~/.decepticon/.starred` and re-enable it with `rm` of the
+	// same path.
+	AckFileName = ".starred"
+
+	// RepoSlug is the canonical "owner/repo" used for every gh API
+	// call and the browser URL. Hardcoded — no scenario justifies
+	// targeting a different repository.
+	RepoSlug = "PurpleAILAB/Decepticon"
+	RepoURL  = "https://github.com/" + RepoSlug
+)
+
+// Function-variable indirections so tests can swap each external
+// dependency without invoking real subprocesses, Huh prompts, or TTY
+// checks. Matches the pattern PR #193 introduced for `executableFn`
+// and `cmd/start.go` uses for `isWSLFn` / `wslHostIPFn`.
+var (
+	ghReadyFn         = ghReady
+	checkStarStatusFn = checkStarStatus
+	starViaGhFn       = starViaGh
+	openBrowserFn     = openBrowserToRepo
+	isInteractiveFn   = isInteractiveStdin
+	confirmFn         = runConfirm
+)
+
+// PromptIfNotStarred is the only public entry. Safe to call from
+// multiple sites (onboard end + start flow) because the ack-file
+// check makes any subsequent call a no-op for users who have already
+// gone through the prompt once.
+func PromptIfNotStarred() {
+	ackPath := filepath.Join(config.DecepticonHome(), AckFileName)
+
+	// Stage 0 — already acknowledged.
+	if _, err := os.Stat(ackPath); err == nil {
+		return
+	}
+
+	// Stage 1 — silent skip on non-interactive stdin. No ack so the
+	// next interactive launch reconsiders.
+	if !isInteractiveFn() {
+		return
+	}
+
+	// Stage 2 — gh graceful detection.
+	if ghReadyFn() {
+		switch checkStarStatusFn() {
+		case statusStarred:
+			// Already starred — write ack silently and return.
+			touchAck(ackPath)
+			return
+		case statusNotStarred:
+			promptViaGh(ackPath)
+			return
+		case statusUnknown:
+			// gh call failed or timed out — fall through to browser.
+		}
+	}
+
+	// Stage 3 — browser path (gh missing / unauthenticated / errored).
+	promptViaBrowser(ackPath)
+}
+
+func promptViaGh(ackPath string) {
+	confirmed := confirmFn(
+		"★ Star Decepticon on GitHub?",
+		"Detected gh CLI — we can star the repo in-place.\n"+RepoURL,
+		"Yes, star now",
+		"Skip",
+	)
+	if !confirmed {
+		// Skip = permanent ack. The user opted out; do not nag.
+		touchAck(ackPath)
+		return
+	}
+	if err := starViaGhFn(); err != nil {
+		// PUT failed — fall back to browser. The user already said Yes,
+		// so preserve their intent rather than dropping it on the floor.
+		ui.Warning("gh API call failed — opening browser instead.")
+		if openErr := openBrowserFn(); openErr != nil {
+			ui.Info("Please open: " + RepoURL)
+		}
+	} else {
+		ui.Success("★ Starred. Thank you!")
+	}
+	touchAck(ackPath)
+}
+
+func promptViaBrowser(ackPath string) {
+	confirmed := confirmFn(
+		"★ Star Decepticon on GitHub?",
+		"Opens "+RepoURL+" in your browser.",
+		"Yes, open",
+		"Skip",
+	)
+	if confirmed {
+		if err := openBrowserFn(); err != nil {
+			// Browser unavailable (headless SSH, missing wslu/interop) —
+			// fall through to a textual hint.
+			ui.Info("Please open: " + RepoURL)
+		}
+	}
+	// Both Yes and Skip ack — Skip's intent is "don't ask again".
+	touchAck(ackPath)
+}
+
+// touchAck writes the zero-byte sentinel. Best-effort: a write failure
+// surfaces as a warning but does not abort the launch flow. The next
+// interactive launch will retry because the ack file is missing.
+func touchAck(path string) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		ui.Warning("Could not create " + filepath.Dir(path) + ": " + err.Error())
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		ui.Warning("Could not write star-prompt ack: " + err.Error())
+		return
+	}
+	_ = f.Close()
+}
+
+// runConfirm is the production Huh v2 Confirm renderer. A failure from
+// Run() (TTY closed mid-render, terminal resize race, etc.) is treated
+// as Skip — a user can never be accidentally signed up for an action.
+func runConfirm(title, description, affirmative, negative string) bool {
+	var v bool
+	err := huh.NewConfirm().
+		Title(title).
+		Description(description).
+		Affirmative(affirmative).
+		Negative(negative).
+		Value(&v).
+		Run()
+	if err != nil {
+		return false
+	}
+	return v
+}
+
+func isInteractiveStdin() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}

--- a/clients/launcher/internal/starprompt/starprompt_test.go
+++ b/clients/launcher/internal/starprompt/starprompt_test.go
@@ -1,0 +1,321 @@
+package starprompt
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempHome redirects config.DecepticonHome() output via env so each
+// test owns its own ack-file directory.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("DECEPTICON_HOME", dir)
+	return dir
+}
+
+// stubs collects the externally-injectable state for one test. Tests
+// set the fields they care about; install() swaps the function
+// variables and t.Cleanup restores originals.
+type stubs struct {
+	ghReady       bool
+	starStatus    starStatus
+	starErr       error
+	openErr       error
+	interactive   bool
+	confirmReturn bool
+
+	openCalled    bool
+	starGhCalled  bool
+	confirmCalled bool
+	confirmTitle  string
+}
+
+func install(t *testing.T, s *stubs) {
+	t.Helper()
+	origGhReady := ghReadyFn
+	origStatus := checkStarStatusFn
+	origStar := starViaGhFn
+	origOpen := openBrowserFn
+	origInteractive := isInteractiveFn
+	origConfirm := confirmFn
+
+	ghReadyFn = func() bool { return s.ghReady }
+	checkStarStatusFn = func() starStatus { return s.starStatus }
+	starViaGhFn = func() error {
+		s.starGhCalled = true
+		return s.starErr
+	}
+	openBrowserFn = func() error {
+		s.openCalled = true
+		return s.openErr
+	}
+	isInteractiveFn = func() bool { return s.interactive }
+	confirmFn = func(title, _, _, _ string) bool {
+		s.confirmCalled = true
+		s.confirmTitle = title
+		return s.confirmReturn
+	}
+
+	t.Cleanup(func() {
+		ghReadyFn = origGhReady
+		checkStarStatusFn = origStatus
+		starViaGhFn = origStar
+		openBrowserFn = origOpen
+		isInteractiveFn = origInteractive
+		confirmFn = origConfirm
+	})
+}
+
+func ackExists(t *testing.T, home string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(home, AckFileName))
+	return err == nil
+}
+
+// ── Stage 0: ack already present ────────────────────────────────────
+
+func TestPromptIfNotStarred_AckExists_Returns(t *testing.T) {
+	home := withTempHome(t)
+	if err := os.WriteFile(filepath.Join(home, AckFileName), nil, 0o644); err != nil {
+		t.Fatalf("seed ack: %v", err)
+	}
+	s := &stubs{interactive: true, ghReady: true}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.confirmCalled || s.openCalled || s.starGhCalled {
+		t.Error("ack present must short-circuit before any side effect")
+	}
+}
+
+// ── Stage 1: non-interactive ────────────────────────────────────────
+
+func TestPromptIfNotStarred_NonInteractive_SilentNoOp(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{interactive: false, ghReady: true}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.confirmCalled || s.openCalled || s.starGhCalled {
+		t.Error("non-interactive stdin must produce no side effects")
+	}
+	if ackExists(t, home) {
+		t.Error("non-interactive must NOT write ack (next interactive retries)")
+	}
+}
+
+// ── Stage 2a: gh present, already starred ───────────────────────────
+
+func TestPromptIfNotStarred_GhAlreadyStarred_SilentAck(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{interactive: true, ghReady: true, starStatus: statusStarred}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.confirmCalled {
+		t.Error("already-starred path must not show a prompt")
+	}
+	if !ackExists(t, home) {
+		t.Error("already-starred must write ack")
+	}
+}
+
+// ── Stage 2b: gh present, not starred, user picks Yes ───────────────
+
+func TestPromptIfNotStarred_GhNotStarred_YesStarsInPlace(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       true,
+		starStatus:    statusNotStarred,
+		confirmReturn: true,
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if !s.starGhCalled {
+		t.Error("Yes via gh path must call starViaGh")
+	}
+	if s.openCalled {
+		t.Error("Yes via gh path must NOT open browser when gh succeeds")
+	}
+	if !ackExists(t, home) {
+		t.Error("Yes outcome must write ack")
+	}
+}
+
+// ── Stage 2c: gh present, not starred, user picks Skip ──────────────
+
+func TestPromptIfNotStarred_GhNotStarred_SkipAcksOnly(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       true,
+		starStatus:    statusNotStarred,
+		confirmReturn: false,
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.starGhCalled || s.openCalled {
+		t.Error("Skip must not invoke star/open")
+	}
+	if !ackExists(t, home) {
+		t.Error("Skip must write ack (permanent)")
+	}
+}
+
+// ── Stage 2d: gh PUT fails → browser fallback + ack ─────────────────
+
+func TestPromptIfNotStarred_GhPutFails_FallsBackToBrowser(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       true,
+		starStatus:    statusNotStarred,
+		confirmReturn: true,
+		starErr:       errors.New("gh PUT failed"),
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if !s.starGhCalled {
+		t.Error("gh path must attempt PUT first")
+	}
+	if !s.openCalled {
+		t.Error("gh PUT failure must fall back to browser open")
+	}
+	if !ackExists(t, home) {
+		t.Error("ack must still be written after fallback")
+	}
+}
+
+// ── Stage 2e: gh present, status unknown → browser ──────────────────
+
+func TestPromptIfNotStarred_StatusUnknown_BrowserPath(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       true,
+		starStatus:    statusUnknown,
+		confirmReturn: true,
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.starGhCalled {
+		t.Error("statusUnknown must NOT attempt gh PUT (no trustworthy signal)")
+	}
+	if !s.openCalled {
+		t.Error("statusUnknown must fall through to browser")
+	}
+	if !ackExists(t, home) {
+		t.Error("browser-path Yes must write ack")
+	}
+}
+
+// ── Stage 3: gh absent, user picks Yes → browser ────────────────────
+
+func TestPromptIfNotStarred_NoGh_YesOpensBrowser(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       false,
+		confirmReturn: true,
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if !s.openCalled {
+		t.Error("no gh + Yes must open browser")
+	}
+	if s.starGhCalled {
+		t.Error("no gh path must never call starViaGh")
+	}
+	if !ackExists(t, home) {
+		t.Error("Yes via browser must write ack")
+	}
+}
+
+// ── Stage 3b: gh absent, user picks Skip ────────────────────────────
+
+func TestPromptIfNotStarred_NoGh_SkipAcksOnly(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       false,
+		confirmReturn: false,
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.openCalled || s.starGhCalled {
+		t.Error("Skip must not invoke browser or star")
+	}
+	if !ackExists(t, home) {
+		t.Error("Skip via browser path must write ack")
+	}
+}
+
+// ── Stage 3c: browser open fails → URL hint, ack still written ──────
+
+func TestPromptIfNotStarred_NoGh_BrowserOpenFails_StillAcks(t *testing.T) {
+	home := withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       false,
+		confirmReturn: true,
+		openErr:       errors.New("xdg-open not found"),
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if !s.openCalled {
+		t.Error("browser path Yes must attempt open even if it will fail")
+	}
+	if !ackExists(t, home) {
+		t.Error("open failure must not block ack — user picked Yes intentionally")
+	}
+}
+
+// ── Prompt routing — title matches the path ─────────────────────────
+
+func TestPromptIfNotStarred_GhPath_TitleSet(t *testing.T) {
+	withTempHome(t)
+	s := &stubs{
+		interactive:   true,
+		ghReady:       true,
+		starStatus:    statusNotStarred,
+		confirmReturn: false,
+	}
+	install(t, s)
+
+	PromptIfNotStarred()
+
+	if s.confirmTitle != "★ Star Decepticon on GitHub?" {
+		t.Errorf("title = %q, want gh-path star ask", s.confirmTitle)
+	}
+}
+
+// ── starStatus enum sanity ──────────────────────────────────────────
+
+func TestStarStatus_DistinctEnum(t *testing.T) {
+	if statusUnknown == statusStarred ||
+		statusUnknown == statusNotStarred ||
+		statusStarred == statusNotStarred {
+		t.Error("starStatus values must be distinct")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a one-time GitHub star ask at two natural launcher moments:

1. **End of `decepticon onboard`** — right after the configuration summary box, before the "Run 'decepticon' to start" hint. New installs see this immediately after their first successful setup.
2. **Step 2.6 of `decepticon start`** — after `updater.PromptIfUpdateAvailable`, before the engagement picker. Existing installs that predate this feature get exactly one ask on their next interactive launch.

Both sites call the same `starprompt.PromptIfNotStarred()`. A zero-byte sentinel at `${DECEPTICON_HOME}/.starred` makes the function idempotent — once the operator has been through the prompt once (Yes / Skip / silently acked because already starred), every subsequent invocation returns immediately.

## Behaviour

- **gh CLI graceful detection.** When `gh` is on PATH and authenticated to github.com (`--hostname github.com`), the prompt status-checks the repo via `gh api /user/starred/PurpleAILAB/Decepticon`. Already starred → silent ack, no prompt shown. Not starred → offers in-place star via `gh api -X PUT /user/starred/...`. Any error or 3-second timeout → falls through to the browser path with no user-visible failure.
- **Browser path** covers macOS (`open`), WSL with `wslview` (from `wslu`), and WSL without `wslview` (`cmd.exe /c start` via WSL2 Windows interop). Native Linux gets `xdg-open` as a best-effort fallback for dev machines. A failed open prints the URL textually so the operator always has a way forward.
- **Non-interactive stdin** (CI, pipes, redirected input) is a silent no-op: no prompt, no ack written. The next interactive launch reconsiders.
- **3-second `CommandContext`** deadline on every `gh` subprocess. The launcher's start flow can never be blocked by a stalled `gh` process.

## Why two call sites

The dual integration covers both upgrade paths cleanly:
- Fresh install via `curl|bash` → onboard wizard → star prompt at onboard end. By the time `decepticon start` runs, the ack file exists and the start.go call is a no-op.
- Existing install (already onboarded, this feature was not present at the time) → no ack file → first `decepticon start` after upgrade fires the prompt at step 2.6.

Subsequent runs on either path are short-circuited by the ack.

## File layout

New package `clients/launcher/internal/starprompt/`:

| File | Lines | Purpose |
|------|-------|---------|
| `starprompt.go` | ~180 | `PromptIfNotStarred` entry, flow stages, `promptViaGh`, `promptViaBrowser`, `touchAck`, `runConfirm`, `isInteractiveStdin` |
| `gh.go` | ~80 | `ghReady`, `checkStarStatus`, `starViaGh` — all bounded by `ghCallTimeout = 3 * time.Second` via `exec.CommandContext` |
| `browser.go` | ~50 | `openBrowserToRepo` (macOS / WSL / Linux fallback), `platformIsWSLFn` reuses `internal/platform.IsWSL` |
| `starprompt_test.go` | ~280 | 12 mock-driven tests covering every branch |

Wired in:
- `clients/launcher/cmd/onboard.go` — import + one call after the summary box, before the run hint.
- `clients/launcher/cmd/start.go` — import + one call after `PromptIfUpdateAvailable`.

## Test plan

- [x] `go vet ./...` clean from `clients/launcher/`.
- [x] `go test ./internal/starprompt/...` — 12 tests pass (0.5s).
- [x] `go test ./cmd/...` — existing cmd tests still pass (0.4s).
- [x] `go test ./internal/updater/...` — unaffected (5.4s).
- [ ] CI: Launcher (ubuntu + macOS), Docker build, CodeQL.
- [ ] Manual on macOS: `gh` present + authenticated → Yes path stars in place; `gh` absent → browser path opens GitHub repo.
- [ ] Manual on WSL: `gh` absent + `wslview` present → repo opens in Windows browser; without `wslview` → `cmd.exe /c start` fallback fires.
- [ ] Manual CI repro: `DECEPTICON_HOME=/tmp/test decepticon < /dev/null` produces no prompt and writes no ack file.

## YAGNI (intentionally out of scope)

- No JSON metadata in the ack file (sentinel is enough).
- No `DECEPTICON_NO_STAR_PROMPT` env override (a `touch` does the same).
- No telemetry on prompt outcomes.
- No native Windows / native Linux as primary targets (only macOS + WSL per design).
- No integration in `scripts/install.sh` (onboard handles it).

## Refs

- DI pattern: PR #193 introduced `executableFn` indirection in `internal/updater/updater.go` (now at top of file per PR #217).
- WSL detection: `internal/platform/IsWSL`, already used by `cmd/start.go:26` (`isWSLFn`).
- Huh v2 Confirm UX: same widget the update prompt uses (`internal/updater/updater.go:296`).