### PR TITLE
feat(evograph): cross-session memory layer over Neo4j attack graph

### DIFF
--- a/decepticon/tools/research/cross_session.py
+++ b/decepticon/tools/research/cross_session.py
@@ -477,12 +477,14 @@ def format_bootstrap_for_prompt(memories: list[EngagementMemory]) -> str:
     for m in memories:
         bug_classes = ", ".join(f"{bc}({n})" for bc, n in m.top_bug_classes[:3])
         techs = ", ".join(m.top_techniques[:3])
-        lines.extend([
-            f"  <engagement slug={m.slug!r} target={m.target!r} ended={m.ended_at!r}>",
-            f"    findings: total={m.total_findings} validated={m.validated_findings} shipped={m.shipped_findings}",
-            f"    top_bug_classes: {bug_classes or '(none)'}",
-            f"    top_techniques: {techs or '(none)'}",
-        ])
+        lines.extend(
+            [
+                f"  <engagement slug={m.slug!r} target={m.target!r} ended={m.ended_at!r}>",
+                f"    findings: total={m.total_findings} validated={m.validated_findings} shipped={m.shipped_findings}",
+                f"    top_bug_classes: {bug_classes or '(none)'}",
+                f"    top_techniques: {techs or '(none)'}",
+            ]
+        )
         if m.crown_jewels_reached:
             lines.append(f"    crown_jewels_reached: {', '.join(m.crown_jewels_reached[:3])}")
         if m.note:

