### PR TITLE
feat(cli/server): runtime plugin bundles + /plugins /agent CLI switcher

### DIFF
--- a/clients/cli/src/commands/agent.ts
+++ b/clients/cli/src/commands/agent.ts
@@ -1,0 +1,153 @@
+/**
+ * /agent — switch the active orchestrator for this CLI session.
+ *
+ * Only orchestration agents are surfaced here. Sub-agents (recon,
+ * exploit, postexploit, …) are invoked via the orchestrator's task()
+ * tool and shouldn't be selected directly. The whitelist below pins the
+ * two orchestrators OSS ships:
+ *
+ *   - decepticon   — standard bundle. Always available.
+ *   - vulnresearch — plugins bundle. Available once enabled via /plugins.
+ *
+ * Selection writes to the per-process assistant override (see
+ * commands/assistantOverride.ts) which useAgent reads on every submit()
+ * / resume(), beating the default INITIAL_ASSISTANT_ID and the
+ * soundwave→decepticon in-flight handoff. The choice persists for the
+ * lifetime of this CLI process.
+ *
+ * Usage:
+ *   /agent              List orchestrators + current selection
+ *   /agent <name>       Switch to the named orchestrator
+ *   /agent clear        Clear the override (resume default behaviour)
+ */
+
+import type { Command } from "./types.js";
+import {
+  getAssistantOverride,
+  setAssistantOverride,
+} from "./assistantOverride.js";
+
+const ORCHESTRATOR_ALLOWLIST = ["decepticon", "vulnresearch"] as const;
+type Orchestrator = (typeof ORCHESTRATOR_ALLOWLIST)[number];
+
+interface AssistantRow {
+  assistant_id: string;
+  graph_id: string;
+  name: string;
+}
+
+function apiBase(): string {
+  return process.env.DECEPTICON_API_URL || "http://localhost:2024";
+}
+
+async function listOrchestrators(): Promise<Orchestrator[]> {
+  const res = await fetch(`${apiBase()}/assistants/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) {
+    throw new Error(`assistants/search HTTP ${res.status}: ${await res.text()}`);
+  }
+  const data = (await res.json()) as AssistantRow[];
+  const registered = new Set(data.map((a) => a.graph_id));
+  return ORCHESTRATOR_ALLOWLIST.filter((g) => registered.has(g));
+}
+
+const agent: Command = {
+  name: "agent",
+  description: "Show or switch the active orchestrator for this session",
+  argumentHint: "[<name> | clear]",
+  execute(args, ctx) {
+    const arg = args.trim();
+
+    // No arg → list orchestrators + current override
+    if (!arg) {
+      void (async () => {
+        try {
+          const orchestrators = await listOrchestrators();
+          const current = getAssistantOverride();
+          const lines: string[] = [];
+          if (current) {
+            lines.push(`Active orchestrator override: ${current}`);
+          } else {
+            lines.push(
+              "No override active — using the default orchestrator selection (decepticon, or soundwave→decepticon handoff).",
+            );
+          }
+          lines.push("");
+          lines.push("Available orchestrators:");
+          if (orchestrators.length === 0) {
+            lines.push("  (none — is the langgraph stack up?)");
+          } else {
+            for (const o of orchestrators) {
+              const mark = o === current ? "*" : " ";
+              lines.push(`  ${mark} ${o}`);
+            }
+          }
+          if (!orchestrators.includes("vulnresearch")) {
+            lines.push("");
+            lines.push(
+              "Tip: vulnresearch ships in the 'plugins' bundle. Enable with `/plugins enable plugins`.",
+            );
+          }
+          lines.push("");
+          lines.push("Usage:");
+          lines.push("  /agent <name>     Switch (e.g. /agent vulnresearch)");
+          lines.push("  /agent clear      Drop the override, resume default behaviour");
+          ctx.addSystemEvent(lines.join("\n"));
+        } catch (err) {
+          ctx.addSystemEvent(
+            `Could not list orchestrators: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      })();
+      return;
+    }
+
+    // Clear
+    if (arg === "clear" || arg === "off" || arg === "none") {
+      const prev = getAssistantOverride();
+      setAssistantOverride("");
+      ctx.addSystemEvent(
+        prev
+          ? `Orchestrator override cleared (was '${prev}'). Default behaviour resumes on next message.`
+          : "No override was set.",
+      );
+      return;
+    }
+
+    // Switch
+    if (!ORCHESTRATOR_ALLOWLIST.includes(arg as Orchestrator)) {
+      ctx.addSystemEvent(
+        `'${arg}' is not a known orchestrator. Valid options: ${ORCHESTRATOR_ALLOWLIST.join(", ")}.`,
+      );
+      return;
+    }
+
+    void (async () => {
+      try {
+        const orchestrators = await listOrchestrators();
+        if (!orchestrators.includes(arg as Orchestrator)) {
+          ctx.addSystemEvent(
+            `'${arg}' isn't currently registered with the agent runtime. ` +
+              (arg === "vulnresearch"
+                ? "Enable its bundle first: /plugins enable plugins"
+                : "Check that the agent stack is running."),
+          );
+          return;
+        }
+        setAssistantOverride(arg);
+        ctx.addSystemEvent(
+          `Active orchestrator: ${arg}\nNext message routes here. Type /agent clear to revert.`,
+        );
+      } catch (err) {
+        ctx.addSystemEvent(
+          `Failed to switch orchestrator: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    })();
+  },
+};
+
+export default agent;

--- a/clients/cli/src/commands/assistantOverride.ts
+++ b/clients/cli/src/commands/assistantOverride.ts
@@ -1,0 +1,21 @@
+/**
+ * Per-process orchestrator override store.
+ *
+ * The /agent slash command writes here; useAgent reads here on every
+ * submit() / resume() so user-driven switches take effect on the next
+ * message. When set, the override beats both the default
+ * INITIAL_ASSISTANT_ID and the in-flight soundwave→decepticon handoff
+ * — the user explicitly picked this orchestrator, so honour it.
+ *
+ * Empty string == no override (default useAgent behaviour resumes).
+ */
+
+let _override = "";
+
+export function setAssistantOverride(id: string): void {
+  _override = id.trim();
+}
+
+export function getAssistantOverride(): string {
+  return _override;
+}

--- a/clients/cli/src/commands/plugins.ts
+++ b/clients/cli/src/commands/plugins.ts
@@ -1,0 +1,154 @@
+/**
+ * /plugins — runtime plugin bundle enable/disable.
+ *
+ * OSS default loads the ``standard`` bundle only (10 official agents).
+ * The ``plugins`` bundle ships extras (vulnresearch orchestrator + its
+ * 5 specialists) but is off by default. /plugins lets the operator
+ * toggle bundles without restarting the langgraph container — the
+ * langgraph platform exposes a custom HTTP surface under
+ * ``/_decepticon/bundles`` that calls ``register_graph()`` at runtime.
+ *
+ * Usage:
+ *   /plugins                  Show every bundle + enabled state
+ *   /plugins enable <name>    Activate every graph in the bundle
+ *   /plugins disable <name>   Drop every graph in the bundle
+ *
+ * Enabling a bundle adds its orchestrator(s) to the /agent switcher.
+ * For ``plugins`` that means ``vulnresearch`` becomes selectable.
+ *
+ * Persistence: runtime-only. Bundles activated here do NOT survive a
+ * ``decepticon restart``. To make a selection permanent, set
+ * ``DECEPTICON_PLUGINS=standard,plugins`` in ``~/.decepticon/.env``.
+ */
+
+import type { Command } from "./types.js";
+
+interface BundleStatus {
+  name: string;
+  enabled: boolean;
+  graphs: string[];
+}
+
+interface ListResponse {
+  bundles: BundleStatus[];
+}
+
+interface ToggleResponse {
+  bundle: string;
+  enabled: boolean;
+  graphs: string[];
+  skipped: string[];
+}
+
+function apiBase(): string {
+  return process.env.DECEPTICON_API_URL || "http://localhost:2024";
+}
+
+function formatList(data: ListResponse): string {
+  const lines: string[] = ["Available plugin bundles:", ""];
+  for (const b of data.bundles) {
+    const mark = b.enabled ? "[on] " : "[off]";
+    lines.push(`  ${mark} ${b.name}  (${b.graphs.length} graphs)`);
+    for (const g of b.graphs) {
+      lines.push(`         - ${g}`);
+    }
+  }
+  lines.push("");
+  lines.push("Usage:");
+  lines.push("  /plugins enable <name>    Activate the bundle (runtime, no restart)");
+  lines.push("  /plugins disable <name>   Drop the bundle");
+  lines.push("  /agent <orchestrator>     Switch active orchestrator after enabling");
+  lines.push("");
+  lines.push(
+    "Activations are runtime-only. To persist across `decepticon restart`,",
+  );
+  lines.push("set DECEPTICON_PLUGINS in ~/.decepticon/.env (e.g. standard,plugins).");
+  return lines.join("\n");
+}
+
+async function getJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  const text = await res.text();
+  if (!res.ok) {
+    let detail = text;
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed?.detail) detail = String(parsed.detail);
+    } catch {
+      // not JSON — surface raw text
+    }
+    throw new Error(`HTTP ${res.status}: ${detail}`);
+  }
+  return text ? (JSON.parse(text) as T) : (undefined as T);
+}
+
+const plugins: Command = {
+  name: "plugins",
+  description: "List or toggle agent plugin bundles",
+  argumentHint: "[enable|disable <bundle>]",
+  aliases: ["plugin", "플러그인"],
+  execute(args, ctx) {
+    const parts = args.trim().split(/\s+/).filter(Boolean);
+    const sub = parts[0]?.toLowerCase() ?? "";
+
+    // /plugins (no args) — list current state
+    if (!sub) {
+      void (async () => {
+        try {
+          const data = await getJson<ListResponse>(`${apiBase()}/_decepticon/bundles`);
+          ctx.addSystemEvent(formatList(data));
+        } catch (err) {
+          ctx.addSystemEvent(
+            `Could not reach plugin bundles API at ${apiBase()}: ${err instanceof Error ? err.message : String(err)}\n` +
+              "Is the decepticon stack running?",
+          );
+        }
+      })();
+      return;
+    }
+
+    if (sub !== "enable" && sub !== "disable") {
+      ctx.addSystemEvent(
+        `Unknown subcommand '${sub}'. Use /plugins, /plugins enable <name>, or /plugins disable <name>.`,
+      );
+      return;
+    }
+
+    const bundle = parts[1]?.trim() ?? "";
+    if (!bundle) {
+      ctx.addSystemEvent(`Missing bundle name. Try: /plugins ${sub} plugins`);
+      return;
+    }
+
+    void (async () => {
+      try {
+        const url = `${apiBase()}/_decepticon/bundles/${encodeURIComponent(bundle)}/${sub}`;
+        const data = await getJson<ToggleResponse>(url, { method: "POST" });
+
+        const verb = sub === "enable" ? "enabled" : "disabled";
+        const lines: string[] = [
+          `Bundle '${data.bundle}' ${verb}.`,
+        ];
+        if (data.graphs.length > 0) {
+          lines.push(`  ${verb === "enabled" ? "Registered" : "Removed"}: ${data.graphs.join(", ")}`);
+        }
+        if (data.skipped.length > 0) {
+          lines.push(
+            `  Skipped (already ${verb === "enabled" ? "active" : "absent"}): ${data.skipped.join(", ")}`,
+          );
+        }
+        if (verb === "enabled" && data.bundle === "plugins") {
+          lines.push("");
+          lines.push("Tip: switch to the new orchestrator with `/agent vulnresearch`.");
+        }
+        ctx.addSystemEvent(lines.join("\n"));
+      } catch (err) {
+        ctx.addSystemEvent(
+          `Failed to ${sub} bundle '${bundle}': ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    })();
+  },
+};
+
+export default plugins;

