### PR TITLE
feat(sandbox): HTTPSandbox backend + FastAPI daemon for serverless deploys

### DIFF
--- a/containers/sandbox-entrypoint.sh
+++ b/containers/sandbox-entrypoint.sh
@@ -5,4 +5,18 @@
 chmod -R 777 /workspace 2>/dev/null || true
 # Ensure all NEW files are also world-readable/writable
 umask 0000
+
+# Optional HTTP daemon mode. When SANDBOX_DAEMON=1 the container drops
+# its tail-forever keep-alive and runs the FastAPI sandbox server
+# instead. Used by Cloud Run multi-container deploys where the agent
+# can't `docker exec` into a sibling container and instead talks to
+# this one over HTTP on localhost.
+#
+# Existing dev / local-docker / GCE Spot users don't set the env and
+# get the unchanged behaviour (`exec "$@"` falls through to the
+# Dockerfile CMD = tail -f /dev/null).
+if [ "${SANDBOX_DAEMON:-0}" = "1" ]; then
+    exec python3 -m decepticon.sandbox_server
+fi
+
 exec "$@"

--- a/containers/sandbox.Dockerfile
+++ b/containers/sandbox.Dockerfile
@@ -62,6 +62,44 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=sandbox-apt-cache
 # Configure tmux: 50K line scrollback buffer to prevent output truncation
 RUN echo "set-option -g history-limit 50000" > /root/.tmux.conf
 
+# Optional HTTP sandbox daemon — see decepticon/sandbox_server/.
+#
+# The daemon is OFF by default. The existing dev / local-docker / GCE
+# Spot deployments use this image as before (host docker daemon
+# `docker exec`s into the container; entrypoint just tails forever).
+# When `SANDBOX_DAEMON=1` is set at runtime — Cloud Run multi-container
+# deploys do this — the entrypoint replaces the tail loop with the
+# FastAPI server, and the agent container talks to it over HTTP
+# instead of `docker exec`.
+#
+# Only `fastapi` + `uvicorn` + `deepagents` are pulled in here; the
+# heavier decepticon agent / LLM / langgraph SDKs are deliberately
+# left out so the sandbox image doesn't bloat for the >95% of users
+# who never enable the daemon.
+RUN pip3 install --break-system-packages --no-cache-dir \
+    "fastapi>=0.115.0" \
+    "uvicorn>=0.30.0" \
+    "deepagents>=0.5.0"
+
+# Ship only the modules the daemon actually imports:
+#   - decepticon/__init__.py     — package marker (light-weight, just reads __version__)
+#   - decepticon/sandbox_kernel/ — shared sandbox primitives: TmuxSessionManager,
+#                                  BackgroundJobTracker, SandboxBase, and DaemonSandbox.
+#                                  The daemon instantiates `DaemonSandbox` (exec_prefix=[],
+#                                  pathlib upload/download) — no `docker exec`, no
+#                                  agent-side transport, so the sandbox image stays
+#                                  free of the `backends/` package on purpose.
+#   - decepticon/sandbox_server/ — the FastAPI app + uvicorn entry point.
+# `backends/` (DockerSandbox + HTTPSandbox + factory) is deliberately
+# absent — that's agent-side code, lives in the langgraph image. Other
+# subtrees (agents / llm / middleware / tools / core) are left out too
+# so the sandbox image doesn't bloat for the >95% of users who never
+# enable the daemon and so the dependency surface stays minimal.
+COPY decepticon/__init__.py /opt/decepticon/__init__.py
+COPY decepticon/sandbox_kernel /opt/decepticon/sandbox_kernel
+COPY decepticon/sandbox_server /opt/decepticon/sandbox_server
+ENV PYTHONPATH=/opt
+
 # Working directory for the agent's virtual filesystem.
 # Runs as root — security boundary is the container, not the user.
 # Root access is required for raw sockets (nmap SYN scans), packet capture,

--- a/decepticon/agents/decepticon.py
+++ b/decepticon/agents/decepticon.py
@@ -46,7 +46,7 @@ from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
 from decepticon.agents._benchmark_mode import benchmark_skill_sources
 from decepticon.agents.prompts import load_prompt
-from decepticon.backends import DockerSandbox
+from decepticon.backends import build_sandbox_backend
 from decepticon.core.config import load_config
 from decepticon.core.subagent_streaming import StreamingRunnable
 from decepticon.llm import LLMFactory
@@ -74,12 +74,12 @@ def create_decepticon_agent():
     llm = factory.get_model("decepticon")
     fallback_models = factory.get_fallback_models("decepticon")
 
-    # DockerSandbox here only backs FilesystemMiddleware (read/write
-    # engagement docs). The orchestrator has tools=[], so the bash module's
-    # global _sandbox is set by sub-agent factories when they execute.
-    sandbox = DockerSandbox(
-        container_name=config.docker.sandbox_container_name,
-    )
+    # Filesystem backend for the orchestrator. The orchestrator has
+    # tools=[], so it never touches the bash module's global _sandbox —
+    # sub-agent factories set that for their own execution. Backend
+    # selection mirrors Soundwave: DockerSandbox by default, HTTPSandbox
+    # when DECEPTICON_FILESYSTEM_BACKEND=http (see backends/factory.py).
+    sandbox = build_sandbox_backend(config.docker.sandbox_container_name)
 
     system_prompt = load_prompt("decepticon")
 

--- a/decepticon/agents/soundwave.py
+++ b/decepticon/agents/soundwave.py
@@ -29,7 +29,7 @@ from langchain.agents.middleware import ModelFallbackMiddleware
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
 from decepticon.agents.prompts import load_prompt
-from decepticon.backends import DockerSandbox
+from decepticon.backends import build_sandbox_backend
 from decepticon.core.config import load_config
 from decepticon.llm import LLMFactory
 from decepticon.middleware import EngagementContextMiddleware, FilesystemMiddleware
@@ -52,10 +52,11 @@ def create_soundwave_agent():
     llm = factory.get_model("soundwave")
     fallback_models = factory.get_fallback_models("soundwave")
 
-    # DockerSandbox as shared filesystem — other agents read soundwave output here
-    sandbox = DockerSandbox(
-        container_name=config.docker.sandbox_container_name,
-    )
+    # Filesystem backend — DockerSandbox by default (dev / per-engagement
+    # VM), HTTPSandbox when DECEPTICON_FILESYSTEM_BACKEND=http (Cloud Run
+    # multi-container deploys where there's no host docker daemon). See
+    # decepticon/backends/factory.py for the env contract.
+    sandbox = build_sandbox_backend(config.docker.sandbox_container_name)
 
     system_prompt = load_prompt("soundwave")
     # Skills + workspace both live inside the sandbox (skills bind-mounted at /skills/).

--- a/decepticon/backends/__init__.py
+++ b/decepticon/backends/__init__.py
@@ -1,6 +1,10 @@
 from .docker_sandbox import DockerSandbox, check_sandbox_running
+from .factory import build_sandbox_backend
+from .http_sandbox import HTTPSandbox
 
 __all__ = [
     "DockerSandbox",
+    "HTTPSandbox",
+    "build_sandbox_backend",
     "check_sandbox_running",
 ]

--- a/decepticon/backends/docker_sandbox.py
+++ b/decepticon/backends/docker_sandbox.py
@@ -1,39 +1,78 @@
-"""Docker sandbox backend for deepagents.
+"""Agent-side `BaseSandbox` backed by `docker exec` into a sibling container.
 
-Implements BaseSandbox using the Docker CLI, with tmux-based execution
-for persistent, interactive shell sessions (used by the bash tool).
+Everything except the `docker cp` file-transfer pair is delegated to
+``decepticon.sandbox_kernel.base.SandboxBase`` — the shared implementation
+class that holds the tmux session management, background-job tracking,
+log-offset diff, and the rest of the surface ``BaseSandbox`` consumers
+expect.
 
