### PR TITLE
feat(obs): 5 per-engagement Grafana dashboards + canonical metrics module

### DIFF
--- a/containers/observability/docker-compose.observability.yml
+++ b/containers/observability/docker-compose.observability.yml
@@ -1,0 +1,201 @@
+# Decepticon observability stack — opt-in supplement to docker-compose.yml.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f containers/observability/docker-compose.observability.yml up -d
+#
+# Or via Makefile shortcut:
+#   make obs-up
+#
+# Services:
+#   - langfuse        — LLM observability (traces, evals, prompts)
+#   - langfuse-db     — Postgres for Langfuse metadata
+#   - clickhouse      — analytics column store for Langfuse v3+
+#   - prometheus      — metrics scraper
+#   - grafana         — dashboards
+#   - jaeger-all-in-one — distributed traces (OTel/OpenTelemetry)
+#
+# Networks: attaches to existing decepticon-net so the langgraph + sub-agent
+# containers can reach the OTel collector at otel-collector:4318 and the
+# Langfuse API at langfuse:3000.
+#
+# Storage: all stateful services use named volumes prefixed obs-* so they
+# can be wiped independently of the main Decepticon stack via:
+#   docker volume rm $(docker volume ls -q | grep '^decepticon_obs-')
+#
+# Resource footprint: ~2.5 GB RAM idle, ~5 GB RAM under engagement load.
+# If running on a constrained host, comment out clickhouse + jaeger and
+# keep only langfuse + prometheus + grafana (drops to ~1 GB RAM).
+
+services:
+  # ── Langfuse — LLM-specific observability ─────────────────────────
+  langfuse-db:
+    image: postgres:16-alpine
+    container_name: decepticon-langfuse-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: ${LANGFUSE_DB_PASSWORD:-langfuse-dev-changeme}
+      POSTGRES_DB: langfuse
+    volumes:
+      - obs-langfuse-db:/var/lib/postgresql/data
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    container_name: decepticon-clickhouse
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_DB: langfuse
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse-dev-changeme}
+    volumes:
+      - obs-clickhouse-data:/var/lib/clickhouse
+      - obs-clickhouse-logs:/var/log/clickhouse-server
+    ulimits:
+      nofile: 262144
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8123/ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
+  langfuse:
+    # v3 has Postgres + ClickHouse split. Pin to a specific minor for
+    # deterministic Decepticon deployments — bump when validated.
+    image: langfuse/langfuse:3
+    container_name: decepticon-langfuse
+    restart: unless-stopped
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    environment:
+      # Required
+      DATABASE_URL: postgresql://langfuse:${LANGFUSE_DB_PASSWORD:-langfuse-dev-changeme}@langfuse-db:5432/langfuse
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-decepticon-langfuse-nextauth-dev}
+      NEXTAUTH_URL: ${LANGFUSE_PUBLIC_URL:-http://localhost:3700}
+      SALT: ${LANGFUSE_SALT:-decepticon-langfuse-salt-dev}
+      ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+      # ClickHouse analytics backend (v3)
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: langfuse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse-dev-changeme}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      # Optional — disable telemetry to upstream Langfuse
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Decepticon}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-decepticon-default}
+      # Init user (created on first boot if env vars present)
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@decepticon.local}
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-changeme-on-first-login}
+      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Decepticon Admin}
+    ports:
+      - "${LANGFUSE_PORT:-3700}:3000"
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:3000/api/public/health"]
+      interval: 20s
+      timeout: 5s
+      retries: 10
+      start_period: 90s
+
+  # ── OpenTelemetry collector ───────────────────────────────────────
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.107.0
+    container_name: decepticon-otel-collector
+    restart: unless-stopped
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel-collector.yaml:ro
+    ports:
+      # OTLP gRPC
+      - "${OTEL_GRPC_PORT:-4317}:4317"
+      # OTLP HTTP
+      - "${OTEL_HTTP_PORT:-4318}:4318"
+      # Prometheus exporter
+      - "${OTEL_PROMETHEUS_PORT:-8889}:8889"
+    networks:
+      - decepticon-net
+
+  # ── Prometheus + Grafana ──────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: decepticon-prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - obs-prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=14d"
+      - "--web.enable-lifecycle"
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    networks:
+      - decepticon-net
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: decepticon-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-decepticon-grafana-dev}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_INSTALL_PLUGINS: ""
+    volumes:
+      - obs-grafana-data:/var/lib/grafana
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "${GRAFANA_PORT:-3701}:3000"
+    networks:
+      - decepticon-net
+
+  # ── Jaeger — distributed traces ───────────────────────────────────
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    container_name: decepticon-jaeger
+    restart: unless-stopped
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+      SPAN_STORAGE_TYPE: badger
+      BADGER_EPHEMERAL: "false"
+      BADGER_DIRECTORY_VALUE: /badger/data
+      BADGER_DIRECTORY_KEY: /badger/key
+    volumes:
+      - obs-jaeger-badger:/badger
+    ports:
+      # Jaeger UI
+      - "${JAEGER_UI_PORT:-3702}:16686"
+      # OTLP HTTP — agents can ship traces here directly (alt to otel-collector)
+      - "4318:4318"
+    networks:
+      - decepticon-net
+
+volumes:
+  obs-langfuse-db:
+  obs-clickhouse-data:
+  obs-clickhouse-logs:
+  obs-prometheus-data:
+  obs-grafana-data:
+  obs-jaeger-badger:
+
+networks:
+  decepticon-net:
+    external: true
+    name: decepticon_decepticon-net