--- a/clients/cli/src/commands/registry.ts
+++ b/clients/cli/src/commands/registry.ts
@@ -12,9 +12,11 @@ import file from "./file.js";
 import quit from "./quit.js";
 import resume from "./resume.js";
 import model from "./model.js";
+import plugins from "./plugins.js";
+import agent from "./agent.js";
 
 /** All registered commands. Add new commands here. */
-const COMMANDS: Command[] = [help, clear, file, quit, resume, model];
+const COMMANDS: Command[] = [help, clear, file, quit, resume, model, plugins, agent];
 
 /** Get all registered commands. */
 export function getCommands(): Command[] {

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -25,6 +25,7 @@ import {
   stripResultTags,
 } from "@decepticon/streaming";
 import { getModelOverride } from "../commands/modelOverride.js";
+import { getAssistantOverride } from "../commands/assistantOverride.js";
 
 interface LangChainMessage {
   type: string; // "human", "ai", "tool"
@@ -303,6 +304,18 @@ export function useAgent({
             // message); thread handoff fires from handleStreamComplete.
             // Pure boolean signal — the engagement slug travels independently
             // via config.configurable from the launcher's env.
+            //
+            // When the operator has explicitly picked another orchestrator
+            // via /agent (e.g. "vulnresearch"), skip this auto-handoff —
+            // their explicit choice beats the soundwave→decepticon default.
+            if (getAssistantOverride()) {
+              addEvent({
+                type: "system",
+                content:
+                  "Engagement planning complete — keeping operator-chosen orchestrator (use /agent to switch).",
+              });
+              break;
+            }
             pendingHandoffRef.current = true;
             assistantIdRef.current = "decepticon";
             setAssistantId("decepticon");
@@ -710,7 +723,7 @@ export function useAgent({
         try {
           const stream = client.runs.stream(
             threadIdRef.current!,
-            assistantIdRef.current,
+            getAssistantOverride() || assistantIdRef.current,
             {
               input,
               ...(streamConfig ? { config: streamConfig } : {}),
@@ -796,7 +809,7 @@ export function useAgent({
         try {
           const stream = client.runs.stream(
             threadIdRef.current!,
-            assistantIdRef.current,
+            getAssistantOverride() || assistantIdRef.current,
             {
               command: { resume: value },
               ...STREAM_OPTIONS,
@@ -858,7 +871,7 @@ export function useAgent({
           try {
             const stream = client.runs.stream(
               threadIdRef.current!,
-              assistantIdRef.current,
+              getAssistantOverride() || assistantIdRef.current,
               {
                 command: { resume: value ?? true },
                 ...STREAM_OPTIONS,

--- a/decepticon/server/__init__.py
+++ b/decepticon/server/__init__.py
@@ -1,0 +1,15 @@
+"""Decepticon server-side custom HTTP surface mounted on LangGraph platform.
+
+LangGraph Platform's ``langgraph.json`` allows mounting a user-defined
+ASGI app via the ``http.app`` field. We use that hook to add endpoints
+that aren't part of the standard /threads | /assistants | /runs surface
+but still need to live inside the same process — currently:
+
+  - ``/_decepticon/bundles`` — runtime plugin bundle enable/disable, see
+    :mod:`decepticon.server.plugins_api`.
+
+Anything mounted here runs inside the same Python process as the agent
+graphs, so it can mutate ``langgraph_api.graph.GRAPHS`` and call
+``register_graph()`` directly — that's what makes runtime plugin
+activation possible without a container restart.
+"""

--- a/decepticon/server/plugins_api.py
+++ b/decepticon/server/plugins_api.py
@@ -1,0 +1,280 @@
+"""Runtime plugin bundle activation API.
+
+Mounted into the LangGraph platform via ``langgraph.json`` ``http.app``.
+Lets the CLI ``/plugins`` slash command flip plugin bundles on or off
+without restarting the langgraph container — by calling the same
+``langgraph_api.graph.register_graph()`` the platform itself uses at
+startup.
+
+Bundle model
+------------
+Decepticon's graph manifest is split into two bundles by
+``decepticon.graph_registry``:
+
+  - ``standard``: official OSS agents (decepticon + 9 specialists).
+    Always loaded at startup.
+  - ``plugins``: vulnresearch family (orchestrator + 5 specialists).
+    Off by default. Activated either via ``DECEPTICON_PLUGINS`` env
+    (next-restart) or this API (immediately).
+
+Endpoints
+---------
+GET  ``/_decepticon/bundles``                 — list bundles + enabled state
+POST ``/_decepticon/bundles/{name}/enable``   — register every graph in bundle
+POST ``/_decepticon/bundles/{name}/disable``  — drop every graph in bundle
+
+Enable is idempotent (``register_graph`` uses ``if_exists="do_nothing"``
+in the Assistants table). Disable mutates the in-memory ``GRAPHS`` dict
+and removes the system-created assistant row, so the next
+``/assistants/search`` no longer returns it.
+
+Persistence
+-----------
+This API is **runtime-only** in this iteration. Bundles re-enabled here
+do NOT persist across ``decepticon restart`` — for permanent activation
+set ``DECEPTICON_PLUGINS=standard,plugins`` in ``~/.decepticon/.env``.
+A future iteration will add a state file so the API also persists.
+"""
+
+# NOTE: deliberately NO ``from __future__ import annotations`` here —
+# LangGraph Platform mounts this module under a synthetic name
+# (``user_router_module``) and pydantic's lazy forward-ref resolution
+# fails to find ``BundleStatus`` etc. when the response models are
+# introspected for OpenAPI schema generation. Eager-evaluating
+# annotations sidesteps the namespace mismatch.
+
+import importlib
+import logging
+from typing import Annotated
+from uuid import uuid5
+
+from fastapi import FastAPI, HTTPException, Path
+from pydantic import BaseModel
+
+from decepticon.graph_registry import _BUNDLE_TO_GRAPHS  # private, but stable: bundle->graphs map
+
+logger = logging.getLogger(__name__)
+
+
+# ── Wire models ──────────────────────────────────────────────────────────────
+
+
+class BundleStatus(BaseModel):
+    name: str
+    enabled: bool
+    graphs: list[str]
+
+
+class BundlesResponse(BaseModel):
+    bundles: list[BundleStatus]
+
+
+class ToggleResponse(BaseModel):
+    bundle: str
+    enabled: bool
+    graphs: list[str]
+    skipped: list[str] = []
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _path_to_module(spec: str) -> tuple[str, str]:
+    """Turn ``"./decepticon/agents/plugins/vulnresearch.py:graph"`` into
+    ``("decepticon.agents.plugins.vulnresearch", "graph")``.
+
+    The graph_registry stores entries in the file-path form LangGraph
+    Platform expects in ``langgraph.json``. For runtime registration we
+    need importable module + attribute, which is more robust against
+    CWD changes.
+    """
+    path, _, variable = spec.partition(":")
+    if not variable:
+        raise ValueError(f"bundle spec missing ':variable' suffix: {spec!r}")
+    module = path.removeprefix("./").removesuffix(".py").replace("/", ".").lstrip(".")
+    return module, variable
+
+
+def _load_graph(module_path: str, variable: str):
+    """Import the module and pull out the compiled graph attribute."""
+    module = importlib.import_module(module_path)
+    try:
+        return getattr(module, variable)
+    except AttributeError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=(f"module {module_path!r} does not export attribute {variable!r}"),
+        ) from exc
+
+
+def _resolve_bundle(name: str) -> dict[str, str]:
+    """Look up a bundle by name, 404 on unknown."""
+    try:
+        return _BUNDLE_TO_GRAPHS[name]
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"unknown bundle: {name!r}") from exc
+
+
+def _registered_graph_ids() -> set[str]:
+    """Snapshot of which graph IDs the platform currently exposes.
+
+    Imported lazily because ``langgraph_api`` is only importable inside
+    the LangGraph platform process — pulling it at module load time
+    would make ``decepticon.server.plugins_api`` un-importable from
+    plain unit tests / scripts.
+    """
+    from langgraph_api.graph import GRAPHS  # noqa: PLC0415
+
+    return set(GRAPHS.keys())
+
+
+# ── App ──────────────────────────────────────────────────────────────────────
+
+
+app = FastAPI(
+    title="Decepticon plugin bundle API",
+    summary="Runtime activation/deactivation of agent bundles on the LangGraph platform.",
+)
+
+
+@app.get("/_decepticon/bundles", response_model=BundlesResponse)
+async def list_bundles() -> BundlesResponse:
+    """List every known bundle plus its current enabled state.
+
+    A bundle is *enabled* iff every graph it contributes is currently in
+    ``GRAPHS``. Partial state (some graphs registered, some not) is
+    reported as enabled=False — that should never happen under normal
+    operation but the check is cheap.
+    """
+    registered = _registered_graph_ids()
+    return BundlesResponse(
+        bundles=[
+            BundleStatus(
+                name=name,
+                enabled=all(gid in registered for gid in graphs),
+                graphs=list(graphs),
+            )
+            for name, graphs in _BUNDLE_TO_GRAPHS.items()
+        ]
+    )
+
+
+@app.post("/_decepticon/bundles/{name}/enable", response_model=ToggleResponse)
+async def enable_bundle(
+    name: Annotated[str, Path(min_length=1, max_length=64)],
+) -> ToggleResponse:
+    """Register every graph in the named bundle into the live LangGraph platform.
+
+    Idempotent: re-enabling an already-loaded bundle is a no-op (the
+    underlying ``register_graph`` uses ``if_exists="do_nothing"`` on the
+    Assistants table and re-assigning ``GRAPHS[gid]`` is harmless).
+    """
+    from langgraph_api.graph import GRAPHS, register_graph  # noqa: PLC0415
+
+    graphs = _resolve_bundle(name)
+    registered: list[str] = []
+    skipped: list[str] = []
+
+    for graph_id, spec in graphs.items():
+        if graph_id in GRAPHS:
+            skipped.append(graph_id)
+            continue
+        module_path, variable = _path_to_module(spec)
+        graph_obj = _load_graph(module_path, variable)
+        try:
+            await register_graph(graph_id, graph_obj, config=None)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("register_graph failed for %s", graph_id)
+            raise HTTPException(
+                status_code=500,
+                detail=f"register_graph({graph_id}) failed: {exc}",
+            ) from exc
+        registered.append(graph_id)
+        logger.info("plugin bundle %r: registered graph %r", name, graph_id)
+
+    return ToggleResponse(
+        bundle=name,
+        enabled=True,
+        graphs=registered,
+        skipped=skipped,
+    )
+
+
+@app.post("/_decepticon/bundles/{name}/disable", response_model=ToggleResponse)
+async def disable_bundle(
+    name: Annotated[str, Path(min_length=1, max_length=64)],
+) -> ToggleResponse:
+    """Drop every graph in the named bundle.
+
+    Removes the in-memory ``GRAPHS`` entry and deletes the system-owned
+    Assistants row that ``register_graph`` created at enable time. The
+    UUID for that row is deterministic (``uuid5(NAMESPACE_GRAPH,
+    graph_id)``) — see ``langgraph_api.graph.register_graph``.
+
+    Refuses to disable the ``standard`` bundle: those graphs are the
+    core agent set and removing them mid-session would brick the
+    orchestrator.
+    """
+    if name == "standard":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "'standard' bundle cannot be disabled — it carries the "
+                "core orchestrator. Set DECEPTICON_PLUGINS at startup to "
+                "ship a custom baseline."
+            ),
+        )
+
+    from langgraph_api.graph import (  # noqa: PLC0415
+        GRAPHS,
+        NAMESPACE_GRAPH,
+        SYSTEM_ASSISTANT_IDS,
+    )
+    from langgraph_runtime.database import connect  # noqa: PLC0415
+
+    if lg_api_feature_postgres():
+        from langgraph_api.grpc.ops import Assistants  # noqa: PLC0415
+    else:
+        from langgraph_runtime.ops import Assistants  # noqa: PLC0415
+
+    graphs = _resolve_bundle(name)
+    removed: list[str] = []
+    skipped: list[str] = []
+
+    for graph_id in graphs:
+        if graph_id not in GRAPHS:
+            skipped.append(graph_id)
+            continue
+        del GRAPHS[graph_id]
+        assistant_id = uuid5(NAMESPACE_GRAPH, graph_id)
+        SYSTEM_ASSISTANT_IDS.discard(str(assistant_id))
+        try:
+            async with connect() as conn:
+                async for _ in await Assistants.delete(conn, assistant_id):
+                    pass
+        except Exception:  # noqa: BLE001
+            # Assistants row may not exist (e.g. the user manually
+            # deleted it via /assistants/{id} DELETE). The in-memory
+            # mutation is what gates further usage; DB cleanup is
+            # best-effort. Log and continue.
+            logger.warning(
+                "could not delete Assistants row for %s — proceeding",
+                graph_id,
+                exc_info=True,
+            )
+        removed.append(graph_id)
+        logger.info("plugin bundle %r: unregistered graph %r", name, graph_id)
+
+    return ToggleResponse(
+        bundle=name,
+        enabled=False,
+        graphs=removed,
+        skipped=skipped,
+    )
+
+
+def lg_api_feature_postgres() -> bool:
+    """Mirror the same backend selector langgraph_api.graph uses."""
+    from langgraph_api.feature_flags import IS_POSTGRES_OR_GRPC_BACKEND  # noqa: PLC0415
+
+    return IS_POSTGRES_OR_GRPC_BACKEND

--- a/langgraph.json
+++ b/langgraph.json
@@ -15,6 +15,7 @@
   "env": ".env",
   "python_version": "3.13",
   "http": {
-    "multitask_strategy": "interrupt"
+    "multitask_strategy": "interrupt",
+    "app": "./decepticon/server/plugins_api.py:app"
   }
 }


### PR DESCRIPTION
## Summary
Opt-in plugin bundles with **runtime activation** (no langgraph restart) plus two operator-facing CLI commands.

- **Backend** (commit 1): a tiny FastAPI app mounted on LangGraph Platform's ``http.app`` slot exposes `/_decepticon/bundles` GET/POST. Enable calls the platform's own `langgraph_api.graph.register_graph()` — same code path the platform uses at startup — so toggling is instant.
- **CLI** (commit 2): `/plugins [enable|disable] <name>` drives the HTTP surface; `/agent <name>` switches the active orchestrator for the session by writing a per-process override that `useAgent` honours on every submit/resume.

## Why
Lets OSS default to a lean baseline (the `standard` bundle: decepticon + 9 specialists) while keeping `plugins` (vulnresearch family) one slash-command away. Previously every bundle had to be activated at startup via `DECEPTICON_PLUGINS`, forcing a container restart on every change.

## Commit structure
1. `feat(server): runtime plugin bundle activation via custom HTTP app` — `decepticon/server/__init__.py`, `decepticon/server/plugins_api.py`, `langgraph.json` (+ http.app).
2. `feat(cli): /plugins and /agent slash commands for runtime bundle + orchestrator switching` — `assistantOverride.ts`, `plugins.ts`, `agent.ts`, `registry.ts`, `useAgent.ts` integration.

## Design notes
- Orchestrator allowlist (`decepticon`, `vulnresearch`) is hardcoded in `/agent` so sub-agents (recon, exploit, …) never appear in the switcher — they live behind the orchestrator's `task()` tool.
- `assistantOverride` mirrors the existing `modelOverride` pattern; the soundwave→decepticon in-flight handoff is **suppressed while an override is active** so an explicit user choice wins over the default flow.
- `standard` bundle is not disable-able (400) — those graphs carry the core orchestrator.
- `plugins_api.py` deliberately **omits** `from __future__ import annotations`: LangGraph Platform mounts user apps under a synthetic module name (`user_router_module`), and pydantic's lazy forward-ref resolution fails to find sibling response models in that namespace during OpenAPI schema generation. Eager annotation evaluation is the fix.

## Test plan
- [x] `uv run ruff check .` — pass
- [x] `uv run ruff format --check .` — 236 files clean
- [x] `uv run basedpyright --level error` — 0 errors / 0 warnings
- [x] `uv run pytest -n auto -q -m "not slow"` — 900 passed
- [x] CLI `tsc --noEmit` — pass
- [x] `make smoke` — 7 containers healthy, langgraph picks up `http.app`
- [x] **E2E** (via curl against running stack):
  - Initial: `/_decepticon/bundles` reports `standard` enabled, `plugins` disabled; `/assistants/search` returns only the 10 standard graphs.
  - Enable: `POST /_decepticon/bundles/plugins/enable` → registers 6 graphs (vulnresearch + 5 specialists); `/assistants/search` immediately returns 16.
  - Idempotent: re-enable returns `skipped: [...]` for already-registered graphs.
  - Guards: `POST .../standard/disable` → 400 with explanatory detail; `POST .../garbage/enable` → 404 "unknown bundle".
  - Disable: `POST .../plugins/disable` → drops all 6 graphs, `/assistants/search` back to 10.
  - **Runtime invocation**: re-enable + `POST /threads/{tid}/runs/wait` against `vulnresearch` reached the worker, graph executed, model node called litellm — proves the runtime-registered graph is actually executable (final 401 was an unrelated OAuth credential mount issue from the dev shell, not a plugin-system failure).

## Persistence
Runtime-only in this iteration. Activations made via `/plugins` do NOT survive `decepticon restart`. For permanent activation set `DECEPTICON_PLUGINS=standard,plugins` in `~/.decepticon/.env`. Follow-up PR will add a state file so the API also persists.

## Follow-up
- Persistent activation state (file or DB)
- `/plugins` autocomplete with bundle names
- `/agent` integration into the picker UI (currently text-only)