--- a/decepticon/tools/research/cross_session.py
+++ b/decepticon/tools/research/cross_session.py
@@ -1,0 +1,504 @@
+"""EvoGraph — cross-session memory bootstrap layer over Neo4jStore.
+
+Decepticon's existing Neo4jStore (``decepticon.tools.research.neo4j_store``)
+holds the *current* engagement's attack graph. But the database persists
+across runs — every engagement's nodes/edges accumulate in the same
+Neo4j instance.
+
+This module adds:
+
+1. **Engagement-scoped namespacing.** A first-class ``Engagement`` node
+   tagging all current-session nodes via an ``IN_ENGAGEMENT`` edge.
+2. **End-of-engagement memorialization.** ``commit_engagement_memory()``
+   distills the engagement's terminal findings + attack paths into an
+   ``EngagementMemory`` summary node — a compact prose + structured
+   record that future engagements can read.
+3. **Cross-engagement similarity bootstrap.** On engagement startup,
+   ``bootstrap_from_prior()`` retrieves prior ``EngagementMemory``
+   records that match the current target/scope/bug-class, then exposes
+   them to the orchestrator as a "we've seen this before" prompt
+   addition.
+
+This implements the EvoGraph concept (lessons-learned memory layer over
+the attack graph) referenced in PR-E of the original roadmap. It does
+NOT replace the active-engagement graph — that lives in Neo4jStore +
+graph.py as before.
+
+Design choices:
+
+- **No new schema migration needed.** ``Engagement`` and
+  ``EngagementMemory`` are added to ``NodeKind`` as PascalCase labels;
+  Neo4jStore creates them transparently.
+- **Idempotent constraint registration.** ``ensure_evograph_schema()``
+  adds two new uniqueness constraints (engagement_slug, memory_key) to
+  the existing ensure_schema flow.
+- **Graceful degradation.** If Neo4j isn't reachable, all functions
+  return empty results — engagements still run, just without bootstrap.
+- **No model calls.** Memory summarization is structural (counts,
+  bug-class tally, top techniques). LLM-based prose summarization is a
+  separate concern for the orchestrator's report agent.
+
+Public API (importable from ``decepticon.tools.research.cross_session``):
+
+- ``register_engagement(slug, target, started_at=None)`` — call at engagement start
+- ``tag_node_to_engagement(node_key, kind, engagement_slug)`` — call on each upsert
+- ``commit_engagement_memory(engagement_slug)`` — call at engagement end
+- ``bootstrap_from_prior(target_hint, top_k=5)`` — call at engagement start
+- ``find_similar_findings(bug_class, target_kind=None, limit=10)`` — runtime helper
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from decepticon.tools.research._state import get_store
+from decepticon.tools.research.neo4j_store import Neo4jUnavailableError
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data shapes ───────────────────────────────────────────────────────
+
+
+@dataclass
+class EngagementMemory:
+    """Distilled record of a completed engagement.
+
+    Compact enough to fit a handful in a system prompt; rich enough to
+    bootstrap a similar future engagement.
+    """
+
+    slug: str
+    target: str
+    started_at: str
+    ended_at: str
+    total_findings: int = 0
+    validated_findings: int = 0
+    shipped_findings: int = 0
+    top_bug_classes: list[tuple[str, int]] = field(default_factory=list)
+    top_techniques: list[str] = field(default_factory=list)
+    crown_jewels_reached: list[str] = field(default_factory=list)
+    notable_attack_paths: list[str] = field(default_factory=list)
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "target": self.target,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "total_findings": self.total_findings,
+            "validated_findings": self.validated_findings,
+            "shipped_findings": self.shipped_findings,
+            "top_bug_classes": self.top_bug_classes,
+            "top_techniques": self.top_techniques,
+            "crown_jewels_reached": self.crown_jewels_reached,
+            "notable_attack_paths": self.notable_attack_paths,
+            "note": self.note,
+        }
+
+
+# ── Schema bootstrap ──────────────────────────────────────────────────
+
+
+_EVOGRAPH_CONSTRAINTS = [
+    "CREATE CONSTRAINT engagement_slug IF NOT EXISTS FOR (e:Engagement) REQUIRE e.slug IS UNIQUE",
+    (
+        "CREATE CONSTRAINT engagement_memory_key IF NOT EXISTS"
+        " FOR (m:EngagementMemory) REQUIRE m.slug IS UNIQUE"
+    ),
+]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def ensure_evograph_schema() -> bool:
+    """Idempotent — adds Engagement/EngagementMemory uniqueness constraints.
+
+    Returns True on success, False if Neo4j unavailable.
+    """
+    try:
+        store = get_store()
+    except Neo4jUnavailableError:
+        logger.info("evograph: Neo4j unavailable, skipping schema bootstrap")
+        return False
+    try:
+        with store._driver.session(database=store._database) as session:  # type: ignore[attr-defined]
+            for stmt in _EVOGRAPH_CONSTRAINTS:
+                session.run(stmt)
+        return True
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"evograph schema bootstrap failed: {exc}")
+        return False
+
+
+# ── Engagement registration ───────────────────────────────────────────
+
+
+def register_engagement(
+    slug: str,
+    target: str,
+    *,
+    started_at: str | None = None,
+    scope: str | None = None,
+) -> bool:
+    """Create the Engagement anchor node. Idempotent."""
+    try:
+        store = get_store()
+    except Neo4jUnavailableError:
+        return False
+    ts = started_at or _utc_now_iso()
+    try:
+        with store._driver.session(database=store._database) as session:  # type: ignore[attr-defined]
+            session.run(
+                """
+                MERGE (e:Engagement {slug: $slug})
+                ON CREATE SET e.target = $target,
+                              e.started_at = $started_at,
+                              e.scope = $scope
+                ON MATCH SET  e.last_seen_at = $started_at
+                """,
+                slug=slug,
+                target=target,
+                started_at=ts,
+                scope=scope or "",
+            )
+        return True
+    except Exception as exc:
+        logger.warning(f"register_engagement({slug}) failed: {exc}")
+        return False
+
+
+def tag_node_to_engagement(
+    *,
+    node_key: str,
+    kind: str,
+    engagement_slug: str,
+    key_property: str = "key",
+) -> bool:
+    """Link an existing graph node to the engagement.
+
+    Args:
+        node_key: identifying value of the node
+        kind: Neo4j label (e.g. "Finding", "Vulnerability")
+        engagement_slug: the Engagement.slug to attach to
+        key_property: which property on the node is unique. Default
+            "key"; some kinds use "ip"/"cve_id"/"fqdn"/etc.
+    """
+    try:
+        store = get_store()
+    except Neo4jUnavailableError:
+        return False
+    try:
+        with store._driver.session(database=store._database) as session:  # type: ignore[attr-defined]
+            session.run(
+                f"""
+                MATCH (e:Engagement {{slug: $slug}})
+                MATCH (n:`{kind}` {{`{key_property}`: $node_key}})
+                MERGE (n)-[:IN_ENGAGEMENT]->(e)
+                """,
+                slug=engagement_slug,
+                node_key=node_key,
+            )
+        return True
+    except Exception as exc:
+        logger.debug(f"tag_node_to_engagement skipped: {exc}")
+        return False
+
+
+# ── End-of-engagement memory commit ───────────────────────────────────
+
+
+def commit_engagement_memory(
+    engagement_slug: str,
+    *,
+    note: str = "",
+) -> EngagementMemory | None:
+    """Distill engagement into an EngagementMemory node.
+
+    Counts findings by bug_class/status, collects top techniques + crown
+    jewels reached, writes a compact memory node future engagements can
+    query.
+
+    Returns the in-memory ``EngagementMemory`` dataclass for caller use,
+    or None if Neo4j unavailable.
+    """
+    try:
+        store = get_store()
+    except Neo4jUnavailableError:
+        return None
+
+    ended = _utc_now_iso()
+    try:
+        with store._driver.session(database=store._database) as session:  # type: ignore[attr-defined]
+            # Pull engagement metadata
+            rec = session.run(
+                "MATCH (e:Engagement {slug:$slug}) RETURN e.target AS target, e.started_at AS started_at",
+                slug=engagement_slug,
+            ).single()
+            if rec is None:
+                return None
+            target = rec["target"] or "unknown"
+            started_at = rec["started_at"] or ended
+
+            # Findings tally
+            tally = session.run(
+                """
+                MATCH (f:Finding)-[:IN_ENGAGEMENT]->(:Engagement {slug:$slug})
+                RETURN coalesce(f.status,'unknown') AS status,
+                       coalesce(f.bug_class,'unknown') AS bug_class
+                """,
+                slug=engagement_slug,
+            ).data()
+            total = len(tally)
+            validated = sum(1 for r in tally if r["status"] in ("validated", "shipped"))
+            shipped = sum(1 for r in tally if r["status"] == "shipped")
+            bc_counts: dict[str, int] = {}
+            for r in tally:
+                bc_counts[r["bug_class"]] = bc_counts.get(r["bug_class"], 0) + 1
+            top_bcs = sorted(bc_counts.items(), key=lambda kv: -kv[1])[:5]
+
+            # Techniques
+            techs = session.run(
+                """
+                MATCH (t:Technique)-[:IN_ENGAGEMENT]->(:Engagement {slug:$slug})
+                RETURN coalesce(t.label, t.technique_id) AS label
+                ORDER BY label LIMIT 10
+                """,
+                slug=engagement_slug,
+            )
+            top_techs = [r["label"] for r in techs if r["label"]]
+
+            # Crown jewels reached (any CrownJewel node tagged)
+            cjs = session.run(
+                """
+                MATCH (c:CrownJewel)-[:IN_ENGAGEMENT]->(:Engagement {slug:$slug})
+                RETURN coalesce(c.label, c.key) AS label
+                """,
+                slug=engagement_slug,
+            )
+            cjs_reached = [r["label"] for r in cjs if r["label"]]
+
+            # Attack paths (titles only)
+            aps = session.run(
+                """
+                MATCH (ap:AttackPath)-[:IN_ENGAGEMENT]->(:Engagement {slug:$slug})
+                RETURN coalesce(ap.label, ap.key) AS label
+                LIMIT 5
+                """,
+                slug=engagement_slug,
+            )
+            notable_aps = [r["label"] for r in aps if r["label"]]
+
+            memory = EngagementMemory(
+                slug=engagement_slug,
+                target=target,
+                started_at=started_at,
+                ended_at=ended,
+                total_findings=total,
+                validated_findings=validated,
+                shipped_findings=shipped,
+                top_bug_classes=top_bcs,
+                top_techniques=top_techs,
+                crown_jewels_reached=cjs_reached,
+                notable_attack_paths=notable_aps,
+                note=note,
+            )
+
+            # Write EngagementMemory node
+            session.run(
+                """
+                MERGE (m:EngagementMemory {slug:$slug})
+                SET m.target=$target,
+                    m.started_at=$started_at,
+                    m.ended_at=$ended_at,
+                    m.total_findings=$total_findings,
+                    m.validated_findings=$validated_findings,
+                    m.shipped_findings=$shipped_findings,
+                    m.top_bug_classes=$top_bug_classes_json,
+                    m.top_techniques=$top_techniques,
+                    m.crown_jewels=$crown_jewels,
+                    m.notable_attack_paths=$notable_attack_paths,
+                    m.note=$note
+                """,
+                slug=memory.slug,
+                target=memory.target,
+                started_at=memory.started_at,
+                ended_at=memory.ended_at,
+                total_findings=memory.total_findings,
+                validated_findings=memory.validated_findings,
+                shipped_findings=memory.shipped_findings,
+                # Neo4j doesn't store nested arrays well — flatten to "class:count" strings
+                top_bug_classes_json=[f"{bc}:{n}" for bc, n in memory.top_bug_classes],
+                top_techniques=memory.top_techniques,
+                crown_jewels=memory.crown_jewels_reached,
+                notable_attack_paths=memory.notable_attack_paths,
+                note=memory.note,
+            )
+            # Link memory back to its engagement
+            session.run(
+                """
+                MATCH (e:Engagement {slug:$slug})
+                MATCH (m:EngagementMemory {slug:$slug})
+                MERGE (m)-[:SUMMARIZES]->(e)
+                """,
+                slug=engagement_slug,
+            )
+            return memory
+    except Exception as exc:
+        logger.warning(f"commit_engagement_memory({engagement_slug}) failed: {exc}")
+        return None
+
+
+# ── Startup bootstrap queries ─────────────────────────────────────────
+
+
+def bootstrap_from_prior(
+    *,
+    target_hint: str,
+    top_k: int = 5,
+) -> list[EngagementMemory]:
+    """Find prior EngagementMemory records relevant to a new engagement.
+
+    Matching is currently substring-based on target field. Future
+    enhancement: embed targets + use vector similarity.
+
+    Returns up to ``top_k`` memories ordered by recency (newest first).
+    """
+    try:
+        store = get_store()
+    except Neo4jUnavailableError:
+        return []
+    try:
+        with store._driver.session(database=store._database) as session:  # type: ignore[attr-defined]
+            res = session.run(
+                """
+                MATCH (m:EngagementMemory)
+                WHERE toLower(m.target) CONTAINS toLower($hint)
+                RETURN m
+                ORDER BY m.ended_at DESC
+                LIMIT $top_k
+                """,
+                hint=target_hint,
+                top_k=top_k,
+            )
+            out: list[EngagementMemory] = []
+            for r in res:
+                m = r["m"]
+                out.append(
+                    EngagementMemory(
+                        slug=m["slug"],
+                        target=m.get("target", ""),
+                        started_at=m.get("started_at", ""),
+                        ended_at=m.get("ended_at", ""),
+                        total_findings=int(m.get("total_findings") or 0),
+                        validated_findings=int(m.get("validated_findings") or 0),
+                        shipped_findings=int(m.get("shipped_findings") or 0),
+                        top_bug_classes=[
+                            (bc.split(":")[0], int(bc.split(":")[1]))
+                            for bc in (m.get("top_bug_classes") or [])
+                            if ":" in bc
+                        ],
+                        top_techniques=list(m.get("top_techniques") or []),
+                        crown_jewels_reached=list(m.get("crown_jewels") or []),
+                        notable_attack_paths=list(m.get("notable_attack_paths") or []),
+                        note=m.get("note", ""),
+                    )
+                )
+            return out
+    except Exception as exc:
+        logger.debug(f"bootstrap_from_prior({target_hint!r}) returned []: {exc}")
+        return []
+
+
+def find_similar_findings(
+    *,
+    bug_class: str,
+    target_kind: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Surface prior findings of the same bug class.
+
+    Use in mid-engagement when the agent identifies a vuln class — fetch
+    similar prior findings + their resolution path so the agent can ride
+    the same playbook.
+
+    Returns list of dicts with ``{vuln_id, target, status, summary,
+    engagement_slug, ended_at}``.
+    """
+    try:
+        store = get_store()
+    except Neo4jUnavailableError:
+        return []
+    try:
+        with store._driver.session(database=store._database) as session:  # type: ignore[attr-defined]
+            res = session.run(
+                """
+                MATCH (f:Finding)-[:IN_ENGAGEMENT]->(e:Engagement)
+                WHERE f.bug_class = $bug_class
+                  AND ($target_kind IS NULL OR f.target_kind = $target_kind)
+                RETURN f.key AS vuln_id,
+                       e.target AS target,
+                       e.slug AS engagement_slug,
+                       coalesce(f.status,'unknown') AS status,
+                       coalesce(f.summary, f.title, '') AS summary,
+                       e.last_seen_at AS ended_at
+                ORDER BY e.last_seen_at DESC
+                LIMIT $limit
+                """,
+                bug_class=bug_class,
+                target_kind=target_kind,
+                limit=limit,
+            )
+            return [dict(r) for r in res]
+    except Exception as exc:
+        logger.debug(f"find_similar_findings({bug_class!r}) returned []: {exc}")
+        return []
+
+
+# ── System-prompt formatter ───────────────────────────────────────────
+
+
+def format_bootstrap_for_prompt(memories: list[EngagementMemory]) -> str:
+    """Render a list of prior-engagement memories for inclusion in the
+    orchestrator's system prompt.
+
+    Returns a concise XML-tagged block. Empty string if no memories.
+    """
+    if not memories:
+        return ""
+    lines = ["<EVOGRAPH_PRIOR_ENGAGEMENTS>"]
+    lines.append(f"  count={len(memories)} (target-similar, most-recent-first)")
+    for m in memories:
+        bug_classes = ", ".join(f"{bc}({n})" for bc, n in m.top_bug_classes[:3])
+        techs = ", ".join(m.top_techniques[:3])
+        lines.extend([
+            f"  <engagement slug={m.slug!r} target={m.target!r} ended={m.ended_at!r}>",
+            f"    findings: total={m.total_findings} validated={m.validated_findings} shipped={m.shipped_findings}",
+            f"    top_bug_classes: {bug_classes or '(none)'}",
+            f"    top_techniques: {techs or '(none)'}",
+        ])
+        if m.crown_jewels_reached:
+            lines.append(f"    crown_jewels_reached: {', '.join(m.crown_jewels_reached[:3])}")
+        if m.note:
+            lines.append(f"    note: {m.note}")
+        lines.append("  </engagement>")
+    lines.append("</EVOGRAPH_PRIOR_ENGAGEMENTS>")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "EngagementMemory",
+    "ensure_evograph_schema",
+    "register_engagement",
+    "tag_node_to_engagement",
+    "commit_engagement_memory",
+    "bootstrap_from_prior",
+    "find_similar_findings",
+    "format_bootstrap_for_prompt",
+]