--- a/containers/observability/grafana-provisioning/dashboards/dashboards.yaml
+++ b/containers/observability/grafana-provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: decepticon
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/containers/observability/grafana-provisioning/dashboards/decepticon/01-engagement-overview.json
+++ b/containers/observability/grafana-provisioning/dashboards/decepticon/01-engagement-overview.json
@@ -1,0 +1,163 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Top-level engagement dashboard — duration, tool calls, agent dispatches, findings outcome, vaccine throughput. Filter by ${engagement} variable.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}},
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "sum(decepticon_tool_calls_total{engagement=~\"$engagement\"})", "refId": "A"}],
+      "title": "Total Tool Calls",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "sum(decepticon_agent_dispatches_total{engagement=~\"$engagement\"})", "refId": "A"}],
+      "title": "Sub-agent Dispatches",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "green"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "sum(decepticon_finding_outcomes_total{engagement=~\"$engagement\", status=\"passed\"})", "refId": "A"}],
+      "title": "Findings Validated",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "red"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+      "id": 4,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "sum(decepticon_finding_outcomes_total{engagement=~\"$engagement\", status=\"false_positive\"})", "refId": "A"}],
+      "title": "False Positives Killed",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "purple"}, "unit": "percentunit", "min": 0, "max": 1, "thresholds": {"mode": "absolute", "steps": [{"color": "red"}, {"color": "yellow", "value": 0.5}, {"color": "green", "value": 0.8}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+      "id": 5,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "sum(decepticon_finding_outcomes_total{engagement=~\"$engagement\", status=\"passed\"}) / clamp_min(sum(decepticon_finding_outcomes_total{engagement=~\"$engagement\"}), 1)", "refId": "A"}],
+      "title": "Validity Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "blue"}, "unit": "currencyUSD", "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 0},
+      "id": 6,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "sum(decepticon_llm_cost_usd_total{engagement=~\"$engagement\"})", "refId": "A"}],
+      "title": "LLM Spend (USD)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "normal"}, "thresholdsStyle": {"mode": "off"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "id": 7,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (tool) (rate(decepticon_tool_calls_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Tool Call Rate (top 10 tools)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "id": 8,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (agent) (rate(decepticon_agent_dispatches_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{agent}}", "refId": "A"}],
+      "title": "Sub-agent Dispatch Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "lineInterpolation": "linear", "lineWidth": 1, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "validated"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]}, {"matcher": {"id": "byName", "options": "patched"}, "properties": [{"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}}]}, {"matcher": {"id": "byName", "options": "defended"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]}, {"matcher": {"id": "byName", "options": "shipped"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]}]},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "id": 9,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [{"expr": "sum by (stage) (rate(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{stage}}", "refId": "A"}],
+      "title": "Vaccine Pipeline Flow",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "ms"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "id": 10,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (le, agent) (rate(decepticon_agent_latency_ms_bucket{engagement=~\"$engagement\"}[5m])))", "legendFormat": "p95 {{agent}}", "refId": "A"}],
+      "title": "Agent Latency p95 (per turn)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["decepticon", "engagement"],
+  "templating": {
+    "list": [
+      {
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(decepticon_tool_calls_total, engagement)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Engagement",
+        "multi": false,
+        "name": "engagement",
+        "options": [],
+        "query": {"query": "label_values(decepticon_tool_calls_total, engagement)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Decepticon — Engagement Overview",
+  "uid": "dec-engagement-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/containers/observability/grafana-provisioning/dashboards/decepticon/02-tool-call-detail.json
+++ b/containers/observability/grafana-provisioning/dashboards/decepticon/02-tool-call-detail.json
@@ -1,0 +1,63 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "description": "Tool-call-level forensics — which tools are firing, from which agent, against which target, with what success rate. Crucial for benchmark optimization (find slow tools, kill noisy ones).",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 30, "lineInterpolation": "stepAfter", "lineWidth": 1, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (tool) (rate(decepticon_tool_calls_total{engagement=~\"$engagement\", agent=~\"$agent\"}[1m]))", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Tool Calls by Tool (stacked)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "p95_ms"}, "properties": [{"id": "unit", "value": "ms"}, {"id": "custom.cellOptions", "value": {"type": "color-background", "mode": "gradient"}}, {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 5000}, {"color": "red", "value": 30000}]}}]}, {"matcher": {"id": "byName", "options": "error_rate"}, "properties": [{"id": "unit", "value": "percentunit"}, {"id": "custom.cellOptions", "value": {"type": "color-background", "mode": "gradient"}}, {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 0.05}, {"color": "red", "value": 0.20}]}}]}]},
+      "gridPos": {"h": 11, "w": 12, "x": 0, "y": 9},
+      "id": 2,
+      "options": {"cellHeight": "sm", "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false}, "showHeader": true, "sortBy": [{"desc": true, "displayName": "calls"}]},
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {"expr": "sum by (tool) (increase(decepticon_tool_calls_total{engagement=~\"$engagement\"}[$__range]))", "format": "table", "instant": true, "legendFormat": "calls", "refId": "A"},
+        {"expr": "histogram_quantile(0.95, sum by (le, tool) (rate(decepticon_tool_latency_ms_bucket{engagement=~\"$engagement\"}[$__range])))", "format": "table", "instant": true, "legendFormat": "p95_ms", "refId": "B"},
+        {"expr": "sum by (tool) (increase(decepticon_tool_calls_total{engagement=~\"$engagement\", status=\"error\"}[$__range])) / clamp_min(sum by (tool) (increase(decepticon_tool_calls_total{engagement=~\"$engagement\"}[$__range])), 1)", "format": "table", "instant": true, "legendFormat": "error_rate", "refId": "C"}
+      ],
+      "title": "Tool Performance Table",
+      "transformations": [
+        {"id": "joinByField", "options": {"byField": "tool", "mode": "outer"}},
+        {"id": "organize", "options": {"excludeByName": {"Time 1": true, "Time 2": true, "Time 3": true}, "renameByName": {"Value #A": "calls", "Value #B": "p95_ms", "Value #C": "error_rate"}}}
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "mappings": []}, "overrides": []},
+      "gridPos": {"h": 11, "w": 12, "x": 12, "y": 9},
+      "id": 3,
+      "options": {"displayLabels": ["percent"], "legend": {"displayMode": "list", "placement": "right", "showLegend": true, "values": ["value"]}, "pieType": "donut", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "tooltip": {"mode": "single"}},
+      "pluginVersion": "10.0.0",
+      "targets": [{"expr": "topk(10, sum by (tool) (increase(decepticon_tool_calls_total{engagement=~\"$engagement\"}[$__range])))", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Top 10 Tools by Call Volume",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["decepticon", "tools"],
+  "templating": {
+    "list": [
+      {"datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(decepticon_tool_calls_total, engagement)", "includeAll": true, "label": "Engagement", "multi": false, "name": "engagement", "options": [], "query": {"query": "label_values(decepticon_tool_calls_total, engagement)", "refId": "var"}, "refresh": 2, "type": "query"},
+      {"datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(decepticon_tool_calls_total{engagement=~\"$engagement\"}, agent)", "includeAll": true, "label": "Agent", "multi": true, "name": "agent", "options": [], "query": {"query": "label_values(decepticon_tool_calls_total{engagement=~\"$engagement\"}, agent)", "refId": "var"}, "refresh": 2, "type": "query"}
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "",
+  "title": "Decepticon — Tool-Call Forensics",
+  "uid": "dec-tool-forensics",
+  "version": 1
+}

--- a/containers/observability/grafana-provisioning/dashboards/decepticon/03-llm-cost.json
+++ b/containers/observability/grafana-provisioning/dashboards/decepticon/03-llm-cost.json
@@ -1,0 +1,94 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "description": "Per-engagement LLM cost ledger — tokens, USD, model breakdown. Sources: Prometheus counters emitted by decepticon.core.telemetry + Langfuse Postgres for full per-trace cost.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "currencyUSD", "thresholds": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 5}, {"color": "red", "value": 25}]}}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_llm_cost_usd_total{engagement=~\"$engagement\"})", "refId": "A"}],
+      "title": "Total Cost (USD)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "blue"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_llm_tokens_total{engagement=~\"$engagement\", type=\"in\"})", "refId": "A"}],
+      "title": "Input Tokens",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "purple"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_llm_tokens_total{engagement=~\"$engagement\", type=\"out\"})", "refId": "A"}],
+      "title": "Output Tokens",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "currencyUSD", "decimals": 4, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "red", "value": 0.5}]}}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
+      "id": 4,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_llm_cost_usd_total{engagement=~\"$engagement\"}) / clamp_min(sum(decepticon_finding_outcomes_total{engagement=~\"$engagement\", status=\"passed\"}), 1)", "refId": "A"}],
+      "title": "Cost per Validated Finding",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 30, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "unit": "currencyUSD"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 5},
+      "id": 5,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (model) (rate(decepticon_llm_cost_usd_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{model}}", "refId": "A"}],
+      "title": "Cost Rate by Model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 5},
+      "id": 6,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi"}},
+      "targets": [{"expr": "sum by (agent) (rate(decepticon_llm_tokens_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{agent}}", "refId": "A"}],
+      "title": "Token Rate by Agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}}, "overrides": [{"matcher": {"id": "byName", "options": "cost_usd"}, "properties": [{"id": "unit", "value": "currencyUSD"}, {"id": "custom.cellOptions", "value": {"type": "color-background", "mode": "gradient"}}]}, {"matcher": {"id": "byName", "options": "tokens_in"}, "properties": [{"id": "unit", "value": "short"}]}, {"matcher": {"id": "byName", "options": "tokens_out"}, "properties": [{"id": "unit", "value": "short"}]}]},
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 14},
+      "id": 7,
+      "options": {"cellHeight": "sm", "footer": {"show": false}, "showHeader": true, "sortBy": [{"desc": true, "displayName": "cost_usd"}]},
+      "targets": [
+        {"expr": "sum by (model) (increase(decepticon_llm_cost_usd_total{engagement=~\"$engagement\"}[$__range]))", "format": "table", "instant": true, "refId": "A"},
+        {"expr": "sum by (model) (increase(decepticon_llm_tokens_total{engagement=~\"$engagement\", type=\"in\"}[$__range]))", "format": "table", "instant": true, "refId": "B"},
+        {"expr": "sum by (model) (increase(decepticon_llm_tokens_total{engagement=~\"$engagement\", type=\"out\"}[$__range]))", "format": "table", "instant": true, "refId": "C"}
+      ],
+      "title": "Per-Model Breakdown",
+      "transformations": [
+        {"id": "joinByField", "options": {"byField": "model", "mode": "outer"}},
+        {"id": "organize", "options": {"excludeByName": {"Time 1": true, "Time 2": true, "Time 3": true}, "renameByName": {"Value #A": "cost_usd", "Value #B": "tokens_in", "Value #C": "tokens_out"}}}
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["decepticon", "cost", "llm"],
+  "templating": {"list": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(decepticon_llm_cost_usd_total, engagement)", "includeAll": true, "label": "Engagement", "name": "engagement", "query": {"query": "label_values(decepticon_llm_cost_usd_total, engagement)"}, "refresh": 2, "type": "query"}]},
+  "time": {"from": "now-24h", "to": "now"},
+  "title": "Decepticon — LLM Cost Ledger",
+  "uid": "dec-llm-cost",
+  "version": 1
+}

--- a/containers/observability/grafana-provisioning/dashboards/decepticon/04-vaccine-pipeline.json
+++ b/containers/observability/grafana-provisioning/dashboards/decepticon/04-vaccine-pipeline.json
@@ -1,0 +1,100 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "description": "Offensive Vaccine pipeline funnel — Scanner→Detector→Verifier→Patcher→Defender→Shipped. Highlights pipeline bottlenecks + drop-off rate at each stage.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "blue"}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"validated\"})", "refId": "A"}],
+      "title": "Validated",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "yellow"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 4, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"patched\"})", "refId": "A"}],
+      "title": "Patched",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "orange"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 8, "y": 0},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"defended\"})", "refId": "A"}],
+      "title": "Defended",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "green"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 12, "y": 0},
+      "id": 4,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"shipped\"})", "refId": "A"}],
+      "title": "Shipped",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red"}, {"color": "yellow", "value": 0.5}, {"color": "green", "value": 0.8}]}, "unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "gridPos": {"h": 5, "w": 8, "x": 16, "y": 0},
+      "id": 5,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"]}, "textMode": "auto"},
+      "targets": [{"expr": "sum(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"shipped\"}) / clamp_min(sum(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"validated\"}), 1)", "refId": "A"}],
+      "title": "End-to-End Conversion (validated → shipped)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 30, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never"}, "unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "validated"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]}, {"matcher": {"id": "byName", "options": "patched"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]}, {"matcher": {"id": "byName", "options": "defended"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]}, {"matcher": {"id": "byName", "options": "shipped"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}]},
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 5},
+      "id": 6,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi"}},
+      "targets": [{"expr": "sum by (stage) (increase(decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{stage}}", "refId": "A"}],
+      "title": "Stage Transitions Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 60}, {"color": "red", "value": 600}]}, "unit": "s"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 15},
+      "id": 7,
+      "options": {"legend": {"calcs": ["mean"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"expr": "histogram_quantile(0.50, sum by (le) (rate(decepticon_vaccine_dwell_time_seconds_bucket{engagement=~\"$engagement\", stage=\"validated\"}[$__range])))", "legendFormat": "validated→patched p50", "refId": "A"},
+        {"expr": "histogram_quantile(0.50, sum by (le) (rate(decepticon_vaccine_dwell_time_seconds_bucket{engagement=~\"$engagement\", stage=\"patched\"}[$__range])))", "legendFormat": "patched→defended p50", "refId": "B"},
+        {"expr": "histogram_quantile(0.50, sum by (le) (rate(decepticon_vaccine_dwell_time_seconds_bucket{engagement=~\"$engagement\", stage=\"defended\"}[$__range])))", "legendFormat": "defended→shipped p50", "refId": "C"}
+      ],
+      "title": "Stage Dwell Time (p50)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "mappings": []}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 15},
+      "id": 8,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"]}, "pieType": "donut", "reduceOptions": {"calcs": ["lastNotNull"]}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "sum by (bug_class) (decepticon_vaccine_stage_transitions_total{engagement=~\"$engagement\", stage=\"shipped\"})", "legendFormat": "{{bug_class}}", "refId": "A"}],
+      "title": "Shipped Findings by Bug Class",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["decepticon", "vaccine", "pipeline"],
+  "templating": {"list": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(decepticon_vaccine_stage_transitions_total, engagement)", "includeAll": true, "label": "Engagement", "name": "engagement", "query": {"query": "label_values(decepticon_vaccine_stage_transitions_total, engagement)"}, "refresh": 2, "type": "query"}]},
+  "time": {"from": "now-24h", "to": "now"},
+  "title": "Decepticon — Vaccine Pipeline Flow",
+  "uid": "dec-vaccine-flow",
+  "version": 1
+}

--- a/containers/observability/grafana-provisioning/dashboards/decepticon/05-agent-handoffs.json
+++ b/containers/observability/grafana-provisioning/dashboards/decepticon/05-agent-handoffs.json
@@ -1,0 +1,56 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "description": "Agent-handoff topology — who dispatches whom, with what frequency, with what latency. Surfaces orchestrator/sub-agent ratio + bottleneck agents.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"align": "auto", "cellOptions": {"type": "auto"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}, "unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "dispatches"}, "properties": [{"id": "custom.cellOptions", "value": {"type": "color-background", "mode": "gradient"}}, {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 10}, {"color": "red", "value": 50}]}}]}, {"matcher": {"id": "byName", "options": "p95_ms"}, "properties": [{"id": "unit", "value": "ms"}, {"id": "custom.cellOptions", "value": {"type": "color-background", "mode": "gradient"}}, {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 30000}, {"color": "red", "value": 120000}]}}]}]},
+      "gridPos": {"h": 12, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"cellHeight": "sm", "showHeader": true, "sortBy": [{"desc": true, "displayName": "dispatches"}]},
+      "targets": [
+        {"expr": "sum by (parent, agent) (increase(decepticon_agent_dispatches_total{engagement=~\"$engagement\"}[$__range]))", "format": "table", "instant": true, "refId": "A"},
+        {"expr": "histogram_quantile(0.95, sum by (le, parent, agent) (rate(decepticon_agent_latency_ms_bucket{engagement=~\"$engagement\"}[$__range])))", "format": "table", "instant": true, "refId": "B"}
+      ],
+      "title": "Handoff Edges (parent → agent)",
+      "transformations": [
+        {"id": "joinByField", "options": {"byField": "parent,agent", "mode": "outer"}},
+        {"id": "organize", "options": {"excludeByName": {"Time 1": true, "Time 2": true}, "renameByName": {"Value #A": "dispatches", "Value #B": "p95_ms"}}}
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 30, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 12},
+      "id": 2,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (agent) (rate(decepticon_agent_dispatches_total{engagement=~\"$engagement\"}[5m]))", "legendFormat": "{{agent}}", "refId": "A"}],
+      "title": "Dispatch Rate by Receiving Agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never"}, "unit": "ms"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 12},
+      "id": 3,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"expr": "histogram_quantile(0.50, sum by (le, agent) (rate(decepticon_agent_latency_ms_bucket{engagement=~\"$engagement\"}[5m])))", "legendFormat": "p50 {{agent}}", "refId": "A"},
+        {"expr": "histogram_quantile(0.95, sum by (le, agent) (rate(decepticon_agent_latency_ms_bucket{engagement=~\"$engagement\"}[5m])))", "legendFormat": "p95 {{agent}}", "refId": "B"}
+      ],
+      "title": "Per-Agent Turn Latency (p50 + p95)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["decepticon", "agents", "handoffs"],
+  "templating": {"list": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(decepticon_agent_dispatches_total, engagement)", "includeAll": true, "label": "Engagement", "name": "engagement", "query": {"query": "label_values(decepticon_agent_dispatches_total, engagement)"}, "refresh": 2, "type": "query"}]},
+  "time": {"from": "now-6h", "to": "now"},
+  "title": "Decepticon — Agent Handoff Topology",
+  "uid": "dec-agent-handoffs",
+  "version": 1
+}