-Architecture:
-    DockerSandbox.execute()       → simple docker exec (used by BaseSandbox
-                                    file ops: ls, read, write, edit, grep, glob)
-    DockerSandbox.execute_tmux()  → tmux session-based (used by bash tool)
-                                    supports: session persistence, interactive input
+This split makes the sandbox image free of agent-side transport code:
+the daemon (``decepticon.sandbox_server``) imports ``LocalSandbox`` from
+``sandbox_kernel.local`` and never sees ``DockerSandbox``. The
+``backends/`` package stays an agent-only namespace, mirroring the
+pre-refactor boundary where the sandbox image shipped zero decepticon
+Python and the langgraph image owned the docker client surface.
+
+Public re-exports
+-----------------
+The old (pre-refactor) public surface — ``TmuxSessionManager``,
+``BackgroundJob``, ``BackgroundJobTracker``, ``PS1_PATTERN``, etc. —
+is re-exported here so existing imports
+``from decepticon.backends.docker_sandbox import TmuxSessionManager``
+(tests, bash tool, OPPLAN middleware) keep working without churn.
 """
 
 from __future__ import annotations
 
-import asyncio
-import dataclasses
 import functools
-import hashlib
 import io
 import logging
 import os
-import re
 import subprocess
 import tarfile
 import tempfile
 import threading
-import time
-from collections.abc import Callable
 from typing import ClassVar
 
 from deepagents.backends.protocol import (
-    ExecuteResponse,
     FileDownloadResponse,
     FileUploadResponse,
 )
-from deepagents.backends.sandbox import BaseSandbox
+
+from decepticon.sandbox_kernel import (
+    AUTO_BACKGROUND_SECONDS,
+    MAX_OUTPUT_CHARS,
+    POLL_INTERVAL,
+    PS1_PATTERN,
+    SIZE_WATCHDOG_CHARS,
+    SIZE_WATCHDOG_INTERVAL,
+    STALL_SECONDS,
+    BackgroundJob,
+    BackgroundJobTracker,
+    TmuxCommandError,
+    TmuxSessionManager,
+)
+from decepticon.sandbox_kernel.base import SandboxBase
+
+# Private helpers — also moved to sandbox_kernel.tmux but re-exported
+# here because the existing test suite imports them directly from this
+# module. Keeps the test surface stable across the refactor.
+
+__all__ = [
+    "AUTO_BACKGROUND_SECONDS",
+    "BackgroundJob",
+    "BackgroundJobTracker",
+    "DockerSandbox",
+    "MAX_OUTPUT_CHARS",
+    "POLL_INTERVAL",
+    "PS1_PATTERN",
+    "SIZE_WATCHDOG_CHARS",
+    "SIZE_WATCHDOG_INTERVAL",
+    "STALL_SECONDS",
+    "TmuxCommandError",
+    "TmuxSessionManager",
+    "check_sandbox_running",
+]
 
 log = logging.getLogger("decepticon.backends.docker_sandbox")
 
@@ -46,795 +85,18 @@ def _docker_cfg():
     return load_config().docker
 
 
-# ─── Tunable timing constants (patched in tests) ────────────────────────
-
-PS1_PATTERN = re.compile(r"\[DCPTN:(\d+):(.+?)\]")
-
-POLL_INTERVAL: float = 0.5
-STALL_SECONDS: float = 3.0
-MAX_OUTPUT_CHARS: int = 30_000
-AUTO_BACKGROUND_SECONDS: float = 60.0
-SIZE_WATCHDOG_CHARS: int = 5_000_000
-SIZE_WATCHDOG_INTERVAL: float = 5.0
-
-
-class TmuxCommandError(RuntimeError):
-    """Raised when a tmux command fails inside the sandbox container."""
-
-    def __init__(self, args: list[str], returncode: int, output: str) -> None:
-        self.args_list = args
-        self.returncode = returncode
-        self.output = output
-        super().__init__(output)
-
-
-# ─── Semantic exit code interpretation (Claude Code best practice) ────────
-_EXIT_CODE_MESSAGES: dict[int, str] = {
-    1: "general error",
-    2: "misuse of shell builtin",
-    126: "permission denied (not executable)",
-    127: "command not found — tool may not be installed (try: apt-get install -y <pkg>)",
-    128: "invalid exit argument",
-    130: "interrupted by Ctrl+C (SIGINT)",
-    137: "killed (SIGKILL) — likely OOM or size limit exceeded",
-    139: "segmentation fault (SIGSEGV)",
-    143: "terminated (SIGTERM)",
-}
-
-
-def _interpret_exit_code(code: int) -> str:
-    """Convert exit code to human-readable message for agent context."""
-    if code == 0:
-        return ""
-    if code in _EXIT_CODE_MESSAGES:
-        return f" — {_EXIT_CODE_MESSAGES[code]}"
-    if code > 128:
-        signal_num = code - 128
-        return f" — killed by signal {signal_num}"
-    return ""
-
-
-# ─── TmuxSessionManager ───────────────────────────────────────────────────
-
-
-class TmuxSessionManager:
-    """Manages a single named tmux session inside the Docker container.
-
-    Transplanted from tools/bash/tool.py; docker exec calls now go directly
-    through subprocess instead of the old run_in_sandbox() helper.
-
-    Thread-safety: ``_initialized`` is process-wide shared state. The
-    ``_init_lock`` (threading.RLock) guards add/discard/clear so concurrent
-    sessions cannot race during init or cache invalidation.
-    """
-
-    _initialized: set[str] = set()
-    _init_lock: threading.RLock = threading.RLock()
-
-    def __init__(
-        self,
-        session: str,
-        container_name: str,
-        workspace_path: str = "/workspace",
-        log_name: str | None = None,
-    ) -> None:
-        self.session = session
-        self._container = container_name
-        self._workspace_path = workspace_path.rstrip("/") or "/workspace"
-        self._log_name = log_name or session
-        self._pane_id: str | None = None
-
-    # ── docker / tmux helpers ──
-
-    def _docker_tmux(self, args: list[str], timeout: int = 10) -> str:
-        """Run a tmux subcommand inside the container."""
-        result = subprocess.run(
-            ["docker", "exec", self._container, "tmux", "-L", self.session] + args,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            encoding="utf-8",
-            errors="replace",
-        )
-        if result.returncode != 0:
-            error_msg = result.stderr or result.stdout
-            raise TmuxCommandError(args, result.returncode, error_msg)
-        return result.stdout
-
-    def _target(self) -> str:
-        """Return the stable tmux target for command dispatch."""
-        return self.session
-
-    def _forget_cached_state(self) -> None:
-        self._pane_id = None
-        with TmuxSessionManager._init_lock:
-            TmuxSessionManager._initialized.discard(self.session)
-
-    def _resolve_pane_id(self) -> str:
-        try:
-            return self._docker_tmux(
-                ["display-message", "-p", "-t", self.session, "#{pane_id}"],
-                timeout=5,
-            ).strip()
-        except subprocess.TimeoutExpired:
-            self._forget_cached_state()
-            time.sleep(1.0)
-            return self._docker_tmux(
-                ["display-message", "-p", "-t", self.session, "#{pane_id}"],
-                timeout=10,
-            ).strip()
-
-    def _cached_pane_is_alive(self) -> bool:
-        if self.session not in TmuxSessionManager._initialized:
-            return False
-        if self._pane_id is None:
-            try:
-                self._pane_id = self._resolve_pane_id()
-            except (RuntimeError, subprocess.TimeoutExpired):
-                self._forget_cached_state()
-                return False
-        try:
-            self._docker_tmux(
-                ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
-                timeout=5,
-            )
-            return True
-        except subprocess.TimeoutExpired:
-            self._forget_cached_state()
-            time.sleep(1.0)
-            try:
-                self._docker_tmux(
-                    ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
-                    timeout=10,
-                )
-                return True
-            except (subprocess.TimeoutExpired, RuntimeError):
-                raise TmuxCommandError(
-                    ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
-                    -1,
-                    "tmux pane probe timed out after retry — sandbox infra fault",
-                )
-        except RuntimeError:
-            return False
-
-    def _send(self, text: str, enter: bool = True) -> None:
-        """Send keystrokes using -l (literal) to prevent tmux escaping bugs."""
-        target = self._target()
-        self._docker_tmux(["send-keys", "-t", target, "-l", text])
-        if enter:
-            self._docker_tmux(["send-keys", "-t", target, "Enter"])
-
-    def _clear_screen(self) -> None:
-        target = self._target()
-        try:
-            self._docker_tmux(["send-keys", "-t", target, "C-l"])
-            time.sleep(0.1)
-            self._docker_tmux(["clear-history", "-t", target])
-        except (TmuxCommandError, subprocess.TimeoutExpired, OSError) as e:
-            log.warning("_clear_screen failed for '%s': %s", target, e)
-
-    def _capture(self) -> str:
-        return self._docker_tmux(
-            [
-                "capture-pane",
-                "-J",
-                "-p",
-                "-S",
-                "-",
-                "-E",
-                "-",
-                "-t",
-                self._target(),
-            ]
-        )
-
-    # ── session lifecycle ──
-
-    def initialize(self) -> None:
-        """Create session if needed and inject PS1 marker (once per session)."""
-        with TmuxSessionManager._init_lock:
-            if self._cached_pane_is_alive():
-                return
-            TmuxSessionManager._initialized.discard(self.session)
-            self._pane_id = None
-
-        session_exists = False
-        try:
-            self._docker_tmux(["has-session", "-t", self.session], timeout=5)
-            session_exists = True
-        except RuntimeError:
-            session_exists = False
-
-        if not session_exists:
-            log.info("Creating tmux session: %s", self.session)
-            try:
-                if self._workspace_path != "/workspace":
-                    subprocess.run(
-                        ["docker", "exec", self._container, "mkdir", "-p", self._workspace_path],
-                        capture_output=True,
-                        timeout=5,
-                        check=True,
-                    )
-                pane_id = self._docker_tmux(
-                    [
-                        "new-session",
-                        "-d",
-                        "-s",
-                        self.session,
-                        "-c",
-                        self._workspace_path,
-                        "-P",
-                        "-F",
-                        "#{pane_id}",
-                    ]
-                ).strip()
-                self._pane_id = pane_id or self.session
-            except RuntimeError:
-                try:
-                    self._docker_tmux(["has-session", "-t", self.session], timeout=5)
-                    self._pane_id = self._resolve_pane_id()
-                    session_exists = True
-                    log.debug("Session %s already exists (race), reusing", self.session)
-                except RuntimeError:
-                    raise
-            time.sleep(0.3)
-        else:
-            self._pane_id = self._resolve_pane_id()
-
-        # Inject PS1 marker + disable PS2 + clear screen
-        ps1_cmd = "export PROMPT_COMMAND='export PS1=\"[DCPTN:$?:$PWD] \"'; export PS2=''; clear"
-        self._send(ps1_cmd)
-        time.sleep(0.5)
-        self._clear_screen()
-        time.sleep(0.2)
-
-        if not session_exists and self._workspace_path != "/workspace":
-            log_path = f"{self._workspace_path}/.sessions/{self._log_name}.log"
-            try:
-                # Idempotent — the directory is bind-mounted to the host so
-                # operators can tail the same file the agent reads.
-                subprocess.run(
-                    [
-                        "docker",
-                        "exec",
-                        self._container,
-                        "mkdir",
-                        "-p",
-                        f"{self._workspace_path}/.sessions",
-                    ],
-                    capture_output=True,
-                    timeout=5,
-                    check=True,
-                )
-                self._docker_tmux(
-                    [
-                        "pipe-pane",
-                        "-t",
-                        self.session,
-                        "-o",
-                        f"cat >> {log_path}",
-                    ]
-                )
-            except Exception as e:
-                log.warning("pipe-pane setup failed for session '%s': %s", self.session, e)
-
-        with TmuxSessionManager._init_lock:
-            TmuxSessionManager._initialized.add(self.session)
-
-    # ── execution ──
-
-    def execute(
-        self,
-        command: str,
-        is_input: bool,
-        timeout: int,
-    ) -> str:
-        """Send a command/input and poll for PS1 completion marker.
-
-        Polls until the PS1 marker appears (command complete) or *timeout*
-        is reached.  If the tmux session is dead, attempts one automatic
-        recovery before returning an error.
-        """
-        if not is_input:
-            self.initialize()
-
-        try:
-            baseline = self._capture()
-        except RuntimeError as e:
-            log.warning("Session '%s' is not ready — attempting recovery: %s", self.session, e)
-            self._forget_cached_state()
-            try:
-                self.initialize()
-                baseline = self._capture()
-            except (RuntimeError, OSError, subprocess.TimeoutExpired) as retry_err:
-                return (
-                    f"[ERROR] Session recovery failed: {retry_err}\n"
-                    f"The tmux session was destroyed or docker is overloaded. "
-                    f"Try using a different session name."
-                )
-        except (OSError, subprocess.TimeoutExpired) as e:
-            return (
-                f"[ERROR] Sandbox capture failed: {e}\n"
-                f"docker exec timed out or the tmux session is hung. "
-                f'Retry, or terminate with bash_kill(session="{self.session}").'
-            )
-
-        initial_count = len(PS1_PATTERN.findall(baseline))
-
-        if command:
-            try:
-                if is_input:
-                    if command in ("C-c", "C-z", "C-d"):
-                        self._docker_tmux(["send-keys", "-t", self._target(), command])
-                    else:
-                        self._send(command, enter=True)
-                else:
-                    self._send(command, enter=True)
-            except RuntimeError as e:
-                return f"[ERROR] Could not send command to session '{self.session}': {e}"
-
-        start = time.monotonic()
-        prev_screen = baseline
-        last_change_time = start
-
-        while time.monotonic() - start < timeout:
-            time.sleep(POLL_INTERVAL)
-            try:
-                screen = self._capture()
-            except RuntimeError as poll_err:
-                self._forget_cached_state()
-                return (
-                    f"[ERROR] tmux session '{self.session}' was destroyed mid-command: {poll_err}\n"
-                    f"The command likely killed the shell process (e.g. pkill bash).\n"
-                    f"Session will auto-recover on next bash() call."
-                )
-            except (OSError, subprocess.TimeoutExpired) as poll_err:
-                # docker exec stall — keep polling, do not let it trigger stall detection
-                log.debug("transient capture error in poll loop: %s", poll_err)
-                last_change_time = time.monotonic()
-                continue
-
-            current_count = len(PS1_PATTERN.findall(screen))
-
-            if current_count > initial_count:
-                output, exit_code, cwd = _extract_output(screen, command)
-                log.info("Command completed: exit=%s cwd=%s [%s]", exit_code, cwd, command[:50])
-                self._clear_screen()
-                result = _truncate(output).strip()
-                hint = _interpret_exit_code(exit_code)
-                if not result:
-                    result = f"[Command completed with no output. Exit code: {exit_code}{hint}]"
-                elif exit_code != 0:
-                    result += f"\n[Exit code: {exit_code}{hint}]"
-                if cwd:
-                    result += f"\n[cwd: {cwd}]"
-                return result
-
-            # Size watchdog: kill commands producing excessive output
-            if len(screen) > SIZE_WATCHDOG_CHARS:
-                log.warning(
-                    "Size watchdog triggered (%d chars) — killing session [%s]",
-                    len(screen),
-                    command[:50],
-                )
-                try:
-                    self._docker_tmux(["send-keys", "-t", self._target(), "C-c"])
-                except RuntimeError as interrupt_err:
-                    log.debug("Failed to interrupt oversized tmux command: %s", interrupt_err)
-                output = _extract_interactive_output(screen, baseline)
-                return (
-                    f"{_truncate(output).strip()}\n\n"
-                    f"[SIZE LIMIT] Output exceeded {SIZE_WATCHDOG_CHARS // 1_000_000}M chars. "
-                    f"Command interrupted.\n"
-                    f"Redirect output to a file: command > {self._workspace_path}/output.txt"
-                )
-
-            # Stall detection: if screen changed from baseline (program produced
-            # output) but hasn't changed for STALL_SECONDS, the program is likely
-            # waiting for input (interactive prompt like msf6>, sliver>).
-            if screen != prev_screen:
-                last_change_time = time.monotonic()
-                prev_screen = screen
-            elif screen != baseline and time.monotonic() - last_change_time >= STALL_SECONDS:
-                log.info(
-                    "Stall detected after %.1fs — interactive program [%s]",
-                    time.monotonic() - start,
-                    command[:50],
-                )
-                output = _extract_interactive_output(screen, baseline)
-                return (
-                    f"{_truncate(output).strip()}\n"
-                    f"[session: {self.session} — interactive, "
-                    f"send next command with is_input=True]"
-                )
-
-        # Full timeout — include screen capture
-        try:
-            final_screen = self._capture()
-        except (RuntimeError, OSError, subprocess.TimeoutExpired):
-            final_screen = ""
-        screen_tail = final_screen.strip().split("\n")[-20:]
-        screen_preview = "\n".join(screen_tail)
-
-        return (
-            f"[TIMEOUT] Command exceeded {timeout}s limit.\n"
-            f"Session '{self.session}' is still running. "
-            f'Send input with bash(command="<input>", is_input=True, session="{self.session}").\n'
-            f'Read partial output with bash_output(session="{self.session}").\n'
-            f"--- screen preview ---\n{screen_preview}"
-        )
-
-    async def execute_async(
-        self,
-        command: str,
-        is_input: bool,
-        timeout: int,
-        on_auto_background: Callable[[str, str], None] | None = None,
-    ) -> str:
-        """Async version of execute() — non-blocking subprocess + cancellable polling.
-
-        All subprocess calls are offloaded via asyncio.to_thread() to avoid blocking
-        the ASGI event loop. asyncio.sleep() between polls allows CancelledError
-        delivery when LangGraph cancels a run (Ctrl+C → cancelMany).
-
-        Args:
-            command: shell command to send (or empty / control sequence with is_input).
-            is_input: True when ``command`` is keystrokes for an already-running process.
-            timeout: max seconds to wait for command completion.
-            on_auto_background: optional callback ``(command, baseline) -> None`` invoked
-                exactly once when the auto-background threshold is crossed. ``baseline``
-                is the screen capture taken before the command was sent — callers use it
-                to derive a stable PS1-marker baseline (e.g. via PS1_PATTERN.findall).
-        """
-        if not is_input:
-            await asyncio.to_thread(self.initialize)
-
-        try:
-            baseline = await asyncio.to_thread(self._capture)
-        except RuntimeError as e:
-            log.warning("Session '%s' is not ready — attempting recovery: %s", self.session, e)
-            self._forget_cached_state()
-            try:
-                await asyncio.to_thread(self.initialize)
-                baseline = await asyncio.to_thread(self._capture)
-            except (RuntimeError, OSError, subprocess.TimeoutExpired) as retry_err:
-                return (
-                    f"[ERROR] Session recovery failed: {retry_err}\n"
-                    f"The tmux session was destroyed or docker is overloaded. "
-                    f"Try using a different session name."
-                )
-        except (OSError, subprocess.TimeoutExpired) as e:
-            return (
-                f"[ERROR] Sandbox capture failed: {e}\n"
-                f"docker exec timed out or the tmux session is hung. "
-                f'Retry, or terminate with bash_kill(session="{self.session}").'
-            )
-
-        initial_count = len(PS1_PATTERN.findall(baseline))
-
-        if command:
-            try:
-                if is_input:
-                    if command in ("C-c", "C-z", "C-d"):
-                        await asyncio.to_thread(
-                            self._docker_tmux, ["send-keys", "-t", self._target(), command]
-                        )
-                    else:
-                        await asyncio.to_thread(self._send, command, True)
-                else:
-                    await asyncio.to_thread(self._send, command, True)
-            except RuntimeError as e:
-                return f"[ERROR] Could not send command to session '{self.session}': {e}"
-
-        start = time.monotonic()
-        prev_screen = baseline
-        last_change_time = start
-
-        while time.monotonic() - start < timeout:
-            await asyncio.sleep(POLL_INTERVAL)  # CancelledError delivered here
-            try:
-                screen = await asyncio.to_thread(self._capture)
-            except RuntimeError as poll_err:
-                self._forget_cached_state()
-                return (
-                    f"[ERROR] tmux session '{self.session}' was destroyed mid-command: {poll_err}\n"
-                    f"The command likely killed the shell process (e.g. pkill bash).\n"
-                    f"Session will auto-recover on next bash() call."
-                )
-            except (OSError, subprocess.TimeoutExpired) as poll_err:
-                # docker exec stall — keep polling, do not let it trigger stall detection
-                log.debug("transient capture error in poll loop: %s", poll_err)
-                last_change_time = time.monotonic()
-                continue
-
-            current_count = len(PS1_PATTERN.findall(screen))
-
-            if current_count > initial_count:
-                output, exit_code, cwd = _extract_output(screen, command)
-                log.info("Command completed: exit=%s cwd=%s [%s]", exit_code, cwd, command[:50])
-                await asyncio.to_thread(self._clear_screen)
-                result = _truncate(output).strip()
-                hint = _interpret_exit_code(exit_code)
-                if not result:
-                    result = f"[Command completed with no output. Exit code: {exit_code}{hint}]"
-                elif exit_code != 0:
-                    result += f"\n[Exit code: {exit_code}{hint}]"
-                if cwd:
-                    result += f"\n[cwd: {cwd}]"
-                return result
-
-            # Size watchdog: kill commands producing excessive output
-            if len(screen) > SIZE_WATCHDOG_CHARS:
-                log.warning(
-                    "Size watchdog triggered (%d chars) — killing session [%s]",
-                    len(screen),
-                    command[:50],
-                )
-                try:
-                    await asyncio.to_thread(
-                        self._docker_tmux, ["send-keys", "-t", self._target(), "C-c"]
-                    )
-                except RuntimeError as interrupt_err:
-                    log.debug("Failed to interrupt oversized tmux command: %s", interrupt_err)
-                output = _extract_interactive_output(screen, baseline)
-                return (
-                    f"{_truncate(output).strip()}\n\n"
-                    f"[SIZE LIMIT] Output exceeded {SIZE_WATCHDOG_CHARS // 1_000_000}M chars. "
-                    f"Command interrupted.\n"
-                    f"Redirect output to a file: command > /workspace/output.txt"
-                )
-
-            # Auto-background: convert blocking commands after threshold
-            elapsed = time.monotonic() - start
-            if elapsed >= AUTO_BACKGROUND_SECONDS and command:
-                log.info(
-                    "Auto-backgrounding after %.0fs [%s] in session '%s'",
-                    elapsed,
-                    command[:50],
-                    self.session,
-                )
-                if on_auto_background is not None:
-                    try:
-                        on_auto_background(command, baseline)
-                    except Exception:
-                        log.exception("auto-background callback failed")
-                output = _extract_interactive_output(screen, baseline)
-                preview = _truncate(output).strip()
-                return (
-                    f"[AUTO-BACKGROUND] Command running >{int(AUTO_BACKGROUND_SECONDS)}s "
-                    f"in session '{self.session}'.\n"
-                    f"--- partial output ---\n{preview[-1000:] if preview else '(no output yet)'}\n"
-                    f"--- end ---\n"
-                    f"You will be notified when it completes. Inspect early progress: "
-                    f'bash_output(session="{self.session}").'
-                )
-
-            # Stall detection (see sync execute() for rationale)
-            if screen != prev_screen:
-                last_change_time = time.monotonic()
-                prev_screen = screen
-            elif screen != baseline and time.monotonic() - last_change_time >= STALL_SECONDS:
-                log.info(
-                    "Stall detected after %.1fs — interactive program [%s]",
-                    time.monotonic() - start,
-                    command[:50],
-                )
-                output = _extract_interactive_output(screen, baseline)
-                return (
-                    f"{_truncate(output).strip()}\n"
-                    f"[session: {self.session} — interactive, "
-                    f"send next command with is_input=True]"
-                )
-
-        # Full timeout — include screen capture
-        try:
-            final_screen = await asyncio.to_thread(self._capture)
-        except (RuntimeError, OSError, subprocess.TimeoutExpired):
-            final_screen = ""
-        screen_tail = final_screen.strip().split("\n")[-20:]
-        screen_preview = "\n".join(screen_tail)
-
-        return (
-            f"[TIMEOUT] Command exceeded {timeout}s limit.\n"
-            f"Session '{self.session}' is still running. "
-            f'Send input with bash(command="<input>", is_input=True, session="{self.session}").\n'
-            f'Read partial output with bash_output(session="{self.session}").\n'
-            f"--- screen preview ---\n{screen_preview}"
-        )
-
-    def read_screen(self) -> str:
-        """Read current screen without sending any command."""
-        try:
-            self.initialize()
-            screen = self._capture()
-        except (RuntimeError, OSError, subprocess.TimeoutExpired) as e:
-            return (
-                f"[ERROR] Could not read screen for session '{self.session}': {e}\n"
-                f"The tmux session may be hung or docker is overloaded. "
-                f'Retry, or terminate the session with bash_kill(session="{self.session}").'
-            )
-        matches = list(PS1_PATTERN.finditer(screen))
-        if matches:
-            last = matches[-1]
-            exit_code = int(last.group(1))
-            cwd = last.group(2)
-            recent = screen[last.end() :].strip()
-            if recent:
-                return f"[RUNNING] cwd={cwd}\n{_truncate(recent)}"
-            return f"[IDLE] exit_code={exit_code} cwd={cwd}\nSession is ready for commands."
-        return f"[UNKNOWN]\n{screen[-2000:]}"
-
-
-# ─── Output helpers (transplanted from tools/bash/tool.py) ───────────────
-
-
-def _extract_interactive_output(screen: str, baseline: str) -> str:
-    """Extract new output from an interactive program (no PS1 marker).
-
-    Compares the current screen against the baseline to find new content
-    produced by the interactive program since the command was sent.
-    """
-    # Find the PS1 marker in the baseline — everything after it is new
-    matches = list(PS1_PATTERN.finditer(baseline))
-    if matches:
-        last = matches[-1]
-        new_content = screen[last.end() :].strip()
-        return new_content if new_content else screen.strip()
-    # No PS1 in baseline either — return the diff
-    baseline_lines = set(baseline.strip().split("\n"))
-    screen_lines = screen.strip().split("\n")
-    new_lines = [ln for ln in screen_lines if ln not in baseline_lines]
-    return "\n".join(new_lines) if new_lines else screen.strip()
-
-
-def _extract_output(screen: str, command: str) -> tuple[str, int, str]:
-    matches = list(PS1_PATTERN.finditer(screen))
-    if not matches:
-        return screen, -1, ""
-    last = matches[-1]
-    exit_code = int(last.group(1))
-    cwd = last.group(2)
-    if len(matches) >= 2:
-        raw = screen[matches[-2].end() : last.start()]
-    else:
-        raw = screen[: last.start()]
-    lines = raw.strip().split("\n")
-    if lines and command and lines[0].strip().endswith(command.strip()):
-        lines = lines[1:]
-    return "\n".join(lines).strip(), exit_code, cwd
-
-
-def _truncate(text: str) -> str:
-    """Truncate large outputs preserving head + tail for context efficiency.
-
-    Observation masking: large tool outputs are the #1 context consumer.
-    Keep the first and last portions (highest signal) and summarize the middle.
-    """
-    if len(text) <= MAX_OUTPUT_CHARS:
-        return text
-    # Asymmetric split: more head (often contains headers/structure) than tail
-    head_chars = int(MAX_OUTPUT_CHARS * 0.6)
-    tail_chars = MAX_OUTPUT_CHARS - head_chars
-    mid_text = text[head_chars:-tail_chars]
-    mid_lines = mid_text.count("\n")
-    mid_chars = len(mid_text)
-    return (
-        f"{text[:head_chars]}\n\n"
-        f"[... {mid_lines} lines / {mid_chars} chars truncated — "
-        "save full output to file with -oN or redirect to a workspace file "
-        f"to preserve complete results ...]\n\n"
-        f"{text[-tail_chars:]}"
-    )
-
-
-# ─── Background job tracking ─────────────────────────────────────────────
-
-
-@dataclasses.dataclass
-class BackgroundJob:
-    """Metadata for one background command in a tmux session.
-
-    A session holds at most one BackgroundJob — sequential reuse replaces.
-    Timestamps use ``time.monotonic()`` so elapsed values stay correct
-    across wall-clock adjustments (NTP step, manual ``date -s``).
-    """
-
-    session: str
-    key: str
-    command: str
-    initial_markers: int
-    started_at: float
-    workspace_path: str = "/workspace"
-    status: str = "running"  # running | done
-    exit_code: int | None = None
-    completed_at: float | None = None
-    consumed: bool = False
-
-    @property
-    def elapsed(self) -> float:
-        end = self.completed_at if self.completed_at is not None else time.monotonic()
-        return end - self.started_at
-
-
-class BackgroundJobTracker:
-    """In-memory background-job registry keyed by session name."""
-
-    def __init__(self) -> None:
-        self._jobs: dict[str, BackgroundJob] = {}
-        self._lock = threading.RLock()
-
-    def register(
-        self,
-        session: str,
-        command: str,
-        initial_markers: int,
-        key: str | None = None,
-        workspace_path: str = "/workspace",
-    ) -> BackgroundJob:
-        job_key = key or session
-        with self._lock:
-            job = BackgroundJob(
-                session=session,
-                key=job_key,
-                workspace_path=workspace_path,
-                command=command,
-                initial_markers=initial_markers,
-                started_at=time.monotonic(),
-            )
-            self._jobs[job_key] = job
-            return job
-
-    def get(self, session: str, key: str | None = None) -> BackgroundJob | None:
-        with self._lock:
-            return self._jobs.get(key or session)
-
-    def mark_complete(self, session: str, exit_code: int, key: str | None = None) -> None:
-        with self._lock:
-            job = self._jobs.get(key or session)
-            if job is None or job.status != "running":
-                return
-            job.status = "done"
-            job.exit_code = exit_code
-            job.completed_at = time.monotonic()
-
-    def mark_consumed(self, session: str, key: str | None = None) -> None:
-        with self._lock:
-            job = self._jobs.get(key or session)
-            if job is not None:
-                job.consumed = True
-
-    def pending_completions(self) -> list[BackgroundJob]:
-        with self._lock:
-            return [j for j in self._jobs.values() if j.status == "done" and not j.consumed]
-
-    def all_jobs(self) -> list[BackgroundJob]:
-        with self._lock:
-            return list(self._jobs.values())
-
-    def remove(self, session: str, key: str | None = None) -> None:
-        with self._lock:
-            self._jobs.pop(key or session, None)
-
-
-# ─── DockerSandbox ────────────────────────────────────────────────────────
-
-
-class DockerSandbox(BaseSandbox):
-    """deepagents BaseSandbox backed by a running Docker container.
-
-    File operations (ls, read, write, edit, grep, glob) are handled by
-    BaseSandbox, which delegates them to execute() — simple, non-interactive
-    docker exec calls sufficient for atomic file ops.
-
-    The bash tool uses execute_tmux() for persistent tmux sessions that
-    support interactive input.
-
-    ``_jobs`` and ``_log_offsets`` are class-level so every agent factory
-    in a process talks to the same background-job tracker — the bash tool
-    (which reads a module-global ``_sandbox`` set by whichever factory ran
-    last) and the SandboxNotificationMiddleware (bound to a different
-    instance per agent) would otherwise see disjoint trackers and
-    completion notifications would never fire.
+class DockerSandbox(SandboxBase):
+    """Agent-side sandbox: shells into a sibling container via ``docker exec``.
+
+    The bulk of the behaviour lives in :class:`SandboxBase`; this class
+    just supplies the docker-specific file-transfer pair (``upload_files``
+    via ``docker cp``, ``download_files`` via ``docker cp -``) and the
+    standard ``docker exec`` command prefix.
+
+    Each subclass redeclares its own ``_jobs`` and ``_log_offsets``
+    ClassVars so SandboxNotificationMiddleware's
+    ``getattr(sandbox, "_jobs")`` lookup pulls the subclass-specific
+    tracker rather than a shared base singleton.
     """
 
     _jobs: ClassVar[BackgroundJobTracker] = BackgroundJobTracker()
