### PR TITLE
fix(opplan): guard vacuous all() for empty objectives list

### DIFF
--- a/decepticon/tools/opplan.py
+++ b/decepticon/tools/opplan.py
@@ -280,7 +280,7 @@ def _format_opplan_for_agent(
             f"(phase: {nxt.get('phase')}, priority: {nxt.get('priority')})"
         )
     else:
-        all_done = all(o.get("status") == "completed" for o in objectives)
+        all_done = bool(objectives) and all(o.get("status") == "completed" for o in objectives)
         if all_done:
             lines.append("ALL OBJECTIVES COMPLETE — Generate final engagement report.")
         else:

--- a/tests/unit/middleware/test_opplan_persistence.py
+++ b/tests/unit/middleware/test_opplan_persistence.py
@@ -408,3 +408,9 @@ def test_format_opplan_status_empty_does_not_say_all_complete() -> None:
     out = opplan_mod._format_opplan_status([], "demo", "apt-x")
     assert "ALL OBJECTIVES COMPLETE" not in out
     assert "No objectives defined" in out
+
+
+def test_format_opplan_for_agent_empty_does_not_say_all_complete() -> None:
+    """Regression: empty objectives list must not report all-done (vacuous all())."""
+    out = _format_opplan_for_agent([], "demo", "apt-x")
+    assert "ALL OBJECTIVES COMPLETE" not in out


### PR DESCRIPTION
## Summary

Fixes `_format_opplan_for_agent` reporting "ALL OBJECTIVES COMPLETE" when the objectives list is empty due to Python's vacuous `all()` returning `True` on empty iterables.

## Root Cause

In `decepticon/tools/opplan.py:283`, the expression:
```python
all_done = all(o.get("status") == "completed" for o in objectives)
```
returns `True` when `objectives == []`, causing an empty OPPLAN to render "ALL OBJECTIVES COMPLETE" to the agent-facing status string. This was flagged in audit #157 (LOW #10) but missed in PR #190.

## What Was Fixed

Added `bool(objectives)` guard:
```python
all_done = bool(objectives) and all(o.get("status") == "completed" for o in objectives)
```

## Testing

- Added `test_format_opplan_for_agent_empty_does_not_say_all_complete` to `tests/unit/middleware/test_opplan_persistence.py`
- Verified fix logic: empty list → `all_done=False` (correct), populated lists behave identically to before
- All edge cases verified (single completed, single pending, mixed, all completed)

Closes #213