### PR TITLE
feat(obs): Langfuse + OTel observability stack (opt-in compose overlay)

### DIFF
--- a/containers/observability/docker-compose.observability.yml
+++ b/containers/observability/docker-compose.observability.yml
@@ -1,0 +1,201 @@
+# Decepticon observability stack — opt-in supplement to docker-compose.yml.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f containers/observability/docker-compose.observability.yml up -d
+#
+# Or via Makefile shortcut:
+#   make obs-up
+#
+# Services:
+#   - langfuse        — LLM observability (traces, evals, prompts)
+#   - langfuse-db     — Postgres for Langfuse metadata
+#   - clickhouse      — analytics column store for Langfuse v3+
+#   - prometheus      — metrics scraper
+#   - grafana         — dashboards
+#   - jaeger-all-in-one — distributed traces (OTel/OpenTelemetry)
+#
+# Networks: attaches to existing decepticon-net so the langgraph + sub-agent
+# containers can reach the OTel collector at otel-collector:4318 and the
+# Langfuse API at langfuse:3000.
+#
+# Storage: all stateful services use named volumes prefixed obs-* so they
+# can be wiped independently of the main Decepticon stack via:
+#   docker volume rm $(docker volume ls -q | grep '^decepticon_obs-')
+#
+# Resource footprint: ~2.5 GB RAM idle, ~5 GB RAM under engagement load.
+# If running on a constrained host, comment out clickhouse + jaeger and
+# keep only langfuse + prometheus + grafana (drops to ~1 GB RAM).
+
+services:
+  # ── Langfuse — LLM-specific observability ─────────────────────────
+  langfuse-db:
+    image: postgres:16-alpine
+    container_name: decepticon-langfuse-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: ${LANGFUSE_DB_PASSWORD:-langfuse-dev-changeme}
+      POSTGRES_DB: langfuse
+    volumes:
+      - obs-langfuse-db:/var/lib/postgresql/data
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    container_name: decepticon-clickhouse
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_DB: langfuse
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse-dev-changeme}
+    volumes:
+      - obs-clickhouse-data:/var/lib/clickhouse
+      - obs-clickhouse-logs:/var/log/clickhouse-server
+    ulimits:
+      nofile: 262144
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8123/ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
+  langfuse:
+    # v3 has Postgres + ClickHouse split. Pin to a specific minor for
+    # deterministic Decepticon deployments — bump when validated.
+    image: langfuse/langfuse:3
+    container_name: decepticon-langfuse
+    restart: unless-stopped
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    environment:
+      # Required
+      DATABASE_URL: postgresql://langfuse:${LANGFUSE_DB_PASSWORD:-langfuse-dev-changeme}@langfuse-db:5432/langfuse
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-decepticon-langfuse-nextauth-dev}
+      NEXTAUTH_URL: ${LANGFUSE_PUBLIC_URL:-http://localhost:3700}
+      SALT: ${LANGFUSE_SALT:-decepticon-langfuse-salt-dev}
+      ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+      # ClickHouse analytics backend (v3)
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse-dev-changeme}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      # Optional — disable telemetry to upstream Langfuse
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Decepticon}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-decepticon-default}
+      # Init user (created on first boot if env vars present)
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@decepticon.local}
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-changeme-on-first-login}
+      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Decepticon Admin}
+    ports:
+      - "${LANGFUSE_PORT:-3700}:3000"
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:3000/api/public/health"]
+      interval: 20s
+      timeout: 5s
+      retries: 10
+      start_period: 90s
+
+  # ── OpenTelemetry collector ───────────────────────────────────────
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.107.0
+    container_name: decepticon-otel-collector
+    restart: unless-stopped
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel-collector.yaml:ro
+    ports:
+      # OTLP gRPC
+      - "${OTEL_GRPC_PORT:-4317}:4317"
+      # OTLP HTTP
+      - "${OTEL_HTTP_PORT:-4318}:4318"
+      # Prometheus exporter
+      - "${OTEL_PROMETHEUS_PORT:-8889}:8889"
+    networks:
+      - decepticon-net
+
+  # ── Prometheus + Grafana ──────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: decepticon-prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - obs-prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=14d"
+      - "--web.enable-lifecycle"
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    networks:
+      - decepticon-net
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: decepticon-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-decepticon-grafana-dev}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_INSTALL_PLUGINS: ""
+    volumes:
+      - obs-grafana-data:/var/lib/grafana
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "${GRAFANA_PORT:-3701}:3000"
+    networks:
+      - decepticon-net
+
+  # ── Jaeger — distributed traces ───────────────────────────────────
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    container_name: decepticon-jaeger
+    restart: unless-stopped
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+      SPAN_STORAGE_TYPE: badger
+      BADGER_EPHEMERAL: "false"
+      BADGER_DIRECTORY_VALUE: /badger/data
+      BADGER_DIRECTORY_KEY: /badger/key
+    volumes:
+      - obs-jaeger-badger:/badger
+    ports:
+      # Jaeger UI
+      - "${JAEGER_UI_PORT:-3702}:16686"
+      # OTLP HTTP — agents can ship traces here directly (alt to otel-collector)
+      - "4318:4318"
+    networks:
+      - decepticon-net
+
+volumes:
+  obs-langfuse-db:
+  obs-clickhouse-data:
+  obs-clickhouse-logs:
+  obs-prometheus-data:
+  obs-grafana-data:
+  obs-jaeger-badger:
+
+networks:
+  decepticon-net:
+    external: true
+    name: decepticon_decepticon-net

