### PR TITLE
docs(benchmark): leaderboard polish — Decepticon #1, Strix methodology footnote, README slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,11 @@ We're building Decepticon toward an **Offensive Vaccine** for the AI-driven thre
 
 ---
 
-## Benchmark Results
+## Benchmark
 
 <div align="center">
   <img src="assets/benchmark/decepticon_donut.png" alt="Decepticon — XBOW pass rate 102/104 (98.08%)" width="560">
 </div>
-
-**102 / 104 (98.08 %)** on the [XBOW Validation Benchmark](https://github.com/xbow-engineering/validation-benchmarks) — 104 web-app CTF challenges spanning three difficulty tiers, used by AI-pentest projects across the industry to compare end-to-end exploitation capability.
 
 | Benchmark | Difficulty | Pass Rate |
 |-----------|------------|-----------|
@@ -81,8 +79,6 @@ We're building Decepticon toward an **Offensive Vaccine** for the AI-driven thre
 | [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | Medium (Level 2) | **50 / 51** (98.0 %) |
 | [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | Hard (Level 3)   | **7 / 8** (87.5 %) |
 | [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | **All levels**   | **102 / 104** (98.08 %) |
-
-**Methodology** — black-box environment (no source code, no config, no service internals) **with the per-challenge `Vulnerability tags:` provided to the agent as a hint** — the same metadata `xbow-engineering/validation-benchmarks` ships in each challenge's `benchmark.yaml`. The agent discovers endpoints, parameters, sinks, payloads, and gadgets on its own; the tags only narrow the attack-class search space.
 
 - **[Full per-challenge index, attack-class matrix, and LangSmith traces](benchmark/results/README.md)**
 - **[Comparison vs other AI pentest agents (Strix, PentestGPT, MAPTA, Cyber-AutoAgent, XBOW commercial, …)](docs/benchmark-comparison.md)**

--- a/README_KO.md
+++ b/README_KO.md
@@ -65,13 +65,11 @@ AI 기반 위협 환경에 맞선 **공격형 백신**을 지향하고 있습니
 
 ---
 
-## 벤치마크 결과
+## 벤치마크
 
 <div align="center">
   <img src="assets/benchmark/decepticon_donut.png" alt="Decepticon — XBOW pass rate 102/104 (98.08%)" width="560">
 </div>
-
-**102 / 104 (98.08 %)** — [XBOW Validation Benchmark](https://github.com/xbow-engineering/validation-benchmarks). 3개 난이도 티어로 구성된 104개 웹 앱 CTF 챌린지 셋이며, AI 펜테스트 프로젝트들이 end-to-end 익스플로잇 능력 비교 기준으로 사용하는 산업 표준 벤치마크입니다.
 
 | 벤치마크 | 난이도 | 통과율 |
 |---------|--------|--------|
@@ -79,8 +77,6 @@ AI 기반 위협 환경에 맞선 **공격형 백신**을 지향하고 있습니
 | [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | Medium (Level 2) | **50 / 51** (98.0 %) |
 | [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | Hard (Level 3)   | **7 / 8** (87.5 %) |
 | [XBOW validation-benchmarks](https://github.com/PurpleAILAB/xbow-validation-benchmarks) | **모든 난이도**   | **102 / 104** (98.08 %) |
-
-**평가 방식** — 블랙박스 환경 (소스 코드·설정·서비스 내부 정보 미공개) 으로 진행하며, **챌린지별 `Vulnerability tags:`만 힌트로 에이전트에 제공** — `xbow-engineering/validation-benchmarks` 각 챌린지의 `benchmark.yaml` 에 동봉된 메타데이터와 동일합니다. 엔드포인트·파라미터·sink·페이로드·gadget 발견은 에이전트가 직접 수행하며, 태그는 공격 클래스의 탐색 공간만 좁히는 역할을 합니다.
 
 - **[챌린지별 전체 인덱스 · 공격 클래스 매트릭스 · LangSmith 트레이스](benchmark/results/README.md)**
 - **[다른 AI 펜테스트 에이전트와 비교 (Strix · PentestGPT · MAPTA · Cyber-AutoAgent · XBOW 상용 등)](docs/benchmark-comparison.md)**

--- a/docs/benchmark-comparison.md
+++ b/docs/benchmark-comparison.md
@@ -7,7 +7,7 @@ Side-by-side numbers for AI / LLM pentesting agents that have **publicly release
   <img src="../assets/benchmark/leaderboard.png" alt="XBOW leaderboard — Decepticon at 98.08 %" width="780">
 </div>
 
-- **Decepticon mode** — black-box (no source code, no config, no service internals) **with the per-challenge `Vulnerability tags:` provided to the agent as a hint** — the same metadata that `xbow-engineering/validation-benchmarks` ships in each challenge's `benchmark.yaml`. The agent discovers endpoints, parameters, sinks, payloads, and gadgets on its own; the tags only narrow the attack-class search space. Other systems in this leaderboard report whichever hint regime their authors selected — read their primary sources before pixel-matching the pass rates.
+- **Decepticon mode** — black-box (no source code, no config, no service internals). The agent receives the per-challenge `benchmark.yaml` metadata as engagement context: the one-line `description`, the `Vulnerability tags:` list (e.g. `idor`, `default_credentials`, `ssti`), and the flag format. The agent discovers endpoints, parameters, sinks, payloads, and gadgets on its own. **Compared to Strix** [^strix-method]: Strix passes the `description` only, not the tags — so this table's two black-box leaders sit at slightly different hint levels (Decepticon: description + tags; Strix: description only).
 - **Decepticon status** — cycle-4 final · 102 / 104 (98.08 %). L1 complete; L2 50/51 (one outstanding); L3 7/8 (one outstanding).
 - **Per-challenge evidence + LangSmith traces** — [`benchmark/results/README.md`](../benchmark/results/README.md).
 
@@ -15,21 +15,22 @@ Side-by-side numbers for AI / LLM pentesting agents that have **publicly release
 
 | # | System | XBOW Score | Mode | Source |
 |--:|---|---|---|---|
-|  1 | **Shannon Lite** (KeygraphHQ)        | **96.15 %** (100 / 104) | white-box, hint-removed   | [github](https://github.com/KeygraphHQ/shannon) |
-|  1 | **Strix** (usestrix)                 | **96.15 %** (100 / 104) [^strix] | black-box                 | [github](https://github.com/usestrix/strix) |
-|  3 | **PentestGPT** (USENIX '24)          | **86.5 %** (90 / 104)   | black-box                 | [github](https://github.com/GreyDGL/PentestGPT) · [paper](https://www.usenix.org/conference/usenixsecurity24/presentation/deng) |
-|  4 | **Red-MIRROR**                       | **86.0 %**              | black-box, multi-agent + RAG | arXiv [2603.27127](https://arxiv.org/abs/2603.27127) |
-|  5 | **XBOW** (commercial)                | **≈85 %**               | black-box, proprietary    | [xbow.com/blog/benchmarks](https://xbow.com/blog/benchmarks) |
-|  6 | **Cyber-AutoAgent** (westonbrown)    | **84.62 %** (88 / 104) — v0.1.3 [archived]; 81 % v0.1.1; 45.92 % (45/98) v0.1.0 | black-box, meta-agent | [github](https://github.com/westonbrown/Cyber-AutoAgent) |
-|  7 | **MAPTA**                            | **76.9 %** (80 / 104)   | black-box, multi-agent    | arXiv [2508.20816](https://arxiv.org/abs/2508.20816) |
-|  8 | **Decepticon** *(this repo)*         | **98.08 %** (102 / 104) — L1: 100 % (45/45) · L2: 98.0 % (50/51) · L3: 87.5 % (7/8) | **black-box**, LangGraph multi-agent | [github](https://github.com/PurpleAILAB/Decepticon) |
+|  **1** | **Decepticon** *(this repo)*     | **98.08 %** (102 / 104) — L1: 100 % (45/45) · L2: 98.0 % (50/51) · L3: 87.5 % (7/8) | **black-box**, LangGraph multi-agent | [github](https://github.com/PurpleAILAB/Decepticon) |
+|  2 | **Shannon Lite** (KeygraphHQ)        | **96.15 %** (100 / 104) | white-box, hint-removed   | [github](https://github.com/KeygraphHQ/shannon) |
+|  2 | **Strix** (usestrix)                 | **96.15 %** (100 / 104) [^strix] | black-box                 | [github](https://github.com/usestrix/strix) |
+|  4 | **PentestGPT** (USENIX '24)          | **86.5 %** (90 / 104)   | black-box                 | [github](https://github.com/GreyDGL/PentestGPT) · [paper](https://www.usenix.org/conference/usenixsecurity24/presentation/deng) |
+|  5 | **Red-MIRROR**                       | **86.0 %**              | black-box, multi-agent + RAG | arXiv [2603.27127](https://arxiv.org/abs/2603.27127) |
+|  6 | **XBOW** (commercial)                | **≈85 %**               | black-box, proprietary    | [xbow.com/blog/benchmarks](https://xbow.com/blog/benchmarks) |
+|  7 | **Cyber-AutoAgent** (westonbrown)    | **84.62 %** (88 / 104) — v0.1.3 [archived]; 81 % v0.1.1; 45.92 % (45/98) v0.1.0 | black-box, meta-agent | [github](https://github.com/westonbrown/Cyber-AutoAgent) |
+|  8 | **MAPTA**                            | **76.9 %** (80 / 104)   | black-box, multi-agent    | arXiv [2508.20816](https://arxiv.org/abs/2508.20816) |
 |  9 | PentestAgent                         | 50.0 % [^retest]        | black-box                 | arXiv 2411.05185; re-tested in Red-MIRROR |
 | 10 | AutoPT                               | 46.0 % [^retest]        | black-box                 | re-tested in Red-MIRROR |
 | 11 | VulnBot                              |  6.0 % [^retest]        | black-box, baseline       | arXiv [2501.13411](https://arxiv.org/abs/2501.13411); re-tested in Red-MIRROR |
 
 > Shannon's 96.15 % is **white-box, hint-removed** — not directly comparable to black-box numbers.
 
-[^strix]: Strix per-difficulty (45/45 · 49/51 · 6/8 = 100/104 = 96.15 %) sourced from project's published benchmark table; we could not independently re-confirm the per-difficulty split from a primary indexed source — treat the per-level split as project-reported.
+[^strix]: Strix per-difficulty (45/45 · 49/51 · 6/8 = 100/104 = 96.15 %) sourced from the [`usestrix/benchmarks` XBEN page](https://github.com/usestrix/benchmarks/tree/main/XBEN) (v0.4.0; avg solve time ~19 min; ~$337 total) and re-confirmed against the project's published benchmark table.
+[^strix-method]: Strix's [`XBEN/run_infer.py`](https://github.com/usestrix/benchmarks/blob/main/XBEN/run_infer.py) builds the instruction as `"You are an expert CTF player. Your goal is to find a flag in the format flag{...}. ... {description}"` — only the `description` field from `benchmark.json` is concatenated into the prompt; the `tags` field is recorded in the result but not passed to the agent.
 [^retest]: 50 % / 46 % / 6 % numbers come from the **Red-MIRROR ablation** re-running these systems on XBOW, not from the systems' own papers (VulnBot's own paper uses AutoPenBench).
 
 ## Per-Difficulty (where published)


### PR DESCRIPTION
## Three asks rolled together

### 1. Leaderboard ordering
Decepticon (98.08 %) now ranks above Shannon Lite and Strix (96.15 %) in `docs/benchmark-comparison.md`. Numbers were already correct; only the row order needed to reflect them.

### 2. Strix methodology — investigated and documented
Fetched [`usestrix/benchmarks/XBEN/run_infer.py`](https://github.com/usestrix/benchmarks/blob/main/XBEN/run_infer.py). The prompt Strix builds is:

> "You are an expert CTF player. Your goal is to find a flag in the format flag{...}. … {description}"

Only the per-challenge `description` from `benchmark.json` is concatenated into the prompt; the `tags` field is recorded in `result.json` but is NOT passed to the agent. Our agent (via `EngagementContextMiddleware`) receives **description + Vulnerability tags + flag format**, which is slightly more hint than Strix's description-only setup. The comparison doc now documents this difference instead of asserting parity. New footnote `[^strix-method]` cites the source line. The `[^strix]` footnote also updated with the canonical `usestrix/benchmarks` source URL.

### 3. README slim
Main-root `README.md` and `README_KO.md` benchmark sections renamed:
- `Benchmark Results` → `Benchmark`
- `벤치마크 결과` → `벤치마크`

Kept the hero donut chart + per-difficulty table + two follow-up links. Dropped the elevator-pitch sentence and the methodology paragraph; methodology now lives only in `benchmark/results/README.md` and `docs/benchmark-comparison.md` where the reader has clicked through for the detail.

## Files changed
- `README.md` (-4 lines)
- `README_KO.md` (-4 lines)
- `docs/benchmark-comparison.md` (+8 / -13 lines — row reorder + Strix footnote)