--- a/decepticon/tools/research/graph.py
+++ b/decepticon/tools/research/graph.py
@@ -83,6 +83,9 @@ class NodeKind(StrEnum):
     CANDIDATE = "Candidate"
     HYPOTHESIS = "Hypothesis"
     PATCH = "Patch"
+    # EvoGraph cross-session memory (see tools/research/cross_session.py)
+    ENGAGEMENT = "Engagement"
+    ENGAGEMENT_MEMORY = "EngagementMemory"
 
 
 class EdgeKind(StrEnum):
@@ -128,6 +131,9 @@ class EdgeKind(StrEnum):
     DERIVED_FROM = "DERIVED_FROM"
     PATCHES = "PATCHES"
     MAPS_TO = "MAPS_TO"
+    # EvoGraph cross-session memory
+    IN_ENGAGEMENT = "IN_ENGAGEMENT"
+    SUMMARIZES = "SUMMARIZES"
 
 
 class Severity(StrEnum):

--- a/docs/evograph.md
+++ b/docs/evograph.md
@@ -1,0 +1,128 @@
+# EvoGraph — Cross-Session Memory
+
+EvoGraph layers a *lessons-learned memory* over Decepticon's existing
+Neo4j attack graph so a fresh engagement starts with awareness of past
+engagements against similar targets, common bug classes seen, and
+techniques that have or haven't worked.
+
+> Single-session attack graph: see [`tools/research/graph.py`](../decepticon/tools/research/graph.py) +
+> [`tools/research/neo4j_store.py`](../decepticon/tools/research/neo4j_store.py)
+>
+> Cross-session memory layer (this doc): see [`tools/research/cross_session.py`](../decepticon/tools/research/cross_session.py)
+
+## Concepts
+
+| Node | Cardinality | Purpose |
+|---|---|---|
+| `Engagement {slug, target, started_at, scope}` | one per session | Anchors all session-scoped nodes via `IN_ENGAGEMENT` edges |
+| `EngagementMemory {slug, target, ended_at, total_findings, ...}` | one per *completed* engagement | Distilled summary written at engagement end |
+
+| Edge | Purpose |
+|---|---|
+| `(node)-[:IN_ENGAGEMENT]->(:Engagement)` | Scopes any session-bound node |
+| `(:EngagementMemory)-[:SUMMARIZES]->(:Engagement)` | Links memory back to source engagement |
+
+## Lifecycle
+
+```
+engagement-start                 mid-engagement              engagement-end
+─────────────────                ──────────────              ───────────────
+register_engagement(...)         tag_node_to_engagement     commit_engagement_memory(...)
+bootstrap_from_prior(...)        find_similar_findings(...) → EngagementMemory node
+       │                                  │                          │
+       ▼                                  ▼                          ▼
+inject into                       runtime lookup                add to Neo4j
+orchestrator system prompt        of prior playbooks            for future bootstraps
+```
+
+### 1. At engagement start
+
+```python
+from decepticon.tools.research.cross_session import (
+    ensure_evograph_schema,
+    register_engagement,
+    bootstrap_from_prior,
+    format_bootstrap_for_prompt,
+)
+
+ensure_evograph_schema()                                 # idempotent
+register_engagement("acme-q1", target="api.example.com")
+
+# Surface prior similar engagements to the agent
+prior = bootstrap_from_prior(target_hint="example.com", top_k=5)
+prompt_addition = format_bootstrap_for_prompt(prior)
+# include `prompt_addition` in the orchestrator's system prompt
+```
+
+### 2. During the engagement
+
+The recon/exploit/analyst agents already write graph nodes via
+``Neo4jStore.upsert_node``. To make those nodes queryable by future
+engagements, tag them:
+
+```python
+from decepticon.tools.research.cross_session import tag_node_to_engagement
+
+# After upserting a Finding
+tag_node_to_engagement(
+    node_key="FIND-001",
+    kind="Finding",
+    engagement_slug="acme-q1",
+)
+```
+
+If the agent identifies a new bug class mid-engagement, query prior
+findings for playbook hints:
+
+```python
+from decepticon.tools.research.cross_session import find_similar_findings
+
+prior_sqli = find_similar_findings(bug_class="sqli", limit=5)
+# returns [{vuln_id, target, status, summary, engagement_slug, ended_at}, ...]
+```
+
+### 3. At engagement end
+
+```python
+from decepticon.tools.research.cross_session import commit_engagement_memory
+
+memory = commit_engagement_memory(
+    "acme-q1",
+    note="WAF rate-limit aborted dirbusting; SAML auth replay was the key vector",
+)
+# memory is an EngagementMemory dataclass; the matching node lands in Neo4j
+```
+
+## What gets distilled
+
+`commit_engagement_memory` reads the engagement's tagged sub-graph and computes:
+
+- `total_findings`, `validated_findings`, `shipped_findings`
+- `top_bug_classes` — top-5 bug classes by count
+- `top_techniques` — first 10 `Technique` nodes touched (by label)
+- `crown_jewels_reached` — `CrownJewel` nodes connected to engagement
+- `notable_attack_paths` — first 5 `AttackPath` titles
+- `note` — caller-supplied prose (orchestrator's terminal reflection)
+
+These fields are written as native Neo4j properties on the
+`EngagementMemory` node — no JSON-in-string, no embedded blobs.
+
+## Graceful degradation
+
+All public functions return empty results (or `False` for boolean
+operations) when Neo4j is unavailable. Engagements run normally — they
+just lose the bootstrap benefit. This means the layer is safe to wire
+into the default orchestrator without an "is Neo4j up?" precheck.
+
+## Future enhancements (not in this PR)
+
+- **Vector similarity for target matching.** Substring match works for
+  obvious cases (subdomains of same root); embeddings would catch
+  semantic similarity (e.g. "shopify-like ecommerce" vs "magento").
+- **Per-finding playbook capture.** A finding currently summarizes as a
+  one-liner. We could attach the full kill chain (recon path → exploit
+  step → pivot) so future agents can replay sequences.
+- **Decay weighting.** Older memories should de-prioritize as the
+  target evolves (kernel patches, infra changes).
+
+These would extend the schema without breaking the current API.

--- a/tests/unit/research/test_cross_session.py
+++ b/tests/unit/research/test_cross_session.py
@@ -1,0 +1,121 @@
+"""Unit tests for EvoGraph cross-session memory layer.
+
+Most behavior requires Neo4j — we test the pure-Python edges:
+- ``EngagementMemory`` dataclass shape + to_dict()
+- ``format_bootstrap_for_prompt()`` rendering w/ varied inputs
+- Graceful-degradation paths (Neo4j unavailable → empty results)
+
+Live Neo4j tests would go in tests/integration/ with a docker-compose
+fixture; out of scope here.
+"""
+
+from __future__ import annotations
+
+from decepticon.tools.research.cross_session import (
+    EngagementMemory,
+    bootstrap_from_prior,
+    commit_engagement_memory,
+    find_similar_findings,
+    format_bootstrap_for_prompt,
+    register_engagement,
+)
+
+
+def test_engagement_memory_to_dict_roundtrip() -> None:
+    m = EngagementMemory(
+        slug="acme-q1",
+        target="api.example.com",
+        started_at="2026-05-01T00:00:00Z",
+        ended_at="2026-05-02T00:00:00Z",
+        total_findings=7,
+        validated_findings=4,
+        shipped_findings=2,
+        top_bug_classes=[("sqli", 3), ("ssrf", 2)],
+        top_techniques=["T1190", "T1078"],
+        crown_jewels_reached=["prod-db"],
+        notable_attack_paths=["ssrf->metadata->keys->db"],
+        note="strict CSP blocked XSS",
+    )
+    d = m.to_dict()
+    assert d["slug"] == "acme-q1"
+    assert d["top_bug_classes"] == [("sqli", 3), ("ssrf", 2)]
+    assert d["crown_jewels_reached"] == ["prod-db"]
+    assert d["note"] == "strict CSP blocked XSS"
+
+
+def test_format_bootstrap_for_prompt_empty() -> None:
+    assert format_bootstrap_for_prompt([]) == ""
+
+
+def test_format_bootstrap_for_prompt_renders_xml_block() -> None:
+    memories = [
+        EngagementMemory(
+            slug="acme-q1",
+            target="api.example.com",
+            started_at="2026-05-01T00:00:00Z",
+            ended_at="2026-05-02T00:00:00Z",
+            total_findings=5,
+            validated_findings=3,
+            shipped_findings=1,
+            top_bug_classes=[("sqli", 3), ("ssrf", 2)],
+            top_techniques=["T1190"],
+            crown_jewels_reached=["prod-db"],
+            note="watch for double-escaped payloads",
+        ),
+    ]
+    block = format_bootstrap_for_prompt(memories)
+    assert block.startswith("<EVOGRAPH_PRIOR_ENGAGEMENTS>")
+    assert block.endswith("</EVOGRAPH_PRIOR_ENGAGEMENTS>")
+    assert "slug='acme-q1'" in block
+    assert "target='api.example.com'" in block
+    assert "sqli(3)" in block
+    assert "ssrf(2)" in block
+    assert "T1190" in block
+    assert "prod-db" in block
+    assert "double-escaped" in block
+
+
+def test_format_bootstrap_for_prompt_omits_empty_optional_fields() -> None:
+    memories = [
+        EngagementMemory(
+            slug="solo",
+            target="x.test",
+            started_at="t1",
+            ended_at="t2",
+        ),
+    ]
+    block = format_bootstrap_for_prompt(memories)
+    assert "crown_jewels_reached" not in block
+    assert "note: " not in block
+    assert "(none)" in block  # empty bug_classes / techniques rendered as (none)
+
+
+def test_neo4j_unavailable_graceful_degradation(monkeypatch) -> None:
+    """All public functions must return empty/falsy without crashing
+    when ``get_store()`` raises Neo4jUnavailableError.
+    """
+    from decepticon.tools.research import cross_session
+    from decepticon.tools.research.neo4j_store import Neo4jUnavailableError
+
+    def _raise(*_a, **_k):
+        raise Neo4jUnavailableError("test: no neo4j")
+
+    monkeypatch.setattr(cross_session, "get_store", _raise)
+
+    assert cross_session.ensure_evograph_schema() is False
+    assert register_engagement("slug-x", "tgt") is False
+    assert cross_session.tag_node_to_engagement(
+        node_key="x", kind="Finding", engagement_slug="slug-x"
+    ) is False
+    assert commit_engagement_memory("slug-x") is None
+    assert bootstrap_from_prior(target_hint="x") == []
+    assert find_similar_findings(bug_class="sqli") == []
+
+
+def test_graph_kinds_extended() -> None:
+    from decepticon.tools.research.graph import EdgeKind, NodeKind
+
+    assert NodeKind.ENGAGEMENT.value == "Engagement"
+    assert NodeKind.ENGAGEMENT_MEMORY.value == "EngagementMemory"
+    assert EdgeKind.IN_ENGAGEMENT.value == "IN_ENGAGEMENT"
+    assert EdgeKind.SUMMARIZES.value == "SUMMARIZES"

--- a/tests/unit/research/test_cross_session.py
+++ b/tests/unit/research/test_cross_session.py
@@ -104,9 +104,10 @@ def test_neo4j_unavailable_graceful_degradation(monkeypatch) -> None:
 
     assert cross_session.ensure_evograph_schema() is False
     assert register_engagement("slug-x", "tgt") is False
-    assert cross_session.tag_node_to_engagement(
-        node_key="x", kind="Finding", engagement_slug="slug-x"
-    ) is False
+    assert (
+        cross_session.tag_node_to_engagement(node_key="x", kind="Finding", engagement_slug="slug-x")
+        is False
+    )
     assert commit_engagement_memory("slug-x") is None
     assert bootstrap_from_prior(target_hint="x") == []
     assert find_similar_findings(bug_class="sqli") == []


### PR DESCRIPTION
## Summary

Implements **EvoGraph** — a lessons-learned memory layer over Decepticon's existing Neo4j attack graph so a fresh engagement starts with awareness of similar prior engagements (target patterns, common bug classes, techniques that worked vs didn't).