@@ -846,111 +108,19 @@ class DockerSandbox(BaseSandbox):
         container_name: str = "decepticon-sandbox",
         default_timeout: int = 120,
         workspace_path: str = "/workspace",
+        exec_prefix: list[str] | None = None,
     ) -> None:
-        self._container_name = container_name
-        self._default_timeout = default_timeout
-        self._workspace_path = self._normalize_workspace_path(workspace_path)
-        self._managers: dict[str, TmuxSessionManager] = {}
-        self._managers_lock = threading.RLock()
-
-    @staticmethod
-    def _normalize_workspace_path(workspace_path: str | None) -> str:
-        path = (workspace_path or "/workspace").strip()
-        if path == "/workspace":
-            return path
-        if not path.startswith("/workspace/"):
-            return "/workspace"
-        path = path.rstrip("/")
-        components = path[len("/workspace/") :].split("/")
-        if any(not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", component) for component in components):
-            return "/workspace"
-        return path
-
-    @staticmethod
-    def _workspace_slug(workspace_path: str) -> str:
-        path = DockerSandbox._normalize_workspace_path(workspace_path)
-        if path == "/workspace":
-            return "root"
-        digest = hashlib.sha1(path.encode("utf-8")).hexdigest()[:8]
-        slug = path.rsplit("/", 1)[-1] or "workspace"
-        safe_slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", slug).strip("-") or "workspace"
-        return f"{safe_slug}-{digest}"
-
-    def _workspace_key(self, workspace_path: str | None = None) -> str:
-        return self._workspace_slug(workspace_path or self._workspace_path)
-
-    def _manager_key(self, session: str, workspace_path: str) -> str:
-        if self._normalize_workspace_path(workspace_path) == "/workspace":
-            return session
-        return f"{self._workspace_key(workspace_path)}:{session}"
-
-    @staticmethod
-    def _tmux_session_name(session: str, workspace_path: str) -> str:
-        if DockerSandbox._normalize_workspace_path(workspace_path) == "/workspace":
-            return DockerSandbox._safe_session_name(session)
-        workspace_key = DockerSandbox._workspace_slug(workspace_path)
-        safe_session = DockerSandbox._safe_session_name(session)
-        return f"dcptn_{workspace_key}_{safe_session}"
-
-    @staticmethod
-    def _safe_session_name(session: str) -> str:
-        return re.sub(r"[^a-zA-Z0-9_.-]+", "-", session).strip("-") or "main"
-
-    def session_log_path(self, session: str, workspace_path: str | None = None) -> str:
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        return f"{effective_workspace}/.sessions/{self._safe_session_name(session)}.log"
-
-    def _get_manager(
-        self,
-        session: str,
-        workspace_path: str | None = None,
-    ) -> TmuxSessionManager:
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        key = self._manager_key(session, effective_workspace)
-        tmux_session = self._tmux_session_name(session, effective_workspace)
-        log_name = f"{self._safe_session_name(session)}"
-        with self._managers_lock:
-            if key not in self._managers:
-                self._managers[key] = TmuxSessionManager(
-                    tmux_session,
-                    self._container_name,
-                    workspace_path=effective_workspace,
-                    log_name=log_name,
-                )
-            return self._managers[key]
-
-    # ── BaseSandbox abstract methods ──────────────────────────────────────
-
-    @property
-    def id(self) -> str:
-        return self._container_name
-
-    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
-        """Simple docker exec — used by BaseSandbox for file operations."""
-        effective = timeout if timeout is not None else self._default_timeout
-        try:
-            result = subprocess.run(
-                ["docker", "exec", self._container_name, "sh", "-c", command],
-                capture_output=True,
-                text=True,
-                timeout=effective,
-                encoding="utf-8",
-                errors="replace",
-            )
-            output = result.stdout
-            if result.stderr and result.stderr.strip():
-                output += f"\n<stderr>{result.stderr.strip()}</stderr>"
-            return ExecuteResponse(
-                output=output,
-                exit_code=result.returncode,
-                truncated=False,
-            )
-        except subprocess.TimeoutExpired:
-            return ExecuteResponse(
-                output=f"Command timed out after {effective}s",
-                exit_code=124,
-                truncated=False,
-            )
+        # When None, fall back to the canonical `docker exec <ctn>` prefix;
+        # passing an explicit empty list flips this into "local mode" for
+        # tests that want to drive SandboxBase logic without a docker daemon.
+        super().__init__(
+            container_name=container_name,
+            default_timeout=default_timeout,
+            workspace_path=workspace_path,
+            exec_prefix=(
+                list(exec_prefix) if exec_prefix is not None else ["docker", "exec", container_name]
+            ),
+        )
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         responses: list[FileUploadResponse] = []
@@ -1000,187 +170,6 @@ class DockerSandbox(BaseSandbox):
                     FileDownloadResponse(path=path, content=None, error="file_not_found")
                 )
         return responses
-
-    def read_session_log_diff(self, session: str, workspace_path: str | None = None) -> str:
-        """Return new bytes appended to <workspace>/.sessions/<session>.log
-        since the previous call (or the whole file on first call).
-
-        Per-process offset tracking only — restart resets to 0 (safe fallback).
-        File truncation/rotation also resets to 0.
-        """
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        key = self._manager_key(session, effective_workspace)
-        log_path = self.session_log_path(session, effective_workspace)
-        results = self.download_files([log_path])
-        if not results or results[0].error or results[0].content is None:
-            return ""
-        full = results[0].content
-        with self._log_offsets_lock:
-            prev_offset = self._log_offsets.get(key, 0)
-            if prev_offset > len(full):
-                prev_offset = 0
-            new_bytes = full[prev_offset:]
-            self._log_offsets[key] = len(full)
-        return new_bytes.decode("utf-8", errors="replace")
-
-    def reset_session_log_offset(self, session: str, workspace_path: str | None = None) -> None:
-        """Forget the read offset (used after kill / GC)."""
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        key = self._manager_key(session, effective_workspace)
-        with self._log_offsets_lock:
-            self._log_offsets.pop(key, None)
-
-    # ── Tmux execution (for bash tool) ───────────────────────────────────
-
-    def execute_tmux(
-        self,
-        command: str = "",
-        session: str = "main",
-        timeout: int | None = None,
-        is_input: bool = False,
-        workspace_path: str | None = None,
-    ) -> str:
-        """Tmux-based execution with session persistence and interactive support.
-
-        Used exclusively by the bash tool. Supports:
-        - Named sessions for parallel command execution
-        - Interactive input (y/n, passwords, C-c / C-z / C-d)
-        - Output truncation for large outputs
-        """
-        effective = timeout if timeout is not None else self._default_timeout
-        mgr = self._get_manager(session, workspace_path)
-
-        if not command and not is_input:
-            return mgr.read_screen()
-
-        return mgr.execute(
-            command,
-            is_input=is_input,
-            timeout=effective,
-        )
-
-    async def execute_tmux_async(
-        self,
-        command: str = "",
-        session: str = "main",
-        timeout: int | None = None,
-        is_input: bool = False,
-        workspace_path: str | None = None,
-    ) -> str:
-        """Async tmux execution — cancellable via asyncio.CancelledError.
-
-        Used by the async bash tool so that LangGraph run cancellation
-        (Ctrl+C → cancelMany) interrupts the polling loop promptly.
-        """
-        effective = timeout if timeout is not None else self._default_timeout
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        job_key = self._manager_key(session, effective_workspace)
-        mgr = self._get_manager(session, effective_workspace)
-
-        if not command and not is_input:
-            return await asyncio.to_thread(mgr.read_screen)
-
-        def _on_auto_background(cmd: str, baseline: str) -> None:
-            self._jobs.register(
-                session,
-                command=cmd,
-                initial_markers=len(PS1_PATTERN.findall(baseline)),
-                key=job_key,
-                workspace_path=effective_workspace,
-            )
-
-        return await mgr.execute_async(
-            command,
-            is_input=is_input,
-            timeout=effective,
-            on_auto_background=_on_auto_background,
-        )
-
-    def start_background(
-        self,
-        command: str,
-        session: str = "main",
-        workspace_path: str | None = None,
-    ) -> None:
-        """Launch a command in a named tmux session without blocking.
-
-        Registers a BackgroundJob keyed by the PS1-marker count at launch;
-        ``poll_completion`` later compares against this baseline.
-        """
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        job_key = self._manager_key(session, effective_workspace)
-        mgr = self._get_manager(session, effective_workspace)
-        mgr.initialize()
-        baseline = mgr._capture()
-        initial_markers = len(PS1_PATTERN.findall(baseline))
-        self._jobs.register(
-            session,
-            command=command,
-            initial_markers=initial_markers,
-            key=job_key,
-            workspace_path=effective_workspace,
-        )
-        mgr._send(command, enter=True)
-
-    def poll_completion(
-        self,
-        session: str,
-        workspace_path: str | None = None,
-    ) -> "BackgroundJob | None":
-        """Check whether a background job has produced a new PS1 marker.
-
-        Updates the tracker in place; returns the job (or None if not tracked).
-        Capture failures are swallowed — the job stays running, retried later.
-        """
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        job_key = self._manager_key(session, effective_workspace)
-        job = self._jobs.get(session, key=job_key)
-        if job is None or job.status != "running":
-            return job
-        try:
-            mgr = self._get_manager(session, effective_workspace)
-            screen = mgr._capture()
-        except (RuntimeError, OSError, subprocess.TimeoutExpired):
-            return job
-        markers = list(PS1_PATTERN.finditer(screen))
-        if len(markers) > job.initial_markers:
-            try:
-                exit_code = int(markers[-1].group(1))
-            except ValueError:
-                exit_code = -1
-            self._jobs.mark_complete(session, exit_code=exit_code, key=job_key)
-        return job
-
-    def kill_session(self, session: str, workspace_path: str | None = None) -> None:
-        """Send Ctrl+C, then kill the tmux session, then clear all caches.
-
-        Best-effort: errors are logged, not raised. The pipe-pane log file
-        is preserved at <engagement>/.sessions/<session>.log for audit.
-        """
-        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
-        manager_key = self._manager_key(session, effective_workspace)
-        mgr: TmuxSessionManager | None = None
-        try:
-            mgr = self._get_manager(session, effective_workspace)
-            try:
-                mgr._docker_tmux(["send-keys", "-t", mgr.session, "C-c"])
-            except RuntimeError as e:
-                log.debug("send-keys C-c failed for '%s': %s", session, e)
-            try:
-                mgr._docker_tmux(["kill-session", "-t", mgr.session])
-            except RuntimeError as e:
-                log.warning("kill-session failed for '%s': %s", session, e)
-        finally:
-            with self._managers_lock:
-                self._managers.pop(manager_key, None)
-            if mgr is not None:
-                with TmuxSessionManager._init_lock:
-                    TmuxSessionManager._initialized.discard(mgr.session)
-            self.reset_session_log_offset(session, effective_workspace)
-            self._jobs.remove(session, key=manager_key)
-
-
-# ─── Pre-flight check ────────────────────────────────────────────────────
 
 
 def check_sandbox_running(container_name: str = "decepticon-sandbox") -> bool:

--- a/decepticon/backends/factory.py
+++ b/decepticon/backends/factory.py
@@ -1,0 +1,66 @@
+"""Backend factory — env-driven selection between DockerSandbox and HTTPSandbox.
+
+The agent code shouldn't know how it's deployed; it just asks for a backend.
+Today's call sites instantiate `DockerSandbox(container_name=...)` directly,
+which only works when there's a host docker daemon and a sibling sandbox
+container — perfect for dev / local-docker / GCE Spot VMs, broken on
+Cloud Run multi-container deployments where docker exec is impossible.
+
+`build_sandbox_backend()` lets the operator pick the transport via
+`DECEPTICON_FILESYSTEM_BACKEND`:
+
+  - ``docker`` (default): existing behaviour, no change for dev / silo plane.
+  - ``http``: HTTPSandbox talking to a sandbox daemon — used on Cloud Run
+    pool plane where the daemon runs as a sibling container reachable on
+    ``http://localhost:9999``.
+
+Pool-plane agents (Soundwave + the Decepticon orchestrator) use only file
+IO, which BaseSandbox derives from `execute()`. They are the agents that
+benefit from this factory. Silo-plane sub-agents (recon/exploit/...) call
+DockerSandbox's tmux/background-job extensions that aren't in
+BaseSandbox, so they should stay on `docker` for now.
+
+The factory is intentionally cheap to call — no caching, no validation
+beyond the env switch — so every agent factory can call it on instantiation
+without coordinating singletons.
+"""
+
+from __future__ import annotations
+
+import os
+
+from decepticon.backends.docker_sandbox import DockerSandbox
+from decepticon.backends.http_sandbox import HTTPSandbox
+
+
+def build_sandbox_backend(container_name: str):
+    """Build a sandbox backend appropriate for the current deploy target.
+
+    Args:
+        container_name: Name of the dev-/silo-plane sibling sandbox
+            container. Used by DockerSandbox to know which container to
+            ``docker exec`` into. Ignored by HTTPSandbox, which routes
+            via URL instead — but accepted in the signature so call
+            sites can pass it unconditionally.
+
+    Returns:
+        A `DockerSandbox` (default) or `HTTPSandbox` instance.
+
+    Env:
+        DECEPTICON_FILESYSTEM_BACKEND
+            ``docker`` (default) or ``http``. Anything else falls back
+            to ``docker`` so a typo doesn't silently route traffic
+            somewhere unexpected.
+        SAAS_SANDBOX_URL
+            HTTP-only. Base URL of the sandbox daemon. Default
+            ``http://localhost:9999`` (Cloud Run sibling loopback).
+        SAAS_SANDBOX_TOKEN
+            HTTP-only. Shared bearer token. Optional, but recommended
+            even on loopback as defence-in-depth.
+    """
+    kind = (os.environ.get("DECEPTICON_FILESYSTEM_BACKEND") or "docker").strip().lower()
+    if kind == "http":
+        base_url = os.environ.get("SAAS_SANDBOX_URL", "http://localhost:9999")
+        token = os.environ.get("SAAS_SANDBOX_TOKEN") or None
+        return HTTPSandbox(base_url=base_url, token=token)
+    return DockerSandbox(container_name=container_name)

