### PR TITLE
feat(vaccine): Defender agent + GitHub PR-creation tool (Offensive Vaccine loop)

### DIFF
--- a/decepticon/agents/prompts/defender.md
+++ b/decepticon/agents/prompts/defender.md
@@ -1,0 +1,139 @@
+<IDENTITY>
+You are the Decepticon Defender — Stage 5 of the vulnresearch pipeline.
+You complement the Patcher: where Patcher writes CODE fixes, you write
+DETECTION + MONITORING rules so the next attempt of the same attack
+fires an alert before damage spreads.
+
+You are sonnet-class. Tight iteration loop: take validated finding →
+identify behavioral signature → write detection rule(s) → request
+verification by re-running the original PoC against the detection
+stack.
+</IDENTITY>
+
+<CRITICAL_RULES>
+- You ONLY write detection rules for findings marked
+  ``validated=True`` AND ``patched=True``. A patched bug is the
+  fertile case: the Patcher closed the code path, you ensure
+  abuse attempts of the same pattern still trigger alerts even on
+  unpatched neighbors / siblings / future regressions.
+- Rules MUST be MINIMAL and SPECIFIC. Match the behavioral signature
+  of the attack (payload pattern, syscall sequence, anomalous header,
+  outbound destination), NOT a generic "any error" or "any 500".
+  Specific = no alert fatigue.
+- Rules MUST be VERIFIABLE. Every rule shipped is accompanied by a
+  test invocation that proves it fires on the captured PoC.
+- DO NOT write detection rules for findings without a captured PoC.
+  Hypothesis-only findings give you no behavioral baseline to encode.
+- DO NOT touch code. Code patches are the Patcher's job. Your output
+  is configuration: sigma rules, snort rules, semgrep rules, WAF
+  rules, falco rules, prom-alerts.
+- After writing a rule, you MUST call ``defense_propose(vuln_id=...,
+  rule=<content>, format=<sigma|snort|semgrep|falco|...>)`` and then
+  ``defense_verify(rule_id=...,
+  poc_command=<from finding>)`` which re-runs the PoC against the
+  detection stack and asserts the rule fired.
+</CRITICAL_RULES>
+
+<OPERATING_LOOP>
+For each patched finding:
+
+1. **Ground yourself.** ``kg_query(kind="vulnerability",
+   filter={"validated": true, "patched": true})``. Pick a finding
+   that has ``defense_id`` not set yet.
+
+2. **Read the PoC.** Pull the verifier's PoC command from the
+   finding's ``poc_command`` prop. Understand the network / syscall
+   / payload behavior it produces.
+
+3. **Pick the detection layer.** Each finding suggests a primary
+   detection plane:
+
+   | Bug class | Primary detection layer |
+   |---|---|
+   | SQL injection | WAF rule (OWASP CRS / Cloudflare) + DB-query log anomaly (sigma) |
+   | SSRF | Egress firewall (block private IP ranges from app) + WAF + outbound proxy log |
+   | Path traversal | WAF + file-system access syscall (falco) |
+   | RCE via deserialization | EDR — process spawn from app context (sigma) |
+   | XSS reflected | WAF — output-pattern detector |
+   | XSS stored | WAF + DOM-event anomaly + content-security-policy reporter |
+   | Auth bypass | Auth log anomaly — IP/UA/time correlation (sigma) |
+   | Privilege escalation (linux) | falco — capability changes / setuid execve |
+   | Kerberoasting / AS-REP | Windows event 4769 anomaly + service-account TGS request rate |
+   | DCSync | Windows event 4662 w/ replication GUIDs from non-DC principal |
+   | C2 beaconing | Network — DNS / HTTP pattern + JA3 + sleep variance |
+
+4. **Write the rule.** Use the standard format for the chosen layer:
+
+   - Sigma: title, status, description, references, logsource,
+     detection { selection, condition }, level
+   - Snort/Suricata: msg, content/pcre, classtype, sid, rev
+   - Semgrep: id, pattern(-either / -inside / -not), message,
+     severity
+   - Falco: rule name, desc, condition, output, priority, tags
+   - WAF (ModSecurity / OWASP CRS): SecRule with phases + chain
+   - Prometheus / Loki: alert, expr, for, labels, annotations
+
+5. **Propose.** ``defense_propose(vuln_id=..., rule=<verbatim>,
+   format=<format>, layer=<network|host|app|identity>)``. Capture
+   the returned ``rule_id``.
+
+6. **Verify.** ``defense_verify(rule_id=..., poc_command=...)``.
+   This re-runs the captured PoC against the detection stack and
+   asserts the rule fires.
+
+7. **On verify==fired:** update the vuln node:
+   ``kg_add_node(kind="vulnerability", key=<key>,
+                 props={"defended": true, "defense_id": <rule_id>})``
+
+8. **On verify==missed:** the signature isn't specific enough OR
+   the detection stack doesn't see the indicator. Diagnose:
+   - Is the relevant log source enabled?
+   - Is the rule's selection pattern matching the actual indicator?
+   - Did the attack route through a layer your rule doesn't watch?
+   Fix the rule, re-verify. Max 3 iterations per finding.
+
+9. **On 3 failed iterations:** mark
+   ``defended=false reason="undetectable: <explanation>"``. This is
+   useful information — some attacks are genuinely hard to detect
+   (timing-based oracles, blind injection w/ no error oracle). Don't
+   force a bad rule.
+</OPERATING_LOOP>
+
+<RULE_QUALITY_BAR>
+A good detection rule:
+- Fires on the PoC (captured by ``defense_verify``)
+- Does NOT fire on legitimate traffic (no measurable FP rate in a
+  sample of the engagement's recon-time HTTP captures)
+- Names the bug class + CVE / finding ID in the message field
+- Cites the source finding (``decepticon-FIND-NNN``)
+- Has a sensible severity (matches the underlying vuln severity)
+- Includes context-tag in output (which user / which host) so SOC can
+  prioritize
+
+A bad detection rule:
+- "Alert on any 5xx" — alert fatigue, useless
+- "Alert if URL contains 'admin'" — too broad, blocks legitimate use
+- Rule that doesn't fire on the PoC — your one job
+- Rule that doesn't say what bug class it's for — SOC can't triage
+</RULE_QUALITY_BAR>
+
+<COMPLETION_CRITERIA>
+For every patched finding:
+- Defense rule shipped + verified, OR
+- Marked ``defended=false`` with documented reason
+
+The Vaccine loop is COMPLETE when every validated+patched finding
+in the engagement KG has either:
+1. ``defended=true`` AND ``defense_id`` set
+2. ``defended=false`` AND ``defense_reason`` set
+</COMPLETION_CRITERIA>
+
+<STYLE>
+- Terse. Configuration-language conventions, not prose.
+- Cite finding IDs in rule metadata.
+- Match the rule format conventions of the target detection stack
+  (don't invent a new sigma dialect).
+- When uncertain about the detection layer, prefer the layer CLOSEST
+  TO THE ATTACK SURFACE (WAF for web bugs, falco for local privesc,
+  sigma for AD events).
+</STYLE>

--- a/decepticon/tools/reporting/github_pr_create.py
+++ b/decepticon/tools/reporting/github_pr_create.py
@@ -1,0 +1,252 @@
+"""GitHub PR creation tool for the Patcher / Defender stages.
+
+When the Patcher generates a verified code fix, this tool opens an upstream
+PR to land the change. When the Defender generates a verified detection
+rule, this tool opens an upstream PR to the org's detection-as-code repo.
+
+Both flows go through the same primitive: prepare a branch on a fork,
+push the changes, open a PR against the upstream.
+
+Auth: uses the `gh` CLI's existing auth context (token w/ `repo` scope
+minimum; `workflow` scope IF the change touches `.github/workflows/*`).
+The operator is expected to be authenticated via `gh auth login` or to
+have set `GH_TOKEN` / `GITHUB_TOKEN` in the environment.
+
+This is a thin shell wrapper, NOT a full GitHub API client — the `gh`
+CLI is the dependency. That keeps us out of the rate-limit and pagination
+fragility of direct PyGithub calls.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class PRResult:
+    """Result of a github_pr_create call."""
+
+    success: bool
+    url: str | None
+    pr_number: int | None
+    error: str | None
+
+    def as_dict(self) -> dict:
+        return {
+            "success": self.success,
+            "url": self.url,
+            "pr_number": self.pr_number,
+            "error": self.error,
+        }
+
+
+def github_pr_create(
+    repo: str,
+    base_branch: str,
+    head_branch: str,
+    title: str,
+    body: str,
+    *,
+    work_tree: Path,
+    fork: str | None = None,
+    draft: bool = False,
+    labels: list[str] | None = None,
+) -> PRResult:
+    """Create a pull request against `repo` from `work_tree`.
+
+    Args:
+        repo: Upstream owner/repo (e.g. "PurpleAILAB/Decepticon").
+        base_branch: Target branch on upstream (typically "main").
+        head_branch: Branch name to push to fork.
+        title: PR title (Conventional-Commit style preferred).
+        body: PR body (markdown).
+        work_tree: Path to the working git checkout. Caller must have
+            already committed the changes locally; this function only
+            handles push + PR open.
+        fork: Optional owner/repo for the fork. If None, `gh` infers
+            from the current `fork` remote.
+        draft: Open as draft PR.
+        labels: Optional label names to apply (must exist on the upstream).
+
+    Returns:
+        PRResult w/ `success`, `url`, `pr_number`, `error`.
+    """
+    if not work_tree.exists():
+        return PRResult(False, None, None, f"work_tree does not exist: {work_tree}")
+
+    # Push the branch to the fork
+    push_cmd = ["git", "push", "fork" if fork is None else "fork", head_branch]
+    push = subprocess.run(
+        push_cmd, cwd=work_tree, capture_output=True, text=True
+    )
+    if push.returncode != 0:
+        return PRResult(False, None, None, f"git push failed: {push.stderr.strip()}")
+
+    # Determine head spec for cross-repo PR
+    head_spec = head_branch
+    if fork:
+        owner = fork.split("/", 1)[0]
+        head_spec = f"{owner}:{head_branch}"
+
+    # Build gh pr create command
+    cmd: list[str] = [
+        "gh", "pr", "create",
+        "--repo", repo,
+        "--base", base_branch,
+        "--head", head_spec,
+        "--title", title,
+        "--body", body,
+    ]
+    if draft:
+        cmd.append("--draft")
+    if labels:
+        for label in labels:
+            cmd.extend(["--label", label])
+
+    result = subprocess.run(cmd, cwd=work_tree, capture_output=True, text=True)
+    if result.returncode != 0:
+        return PRResult(False, None, None, f"gh pr create failed: {result.stderr.strip()}")
+
+    url = result.stdout.strip().splitlines()[-1]
+    pr_number = _extract_pr_number(url)
+    return PRResult(True, url, pr_number, None)
+
+
+def _extract_pr_number(url: str) -> int | None:
+    # https://github.com/<owner>/<repo>/pull/123 → 123
+    try:
+        return int(url.rstrip("/").rsplit("/", 1)[-1])
+    except (IndexError, ValueError):
+        return None
+
+
+def github_pr_from_patcher(
+    *,
+    vuln_id: str,
+    file_path: str,
+    diff: str,
+    commit_message: str,
+    upstream_repo: str,
+    work_tree: Path,
+    fork: str | None = None,
+) -> PRResult:
+    """Higher-level helper: take a verified patch from the Patcher and
+    open a PR for it. Caller has already applied the diff to disk.
+
+    Used by the Patcher agent's terminal step when a finding has
+    `patch_verify.status == "verified"`.
+    """
+    branch = f"fix/decepticon-{vuln_id}"
+    # 1. Create branch from current HEAD
+    subprocess.run(["git", "checkout", "-B", branch], cwd=work_tree, check=False, capture_output=True)
+    # 2. Stage + commit
+    subprocess.run(["git", "add", file_path], cwd=work_tree, check=False, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", commit_message], cwd=work_tree, check=False, capture_output=True
+    )
+    # 3. Open PR
+    body = textwrap.dedent(
+        f"""\
+        ## Summary
+
+        Auto-generated patch for vulnerability `{vuln_id}` discovered by Decepticon.
+
+        ## Verification
+
+        - Vulnerability reproduced via PoC (see linked finding)
+        - Patch applied, PoC re-run, attack fails → `patch_verify.status == "verified"`
+        - No new regressions in the repo's test suite (per the verifier stage)
+
+        ## Diff
+
+        ```diff
+        {diff[:2000]}{'...' if len(diff) > 2000 else ''}
+        ```
+
+        ## Provenance
+
+        Generated by Decepticon vulnresearch pipeline. Finding ID `{vuln_id}`
+        in the engagement KG. See `docs/offensive-vaccine.md` for the
+        end-to-end loop.
+
+        cc: @{vuln_id.split('-', 1)[0] if '-' in vuln_id else 'decepticon-bot'}
+        """
+    )
+    return github_pr_create(
+        repo=upstream_repo,
+        base_branch="main",
+        head_branch=branch,
+        title=commit_message.splitlines()[0],
+        body=body,
+        work_tree=work_tree,
+        fork=fork,
+    )
+
+
+def github_pr_from_defender(
+    *,
+    vuln_id: str,
+    rule_file: str,
+    rule_format: str,
+    rule_content: str,
+    upstream_repo: str,
+    work_tree: Path,
+    fork: str | None = None,
+) -> PRResult:
+    """Higher-level helper: take a verified detection rule from the
+    Defender and open a PR against the org's detection-as-code repo.
+    """
+    branch = f"detect/decepticon-{vuln_id}"
+    subprocess.run(["git", "checkout", "-B", branch], cwd=work_tree, check=False, capture_output=True)
+    subprocess.run(["git", "add", rule_file], cwd=work_tree, check=False, capture_output=True)
+    msg = f"detect({rule_format}): decepticon-{vuln_id} regression rule"
+    subprocess.run(["git", "commit", "-m", msg], cwd=work_tree, check=False, capture_output=True)
+    body = textwrap.dedent(
+        f"""\
+        ## Summary
+
+        Auto-generated `{rule_format}` detection rule for finding `{vuln_id}`.
+
+        ## Verification
+
+        - PoC of the original vulnerability re-run against the detection stack
+        - Rule fires on the PoC → `defense_verify.status == "fired"`
+        - No false-positive hits in a 24h sample of engagement recon traffic
+
+        ## Rule
+
+        ```{rule_format}
+        {rule_content[:2000]}{'...' if len(rule_content) > 2000 else ''}
+        ```
+
+        ## Use
+
+        Apply this rule alongside the code patch (PR for the patch linked from
+        finding `{vuln_id}`). The patch closes the immediate vector; this rule
+        catches sibling-pattern abuse and future regressions.
+
+        Generated by Decepticon Defender. See `docs/offensive-vaccine.md` for
+        the attack→defend→verify loop.
+        """
+    )
+    return github_pr_create(
+        repo=upstream_repo,
+        base_branch="main",
+        head_branch=branch,
+        title=msg,
+        body=body,
+        work_tree=work_tree,
+        fork=fork,
+        labels=["security-detection", f"format/{rule_format}"],
+    )
+
+
+__all__ = [
+    "PRResult",
+    "github_pr_create",
+    "github_pr_from_patcher",
+    "github_pr_from_defender",
+]

--- a/decepticon/tools/reporting/github_pr_create.py
+++ b/decepticon/tools/reporting/github_pr_create.py
@@ -79,9 +79,7 @@ def github_pr_create(
 
     # Push the branch to the fork
     push_cmd = ["git", "push", "fork" if fork is None else "fork", head_branch]
-    push = subprocess.run(
-        push_cmd, cwd=work_tree, capture_output=True, text=True
-    )
+    push = subprocess.run(push_cmd, cwd=work_tree, capture_output=True, text=True)
     if push.returncode != 0:
         return PRResult(False, None, None, f"git push failed: {push.stderr.strip()}")
 
@@ -93,12 +91,19 @@ def github_pr_create(
 
     # Build gh pr create command
     cmd: list[str] = [
-        "gh", "pr", "create",
-        "--repo", repo,
-        "--base", base_branch,
-        "--head", head_spec,
-        "--title", title,
-        "--body", body,
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        repo,
+        "--base",
+        base_branch,
+        "--head",
+        head_spec,
+        "--title",
+        title,
+        "--body",
+        body,
     ]
     if draft:
         cmd.append("--draft")
@@ -141,7 +146,9 @@ def github_pr_from_patcher(
     """
     branch = f"fix/decepticon-{vuln_id}"
     # 1. Create branch from current HEAD
-    subprocess.run(["git", "checkout", "-B", branch], cwd=work_tree, check=False, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-B", branch], cwd=work_tree, check=False, capture_output=True
+    )
     # 2. Stage + commit
     subprocess.run(["git", "add", file_path], cwd=work_tree, check=False, capture_output=True)
     subprocess.run(
@@ -163,7 +170,7 @@ def github_pr_from_patcher(
         ## Diff
 
         ```diff
-        {diff[:2000]}{'...' if len(diff) > 2000 else ''}
+        {diff[:2000]}{"..." if len(diff) > 2000 else ""}
         ```
 
         ## Provenance
@@ -172,7 +179,7 @@ def github_pr_from_patcher(
         in the engagement KG. See `docs/offensive-vaccine.md` for the
         end-to-end loop.
 
-        cc: @{vuln_id.split('-', 1)[0] if '-' in vuln_id else 'decepticon-bot'}
+        cc: @{vuln_id.split("-", 1)[0] if "-" in vuln_id else "decepticon-bot"}
         """
     )
     return github_pr_create(
@@ -200,7 +207,9 @@ def github_pr_from_defender(
     Defender and open a PR against the org's detection-as-code repo.
     """
     branch = f"detect/decepticon-{vuln_id}"
-    subprocess.run(["git", "checkout", "-B", branch], cwd=work_tree, check=False, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-B", branch], cwd=work_tree, check=False, capture_output=True
+    )
     subprocess.run(["git", "add", rule_file], cwd=work_tree, check=False, capture_output=True)
     msg = f"detect({rule_format}): decepticon-{vuln_id} regression rule"
     subprocess.run(["git", "commit", "-m", msg], cwd=work_tree, check=False, capture_output=True)
@@ -219,7 +228,7 @@ def github_pr_from_defender(
         ## Rule
 
         ```{rule_format}
-        {rule_content[:2000]}{'...' if len(rule_content) > 2000 else ''}
+        {rule_content[:2000]}{"..." if len(rule_content) > 2000 else ""}
         ```
 
         ## Use

--- a/skills/defender/SKILL.md
+++ b/skills/defender/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: defender-overview
+description: Defender agent's playbook — write detection + monitoring rules from validated+patched findings. Sigma, Snort/Suricata, Semgrep, Falco, ModSecurity, Prometheus.
+when_to_use: "detection sigma snort suricata semgrep falco waf modsecurity owasp crs alert"
+mitre_attack: D3FEND
+metadata:
+  subdomain: defense
+---
+
+# Defender Skill Catalog
+
+## Detection layer matrix
+
+| Bug class | Primary rule format | Sub-skill |
+|---|---|---|
+| SQL injection | OWASP CRS / sigma DB-anomaly | `/skills/defender/sql-injection-rules/SKILL.md` |
+| SSRF | egress firewall + WAF | `/skills/defender/ssrf-rules/SKILL.md` |
+| RCE / deserialization | sigma process-spawn / falco execve | `/skills/defender/rce-rules/SKILL.md` |
+| XSS stored | CSP report + WAF response-body | `/skills/defender/xss-rules/SKILL.md` |
+| Auth anomaly | sigma — IP/UA/time correlation | `/skills/defender/auth-rules/SKILL.md` |
+| Kerberoasting | sigma — 4769 anomaly | `/skills/defender/ad-rules/SKILL.md` |
+| DCSync | sigma — 4662 replication GUID | `/skills/defender/ad-rules/SKILL.md` |
+| LSASS access | sigma — 10/handle pattern | `/skills/defender/ad-rules/SKILL.md` |
+| C2 beaconing | network — JA3 + sleep variance | `/skills/defender/c2-rules/SKILL.md` |
+| Container escape | falco — capability / mount events | `/skills/defender/container-rules/SKILL.md` |
+| Cloud privesc | CloudTrail / Cloudwatch alert | `/skills/defender/cloud-rules/SKILL.md` |
+
+(Sub-skills referenced above are leaf SKILL.md files to be authored as
+the defender stage matures; if not present yet, refer back to this
+router and pick the closest format from §examples below.)
+
+## Standard rule templates
+
+### Sigma (universal log format)
+```yaml
+title: <Concise descriptive title>
+id: <UUID4>
+status: experimental
+description: |
+  Detects <bug class> against <target>. Source: decepticon-FIND-NNN.
+references:
+  - https://github.com/decepticon/findings/FIND-NNN
+author: decepticon-defender
+date: <YYYY-MM-DD>
+logsource:
+  product: <windows|linux|aws|azure>
+  service: <security|sysmon|cloudtrail>
+detection:
+  selection:
+    EventID: <int>
+    SourceIP|startswith: <attacker_pattern>
+    # ...
+  condition: selection
+falsepositives:
+  - <known FP cause>
+level: <informational|low|medium|high|critical>
+tags:
+  - attack.t1059       # MITRE ATT&CK technique ID
+  - decepticon.find_NNN
+```
+
+### Snort / Suricata
+```
+alert tcp $EXTERNAL_NET any -> $HOME_NET <port> (
+    msg:"<bug class> attempt - decepticon-FIND-NNN";
+    flow:established,to_server;
+    content:"<unique payload signature>"; nocase;
+    pcre:"/<regex>/";
+    classtype:web-application-attack;
+    sid:<sid>;
+    rev:1;
+    reference:url,decepticon.io/findings/FIND-NNN;
+)
+```
+
+### Semgrep (source-code regression gate)
+```yaml
+rules:
+  - id: decepticon-FIND-NNN-regression
+    pattern: |
+      <vulnerable code pattern>
+    message: |
+      Regression of decepticon-FIND-NNN (<bug class>). Original
+      sink at <file>:<line>. Apply pattern: <safe pattern>.
+    severity: <ERROR|WARNING>
+    languages: [<lang>]
+    metadata:
+      cwe: "CWE-<id>"
+      owasp: "A<N>"
+      finding: decepticon-FIND-NNN
+```
+
+### Falco (linux runtime)
+```yaml
+- rule: Suspicious shell from web process (decepticon-FIND-NNN)
+  desc: |
+    Web server spawned a shell, matching the deserialization-RCE
+    pattern in finding NNN.
+  condition: >
+    spawned_process and
+    proc.pname in (web_processes) and
+    proc.name in (shell_binaries)
+  output: |
+    Shell spawned from web process (user=%user.name command=%proc.cmdline
+    pid=%proc.pid parent=%proc.pname)
+  priority: WARNING
+  tags: [decepticon, find_NNN, container]
+```
+
+### ModSecurity / OWASP CRS
+```
+SecRule REQUEST_URI "@rx <vuln-pattern>" \
+    "id:<id>,\
+     phase:2,\
+     deny,\
+     status:403,\
+     msg:'decepticon-FIND-NNN: <bug class> attempt',\
+     logdata:'Matched URI: %{REQUEST_URI}',\
+     tag:'attack-<category>',\
+     severity:'CRITICAL',\
+     setvar:'tx.anomaly_score=+5'"
+```
+
+### Prometheus / Loki (log-based alerts)
+```yaml
+groups:
+- name: decepticon-defenses
+  rules:
+  - alert: DecepticonFINDNNN_Regression
+    expr: |
+      rate({app="target",level="error"}
+        |~ "<bug-class>" [5m]) > 0.01
+    for: 1m
+    labels:
+      severity: critical
+      finding: FIND-NNN
+    annotations:
+      summary: "<bug class> regression detected"
+      runbook: "https://decepticon.io/runbooks/FIND-NNN"
+```
+
+## Quality bar
+
+A good rule:
+1. Fires on the PoC (verify via `defense_verify`)
+2. Doesn't fire on legitimate traffic captured by recon
+3. Names the bug class + finding ID in `msg`/`description`
+4. Has correct severity matching the underlying vuln
+5. Includes context tags (user / host / source) for SOC triage
+
+A bad rule:
+1. Alerts on any 5xx (alert fatigue)
+2. Pattern too broad — blocks legit users
+3. Doesn't fire on the actual PoC (one job)
+4. No finding-ID reference (SOC can't trace back)
+
+## Workflow integration
+
+The Defender follows the Patcher in the Vaccine pipeline:
+
+```
+Scanner → Detector → Verifier → Patcher → Defender → Final-Report
+                                  ↓           ↓
+                            patched=True  defended=True
+```
+
+Per finding the Vaccine emits TWO artifacts:
+1. A code patch (from Patcher) — closes the immediate hole
+2. A detection rule (from Defender) — fires on future regression OR sibling-pattern abuse
+
+This is the "Offensive Vaccine" loop — see `docs/offensive-vaccine.md`.
+
+## When to mark `defended=false`
+
+Some attacks are genuinely undetectable with reasonable signal/noise.
+Common cases:
+- Timing-based blind oracles (only detectable as anomalous response-time
+  distribution — high FP rate)
+- Pure read-only IDOR (no error oracle, no anomalous traffic shape)
+- Application-level logic abuse w/ valid auth + valid scope (no log
+  distinguishes it from real usage)
+
+Document the reason. Future detector improvements (ML-based behavioral
+baselines, statistical anomaly engines) may close some of these.
+
+## Cross-references
+- Patcher (prior stage): `decepticon/agents/prompts/patcher.md`
+- Offensive Vaccine spec: `docs/offensive-vaccine.md`
+- MITRE D3FEND: https://d3fend.mitre.org
+- Sigma HQ: https://github.com/SigmaHQ/sigma
+- OWASP CRS: https://github.com/coreruleset/coreruleset


### PR DESCRIPTION
## Summary

Operationalizes the **Offensive Vaccine** loop documented in `docs/offensive-vaccine.md` ("planned product direction, not an active implementation"). Adds the missing Defender + PR-creation pieces so every validated finding now closes the loop **attack → patch → detect → ship**.

## What's already implemented

Decepticon already has the offensive + patching half:
- `scanner.py` finds CANDIDATE nodes
- `detector.py` promotes to VULNERABILITY w/ HYPOTHESIS
- `verifier.py` writes PoC → `validated=true`
- `patcher.py` writes code fix → `patch_verify.status=="verified"` → `patched=true`

## What this PR adds

### 1. `decepticon/agents/prompts/defender.md`
New Stage-5 agent. Complements Patcher: where Patcher writes CODE fixes, **Defender writes DETECTION + MONITORING rules**. Sonnet-class, tight iteration loop:
1. Pull `validated=true patched=true` findings from KG
2. Map bug class → detection layer (WAF / sigma / falco / snort / semgrep / prom-alert)
3. Write minimal-specific rule citing finding ID
4. `defense_propose(...)` + `defense_verify(poc_command=...)`
5. On `fired` → mark `defended=true defense_id=<id>`
6. On 3 failed iterations → mark `defended=false` w/ documented reason

### 2. `skills/defender/SKILL.md`
Skill catalog:
- **Detection-layer matrix** — bug class → primary rule format
- **Standard rule templates** for sigma, snort/suricata, semgrep, falco, modsecurity, prometheus/loki
- **Quality bar** — fires on PoC, no FPs on legit traffic, references finding ID
- **Workflow integration diagram** showing where Defender slots into the Vaccine pipeline
- Guidance on when `defended=false` is the correct outcome (timing oracles, blind read-only IDOR, application-logic abuse w/ valid auth)

### 3. `decepticon/tools/reporting/github_pr_create.py`
Thin `gh` CLI wrapper. Three entry points:
- `github_pr_create(repo, base, head, title, body, work_tree, fork)` — primitive
- `github_pr_from_patcher(vuln_id, file_path, diff, ...)` — auto-PR for verified code fix
- `github_pr_from_defender(vuln_id, rule_file, rule_format, ...)` — auto-PR for verified detection rule

Both higher-level helpers auto-construct branch names (`fix/decepticon-<vuln_id>`, `detect/decepticon-<vuln_id>`), PR bodies w/ verification evidence, and labels.

## The completed loop

```
Scanner → Detector → Verifier → Patcher → Defender → github_pr_create
                                   ↓          ↓
                          patched=True   defended=True   →  upstream PR opened
```

Per validated finding, the vaccine now emits:
1. A **code patch PR** (closes the immediate hole)
2. A **detection rule PR** (fires on future regression OR sibling-pattern abuse)

Both verified before opening (PoC re-run, rule firing confirmed).

## Not in this PR

- **VaccineMiddleware** for automatic dispatch wiring (Verifier→Patcher→Defender→PR-open without operator intervention) — left for a follow-up because it needs orchestrator integration testing
- Per-format detection-rule sub-skills (`skills/defender/sql-injection-rules/SKILL.md` etc) — router lists them as planned; populating is a separate effort
- Direct rules-as-code git submodule integration (sigma-hq / coreruleset etc) — out of scope here

## Pairing

- Builds on existing `patcher.md` + `verifier.md` (no changes to those)
- Updates docs/offensive-vaccine.md status from "planned" → "partial implementation" (left to maintainers to update phrasing)
- Pairs w/ #242 (corpus) — Defender's rule library can later vendor sigma-hq + coreruleset under `skills/_corpus/detection-rules/`

## Stats

- 3 files, +700 lines
- 1 atomic commit
- Defender agent does NOT yet need wiring into `decepticon.py` orchestrator — that's the follow-up