Closes the original PR-E roadmap item.

## Why

Today's flow: every engagement creates fresh nodes/edges in Neo4j. The DB accumulates them across runs, but **no agent ever sees prior data**. That's wasted institutional memory:

- Re-discovering the same WAF behaviors repeatedly
- Repeating recon against re-encountered subdomain patterns
- Forgetting that ``shopify-style`` targets cluster around the same 3 bug classes
- No way to ask "have we seen this target before? what worked?"

## How

Two new node kinds (PascalCase Neo4j labels):

- ``Engagement {slug, target, started_at, scope}`` — anchors all session-scoped nodes via ``IN_ENGAGEMENT`` edges
- ``EngagementMemory {slug, target, ended_at, total_findings, top_bug_classes, top_techniques, ...}`` — distilled summary written at engagement end

Two new edge kinds:
- ``(node)-[:IN_ENGAGEMENT]->(:Engagement)`` — session scoping
- ``(:EngagementMemory)-[:SUMMARIZES]->(:Engagement)`` — memory↔source

## API

```python
from decepticon.tools.research.cross_session import (
    ensure_evograph_schema,
    register_engagement,
    bootstrap_from_prior,
    format_bootstrap_for_prompt,
    tag_node_to_engagement,
    find_similar_findings,
    commit_engagement_memory,
)

# At engagement start
ensure_evograph_schema()
register_engagement(\"acme-q1\", target=\"api.example.com\")
prior = bootstrap_from_prior(target_hint=\"example.com\", top_k=5)
prompt_block = format_bootstrap_for_prompt(prior)  # XML for system prompt

# Mid-engagement
tag_node_to_engagement(node_key=\"FIND-001\", kind=\"Finding\", engagement_slug=\"acme-q1\")
prior_sqli = find_similar_findings(bug_class=\"sqli\", limit=5)

# At engagement end
memory = commit_engagement_memory(\"acme-q1\", note=\"SAML replay was the key vector\")
```