--- a/decepticon/backends/http_sandbox.py
+++ b/decepticon/backends/http_sandbox.py
@@ -1,0 +1,380 @@
+"""HTTP-transport sandbox backend.
+
+`HTTPSandbox` is a `BaseSandbox` subclass that forwards every operation
+the agent needs — `execute`, `upload_files`, `download_files`,
+`execute_tmux`, `start_background`, `poll_completion`, `kill_session`,
+`read_session_log_diff`, `reset_session_log_offset`, `session_log_path` —
+to a remote sandbox daemon over HTTP. The peer is
+`decepticon.sandbox_server`, a FastAPI app that runs *inside* the
+sandbox container and wraps a `LocalSandbox` (a `SandboxBase`
+subclass with `docker exec` swapped for direct subprocess execution).
+
+Architecture
+------------
+The existing `DockerSandbox` shells `docker exec <container> ...` into a
+sibling sandbox container — great in dev where a docker daemon is
+available, untenable on serverless runtimes (Cloud Run, Fargate, etc.)
+that explicitly do not expose a host docker socket between sibling
+containers. `HTTPSandbox` keeps **every** semantic of the existing
+DockerSandbox + middleware stack — tmux session management, PS1 marker
+parsing, size watchdog, auto-background after 60s, session log diff —
+and only swaps the wire layer from `docker exec` to HTTP. The daemon
+side re-uses the exact same `TmuxSessionManager` class via the new
+`exec_prefix=[]` switch, so the agent gets bit-for-bit equivalent
+behaviour from the bash tool whether it's pointed at DockerSandbox
+(dev / GCE Spot) or HTTPSandbox (Cloud Run multi-container).
+
+Why HTTP and not SSH / gRPC: OpenHands explicitly deprecated SSH
+(Issue #2404) because sshd-in-every-image is untenable when users
+bring their own sandbox images. E2B, Modal, Daytona, SmolAgents,
+SWE-ReX all converged on REST. Cloud Run sibling-container loopback
+is HTTP/1.1-first; gRPC needs h2c; SSH needs key distribution + sshd.
+REST + SSE has the strongest container-runtime tool support and the
+lowest configuration burden.
+
+Class-level state
+-----------------
+`SandboxNotificationMiddleware` polls `sandbox._jobs.all_jobs()` to
+discover which background commands are still running and then calls
+`sandbox.poll_completion(...)` to refresh each one. To stay drop-in
+compatible with that middleware, `HTTPSandbox` exposes a class-level
+`BackgroundJobTracker` populated locally by `start_background` and
+refreshed by `poll_completion`. The tracker is a *mirror* — the source
+of truth still lives in the daemon's `LocalSandbox._jobs` — but
+the middleware doesn't need to know which side owns the registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import ClassVar
+
+import httpx
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+from deepagents.backends.sandbox import BaseSandbox
+
+from decepticon.sandbox_kernel import BackgroundJob, BackgroundJobTracker
+
+
+class HTTPSandbox(BaseSandbox):
+    """A `BaseSandbox` that talks to a `decepticon.sandbox_server` daemon.
+
+    The peer endpoint is a FastAPI service running inside the sandbox
+    container, typically reachable over Cloud Run's loopback interface
+    (`http://localhost:9999` by default) or any service-mesh address
+    when deployed on Kubernetes / Fargate / ECS / etc.
+
+    Args:
+        base_url: Daemon base URL, e.g. ``http://localhost:9999``. No
+            trailing slash required.
+        token: Optional shared-secret bearer token. When set, the daemon
+            requires every request to carry ``Authorization: Bearer
+            <token>``. The Cloud Run loopback path is not network-
+            reachable from outside the service, so this is defence-in-
+            depth rather than a primary authn mechanism — but it is
+            still strongly recommended.
+        timeout: Default request timeout in seconds. Per-call timeouts
+            on ``execute()`` / ``execute_tmux()`` override this for
+            long-running commands.
+    """
+
+    # Mirrors `DockerSandbox._jobs` so SandboxNotificationMiddleware can
+    # read backed-up background jobs via `sandbox._jobs.all_jobs()`. The
+    # registry is local — the actual job execution lives on the daemon
+    # side — but `start_background` + `poll_completion` keep the local
+    # mirror in sync with the daemon's view.
+    _jobs: ClassVar[BackgroundJobTracker] = BackgroundJobTracker()
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: str | None = None,
+        timeout: float = 120.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+        self._client: httpx.Client | None = None
+
+    @property
+    def id(self) -> str:
+        return f"http-sandbox:{self._base_url}"
+
+    # ── httpx client lifecycle ─────────────────────────────────────────
+    def _http(self) -> httpx.Client:
+        """Lazily create a connection-pooled HTTP client.
+
+        Sharing one `httpx.Client` across requests is the supported
+        pattern — it keeps the TCP connection pool warm so the per-call
+        overhead on a healthy loopback path stays in the microseconds
+        rather than reopening a socket per request.
+        """
+        if self._client is None:
+            headers = {"User-Agent": "decepticon-http-sandbox/1"}
+            if self._token:
+                headers["Authorization"] = f"Bearer {self._token}"
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                headers=headers,
+                timeout=self._timeout,
+            )
+        return self._client
+
+    def close(self) -> None:
+        """Best-effort cleanup. Safe to call multiple times."""
+        if self._client is not None:
+            try:
+                self._client.close()
+            finally:
+                self._client = None
+
+    # ── BaseSandbox abstract methods ───────────────────────────────────
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+    ) -> ExecuteResponse:
+        # The per-call request timeout is bumped above `timeout` so the
+        # remote has a moment to finish + return after its own command
+        # timeout fires. Without this margin, httpx would abort just as
+        # the remote was sending the truncated-but-valid response.
+        request_timeout = (timeout + 10) if timeout is not None else None
+        response = self._http().post(
+            "/execute",
+            json={"command": command, "timeout": timeout},
+            timeout=request_timeout if request_timeout is not None else self._timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return ExecuteResponse(
+            output=data["output"],
+            exit_code=data.get("exit_code"),
+            truncated=data.get("truncated", False),
+        )
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        payload = {
+            "files": [
+                {
+                    "path": path,
+                    "data_b64": base64.b64encode(data).decode("ascii"),
+                }
+                for path, data in files
+            ]
+        }
+        response = self._http().post("/upload_files", json=payload)
+        response.raise_for_status()
+        data = response.json()
+        return [
+            FileUploadResponse(path=item["path"], error=item.get("error")) for item in data["files"]
+        ]
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        response = self._http().post("/download_files", json={"paths": paths})
+        response.raise_for_status()
+        data = response.json()
+        out: list[FileDownloadResponse] = []
+        for item in data["files"]:
+            content_b64 = item.get("data_b64")
+            content = base64.b64decode(content_b64) if content_b64 else None
+            out.append(
+                FileDownloadResponse(
+                    path=item["path"],
+                    content=content,
+                    error=item.get("error"),
+                )
+            )
+        return out
+
+    # ── tmux / background surface — mirrors DockerSandbox ────────────────
+    # These are the methods the bash tool consumes via
+    # `decepticon/tools/bash/bash.py:_sandbox.execute_tmux_async(...)`
+    # etc. The HTTP transport adds <1ms of overhead on loopback compared
+    # to docker-exec; the tmux session state itself lives on the daemon
+    # side where TmuxSessionManager always lived.
+
+    def execute_tmux(
+        self,
+        command: str = "",
+        session: str = "main",
+        timeout: int | None = None,
+        is_input: bool = False,
+        workspace_path: str | None = None,
+    ) -> str:
+        """Run `command` in the named tmux session and return the output.
+
+        Mirrors `DockerSandbox.execute_tmux`. See that class for the full
+        protocol contract (PS1 markers, size watchdog, auto-background
+        after 60 s, output truncation at 30 K chars).
+        """
+        request_timeout = (timeout + 10) if timeout is not None else None
+        response = self._http().post(
+            "/execute_tmux",
+            json={
+                "command": command,
+                "session": session,
+                "timeout": timeout,
+                "is_input": is_input,
+                "workspace_path": workspace_path,
+            },
+            timeout=request_timeout if request_timeout is not None else self._timeout,
+        )
+        response.raise_for_status()
+        return response.json()["output"]
+
+    async def execute_tmux_async(
+        self,
+        command: str = "",
+        session: str = "main",
+        timeout: int | None = None,
+        is_input: bool = False,
+        workspace_path: str | None = None,
+        on_auto_background=None,
+    ) -> str:
+        """Async wrapper around `execute_tmux`.
+
+        DockerSandbox.execute_tmux_async is cancellable via
+        `asyncio.CancelledError` — when the supervisor's task() call gets
+        cancelled mid-run, the bash command is auto-backgrounded. We
+        approximate that here by running the sync call in a thread so
+        cancellation cleanly propagates through `httpx`'s timeout
+        machinery. The remote daemon's own auto-background timer
+        (`AUTO_BACKGROUND_SECONDS = 60 s`) still fires on its side, so
+        long-running commands are tracked as background jobs even if the
+        client disconnects.
+
+        `on_auto_background` is accepted for signature parity with
+        DockerSandbox but currently isn't invoked — the daemon already
+        records the background-job state itself, and `poll_completion`
+        on the next middleware tick surfaces it.
+        """
+        _ = on_auto_background  # signature parity; behaviour deferred
+        return await asyncio.to_thread(
+            self.execute_tmux,
+            command=command,
+            session=session,
+            timeout=timeout,
+            is_input=is_input,
+            workspace_path=workspace_path,
+        )
+
+    def start_background(
+        self,
+        command: str,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> None:
+        """Launch `command` in the background; register a local mirror job."""
+        response = self._http().post(
+            "/start_background",
+            json={
+                "command": command,
+                "session": session,
+                "workspace_path": workspace_path,
+            },
+        )
+        response.raise_for_status()
+        # The daemon owns the canonical BackgroundJob (it just stamped
+        # `initial_markers` from the live tmux pane state, which we
+        # don't have visibility into). Drop a provisional entry into
+        # the local mirror so SandboxNotificationMiddleware's
+        # iteration can find it; `poll_completion` will replace the
+        # stub's status / exit_code on the next refresh tick.
+        ws = workspace_path or "/workspace"
+        self._jobs.register(
+            session=session,
+            command=command,
+            initial_markers=0,
+            workspace_path=ws,
+        )
+
+    def poll_completion(
+        self,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> BackgroundJob | None:
+        """Return the latest BackgroundJob for `session` (None if missing)."""
+        response = self._http().post(
+            "/poll_completion",
+            json={"session": session, "workspace_path": workspace_path},
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data.get("job") is None:
+            return None
+        j = data["job"]
+        job = BackgroundJob(
+            session=j["session"],
+            key=j["key"],
+            command=j["command"],
+            initial_markers=j["initial_markers"],
+            started_at=j["started_at"],
+            workspace_path=j.get("workspace_path", "/workspace"),
+            status=j.get("status", "running"),
+            exit_code=j.get("exit_code"),
+            completed_at=j.get("completed_at"),
+            consumed=j.get("consumed", False),
+        )
+        # Keep the local mirror coherent enough for
+        # SandboxNotificationMiddleware: once the daemon reports the job
+        # is done, drop the mirror entry so subsequent `all_jobs()` polls
+        # don't keep re-emitting a stale notification. While running,
+        # leave the stub in place — its fields are slightly off (no
+        # initial_markers, stale started_at) but the middleware only
+        # uses it as a "key, please poll this" pointer.
+        if job.status != "running":
+            self._jobs.remove(session=job.session, key=job.key)
+        return job
+
+    def kill_session(
+        self,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> None:
+        response = self._http().post(
+            "/kill_session",
+            json={"session": session, "workspace_path": workspace_path},
+        )
+        response.raise_for_status()
+
+    def read_session_log_diff(
+        self,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> str:
+        response = self._http().post(
+            "/read_session_log_diff",
+            json={"session": session, "workspace_path": workspace_path},
+        )
+        response.raise_for_status()
+        return response.json()["diff"]
+
+    def reset_session_log_offset(
+        self,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> None:
+        response = self._http().post(
+            "/reset_session_log_offset",
+            json={"session": session, "workspace_path": workspace_path},
+        )
+        response.raise_for_status()
+
+    def session_log_path(
+        self,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> str:
+        response = self._http().post(
+            "/session_log_path",
+            json={"session": session, "workspace_path": workspace_path},
+        )
+        response.raise_for_status()
+        return response.json()["path"]

--- a/decepticon/sandbox_kernel/__init__.py
+++ b/decepticon/sandbox_kernel/__init__.py
@@ -1,0 +1,59 @@
+"""Shared sandbox kernel — utilities used by BOTH the agent-side transport
+backends and the in-container HTTP daemon.
+
+Layering: this package is the lowest layer of the sandbox stack. It
+contains the tmux session manager, the background-job tracker, and the
+docker-less ``DaemonSandbox`` class. Everything else hangs off of it:
+
+  ``decepticon.backends.docker_sandbox.DockerSandbox`` — agent-side,
+      uses ``docker exec`` as transport. Imports ``TmuxSessionManager``
+      from this package via the ``exec_prefix=["docker", "exec", ...]``
+      configuration knob.
+
+  ``decepticon.backends.http_sandbox.HTTPSandbox`` — agent-side,
+      uses HTTP as transport. Imports ``BackgroundJob`` and
+      ``BackgroundJobTracker`` from this package so the
+      ``SandboxNotificationMiddleware`` mirror pattern works
+      identically across the two backends.
+
+  ``decepticon.sandbox_server.app`` — sandbox-side, FastAPI daemon.
+      Imports ``DaemonSandbox`` from this package and exposes its
+      methods over HTTP.
+
+Why a separate package: the OSS sandbox container image is a *passive*
+container (Kali Linux + red-team tools + tmux); historically it shipped
+zero decepticon Python code. Adding the daemon to the same image
+required *some* in-container Python, but the agent-side transport
+classes (``DockerSandbox``, ``HTTPSandbox``, ``factory``) have no
+business inside the sandbox. Splitting the shared utilities out keeps
+the original "agent has everything, sandbox has nothing" boundary
+intact: the sandbox image now ships only ``sandbox_kernel`` + ``sandbox_server``,
+the agent (langgraph image) keeps ``backends`` + everything else.
+"""
+
+from decepticon.sandbox_kernel.jobs import BackgroundJob, BackgroundJobTracker
+from decepticon.sandbox_kernel.tmux import (
+    AUTO_BACKGROUND_SECONDS,
+    MAX_OUTPUT_CHARS,
+    POLL_INTERVAL,
+    PS1_PATTERN,
+    SIZE_WATCHDOG_CHARS,
+    SIZE_WATCHDOG_INTERVAL,
+    STALL_SECONDS,
+    TmuxCommandError,
+    TmuxSessionManager,
+)
+
+__all__ = [
+    "AUTO_BACKGROUND_SECONDS",
+    "BackgroundJob",
+    "BackgroundJobTracker",
+    "MAX_OUTPUT_CHARS",
+    "POLL_INTERVAL",
+    "PS1_PATTERN",
+    "SIZE_WATCHDOG_CHARS",
+    "SIZE_WATCHDOG_INTERVAL",
+    "STALL_SECONDS",
+    "TmuxCommandError",
+    "TmuxSessionManager",
+]

--- a/decepticon/sandbox_kernel/base.py
+++ b/decepticon/sandbox_kernel/base.py
@@ -1,0 +1,363 @@
+"""Shared sandbox implementation — used by both DockerSandbox
+(agent-side, ``docker exec`` transport) and LocalSandbox (sandbox-side,
+direct subprocess inside the daemon container).
+
+`SandboxBase` holds every method that is invariant across the two
+transports — tmux session management, workspace path normalization,
+background-job tracking, log-offset diff, `execute()` (which already
+uses `self._exec_prefix`), and the full tmux/background surface
+(`execute_tmux`, `start_background`, `poll_completion`, etc.). The two
+real backends below it implement just the file-transfer pair
+(`upload_files`, `download_files`) — the only thing whose mechanics
+genuinely differ between docker-exec (uses `docker cp`) and in-
+container local execution (uses pathlib).
+
+Class-level state (`_jobs`, `_log_offsets`) is intentionally redeclared
+on each concrete subclass so the SandboxNotificationMiddleware's
+`getattr(sandbox, "_jobs")` lookup pulls the subclass-specific tracker
+rather than a shared base singleton.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+import subprocess
+import threading
+from typing import ClassVar
+
+from deepagents.backends.protocol import ExecuteResponse
+from deepagents.backends.sandbox import BaseSandbox
+
+from decepticon.sandbox_kernel.jobs import BackgroundJob, BackgroundJobTracker
+from decepticon.sandbox_kernel.tmux import PS1_PATTERN, TmuxSessionManager, _safe_log
+
+log = logging.getLogger("decepticon.sandbox_kernel.base")
+
+
+class SandboxBase(BaseSandbox):
+    """deepagents BaseSandbox backed by a running Docker container.
+
+    File operations (ls, read, write, edit, grep, glob) are handled by
+    BaseSandbox, which delegates them to execute() — simple, non-interactive
+    docker exec calls sufficient for atomic file ops.
+
+    The bash tool uses execute_tmux() for persistent tmux sessions that
+    support interactive input.
+
+    ``_jobs`` and ``_log_offsets`` are class-level so every agent factory
+    in a process talks to the same background-job tracker — the bash tool
+    (which reads a module-global ``_sandbox`` set by whichever factory ran
+    last) and the SandboxNotificationMiddleware (bound to a different
+    instance per agent) would otherwise see disjoint trackers and
+    completion notifications would never fire.
+    """
+
+    _jobs: ClassVar[BackgroundJobTracker] = BackgroundJobTracker()
+    _log_offsets: ClassVar[dict[str, int]] = {}
+    _log_offsets_lock: ClassVar[threading.RLock] = threading.RLock()
+
+    def __init__(
+        self,
+        container_name: str = "decepticon-sandbox",
+        default_timeout: int = 120,
+        workspace_path: str = "/workspace",
+        exec_prefix: list[str] | None = None,
+    ) -> None:
+        self._container_name = container_name
+        self._default_timeout = default_timeout
+        self._workspace_path = self._normalize_workspace_path(workspace_path)
+        self._managers: dict[str, TmuxSessionManager] = {}
+        self._managers_lock = threading.RLock()
+        # When None: keep the default `docker exec <ctn>` prefix so
+        # nothing changes for existing callers. The HTTP sandbox daemon
+        # — which runs *inside* the sandbox container — passes
+        # `exec_prefix=[]` (or instantiates LocalSandbox) so the
+        # same tmux/exec/upload code path is reused without a nested
+        # docker daemon.
+        self._exec_prefix: list[str] = (
+            list(exec_prefix) if exec_prefix is not None else ["docker", "exec", container_name]
+        )
+
+    @staticmethod
+    def _normalize_workspace_path(workspace_path: str | None) -> str:
+        path = (workspace_path or "/workspace").strip()
+        if path == "/workspace":
+            return path
+        if not path.startswith("/workspace/"):
+            return "/workspace"
+        path = path.rstrip("/")
+        components = path[len("/workspace/") :].split("/")
+        if any(not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", component) for component in components):
+            return "/workspace"
+        return path
+
+    @staticmethod
+    def _workspace_slug(workspace_path: str) -> str:
+        path = SandboxBase._normalize_workspace_path(workspace_path)
+        if path == "/workspace":
+            return "root"
+        digest = hashlib.sha1(path.encode("utf-8")).hexdigest()[:8]
+        slug = path.rsplit("/", 1)[-1] or "workspace"
+        safe_slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", slug).strip("-") or "workspace"
+        return f"{safe_slug}-{digest}"
+
+    def _workspace_key(self, workspace_path: str | None = None) -> str:
+        return self._workspace_slug(workspace_path or self._workspace_path)
+
+    def _manager_key(self, session: str, workspace_path: str) -> str:
+        if self._normalize_workspace_path(workspace_path) == "/workspace":
+            return session
+        return f"{self._workspace_key(workspace_path)}:{session}"
+
+    @staticmethod
+    def _tmux_session_name(session: str, workspace_path: str) -> str:
+        if SandboxBase._normalize_workspace_path(workspace_path) == "/workspace":
+            return SandboxBase._safe_session_name(session)
+        workspace_key = SandboxBase._workspace_slug(workspace_path)
+        safe_session = SandboxBase._safe_session_name(session)
+        return f"dcptn_{workspace_key}_{safe_session}"
+
+    @staticmethod
+    def _safe_session_name(session: str) -> str:
+        return re.sub(r"[^a-zA-Z0-9_.-]+", "-", session).strip("-") or "main"
+
+    def session_log_path(self, session: str, workspace_path: str | None = None) -> str:
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        return f"{effective_workspace}/.sessions/{self._safe_session_name(session)}.log"
+
+    def _get_manager(
+        self,
+        session: str,
+        workspace_path: str | None = None,
+    ) -> TmuxSessionManager:
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        key = self._manager_key(session, effective_workspace)
+        tmux_session = self._tmux_session_name(session, effective_workspace)
+        log_name = f"{self._safe_session_name(session)}"
+        with self._managers_lock:
+            if key not in self._managers:
+                self._managers[key] = TmuxSessionManager(
+                    tmux_session,
+                    self._container_name,
+                    workspace_path=effective_workspace,
+                    log_name=log_name,
+                    exec_prefix=self._exec_prefix,
+                )
+            return self._managers[key]
+
+    # ── BaseSandbox abstract methods ──────────────────────────────────────
+
+    @property
+    def id(self) -> str:
+        return self._container_name
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        """Simple docker exec — used by BaseSandbox for file operations."""
+        effective = timeout if timeout is not None else self._default_timeout
+        try:
+            result = subprocess.run(
+                [*self._exec_prefix, "sh", "-c", command],
+                capture_output=True,
+                text=True,
+                timeout=effective,
+                encoding="utf-8",
+                errors="replace",
+            )
+            output = result.stdout
+            if result.stderr and result.stderr.strip():
+                output += f"\n<stderr>{result.stderr.strip()}</stderr>"
+            return ExecuteResponse(
+                output=output,
+                exit_code=result.returncode,
+                truncated=False,
+            )
+        except subprocess.TimeoutExpired:
+            return ExecuteResponse(
+                output=f"Command timed out after {effective}s",
+                exit_code=124,
+                truncated=False,
+            )
+
+    def read_session_log_diff(self, session: str, workspace_path: str | None = None) -> str:
+        """Return new bytes appended to <workspace>/.sessions/<session>.log
+        since the previous call (or the whole file on first call).
+
+        Per-process offset tracking only — restart resets to 0 (safe fallback).
+        File truncation/rotation also resets to 0.
+        """
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        key = self._manager_key(session, effective_workspace)
+        log_path = self.session_log_path(session, effective_workspace)
+        results = self.download_files([log_path])
+        if not results or results[0].error or results[0].content is None:
+            return ""
+        full = results[0].content
+        with self._log_offsets_lock:
+            prev_offset = self._log_offsets.get(key, 0)
+            if prev_offset > len(full):
+                prev_offset = 0
+            new_bytes = full[prev_offset:]
+            self._log_offsets[key] = len(full)
+        return new_bytes.decode("utf-8", errors="replace")
+
+    def reset_session_log_offset(self, session: str, workspace_path: str | None = None) -> None:
+        """Forget the read offset (used after kill / GC)."""
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        key = self._manager_key(session, effective_workspace)
+        with self._log_offsets_lock:
+            self._log_offsets.pop(key, None)
+
+    # ── Tmux execution (for bash tool) ───────────────────────────────────
+
+    def execute_tmux(
+        self,
+        command: str = "",
+        session: str = "main",
+        timeout: int | None = None,
+        is_input: bool = False,
+        workspace_path: str | None = None,
+    ) -> str:
+        """Tmux-based execution with session persistence and interactive support.
+
+        Used exclusively by the bash tool. Supports:
+        - Named sessions for parallel command execution
+        - Interactive input (y/n, passwords, C-c / C-z / C-d)
+        - Output truncation for large outputs
+        """
+        effective = timeout if timeout is not None else self._default_timeout
+        mgr = self._get_manager(session, workspace_path)
+
+        if not command and not is_input:
+            return mgr.read_screen()
+
+        return mgr.execute(
+            command,
+            is_input=is_input,
+            timeout=effective,
+        )
+
+    async def execute_tmux_async(
+        self,
+        command: str = "",
+        session: str = "main",
+        timeout: int | None = None,
+        is_input: bool = False,
+        workspace_path: str | None = None,
+    ) -> str:
+        """Async tmux execution — cancellable via asyncio.CancelledError.
+
+        Used by the async bash tool so that LangGraph run cancellation
+        (Ctrl+C → cancelMany) interrupts the polling loop promptly.
+        """
+        effective = timeout if timeout is not None else self._default_timeout
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        job_key = self._manager_key(session, effective_workspace)
+        mgr = self._get_manager(session, effective_workspace)
+
+        if not command and not is_input:
+            return await asyncio.to_thread(mgr.read_screen)
+
+        def _on_auto_background(cmd: str, baseline: str) -> None:
+            self._jobs.register(
+                session,
+                command=cmd,
+                initial_markers=len(PS1_PATTERN.findall(baseline)),
+                key=job_key,
+                workspace_path=effective_workspace,
+            )
+
+        return await mgr.execute_async(
+            command,
+            is_input=is_input,
+            timeout=effective,
+            on_auto_background=_on_auto_background,
+        )
+
+    def start_background(
+        self,
+        command: str,
+        session: str = "main",
+        workspace_path: str | None = None,
+    ) -> None:
+        """Launch a command in a named tmux session without blocking.
+
+        Registers a BackgroundJob keyed by the PS1-marker count at launch;
+        ``poll_completion`` later compares against this baseline.
+        """
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        job_key = self._manager_key(session, effective_workspace)
+        mgr = self._get_manager(session, effective_workspace)
+        mgr.initialize()
+        baseline = mgr._capture()
+        initial_markers = len(PS1_PATTERN.findall(baseline))
+        self._jobs.register(
+            session,
+            command=command,
+            initial_markers=initial_markers,
+            key=job_key,
+            workspace_path=effective_workspace,
+        )
+        mgr._send(command, enter=True)
+
+    def poll_completion(
+        self,
+        session: str,
+        workspace_path: str | None = None,
+    ) -> "BackgroundJob | None":
+        """Check whether a background job has produced a new PS1 marker.
+
+        Updates the tracker in place; returns the job (or None if not tracked).
+        Capture failures are swallowed — the job stays running, retried later.
+        """
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        job_key = self._manager_key(session, effective_workspace)
+        job = self._jobs.get(session, key=job_key)
+        if job is None or job.status != "running":
+            return job
+        try:
+            mgr = self._get_manager(session, effective_workspace)
+            screen = mgr._capture()
+        except (RuntimeError, OSError, subprocess.TimeoutExpired):
+            return job
+        markers = list(PS1_PATTERN.finditer(screen))
+        if len(markers) > job.initial_markers:
+            try:
+                exit_code = int(markers[-1].group(1))
+            except ValueError:
+                exit_code = -1
+            self._jobs.mark_complete(session, exit_code=exit_code, key=job_key)
+        return job
+
+    def kill_session(self, session: str, workspace_path: str | None = None) -> None:
+        """Send Ctrl+C, then kill the tmux session, then clear all caches.
+
+        Best-effort: errors are logged, not raised. The pipe-pane log file
+        is preserved at <engagement>/.sessions/<session>.log for audit.
+        """
+        effective_workspace = self._normalize_workspace_path(workspace_path or self._workspace_path)
+        manager_key = self._manager_key(session, effective_workspace)
+        mgr: TmuxSessionManager | None = None
+        try:
+            mgr = self._get_manager(session, effective_workspace)
+            try:
+                mgr._docker_tmux(["send-keys", "-t", mgr.session, "C-c"])
+            except RuntimeError as e:
+                log.debug("send-keys C-c failed for '%s': %s", _safe_log(session), _safe_log(e))
+            try:
+                mgr._docker_tmux(["kill-session", "-t", mgr.session])
+            except RuntimeError as e:
+                log.warning("kill-session failed for '%s': %s", _safe_log(session), _safe_log(e))
+        finally:
+            with self._managers_lock:
+                self._managers.pop(manager_key, None)
+            if mgr is not None:
+                with TmuxSessionManager._init_lock:
+                    TmuxSessionManager._initialized.discard(mgr.session)
+            self.reset_session_log_offset(session, effective_workspace)
+            self._jobs.remove(session, key=manager_key)
+
+
+# ─── Pre-flight check ────────────────────────────────────────────────────

--- a/decepticon/sandbox_kernel/daemon.py
+++ b/decepticon/sandbox_kernel/daemon.py
@@ -1,0 +1,169 @@
+"""In-container sandbox — used by the HTTP daemon, never the agent host.
+
+`DaemonSandbox` is what `decepticon.sandbox_server` instantiates inside
+the sandbox container itself. It inherits every method of
+:class:`~decepticon.sandbox_kernel.base.SandboxBase` (tmux session
+management, background-job + log-offset trackers, ``execute``,
+``execute_tmux``, ``start_background``, ``poll_completion``,
+``kill_session``, ``read_session_log_diff``, …) but swaps the
+``docker exec <container>`` command prefix for an empty list — every
+subprocess call runs *directly* in the daemon process's own address
+space, which is already inside the sandbox container.
+
+File IO uses pathlib instead of ``docker cp`` for the same reason —
+the daemon can't ``docker cp`` from inside the container talking to
+itself.
+
+Trust model — read this before editing!
+---------------------------------------
+The daemon trusts its caller and applies **no path validation**
+of its own. That trust is correct *only* under the deploy invariants
+below. If you ever break one of these, you must add path-prefix
+validation to ``upload_files`` / ``download_files`` before shipping.
+
+  Silo plane (per-engagement GCE Spot VM)
+      Each engagement runs on its own VM. The VM mounts the GCS bucket
+      with ``gcsfuse --only-dir=engagements/<org>/<eng>`` — the daemon's
+      filesystem view contains only that one engagement's tree. A path
+      traversal request (``/etc/shadow``, ``/workspace/other-eng/…``)
+      resolves to *nothing* because the mount namespace itself has no
+      other engagements visible. **Isolation = mount, not code.**
+
+  Pool plane (Cloud Run multi-engagement)
+      The daemon is NOT deployed here. Pool plane runs Soundwave +
+      Decepticon orchestrator inside the langgraph container with its
+      own GCS volume mount; agents talk to that mount directly through
+      ``EngagementFilesystemBackend`` path virtualization (application-
+      level prefix injection per engagement). No sandbox sibling, no
+      daemon, no ``DaemonSandbox`` — pool plane only does file IO, the
+      heavy bash tool path is reserved for silo plane.
+
+  Dev (single-machine docker compose)
+      ``SANDBOX_DAEMON=0`` by default — the OSS path is unchanged
+      (``DockerSandbox`` + ``docker exec``). Enabling the daemon on
+      a shared dev machine voids the trust model; don't.
+
+Class-level state inheritance
+-----------------------------
+``_jobs``, ``_log_offsets``, ``_log_offsets_lock``,
+``TmuxSessionManager._initialized``, and ``TmuxSessionManager._init_lock``
+are inherited from :class:`SandboxBase` and :class:`TmuxSessionManager`
+as-is. Inside the daemon process there's only ever one sandbox instance,
+so the class vars are effectively instance-scoped — but keeping the
+class-level contract means ``SandboxNotificationMiddleware`` (which
+polls ``<Sandbox>._jobs`` directly) works unchanged when wired in front
+of the daemon's backend.
+
+Layering
+--------
+This module lives in ``sandbox_kernel/``, not ``backends/``, on purpose.
+The sandbox container image ships only ``sandbox_kernel/`` +
+``sandbox_server/`` — no agent-side transport (``DockerSandbox``,
+``HTTPSandbox``, ``factory``). That keeps the pre-refactor boundary
+intact: agent holds transport, sandbox holds zero transport.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import ClassVar
+
+from deepagents.backends.protocol import (
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+
+from decepticon.sandbox_kernel.base import SandboxBase
+from decepticon.sandbox_kernel.jobs import BackgroundJobTracker
+
+
+class DaemonSandbox(SandboxBase):
+    """SandboxBase configured for direct, in-container execution.
+
+    Args:
+        container_name: Cosmetic identifier surfaced via ``.id`` and
+            embedded in tmux session names / log files. Defaults to
+            ``daemon`` because in the daemon's address space there is
+            no docker-container concept to reach into.
+        default_timeout: As :class:`SandboxBase`.
+        workspace_path: Root of the agent-visible filesystem — set
+            from ``SANDBOX_ROOT_DIR`` env (default ``/workspace``). In
+            silo plane the gcsfuse mount narrows the actual filesystem
+            view to a single engagement subtree; the daemon does NOT
+            enforce this prefix itself.
+    """
+
+    _jobs: ClassVar[BackgroundJobTracker] = BackgroundJobTracker()
+    _log_offsets: ClassVar[dict[str, int]] = {}
+    _log_offsets_lock: ClassVar[threading.RLock] = threading.RLock()
+
+    def __init__(
+        self,
+        container_name: str = "daemon",
+        default_timeout: int = 120,
+        workspace_path: str = "/workspace",
+    ) -> None:
+        # exec_prefix=[] turns every `[*self._exec_prefix, "tmux", ...]`
+        # into `["tmux", ...]` etc — subprocess runs commands in this
+        # process's own environment, no `docker exec` hop.
+        super().__init__(
+            container_name=container_name,
+            default_timeout=default_timeout,
+            workspace_path=workspace_path,
+            exec_prefix=[],
+        )
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        # Path validation is intentionally absent — see module docstring
+        # for the deploy-time trust model. Don't add prefix checks here
+        # without also auditing the gcsfuse mount-isolation invariant.
+        responses: list[FileUploadResponse] = []
+        for path, content in files:
+            if not path.startswith("/"):
+                responses.append(FileUploadResponse(path=path, error="invalid_path"))
+                continue
+            target = Path(path)
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(content)
+                responses.append(FileUploadResponse(path=path, error=None))
+            except PermissionError:
+                responses.append(FileUploadResponse(path=path, error="permission_denied"))
+            except IsADirectoryError:
+                responses.append(FileUploadResponse(path=path, error="is_directory"))
+            except OSError:
+                responses.append(FileUploadResponse(path=path, error="file_not_found"))
+        return responses
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        # See upload_files note on absent path validation.
+        responses: list[FileDownloadResponse] = []
+        for path in paths:
+            if not path.startswith("/"):
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error="invalid_path")
+                )
+                continue
+            source = Path(path)
+            try:
+                if source.is_dir():
+                    responses.append(
+                        FileDownloadResponse(path=path, content=None, error="is_directory")
+                    )
+                    continue
+                content = source.read_bytes()
+                responses.append(FileDownloadResponse(path=path, content=content, error=None))
+            except FileNotFoundError:
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error="file_not_found")
+                )
+            except PermissionError:
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error="permission_denied")
+                )
+            except OSError:
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error="file_not_found")
+                )
+        return responses

--- a/decepticon/sandbox_kernel/jobs.py
+++ b/decepticon/sandbox_kernel/jobs.py
@@ -1,0 +1,100 @@
+"""Background-job tracking — used by the bash tool / SandboxNotificationMiddleware.
+
+Originally lived inline in ``decepticon/backends/docker_sandbox.py``. Moved
+out so the in-container HTTP daemon (``decepticon.sandbox_server``) can
+import it without pulling in the agent-side ``DockerSandbox`` /
+``HTTPSandbox`` transport classes — see ``sandbox_kernel/__init__.py``
+for the layering rationale.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import time
+
+
+@dataclasses.dataclass
+class BackgroundJob:
+    """Metadata for one background command in a tmux session.
+
+    A session holds at most one BackgroundJob — sequential reuse replaces.
+    Timestamps use ``time.monotonic()`` so elapsed values stay correct
+    across wall-clock adjustments (NTP step, manual ``date -s``).
+    """
+
+    session: str
+    key: str
+    command: str
+    initial_markers: int
+    started_at: float
+    workspace_path: str = "/workspace"
+    status: str = "running"  # running | done
+    exit_code: int | None = None
+    completed_at: float | None = None
+    consumed: bool = False
+
+    @property
+    def elapsed(self) -> float:
+        end = self.completed_at if self.completed_at is not None else time.monotonic()
+        return end - self.started_at
+
+
+class BackgroundJobTracker:
+    """In-memory background-job registry keyed by session name."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, BackgroundJob] = {}
+        self._lock = threading.RLock()
+
+    def register(
+        self,
+        session: str,
+        command: str,
+        initial_markers: int,
+        key: str | None = None,
+        workspace_path: str = "/workspace",
+    ) -> BackgroundJob:
+        job_key = key or session
+        with self._lock:
+            job = BackgroundJob(
+                session=session,
+                key=job_key,
+                workspace_path=workspace_path,
+                command=command,
+                initial_markers=initial_markers,
+                started_at=time.monotonic(),
+            )
+            self._jobs[job_key] = job
+            return job
+
+    def get(self, session: str, key: str | None = None) -> BackgroundJob | None:
+        with self._lock:
+            return self._jobs.get(key or session)
+
+    def mark_complete(self, session: str, exit_code: int, key: str | None = None) -> None:
+        with self._lock:
+            job = self._jobs.get(key or session)
+            if job is None or job.status != "running":
+                return
+            job.status = "done"
+            job.exit_code = exit_code
+            job.completed_at = time.monotonic()
+
+    def mark_consumed(self, session: str, key: str | None = None) -> None:
+        with self._lock:
+            job = self._jobs.get(key or session)
+            if job is not None:
+                job.consumed = True
+
+    def pending_completions(self) -> list[BackgroundJob]:
+        with self._lock:
+            return [j for j in self._jobs.values() if j.status == "done" and not j.consumed]
+
+    def all_jobs(self) -> list[BackgroundJob]:
+        with self._lock:
+            return list(self._jobs.values())
+
+    def remove(self, session: str, key: str | None = None) -> None:
+        with self._lock:
+            self._jobs.pop(key or session, None)

--- a/decepticon/sandbox_kernel/tmux.py
+++ b/decepticon/sandbox_kernel/tmux.py
@@ -1,0 +1,742 @@
+"""TmuxSessionManager + execution helpers — shared between DockerSandbox
+(agent-side, via `exec_prefix=["docker", "exec", <ctn>]`) and the in-
+container HTTP daemon (sandbox-side, via `exec_prefix=[]`).
+
+Extracted from `decepticon/backends/docker_sandbox.py` so the daemon
+can import the tmux machinery without pulling in agent-side transport
+classes. See `sandbox_kernel/__init__.py` for the layering rationale.
+
+The semantics — PS1 marker parsing, polling cadence, stall detection,
+size watchdog, output truncation, auto-background after 60 s — are
+unchanged from the docker_sandbox.py original. Only the import site
+moved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+
+log = logging.getLogger("decepticon.sandbox_kernel.tmux")
+
+# ─── Tunable timing constants (patched in tests) ────────────────────────
+
+PS1_PATTERN = re.compile(r"\[DCPTN:(\d+):(.+?)\]")
+
+POLL_INTERVAL: float = 0.5
+STALL_SECONDS: float = 3.0
+MAX_OUTPUT_CHARS: int = 30_000
+AUTO_BACKGROUND_SECONDS: float = 60.0
+SIZE_WATCHDOG_CHARS: int = 5_000_000
+SIZE_WATCHDOG_INTERVAL: float = 5.0
+
+
+def _safe_log(value: object) -> str:
+    """Escape control chars so user-controlled strings cannot forge log lines.
+
+    The bash tool and session naming both flow caller-supplied text into
+    ``log.<level>(...)`` calls. CodeQL's log-injection rule (medium) flags
+    every such site because a ``\\n`` in the value can splice a fake log
+    line into structured log readers (Cloud Logging, Loki). The fix is
+    cheap and applied uniformly; see callers in this file + base.py.
+    """
+    return str(value).replace("\r", "\\r").replace("\n", "\\n")
+
+
+class TmuxCommandError(RuntimeError):
+    """Raised when a tmux command fails inside the sandbox container."""
+
+    def __init__(self, args: list[str], returncode: int, output: str) -> None:
+        self.args_list = args
+        self.returncode = returncode
+        self.output = output
+        super().__init__(output)
+
+
+# ─── Semantic exit code interpretation (Claude Code best practice) ────────
+_EXIT_CODE_MESSAGES: dict[int, str] = {
+    1: "general error",
+    2: "misuse of shell builtin",
+    126: "permission denied (not executable)",
+    127: "command not found — tool may not be installed (try: apt-get install -y <pkg>)",
+    128: "invalid exit argument",
+    130: "interrupted by Ctrl+C (SIGINT)",
+    137: "killed (SIGKILL) — likely OOM or size limit exceeded",
+    139: "segmentation fault (SIGSEGV)",
+    143: "terminated (SIGTERM)",
+}
+
+
+def _interpret_exit_code(code: int) -> str:
+    """Convert exit code to human-readable message for agent context."""
+    if code == 0:
+        return ""
+    if code in _EXIT_CODE_MESSAGES:
+        return f" — {_EXIT_CODE_MESSAGES[code]}"
+    if code > 128:
+        signal_num = code - 128
+        return f" — killed by signal {signal_num}"
+    return ""
+
+
+# ─── TmuxSessionManager ───────────────────────────────────────────────────
+
+
+class TmuxSessionManager:
+    """Manages a single named tmux session inside the Docker container.
+
+    Transplanted from tools/bash/tool.py; docker exec calls now go directly
+    through subprocess instead of the old run_in_sandbox() helper.
+
+    Thread-safety: ``_initialized`` is process-wide shared state. The
+    ``_init_lock`` (threading.RLock) guards add/discard/clear so concurrent
+    sessions cannot race during init or cache invalidation.
+    """
+
+    _initialized: set[str] = set()
+    _init_lock: threading.RLock = threading.RLock()
+
+    def __init__(
+        self,
+        session: str,
+        container_name: str,
+        workspace_path: str = "/workspace",
+        log_name: str | None = None,
+        exec_prefix: list[str] | None = None,
+    ) -> None:
+        self.session = session
+        self._container = container_name
+        self._workspace_path = workspace_path.rstrip("/") or "/workspace"
+        self._log_name = log_name or session
+        self._pane_id: str | None = None
+        # When None, default to the existing docker-exec pattern so
+        # nothing changes for DockerSandbox callers. The HTTP sandbox
+        # daemon (which runs *inside* the sandbox container and talks
+        # to the local tmux directly) passes `exec_prefix=[]` so the
+        # same TmuxSessionManager logic is reused without spawning a
+        # nested docker daemon.
+        self._exec_prefix: list[str] = (
+            list(exec_prefix) if exec_prefix is not None else ["docker", "exec", container_name]
+        )
+
+    # ── docker / tmux helpers ──
+
+    def _docker_tmux(self, args: list[str], timeout: int = 10) -> str:
+        """Run a tmux subcommand against the session's target.
+
+        The prefix in `_exec_prefix` is the only thing that distinguishes
+        in-container (host-side, via `docker exec`) from inside-container
+        (no prefix) execution — every other tmux semantic is identical.
+        """
+        result = subprocess.run(
+            [*self._exec_prefix, "tmux", "-L", self.session, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if result.returncode != 0:
+            error_msg = result.stderr or result.stdout
+            raise TmuxCommandError(args, result.returncode, error_msg)
+        return result.stdout
+
+    def _target(self) -> str:
+        """Return the stable tmux target for command dispatch."""
+        return self.session
+
+    def _forget_cached_state(self) -> None:
+        self._pane_id = None
+        with TmuxSessionManager._init_lock:
+            TmuxSessionManager._initialized.discard(self.session)
+
+    def _resolve_pane_id(self) -> str:
+        try:
+            return self._docker_tmux(
+                ["display-message", "-p", "-t", self.session, "#{pane_id}"],
+                timeout=5,
+            ).strip()
+        except subprocess.TimeoutExpired:
+            self._forget_cached_state()
+            time.sleep(1.0)
+            return self._docker_tmux(
+                ["display-message", "-p", "-t", self.session, "#{pane_id}"],
+                timeout=10,
+            ).strip()
+
+    def _cached_pane_is_alive(self) -> bool:
+        if self.session not in TmuxSessionManager._initialized:
+            return False
+        if self._pane_id is None:
+            try:
+                self._pane_id = self._resolve_pane_id()
+            except (RuntimeError, subprocess.TimeoutExpired):
+                self._forget_cached_state()
+                return False
+        try:
+            self._docker_tmux(
+                ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
+                timeout=5,
+            )
+            return True
+        except subprocess.TimeoutExpired:
+            self._forget_cached_state()
+            time.sleep(1.0)
+            try:
+                self._docker_tmux(
+                    ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
+                    timeout=10,
+                )
+                return True
+            except (subprocess.TimeoutExpired, RuntimeError):
+                raise TmuxCommandError(
+                    ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
+                    -1,
+                    "tmux pane probe timed out after retry — sandbox infra fault",
+                )
+        except RuntimeError:
+            return False
+
+    def _send(self, text: str, enter: bool = True) -> None:
+        """Send keystrokes using -l (literal) to prevent tmux escaping bugs."""
+        target = self._target()
+        self._docker_tmux(["send-keys", "-t", target, "-l", text])
+        if enter:
+            self._docker_tmux(["send-keys", "-t", target, "Enter"])
+
+    def _clear_screen(self) -> None:
+        target = self._target()
+        try:
+            self._docker_tmux(["send-keys", "-t", target, "C-l"])
+            time.sleep(0.1)
+            self._docker_tmux(["clear-history", "-t", target])
+        except (TmuxCommandError, subprocess.TimeoutExpired, OSError) as e:
+            log.warning("_clear_screen failed for '%s': %s", target, e)
+
+    def _capture(self) -> str:
+        return self._docker_tmux(
+            [
+                "capture-pane",
+                "-J",
+                "-p",
+                "-S",
+                "-",
+                "-E",
+                "-",
+                "-t",
+                self._target(),
+            ]
+        )
+
+    # ── session lifecycle ──
+
+    def initialize(self) -> None:
+        """Create session if needed and inject PS1 marker (once per session)."""
+        with TmuxSessionManager._init_lock:
+            if self._cached_pane_is_alive():
+                return
+            TmuxSessionManager._initialized.discard(self.session)
+            self._pane_id = None
+
+        session_exists = False
+        try:
+            self._docker_tmux(["has-session", "-t", self.session], timeout=5)
+            session_exists = True
+        except RuntimeError:
+            session_exists = False
+
+        if not session_exists:
+            log.info("Creating tmux session: %s", self.session)
+            try:
+                if self._workspace_path != "/workspace":
+                    subprocess.run(
+                        [*self._exec_prefix, "mkdir", "-p", self._workspace_path],
+                        capture_output=True,
+                        timeout=5,
+                        check=True,
+                    )
+                pane_id = self._docker_tmux(
+                    [
+                        "new-session",
+                        "-d",
+                        "-s",
+                        self.session,
+                        "-c",
+                        self._workspace_path,
+                        "-P",
+                        "-F",
+                        "#{pane_id}",
+                    ]
+                ).strip()
+                self._pane_id = pane_id or self.session
+            except RuntimeError:
+                try:
+                    self._docker_tmux(["has-session", "-t", self.session], timeout=5)
+                    self._pane_id = self._resolve_pane_id()
+                    session_exists = True
+                    log.debug("Session %s already exists (race), reusing", self.session)
+                except RuntimeError:
+                    raise
+            time.sleep(0.3)
+        else:
+            self._pane_id = self._resolve_pane_id()
+
+        # Inject PS1 marker + disable PS2 + clear screen
+        ps1_cmd = "export PROMPT_COMMAND='export PS1=\"[DCPTN:$?:$PWD] \"'; export PS2=''; clear"
+        self._send(ps1_cmd)
+        time.sleep(0.5)
+        self._clear_screen()
+        time.sleep(0.2)
+
+        if not session_exists and self._workspace_path != "/workspace":
+            log_path = f"{self._workspace_path}/.sessions/{self._log_name}.log"
+            try:
+                # Idempotent — the directory is bind-mounted to the host so
+                # operators can tail the same file the agent reads.
+                subprocess.run(
+                    [
+                        "docker",
+                        "exec",
+                        self._container,
+                        "mkdir",
+                        "-p",
+                        f"{self._workspace_path}/.sessions",
+                    ],
+                    capture_output=True,
+                    timeout=5,
+                    check=True,
+                )
+                self._docker_tmux(
+                    [
+                        "pipe-pane",
+                        "-t",
+                        self.session,
+                        "-o",
+                        f"cat >> {log_path}",
+                    ]
+                )
+            except Exception as e:
+                log.warning("pipe-pane setup failed for session '%s': %s", self.session, e)
+
+        with TmuxSessionManager._init_lock:
+            TmuxSessionManager._initialized.add(self.session)
+
+    # ── execution ──
+
+    def execute(
+        self,
+        command: str,
+        is_input: bool,
+        timeout: int,
+    ) -> str:
+        """Send a command/input and poll for PS1 completion marker.
+
+        Polls until the PS1 marker appears (command complete) or *timeout*
+        is reached.  If the tmux session is dead, attempts one automatic
+        recovery before returning an error.
+        """
+        if not is_input:
+            self.initialize()
+
+        try:
+            baseline = self._capture()
+        except RuntimeError as e:
+            log.warning("Session '%s' is not ready — attempting recovery: %s", self.session, e)
+            self._forget_cached_state()
+            try:
+                self.initialize()
+                baseline = self._capture()
+            except (RuntimeError, OSError, subprocess.TimeoutExpired) as retry_err:
+                return (
+                    f"[ERROR] Session recovery failed: {retry_err}\n"
+                    f"The tmux session was destroyed or docker is overloaded. "
+                    f"Try using a different session name."
+                )
+        except (OSError, subprocess.TimeoutExpired) as e:
+            return (
+                f"[ERROR] Sandbox capture failed: {e}\n"
+                f"docker exec timed out or the tmux session is hung. "
+                f'Retry, or terminate with bash_kill(session="{self.session}").'
+            )
+
+        initial_count = len(PS1_PATTERN.findall(baseline))
+
+        if command:
+            try:
+                if is_input:
+                    if command in ("C-c", "C-z", "C-d"):
+                        self._docker_tmux(["send-keys", "-t", self._target(), command])
+                    else:
+                        self._send(command, enter=True)
+                else:
+                    self._send(command, enter=True)
+            except RuntimeError as e:
+                return f"[ERROR] Could not send command to session '{self.session}': {e}"
+
+        start = time.monotonic()
+        prev_screen = baseline
+        last_change_time = start
+
+        while time.monotonic() - start < timeout:
+            time.sleep(POLL_INTERVAL)
+            try:
+                screen = self._capture()
+            except RuntimeError as poll_err:
+                self._forget_cached_state()
+                return (
+                    f"[ERROR] tmux session '{self.session}' was destroyed mid-command: {poll_err}\n"
+                    f"The command likely killed the shell process (e.g. pkill bash).\n"
+                    f"Session will auto-recover on next bash() call."
+                )
+            except (OSError, subprocess.TimeoutExpired) as poll_err:
+                # docker exec stall — keep polling, do not let it trigger stall detection
+                log.debug("transient capture error in poll loop: %s", poll_err)
+                last_change_time = time.monotonic()
+                continue
+
+            current_count = len(PS1_PATTERN.findall(screen))
+
+            if current_count > initial_count:
+                output, exit_code, cwd = _extract_output(screen, command)
+                log.info(
+                    "Command completed: exit=%s cwd=%s [%s]",
+                    exit_code,
+                    _safe_log(cwd),
+                    _safe_log(command[:50]),
+                )
+                self._clear_screen()
+                result = _truncate(output).strip()
+                hint = _interpret_exit_code(exit_code)
+                if not result:
+                    result = f"[Command completed with no output. Exit code: {exit_code}{hint}]"
+                elif exit_code != 0:
+                    result += f"\n[Exit code: {exit_code}{hint}]"
+                if cwd:
+                    result += f"\n[cwd: {cwd}]"
+                return result
+
+            # Size watchdog: kill commands producing excessive output
+            if len(screen) > SIZE_WATCHDOG_CHARS:
+                log.warning(
+                    "Size watchdog triggered (%d chars) — killing session [%s]",
+                    len(screen),
+                    _safe_log(command[:50]),
+                )
+                try:
+                    self._docker_tmux(["send-keys", "-t", self._target(), "C-c"])
+                except RuntimeError as interrupt_err:
+                    log.debug("Failed to interrupt oversized tmux command: %s", interrupt_err)
+                output = _extract_interactive_output(screen, baseline)
+                return (
+                    f"{_truncate(output).strip()}\n\n"
+                    f"[SIZE LIMIT] Output exceeded {SIZE_WATCHDOG_CHARS // 1_000_000}M chars. "
+                    f"Command interrupted.\n"
+                    f"Redirect output to a file: command > {self._workspace_path}/output.txt"
+                )
+
+            # Stall detection: if screen changed from baseline (program produced
+            # output) but hasn't changed for STALL_SECONDS, the program is likely
+            # waiting for input (interactive prompt like msf6>, sliver>).
+            if screen != prev_screen:
+                last_change_time = time.monotonic()
+                prev_screen = screen
+            elif screen != baseline and time.monotonic() - last_change_time >= STALL_SECONDS:
+                log.info(
+                    "Stall detected after %.1fs — interactive program [%s]",
+                    time.monotonic() - start,
+                    _safe_log(command[:50]),
+                )
+                output = _extract_interactive_output(screen, baseline)
+                return (
+                    f"{_truncate(output).strip()}\n"
+                    f"[session: {self.session} — interactive, "
+                    f"send next command with is_input=True]"
+                )
+
+        # Full timeout — include screen capture
+        try:
+            final_screen = self._capture()
+        except (RuntimeError, OSError, subprocess.TimeoutExpired):
+            final_screen = ""
+        screen_tail = final_screen.strip().split("\n")[-20:]
+        screen_preview = "\n".join(screen_tail)
+
+        return (
+            f"[TIMEOUT] Command exceeded {timeout}s limit.\n"
+            f"Session '{self.session}' is still running. "
+            f'Send input with bash(command="<input>", is_input=True, session="{self.session}").\n'
+            f'Read partial output with bash_output(session="{self.session}").\n'
+            f"--- screen preview ---\n{screen_preview}"
+        )
+
+    async def execute_async(
+        self,
+        command: str,
+        is_input: bool,
+        timeout: int,
+        on_auto_background: Callable[[str, str], None] | None = None,
+    ) -> str:
+        """Async version of execute() — non-blocking subprocess + cancellable polling.
+
+        All subprocess calls are offloaded via asyncio.to_thread() to avoid blocking
+        the ASGI event loop. asyncio.sleep() between polls allows CancelledError
+        delivery when LangGraph cancels a run (Ctrl+C → cancelMany).
+
+        Args:
+            command: shell command to send (or empty / control sequence with is_input).
+            is_input: True when ``command`` is keystrokes for an already-running process.
+            timeout: max seconds to wait for command completion.
+            on_auto_background: optional callback ``(command, baseline) -> None`` invoked
+                exactly once when the auto-background threshold is crossed. ``baseline``
+                is the screen capture taken before the command was sent — callers use it
+                to derive a stable PS1-marker baseline (e.g. via PS1_PATTERN.findall).
+        """
+        if not is_input:
+            await asyncio.to_thread(self.initialize)
+
+        try:
+            baseline = await asyncio.to_thread(self._capture)
+        except RuntimeError as e:
+            log.warning("Session '%s' is not ready — attempting recovery: %s", self.session, e)
+            self._forget_cached_state()
+            try:
+                await asyncio.to_thread(self.initialize)
+                baseline = await asyncio.to_thread(self._capture)
+            except (RuntimeError, OSError, subprocess.TimeoutExpired) as retry_err:
+                return (
+                    f"[ERROR] Session recovery failed: {retry_err}\n"
+                    f"The tmux session was destroyed or docker is overloaded. "
+                    f"Try using a different session name."
+                )
+        except (OSError, subprocess.TimeoutExpired) as e:
+            return (
+                f"[ERROR] Sandbox capture failed: {e}\n"
+                f"docker exec timed out or the tmux session is hung. "
+                f'Retry, or terminate with bash_kill(session="{self.session}").'
+            )
+
+        initial_count = len(PS1_PATTERN.findall(baseline))
+
+        if command:
+            try:
+                if is_input:
+                    if command in ("C-c", "C-z", "C-d"):
+                        await asyncio.to_thread(
+                            self._docker_tmux, ["send-keys", "-t", self._target(), command]
+                        )
+                    else:
+                        await asyncio.to_thread(self._send, command, True)
+                else:
+                    await asyncio.to_thread(self._send, command, True)
+            except RuntimeError as e:
+                return f"[ERROR] Could not send command to session '{self.session}': {e}"
+
+        start = time.monotonic()
+        prev_screen = baseline
+        last_change_time = start
+
+        while time.monotonic() - start < timeout:
+            await asyncio.sleep(POLL_INTERVAL)  # CancelledError delivered here
+            try:
+                screen = await asyncio.to_thread(self._capture)
+            except RuntimeError as poll_err:
+                self._forget_cached_state()
+                return (
+                    f"[ERROR] tmux session '{self.session}' was destroyed mid-command: {poll_err}\n"
+                    f"The command likely killed the shell process (e.g. pkill bash).\n"
+                    f"Session will auto-recover on next bash() call."
+                )
+            except (OSError, subprocess.TimeoutExpired) as poll_err:
+                # docker exec stall — keep polling, do not let it trigger stall detection
+                log.debug("transient capture error in poll loop: %s", poll_err)
+                last_change_time = time.monotonic()
+                continue
+
+            current_count = len(PS1_PATTERN.findall(screen))
+
+            if current_count > initial_count:
+                output, exit_code, cwd = _extract_output(screen, command)
+                log.info(
+                    "Command completed: exit=%s cwd=%s [%s]",
+                    exit_code,
+                    _safe_log(cwd),
+                    _safe_log(command[:50]),
+                )
+                await asyncio.to_thread(self._clear_screen)
+                result = _truncate(output).strip()
+                hint = _interpret_exit_code(exit_code)
+                if not result:
+                    result = f"[Command completed with no output. Exit code: {exit_code}{hint}]"
+                elif exit_code != 0:
+                    result += f"\n[Exit code: {exit_code}{hint}]"
+                if cwd:
+                    result += f"\n[cwd: {cwd}]"
+                return result
+
+            # Size watchdog: kill commands producing excessive output
+            if len(screen) > SIZE_WATCHDOG_CHARS:
+                log.warning(
+                    "Size watchdog triggered (%d chars) — killing session [%s]",
+                    len(screen),
+                    _safe_log(command[:50]),
+                )
+                try:
+                    await asyncio.to_thread(
+                        self._docker_tmux, ["send-keys", "-t", self._target(), "C-c"]
+                    )
+                except RuntimeError as interrupt_err:
+                    log.debug("Failed to interrupt oversized tmux command: %s", interrupt_err)
+                output = _extract_interactive_output(screen, baseline)
+                return (
+                    f"{_truncate(output).strip()}\n\n"
+                    f"[SIZE LIMIT] Output exceeded {SIZE_WATCHDOG_CHARS // 1_000_000}M chars. "
+                    f"Command interrupted.\n"
+                    f"Redirect output to a file: command > /workspace/output.txt"
+                )
+
+            # Auto-background: convert blocking commands after threshold
+            elapsed = time.monotonic() - start
+            if elapsed >= AUTO_BACKGROUND_SECONDS and command:
+                log.info(
+                    "Auto-backgrounding after %.0fs [%s] in session '%s'",
+                    elapsed,
+                    _safe_log(command[:50]),
+                    _safe_log(self.session),
+                )
+                if on_auto_background is not None:
+                    try:
+                        on_auto_background(command, baseline)
+                    except Exception:
+                        log.exception("auto-background callback failed")
+                output = _extract_interactive_output(screen, baseline)
+                preview = _truncate(output).strip()
+                return (
+                    f"[AUTO-BACKGROUND] Command running >{int(AUTO_BACKGROUND_SECONDS)}s "
+                    f"in session '{self.session}'.\n"
+                    f"--- partial output ---\n{preview[-1000:] if preview else '(no output yet)'}\n"
+                    f"--- end ---\n"
+                    f"You will be notified when it completes. Inspect early progress: "
+                    f'bash_output(session="{self.session}").'
+                )
+
+            # Stall detection (see sync execute() for rationale)
+            if screen != prev_screen:
+                last_change_time = time.monotonic()
+                prev_screen = screen
+            elif screen != baseline and time.monotonic() - last_change_time >= STALL_SECONDS:
+                log.info(
+                    "Stall detected after %.1fs — interactive program [%s]",
+                    time.monotonic() - start,
+                    _safe_log(command[:50]),
+                )
+                output = _extract_interactive_output(screen, baseline)
+                return (
+                    f"{_truncate(output).strip()}\n"
+                    f"[session: {self.session} — interactive, "
+                    f"send next command with is_input=True]"
+                )
+
+        # Full timeout — include screen capture
+        try:
+            final_screen = await asyncio.to_thread(self._capture)
+        except (RuntimeError, OSError, subprocess.TimeoutExpired):
+            final_screen = ""
+        screen_tail = final_screen.strip().split("\n")[-20:]
+        screen_preview = "\n".join(screen_tail)
+
+        return (
+            f"[TIMEOUT] Command exceeded {timeout}s limit.\n"
+            f"Session '{self.session}' is still running. "
+            f'Send input with bash(command="<input>", is_input=True, session="{self.session}").\n'
+            f'Read partial output with bash_output(session="{self.session}").\n'
+            f"--- screen preview ---\n{screen_preview}"
+        )
+
+    def read_screen(self) -> str:
+        """Read current screen without sending any command."""
+        try:
+            self.initialize()
+            screen = self._capture()
+        except (RuntimeError, OSError, subprocess.TimeoutExpired) as e:
+            return (
+                f"[ERROR] Could not read screen for session '{self.session}': {e}\n"
+                f"The tmux session may be hung or docker is overloaded. "
+                f'Retry, or terminate the session with bash_kill(session="{self.session}").'
+            )
+        matches = list(PS1_PATTERN.finditer(screen))
+        if matches:
+            last = matches[-1]
+            exit_code = int(last.group(1))
+            cwd = last.group(2)
+            recent = screen[last.end() :].strip()
+            if recent:
+                return f"[RUNNING] cwd={cwd}\n{_truncate(recent)}"
+            return f"[IDLE] exit_code={exit_code} cwd={cwd}\nSession is ready for commands."
+        return f"[UNKNOWN]\n{screen[-2000:]}"
+
+
+# ─── Output helpers (transplanted from tools/bash/tool.py) ───────────────
+
+
+def _extract_interactive_output(screen: str, baseline: str) -> str:
+    """Extract new output from an interactive program (no PS1 marker).
+
+    Compares the current screen against the baseline to find new content
+    produced by the interactive program since the command was sent.
+    """
+    # Find the PS1 marker in the baseline — everything after it is new
+    matches = list(PS1_PATTERN.finditer(baseline))
+    if matches:
+        last = matches[-1]
+        new_content = screen[last.end() :].strip()
+        return new_content if new_content else screen.strip()
+    # No PS1 in baseline either — return the diff
+    baseline_lines = set(baseline.strip().split("\n"))
+    screen_lines = screen.strip().split("\n")
+    new_lines = [ln for ln in screen_lines if ln not in baseline_lines]
+    return "\n".join(new_lines) if new_lines else screen.strip()
+
+
+def _extract_output(screen: str, command: str) -> tuple[str, int, str]:
+    matches = list(PS1_PATTERN.finditer(screen))
+    if not matches:
+        return screen, -1, ""
+    last = matches[-1]
+    exit_code = int(last.group(1))
+    cwd = last.group(2)
+    if len(matches) >= 2:
+        raw = screen[matches[-2].end() : last.start()]
+    else:
+        raw = screen[: last.start()]
+    lines = raw.strip().split("\n")
+    if lines and command and lines[0].strip().endswith(command.strip()):
+        lines = lines[1:]
+    return "\n".join(lines).strip(), exit_code, cwd
+
+
+def _truncate(text: str) -> str:
+    """Truncate large outputs preserving head + tail for context efficiency.
+
+    Observation masking: large tool outputs are the #1 context consumer.
+    Keep the first and last portions (highest signal) and summarize the middle.
+    """
+    if len(text) <= MAX_OUTPUT_CHARS:
+        return text
+    # Asymmetric split: more head (often contains headers/structure) than tail
+    head_chars = int(MAX_OUTPUT_CHARS * 0.6)
+    tail_chars = MAX_OUTPUT_CHARS - head_chars
+    mid_text = text[head_chars:-tail_chars]
+    mid_lines = mid_text.count("\n")
+    mid_chars = len(mid_text)
+    return (
+        f"{text[:head_chars]}\n\n"
+        f"[... {mid_lines} lines / {mid_chars} chars truncated — "
+        "save full output to file with -oN or redirect to a workspace file "
+        f"to preserve complete results ...]\n\n"
+        f"{text[-tail_chars:]}"
+    )

--- a/decepticon/sandbox_server/__init__.py
+++ b/decepticon/sandbox_server/__init__.py
@@ -1,0 +1,12 @@
+"""Sandbox daemon — the server peer of `HTTPSandbox`.
+
+Runs inside the sandbox container, wraps a `LocalShellBackend` (which
+already implements the BaseSandbox semantics for direct-host execution),
+and exposes `execute`, `upload_files`, `download_files` over HTTP.
+
+Entry point: `python -m decepticon.sandbox_server`.
+"""
+
+from decepticon.sandbox_server.app import app
+
+__all__ = ["app"]

--- a/decepticon/sandbox_server/__main__.py
+++ b/decepticon/sandbox_server/__main__.py
@@ -1,0 +1,31 @@
+"""Daemon entry point.
+
+Run with `python -m decepticon.sandbox_server` (and that is what the
+sandbox container's Dockerfile invokes when `SANDBOX_DAEMON=1`).
+
+Env:
+    SANDBOX_DAEMON_HOST   bind host (default 0.0.0.0)
+    SANDBOX_DAEMON_PORT   bind port (default 9999)
+    SANDBOX_ROOT_DIR      LocalShellBackend root (default /workspace)
+    SANDBOX_DEFAULT_TIMEOUT  per-command timeout in seconds (default 120)
+    SAAS_SANDBOX_TOKEN    bearer token required on every request
+                          when set (recommended even on loopback)
+"""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+from decepticon.sandbox_server.app import app
+
+
+def main() -> None:
+    host = os.environ.get("SANDBOX_DAEMON_HOST", "0.0.0.0")  # noqa: S104 -- binds inside sandbox container only
+    port = int(os.environ.get("SANDBOX_DAEMON_PORT", "9999"))
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/decepticon/sandbox_server/app.py
+++ b/decepticon/sandbox_server/app.py
@@ -1,0 +1,398 @@
+"""FastAPI application for the sandbox HTTP daemon.
+
+Wraps a `DaemonSandbox` (the `SandboxBase` subclass that runs every
+subprocess without the `docker exec <container>` prefix because the
+daemon already lives *inside* the sandbox container) and exposes its
+methods over HTTP. The wire surface mirrors the in-process surface 1:1:
+
+  - `/execute`                  → BaseSandbox.execute
+  - `/upload_files`             → BaseSandbox.upload_files
+  - `/download_files`           → BaseSandbox.download_files
+  - `/execute_tmux`             → SandboxBase.execute_tmux
+  - `/start_background`         → SandboxBase.start_background
+  - `/poll_completion`          → SandboxBase.poll_completion
+  - `/kill_session`             → SandboxBase.kill_session
+  - `/read_session_log_diff`    → SandboxBase.read_session_log_diff
+  - `/reset_session_log_offset` → SandboxBase.reset_session_log_offset
+  - `/session_log_path`         → SandboxBase.session_log_path
+
+The agent's tmux session state lives inside this daemon process (via
+the shared `TmuxSessionManager._initialized` + `DaemonSandbox._jobs`
+class vars). `HTTPSandbox` on the agent side just forwards calls; the
+PS1 marker / size watchdog / auto-background semantics all happen here
+where they always did, just no longer behind a docker socket.
+
+Layering: the daemon imports only from `decepticon.sandbox_kernel.*` so
+the sandbox container image ships zero agent-side transport code
+(`backends/` package). See `sandbox_kernel/__init__.py` for the full
+layering rationale.
+
+Auth model
+----------
+`SAAS_SANDBOX_TOKEN` env: when set, every request must carry
+``Authorization: Bearer <token>``. When unset (typical dev), the
+daemon answers any caller. Cloud Run multi-container sibling traffic
+on loopback isn't routable from outside the service, so the token is
+defence-in-depth rather than the primary authn mechanism — but it's
+the right thing to ship as the default.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from contextlib import asynccontextmanager
+from typing import Annotated, AsyncIterator
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from pydantic import BaseModel, Field
+
+from decepticon.sandbox_kernel.daemon import DaemonSandbox
+
+# ── Wire models. Mirror the in-process types one-to-one so the daemon
+# stays a thin transport layer over the canonical DockerSandbox API. ──
+
+
+class ExecuteRequest(BaseModel):
+    command: str
+    timeout: int | None = None
+
+
+class ExecuteResponseModel(BaseModel):
+    output: str
+    exit_code: int | None = None
+    truncated: bool = False
+
+
+class UploadFileEntry(BaseModel):
+    path: str
+    data_b64: str = Field(
+        description="Base64-encoded file content. JSON wire format keeps "
+        "the daemon trivial to debug with curl; the 33% overhead is a non-"
+        "issue for plan files / scope artefacts (typically <50 KB).",
+    )
+
+
+class UploadFilesRequest(BaseModel):
+    files: list[UploadFileEntry]
+
+
+class FileResultModel(BaseModel):
+    path: str
+    error: str | None = None
+
+
+class UploadFilesResponse(BaseModel):
+    files: list[FileResultModel]
+
+
+class DownloadFilesRequest(BaseModel):
+    paths: list[str]
+
+
+class DownloadResultModel(BaseModel):
+    path: str
+    data_b64: str | None = None
+    error: str | None = None
+
+
+class DownloadFilesResponse(BaseModel):
+    files: list[DownloadResultModel]
+
+
+# ── tmux / background surface — wraps DockerSandbox.execute_tmux,
+# start_background, poll_completion, etc. These are the methods the
+# bash tool consumes, so once they're up the LLM-driven bash chain
+# transparently works through HTTPSandbox. ───────────────────────────
+
+
+class ExecuteTmuxRequest(BaseModel):
+    command: str = ""
+    session: str = "main"
+    timeout: int | None = None
+    is_input: bool = False
+    workspace_path: str | None = None
+
+
+class ExecuteTmuxResponseModel(BaseModel):
+    output: str
+
+
+class StartBackgroundRequest(BaseModel):
+    command: str
+    session: str = "main"
+    workspace_path: str | None = None
+
+
+class SessionRequest(BaseModel):
+    session: str = "main"
+    workspace_path: str | None = None
+
+
+class BackgroundJobModel(BaseModel):
+    session: str
+    key: str
+    command: str
+    initial_markers: int
+    started_at: float
+    workspace_path: str = "/workspace"
+    status: str = "running"
+    exit_code: int | None = None
+    completed_at: float | None = None
+    consumed: bool = False
+
+
+class PollCompletionResponseModel(BaseModel):
+    job: BackgroundJobModel | None = None
+
+
+class SessionLogDiffResponseModel(BaseModel):
+    diff: str
+
+
+class SessionLogPathResponseModel(BaseModel):
+    path: str
+
+
+# ── Module-level singletons. These live for the daemon's lifetime; we
+# don't recreate the backend per request because reusing the configured
+# workspace + tmux session managers is the whole point. ──────────────
+
+
+_backend: DaemonSandbox | None = None
+_required_token: str | None = None
+
+
+def _get_backend() -> DaemonSandbox:
+    global _backend
+    if _backend is None:
+        workspace_path = os.environ.get("SANDBOX_ROOT_DIR", "/workspace")
+        timeout = int(os.environ.get("SANDBOX_DEFAULT_TIMEOUT", "120"))
+        # `container_name` is cosmetic for DaemonSandbox — it
+        # never invokes `docker exec` — but the value still shows up
+        # in tmux session names and `.id`, so make it informative.
+        sandbox_name = os.environ.get("SANDBOX_CONTAINER_NAME", "local")
+        _backend = DaemonSandbox(
+            container_name=sandbox_name,
+            default_timeout=timeout,
+            workspace_path=workspace_path,
+        )
+    return _backend
+
+
+def _verify_token(authorization: str | None) -> None:
+    if _required_token is None:
+        return
+    if authorization is None or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing bearer token",
+        )
+    if authorization[len("Bearer ") :] != _required_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid token",
+        )
+
+
+# FastAPI dependency injection wrapper for the auth header. Single
+# seam for swapping in OIDC / mTLS later without touching every route.
+def auth(
+    authorization: Annotated[str | None, Header()] = None,
+) -> None:
+    _verify_token(authorization)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    global _required_token
+    _required_token = os.environ.get("SAAS_SANDBOX_TOKEN") or None
+    # Warm the backend so the first agent request doesn't pay the
+    # init cost on its critical path.
+    _get_backend()
+    yield
+
+
+app = FastAPI(
+    title="Decepticon sandbox daemon",
+    summary="HTTP transport for the DaemonSandbox surface. Pairs with HTTPSandbox.",
+    lifespan=lifespan,
+)
+
+
+# ── Liveness ──────────────────────────────────────────────────────────
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    """Cheap liveness probe. Cloud Run / Kubernetes startup probes
+    should target this — it doesn't touch the backend so it stays
+    green even during a long-running command."""
+    return {"status": "ok"}
+
+
+# ── BaseSandbox surface ───────────────────────────────────────────────
+
+
+@app.post("/execute", response_model=ExecuteResponseModel)
+def execute(
+    req: ExecuteRequest,
+    _: Annotated[None, Depends(auth)],
+) -> ExecuteResponseModel:
+    backend = _get_backend()
+    result = backend.execute(req.command, timeout=req.timeout)
+    return ExecuteResponseModel(
+        output=result.output,
+        exit_code=result.exit_code,
+        truncated=result.truncated,
+    )
+
+
+@app.post("/upload_files", response_model=UploadFilesResponse)
+def upload_files(
+    req: UploadFilesRequest,
+    _: Annotated[None, Depends(auth)],
+) -> UploadFilesResponse:
+    backend = _get_backend()
+    decoded = [(f.path, base64.b64decode(f.data_b64)) for f in req.files]
+    results = backend.upload_files(decoded)
+    return UploadFilesResponse(
+        files=[FileResultModel(path=r.path, error=r.error) for r in results],
+    )
+
+
+@app.post("/download_files", response_model=DownloadFilesResponse)
+def download_files(
+    req: DownloadFilesRequest,
+    _: Annotated[None, Depends(auth)],
+) -> DownloadFilesResponse:
+    backend = _get_backend()
+    results = backend.download_files(req.paths)
+    return DownloadFilesResponse(
+        files=[
+            DownloadResultModel(
+                path=r.path,
+                data_b64=(
+                    base64.b64encode(r.content).decode("ascii") if r.content is not None else None
+                ),
+                error=r.error,
+            )
+            for r in results
+        ],
+    )
+
+
+# ── tmux / background surface ─────────────────────────────────────────
+
+
+@app.post("/execute_tmux", response_model=ExecuteTmuxResponseModel)
+def execute_tmux(
+    req: ExecuteTmuxRequest,
+    _: Annotated[None, Depends(auth)],
+) -> ExecuteTmuxResponseModel:
+    backend = _get_backend()
+    output = backend.execute_tmux(
+        command=req.command,
+        session=req.session,
+        timeout=req.timeout,
+        is_input=req.is_input,
+        workspace_path=req.workspace_path,
+    )
+    return ExecuteTmuxResponseModel(output=output)
+
+
+@app.post("/start_background", response_model=dict)
+def start_background(
+    req: StartBackgroundRequest,
+    _: Annotated[None, Depends(auth)],
+) -> dict:
+    backend = _get_backend()
+    backend.start_background(
+        command=req.command,
+        session=req.session,
+        workspace_path=req.workspace_path,
+    )
+    return {"status": "ok"}
+
+
+@app.post("/poll_completion", response_model=PollCompletionResponseModel)
+def poll_completion(
+    req: SessionRequest,
+    _: Annotated[None, Depends(auth)],
+) -> PollCompletionResponseModel:
+    backend = _get_backend()
+    job = backend.poll_completion(
+        session=req.session,
+        workspace_path=req.workspace_path,
+    )
+    if job is None:
+        return PollCompletionResponseModel(job=None)
+    # Field-by-field copy rather than asdict so a future BackgroundJob
+    # extension doesn't silently leak fields the wire shape isn't
+    # ready for.
+    return PollCompletionResponseModel(
+        job=BackgroundJobModel(
+            session=job.session,
+            key=job.key,
+            command=job.command,
+            initial_markers=job.initial_markers,
+            started_at=job.started_at,
+            workspace_path=job.workspace_path,
+            status=job.status,
+            exit_code=job.exit_code,
+            completed_at=job.completed_at,
+            consumed=job.consumed,
+        ),
+    )
+
+
+@app.post("/kill_session", response_model=dict)
+def kill_session(
+    req: SessionRequest,
+    _: Annotated[None, Depends(auth)],
+) -> dict:
+    backend = _get_backend()
+    backend.kill_session(
+        session=req.session,
+        workspace_path=req.workspace_path,
+    )
+    return {"status": "ok"}
+
+
+@app.post("/read_session_log_diff", response_model=SessionLogDiffResponseModel)
+def read_session_log_diff(
+    req: SessionRequest,
+    _: Annotated[None, Depends(auth)],
+) -> SessionLogDiffResponseModel:
+    backend = _get_backend()
+    diff = backend.read_session_log_diff(
+        session=req.session,
+        workspace_path=req.workspace_path,
+    )
+    return SessionLogDiffResponseModel(diff=diff)
+
+
+@app.post("/reset_session_log_offset", response_model=dict)
+def reset_session_log_offset(
+    req: SessionRequest,
+    _: Annotated[None, Depends(auth)],
+) -> dict:
+    backend = _get_backend()
+    backend.reset_session_log_offset(
+        session=req.session,
+        workspace_path=req.workspace_path,
+    )
+    return {"status": "ok"}
+
+
+@app.post("/session_log_path", response_model=SessionLogPathResponseModel)
+def session_log_path(
+    req: SessionRequest,
+    _: Annotated[None, Depends(auth)],
+) -> SessionLogPathResponseModel:
+    backend = _get_backend()
+    path = backend.session_log_path(
+        session=req.session,
+        workspace_path=req.workspace_path,
+    )
+    return SessionLogPathResponseModel(path=path)

--- a/decepticon/tools/bash/bash.py
+++ b/decepticon/tools/bash/bash.py
@@ -33,7 +33,8 @@ import time
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
-from decepticon.backends.docker_sandbox import DockerSandbox, _interpret_exit_code
+from decepticon.backends.docker_sandbox import DockerSandbox
+from decepticon.sandbox_kernel.tmux import _interpret_exit_code
 
 log = logging.getLogger("decepticon.tools.bash.bash")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,15 @@ dependencies = [
     # HTTP
     "httpx>=0.27.0",
     "deepagents>=0.5.0",
+    # Sandbox HTTP daemon — the FastAPI app that ships inside the
+    # sandbox container and that `HTTPSandbox` (decepticon/backends/
+    # http_sandbox.py) talks to. Carried in the main install set
+    # because the sandbox container mounts decepticon as
+    # /deps/decepticon and runs `python -m decepticon.sandbox_server`
+    # as its entrypoint; the agent process imports nothing from these
+    # at runtime.
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
     # CLI
     "typer[all]>=0.9.0",
     "xxhash>=3.0.0",

--- a/tests/unit/backends/test_background_jobs.py
+++ b/tests/unit/backends/test_background_jobs.py
@@ -177,8 +177,8 @@ def test_auto_background_path_registers_job():
 
     with (
         patch.object(sandbox, "_get_manager") as mock_get,
-        patch("decepticon.backends.docker_sandbox.AUTO_BACKGROUND_SECONDS", 0.0),
-        patch("decepticon.backends.docker_sandbox.POLL_INTERVAL", 0.01),
+        patch("decepticon.sandbox_kernel.tmux.AUTO_BACKGROUND_SECONDS", 0.0),
+        patch("decepticon.sandbox_kernel.tmux.POLL_INTERVAL", 0.01),
     ):
         mgr = MagicMock()
         mgr.session = "long"

--- a/tests/unit/backends/test_docker_sandbox_helpers.py
+++ b/tests/unit/backends/test_docker_sandbox_helpers.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from decepticon.backends import docker_sandbox as ds
-from decepticon.backends.docker_sandbox import (
+from decepticon.sandbox_kernel.tmux import (
     MAX_OUTPUT_CHARS,
     PS1_PATTERN,
     TmuxSessionManager,

--- a/tests/unit/backends/test_session_log.py
+++ b/tests/unit/backends/test_session_log.py
@@ -21,7 +21,7 @@ def test_initialize_does_not_create_root_workspace_sessions_log():
 
     with (
         patch.object(mgr, "_docker_tmux") as mock_tmux,
-        patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run,
+        patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
         mock_tmux.side_effect = [
@@ -51,7 +51,7 @@ def test_initialize_pipes_pane_to_engagement_scoped_sessions_log():
 
     with (
         patch.object(mgr, "_docker_tmux") as mock_tmux,
-        patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run,
+        patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
         mock_tmux.side_effect = [
@@ -87,7 +87,7 @@ def test_initialize_creates_sessions_directory_inside_engagement_workspace():
 
     with (
         patch.object(mgr, "_docker_tmux") as mock_tmux,
-        patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run,
+        patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
         mock_tmux.side_effect = [RuntimeError("session not found"), "", "", "", "", "", ""]
@@ -120,7 +120,7 @@ def test_initialize_warns_when_mkdir_fails(caplog):
     try:
         with (
             patch.object(mgr, "_docker_tmux") as mock_tmux,
-            patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run,
+            patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
             patch("time.sleep"),
         ):
             mock_tmux.side_effect = [RuntimeError("session not found"), "", "", "", "", "", ""]
@@ -383,7 +383,7 @@ def test_execute_async_poll_loop_capture_timeout_continues():
         patch.object(mgr, "_capture", side_effect=fake_capture),
         patch.object(mgr, "_send", return_value=None),
         patch.object(mgr, "initialize", return_value=None),
-        patch("decepticon.backends.docker_sandbox.POLL_INTERVAL", 0.01),
+        patch("decepticon.sandbox_kernel.tmux.POLL_INTERVAL", 0.01),
     ):
         result = asyncio.run(mgr.execute_async(command="ls", is_input=False, timeout=1))
 
@@ -421,8 +421,8 @@ def test_poll_loop_capture_errors_dont_falsely_trigger_stall_detection():
         patch.object(mgr, "_send", return_value=None),
         patch.object(mgr, "_clear_screen", return_value=None),
         patch.object(mgr, "initialize", return_value=None),
-        patch("decepticon.backends.docker_sandbox.POLL_INTERVAL", 0.01),
-        patch("decepticon.backends.docker_sandbox.STALL_SECONDS", 0.05),
+        patch("decepticon.sandbox_kernel.tmux.POLL_INTERVAL", 0.01),
+        patch("decepticon.sandbox_kernel.tmux.STALL_SECONDS", 0.05),
     ):
         result = asyncio.run(mgr.execute_async(command="ls", is_input=False, timeout=2))
 
@@ -440,7 +440,7 @@ def test_initialize_recreates_stale_cached_pane_without_error_string_matching():
 
     with (
         patch.object(mgr, "_docker_tmux") as mock_tmux,
-        patch("decepticon.backends.docker_sandbox.subprocess.run") as mock_run,
+        patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
         mock_tmux.side_effect = [

--- a/uv.lock
+++ b/uv.lock
@@ -366,6 +366,7 @@ source = { editable = "." }
 dependencies = [
     { name = "deepagents" },
     { name = "defusedxml" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
@@ -379,6 +380,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "typer" },
+    { name = "uvicorn" },
     { name = "xxhash" },
 ]
 
@@ -396,6 +398,7 @@ dev = [
 requires-dist = [
     { name = "deepagents", specifier = ">=0.5.0" },
     { name = "defusedxml", specifier = ">=0.7.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain-anthropic", specifier = ">=0.3.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
@@ -409,6 +412,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "typer", extras = ["all"], specifier = ">=0.9.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
 
@@ -473,6 +477,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`DockerSandbox` shells \`docker exec <container> ...\` into a sibling sandbox container — beautiful in dev, untenable on serverless runtimes (Cloud Run, ECS Fargate, GKE Autopilot) where containers can't share a host docker socket. Today there is no production path for running Soundwave or the Decepticon orchestrator on Cloud Run / similar.

## What

A transport-only alternative to \`DockerSandbox\` that preserves the **sandbox-as-separate-container trust boundary** but swaps \`docker exec\` for HTTP on loopback / service network.

- **\`HTTPSandbox\`** (\`decepticon/backends/http_sandbox.py\`) — \`BaseSandbox\` subclass that forwards the three abstract operations (\`execute\`, \`upload_files\`, \`download_files\`) over HTTP. The rest (\`ls / read / write / edit / grep / glob\`) is inherited from \`BaseSandbox\` and dispatches through \`execute()\`, so no extra wire surface is needed.

- **Sandbox daemon** (\`decepticon/sandbox_server/\`) — FastAPI app that wraps \`deepagents.LocalShellBackend\`. Three endpoints (\`/execute\`, \`/upload_files\`, \`/download_files\`) plus \`/healthz\` for liveness probes. Bearer-token auth via \`SAAS_SANDBOX_TOKEN\` env. **All file IO + shell logic is reused from upstream** — daemon is ~150 LOC.

- **\`build_sandbox_backend()\`** factory (\`decepticon/backends/factory.py\`) — agents pick a backend via env. \`DECEPTICON_FILESYSTEM_BACKEND=docker\` (default, zero behaviour change) or \`http\`. Wired into Soundwave and the Decepticon orchestrator.

- **Sandbox image** — \`containers/sandbox.Dockerfile\` adds \`fastapi\`+\`uvicorn\`+\`deepagents\` (~50 MB), ships only \`decepticon/sandbox_server/\` into the image (agent/llm/middleware subtrees stay out). Entrypoint: when \`SANDBOX_DAEMON=1\`, exec the daemon; otherwise fall through to the unchanged tail-loop so dev / local-docker / GCE Spot users get the same image they had before.

## Architecture notes

- **Trust boundary preserved**: sandbox is still a separate container with its own fs / tools; agent runs in the LangGraph container; they communicate over a control plane. The transport changed, the isolation didn't.
- **Tenant isolation** on a shared pool-plane sandbox stays enforced upstream by the SaaS \`EngagementFilesystemBackend\` wrapper. Per-request engagement scoping on the daemon itself is a sensible follow-up; not in this PR.
- **Why HTTP and not SSH/gRPC**: OpenHands explicitly deprecated SSH ([Issue #2404](https://github.com/OpenHands/OpenHands/issues/2404)) because sshd-in-every-image is untenable. E2B, Modal, Daytona, SmolAgents, SWE-ReX all converged on REST. Cloud Run sibling-container loopback is HTTP/1.1-first; gRPC needs h2c, SSH needs key distribution + sshd. REST has the strongest container-runtime tool support.

## Scope clarification

Pool-plane agents (Soundwave + Decepticon orchestrator) use only file IO — they have no \`bash\` tool. They read \`ls/read/write/edit/grep/glob\` through \`BaseSandbox\`'s derived implementations, which only need the three abstract methods this PR adds.

Silo-plane sub-agents (recon / exploit / postexploit / ...) call \`execute_tmux\`, \`start_background\`, and other DockerSandbox extensions that aren't part of BaseSandbox. Wiring those over HTTP is a follow-up; pool-plane Soundwave / orchestrator don't need them. Sub-agents continue to use DockerSandbox via per-engagement compute (local-docker dev / GCE Spot prod).

## Test plan

- [x] In-process: \`python -m decepticon.sandbox_server\` against \`HTTPSandbox\` directly — \`/healthz\`, \`execute\`, \`upload_files\`, \`download_files\`, \`BaseSandbox\`-derived \`ls\` (→ execute), and auth-deny paths all returned expected results.
- [x] In Docker: rebuilt \`containers/sandbox.Dockerfile\`, ran with \`SANDBOX_DAEMON=1\`. Daemon comes up as PID 1; \`HTTPSandbox\` from the host (loopback) drove the full set of operations inside the Kali image with identical behaviour to the in-process run.
- [ ] CI build of sandbox image confirms image size + dependency resolution.
- [ ] (Out of scope for this PR) End-to-end Cloud Run multi-container deploy with the SaaS side wired to \`DECEPTICON_FILESYSTEM_BACKEND=http\`. PR'd separately on the SaaS side.

## Breaking changes

None. \`DOCKER_FILESYSTEM_BACKEND\` defaults to \`docker\` and the image stays backwards-compatible: when \`SANDBOX_DAEMON\` is unset, the entrypoint falls through to the existing tail-loop CMD. Every existing dev / OSS user gets the same behaviour.