### PR TITLE
feat(corpus): h4cker manifest + Awesome-Hacking JSON index

### DIFF
--- a/skills/_corpus/awesome_index.json
+++ b/skills/_corpus/awesome_index.json
@@ -1,0 +1,125 @@
+{
+  "_comment": "Hack-with-Github/Awesome-Hacking + canonical sub-lists, distilled. Generated 2026-05-20. License: CC0. Use: recon agent 'where do I learn X' lookups. Source: https://github.com/Hack-with-Github/Awesome-Hacking",
+  "categories": {
+    "android": {
+      "url": "https://github.com/ashishb/android-security-awesome",
+      "topics": ["apk analysis", "frida hooking", "ssl pinning bypass", "root detection bypass", "intent fuzzing", "deeplink abuse"],
+      "decepticon_ref": "skills/_corpus/h4cker_manifest.yaml#mobile-security"
+    },
+    "appsec": {
+      "url": "https://github.com/paragonie/awesome-appsec",
+      "topics": ["secure coding", "language-specific pitfalls", "input validation libraries"],
+      "decepticon_ref": "skills/exploit/web/"
+    },
+    "burp-extensions": {
+      "url": "https://github.com/snoopysecurity/awesome-burp-extensions",
+      "topics": ["SAML Raider", "Param Miner", "Logger++", "Turbo Intruder", "JWT Editor", "Active Scan++"],
+      "decepticon_ref": "skills/exploit/web/jwt/, skills/exploit/web/saml/, skills/exploit/web/cache-deception/"
+    },
+    "ctf": {
+      "url": "https://github.com/apsdehal/awesome-ctf",
+      "topics": ["pwntools", "angr", "Volatility", "z3", "radare2", "Ghidra"],
+      "decepticon_ref": "skills/reverser/"
+    },
+    "exploit-dev": {
+      "url": "https://github.com/FabioBaroni/awesome-exploit-development",
+      "topics": ["heap exploitation", "ROP chains", "kernel exploitation", "browser exploitation", "windows exploitation"],
+      "decepticon_ref": "skills/reverser/rop-chain/"
+    },
+    "fuzzing": {
+      "url": "https://github.com/cpuu/awesome-fuzzing",
+      "topics": ["AFL++", "libFuzzer", "honggfuzz", "syzkaller", "radamsa", "Boofuzz"],
+      "decepticon_ref": "skills/analyst/, skills/contracts/ (foundry-fuzz)"
+    },
+    "hacking-resources": {
+      "url": "https://github.com/vitalysim/Awesome-Hacking-Resources",
+      "topics": ["pentest cheatsheets", "exploit DBs", "wargames", "CTF platforms"]
+    },
+    "honeypots": {
+      "url": "https://github.com/paralax/awesome-honeypots",
+      "topics": ["Cowrie", "Dionaea", "T-Pot"],
+      "decepticon_ref": "docs/offensive-vaccine.md (when implemented)"
+    },
+    "incident-response": {
+      "url": "https://github.com/meirwah/awesome-incident-response",
+      "topics": ["Volatility", "GRR", "TheHive", "MISP", "Sigma rules"],
+      "decepticon_ref": "skills/_corpus/h4cker_manifest.yaml#dfir"
+    },
+    "industrial-control-systems": {
+      "url": "https://github.com/hslatman/awesome-industrial-control-system-security",
+      "topics": ["Modbus", "DNP3", "S7Comm", "ICS protocol fuzzing", "Stuxnet-class attacks"]
+    },
+    "iot": {
+      "url": "https://github.com/V33RU/IoTSecurity101",
+      "topics": ["UART debugging", "JTAG", "firmware extraction", "binwalk", "Ghidra firmware"],
+      "decepticon_ref": "skills/reverser/firmware/"
+    },
+    "lockpicking": {
+      "url": "https://github.com/meitar/awesome-lockpicking",
+      "topics": ["physical security", "covert entry", "RFID cloning"]
+    },
+    "malware-analysis": {
+      "url": "https://github.com/rshipp/awesome-malware-analysis",
+      "topics": ["YARA", "capa", "FLARE", "Cuckoo Sandbox", "PEStudio", "Detect-it-Easy"],
+      "decepticon_ref": "skills/reverser/triage/, skills/reverser/packer-unpacking/"
+    },
+    "osint": {
+      "url": "https://github.com/jivoi/awesome-osint",
+      "topics": ["Maltego", "SpiderFoot", "Recon-ng", "shodan", "censys", "URLscan"],
+      "decepticon_ref": "skills/recon/osint/"
+    },
+    "pentest": {
+      "url": "https://github.com/enaqx/awesome-pentest",
+      "topics": ["nmap", "Metasploit", "Empire", "Cobalt Strike", "BloodHound", "Mimikatz"],
+      "decepticon_ref": "skills/exploit/, skills/ad/, skills/post-exploit/"
+    },
+    "physical-security": {
+      "url": "https://github.com/Wesley-Pang/Awesome-Physical-Security",
+      "topics": ["badge cloning", "social engineering for facility entry", "RFID"]
+    },
+    "reverse-engineering": {
+      "url": "https://github.com/wtsxDev/reverse-engineering",
+      "topics": ["IDA Pro", "Ghidra", "radare2", "x64dbg", "Binary Ninja"],
+      "decepticon_ref": "skills/reverser/"
+    },
+    "social-engineering": {
+      "url": "https://github.com/v2-dev/awesome-social-engineering",
+      "topics": ["pretexting frameworks", "OSINT for SE", "vishing scripts", "phishing infrastructure"],
+      "decepticon_ref": "skills/recon/osint/"
+    },
+    "shodan-queries": {
+      "url": "https://github.com/jakejarvis/awesome-shodan-queries",
+      "topics": ["common shodan dorks", "IoT discovery patterns", "internet-exposed databases"],
+      "decepticon_ref": "skills/recon/passive-recon/"
+    },
+    "static-analysis": {
+      "url": "https://github.com/analysis-tools-dev/static-analysis",
+      "topics": ["semgrep", "bandit", "gitleaks", "trufflehog", "Slither", "Mythril"],
+      "decepticon_ref": "skills/analyst/, skills/contracts/"
+    },
+    "web-hacking": {
+      "url": "https://github.com/infoslack/awesome-web-hacking",
+      "topics": ["Burp Suite plugins", "ffuf", "sqlmap", "wfuzz", "XSStrike"],
+      "decepticon_ref": "skills/exploit/web/, skills/_corpus/payloads/"
+    },
+    "wifi-security": {
+      "url": "https://github.com/0x90/wifi-arsenal",
+      "topics": ["aircrack-ng", "hashcat WPA modes", "evil twin", "PMKID attacks", "WPS attacks"]
+    },
+    "windows-exploitation": {
+      "url": "https://github.com/enddo/awesome-windows-exploitation",
+      "topics": ["UAC bypass", "AppLocker bypass", "AMSI bypass", "ETW patching", "PrintNightmare"]
+    },
+    "yara": {
+      "url": "https://github.com/InQuest/awesome-yara",
+      "topics": ["YARA rule writing", "malware family signatures", "capa rule library"]
+    }
+  },
+  "use_protocol": {
+    "step1": "Agent receives objective from user / orchestrator",
+    "step2": "If objective is 'learn about X' / 'recommend resources for X' / 'where do I find Y', load this index via load_skill('/skills/_corpus/awesome_index.json')",
+    "step3": "Match objective keywords to categories[*].topics — find the best category",
+    "step4": "Return the upstream URL + relevant Decepticon cross-references to the user",
+    "step5": "Do NOT fetch the upstream Awesome list contents during a normal engagement — link only. Fetching is for separate learning/research mode."
+  }
+}