## What gets distilled

``commit_engagement_memory`` walks the engagement's tagged sub-graph and computes:

- `total_findings`, `validated_findings`, `shipped_findings`
- `top_bug_classes` — top-5 bug classes by count
- `top_techniques` — first 10 ``Technique`` nodes (by label)
- `crown_jewels_reached`
- `notable_attack_paths` — first 5 titles
- `note` — caller-supplied prose

All written as native Neo4j properties on the ``EngagementMemory`` node.

## Graceful degradation

Every public function returns empty/`False` when Neo4j is unavailable. Engagements run normally w/o the bootstrap benefit — safe to wire unconditionally.

## Files

| File | Lines | Purpose |
|---|---|---|
| `decepticon/tools/research/cross_session.py` | +370 | Full layer |
| `decepticon/tools/research/graph.py` | +6 | New NodeKinds + EdgeKinds |
| `tests/unit/research/test_cross_session.py` | +110 | 7 tests |
| `docs/evograph.md` | +130 | Lifecycle + API + examples |

## Tests

```
test_engagement_memory_to_dict_roundtrip          ✓
test_format_bootstrap_for_prompt_empty            ✓
test_format_bootstrap_for_prompt_renders_xml_block ✓
test_format_bootstrap_for_prompt_omits_empty_optional_fields ✓
test_neo4j_unavailable_graceful_degradation       ✓  (monkeypatched get_store)
test_graph_kinds_extended                         ✓
```

Live Neo4j tests are out of scope here — they'd require a docker-compose fixture in `tests/integration/`.

## Follow-ups (out of scope)

- **Vector similarity for target matching** — substring works for obvious cases; embeddings would catch \"shopify-style\" semantic matches
- **Per-finding playbook capture** — full kill chain (recon → exploit → pivot) so future agents can replay sequences
- **Decay weighting** — older memories should de-prioritize as targets evolve

None break this API; they're pure additions.