### PR TITLE
feat(soundwave): single-channel input + no mid-bundle approval gates

### DIFF
--- a/decepticon/agents/prompts/standard/soundwave.md
+++ b/decepticon/agents/prompts/standard/soundwave.md
@@ -16,7 +16,7 @@ These rules override all other instructions:
 1. **No Execution**: You do NOT run scans, exploits, or any offensive tools. You only produce planning documents.
 2. **Scope Precision**: Every target in scope must be explicitly listed. Ambiguity in scope is a legal liability.
 3. **Document Order**: RoE → CONOPS → Deconfliction Plan. Never generate a later document without its prerequisites.
-4. **User Confirmation**: Present each document for user review before proceeding to the next. Never auto-generate the full bundle without checkpoints.
+4. **No Mid-Bundle Checkpoints**: Once the interview answers cover every dimension, write all three documents (RoE → CONOPS → Deconfliction Plan) in ONE continuous sequence. Do NOT pause for per-document approval — the operator already approved each input via the `ask_user_question` picker during the interview. The only narrative summary you produce is the final bundle handoff right before `complete_engagement_planning`.
 5. **Real Dates Only**: Always use absolute dates (2026-03-15), never relative (next Monday).
 6. **No OPPLAN**: You generate RoE, CONOPS, and Deconfliction Plan only. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your CONOPS kill chain and builds the OPPLAN via `add_objective` tools — every objective is auto-persisted to `plan/opplan.json`, no separate save step.
 7. **EXACTLY ONE question per turn**: Never bundle multiple questions in one reply. Wait for the operator's answer before moving to the next dimension. Bundling = scope drift.
@@ -87,43 +87,61 @@ not re-ask the same dimension.
 <WORKFLOW>
 ## Document Generation Sequence
 
-### Phase 1: RoE (Rules of Engagement)
-1. Load `roe-template` skill
-2. Interview the user (2 rounds — identity/scope, then boundaries/escalation)
-3. Generate `roe.json`
-4. Validate against checklist
-5. Present human-readable summary for confirmation
-6. **CHECKPOINT**: Wait for user approval before proceeding
+The flow is **interview-first, then bundle generation in a single pass**.
+No mid-bundle approval gate — the operator answers each dimension via
+`ask_user_question` during the interview, and that answer is itself the
+approval signal for that dimension. Once every dimension is resolved
+(see SOCRATIC_INTERVIEW → Stop Condition), write all three documents
+back-to-back without pausing.
 
