### PR TITLE
feat(vaccine): VaccineWriter — programmatic stage transitions

### DIFF
--- a/decepticon/middleware/__init__.py
+++ b/decepticon/middleware/__init__.py
@@ -7,6 +7,7 @@ from decepticon.middleware.notifications import (
 )
 from decepticon.middleware.opplan import OPPLANMiddleware
 from decepticon.middleware.skills import SkillsMiddleware
+from decepticon.middleware.vaccine import VaccineMiddleware
 
 __all__ = [
     "EngagementContextMiddleware",
@@ -14,4 +15,5 @@ __all__ = [
     "OPPLANMiddleware",
     "SandboxNotificationMiddleware",
     "SkillsMiddleware",
+    "VaccineMiddleware",
 ]

--- a/decepticon/middleware/__init__.py
+++ b/decepticon/middleware/__init__.py
@@ -8,6 +8,7 @@ from decepticon.middleware.notifications import (
 from decepticon.middleware.opplan import OPPLANMiddleware
 from decepticon.middleware.skills import SkillsMiddleware
 from decepticon.middleware.vaccine import VaccineMiddleware
+from decepticon.middleware.vaccine_writer import TransitionResult, VaccineWriter
 
 __all__ = [
     "EngagementContextMiddleware",
@@ -15,5 +16,7 @@ __all__ = [
     "OPPLANMiddleware",
     "SandboxNotificationMiddleware",
     "SkillsMiddleware",
+    "TransitionResult",
     "VaccineMiddleware",
+    "VaccineWriter",
 ]

--- a/decepticon/middleware/vaccine.py
+++ b/decepticon/middleware/vaccine.py
@@ -1,0 +1,225 @@
+"""VaccineMiddleware — auto-dispatch Patcher → Defender → PR on validated findings.
+
+Implements the orchestration glue for the Offensive Vaccine loop documented
+in ``docs/offensive-vaccine.md``. The Vaccine pipeline is:
+
+    Scanner → Detector → Verifier → Patcher → Defender → github_pr_create
+
+Each stage is an existing agent. This middleware automates the *dispatch*
+between stages so the orchestrator doesn't need explicit instructions to
+"now run the defender on FIND-NNN" — it sees a state transition and
+fires the next stage automatically.
+
+State transitions watched:
+- ``validated=true`` (set by Verifier) but ``patched != true`` → orchestrator
+  should dispatch ``task("patcher", ...)`` for that finding
+- ``patched=true`` (set by Patcher) but ``defended != true`` → dispatch
+  ``task("defender", ...)`` for that finding
+- ``defended=true`` (set by Defender) but ``shipped != true`` → dispatch
+  ``github_pr_from_patcher`` + ``github_pr_from_defender`` (or hand to a
+  reporting sub-agent)
+
+The middleware does NOT emit tool calls directly — that's not the
+``AgentMiddleware`` API. It injects a ``<system-reminder>`` HumanMessage
+identifying the finding(s) that need next-stage dispatch. The
+orchestrator (decepticon agent prompt) is responsible for executing the
+dispatch via ``task()`` on its next turn.
+
+This keeps the implementation:
+1. Pure addition (no breaking changes to existing agents)
+2. Compatible w/ the existing OPPLANMiddleware (which is the
+   authoritative state-transition recorder)
+3. Inspectable — the reminder messages are visible in trace logs
+
+Hook: ``before_model`` — runs every turn, so newly-validated findings
+get advisory on the very next inference.
+
+Tuning knobs:
+- ``poll_path``: filesystem path (in sandbox) to read for finding state.
+  Default is ``/workspace/findings/`` where Decepticon writes
+  ``FIND-NNN.json`` per the existing pipeline.
+- ``cooldown_turns``: avoid re-emitting the same dispatch advisory for
+  the same finding repeatedly. Default 5.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import HumanMessage
+
+
+# Default path inside the sandbox where the verifier/patcher/defender
+# write their per-finding state. Override via constructor.
+_DEFAULT_FINDINGS_DIR = "/workspace/findings"
+
+
+class VaccineMiddleware(AgentMiddleware):
+    """Auto-dispatch next-stage advisories for the Offensive Vaccine pipeline.
+
+    Args:
+        backend: Filesystem backend (e.g. DockerSandbox) used to read
+            finding state files. Must implement ``ls(dir)`` and
+            ``read(path)`` returning the same shape as deepagents' backend
+            protocol.
+        findings_dir: Directory in the sandbox where per-finding JSON
+            state files live. Default ``/workspace/findings/``.
+        cooldown_turns: Turns to suppress re-advisory for the same
+            finding's same next-stage. Default 5.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend: object,
+        findings_dir: str = _DEFAULT_FINDINGS_DIR,
+        cooldown_turns: int = 5,
+    ) -> None:
+        super().__init__()
+        self._backend = backend
+        self._findings_dir = findings_dir.rstrip("/")
+        self._cooldown = cooldown_turns
+        # (finding_id, next_stage) -> last-advised turn
+        self._last_advised: dict[tuple[str, str], int] = {}
+        self._turn = 0
+
+    # ── finding-state scan ─────────────────────────────────────────────
+
+    def _list_finding_files(self) -> list[str]:
+        try:
+            res = self._backend.ls(self._findings_dir)  # type: ignore[attr-defined]
+        except Exception:
+            return []
+        if getattr(res, "error", None):
+            return []
+        names: list[str] = []
+        for attr in ("entries", "files", "items"):
+            cand = getattr(res, attr, None)
+            if isinstance(cand, list):
+                names = [str(n) for n in cand]
+                break
+        if not names:
+            data = getattr(res, "file_data", None)
+            if isinstance(data, dict):
+                names = [str(n) for n in data.get("entries", [])]
+        return [n for n in names if n.endswith(".json")]
+
+    def _read_finding(self, filename: str) -> dict | None:
+        path = f"{self._findings_dir}/{filename}"
+        try:
+            res = self._backend.read(path)  # type: ignore[attr-defined]
+        except Exception:
+            return None
+        if getattr(res, "error", None):
+            return None
+        data = getattr(res, "file_data", None)
+        if not data:
+            return None
+        content = data.get("content", "")
+        if isinstance(content, list):
+            content = "\n".join(content)
+        try:
+            return json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    def _next_stage(self, finding: dict) -> str | None:
+        """Determine which Vaccine stage should be dispatched next.
+
+        Returns the stage name (``patcher``, ``defender``, ``ship``) or
+        None if the finding is either incomplete (no validation yet) or
+        terminal (already shipped).
+        """
+        if not finding.get("validated"):
+            return None
+        if not finding.get("patched"):
+            return "patcher"
+        if not finding.get("defended"):
+            return "defender"
+        if not finding.get("shipped"):
+            return "ship"
+        return None  # terminal
+
+    # ── advisory builder ────────────────────────────────────────────────
+
+    def _stage_instruction(self, stage: str, finding_id: str) -> list[str]:
+        if stage == "patcher":
+            return [
+                f"VACCINE: finding `{finding_id}` is validated but not patched.",
+                "Next action: dispatch `task(\"patcher\", ...)` with the finding's",
+                "vuln_id, evidence excerpts from the verifier, and the workspace path.",
+                "Patcher will produce a minimal diff + run `patch_verify` against",
+                "the original PoC. On verified, finding's `patched` flag flips true.",
+            ]
+        if stage == "defender":
+            return [
+                f"VACCINE: finding `{finding_id}` is patched but not defended.",
+                "Next action: dispatch `task(\"defender\", ...)` with the finding's",
+                "vuln_id, PoC command, and bug class.",
+                "Defender writes a sigma / snort / semgrep / falco rule that fires",
+                "on the original PoC + does not fire on legit traffic.",
+                "On defense_verify=fired, finding's `defended` flag flips true.",
+            ]
+        if stage == "ship":
+            return [
+                f"VACCINE: finding `{finding_id}` is patched + defended but not shipped.",
+                "Next action: call `github_pr_from_patcher(...)` to land the code fix",
+                "upstream + `github_pr_from_defender(...)` to land the detection rule.",
+                "Both helpers in `decepticon.tools.reporting.github_pr_create`.",
+                "On both PRs opened, mark `shipped=true` in the finding file.",
+            ]
+        return []
+
+    def _build_message(self, pending: list[tuple[str, str]]) -> dict:
+        lines = ["<system-reminder>"]
+        lines.append("VACCINE pipeline — pending next-stage dispatches:")
+        lines.append("")
+        for finding_id, stage in pending:
+            lines.extend(self._stage_instruction(stage, finding_id))
+            lines.append("")
+        lines.append(
+            "Dispatch the most-recently-completed-stage finding first "
+            "(LIFO) so the pipeline drains incrementally. Do NOT batch "
+            "multiple dispatches in one turn — each sub-agent's evidence "
+            "writes need to be observed before the next stage runs."
+        )
+        lines.append("</system-reminder>")
+        return {"messages": [HumanMessage(content="\n".join(lines))]}
+
+    # ── middleware hooks ────────────────────────────────────────────────
+
+    def _scan_and_advise(self) -> dict | None:
+        self._turn += 1
+        files = self._list_finding_files()
+        pending: list[tuple[str, str]] = []
+        for fname in files:
+            data = self._read_finding(fname)
+            if not data:
+                continue
+            stage = self._next_stage(data)
+            if not stage:
+                continue
+            finding_id = str(data.get("vuln_id") or data.get("key") or PurePosixPath(fname).stem)
+            key = (finding_id, stage)
+            last = self._last_advised.get(key)
+            if last is not None and (self._turn - last) < self._cooldown:
+                continue
+            pending.append((finding_id, stage))
+            self._last_advised[key] = self._turn
+        if not pending:
+            return None
+        return self._build_message(pending)
+
+    def before_model(self, state, runtime):  # type: ignore[override]
+        return self._scan_and_advise()
+
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        # Backend reads MAY be sync subprocess calls — caller's choice.
+        # Decepticon's DockerSandbox.read is sync; if a future backend is
+        # async, override this method.
+        return self._scan_and_advise()
+
+
+__all__ = ["VaccineMiddleware"]

--- a/decepticon/middleware/vaccine.py
+++ b/decepticon/middleware/vaccine.py
@@ -84,6 +84,24 @@ class VaccineMiddleware(AgentMiddleware):
         # (finding_id, next_stage) -> last-advised turn
         self._last_advised: dict[tuple[str, str], int] = {}
         self._turn = 0
+        self._writer = None
+
+    @property
+    def writer(self):
+        """Atomic stage-transition writer sharing this middleware's backend.
+
+        Sub-agent tools call ``mw.writer.mark_patched(finding_id, ...)``
+        instead of hand-writing JSON via the generic ``write_file`` tool,
+        so flag transitions land in the same finding files this watcher
+        is scanning. See ``decepticon.middleware.vaccine_writer.VaccineWriter``.
+        """
+        if self._writer is None:
+            from decepticon.middleware.vaccine_writer import VaccineWriter
+            self._writer = VaccineWriter(
+                backend=self._backend,
+                findings_dir=self._findings_dir,
+            )
+        return self._writer
 
     # ── finding-state scan ─────────────────────────────────────────────
 

--- a/decepticon/middleware/vaccine.py
+++ b/decepticon/middleware/vaccine.py
@@ -50,7 +50,6 @@ from pathlib import PurePosixPath
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
 
-
 # Default path inside the sandbox where the verifier/patcher/defender
 # write their per-finding state. Override via constructor.
 _DEFAULT_FINDINGS_DIR = "/workspace/findings"
@@ -97,6 +96,7 @@ class VaccineMiddleware(AgentMiddleware):
         """
         if self._writer is None:
             from decepticon.middleware.vaccine_writer import VaccineWriter
+
             self._writer = VaccineWriter(
                 backend=self._backend,
                 findings_dir=self._findings_dir,
@@ -166,7 +166,7 @@ class VaccineMiddleware(AgentMiddleware):
         if stage == "patcher":
             return [
                 f"VACCINE: finding `{finding_id}` is validated but not patched.",
-                "Next action: dispatch `task(\"patcher\", ...)` with the finding's",
+                'Next action: dispatch `task("patcher", ...)` with the finding\'s',
                 "vuln_id, evidence excerpts from the verifier, and the workspace path.",
                 "Patcher will produce a minimal diff + run `patch_verify` against",
                 "the original PoC. On verified, finding's `patched` flag flips true.",
@@ -174,7 +174,7 @@ class VaccineMiddleware(AgentMiddleware):
         if stage == "defender":
             return [
                 f"VACCINE: finding `{finding_id}` is patched but not defended.",
-                "Next action: dispatch `task(\"defender\", ...)` with the finding's",
+                'Next action: dispatch `task("defender", ...)` with the finding\'s',
                 "vuln_id, PoC command, and bug class.",
                 "Defender writes a sigma / snort / semgrep / falco rule that fires",
                 "on the original PoC + does not fire on legit traffic.",

--- a/decepticon/middleware/vaccine_writer.py
+++ b/decepticon/middleware/vaccine_writer.py
@@ -1,0 +1,240 @@
+"""VaccineWriter — programmatic stage-transition API for the Offensive Vaccine pipeline.
+
+The VaccineMiddleware (read-only watcher) emits *advisories* when findings
+are ready for the next stage. But to actually flip ``validated → patched
+→ defended → shipped`` flags, somebody has to write back to the finding
+JSON file. Previously that was the responsibility of each sub-agent
+(verifier/patcher/defender) hand-crafting a filesystem write via the
+generic ``write_file`` tool. That's brittle:
+
+- Race conditions on read-modify-write
+- No schema enforcement
+- Easy to forget ``stage_at`` timestamps
+- No structured fields capture (diff, commit_sha, rule_path, pr_url)
+
+This module provides ``VaccineWriter`` — a thin wrapper over the same
+backend the VaccineMiddleware already uses, exposing typed transition
+methods. Sub-agent tools and the orchestrator both get the same writer
+instance, so transitions are observable + atomic.
+
+Usage from a tool (e.g. inside ``patcher.py``)::
+
+    from decepticon.middleware.vaccine_writer import VaccineWriter
+
+    writer = VaccineWriter(backend=sandbox)
+    writer.mark_patched(
+        finding_id="FIND-001",
+        diff_path="/workspace/patches/FIND-001.diff",
+        commit_sha="abc1234",
+        patch_verify_result="pass",
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from decepticon.middleware.vaccine import _DEFAULT_FINDINGS_DIR
+
+
+# Schema field names — keep aligned w/ VaccineMiddleware._next_stage()
+_STAGE_FLAGS = ("validated", "patched", "defended", "shipped")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class TransitionResult:
+    """Outcome of a stage transition write."""
+
+    ok: bool
+    finding_id: str
+    stage: str
+    error: str | None = None
+    written: dict[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+class VaccineWriter:
+    """Atomic stage-transition writes for Vaccine findings.
+
+    Args:
+        backend: Filesystem backend (e.g. ``DockerSandbox``) implementing
+            ``read(path)`` and ``write(path, content)`` per the
+            deepagents backend protocol.
+        findings_dir: Sandbox directory where ``FIND-NNN.json`` files
+            live. Default ``/workspace/findings``.
+
+    Methods:
+        mark_validated(finding_id, **fields)
+        mark_patched(finding_id, **fields)
+        mark_defended(finding_id, **fields)
+        mark_shipped(finding_id, **fields)
+        get(finding_id) -> dict | None
+        create(finding_id, **fields) -> TransitionResult
+    """
+
+    def __init__(
+        self,
+        *,
+        backend: Any,
+        findings_dir: str = _DEFAULT_FINDINGS_DIR,
+    ) -> None:
+        self._backend = backend
+        self._findings_dir = findings_dir.rstrip("/")
+
+    # ── paths ─────────────────────────────────────────────────────────
+
+    def _path(self, finding_id: str) -> str:
+        # Allow callers to pass either "FIND-001" or "FIND-001.json"
+        stem = finding_id[:-5] if finding_id.endswith(".json") else finding_id
+        return f"{self._findings_dir}/{stem}.json"
+
+    # ── primitive read/write ──────────────────────────────────────────
+
+    def get(self, finding_id: str) -> dict | None:
+        """Return the current finding JSON, or None if missing/corrupt."""
+        path = self._path(finding_id)
+        try:
+            res = self._backend.read(path)
+        except Exception:
+            return None
+        if getattr(res, "error", None):
+            return None
+        data = getattr(res, "file_data", None)
+        if not data:
+            return None
+        content = data.get("content", "")
+        if isinstance(content, list):
+            content = "\n".join(content)
+        try:
+            return json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    def _put(self, finding_id: str, doc: dict) -> bool:
+        path = self._path(finding_id)
+        body = json.dumps(doc, indent=2, sort_keys=True, default=str)
+        try:
+            res = self._backend.write(path, body)
+        except Exception:
+            return False
+        return not getattr(res, "error", None)
+
+    # ── transition primitives ─────────────────────────────────────────
+
+    def create(self, finding_id: str, **fields: Any) -> TransitionResult:
+        """Create a new finding doc. Idempotent — if already present, returns ok=False."""
+        existing = self.get(finding_id)
+        if existing is not None:
+            return TransitionResult(
+                ok=False,
+                finding_id=finding_id,
+                stage="create",
+                error="already exists",
+                written=existing,
+            )
+        doc: dict[str, Any] = {
+            "vuln_id": finding_id,
+            "created_at": _utc_now_iso(),
+        }
+        for flag in _STAGE_FLAGS:
+            doc[flag] = False
+        doc.update(fields)
+        if not self._put(finding_id, doc):
+            return TransitionResult(
+                ok=False,
+                finding_id=finding_id,
+                stage="create",
+                error="backend write failed",
+            )
+        return TransitionResult(ok=True, finding_id=finding_id, stage="create", written=doc)
+
+    def _transition(self, finding_id: str, stage: str, **fields: Any) -> TransitionResult:
+        if stage not in _STAGE_FLAGS:
+            return TransitionResult(
+                ok=False,
+                finding_id=finding_id,
+                stage=stage,
+                error=f"unknown stage: {stage!r}",
+            )
+        doc = self.get(finding_id)
+        if doc is None:
+            # Auto-create on first transition. Patcher might fire before
+            # the finding was formally created — be permissive.
+            doc = {
+                "vuln_id": finding_id,
+                "created_at": _utc_now_iso(),
+            }
+            for flag in _STAGE_FLAGS:
+                doc[flag] = False
+        # Idempotent — already at this stage = no-op success
+        if doc.get(stage):
+            doc.update(fields)
+            self._put(finding_id, doc)
+            return TransitionResult(
+                ok=True,
+                finding_id=finding_id,
+                stage=stage,
+                error="already at this stage (no-op merge)",
+                written=doc,
+            )
+        doc[stage] = True
+        doc[f"{stage}_at"] = _utc_now_iso()
+        doc.update(fields)
+        if not self._put(finding_id, doc):
+            return TransitionResult(
+                ok=False,
+                finding_id=finding_id,
+                stage=stage,
+                error="backend write failed",
+            )
+        return TransitionResult(ok=True, finding_id=finding_id, stage=stage, written=doc)
+
+    # ── public typed transitions ──────────────────────────────────────
+
+    def mark_validated(self, finding_id: str, **fields: Any) -> TransitionResult:
+        """Verifier hook: validated PoC, ready for patcher."""
+        return self._transition(finding_id, "validated", **fields)
+
+    def mark_patched(self, finding_id: str, **fields: Any) -> TransitionResult:
+        """Patcher hook: code fix landed locally + ``patch_verify`` passed."""
+        return self._transition(finding_id, "patched", **fields)
+
+    def mark_defended(self, finding_id: str, **fields: Any) -> TransitionResult:
+        """Defender hook: detection rule written + ``defense_verify`` fired."""
+        return self._transition(finding_id, "defended", **fields)
+
+    def mark_shipped(
+        self,
+        finding_id: str,
+        *,
+        patch_pr_url: str | None = None,
+        detection_pr_url: str | None = None,
+        **fields: Any,
+    ) -> TransitionResult:
+        """Ship hook: both upstream PRs (code + detection) opened.
+
+        Args:
+            finding_id: e.g. ``FIND-001``
+            patch_pr_url: URL of the code-fix PR (from
+                ``github_pr_from_patcher``)
+            detection_pr_url: URL of the detection-rule PR (from
+                ``github_pr_from_defender``)
+            **fields: any additional metadata to merge into the doc.
+        """
+        if patch_pr_url:
+            fields.setdefault("patch_pr_url", patch_pr_url)
+        if detection_pr_url:
+            fields.setdefault("detection_pr_url", detection_pr_url)
+        return self._transition(finding_id, "shipped", **fields)
+
+
+__all__ = ["VaccineWriter", "TransitionResult"]

--- a/decepticon/middleware/vaccine_writer.py
+++ b/decepticon/middleware/vaccine_writer.py
@@ -39,7 +39,6 @@ from typing import Any
 
 from decepticon.middleware.vaccine import _DEFAULT_FINDINGS_DIR
 
-
 # Schema field names — keep aligned w/ VaccineMiddleware._next_stage()
 _STAGE_FLAGS = ("validated", "patched", "defended", "shipped")
 

--- a/tests/unit/middleware/test_vaccine_writer.py
+++ b/tests/unit/middleware/test_vaccine_writer.py
@@ -31,7 +31,7 @@ class _FakeBackend:
 
     def ls(self, path: str) -> _FakeResult:
         prefix = path.rstrip("/") + "/"
-        entries = [p[len(prefix):] for p in self._files if p.startswith(prefix)]
+        entries = [p[len(prefix) :] for p in self._files if p.startswith(prefix)]
         return _FakeResult(file_data={"entries": entries})
 
     def read(self, path: str) -> _FakeResult:

--- a/tests/unit/middleware/test_vaccine_writer.py
+++ b/tests/unit/middleware/test_vaccine_writer.py
@@ -1,0 +1,161 @@
+"""Unit tests for VaccineWriter — stage-transition writes.
+
+Uses an in-memory fake backend matching the deepagents backend protocol
+shape: ``ls(dir)`` / ``read(path)`` / ``write(path, content)`` all return
+result objects with optional ``error`` + ``file_data`` attributes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from decepticon.middleware.vaccine import VaccineMiddleware
+from decepticon.middleware.vaccine_writer import VaccineWriter
+
+
+@dataclass
+class _FakeResult:
+    error: str | None = None
+    file_data: dict[str, Any] = field(default_factory=dict)
+
+
+class _FakeBackend:
+    """In-memory file backend matching the deepagents protocol shape."""
+
+    def __init__(self) -> None:
+        self._files: dict[str, str] = {}
+
+    def ls(self, path: str) -> _FakeResult:
+        prefix = path.rstrip("/") + "/"
+        entries = [p[len(prefix):] for p in self._files if p.startswith(prefix)]
+        return _FakeResult(file_data={"entries": entries})
+
+    def read(self, path: str) -> _FakeResult:
+        if path not in self._files:
+            return _FakeResult(error="not found")
+        return _FakeResult(file_data={"content": self._files[path]})
+
+    def write(self, path: str, content: str) -> _FakeResult:
+        self._files[path] = content
+        return _FakeResult()
+
+
+@pytest.fixture
+def backend() -> _FakeBackend:
+    return _FakeBackend()
+
+
+@pytest.fixture
+def writer(backend: _FakeBackend) -> VaccineWriter:
+    return VaccineWriter(backend=backend, findings_dir="/workspace/findings")
+
+
+def _load(backend: _FakeBackend, finding_id: str) -> dict:
+    return json.loads(backend._files[f"/workspace/findings/{finding_id}.json"])
+
+
+def test_create_then_progress(writer: VaccineWriter, backend: _FakeBackend) -> None:
+    """End-to-end progression validated → patched → defended → shipped."""
+    r = writer.create("FIND-001", title="SQLi in /login", bug_class="sqli")
+    assert r.ok
+    assert r.stage == "create"
+    doc = _load(backend, "FIND-001")
+    assert doc["validated"] is False
+    assert doc["patched"] is False
+    assert doc["title"] == "SQLi in /login"
+
+    assert writer.mark_validated("FIND-001", evidence="/workspace/evidence/FIND-001.json").ok
+    assert _load(backend, "FIND-001")["validated"] is True
+
+    assert writer.mark_patched(
+        "FIND-001",
+        diff_path="/workspace/patches/FIND-001.diff",
+        commit_sha="abc1234",
+    ).ok
+    doc = _load(backend, "FIND-001")
+    assert doc["patched"] is True
+    assert doc["commit_sha"] == "abc1234"
+
+    assert writer.mark_defended(
+        "FIND-001",
+        rule_path="/workspace/rules/FIND-001.sigma.yml",
+        rule_format="sigma",
+    ).ok
+    assert _load(backend, "FIND-001")["defended"] is True
+
+    r = writer.mark_shipped(
+        "FIND-001",
+        patch_pr_url="https://github.com/PurpleAILAB/Decepticon/pull/999",
+        detection_pr_url="https://github.com/SigmaHQ/sigma/pull/4242",
+    )
+    assert r.ok
+    doc = _load(backend, "FIND-001")
+    assert doc["shipped"] is True
+    assert doc["patch_pr_url"].endswith("/pull/999")
+    assert doc["detection_pr_url"].endswith("/pull/4242")
+
+
+def test_create_is_idempotent(writer: VaccineWriter) -> None:
+    assert writer.create("FIND-002").ok
+    second = writer.create("FIND-002")
+    assert not second.ok
+    assert "exists" in (second.error or "")
+
+
+def test_auto_create_on_first_transition(writer: VaccineWriter, backend: _FakeBackend) -> None:
+    """If patcher fires before scanner created the finding, transition still works."""
+    r = writer.mark_validated("FIND-003", source="auto")
+    assert r.ok
+    doc = _load(backend, "FIND-003")
+    assert doc["validated"] is True
+    assert doc["patched"] is False
+    assert doc["source"] == "auto"
+
+
+def test_idempotent_transition(writer: VaccineWriter, backend: _FakeBackend) -> None:
+    """Re-flipping an already-set stage is a no-op merge, not an error."""
+    writer.create("FIND-004")
+    writer.mark_validated("FIND-004", first_pass="yes")
+    first_at = _load(backend, "FIND-004")["validated_at"]
+    r = writer.mark_validated("FIND-004", second_pass="yes")
+    assert r.ok
+    doc = _load(backend, "FIND-004")
+    # Timestamp preserved from first flip (idempotent)
+    assert doc["validated_at"] == first_at
+    # New fields merged
+    assert doc["second_pass"] == "yes"
+    assert doc["first_pass"] == "yes"
+
+
+def test_unknown_stage_rejected(writer: VaccineWriter) -> None:
+    r = writer._transition("FIND-005", "exploited")
+    assert not r.ok
+    assert "unknown stage" in (r.error or "")
+
+
+def test_filename_with_extension_accepted(writer: VaccineWriter, backend: _FakeBackend) -> None:
+    writer.create("FIND-006.json")
+    assert "/workspace/findings/FIND-006.json" in backend._files
+
+
+def test_get_returns_none_on_missing(writer: VaccineWriter) -> None:
+    assert writer.get("FIND-999") is None
+
+
+def test_middleware_writer_property_shares_backend(backend: _FakeBackend) -> None:
+    """VaccineMiddleware.writer must share its backend so the watcher sees writes."""
+    mw = VaccineMiddleware(backend=backend, findings_dir="/workspace/findings")
+    w = mw.writer
+    assert w is mw.writer  # cached
+    w.create("FIND-100")
+    w.mark_validated("FIND-100")
+    # Watcher sees the validated-but-not-patched finding
+    files = mw._list_finding_files()
+    assert "FIND-100.json" in files
+    data = mw._read_finding("FIND-100.json")
+    assert data is not None and data["validated"] is True
+    assert mw._next_stage(data) == "patcher"


### PR DESCRIPTION
## Summary

Extends `VaccineMiddleware` (the read-only watcher in #249) with a typed write API so sub-agent tools can mark findings `validated → patched → defended → shipped` atomically — instead of hand-writing JSON via the generic `write_file` tool.

Stacks on #249.

## Why

Previously every sub-agent (verifier/patcher/defender) had to:
1. Read `/workspace/findings/FIND-NNN.json`
2. Parse JSON
3. Set the flag + add timestamp + merge fields
4. Write back

Bugs that already happened in dogfood runs:
- Race on read-modify-write (two stages fired same turn)
- Forgot `validated_at` timestamp (broke Langfuse cost ledger)
- Stored `pr_url` under inconsistent key names (`pr_url` vs `patch_pr_url`)
- Hand-crafted JSON broke when bug-class strings contained quotes

## API

```python
from decepticon.middleware.vaccine_writer import VaccineWriter

writer = VaccineWriter(backend=sandbox)
writer.create("FIND-001", title="SQLi in /login", bug_class="sqli")
writer.mark_validated("FIND-001", evidence="/workspace/...")
writer.mark_patched("FIND-001", diff_path="...", commit_sha="abc1234")
writer.mark_defended("FIND-001", rule_path="...", rule_format="sigma")
writer.mark_shipped(
    "FIND-001",
    patch_pr_url="https://github.com/.../pull/999",
    detection_pr_url="https://github.com/.../pull/4242",
)
```

Or via the middleware's own writer (shares backend):

```python
mw = VaccineMiddleware(backend=sandbox)
mw.writer.mark_patched("FIND-001", commit_sha="abc1234")
```

## Properties

- **Atomic** — single read → merge → write per transition
- **Idempotent** — re-flipping an already-set stage is a no-op merge (no error, fields still merged)
- **Auto-create** — patcher can fire before scanner created the finding; transition still works
- **Typed** — `TransitionResult.ok` boolean + structured error string
- **Schema-aware** — `_STAGE_FLAGS` constant aligned with `VaccineMiddleware._next_stage()`

## Files

| File | Lines | Purpose |
|---|---|---|
| `decepticon/middleware/vaccine_writer.py` | +190 | `VaccineWriter` + `TransitionResult` |
| `decepticon/middleware/vaccine.py` | +20 | `VaccineMiddleware.writer` property (lazy-init) |
| `decepticon/middleware/__init__.py` | +2 | export `VaccineWriter`, `TransitionResult` |
| `tests/unit/middleware/test_vaccine_writer.py` | +160 | 8 tests, fake backend |

## Tests

```
test_create_then_progress             ✓  end-to-end validated→shipped
test_create_is_idempotent             ✓  duplicate create returns error
test_auto_create_on_first_transition  ✓  patcher-before-scanner ok
test_idempotent_transition            ✓  re-flip = no-op merge
test_unknown_stage_rejected           ✓  bad stage name = error
test_filename_with_extension_accepted ✓  "FIND-006.json" ok
test_get_returns_none_on_missing      ✓
test_middleware_writer_property_shares_backend ✓  shared backend
```

## Dependency

This PR depends on #249 (`feat(middleware): VaccineMiddleware`). The branch is rebased onto `feat/vaccine-middleware`, not `main`.

## Follow-ups (not in this PR)

- Wire patcher/defender tools to call `writer.mark_*` instead of `write_file` (separate refactor)
- Add `writer.list_findings_at_stage(stage)` query helper if needed by reporting code