### PR TITLE
fix(opplan): guard all_done with bool(objectives) to prevent vacuous truth

### DIFF
--- a/decepticon/tools/opplan.py
+++ b/decepticon/tools/opplan.py
@@ -280,7 +280,7 @@ def _format_opplan_for_agent(
             f"(phase: {nxt.get('phase')}, priority: {nxt.get('priority')})"
         )
     else:
-        all_done = all(o.get("status") == "completed" for o in objectives)
+        all_done = bool(objectives) and all(o.get("status") == "completed" for o in objectives)
         if all_done:
             lines.append("ALL OBJECTIVES COMPLETE — Generate final engagement report.")
         else:


### PR DESCRIPTION
## Summary

Fixes #213 — `all_done` returns `True` for empty `objectives` due to vacuous truth of `all()`.

## Root Cause

`decepticon/tools/opplan.py:283` uses `all(o.get("status") == "completed" for o in objectives)` without checking if `objectives` is non-empty. Python's `all()` returns `True` for an empty iterable.

## Fix

Gate with `bool(objectives) and ...` — the short-circuit prevents the vacuous `True` when objectives is empty.

## Changes

- `decepticon/tools/opplan.py` (+2 -1): Added `bool(objectives) and` guard at line 283

## Testing

- [x] Empty objectives: `all_done` is now `False` ✅
- [x] All completed: `all_done` is `True` ✅
- [x] Some incomplete: `all_done` is `False` ✅