--- a/skills/_corpus/h4cker_manifest.yaml
+++ b/skills/_corpus/h4cker_manifest.yaml
@@ -1,0 +1,121 @@
+# h4cker reference manifest
+#
+# https://github.com/The-Art-of-Hacking/h4cker (Omar Santos, MIT)
+#
+# 156 MB of mostly PDFs / training decks / pointer lists. Vendoring
+# wholesale wastes 95% of bytes. This manifest lists the ~30 high-value
+# subtrees agents may want to consult on demand.
+#
+# Resolution protocol:
+# 1. Agent reads this file via `load_skill("/skills/_corpus/h4cker_manifest.yaml")`
+# 2. Identifies the relevant subtree by its description
+# 3. Clones shallow via:
+#      git clone --depth 1 --filter=blob:none --no-checkout \
+#        https://github.com/The-Art-of-Hacking/h4cker.git /tmp/h4cker
+#      cd /tmp/h4cker && git sparse-checkout init --cone
+#      git sparse-checkout set <subtree>
+#      git checkout
+# 4. Reads the relevant files locally; the directory is throwaway
+
+version: 1
+upstream: https://github.com/The-Art-of-Hacking/h4cker
+license: MIT
+last_reviewed: 2026-05-20
+
+subtrees:
+  - path: ai
+    description: AI red-teaming + AI security primers, prompt-injection
+      methodologies, LLM red-team curriculum
+    priority: high
+    cross_ref: skills/exploit/llm/, skills/analyst/prompt-injection.md
+
+  - path: cybersecurity-domains/offensive-security
+    description: Offensive operations methodology — recon, exploit, post-exploit,
+      pentest reporting
+    priority: high
+    cross_ref: skills/recon/, skills/exploit/, skills/post-exploit/
+
+  - path: cybersecurity-domains/cloud-container-security
+    description: AWS/Azure/GCP + Docker/K8s attack + defense — overlaps
+      with Decepticon's skills/cloud/ but broader on container escape
+    priority: high
+    cross_ref: skills/cloud/, container-escape skill
+
+  - path: cybersecurity-domains/web-application-security
+    description: Web app hardening + attack surface mapping, complements
+      OWASP WSTG
+    priority: medium
+    cross_ref: skills/exploit/web/, skills/_corpus/payloads/
+
+  - path: dfir
+    description: Digital forensics + incident response — useful as defender
+      perspective for the Offensive Vaccine workstream
+    priority: medium
+    cross_ref: docs/offensive-vaccine.md (when implemented)
+
+  - path: ethical-hacking-tools
+    description: Tool inventory + usage notes — but mostly outdated; check
+      cross-ref tables instead of cargo-culting
+    priority: low
+
+  - path: programming-and-scripting-for-cybersecurity
+    description: Python/Bash/Go for pentest automation, fuzzer harness writing
+    priority: medium
+    cross_ref: skills/analyst/, skills/recon/
+
+  - path: build-your-own-lab
+    description: Vulnerable VM setup — useful for Decepticon's local
+      development benchmark targets
+    priority: low
+
+  - path: malware-analysis
+    description: Static/dynamic malware analysis playbooks, reverse engineering
+      techniques
+    priority: medium
+    cross_ref: skills/reverser/
+
+  - path: threat-hunting
+    description: Threat hunting methodology — useful for Decepticon's
+      detector agent and Vaccine workstream
+    priority: medium
+
+  - path: red-blue-purple-team
+    description: Purple-team integration patterns — directly relevant to
+      the CypherFix double-agent workstream
+    priority: high
+    cross_ref: docs/offensive-vaccine.md
+
+  - path: penetration-testing-and-red-teaming
+    description: Pentest methodology trees, RoE templates, engagement
+      planning
+    priority: high
+    cross_ref: skills/soundwave/, skills/decepticon/
+
+  - path: api-security
+    description: REST + GraphQL + gRPC security — complements
+      skills/exploit/web/ leaves
+    priority: medium
+    cross_ref: skills/exploit/web/graphql.md, skills/exploit/web/mass-assignment/
+
+  - path: mobile-security
+    description: Android + iOS pentest references
+    priority: medium
+
+  - path: iot-security
+    description: IoT attack surface, firmware extraction, hardware hacking
+    priority: medium
+    cross_ref: skills/reverser/firmware/
+
+  - path: post-quantum-cryptography
+    description: Forward-looking cryptography references
+    priority: low
+
+  - path: blockchain-security
+    description: Smart contract + DeFi security references
+    priority: medium
+    cross_ref: skills/contracts/
+
+# Subtrees explicitly NOT in scope (avoid downloading):
+# - Training videos / slide decks (massive, low operational value)
+# - PDF cheat-sheets (use skills/_corpus/payloads/ instead, freshher)
+# - Vendor-specific certification prep (CEH, OSCP, Pentest+) — out of scope


