### PR TITLE
docs(benchmark): comparison-table source verification + Sources refresh

### DIFF
--- a/docs/benchmark-comparison.md
+++ b/docs/benchmark-comparison.md
@@ -75,11 +75,14 @@ XBOW commercial does not publish a per-difficulty breakdown for its own agent �
 
 ## Sources
 
-- XBOW corp — [top-1 blog](https://xbow.com/blog/top-1-how-xbow-did-it) · [1060 attacks](https://xbow.com/blog/we-ran-1060-autonomous-attacks)
-- Shannon — [`xben-benchmark-results/`](https://github.com/KeygraphHQ/shannon/tree/main/xben-benchmark-results)
-- Cyber-AutoAgent — [v0.1.0 results](https://github.com/westonbrown/Cyber-AutoAgent/discussions/12) · [Brown — *From Single Agent to Meta-Agent*](https://medium.com/data-science-collective/from-single-agent-to-meta-agent-building-the-leading-open-source-autonomous-cyber-agent-e1b704f81707)
-- PentestGPT XBOW suite — [DeepWiki](https://deepwiki.com/GreyDGL/PentestGPT/5.1-xbow-validation-suite)
+- XBOW corp — [top-1 blog](https://xbow.com/blog/top-1-how-xbow-did-it) · [1060 attacks](https://xbow.com/blog/we-ran-1060-autonomous-attacks) · [benchmarks page](https://xbow.com/blog/benchmarks)
+- Shannon — [`xben-benchmark-results/`](https://github.com/KeygraphHQ/xbow-validation-benchmarks/tree/main/xben-benchmark-results) (lives in the project's fork of `xbow-validation-benchmarks`, not in the `KeygraphHQ/shannon` repo)
+- Strix — [`usestrix/benchmarks` XBEN](https://github.com/usestrix/benchmarks/tree/main/XBEN) (v0.4.0 results, `run_infer.py` evaluation script, per-difficulty 45/45 · 49/51 · 6/8 = 100/104, avg ~19 min / ~$337 total)
+- Cyber-AutoAgent — [v0.1.0 results](https://github.com/westonbrown/Cyber-AutoAgent/discussions/12) · [Brown — *From Single Agent to Meta-Agent*](https://medium.com/data-science-collective/from-single-agent-to-meta-agent-building-the-leading-open-source-autonomous-cyber-agent-e1b704f81707) (v0.1.1 ≈81 % on 104; v0.1.0 45.92 % on 98)
+- PentestGPT XBOW suite — [DeepWiki](https://deepwiki.com/GreyDGL/PentestGPT/5.1-xbow-validation-suite) (90/104 = 86.5 %; L1 42/46 · L2 43/50 · L3 5/8)
+- MAPTA — [arXiv 2508.20816](https://arxiv.org/abs/2508.20816) (80/104 = 76.9 %)
+- Red-MIRROR — [arXiv 2603.27127](https://arxiv.org/abs/2603.27127) (86.0 %; PentestAgent 50 %, AutoPT 46 %, VulnBot 6 % numbers also come from this paper's re-test of those systems)
 - Survey — [*AI Pentesting Agents 2026*](https://appsecsanta.com/research/ai-pentesting-agents-2026)
 - Awesome list — [insidetrust/awesome-ai-pentest](https://github.com/insidetrust/awesome-ai-pentest)
 
-> *Last updated: 2026-05-16.*
+> *Last updated: 2026-05-17.*


### PR DESCRIPTION
Cross-checked every entry in `docs/benchmark-comparison.md` against primary sources.

## Verified (scores all match)

| System | Score | Primary source |
|---|---|---|
| Shannon Lite | 96.15 % (100/104), white-box hint-removed | [KeygraphHQ/xbow-validation-benchmarks/xben-benchmark-results](https://github.com/KeygraphHQ/xbow-validation-benchmarks/tree/main/xben-benchmark-results) |
| Strix v0.4.0 | 96.15 % (100/104) — L1 45/45 · L2 49/51 · L3 6/8 | [usestrix/benchmarks/XBEN](https://github.com/usestrix/benchmarks/tree/main/XBEN) |
| PentestGPT | 90/104 (86.5 %); L1 42/46 · L2 43/50 · L3 5/8 | [DeepWiki](https://deepwiki.com/GreyDGL/PentestGPT/5.1-xbow-validation-suite) |
| MAPTA | 80/104 (76.9 %); per-class SSRF/Misconfig 100 %, IDOR/SQLi 83 %, SSTI 85 %, XSS 57 %, Blind SQLi 0 % | [arXiv 2508.20816](https://arxiv.org/abs/2508.20816) |
| Red-MIRROR | 86.0 %; PentestAgent 50 % / AutoPT 46 % / VulnBot 6 % numbers come from this paper's re-test | [arXiv 2603.27127](https://arxiv.org/abs/2603.27127) |
| Cyber-AutoAgent | v0.1.0 45.92 % (45/98); v0.1.1 ≈81 %; v0.1.3 84.62 % (88/104) | [v0.1.0 discussion](https://github.com/westonbrown/Cyber-AutoAgent/discussions/12) · [Medium post](https://medium.com/data-science-collective/from-single-agent-to-meta-agent-building-the-leading-open-source-autonomous-cyber-agent-e1b704f81707) |
| XBOW commercial | ≈85 % | [xbow.com/blog/benchmarks](https://xbow.com/blog/benchmarks) |

## Fixes

- **Shannon URL** — old link `github.com/KeygraphHQ/shannon/tree/main/xben-benchmark-results/` 404'd. Replaced with the actual location at the project's fork `KeygraphHQ/xbow-validation-benchmarks/tree/main/xben-benchmark-results/`.
- **Sources section** — every system now has an explicit citation with the verified numbers in parentheses, so future readers can spot drift quickly.
- Added the canonical Strix source entry (`usestrix/benchmarks`).
- Added per-source citations for MAPTA and Red-MIRROR arXiv IDs.
- `Last updated` → 2026-05-17.

## No score changes
Only URL fixes and citation completeness. The leaderboard table itself is unchanged from PR #234.