--- a/containers/observability/grafana-provisioning/dashboards/decepticon/README.md
+++ b/containers/observability/grafana-provisioning/dashboards/decepticon/README.md
@@ -1,0 +1,33 @@
+# Decepticon Grafana Dashboards
+
+Auto-provisioned via `dashboards.yaml`. All dashboards read from the
+Prometheus datasource (UID: `prometheus`) populated by the OTel Collector.
+
+| File | Title | Purpose |
+|---|---|---|
+| `01-engagement-overview.json` | Engagement Overview | Top-level KPIs: tool calls, dispatches, validity ratio, LLM spend |
+| `02-tool-call-detail.json` | Tool-Call Forensics | Per-tool rate, p95 latency, error rate, top-10 piechart |
+| `03-llm-cost.json` | LLM Cost Ledger | Cost per finding, per model, per agent. Critical for benchmark optimization |
+| `04-vaccine-pipeline.json` | Vaccine Pipeline Flow | Funnel: validated → patched → defended → shipped + dwell time |
+| `05-agent-handoffs.json` | Agent Handoff Topology | Per-edge dispatch counts, per-agent latency p50/p95 |
+
+## Variables
+
+All dashboards expose an `${engagement}` template variable populated from
+`label_values(decepticon_tool_calls_total, engagement)`. Default `All`.
+Dashboards `02` adds `${agent}` (multi-select).
+
+## Metric Names
+
+Canonical metric names + labels are defined in
+[`decepticon/core/metrics.py`](../../../../decepticon/core/metrics.py).
+Do NOT edit dashboard PromQL without updating `metrics.py` to match.
+
+## Adding a new dashboard
+
+1. Drop a `NN-name.json` file in this directory
+2. Use `prometheus` as the datasource UID
+3. Reference metrics from `decepticon/core/metrics.py` — don't invent names
+4. Include `${engagement}` template variable for filterability
+5. Set `schemaVersion: 38` (Grafana 10+)
+6. Commit + restart grafana service: `docker compose -f containers/observability/docker-compose.observability.yml restart grafana`

