### PR TITLE
fix(compose): silence DECEPTICON_STACK_NAME 'variable is not set' WARN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,6 +236,12 @@ COMPOSE_PROFILES=c2-sliver
 #   rootless dock: DECEPTICON_DOCKER_SOCKET=$HOME/.docker/run/docker.sock
 # DECEPTICON_DOCKER_SOCKET=/var/run/docker.sock
 
+# Multi-stack container naming (PR #216). Unset/empty keeps the default
+# `decepticon-*` names. Set to e.g. `stack2` to get `decepticon-stack2-*`
+# so two stacks can coexist on the same Docker host. The declaration here
+# (even when blank) silences the compose "variable is not set" WARN.
+DECEPTICON_STACK_NAME=
+
 # --- Language ---
 # Pin agent output language to an ISO 639-1 code. All agent prose output
 # (menus, questions, summaries, errors) renders in this language.


### PR DESCRIPTION
## Summary

- Declare `DECEPTICON_STACK_NAME=` (blank) in `.env.example` so every `docker compose <cmd>` no longer emits 9 `WARN[0000] The "DECEPTICON_STACK_NAME" variable is not set` lines.
- Behavior preserved: `container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-litellm` still resolves to `decepticon-litellm` when blank.

## Root cause

PR #216 (multi-stack container naming) introduced `${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}` in 9 `container_name` fields of `docker-compose.yml`, but never declared the variable in `.env.example`. Compose 2.x emits `WARN[0000] The "X" variable is not set. Defaulting to a blank string.` once per reference when a variable is undeclared — even when the substitution uses `:+`/`:-` defaults — so a default install gets 9 warnings on every compose invocation.

```
$ docker compose down
WARN[0000] The "DECEPTICON_STACK_NAME" variable is not set. Defaulting to a blank string.
WARN[0000] The "DECEPTICON_STACK_NAME" variable is not set. Defaulting to a blank string.
... (×9)
```

## Fix

Declare `DECEPTICON_STACK_NAME=` (blank) in `.env.example`, with a short doc comment explaining the multi-stack toggle and why the empty declaration is kept.

## Test plan

- [x] `docker compose config -q` → no WARN (was 9)
- [x] `docker compose config | grep container_name` → all names remain `decepticon-<svc>` (no double-dash)
- [x] No code paths changed; behavior identical when var is blank, unset, or set to a stack name

🤖 Generated with [Claude Code](https://claude.com/claude-code)