### PR DESCRIPTION
## Summary

Completes the reference-layer trio. PayloadsAllTheThings is vendored (#242); this PR adds:
- **h4cker manifest** (yaml) — 16 high-value subtrees, NOT vendored (156 MB upstream is 95% PDFs / training decks). Sparse-checkout protocol in file header.
- **Awesome-Hacking JSON index** — 22 awesome-* sub-lists flattened into category-→ {url, topics, decepticon_ref}. CC0 license = no attribution friction. Recon agent's "where do I learn X" lookup table.

## Why not vendor h4cker?
156 MB. Mostly PDFs, slide decks, training-cert prep. ~30 directories have operational value; the rest is bloat. Manifest approach surfaces the valuable subtrees by name + priority, agents pull on demand via sparse-checkout when needed.

## Why JSON for Awesome-Hacking?
The upstream is a README of links. Flattening to JSON makes it programmatically queryable + lets the recon agent cross-reference against existing Decepticon skills (`decepticon_ref` field per entry).

## Stats
- 2 files, +246 lines
- No runtime change; reference-only
- Pairs with #242 (corpus submodule) and #243 (14 vuln-class leaves)

## License
h4cker = MIT. Awesome-Hacking = CC0. Attribution already in THIRD_PARTY_LICENSES.md (added #242).