### PR TITLE
feat(cli/notifications): push-style ● Background command notifications with output inline

### DIFF
--- a/clients/cli/src/components/EventItem.tsx
+++ b/clients/cli/src/components/EventItem.tsx
@@ -7,6 +7,7 @@ import { AIMessage } from "./messages/AIMessage.js";
 import { ToolCallMessage } from "./messages/ToolCallMessage.js";
 import { DelegateMessage } from "./messages/DelegateMessage.js";
 import { SystemMessage } from "./messages/SystemMessage.js";
+import { BackgroundCompleteMessage } from "./messages/BackgroundCompleteMessage.js";
 
 interface EventItemProps {
   event: AgentEvent;
@@ -47,6 +48,17 @@ export const EventItem = React.memo(function EventItem({
 
     case "system":
       return <SystemMessage content={event.content} />;
+
+    case "background_complete":
+      return (
+        <BackgroundCompleteMessage
+          command={event.command}
+          session={event.session}
+          exitCode={event.exitCode}
+          elapsed={event.elapsed}
+          output={event.content}
+        />
+      );
 
     default:
       return null;

--- a/clients/cli/src/components/messages/BackgroundCompleteMessage.tsx
+++ b/clients/cli/src/components/messages/BackgroundCompleteMessage.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { GLYPH_DOT } from "../../utils/theme.js";
+
+interface Props {
+  command?: string;
+  session?: string;
+  exitCode: number | null | undefined;
+  elapsed?: number;
+  output: string;
+}
+
+/**
+ * Renders a Claude-Code-style background-job completion notice.
+ *
+ *     ● Background command "nmap -sV target" completed (exit code 0) — session=scan · 12.3s
+ *       <captured output, dim, wrap-on>
+ *
+ * The output is emitted by ``SandboxNotificationMiddleware`` (already
+ * truncated to a head+tail preview when large) so the operator sees the
+ * full bash_output result without the agent having to fetch it.
+ */
+export const BackgroundCompleteMessage = React.memo(
+  function BackgroundCompleteMessage({
+    command,
+    session,
+    exitCode,
+    elapsed,
+    output,
+  }: Props) {
+    const failed = exitCode !== 0 && exitCode !== null && exitCode !== undefined;
+    const exitStr =
+      exitCode === null || exitCode === undefined
+        ? ""
+        : ` (exit code ${exitCode})`;
+    const tail: string[] = [];
+    if (session) tail.push(`session=${session}`);
+    if (typeof elapsed === "number") tail.push(`${elapsed.toFixed(1)}s`);
+    const suffix = tail.length > 0 ? ` — ${tail.join(" · ")}` : "";
+
+    return (
+      <Box marginTop={1} flexDirection="column">
+        <Text color={failed ? "red" : "green"}>
+          {GLYPH_DOT} <Text bold>Background command</Text>
+          {command ? ` "${command}"` : ""} completed{exitStr}
+          <Text dimColor>{suffix}</Text>
+        </Text>
+        {output ? (
+          <Box marginLeft={2} marginTop={0}>
+            <Text dimColor wrap="wrap">
+              {output}
+            </Text>
+          </Box>
+        ) : null}
+      </Box>
+    );
+  },
+);

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -297,6 +297,31 @@ export function useAgent({
             setPendingTool(null);
             break;
 
+          case "background_complete": {
+            // SandboxNotificationMiddleware fires this when a background
+            // bash session finishes. The middleware also injects the
+            // captured output into the agent's message stream as a
+            // <system-reminder>, so the agent doesn't need to call
+            // bash_output — this event exists purely so the CLI can
+            // render a Claude-Code-style "● Background command ..."
+            // line with the output inline, instead of leaving the
+            // operator with just a tool-call shadow.
+            const exit = data.exit_code;
+            const status: "success" | "error" =
+              exit === 0 || exit === null || exit === undefined ? "success" : "error";
+            addEvent({
+              type: "background_complete",
+              content: data.content ?? "",
+              session: data.session,
+              command: data.command,
+              exitCode: exit ?? null,
+              elapsed: data.elapsed,
+              status,
+              subagent: data.agent,
+            });
+            break;
+          }
+
           case "engagement_ready": {
             // Soundwave finished writing the planning bundle. Flip the
             // active assistant so the next submit() lands on decepticon.

--- a/clients/cli/src/types.ts
+++ b/clients/cli/src/types.ts
@@ -44,7 +44,8 @@ export type AgentEventType =
   | "subagent_start"
   | "subagent_end"
   | "ask_user_question"
-  | "ask_user_answer";
+  | "ask_user_answer"
+  | "background_complete";
 
 /** One choice in an ask_user_question picker. */
 export interface AskUserOption {
@@ -71,6 +72,15 @@ export interface AgentEvent {
   options?: AskUserOption[];
   multiSelect?: boolean;
   allowOther?: boolean;
+  // background_complete payload — emitted by SandboxNotificationMiddleware
+  // when a background bash session finishes. The CLI renders this as a
+  // Claude-Code-style ``● Background command "..." completed`` line so
+  // the operator sees the result without the agent having to call
+  // bash_output explicitly.
+  session?: string;
+  command?: string;
+  exitCode?: number | null;
+  elapsed?: number;
 }
 
 /** A pending operator question — present while a picker is awaiting input. */

--- a/clients/shared/streaming/src/types.ts
+++ b/clients/shared/streaming/src/types.ts
@@ -13,7 +13,8 @@ export type SubagentEventType =
   | "subagent_tool_result"
   | "subagent_message"
   | "ask_user_question"
-  | "engagement_ready";
+  | "engagement_ready"
+  | "background_complete";
 
 /** One choice presented in an ask_user_question picker. */
 export interface AskUserOption {
@@ -43,6 +44,12 @@ export interface SubagentCustomEvent {
   options?: AskUserOption[];
   multi_select?: boolean;
   allow_other?: boolean;
+  // background_complete fields (auto-delivered when a bash background
+  // session finishes). ``content`` carries the captured output (already
+  // truncated to a head+tail preview by the middleware when large).
+  session?: string;
+  command?: string;
+  exit_code?: number | null;
 }
 
 /** Minimal event shape accepted by shared utility functions. */

--- a/decepticon/backends/http_sandbox.py
+++ b/decepticon/backends/http_sandbox.py
@@ -322,15 +322,35 @@ class HTTPSandbox(BaseSandbox):
             completed_at=j.get("completed_at"),
             consumed=j.get("consumed", False),
         )
-        # Keep the local mirror coherent enough for
-        # SandboxNotificationMiddleware: once the daemon reports the job
-        # is done, drop the mirror entry so subsequent `all_jobs()` polls
-        # don't keep re-emitting a stale notification. While running,
-        # leave the stub in place — its fields are slightly off (no
-        # initial_markers, stale started_at) but the middleware only
-        # uses it as a "key, please poll this" pointer.
-        if job.status != "running":
-            self._jobs.remove(session=job.session, key=job.key)
+        # Keep the local mirror coherent: refresh status from the
+        # daemon's view so ``BackgroundJobTracker.pending_completions``
+        # surfaces this job to SandboxNotificationMiddleware on its next
+        # tick. Dedupe of already-emitted completions is handled by
+        # ``mark_consumed`` (the middleware calls it post-emit) — not by
+        # removing from the mirror, which would make the done state
+        # invisible to ``pending_completions`` entirely.
+        local = self._jobs.get(session=job.session)
+        if local is None:
+            # Stub entry was never registered (e.g. start_background was
+            # called from a different agent process, or the local mirror
+            # was cleared). Re-register so subsequent polls find it.
+            self._jobs.register(
+                session=job.session,
+                command=job.command,
+                initial_markers=job.initial_markers,
+                workspace_path=job.workspace_path,
+            )
+            local = self._jobs.get(session=job.session)
+        if local is not None and job.status != "running":
+            # The daemon reports exit_code as ``int | None``; if the job
+            # raced past completion before its exit code was captured,
+            # fall back to ``-1`` so the local mirror still flips to
+            # ``done`` and the notification path can fire.
+            self._jobs.mark_complete(
+                session=job.session,
+                exit_code=job.exit_code if job.exit_code is not None else -1,
+                key=local.key,
+            )
         return job
 
     def kill_session(

--- a/decepticon/middleware/notifications.py
+++ b/decepticon/middleware/notifications.py
@@ -1,18 +1,35 @@
 """Push background-job completion notices into the agent message stream.
 
-When a tmux session's background command finishes, prepend a HumanMessage
-with a <system-reminder> tag describing the completion. Anthropic models
-recognize this tag as a runtime signal (the same pattern Claude Code uses)
-without treating it as a real user turn.
+When a tmux session's background command finishes, this middleware:
 
-Hook: before_model — runs every turn, so the agent learns about completions
-on its very next inference even if it didn't poll bash_output.
+  1. Auto-fetches the diff that accumulated in the sandbox while the
+     command was running — the agent no longer needs to call
+     ``bash_output`` to pull it.
+  2. Injects a HumanMessage tagged ``<system-reminder>`` carrying the
+     completion summary AND the captured output, so the agent has
+     everything it needs on its very next inference turn.
+  3. Emits a ``background_complete`` custom stream event so the CLI can
+     render a Claude-Code-style ``● Background command "..." completed
+     (exit code N)`` line in the activity transcript, with the output
+     attached to that single visual unit instead of being scattered
+     across the message stream.
+
+Hook: ``before_model`` — runs every turn, so completions land on the
+very next inference even if the user did nothing between turns.
+
+Cursor semantics
+----------------
+``sandbox.read_session_log_diff`` ADVANCES the per-session byte offset
+each time it's called. Because this middleware reads the diff, a later
+``bash_output(session=...)`` from the agent on the same session will
+return no new bytes — that's intentional. ``bash_output`` is now a
+fallback for explicit re-fetch (e.g. after the agent decides to
+re-inspect a session it already saw), not the primary delivery path.
 """
-
-from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import threading
 from collections import OrderedDict
 
@@ -29,9 +46,66 @@ log = logging.getLogger(__name__)
 # acceptable (the alternative is uncapped growth).
 _NOTIFIED_KEYS_MAX = 4096
 
+# Output budget for the notification body. Anything larger gets sliced
+# to a head+tail preview with a pointer to the on-disk session log so
+# the agent has the option to read the full content if it cares.
+_INLINE_LIMIT = 15_000
+_HEAD_CHARS = 2_000
+_TAIL_CHARS = 1_000
+
+# Strip terminal control sequences — agents waste tokens on bracketed
+# paste markers (``\x1b[?2004l``), OSC application metadata
+# (``\x1b]3008;...\x1b\\``), DEC charset selectors, etc. The pipe-pane
+# log captures the raw stream so these all land in the diff. Patterns:
+#   1. CSI: ESC [ <params with optional ?> <letter>
+#   2. OSC: ESC ] ... terminated by BEL (\x07) or ST (ESC \)
+#   3. G0/G1 charset: ESC ( <c> or ESC ) <c>
+#   4. Application keypad mode: ESC = or ESC >
+_ANSI_ESCAPE = re.compile(
+    r"\x1b\[[?0-9;]*[a-zA-Z~]"
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"
+    r"|\x1b[()][AB012]"
+    r"|\x1b[=>]"
+)
+
+
+def _sanitize(text: str) -> str:
+    """Surrogate-safe + terminal-control-stripped variant of the captured output."""
+    text = text.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
+    return _ANSI_ESCAPE.sub("", text)
+
+
+def _format_output(diff: str, log_path: str | None) -> str:
+    """Return the diff trimmed to ``_INLINE_LIMIT`` with a hint to the
+    session log when content was sliced."""
+    if not diff:
+        return "(no output captured)"
+    if len(diff) <= _INLINE_LIMIT:
+        return diff
+    head = diff[:_HEAD_CHARS].rstrip()
+    tail = diff[-_TAIL_CHARS:].lstrip()
+    chars = len(diff)
+    where = f" — full log at {log_path}" if log_path else ""
+    return f"{head}\n\n[... {chars} chars truncated{where} ...]\n\n{tail}"
+
+
+def _get_stream_writer():
+    """Return ``get_stream_writer()`` or None if no graph context.
+
+    Imported lazily because the LangGraph runtime context isn't available
+    during unit-test instantiation of this middleware; callers fall back
+    to the system-reminder path when no writer is available.
+    """
+    try:
+        from langgraph.config import get_stream_writer  # noqa: PLC0415
+
+        return get_stream_writer()
+    except Exception:  # noqa: BLE001 — writer is optional; degrade gracefully
+        return None
+
 
 class SandboxNotificationMiddleware(AgentMiddleware):
-    """Emit one HumanMessage per turn aggregating new background completions."""
+    """Auto-deliver background-job completions to the agent + CLI."""
 
     def __init__(self, sandbox: HTTPSandbox) -> None:
         super().__init__()
@@ -60,8 +134,62 @@ class SandboxNotificationMiddleware(AgentMiddleware):
         while len(self._notified) > _NOTIFIED_KEYS_MAX:
             self._notified.popitem(last=False)
 
+    def _pull_diff(self, session: str, workspace_path: str | None) -> tuple[str, str | None]:
+        """Read the accumulated diff for ``session`` and return (output, log_path).
+
+        Both calls are wrapped in try/except: a transient sandbox blip
+        cannot crash the agent's model step, and the worst case is that
+        the agent sees a "(no output captured)" stub instead of full
+        results. The job is still marked done so the lifecycle finishes
+        cleanly.
+        """
+        kwargs = {"workspace_path": workspace_path} if workspace_path else {}
+        try:
+            diff = self._sandbox.read_session_log_diff(session, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("read_session_log_diff failed for session=%s: %s", session, exc)
+            diff = ""
+        try:
+            log_path = self._sandbox.session_log_path(session, **kwargs)
+        except Exception:  # noqa: BLE001
+            log_path = None
+        return _sanitize(diff), log_path
+
+    def _emit_stream_event(self, job, output: str) -> None:
+        """Push a custom stream event for the CLI to render the ● bullet."""
+        writer = _get_stream_writer()
+        if writer is None:
+            return
+        try:
+            writer(
+                {
+                    "type": "background_complete",
+                    "agent": "sandbox",
+                    "tool": "bash",
+                    "session": job.session,
+                    "command": job.command or "",
+                    "exit_code": job.exit_code,
+                    "elapsed": float(job.elapsed) if job.elapsed is not None else 0.0,
+                    "content": output,
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("failed to emit background_complete stream event: %s", exc)
+
+    def _format_block(self, job, output: str) -> str:
+        """One ``●`` entry for the system-reminder body."""
+        command = job.command or ""
+        return (
+            f'● Background command "{command}" completed '
+            f"(exit code {job.exit_code}) — session={job.session} "
+            f"elapsed={job.elapsed:.1f}s\n"
+            f"```\n{output}\n```"
+        )
+
     def _build_message(self) -> dict | None:
-        """Build the system-reminder message dict, or None if nothing new."""
+        """Inject completions + emit per-job stream events. Returns the
+        state update (HumanMessage) or None when nothing changed.
+        """
         jobs = self._jobs_view()
         if jobs is None:
             return None
@@ -77,16 +205,33 @@ class SandboxNotificationMiddleware(AgentMiddleware):
                 return None
             self._record_notified(j.key for j in new)
 
-        lines = ["<system-reminder>", "Background sandbox session updates:"]
+        blocks: list[str] = []
         for job in new:
-            command = (job.command or "")[:80]
-            lines.append(
-                f"- {job.session}: completed exit {job.exit_code} "
-                f"({job.elapsed:.0f}s) — command={command}"
-            )
-        lines.append("Use bash_output(session) to retrieve full results.")
-        lines.append("</system-reminder>")
-        return {"messages": [HumanMessage(content="\n".join(lines))]}
+            diff, log_path = self._pull_diff(job.session, job.workspace_path)
+            formatted = _format_output(diff, log_path)
+            blocks.append(self._format_block(job, formatted))
+            self._emit_stream_event(job, formatted)
+            # Mark the daemon-side mirror consumed so a later
+            # ``bash_output`` call returns ``(no new output)`` rather
+            # than re-delivering the same diff, and so
+            # ``pending_completions`` skips it on subsequent middleware
+            # ticks. ``self._notified`` is a belt-and-suspenders dedupe
+            # for the case where mark_consumed silently fails.
+            try:
+                jobs.mark_consumed(session=job.session, key=job.key)
+            except Exception:  # noqa: BLE001 — best-effort
+                log.warning("mark_consumed failed for session=%s", job.session, exc_info=True)
+
+        body = "\n\n".join(blocks)
+        reminder = (
+            "<system-reminder>\n"
+            "Background sandbox sessions completed. Output captured below "
+            "(no need to call bash_output unless you want to re-inspect a "
+            "session):\n\n"
+            f"{body}\n"
+            "</system-reminder>"
+        )
+        return {"messages": [HumanMessage(content=reminder)]}
 
     def _refresh_running_jobs(self) -> None:
         """Sync poll for still-running jobs; swallow per-job subprocess errors."""

--- a/decepticon/sandbox_kernel/tmux.py
+++ b/decepticon/sandbox_kernel/tmux.py
@@ -297,16 +297,14 @@ class TmuxSessionManager:
             log_path = f"{self._workspace_path}/.sessions/{self._log_name}.log"
             try:
                 # Idempotent — the directory is bind-mounted to the host so
-                # operators can tail the same file the agent reads.
+                # operators can tail the same file the agent reads. Use
+                # the configured exec_prefix instead of a hardcoded
+                # ``docker exec`` so this works both when the manager
+                # wraps a sibling docker container AND when it runs
+                # in-process inside the HTTP sandbox daemon (where
+                # exec_prefix is empty and no docker socket is reachable).
                 subprocess.run(
-                    [
-                        "docker",
-                        "exec",
-                        self._container,
-                        "mkdir",
-                        "-p",
-                        f"{self._workspace_path}/.sessions",
-                    ],
+                    [*self._exec_prefix, "mkdir", "-p", f"{self._workspace_path}/.sessions"],
                     capture_output=True,
                     timeout=5,
                     check=True,

--- a/decepticon/tools/bash/prompt.py
+++ b/decepticon/tools/bash/prompt.py
@@ -47,13 +47,13 @@ Returns the diff since the last call PLUS one of:
 - `[DONE exit=N elapsed=Ts]` — completed; details delivered ONCE then marked consumed
 - `[IDLE]` — no background job in this session (also after `bash_kill`)
 
-You ALSO receive automatic `<system-reminder>` notifications at the
-start of the next turn after a background job finishes. Notifications
-fire EXACTLY ONCE per completed session. **When a reminder appears,
-call `bash_output(session=)` to retrieve full results and apply them
-to your work** — ignoring it leaves the lifecycle in a half-state. You
-do NOT need to poll bash_output every turn; it is for explicit fetch
-when you decide to look or after seeing a reminder.
+You receive automatic `<system-reminder>` notifications at the start
+of the next turn after a background job finishes — **with the captured
+output already inlined**. Each completion fires EXACTLY ONCE. You do
+not need to call `bash_output` to retrieve the result; read the
+reminder and apply the output to your work. `bash_output` remains
+available for explicit re-inspection of a session you have already
+seen (it will return `(no new output)` on the consumed completion).
 
 ### bash_status() — list known sessions
 
@@ -86,10 +86,8 @@ bash(..., background=True)            ┐
   poll_completion (each turn) detects → status=done
 
         ↓ (next turn's before_model)
-  <system-reminder> emitted ONCE in agent's message stream
-
-        ↓ (you call bash_output)
-  full results returned, status=consumed
+  <system-reminder> emitted ONCE with output inlined — status=consumed
+  (no need to call bash_output; it is a re-inspect tool from here)
 
         ↓ (you call bash_kill, optional)
   job removed from tracker, session torn down, log preserved

--- a/tests/unit/middleware/test_notifications.py
+++ b/tests/unit/middleware/test_notifications.py
@@ -16,10 +16,19 @@ def _state(*messages):
     return {"messages": list(messages)}
 
 
-def _sandbox_with_tracker():
+def _sandbox_with_tracker(diff: str = ""):
+    """Fixture: a sandbox MagicMock whose job tracker is real and whose
+    bash-output / log-path stubs return the given diff (default empty).
+
+    The middleware pulls the session diff on completion, so any test that
+    triggers a completion has to scaffold both ``read_session_log_diff``
+    and ``session_log_path`` — the helper centralizes that.
+    """
     sandbox = MagicMock()
     sandbox._jobs = BackgroundJobTracker()
     sandbox.poll_completion = MagicMock(side_effect=lambda s: sandbox._jobs.get(s))
+    sandbox.read_session_log_diff = MagicMock(return_value=diff)
+    sandbox.session_log_path = MagicMock(return_value="/workspace/.sessions/scan.log")
     return sandbox
 
 
@@ -33,7 +42,7 @@ def test_no_pending_completions_returns_no_update():
 
 
 def test_pending_completion_appends_human_system_reminder():
-    sandbox = _sandbox_with_tracker()
+    sandbox = _sandbox_with_tracker(diff="PORT  STATE SERVICE\n80/tcp open  http\n")
     sandbox._jobs.register("scan", command="nmap target", initial_markers=1)
     sandbox._jobs.mark_complete("scan", exit_code=0)
     mw = SandboxNotificationMiddleware(sandbox=sandbox)
@@ -46,9 +55,16 @@ def test_pending_completion_appends_human_system_reminder():
     new_messages = update["messages"]
     msg = new_messages[0]
     assert isinstance(msg, HumanMessage)
+    # Claude-Code-style bullet header
     assert "<system-reminder>" in msg.content
-    assert "scan" in msg.content
-    assert "exit 0" in msg.content
+    assert "● Background command" in msg.content
+    assert '"nmap target"' in msg.content
+    assert "exit code 0" in msg.content
+    assert "session=scan" in msg.content
+    # Captured diff is inlined — the agent no longer needs bash_output
+    # to retrieve it.
+    assert "80/tcp open" in msg.content
+    sandbox.read_session_log_diff.assert_called()
 
 
 def test_already_notified_completions_are_not_re_emitted():
@@ -209,8 +225,9 @@ def test_command_none_does_not_crash_message_builder() -> None:
 
     assert update is not None
     msg = update["messages"][0]
-    # Empty command renders as ``command=`` (no value); no crash.
-    assert "command=" in msg.content
+    # Empty command renders as ``"..."`` with an empty quoted name; no crash.
+    assert '""' in msg.content
+    assert "exit code 0" in msg.content
 
 
 def test_notified_set_evicts_oldest_when_capped() -> None:


### PR DESCRIPTION
## Summary
Replace pull-style ``bash_output`` polling with Claude-Code-style push notifications. When a background tmux session finishes, the middleware now auto-fetches the captured diff, injects it into the agent's context, AND fires a CLI custom event so the operator transcript shows:

    ● Background command "nmap -sV target" completed (exit code 0) — session=scan · 12.3s
      <captured output>

The agent no longer has to call ``bash_output`` to learn the result — the output rides on the same notification the CLI renders.

Also fixes a latent HTTP-only regression that was silently breaking every background-job log capture.

## Commit structure
1. ``fix(sandbox): pipe-pane mkdir uses configured exec_prefix`` — pipe-pane setup was using hardcoded ``docker exec`` which couldn't work inside the daemon process after PR #263. ``.sessions/`` was never created, ``read_session_log_diff`` always returned empty.
2. ``feat(notifications): push completion + captured output instead of forcing bash_output`` — middleware reads the diff, inlines it in ``<system-reminder>``, emits ``background_complete`` stream event, marks job consumed; ``HTTPSandbox.poll_completion`` switches from drop-on-done to mark-complete so ``pending_completions`` sees the entry; output sanitizer extended to handle bracketed-paste + OSC sequences; ``bash`` tool prompt updated to reflect new contract.
3. ``feat(cli): ● Background command UI for completion notifications`` — new ``BackgroundCompleteMessage`` Ink component routed via ``EventItem``; ``useAgent`` handles the new custom event type; streaming + CLI ``AgentEvent`` types extended.

## Test plan
- [x] ``uv run ruff check .`` / ``ruff format --check`` — pass
- [x] ``uv run basedpyright --level error`` — 0 errors / 0 warnings
- [x] ``uv run pytest -n auto -q -m "not slow"`` — 900 passed (12 in test_notifications.py covering new format + ``read_session_log_diff`` stubbing)
- [x] CLI ``tsc --noEmit`` — pass
- [x] ``docker compose up --build langgraph sandbox`` — healthy
- [x] **E2E** (in-container probe against running stack):
  - ``sb.start_background(command='echo PAYLOAD-MARKER && uname -s', session='probeY', workspace_path='/workspace/probe-eng2')``
  - poll until ``done``
  - ``mw.before_model({'messages': []}, runtime=None)`` returns a HumanMessage whose content reads:
    ```
    <system-reminder>
    Background sandbox sessions completed. Output captured below (no need to call bash_output unless you want to re-inspect a session):
    ● Background command "echo PAYLOAD-MARKER && uname -s" completed (exit code 0) — session=probeY elapsed=0.5s
    ```
    echo PAYLOAD-MARKER && uname -s
    PAYLOAD-MARKER
    Linux
    [DCPTN:0:/workspace/probe-eng2]
    ```
    </system-reminder>
    ```
  - Marker + ``uname -s`` output both present inline; ANSI/OSC noise stripped.

## Follow-up (out of scope)
- The PS1 marker (``[DCPTN:0:...]``) and the echoed command line still appear in the diff. They're visually low-value but harmless to the agent. A future pass could trim them.
- ``bash`` tool prompt still describes ``bash_output`` as fully-functional; once usage telemetry confirms agents stop calling it, we can mark it deprecated.