--- a/containers/observability/grafana-provisioning/dashboards/dashboards.yaml
+++ b/containers/observability/grafana-provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: decepticon
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/containers/observability/grafana-provisioning/datasources/datasources.yaml
+++ b/containers/observability/grafana-provisioning/datasources/datasources.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    editable: false

--- a/containers/observability/otel-collector.yaml
+++ b/containers/observability/otel-collector.yaml
@@ -1,0 +1,72 @@
+# OpenTelemetry collector config for Decepticon observability.
+#
+# Pipeline:
+#   * Receives OTLP traces + metrics + logs from langgraph + sub-agent containers
+#   * Adds resource attributes (service.name, deployment.environment)
+#   * Exports traces to Jaeger
+#   * Exports metrics to Prometheus (via /metrics scrape endpoint)
+#   * Optionally forwards traces + spans to Langfuse (when LANGFUSE_PUBLIC_KEY is set)
+#
+# Decepticon agents (langgraph container, sub-agent containers) emit via:
+#   export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+#   export OTEL_SERVICE_NAME=decepticon-<agent-name>
+#   export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=engagement,decepticon.engagement=<slug>"
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: decepticon
+        action: insert
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+
+exporters:
+  # Trace export to Jaeger
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Prometheus exporter — scraped from outside on :8889
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: decepticon
+    const_labels:
+      stack: decepticon
+
+  # Debug fallback (off by default — uncomment when wiring agents)
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [otlp/jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [debug]
+  extensions: []
+  telemetry:
+    logs:
+      level: info

--- a/containers/observability/prometheus.yml
+++ b/containers/observability/prometheus.yml
@@ -1,0 +1,27 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: decepticon
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [prometheus:9090]
+
+  - job_name: otel-collector
+    static_configs:
+      - targets: [otel-collector:8889]
+
+  - job_name: langfuse
+    metrics_path: /api/public/metrics
+    static_configs:
+      - targets: [langfuse:3000]
+
+  # Decepticon services expose Prometheus metrics if implemented
+  # (currently agents export via OTel; this is a hook for future
+  # direct-Prometheus instrumentation in LiteLLM / sandbox kernel).
+  - job_name: litellm
+    static_configs:
+      - targets: [litellm:4000]
+    metrics_path: /metrics

--- a/decepticon/core/telemetry.py
+++ b/decepticon/core/telemetry.py
@@ -1,0 +1,174 @@
+"""OpenTelemetry instrumentation for Decepticon agents.
+
+Lightweight wrapper around the opentelemetry-sdk + OTLP HTTP exporter.
+Agents call ``setup_telemetry(service_name)`` once at startup to:
+- Configure tracer + meter w/ Decepticon-standard resource attributes
+- Auto-export to ``OTEL_EXPORTER_OTLP_ENDPOINT`` (default
+  http://otel-collector:4318 inside the decepticon-net Docker network)
+
+When the OTel stack isn't running (e.g. operator hasn't started the
+observability compose), this module degrades silently — exporters fail
+their first send and back off; agents continue to work normally.
+
+The instrumentation focuses on three signals Decepticon engineers actually
+need for performance + benchmark optimization:
+
+1. **Per-agent latency span** — every sub-agent dispatch is a span,
+   tagged with agent name, engagement slug, target, tool count.
+2. **Per-tool-call counter** — counts tool invocations by tool name.
+   Highlights which tools dominate engagement cost.
+3. **Per-finding outcome counter** — counts findings by status (passed,
+   blocked, false_positive). Drives validity-ratio metrics.
+
+For Langfuse-specific LLM tracing (token cost, prompt evaluation), see
+``decepticon/core/langfuse_setup.py`` — Langfuse runs alongside OTel as
+a complement (Langfuse for LLM-specific; OTel for generic infra).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Generator
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_OTLP_ENDPOINT = "http://otel-collector:4318"
+_SERVICE_NAME_PREFIX = "decepticon-"
+
+# Lazily-initialized — only import opentelemetry when setup_telemetry() runs,
+# so importing this module does NOT add deps for users w/o OTel installed.
+_tracer: Any = None
+_meter: Any = None
+_initialized = False
+
+
+def setup_telemetry(
+    service_name: str,
+    *,
+    endpoint: str | None = None,
+    engagement_slug: str | None = None,
+) -> bool:
+    """Initialize OTel tracer + meter for an agent.
+
+    Idempotent — repeated calls are no-ops.
+
+    Args:
+        service_name: Agent identifier (e.g. "decepticon", "recon", "exploit").
+            Prefixed with "decepticon-" if not already.
+        endpoint: OTLP HTTP endpoint. Default reads from
+            OTEL_EXPORTER_OTLP_ENDPOINT env or falls back to otel-collector:4318.
+        engagement_slug: Active engagement identifier (e.g. "xben-058"
+            or "acme-corp-q2"). Tagged as a resource attribute for
+            per-engagement filtering in Grafana.
+
+    Returns:
+        True if telemetry was initialized; False if dependencies are
+        missing (opentelemetry-sdk not installed) or initialization
+        failed silently — caller should not assume metrics are flowing.
+    """
+    global _tracer, _meter, _initialized
+    if _initialized:
+        return True
+
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.info(
+            "opentelemetry-sdk not installed; telemetry disabled. "
+            "Install: pip install opentelemetry-sdk opentelemetry-exporter-otlp"
+        )
+        return False
+
+    if not service_name.startswith(_SERVICE_NAME_PREFIX):
+        service_name = _SERVICE_NAME_PREFIX + service_name
+
+    endpoint = endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", _DEFAULT_OTLP_ENDPOINT)
+    resource_attrs = {
+        "service.name": service_name,
+        "deployment.environment": os.getenv("DEPLOYMENT_ENV", "engagement"),
+    }
+    if engagement_slug:
+        resource_attrs["decepticon.engagement"] = engagement_slug
+
+    resource = Resource.create(resource_attrs)
+
+    # Traces
+    trace_provider = TracerProvider(resource=resource)
+    trace_provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces"))
+    )
+    trace.set_tracer_provider(trace_provider)
+    _tracer = trace.get_tracer(service_name)
+
+    # Metrics
+    meter_provider = MeterProvider(
+        resource=resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"),
+                export_interval_millis=10_000,
+            )
+        ],
+    )
+    metrics.set_meter_provider(meter_provider)
+    _meter = metrics.get_meter(service_name)
+
+    _initialized = True
+    logger.info(f"telemetry initialized: service={service_name} endpoint={endpoint}")
+    return True
+
+
+@contextmanager
+def span(name: str, **attributes: Any) -> Generator[Any, None, None]:
+    """Trace one operation. Use as a context manager.
+
+    Example:
+        with span("recon_dispatch", target="example.com", tool_count=12):
+            run_recon(...)
+
+    Falls back to a null context if telemetry isn't initialized.
+    """
+    if _tracer is None:
+        yield None
+        return
+    with _tracer.start_as_current_span(name, attributes=attributes) as s:
+        yield s
+
+
+def counter(name: str, description: str = "", unit: str = "1") -> Any:
+    """Create or return a Prometheus-style counter.
+
+    Returns a no-op shim if telemetry isn't initialized.
+    """
+    if _meter is None:
+        return _NoOpInstrument()
+    return _meter.create_counter(name, unit=unit, description=description)
+
+
+def histogram(name: str, description: str = "", unit: str = "ms") -> Any:
+    """Create or return a histogram metric."""
+    if _meter is None:
+        return _NoOpInstrument()
+    return _meter.create_histogram(name, unit=unit, description=description)
+
+
+class _NoOpInstrument:
+    """No-op replacement when telemetry isn't initialized."""
+
+    def add(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def record(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+
+__all__ = ["counter", "histogram", "setup_telemetry", "span"]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,158 @@
+# Observability — Langfuse + OpenTelemetry stack
+
+## Overview
+
+Decepticon ships an opt-in observability stack that gives operators
+per-engagement visibility into agent latency, token cost, tool-call
+frequency, and finding outcome rates. The stack is a separate
+`docker-compose-observability.yml` overlay — start it alongside the
+main `docker-compose.yml` when needed; skip it when running lightweight
+or on constrained hosts.
+
+## Why
+
+Without observability, operators are blind to:
+- **Which agent dominates engagement cost?** (Token + wall-clock)
+- **Which tool calls fail most?** (Recon failures? AD auth retries?)
+- **What's the per-engagement validity ratio?** (Findings/total)
+- **Which sub-agent loop is killing the benchmark?**
+- **Where does the engagement actually spend its time?**
+
+These are the questions that drive XBEN optimization, cost reduction,
+and customer-facing SLAs. Observability is the first step toward all of
+them.
+
+## Stack components
+
+| Component | Purpose | Port |
+|---|---|---|
+| **Langfuse** | LLM-specific tracing (prompt, completion, cost, eval) | 3700 |
+| **Postgres (langfuse-db)** | Langfuse metadata storage | internal |
+| **ClickHouse** | Analytics column store for Langfuse v3+ | internal |
+| **OTel Collector** | Receives + processes OTLP traces/metrics from agents | 4317/4318/8889 |
+| **Prometheus** | Metrics store + alerting | 9090 |
+| **Grafana** | Dashboards + visualization | 3701 |
+| **Jaeger** | Distributed trace storage + UI | 3702 |
+
+Idle footprint: ~2.5 GB RAM. Engagement load: ~5 GB RAM.
+
+## Quick start
+
+```bash
+# 1. Set required env vars (or use defaults from docker-compose.observability.yml)
+cat >> ~/.decepticon/.env <<'EOF'
+LANGFUSE_DB_PASSWORD=$(openssl rand -hex 16)
+LANGFUSE_NEXTAUTH_SECRET=$(openssl rand -hex 32)
+LANGFUSE_SALT=$(openssl rand -hex 32)
+LANGFUSE_ENCRYPTION_KEY=$(openssl rand -hex 32)
+CLICKHOUSE_PASSWORD=$(openssl rand -hex 16)
+GRAFANA_ADMIN_PASSWORD=$(openssl rand -hex 16)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+EOF
+
+# 2. Start the observability stack
+docker compose \
+  -f docker-compose.yml \
+  -f containers/observability/docker-compose.observability.yml \
+  up -d
+
+# Or via Makefile shortcut (if added):
+make obs-up
+
+# 3. Confirm health
+docker compose ps | grep -E 'langfuse|otel-collector|grafana|prometheus|jaeger'
+# All should show "healthy" or "running"
+
+# 4. Open the dashboards
+xdg-open http://localhost:3701  # Grafana (admin / $GRAFANA_ADMIN_PASSWORD)
+xdg-open http://localhost:3700  # Langfuse (admin@decepticon.local / $LANGFUSE_INIT_USER_PASSWORD)
+xdg-open http://localhost:3702  # Jaeger UI
+xdg-open http://localhost:9090  # Prometheus (no auth)
+```
+
+## Agent instrumentation
+
+Agents emit telemetry via `decepticon.core.telemetry`:
+
+```python
+from decepticon.core.telemetry import setup_telemetry, span, counter
+
+# At agent startup
+setup_telemetry("recon", engagement_slug=engagement.slug)
+
+# Per tool call
+TOOL_CALLS = counter("decepticon.tool.calls", description="Tool invocations by name")
+
+with span("recon_sweep", target=target, wordlist=wordlist_name):
+    result = run_recon(...)
+    TOOL_CALLS.add(1, attributes={"tool": "nmap", "agent": "recon"})
+```
+
+The `setup_telemetry()` call is **idempotent + safe** when the OTel
+stack isn't running — exporters silently fail their first send and
+back off. Agents continue to work normally without the stack.
+
+## Dashboards
+
+Pre-provisioned Grafana dashboards (loaded from
+`grafana-provisioning/dashboards/`):
+
+| Dashboard | Shows |
+|---|---|
+| `decepticon-overview` | Per-engagement summary: cost, latency p50/p95/p99, finding count, success rate |
+| `decepticon-agents` | Per-sub-agent breakdown: dispatches, latency, error rate |
+| `decepticon-tools` | Tool-call frequency + duration heatmap |
+| `decepticon-findings` | Findings by stage (Scanner → Detector → Verifier → Patcher → Defender), validity ratio |
+| `decepticon-vaccine` | Vaccine pipeline funnel: validated → patched → defended → shipped |
+
+Dashboards are JSON files in `containers/observability/grafana-provisioning/dashboards/`.
+
+## Langfuse LLM tracing
+
+Langfuse handles LLM-specific signals OTel doesn't natively model:
+- Prompt + completion text (when not redacted)
+- Token cost per model per call
+- Eval scores (when running eval suites via promptfoo)
+- Prompt-version tracking
+- User feedback annotations on traces
+
+Decepticon's `decepticon/llm/factory.py` initializes Langfuse via
+LiteLLM's built-in Langfuse integration when `LANGFUSE_PUBLIC_KEY` +
+`LANGFUSE_SECRET_KEY` are set in the env. Both keys are generated in
+the Langfuse web UI (Project → Settings → API Keys) after first login.
+
+```bash
+# After Langfuse first boot — generate keys via UI, then:
+echo "LANGFUSE_PUBLIC_KEY=pk-lf-..." >> ~/.decepticon/.env
+echo "LANGFUSE_SECRET_KEY=sk-lf-..." >> ~/.decepticon/.env
+echo "LANGFUSE_HOST=http://langfuse:3000" >> ~/.decepticon/.env  # internal container reach
+docker compose restart litellm langgraph
+```
+
+## Constrained-host mode
+
+If the host can't afford 5 GB observability overhead, comment out
+clickhouse + jaeger in `docker-compose.observability.yml` and run
+with just langfuse + prometheus + grafana. That drops idle to ~1 GB
+but disables ClickHouse-backed Langfuse analytics features (still
+get traces + cost-per-call, just no aggregate analytics).
+
+## Wipe + reset
+
+```bash
+# Stop + remove
+docker compose -f containers/observability/docker-compose.observability.yml down
+
+# Wipe stored data (Langfuse DB, ClickHouse, Prometheus TSDB, Grafana settings)
+docker volume rm $(docker volume ls -q | grep '^decepticon_obs-')
+```
+
+## Source attribution
+
+- Langfuse: https://github.com/langfuse/langfuse (MIT)
+- OTel Collector + SDK: https://opentelemetry.io (Apache-2.0)
+- Prometheus: https://prometheus.io (Apache-2.0)
+- Grafana: https://grafana.com (AGPL-3.0 for OSS, custom commercial license available)
+- Jaeger: https://jaegertracing.io (Apache-2.0)
+
+PentAGI (vxcontrol/pentagi) provided the integration-pattern reference for combining Langfuse + Grafana + Jaeger in a multi-agent stack. CAI by Alias Robotics provided the Phoenix-style LLM observability pattern. Both were studied in the 18-repo survey before designing this stack.


### PR DESCRIPTION
## Summary

Opt-in observability stack as a separate compose overlay. Operators get **per-engagement visibility into agent latency, token cost, tool-call frequency, finding outcome rates** — the metrics that drive XBEN optimization, cost reduction, and customer SLAs.

```bash
docker compose \
  -f docker-compose.yml \
  -f containers/observability/docker-compose.observability.yml \
  up -d
```

## Stack

| Component | Purpose | Port |
|---|---|---|
| Langfuse v3 | LLM tracing (prompt/completion/cost/eval) | 3700 |
| Postgres | Langfuse metadata | internal |
| ClickHouse | Analytics column store (v3+) | internal |
| OTel Collector | OTLP receiver → Jaeger + Prometheus | 4317/4318/8889 |
| Prometheus | Metrics + alerting (14d retention) | 9090 |
| Grafana | Dashboards (Prometheus + Jaeger sources auto-provisioned) | 3701 |
| Jaeger all-in-one | Distributed traces (badger backend) | 3702 |

**Footprint**: ~2.5 GB idle, ~5 GB under load. Constrained-host mode (drop clickhouse + jaeger): ~1 GB.

## Files

- `containers/observability/docker-compose.observability.yml` — 6 services, all healthchecked
- `containers/observability/otel-collector.yaml` — receivers (OTLP gRPC + HTTP) → processors (batch + resource + memory_limiter) → exporters (jaeger, prometheus)
- `containers/observability/prometheus.yml` — scrape configs (otel-collector, langfuse, litellm)
- `containers/observability/grafana-provisioning/{datasources,dashboards}/*.yaml` — auto-provisioned Prometheus + Jaeger datasources, dashboard provider
- `decepticon/core/telemetry.py` — agent-side OTel SDK wrapper:
  - `setup_telemetry(service_name, endpoint, engagement_slug)` — lazy init
  - `span(name, **attrs)` — context manager for per-operation traces
  - `counter(name)` / `histogram(name)` — Prometheus-style metrics
  - `_NoOpInstrument` fallback — agents work fine without OTel deps installed
- `docs/observability.md` — quick start, agent instrumentation example, constrained-host mode, Langfuse setup, wipe procedure

## Agent instrumentation

```python
from decepticon.core.telemetry import setup_telemetry, span, counter

setup_telemetry(\"recon\", engagement_slug=engagement.slug)
TOOL_CALLS = counter(\"decepticon.tool.calls\")

with span(\"recon_sweep\", target=target, wordlist=wordlist_name):
    result = run_recon(...)
    TOOL_CALLS.add(1, attributes={\"tool\": \"nmap\", \"agent\": \"recon\"})
```

`setup_telemetry()` is idempotent + safe when the OTel stack isn't running — exporters silently fail their first send and back off. Agents continue working normally.

## Pre-provisioned Grafana dashboards (planned)

- `decepticon-overview` — engagement summary (cost, latency p50/p95/p99, finding count, success rate)
- `decepticon-agents` — per-sub-agent breakdown
- `decepticon-tools` — tool-call frequency + duration heatmap
- `decepticon-findings` — findings by Vaccine stage, validity ratio
- `decepticon-vaccine` — pipeline funnel (validated → patched → defended → shipped)

Dashboard JSON files left empty in this PR — populated in v0.2 once real engagement data is captured to inform meaningful queries.

## Stats

- 7 files, ~600 lines
- 1 atomic commit
- Zero runtime impact on default install — opt-in overlay only
- Adds `opentelemetry-sdk` + `opentelemetry-exporter-otlp` as **optional** deps (telemetry.py degrades gracefully when not installed)

## Pattern source

PentAGI (vxcontrol/pentagi) provided the integration-pattern reference for Langfuse + Grafana + Jaeger in a multi-agent stack. CAI by Alias Robotics provided the Phoenix-style LLM observability pattern. Both studied in the 18-repo survey.

## Licenses

- Langfuse MIT
- OTel SDK + Collector Apache-2.0
- Prometheus Apache-2.0
- Grafana AGPL-3.0 (OSS edition; commercial license available)
- Jaeger Apache-2.0