--- a/containers/observability/grafana-provisioning/datasources/datasources.yaml
+++ b/containers/observability/grafana-provisioning/datasources/datasources.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    editable: false

--- a/containers/observability/otel-collector.yaml
+++ b/containers/observability/otel-collector.yaml
@@ -1,0 +1,72 @@
+# OpenTelemetry collector config for Decepticon observability.
+#
+# Pipeline:
+#   * Receives OTLP traces + metrics + logs from langgraph + sub-agent containers
+#   * Adds resource attributes (service.name, deployment.environment)
+#   * Exports traces to Jaeger
+#   * Exports metrics to Prometheus (via /metrics scrape endpoint)
+#   * Optionally forwards traces + spans to Langfuse (when LANGFUSE_PUBLIC_KEY is set)
+#
+# Decepticon agents (langgraph container, sub-agent containers) emit via:
+#   export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+#   export OTEL_SERVICE_NAME=decepticon-<agent-name>
+#   export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=engagement,decepticon.engagement=<slug>"
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: decepticon
+        action: insert
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+
+exporters:
+  # Trace export to Jaeger
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Prometheus exporter — scraped from outside on :8889
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: decepticon
+    const_labels:
+      stack: decepticon
+
+  # Debug fallback (off by default — uncomment when wiring agents)
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [otlp/jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [debug]
+  extensions: []
+  telemetry:
+    logs:
+      level: info

--- a/containers/observability/prometheus.yml
+++ b/containers/observability/prometheus.yml
@@ -1,0 +1,27 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: decepticon
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [prometheus:9090]
+
+  - job_name: otel-collector
+    static_configs:
+      - targets: [otel-collector:8889]
+
+  - job_name: langfuse
+    metrics_path: /api/public/metrics
+    static_configs:
+      - targets: [langfuse:3000]
+
+  # Decepticon services expose Prometheus metrics if implemented
+  # (currently agents export via OTel; this is a hook for future
+  # direct-Prometheus instrumentation in LiteLLM / sandbox kernel).
+  - job_name: litellm
+    static_configs:
+      - targets: [litellm:4000]
+    metrics_path: /metrics

--- a/decepticon/core/metrics.py
+++ b/decepticon/core/metrics.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 from decepticon.core.telemetry import counter, histogram
 
-
 # ── canonical metric instances ────────────────────────────────────────
 #
 # All instances are created lazily on first import — if telemetry isn't

--- a/decepticon/core/metrics.py
+++ b/decepticon/core/metrics.py
@@ -1,0 +1,198 @@
+"""Canonical Prometheus metric names emitted by Decepticon agents.
+
+This module centralizes the metric naming convention so:
+1. Grafana dashboards (in containers/observability/grafana-provisioning)
+   reference the exact same names agents emit.
+2. Agents don't drift apart on label cardinality.
+3. New agents/middleware can be wired in seconds via the pre-built
+   accessor functions.
+
+All metrics follow the convention ``decepticon_<domain>_<thing>_<unit>``
+matching the Prometheus naming guide. Counters end in ``_total``;
+histograms have ``_ms``, ``_seconds`` or similar unit suffix.
+
+Standard labels:
+- ``engagement``: engagement slug (set by EngagementContextMiddleware)
+- ``agent``: agent identifier (decepticon, recon, exploit, ...)
+- ``tool``: tool name (curl, nuclei, sqlmap, ...)
+
+Read by dashboards:
+- 01-engagement-overview.json
+- 02-tool-call-detail.json
+- 03-llm-cost.json
+- 04-vaccine-pipeline.json
+- 05-agent-handoffs.json
+"""
+
+from __future__ import annotations
+
+from decepticon.core.telemetry import counter, histogram
+
+
+# ── canonical metric instances ────────────────────────────────────────
+#
+# All instances are created lazily on first import — if telemetry isn't
+# initialized yet, ``counter()``/``histogram()`` return _NoOpInstrument.
+
+TOOL_CALLS = counter(
+    "decepticon_tool_calls_total",
+    description="Tool invocations. Labels: engagement, agent, tool, status",
+    unit="1",
+)
+
+TOOL_LATENCY_MS = histogram(
+    "decepticon_tool_latency_ms",
+    description="Tool execution wall-clock latency. Labels: engagement, agent, tool",
+    unit="ms",
+)
+
+AGENT_DISPATCHES = counter(
+    "decepticon_agent_dispatches_total",
+    description="Sub-agent task() dispatches. Labels: engagement, parent, agent",
+    unit="1",
+)
+
+AGENT_LATENCY_MS = histogram(
+    "decepticon_agent_latency_ms",
+    description="Per-agent per-turn wall-clock latency. Labels: engagement, agent",
+    unit="ms",
+)
+
+FINDING_OUTCOMES = counter(
+    "decepticon_finding_outcomes_total",
+    description="Finding outcomes by terminal status. Labels: engagement, agent, status (passed|blocked|false_positive)",
+    unit="1",
+)
+
+VACCINE_STAGE_TRANSITIONS = counter(
+    "decepticon_vaccine_stage_transitions_total",
+    description="Vaccine pipeline stage flips. Labels: engagement, stage (validated|patched|defended|shipped), bug_class",
+    unit="1",
+)
+
+VACCINE_DWELL_TIME = histogram(
+    "decepticon_vaccine_dwell_time_seconds",
+    description="Time spent in each pipeline stage. Labels: engagement, stage",
+    unit="s",
+)
+
+LLM_TOKENS = counter(
+    "decepticon_llm_tokens_total",
+    description="LLM tokens consumed. Labels: engagement, agent, model, type (in|out)",
+    unit="1",
+)
+
+LLM_COST_USD = counter(
+    "decepticon_llm_cost_usd_total",
+    description="LLM USD cost. Labels: engagement, agent, model",
+    unit="USD",
+)
+
+
+# ── helper functions ──────────────────────────────────────────────────
+
+
+def record_tool_call(
+    *,
+    engagement: str,
+    agent: str,
+    tool: str,
+    status: str = "ok",
+    latency_ms: float | None = None,
+) -> None:
+    """One-shot helper for tool wrappers."""
+    labels = {"engagement": engagement, "agent": agent, "tool": tool, "status": status}
+    TOOL_CALLS.add(1, attributes=labels)
+    if latency_ms is not None:
+        TOOL_LATENCY_MS.record(
+            latency_ms,
+            attributes={"engagement": engagement, "agent": agent, "tool": tool},
+        )
+
+
+def record_agent_dispatch(
+    *,
+    engagement: str,
+    parent: str,
+    agent: str,
+    latency_ms: float | None = None,
+) -> None:
+    """One-shot helper for orchestrator task() dispatches."""
+    AGENT_DISPATCHES.add(
+        1,
+        attributes={"engagement": engagement, "parent": parent, "agent": agent},
+    )
+    if latency_ms is not None:
+        AGENT_LATENCY_MS.record(
+            latency_ms,
+            attributes={"engagement": engagement, "agent": agent},
+        )
+
+
+def record_finding_outcome(
+    *,
+    engagement: str,
+    agent: str,
+    status: str,
+) -> None:
+    """status ∈ {passed, blocked, false_positive}."""
+    FINDING_OUTCOMES.add(
+        1,
+        attributes={"engagement": engagement, "agent": agent, "status": status},
+    )
+
+
+def record_vaccine_transition(
+    *,
+    engagement: str,
+    stage: str,
+    bug_class: str = "unknown",
+    dwell_time_s: float | None = None,
+) -> None:
+    """stage ∈ {validated, patched, defended, shipped}.
+
+    Best called from VaccineWriter._transition after a successful write.
+    """
+    VACCINE_STAGE_TRANSITIONS.add(
+        1,
+        attributes={"engagement": engagement, "stage": stage, "bug_class": bug_class},
+    )
+    if dwell_time_s is not None:
+        VACCINE_DWELL_TIME.record(
+            dwell_time_s,
+            attributes={"engagement": engagement, "stage": stage},
+        )
+
+
+def record_llm_usage(
+    *,
+    engagement: str,
+    agent: str,
+    model: str,
+    tokens_in: int,
+    tokens_out: int,
+    cost_usd: float,
+) -> None:
+    """Best called from a LangChain callback or model-fallback wrapper."""
+    base = {"engagement": engagement, "agent": agent, "model": model}
+    LLM_TOKENS.add(tokens_in, attributes={**base, "type": "in"})
+    LLM_TOKENS.add(tokens_out, attributes={**base, "type": "out"})
+    LLM_COST_USD.add(cost_usd, attributes=base)
+
+
+__all__ = [
+    "TOOL_CALLS",
+    "TOOL_LATENCY_MS",
+    "AGENT_DISPATCHES",
+    "AGENT_LATENCY_MS",
+    "FINDING_OUTCOMES",
+    "VACCINE_STAGE_TRANSITIONS",
+    "VACCINE_DWELL_TIME",
+    "LLM_TOKENS",
+    "LLM_COST_USD",
+    "record_tool_call",
+    "record_agent_dispatch",
+    "record_finding_outcome",
+    "record_vaccine_transition",
+    "record_llm_usage",
+]

--- a/decepticon/core/telemetry.py
+++ b/decepticon/core/telemetry.py
@@ -1,0 +1,174 @@
+"""OpenTelemetry instrumentation for Decepticon agents.
+
+Lightweight wrapper around the opentelemetry-sdk + OTLP HTTP exporter.
+Agents call ``setup_telemetry(service_name)`` once at startup to:
+- Configure tracer + meter w/ Decepticon-standard resource attributes
+- Auto-export to ``OTEL_EXPORTER_OTLP_ENDPOINT`` (default
+  http://otel-collector:4318 inside the decepticon-net Docker network)
+
+When the OTel stack isn't running (e.g. operator hasn't started the
+observability compose), this module degrades silently — exporters fail
+their first send and back off; agents continue to work normally.
+
+The instrumentation focuses on three signals Decepticon engineers actually
+need for performance + benchmark optimization:
+
+1. **Per-agent latency span** — every sub-agent dispatch is a span,
+   tagged with agent name, engagement slug, target, tool count.
+2. **Per-tool-call counter** — counts tool invocations by tool name.
+   Highlights which tools dominate engagement cost.
+3. **Per-finding outcome counter** — counts findings by status (passed,
+   blocked, false_positive). Drives validity-ratio metrics.
+
+For Langfuse-specific LLM tracing (token cost, prompt evaluation), see
+``decepticon/core/langfuse_setup.py`` — Langfuse runs alongside OTel as
+a complement (Langfuse for LLM-specific; OTel for generic infra).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Generator
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_OTLP_ENDPOINT = "http://otel-collector:4318"
+_SERVICE_NAME_PREFIX = "decepticon-"
+
+# Lazily-initialized — only import opentelemetry when setup_telemetry() runs,
+# so importing this module does NOT add deps for users w/o OTel installed.
+_tracer: Any = None
+_meter: Any = None
+_initialized = False
+
+
+def setup_telemetry(
+    service_name: str,
+    *,
+    endpoint: str | None = None,
+    engagement_slug: str | None = None,
+) -> bool:
+    """Initialize OTel tracer + meter for an agent.
+
+    Idempotent — repeated calls are no-ops.
+
+    Args:
+        service_name: Agent identifier (e.g. "decepticon", "recon", "exploit").
+            Prefixed with "decepticon-" if not already.
+        endpoint: OTLP HTTP endpoint. Default reads from
+            OTEL_EXPORTER_OTLP_ENDPOINT env or falls back to otel-collector:4318.
+        engagement_slug: Active engagement identifier (e.g. "xben-058"
+            or "acme-corp-q2"). Tagged as a resource attribute for
+            per-engagement filtering in Grafana.
+
+    Returns:
+        True if telemetry was initialized; False if dependencies are
+        missing (opentelemetry-sdk not installed) or initialization
+        failed silently — caller should not assume metrics are flowing.
+    """
+    global _tracer, _meter, _initialized
+    if _initialized:
+        return True
+
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.info(
+            "opentelemetry-sdk not installed; telemetry disabled. "
+            "Install: pip install opentelemetry-sdk opentelemetry-exporter-otlp"
+        )
+        return False
+
+    if not service_name.startswith(_SERVICE_NAME_PREFIX):
+        service_name = _SERVICE_NAME_PREFIX + service_name
+
+    endpoint = endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", _DEFAULT_OTLP_ENDPOINT)
+    resource_attrs = {
+        "service.name": service_name,
+        "deployment.environment": os.getenv("DEPLOYMENT_ENV", "engagement"),
+    }
+    if engagement_slug:
+        resource_attrs["decepticon.engagement"] = engagement_slug
+
+    resource = Resource.create(resource_attrs)
+
+    # Traces
+    trace_provider = TracerProvider(resource=resource)
+    trace_provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces"))
+    )
+    trace.set_tracer_provider(trace_provider)
+    _tracer = trace.get_tracer(service_name)
+
+    # Metrics
+    meter_provider = MeterProvider(
+        resource=resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"),
+                export_interval_millis=10_000,
+            )
+        ],
+    )
+    metrics.set_meter_provider(meter_provider)
+    _meter = metrics.get_meter(service_name)
+
+    _initialized = True
+    logger.info(f"telemetry initialized: service={service_name} endpoint={endpoint}")
+    return True
+
+
+@contextmanager
+def span(name: str, **attributes: Any) -> Generator[Any, None, None]:
+    """Trace one operation. Use as a context manager.
+
+    Example:
+        with span("recon_dispatch", target="example.com", tool_count=12):
+            run_recon(...)
+
+    Falls back to a null context if telemetry isn't initialized.
+    """
+    if _tracer is None:
+        yield None
+        return
+    with _tracer.start_as_current_span(name, attributes=attributes) as s:
+        yield s
+
+
+def counter(name: str, description: str = "", unit: str = "1") -> Any:
+    """Create or return a Prometheus-style counter.
+
+    Returns a no-op shim if telemetry isn't initialized.
+    """
+    if _meter is None:
+        return _NoOpInstrument()
+    return _meter.create_counter(name, unit=unit, description=description)
+
+
+def histogram(name: str, description: str = "", unit: str = "ms") -> Any:
+    """Create or return a histogram metric."""
+    if _meter is None:
+        return _NoOpInstrument()
+    return _meter.create_histogram(name, unit=unit, description=description)
+
+
+class _NoOpInstrument:
+    """No-op replacement when telemetry isn't initialized."""
+
+    def add(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def record(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+
+__all__ = ["counter", "histogram", "setup_telemetry", "span"]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,158 @@
+# Observability — Langfuse + OpenTelemetry stack
+
+## Overview
+
+Decepticon ships an opt-in observability stack that gives operators
+per-engagement visibility into agent latency, token cost, tool-call
+frequency, and finding outcome rates. The stack is a separate
+`docker-compose-observability.yml` overlay — start it alongside the
+main `docker-compose.yml` when needed; skip it when running lightweight
+or on constrained hosts.
+
+## Why
+
+Without observability, operators are blind to:
+- **Which agent dominates engagement cost?** (Token + wall-clock)
+- **Which tool calls fail most?** (Recon failures? AD auth retries?)
+- **What's the per-engagement validity ratio?** (Findings/total)
+- **Which sub-agent loop is killing the benchmark?**
+- **Where does the engagement actually spend its time?**
+
+These are the questions that drive XBEN optimization, cost reduction,
+and customer-facing SLAs. Observability is the first step toward all of
+them.
+
+## Stack components
+
+| Component | Purpose | Port |
+|---|---|---|
+| **Langfuse** | LLM-specific tracing (prompt, completion, cost, eval) | 3700 |
+| **Postgres (langfuse-db)** | Langfuse metadata storage | internal |
+| **ClickHouse** | Analytics column store for Langfuse v3+ | internal |
+| **OTel Collector** | Receives + processes OTLP traces/metrics from agents | 4317/4318/8889 |
+| **Prometheus** | Metrics store + alerting | 9090 |
+| **Grafana** | Dashboards + visualization | 3701 |
+| **Jaeger** | Distributed trace storage + UI | 3702 |
+
+Idle footprint: ~2.5 GB RAM. Engagement load: ~5 GB RAM.
+
+## Quick start
+
+```bash
+# 1. Set required env vars (or use defaults from docker-compose.observability.yml)
+cat >> ~/.decepticon/.env <<'EOF'
+LANGFUSE_DB_PASSWORD=$(openssl rand -hex 16)
+LANGFUSE_NEXTAUTH_SECRET=$(openssl rand -hex 32)
+LANGFUSE_SALT=$(openssl rand -hex 32)
+LANGFUSE_ENCRYPTION_KEY=$(openssl rand -hex 32)
+CLICKHOUSE_PASSWORD=$(openssl rand -hex 16)
+GRAFANA_ADMIN_PASSWORD=$(openssl rand -hex 16)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+EOF
+
+# 2. Start the observability stack
+docker compose \
+  -f docker-compose.yml \
+  -f containers/observability/docker-compose.observability.yml \
+  up -d
+
+# Or via Makefile shortcut (if added):
+make obs-up
+
+# 3. Confirm health
+docker compose ps | grep -E 'langfuse|otel-collector|grafana|prometheus|jaeger'
+# All should show "healthy" or "running"
+
+# 4. Open the dashboards
+xdg-open http://localhost:3701  # Grafana (admin / $GRAFANA_ADMIN_PASSWORD)
+xdg-open http://localhost:3700  # Langfuse (admin@decepticon.local / $LANGFUSE_INIT_USER_PASSWORD)
+xdg-open http://localhost:3702  # Jaeger UI
+xdg-open http://localhost:9090  # Prometheus (no auth)
+```
+
+## Agent instrumentation
+
+Agents emit telemetry via `decepticon.core.telemetry`:
+
+```python
+from decepticon.core.telemetry import setup_telemetry, span, counter
+
+# At agent startup
+setup_telemetry("recon", engagement_slug=engagement.slug)
+
+# Per tool call
+TOOL_CALLS = counter("decepticon.tool.calls", description="Tool invocations by name")
+
+with span("recon_sweep", target=target, wordlist=wordlist_name):
+    result = run_recon(...)
+    TOOL_CALLS.add(1, attributes={"tool": "nmap", "agent": "recon"})
+```
+
+The `setup_telemetry()` call is **idempotent + safe** when the OTel
+stack isn't running — exporters silently fail their first send and
+back off. Agents continue to work normally without the stack.
+
+## Dashboards
+
+Pre-provisioned Grafana dashboards (loaded from
+`grafana-provisioning/dashboards/`):
+
+| Dashboard | Shows |
+|---|---|
+| `decepticon-overview` | Per-engagement summary: cost, latency p50/p95/p99, finding count, success rate |
+| `decepticon-agents` | Per-sub-agent breakdown: dispatches, latency, error rate |
+| `decepticon-tools` | Tool-call frequency + duration heatmap |
+| `decepticon-findings` | Findings by stage (Scanner → Detector → Verifier → Patcher → Defender), validity ratio |
+| `decepticon-vaccine` | Vaccine pipeline funnel: validated → patched → defended → shipped |
+
+Dashboards are JSON files in `containers/observability/grafana-provisioning/dashboards/`.
+
+## Langfuse LLM tracing
+
+Langfuse handles LLM-specific signals OTel doesn't natively model:
+- Prompt + completion text (when not redacted)
+- Token cost per model per call
+- Eval scores (when running eval suites via promptfoo)
+- Prompt-version tracking
+- User feedback annotations on traces
+
+Decepticon's `decepticon/llm/factory.py` initializes Langfuse via
+LiteLLM's built-in Langfuse integration when `LANGFUSE_PUBLIC_KEY` +
+`LANGFUSE_SECRET_KEY` are set in the env. Both keys are generated in
+the Langfuse web UI (Project → Settings → API Keys) after first login.
+
+```bash
+# After Langfuse first boot — generate keys via UI, then:
+echo "LANGFUSE_PUBLIC_KEY=pk-lf-..." >> ~/.decepticon/.env
+echo "LANGFUSE_SECRET_KEY=sk-lf-..." >> ~/.decepticon/.env
+echo "LANGFUSE_HOST=http://langfuse:3000" >> ~/.decepticon/.env  # internal container reach
+docker compose restart litellm langgraph
+```
+
+## Constrained-host mode
+
+If the host can't afford 5 GB observability overhead, comment out
+clickhouse + jaeger in `docker-compose.observability.yml` and run
+with just langfuse + prometheus + grafana. That drops idle to ~1 GB
+but disables ClickHouse-backed Langfuse analytics features (still
+get traces + cost-per-call, just no aggregate analytics).
+
+## Wipe + reset
+
+```bash
+# Stop + remove
+docker compose -f containers/observability/docker-compose.observability.yml down
+
+# Wipe stored data (Langfuse DB, ClickHouse, Prometheus TSDB, Grafana settings)
+docker volume rm $(docker volume ls -q | grep '^decepticon_obs-')
+```
+
+## Source attribution
+
+- Langfuse: https://github.com/langfuse/langfuse (MIT)
+- OTel Collector + SDK: https://opentelemetry.io (Apache-2.0)
+- Prometheus: https://prometheus.io (Apache-2.0)
+- Grafana: https://grafana.com (AGPL-3.0 for OSS, custom commercial license available)
+- Jaeger: https://jaegertracing.io (Apache-2.0)
+
+PentAGI (vxcontrol/pentagi) provided the integration-pattern reference for combining Langfuse + Grafana + Jaeger in a multi-agent stack. CAI by Alias Robotics provided the Phoenix-style LLM observability pattern. Both were studied in the 18-repo survey before designing this stack.


### PR DESCRIPTION
## Summary

Populates the previously-empty `containers/observability/grafana-provisioning/dashboards/` directory with the first production-grade dashboards driven by Decepticon's OTel telemetry signals. Plus canonical metric names so agents emit exactly what dashboards read.

Stacks on #255 (observability stack).

## Dashboards (auto-provisioned)

| File | Title | Panels | Purpose |
|---|---|---|---|
| `01-engagement-overview.json` | Engagement Overview | 10 | KPIs: tool calls, dispatches, validity ratio, LLM spend, vaccine flow, agent latency |
| `02-tool-call-detail.json` | Tool-Call Forensics | 3 | Per-tool rate (stacked), perf table (calls/p95/error_rate), top-10 piechart |
| `03-llm-cost.json` | LLM Cost Ledger | 7 | Cost-per-validated-finding, per-model breakdown, token rate by agent |
| `04-vaccine-pipeline.json` | Vaccine Pipeline Flow | 8 | Funnel validated→patched→defended→shipped, dwell time p50, bug-class piechart |
| `05-agent-handoffs.json` | Agent Handoff Topology | 3 | Parent→agent dispatch table, dispatch rate by agent, p50/p95 latency |

All expose `${engagement}` template variable. Dashboard `02` also exposes `${agent}` (multi-select).

## Canonical metrics (`decepticon/core/metrics.py`)

Centralized to prevent drift between agent emit names + dashboard PromQL.

```python
from decepticon.core.metrics import record_tool_call, record_vaccine_transition

record_tool_call(engagement="acme-q1", agent="recon", tool="nmap", status="ok", latency_ms=842.3)
record_vaccine_transition(engagement="acme-q1", stage="patched", bug_class="sqli", dwell_time_s=47.2)
```

Defined metrics:
- `decepticon_tool_calls_total {engagement, agent, tool, status}`
- `decepticon_tool_latency_ms {engagement, agent, tool}`
- `decepticon_agent_dispatches_total {engagement, parent, agent}`
- `decepticon_agent_latency_ms {engagement, agent}`
- `decepticon_finding_outcomes_total {engagement, agent, status}`
- `decepticon_vaccine_stage_transitions_total {engagement, stage, bug_class}`
- `decepticon_vaccine_dwell_time_seconds {engagement, stage}`
- `decepticon_llm_tokens_total {engagement, agent, model, type}`
- `decepticon_llm_cost_usd_total {engagement, agent, model}`

## Tested

JSON validation:
```
01-engagement-overview.json: title='Decepticon — Engagement Overview'           panels=10
02-tool-call-detail.json:    title='Decepticon — Tool-Call Forensics'           panels= 3
03-llm-cost.json:            title='Decepticon — LLM Cost Ledger'               panels= 7
04-vaccine-pipeline.json:    title='Decepticon — Vaccine Pipeline Flow'         panels= 8
05-agent-handoffs.json:      title='Decepticon — Agent Handoff Topology'        panels= 3
```

(Full Grafana live-render verification requires the observability compose stack — that's an operator task post-merge.)

## Follow-ups (out of scope)

- Wire `record_tool_call` into the sandbox tool wrapper (where every tool invocation routes)
- Wire `record_vaccine_transition` into `VaccineWriter._transition` (touched in #258)
- Wire `record_llm_usage` into the ModelFallback callback handler
- Add Loki-backed log dashboards once log shipping lands

These should be small follow-up PRs once agents are emitting the canonical metrics.