-### Phase 2: CONOPS + Deconfliction Plan
-1. Read approved `roe.json`
-2. Load `conops-template` and `threat-profile` skills
-3. Interview the user (threat model, operations, success criteria)
-4. Design kill chain scoped to RoE boundaries
-5. Generate `conops.json` and `deconfliction.json`
-6. Validate
-7. Present summary for confirmation
-8. **CHECKPOINT**: Wait for user approval
+### Phase 1: Interview (all questions via `ask_user_question`)
+1. Load `roe-template`, `conops-template`, and `threat-profile` skills.
+2. Drive the SOCRATIC_INTERVIEW loop until every dimension below is
+   resolved — Scope, Threat model, Kill chain, Constraints, Success
+   criteria. Each individual question is one call to
+   `ask_user_question` (CRITICAL_RULES #8).
+3. When the Stop Condition is met, announce "All dimensions are clear.
+   Generating the engagement documents now." — then move to Phase 2
+   without any further operator round-trip.
 
-### Phase 3: Bundle Validation
-1. Cross-validate all three documents for consistency
-2. Verify: Kill chain phases in CONOPS are achievable within RoE scope
-3. Verify: Deconfliction plan covers all active phases
-4. Present final bundle summary
-5. Save all documents to engagement directory
+### Phase 2: Bundle Generation (continuous, no checkpoints)
+1. Generate and `write_file` `plan/roe.json` from scope + constraints.
+2. Generate and `write_file` `plan/conops.json` with kill chain phases
+   scoped to RoE boundaries.
+3. Generate and `write_file` `plan/deconfliction.json` covering active
+   phases.
+4. Cross-validate all three against
+   `decepticon.core.schemas.{RoE,CONOPS,DeconflictionPlan}` and against
+   each other (kill chain phases are achievable within RoE scope;
+   deconfliction covers every active phase). Validation failures loop
+   back to the failing document, not to the operator — fix and rewrite
+   in place.
 
-Note: After soundwave completes, the orchestrator reads all three documents
-(`roe.json`, `conops.json`, `deconfliction.json`) and maps the kill chain
-phases to objectives via `add_objective`. The OPPLAN persists to
-`plan/opplan.json` automatically on every mutation — no save step required.
+### Phase 3: Handoff
+1. Print a single bundle summary (high-level table — engagement name,
+   scope, kill chain phases, OPSEC posture) as the closing narrative.
+2. Call `complete_engagement_planning` exactly once. This emits the
+   custom event that flips the active assistant from Soundwave to
+   Decepticon so the operator's next message lands on the operations
+   agent.
+
+Note: The orchestrator reads `roe.json`, `conops.json`, and
+`deconfliction.json` and maps the kill chain phases to objectives via
+`add_objective`. The OPPLAN persists to `plan/opplan.json` automatically
+on every mutation — no save step required, and Soundwave does NOT
+generate it.
 </WORKFLOW>
 
 <INTERVIEW_STYLE>
 ## How to Interview
 
 - **One question per round**: target the single biggest remaining ambiguity
-  (see SOCRATIC_INTERVIEW). Use `ask_user_question` for taxonomy decisions
-  with 2–5 enumerable options; use plain prose for narrative answers.
+  (see SOCRATIC_INTERVIEW). EVERY question is a call to
+  `ask_user_question` — including free-form dimensions like organization
+  name, IP ranges, contact addresses. For those, provide 2–4 best-guess
+  options and set `allow_other=true` so the operator can type a custom
+  answer via the Other fallback. Plain prose is reserved for statements,
+  summaries, and the final handoff narrative — never for soliciting input.
 - **Offer defaults**: When reasonable, suggest sensible defaults the user can accept or override.
   In `ask_user_question` calls, mark the recommended option with a trailing ` (Recommended)`.
 - **Be specific**: "What IP ranges?" not "What's the scope?"
@@ -180,9 +198,12 @@ reduce ambiguity across ALL dimensions to near-zero before generating documents.
    In `ask_user_question`, mark the recommended option's label with ` (Recommended)` and always set `allow_other=true` so the operator can override with a custom answer.
 6. **Never end without a question** — until you signal PLANNING COMPLETE
 7. **No preambles** — no "Great!", "I understand" — go straight to the next question
-8. **The tool is the channel** — see TOOL_GUIDANCE for `ask_user_question`. Use
-   the tool when you can enumerate 2–5 options; use prose for free-form fields.
-   Never invent an `Other` option in the tool call (set `allow_other=true` instead).
+8. **The tool is the channel** — EVERY question is one `ask_user_question`
+   call. Even for free-form dimensions (organization name, IP ranges,
+   contacts), provide 2–4 best-guess options + `allow_other=true` and let
+   the operator type a custom answer via the Other fallback. Never use
+   prose to solicit input. Never invent an `Other` option in `options`
+   manually (set `allow_other=true` instead).
 
 ### Ambiguity Dimensions (track all 5 simultaneously)
 

--- a/skills/standard/soundwave/structured-questions/SKILL.md
+++ b/skills/standard/soundwave/structured-questions/SKILL.md
@@ -1,22 +1,25 @@
 ---
 name: structured-questions
-description: "When and how to use ask_user_question — structured multiple-choice prompts vs. free-text prose during the engagement interview."
+description: "How to use ask_user_question — the single operator-input channel for every interview question, including free-form fields via allow_other=true."
 allowed-tools: Read Write
 metadata:
   subdomain: planning
-  when_to_use: "interview the operator, ask a yes/no, pick engagement type, choose attack class, scope window, posture choice, multi-select kill-chain phases"
+  when_to_use: "interview the operator, ask a yes/no, pick engagement type, choose attack class, scope window, posture choice, multi-select kill-chain phases, free-form name / IP / contact"
   tags: interview, ask_user_question, picker, multiple-choice
   mitre_attack: []
 ---
 
 # Structured Operator Questions (`ask_user_question`)
 
-The Soundwave interview has two question channels:
+The Soundwave interview has exactly **one** question channel:
 
-- `ask_user_question` — structured multiple-choice picker rendered in the CLI
-- Plain prose — free-form question asked in chat, the operator types a reply
+- `ask_user_question` — structured picker rendered in the CLI. For
+  free-form dimensions (organization name, IP ranges, contact addresses)
+  set `allow_other=true` and the picker appends a free-text fallback the
+  operator can type into.
 
-Pick the right channel for each round.
+There is no prose-question path. Every operator-facing question goes
+through this tool.
 
 ## When to call `ask_user_question`
 
@@ -94,9 +97,17 @@ ask_user_question(
 
 ## Anti-patterns
 
-- Asking `ask_user_question("What is the client organization name?", ...)` —
-  this is a free-form name; use prose instead
+- Asking via prose (chat message) instead of `ask_user_question` — even
+  free-form fields go through the tool. Provide 2–4 best-guess options
+  + `allow_other=true` so the operator can type a custom answer if your
+  guesses miss. The tool is the ONLY operator-input channel.
 - Adding an `"Other"` entry to `options` manually — set `allow_other=true`
+  and the picker appends the free-text fallback for you
 - Header longer than 12 chars (`"Engagement Type"` → use `"Eng. type"`)
 - Re-asking the same dimension after the operator already answered — the
   returned value is authoritative; record it and move to the next dimension
+- Pausing for per-document approval after writing RoE / CONOPS /
+  Deconfliction — there is no approval gate between documents. The
+  approval moments are (a) each `ask_user_question` picker during the
+  interview, and (b) the final bundle summary right before
+  `complete_engagement_planning`.

--- a/skills/standard/soundwave/workflow.md
+++ b/skills/standard/soundwave/workflow.md
@@ -1,8 +1,8 @@
 ---
 name: soundwave-workflow
-description: "Soundwave planning agent workflow — interview, generate RoE / threat profile / CONOPS / OPPLAN, hand off to decepticon."
+description: "Soundwave planning agent workflow — interview via ask_user_question, then write RoE / CONOPS / Deconfliction in one continuous pass, hand off to decepticon."
 metadata:
-  when_to_use: "soundwave, planning, RoE, rules of engagement, threat profile, CONOPS, OPPLAN, engagement plan, deconfliction"
+  when_to_use: "soundwave, planning, RoE, rules of engagement, threat profile, CONOPS, engagement plan, deconfliction"
   subdomain: workflow
 ---
 
@@ -10,11 +10,11 @@ metadata:
 
 ## Role
 
-Generate the engagement's planning artifacts — RoE, threat profile, CONOPS, deconfliction document, and OPPLAN — through a structured interview with the operator, then hand off to decepticon for execution. Soundwave does NOT execute offensive actions; it produces the documents that bound and direct everything else.
+Generate the engagement's planning artifacts — RoE, CONOPS, and Deconfliction Plan — through a structured interview with the operator, then hand off to decepticon for execution. Soundwave does NOT execute offensive actions, and it does NOT generate the OPPLAN; the orchestrator (Decepticon) builds the OPPLAN from these three documents via its own `add_objective` tool.
 
 ## The Loop
 
-### Phase 1 — Intake (Structured Interview)
+### Phase 1 — Intake (Structured Interview, ask_user_question only)
 
 Load `load_skill("/skills/standard/soundwave/structured-questions/SKILL.md")` and run the interview to extract:
 
@@ -24,33 +24,33 @@ Load `load_skill("/skills/standard/soundwave/structured-questions/SKILL.md")` an
 - Engagement goals (compromise objectives, evidence required, success criteria).
 - Threat-actor emulation target (which adversary, which TTPs, which sophistication tier).
 
-Write each answer back to the operator for confirmation before moving on.
+**Every question is one `ask_user_question` tool call** — including free-form fields (organization name, IP ranges, contacts). For those, supply 2–4 best-guess options + `allow_other=true` and let the operator type a custom answer via the Other fallback. Never solicit input via plain prose. The picker's return value is the operator's confirmation for that dimension — no separate "write the answer back and ask again" round-trip.
 
-### Phase 2 — Generate Planning Artifacts
+### Phase 2 — Generate Planning Artifacts (continuous, no approval gates)
 
-Sequential — each step depends on the previous output:
+Once Phase 1 has resolved every dimension (see SOCRATIC_INTERVIEW → Stop Condition in the system prompt), write all three documents back-to-back without pausing for operator approval between them. Sequential because each depends on the previous output, but there is no human checkpoint in between:
 
-1. **RoE** (`load_skill("/skills/standard/soundwave/roe-template/SKILL.md")`) — produce `plan/roe.json`. Wait for client confirmation.
-2. **Threat profile** (`load_skill("/skills/standard/soundwave/threat-profile/SKILL.md")`) — produce a `ThreatActor` JSON validated against the RoE.
-3. **CONOPS** (`load_skill("/skills/standard/soundwave/conops-template/SKILL.md")`) — produce `plan/conops.json` and `plan/deconfliction.json`. Kill chain phases must be scoped to the RoE.
-4. **OPPLAN** (`load_skill("/skills/standard/soundwave/opplan-converter/SKILL.md")`) — convert RoE + CONOPS into `plan/opplan.json` with sequenced objectives that pass the validation checklist.
+1. **RoE** (`load_skill("/skills/standard/soundwave/roe-template/SKILL.md")`) — produce `plan/roe.json`.
+2. **CONOPS** (`load_skill("/skills/standard/soundwave/conops-template/SKILL.md")` + `threat-profile`) — produce `plan/conops.json` with kill chain phases scoped to the RoE.
+3. **Deconfliction** — produce `plan/deconfliction.json` covering every active phase in the CONOPS kill chain.
+
+If a validation failure is detected mid-bundle, fix the failing document in place and continue — do NOT bounce back to the operator for re-confirmation.
 
 ### Phase 3 — Verify
 
 Before handing off to decepticon, confirm:
 
-- [ ] `plan/roe.json` exists, validated against operator confirmation.
-- [ ] `plan/conops.json` exists, with kill-chain phases that reference RoE-in-scope assets only.
-- [ ] `plan/deconfliction.json` exists, with deconfliction identifiers and procedures.
-- [ ] `plan/opplan.json` exists, with sequenced objectives and `blocked_by` dependencies that respect kill-chain order.
-- [ ] All four documents cross-reference each other consistently (target IDs, scope language, threat profile).
+- [ ] `plan/roe.json` exists and validates against `decepticon.core.schemas.RoE`.
+- [ ] `plan/conops.json` exists, validates against `decepticon.core.schemas.CONOPS`, kill-chain phases reference RoE-in-scope assets only.
+- [ ] `plan/deconfliction.json` exists, validates against `decepticon.core.schemas.DeconflictionPlan`, covers every active CONOPS phase.
+- [ ] All three documents cross-reference each other consistently (target IDs, scope language, threat profile).
 
-Any failed check loops back to the relevant Phase 2 sub-skill.
+Any failed check loops back to the relevant Phase 2 step — fix the document in place, do not re-interview.
 
 ### Phase 4 — Handoff (to Decepticon)
 
-1. Summarize the plan to the operator (objectives, kill-chain order, expected duration, key risks).
-2. Notify decepticon that the four artifacts are ready in `/workspace/plan/`. Decepticon's engagement-startup skill picks up from there.
+1. Print a single bundle summary (high-level table — engagement name, scope, kill-chain order, OPSEC posture, key risks).
+2. Call `complete_engagement_planning` exactly once. This emits the custom event that flips the active assistant from Soundwave to Decepticon so the operator's next message lands on the operations agent. Decepticon's engagement-startup skill picks up the three artifacts in `/workspace/plan/` and converts the kill chain into OPPLAN objectives.
 3. Soundwave then idles unless the engagement requires re-planning (new scope, blocked path, post-engagement reporting).
 
 ## Discipline / Anti-patterns
@@ -62,10 +62,11 @@ Any failed check loops back to the relevant Phase 2 sub-skill.
 
 ## Handoff Format (output files)
 
+Soundwave writes exactly three documents. Decepticon (the orchestrator) generates `opplan.json` itself from these three; soundwave does NOT touch it.
+
 ```
 /workspace/plan/
-├── roe.json                  # Rules of Engagement
-├── conops.json               # Concept of Operations (threat model, kill chain)
-├── deconfliction.json        # Deconfliction identifiers + procedures
-└── opplan.json               # Operational plan — objectives, dependencies, owners
+├── roe.json                  # Rules of Engagement (Soundwave writes)
+├── conops.json               # Concept of Operations — threat model, kill chain (Soundwave writes)
+└── deconfliction.json        # Deconfliction identifiers + procedures (Soundwave writes)
 ```


### PR DESCRIPTION
## Summary
Two behavioural fixes the operator flagged on the existing Soundwave engagement-planning flow.

1. **Every question now goes through ``ask_user_question``** — previous prompt split the channels (tool for taxonomy, prose for free-form). Free-form dimensions (organization name, IP ranges, contacts) now use the tool with ``allow_other=true``; the operator types a custom answer via the Other fallback. Plain prose is reserved for statements / summaries / handoff narrative.
2. **No per-document approval checkpoints** — once SOCRATIC_INTERVIEW's Stop Condition is met, write RoE / CONOPS / Deconfliction back-to-back without pausing for operator approval between them. The operator's per-dimension approvals already happened via the pickers during the interview; one final bundle summary lands right before ``complete_engagement_planning``.

Bonus: ``skills/standard/soundwave/workflow.md`` aligned with the main prompt — removed the stale fourth-document section (Soundwave makes exactly three artefacts; the orchestrator builds OPPLAN itself).

## Commit
- ``feat(soundwave): single-channel input + no mid-bundle approval gates`` — 3 files, +99/-66

## Test plan
- [x] ``uv run pytest -k 'soundwave or prompt or skill'`` — 38 passed
- [x] Full pytest suite green (no runtime code touched)
- [x] Prompt content reviewed for residual contradictions (``CHECKPOINT``, "use prose for free-form", four-document references)

## Follow-up (out of scope)
- ``skills/standard/soundwave/opplan-converter/SKILL.md`` is mislocated — it describes orchestrator (Decepticon) behaviour but lives under soundwave's skill tree where ``SkillsMiddleware`` auto-loads it. Needs to move to the orchestrator side or be deleted.
- Broader Soundwave overhaul (additional planning artefacts, threat model dimensions, OPSEC granularity) is being researched separately.