### PR TITLE
feat(soundwave): expand engagement bundle from 3 to 8 documents + mandatory completion call

### DIFF
--- a/decepticon/agents/prompts/standard/soundwave.md
+++ b/decepticon/agents/prompts/standard/soundwave.md
@@ -15,10 +15,12 @@ These rules override all other instructions:
 
 1. **No Execution**: You do NOT run scans, exploits, or any offensive tools. You only produce planning documents.
 2. **Scope Precision**: Every target in scope must be explicitly listed. Ambiguity in scope is a legal liability.
-3. **Document Order**: RoE → CONOPS → Deconfliction Plan. Never generate a later document without its prerequisites.
-4. **No Mid-Bundle Checkpoints**: Once the interview answers cover every dimension, write all three documents (RoE → CONOPS → Deconfliction Plan) in ONE continuous sequence. Do NOT pause for per-document approval — the operator already approved each input via the `ask_user_question` picker during the interview. The only narrative summary you produce is the final bundle handoff right before `complete_engagement_planning`.
+3. **Document Order**: RoE → Threat Profile → CONOPS → Deconfliction → Contact → Data Handling → Abort → Cleanup. Each later doc may reference fields from earlier ones; never skip ahead. The interview gathers every dimension once; document writing happens in this order without further operator round-trips.
+4. **No Mid-Bundle Checkpoints**: Once the interview answers cover every dimension, write all **eight** documents (RoE → Threat Profile → CONOPS → Deconfliction → Contact → Data Handling → Abort → Cleanup) in ONE continuous sequence. Do NOT pause for per-document approval — the operator already approved each input via the `ask_user_question` picker during the interview. The only narrative summary you produce is the final bundle handoff right before `complete_engagement_planning`.
+
+11. **MANDATORY Completion Signal**: After writing every one of the eight documents successfully, you MUST call `complete_engagement_planning` exactly once. The engagement is NOT complete and the orchestrator handoff does NOT happen until this tool call returns. Skipping it leaves the operator stuck on the Soundwave assistant with no path forward — there is no other way to flip the active assistant. If a document write fails, fix it and continue the sequence; do NOT call the tool until all eight files exist and validate. Do not call it more than once per engagement.
 5. **Real Dates Only**: Always use absolute dates (2026-03-15), never relative (next Monday).
-6. **No OPPLAN**: You generate RoE, CONOPS, and Deconfliction Plan only. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your CONOPS kill chain and builds the OPPLAN via `add_objective` tools — every objective is auto-persisted to `plan/opplan.json`, no separate save step.
+6. **No OPPLAN**: You generate **eight documents** — RoE, CONOPS, Deconfliction, Threat Profile, Contact, Data Handling, Abort, Cleanup. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your bundle (especially CONOPS kill chain + Threat Profile + Cleanup) and builds the OPPLAN via `add_objective` tools — every objective is auto-persisted to `plan/opplan.json`, no separate save step.
 7. **EXACTLY ONE question per turn**: Never bundle multiple questions in one reply. Wait for the operator's answer before moving to the next dimension. Bundling = scope drift.
 8. **EVERY operator-facing question MUST go through `ask_user_question`**: there is no "use the tool for taxonomy and prose for narrative" split. Every time you collect input from the operator, use the tool. Provide 2–5 best-guess options that cover the most common shapes for the dimension, and **always set `allow_other=true`** so the operator can type a custom answer when the predefined options do not fit. Plain prose is reserved for statements, summaries, and document drafts — never for soliciting input.
 9. **Never re-ask for the engagement slug**: the launcher chose it before you started. The slug arrives via the engagement-context block injected into your system prompt — read it there.
@@ -41,16 +43,35 @@ These rules override all other instructions:
 
 <TOOL_GUIDANCE>
 ## write_file — Primary Output Tool
-Save the three planning documents at the workspace root provided in the
-engagement-context block (defaults to `/workspace`):
+Save the **eight** planning documents at the workspace root provided in
+the engagement-context block (defaults to `/workspace`):
 
-- `plan/roe.json` — Rules of Engagement
-- `plan/conops.json` — Concept of Operations
-- `plan/deconfliction.json` — Deconfliction Plan
+| File | Schema | Purpose |
+|---|---|---|
+| `plan/roe.json` | `RoE` | Legal scope + boundaries (always written first) |
+| `plan/threat-profile.json` | `ThreatProfile` | MITRE-mapped adversary persona for OPPLAN's TTP selection |
+| `plan/conops.json` | `CONOPS` | Threat model + kill chain (must stay inside RoE scope) |
+| `plan/deconfliction.json` | `DeconflictionPlan` | Identifiers separating red-team from real-threat activity |
+| `plan/contact.json` | `ContactPlan` | Operator + escalation + abort recipients |
+| `plan/data-handling.json` | `DataHandlingPlan` | Evidence retention + encryption + chain-of-custody |
+| `plan/abort.json` | `AbortPlan` | Halt triggers + AI-aware safety gates |
+| `plan/cleanup.json` | `CleanupPlan` | Expected artifact inventory + removal commands |
 
 The `engagement_name` field inside each document is the operator-facing
 engagement title collected during the interview — distinct from the
 workspace slug.
+
+**Cross-validation invariants** (enforce before handoff):
+- Threat Profile's `initial_access` techniques must be writable under the
+  RoE's `permitted_actions` (e.g. don't list T1566 phishing if RoE
+  forbids social engineering).
+- CONOPS `kill_chain` phases must only reference assets in RoE `in_scope`.
+- Cleanup `artifacts` must list every persistence mechanism implied by
+  the kill chain phases.
+- Abort `halt_triggers` must include at least one EMERGENCY-severity
+  trigger.
+- Data Handling `compliance_frameworks` must match any framework
+  mentioned in RoE prohibited / permitted actions (GDPR, HIPAA, ...).
 
 ## read_file — Reference Loading
 Load skill references for templates and validation checklists.
@@ -105,25 +126,51 @@ back-to-back without pausing.
    without any further operator round-trip.
 
 ### Phase 2: Bundle Generation (continuous, no checkpoints)
-1. Generate and `write_file` `plan/roe.json` from scope + constraints.
-2. Generate and `write_file` `plan/conops.json` with kill chain phases
-   scoped to RoE boundaries.
-3. Generate and `write_file` `plan/deconfliction.json` covering active
-   phases.
-4. Cross-validate all three against
-   `decepticon.core.schemas.{RoE,CONOPS,DeconflictionPlan}` and against
-   each other (kill chain phases are achievable within RoE scope;
-   deconfliction covers every active phase). Validation failures loop
-   back to the failing document, not to the operator — fix and rewrite
-   in place.
 
-### Phase 3: Handoff
+Write all eight documents back-to-back in this order. Each step is a
+single `write_file` call; do not pause for operator approval between
+steps. Validation failures loop back to the failing document, not to
+the operator — fix and rewrite in place.
+
+1. `plan/roe.json` — `RoE` from scope + constraints.
+2. `plan/threat-profile.json` — `ThreatProfile` from threat-actor
+   answers. Pin `tier`, `group_id` (if known), `key_ttps` (5–10 ATT&CK
+   IDs aligned with RoE).
+3. `plan/conops.json` — `CONOPS` with kill chain phases scoped to RoE
+   boundaries. Keep the embedded `threat_actors` (one entry summarizing
+   the standalone profile) for backward-compat.
+4. `plan/deconfliction.json` — `DeconflictionPlan` covering every
+   active phase from CONOPS.
+5. `plan/contact.json` — `ContactPlan` with `primary_operator` and the
+   escalation chain. Set `abort_signal_recipient` to whichever contact
+   should be paged on EMERGENCY triggers.
+6. `plan/data-handling.json` — `DataHandlingPlan`. The schema's default
+   `data_classes` (credentials / pii / source-code / business-data)
+   cover most engagements; override only when compliance frameworks
+   (GDPR / HIPAA / PCI-DSS) demand stricter retention.
+7. `plan/abort.json` — `AbortPlan`. Keep the three default halt triggers
+   (real-incident alert / production data / scope violation) and add
+   engagement-specific triggers from the interview. Tune
+   `hallucination_threshold` and `destructive_action_gate` only when
+   the operator's risk posture demands it.
+8. `plan/cleanup.json` — `CleanupPlan` seeded with expected artifact
+   types implied by the CONOPS kill chain (e.g. persistence implants
+   for any post-exploit phase). Operations agents append concrete
+   entries as they execute.
+
+Cross-validate the bundle (per TOOL_GUIDANCE invariants) before Phase 3.
+
+### Phase 3: Handoff (mandatory — CRITICAL_RULES #11)
 1. Print a single bundle summary (high-level table — engagement name,
-   scope, kill chain phases, OPSEC posture) as the closing narrative.
-2. Call `complete_engagement_planning` exactly once. This emits the
-   custom event that flips the active assistant from Soundwave to
-   Decepticon so the operator's next message lands on the operations
-   agent.
+   scope, kill chain phases, OPSEC posture, threat actor, key abort
+   triggers) as the closing narrative.
+2. **Call `complete_engagement_planning` immediately after the
+   summary, in the same turn.** This is non-negotiable: until this
+   tool fires, the active assistant stays on Soundwave and the
+   operator cannot reach Decepticon. The tool takes no arguments. If
+   you find yourself writing closing prose instead of calling the
+   tool, stop and call the tool first — the prose comes from the
+   tool's emitted event, not from a chat message.
 
 Note: The orchestrator reads `roe.json`, `conops.json`, and
 `deconfliction.json` and maps the kill chain phases to objectives via
@@ -176,9 +223,17 @@ After each phase, show:
 
 <SCHEMA_REFERENCE>
 All documents must validate against schemas in `decepticon.core.schemas`:
-- `RoE` — Rules of Engagement
-- `CONOPS` — Concept of Operations
-- `DeconflictionPlan` — Deconfliction identifiers and procedures
+
+| Schema | Output | Notes |
+|---|---|---|
+| `RoE` | `plan/roe.json` | Legal scope. ``data_handling`` / ``cleanup_required`` / ``incident_procedure`` fields are DEPRECATED — populate the dedicated docs instead. |
+| `ThreatProfile` | `plan/threat-profile.json` | Standalone adversary persona; ``CONOPS.threat_actors`` keeps a one-entry summary for backward-compat. |
+| `CONOPS` | `plan/conops.json` | ``communication_plan`` field is DEPRECATED — populate ``ContactPlan`` instead. |
+| `DeconflictionPlan` | `plan/deconfliction.json` | Identifiers + SOC notification procedure. |
+| `ContactPlan` | `plan/contact.json` | Operator + escalation chain + abort signal recipient. |
+| `DataHandlingPlan` | `plan/data-handling.json` | Per-class retention / encryption; defaults cover most engagements. |
+| `AbortPlan` | `plan/abort.json` | Halt triggers + AI-aware safety gates (`hallucination_threshold`, `destructive_action_gate`). |
+| `CleanupPlan` | `plan/cleanup.json` | Artifact inventory + removal commands; operations agents append entries during execution. |
 </SCHEMA_REFERENCE>
 
 <SOCRATIC_INTERVIEW>
@@ -205,15 +260,19 @@ reduce ambiguity across ALL dimensions to near-zero before generating documents.
    prose to solicit input. Never invent an `Other` option in `options`
    manually (set `allow_other=true` instead).
 
-### Ambiguity Dimensions (track all 5 simultaneously)
+### Ambiguity Dimensions (track all 9 simultaneously)
 
-| Dimension | Key question | Clear when |
-|-----------|-------------|------------|
-| **Scope** | What's in/out? IPs, domains, cloud, physical | Explicit target list + exclusions |
-| **Threat model** | Who are we simulating? | Actor profile with TTPs |
-| **Kill chain** | How deep? Which phases? | Phase list with dependencies |
-| **Constraints** | OPSEC, time, exclusions, tools | All limits explicit |
-| **Success criteria** | Crown jewels — what = win? | Single measurable end-state |
+| Dimension | Key question | Clear when | Document(s) it feeds |
+|-----------|-------------|------------|----------------------|
+| **Scope** | What's in/out? IPs, domains, cloud, physical | Explicit target list + exclusions | RoE |
+| **Threat model** | Who are we simulating? Tier, group ID, motivation | Actor profile with TTPs + CTI delta | ThreatProfile, CONOPS |
+| **Kill chain** | How deep? Which phases? | Phase list with dependencies | CONOPS, Cleanup |
+| **Constraints** | OPSEC, time, exclusions, tools | All limits explicit | RoE, CONOPS |
+| **Success criteria** | Crown jewels — what = win? | Single measurable end-state | CONOPS |
+| **Contacts** | Operator + escalation + abort recipient | Each contact has resolvable channel | ContactPlan |
+| **Data sensitivity** | Will PII / health / source / business data be touched? Compliance frameworks? | Per-class retention + handling notes | DataHandlingPlan |
+| **Abort triggers** | What forces an emergency halt? Custom triggers beyond defaults? | At least one EMERGENCY trigger | AbortPlan |
+| **Persistence footprint** | What artifacts will the kill chain leave behind? | Per-phase implant types + removal commands | CleanupPlan |
 
 ### Questioning Strategy
 
@@ -262,13 +321,19 @@ Once the interview concludes, generate the planning documents:
 
 All three must validate against `decepticon.core.schemas` (RoE, CONOPS, DeconflictionPlan).
 
-### Completion Signal
+### Completion Signal (MANDATORY)
 
-After writing and validating all three files, call the
-`complete_engagement_planning` tool. It takes no arguments — the launcher
-already established the engagement slug, and the tool's emitted event
-flips the active assistant from Soundwave to Decepticon so the operator's
-next message lands on the operations agent without restarting the CLI.
+After writing and validating all **eight** files, call the
+`complete_engagement_planning` tool. **This is not optional.** Without
+it the launcher has no way to flip the active assistant from Soundwave
+to Decepticon — the operator gets stuck.
+
+The tool:
+- Takes no arguments (the launcher already established the engagement slug)
+- Emits a `engagement_ready` custom event that the CLI / web client
+  consumes to swap assistants
+- Returns immediately; you do NOT need to await any further
+  acknowledgement before printing your closing prose
 
 After the tool returns, your closing chat message should confirm the
 handoff in plain prose, for example:
@@ -280,5 +345,11 @@ Planning complete. Decepticon will pick up from your next message.
 You may reference the engagement by name in prose if helpful, but do not
 treat the slug as a tool argument.
 
-Do **not** call `complete_engagement_planning` more than once per engagement.
+**Hard rules:**
+- Do NOT skip the call under any circumstance. Even if the operator
+  says "we'll review first" — call the tool, then await their next
+  message; Decepticon's startup will re-load your documents.
+- Do NOT call `complete_engagement_planning` more than once per engagement.
+- Do NOT call it before all eight `plan/*.json` files exist and
+  validate. If a write fails, fix it first.
 </SOCRATIC_INTERVIEW>

--- a/decepticon/core/schemas.py
+++ b/decepticon/core/schemas.py
@@ -289,9 +289,7 @@ class RoE(BaseModel):
         default=(
             "Stop immediately, document the incident, notify engagement lead within 15 minutes."
         ),
-        description=(
-            "DEPRECATED one-liner — see plan/abort.json for structured halt-triggers."
-        ),
+        description=("DEPRECATED one-liner — see plan/abort.json for structured halt-triggers."),
     )
 
     # Legal

--- a/decepticon/core/schemas.py
+++ b/decepticon/core/schemas.py
@@ -282,8 +282,16 @@ class RoE(BaseModel):
 
     # Escalation
     escalation_contacts: list[EscalationContact] = Field(default_factory=list)
+    # Deprecated: prefer AbortPlan (``plan/abort.json``) for structured
+    # halt-triggers + AI-aware safety gates. Kept as a one-line legacy
+    # default for readers that don't load the expansion doc.
     incident_procedure: str = Field(
-        default="Stop immediately, document the incident, notify engagement lead within 15 minutes."
+        default=(
+            "Stop immediately, document the incident, notify engagement lead within 15 minutes."
+        ),
+        description=(
+            "DEPRECATED one-liner — see plan/abort.json for structured halt-triggers."
+        ),
     )
 
     # Legal
@@ -292,13 +300,26 @@ class RoE(BaseModel):
     )
 
     # Operational limits
+    # Deprecated: prefer DataHandlingPlan (``plan/data-handling.json``) for
+    # structured fields (data classes, retention, encryption). Kept here
+    # as a one-line summary for legacy readers that don't load the
+    # expansion doc.
     data_handling: str = Field(
         default="",
-        description="How discovered PII, credentials, and client data must be handled",
+        description=(
+            "DEPRECATED summary — see plan/data-handling.json for structured fields. "
+            "Kept as a one-line legacy summary."
+        ),
     )
+    # Deprecated: prefer CleanupPlan (``plan/cleanup.json``) for the
+    # full artifact inventory + removal commands. The bool is kept as
+    # a legacy "did the engagement opt out of cleanup entirely?" flag.
     cleanup_required: bool = Field(
         default=True,
-        description="Whether red team must remove tools/artifacts after engagement",
+        description=(
+            "DEPRECATED flag — see plan/cleanup.json for the full artifact "
+            "inventory and removal commands. Kept as a legacy opt-out switch."
+        ),
     )
 
     # Metadata
@@ -352,8 +373,15 @@ class CONOPS(BaseModel):
 
     # Operational
     methodology: str = Field(default="PTES + MITRE ATT&CK framework")
+    # Deprecated: prefer ContactPlan (``plan/contact.json``) for the
+    # structured operator + escalation + abort channels matrix. Kept as
+    # a one-line legacy summary.
     communication_plan: str = Field(
-        default="", description="How red cell communicates with client and internally"
+        default="",
+        description=(
+            "DEPRECATED one-liner — see plan/contact.json for the structured operator + "
+            "escalation + abort channels."
+        ),
     )
 
     # Timeline
@@ -538,20 +566,464 @@ class OPPLAN(BaseModel):
         return _build(None)
 
 
+# ── ThreatProfile (standalone) ───────────────────────────────────────
+#
+# Distinct from ``CONOPS.threat_actors`` (which stays for backward-compat
+# inside the CONOPS doc): the standalone ``plan/threat-profile.json``
+# carries the MITRE-group-ID-keyed adversary persona that Decepticon's
+# OPPLAN builder consults to pick TTP sequences. CTI delta and per-tier
+# numeric grading live here, not in CONOPS.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class ThreatTier(StrEnum):
+    """Adversary tier — numeric grading aligned with the threat-profile
+    skill (Tier 1–4). Distinct from ``ThreatActor.sophistication``,
+    which stays as the free-form CONOPS embedded field."""
+
+    TIER_1 = "tier-1"  # Opportunistic attacker (script-kiddie, opportunistic)
+    TIER_2 = "tier-2"  # Targeted cybercriminal (ransomware crew, financial)
+    TIER_3 = "tier-3"  # APT / nation-state
+    TIER_4 = "tier-4"  # Insider threat (privileged access)
+
+
+class ThreatProfile(BaseModel):
+    """Adversary persona for emulation — stored at ``plan/threat-profile.json``.
+
+    Distinct from ``CONOPS.threat_actors`` (embedded), this is the
+    standalone JSON the orchestrator's OPPLAN-builder consults to choose
+    TTP sequences and the operations agents consult to bound tool
+    selection. One profile per engagement; multi-actor scenarios should
+    pick the dominant emulation target.
+    """
+
+    engagement_name: str
+    actor_name: str = Field(
+        description="Primary actor identifier, e.g. 'APT29-like (Cozy Bear)' or 'Custom — Insider'"
+    )
+    actor_aliases: list[str] = Field(default_factory=list)
+    group_id: str = Field(default="", description="MITRE Groups ID if known, e.g. 'G0050'")
+    tier: ThreatTier
+    sophistication: str = Field(description="low / medium / high / nation-state")
+    motivation: str = Field(description="espionage / financial / disruption / hacktivism / insider")
+    initial_access: list[str] = Field(
+        default_factory=list,
+        description="MITRE ATT&CK initial-access technique IDs (TA0001)",
+    )
+    key_ttps: list[str] = Field(
+        default_factory=list,
+        description="Top 5–10 MITRE ATT&CK technique IDs this actor relies on",
+    )
+    tools: list[str] = Field(
+        default_factory=list,
+        description="Realistic toolset for emulation (e.g. Cobalt Strike, Mimikatz, custom RAT)",
+    )
+    infrastructure: list[str] = Field(
+        default_factory=list,
+        description="C2 patterns, VPS providers, domain naming heuristics",
+    )
+    recent_cti_delta: str = Field(
+        default="",
+        description="Free-text summary of CTI deltas from the most recent 12 months",
+    )
+    confidence: FindingConfidence = Field(
+        default=FindingConfidence.PROBABLE,
+        description="Confidence that the live actor matches this profile",
+    )
+
+    version: str = "1.0"
+    last_updated: str = Field(default_factory=lambda: datetime.now().isoformat())
+
+
+# ── Cleanup & Restoration Plan ───────────────────────────────────────
+#
+# Inventory of every artifact the agent will (or did) create during the
+# engagement, plus the concrete command to remove each one and a
+# verifier command to confirm removal. Drives the post-engagement
+# cleanup tool — without this list, dummy accounts / beacons / scheduled
+# tasks routinely outlive the engagement.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class CleanupArtifact(BaseModel):
+    """Single artifact the agent created on a target during the engagement.
+
+    Filled in mostly during execution (by the operations agents) but
+    Soundwave seeds the plan with the expected categories based on the
+    CONOPS kill chain so each phase has a place to record what it
+    touched.
+    """
+
+    artifact_type: str = Field(
+        description=(
+            "Category: beacon / account / file / scheduled-task / service / "
+            "registry-key / persistence-mechanism / tool / network-rule"
+        )
+    )
+    host: str = Field(description="Hostname, IP, or asset identifier where the artifact lives")
+    path: str = Field(
+        description="File path, registry key, account name, or other concrete locator"
+    )
+    sha256: str = Field(default="", description="SHA-256 of the artifact when it's a file")
+    persistence_mech: str = Field(
+        default="",
+        description=(
+            "If this is a persistence implant: which mech "
+            "(scheduled-task, service, registry-run, cron, systemd-unit, ...)"
+        ),
+    )
+    removal_command: str = Field(
+        description="Concrete command to remove the artifact (idempotent if possible)"
+    )
+    verifier_command: str = Field(
+        default="", description="Command whose zero exit confirms removal"
+    )
+    created_by_objective: str = Field(
+        default="", description="OPPLAN objective ID that created this artifact"
+    )
+    removed: bool = False
+    removed_at: str = Field(default="", description="ISO 8601 timestamp of confirmed removal")
+
+
+class CleanupPlan(BaseModel):
+    """Post-engagement cleanup roster — ``plan/cleanup.json``.
+
+    Replaces ``RoE.cleanup_required`` (deprecated bool flag). The
+    orchestrator and operations agents append to ``artifacts`` as they
+    create persistent state on targets; the engagement is not "complete"
+    until every artifact has ``removed=True`` or has an explicit
+    ``cancellation_reason`` recorded.
+    """
+
+    engagement_name: str
+    completion_criteria: str = Field(
+        default=(
+            "All listed artifacts have removed=True OR a documented "
+            "cancellation_reason (e.g. operator decided to leave a "
+            "honeyfile for blue team training)."
+        )
+    )
+    artifacts: list[CleanupArtifact] = Field(default_factory=list)
+    pre_engagement_baseline: str = Field(
+        default="",
+        description=(
+            "Reference to a pre-engagement system snapshot or backup "
+            "(volume ID, snapshot timestamp, restore command) so the "
+            "operator can roll back if cleanup is incomplete."
+        ),
+    )
+
+    version: str = "1.0"
+    last_updated: str = Field(default_factory=lambda: datetime.now().isoformat())
+
+
+# ── Abort / Crisis Plan ──────────────────────────────────────────────
+#
+# Halt triggers, response actions, and AI-aware safety gates. Replaces
+# ``RoE.incident_procedure`` (deprecated free-form string). The
+# orchestrator's SafetyMiddleware reads this to decide when to freeze
+# the agent loop.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TriggerSeverity(StrEnum):
+    """Severity tier for an abort trigger — drives the agent's response."""
+
+    INFO = "info"  # Log only, continue
+    WARNING = "warning"  # Pause current step, ask operator
+    CRITICAL = "critical"  # Halt the active objective, preserve evidence
+    EMERGENCY = "emergency"  # Halt all agents, freeze workspace, page operator
+
+
+class AbortTrigger(BaseModel):
+    """A single condition that, when matched, triggers the response_action."""
+
+    condition: str = Field(
+        description=(
+            "Concrete condition, e.g. 'SOC issues real-incident alert', "
+            "'real production data observed in scan output', 'scope "
+            "boundary violation detected'"
+        )
+    )
+    severity: TriggerSeverity
+    response_action: str = Field(
+        description=(
+            "Agent's mandated action, e.g. 'halt current objective, "
+            "snapshot workspace, notify operator within 60s'"
+        )
+    )
+    auto_halt: bool = Field(
+        default=True,
+        description=(
+            "Whether the agent halts itself on detection (True) or only "
+            "flags the trigger and awaits operator decision (False)"
+        ),
+    )
+
+
+class AbortPlan(BaseModel):
+    """Halt-trigger roster + AI-aware safety gates — ``plan/abort.json``.
+
+    AI-specific fields (``hallucination_threshold``, ``destructive_action_gate``,
+    ``output_validation``) defend against the LLM-driven failure modes
+    documented in OWASP Top 10 for Agentic Applications (2025.12).
+    """
+
+    engagement_name: str
+    halt_triggers: list[AbortTrigger] = Field(
+        default_factory=lambda: [
+            AbortTrigger(
+                condition="Real-incident alert from blue team / SOC",
+                severity=TriggerSeverity.EMERGENCY,
+                response_action="Halt all agents; preserve evidence; notify operator immediately",
+                auto_halt=True,
+            ),
+            AbortTrigger(
+                condition="Production data observed in collected evidence",
+                severity=TriggerSeverity.CRITICAL,
+                response_action="Halt active objective; quarantine evidence; await operator",
+                auto_halt=True,
+            ),
+            AbortTrigger(
+                condition="Scope boundary violation detected",
+                severity=TriggerSeverity.CRITICAL,
+                response_action="Halt active objective; document the violation; await operator",
+                auto_halt=True,
+            ),
+        ]
+    )
+    abort_signal_channel: str = Field(
+        default="",
+        description=(
+            "Operator-side mechanism to signal abort (file marker, HTTP "
+            "endpoint, ask_user_question response). Empty = no out-of-band "
+            "abort channel; operator pauses via CLI Ctrl+C only."
+        ),
+    )
+    recovery_procedure: str = Field(
+        default=(
+            "After abort: snapshot workspace; export evidence with chain-of-custody; "
+            "run cleanup.json removal commands; require operator approval before resume."
+        )
+    )
+
+    # ── AI-aware safety gates (OWASP Top 10 for Agentic Applications, 2025.12) ──
+    hallucination_threshold: int = Field(
+        default=3,
+        description=(
+            "Count of consecutive unverified-success claims before the agent "
+            "is forced into evidence-collection mode rather than progress"
+        ),
+        ge=1,
+    )
+    destructive_action_gate: bool = Field(
+        default=True,
+        description=(
+            "If True, every command flagged as destructive (rm -rf, drop "
+            "table, format, ...) must pass verify-before-run policy. "
+            "Disable only for read-only engagements."
+        ),
+    )
+    output_validation: str = Field(
+        default="verify-evidence-hash",
+        description=(
+            "Method used to validate agent-reported successes: "
+            "'verify-evidence-hash' (sha256 every artifact), "
+            "'second-tool-confirm' (re-run with different tool), "
+            "'operator-spot-check' (ask_user_question)"
+        ),
+    )
+
+    version: str = "1.0"
+    last_updated: str = Field(default_factory=lambda: datetime.now().isoformat())
+
+
+# ── Contact Plan ─────────────────────────────────────────────────────
+#
+# Slim version of the traditional white-cell/blue-cell/red-cell matrix.
+# For Decepticon's autonomous flow the agent only needs the operator
+# channel, escalation chain, and abort recipient — full red-team
+# cell-management lives outside the agent. Replaces
+# ``CONOPS.communication_plan`` (deprecated free-form string).
+# ─────────────────────────────────────────────────────────────────────
+
+
+class Contact(BaseModel):
+    """A single human contact reachable by the agent or operator."""
+
+    name: str
+    role: str = Field(description="e.g. 'Primary Operator', 'Client SOC Lead', 'Engagement Owner'")
+    channel: str = Field(
+        description=(
+            "Resolvable channel: 'signal:+1234567890', 'email:soc@client.example', "
+            "'pagerduty:service-key', 'slack:#redteam-ops'"
+        )
+    )
+    availability: str = Field(default="24/7", description="Coverage window")
+
+
+class ContactPlan(BaseModel):
+    """Operator + escalation + abort channels — ``plan/contact.json``.
+
+    Designed for autonomous-AI engagements where the agent itself is the
+    "red cell" and only humans staff the white / blue cells. Full
+    multi-cell rosters belong in an external comms doc.
+    """
+
+    engagement_name: str
+    primary_operator: Contact
+    escalation_chain: list[Contact] = Field(
+        default_factory=list,
+        description=(
+            "Ordered list — agent escalates down this chain when the "
+            "primary operator is unreachable past the abort_plan's "
+            "response window."
+        ),
+    )
+    abort_signal_recipient: Contact | None = Field(
+        default=None,
+        description="Who the agent pages on EMERGENCY-severity abort triggers",
+    )
+    external_soc_endpoint: str = Field(
+        default="",
+        description=(
+            "Optional webhook the agent POSTs to before active scanning "
+            "(deconfliction notice). Empty = no external SOC integration."
+        ),
+    )
+    blackout_windows: list[str] = Field(
+        default_factory=list,
+        description=(
+            "ISO 8601 datetime ranges (e.g. '2026-05-21T22:00:00+09:00/PT8H') "
+            "during which the agent must not run active operations"
+        ),
+    )
+
+    version: str = "1.0"
+    last_updated: str = Field(default_factory=lambda: datetime.now().isoformat())
+
+
+# ── Data Handling Plan ───────────────────────────────────────────────
+#
+# Evidence collection, storage, encryption, retention, and chain of
+# custody. Replaces ``RoE.data_handling`` (deprecated free-form string).
+# Drives the operations agents' evidence-storage logic and the post-
+# engagement purge.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class DataClass(BaseModel):
+    """A single category of data the agent may encounter or collect."""
+
+    name: str = Field(
+        description="e.g. 'credentials', 'pii', 'health-records', 'trade-secrets', 'source-code'"
+    )
+    classification: str = Field(description="public / internal / restricted / secret")
+    retention_days: int = Field(
+        description="Days to keep collected evidence of this class before automatic purge",
+        ge=0,
+    )
+    encryption_at_rest: bool = True
+    encryption_in_transit: bool = True
+    handling_notes: str = Field(
+        default="",
+        description=(
+            "Class-specific rules, e.g. 'redact PII before quoting in findings', "
+            "'never store cleartext credentials — hash with bcrypt before logging'"
+        ),
+    )
+
+
+class DataHandlingPlan(BaseModel):
+    """Evidence storage + chain-of-custody — ``plan/data-handling.json``.
+
+    Default ``data_classes`` cover credentials / PII / source-code with
+    conservative retention; engagements with compliance requirements
+    (GDPR, HIPAA, PCI-DSS) override via the interview.
+    """
+
+    engagement_name: str
+    data_classes: list[DataClass] = Field(
+        default_factory=lambda: [
+            DataClass(
+                name="credentials",
+                classification="restricted",
+                retention_days=30,
+                handling_notes="Hash before logging; never quote cleartext in findings.",
+            ),
+            DataClass(
+                name="pii",
+                classification="restricted",
+                retention_days=14,
+                handling_notes="Redact PII fields in findings; aggregate before reporting.",
+            ),
+            DataClass(
+                name="source-code",
+                classification="internal",
+                retention_days=90,
+                handling_notes="OK to quote relevant snippets in findings under fair use.",
+            ),
+            DataClass(
+                name="business-data",
+                classification="restricted",
+                retention_days=14,
+                handling_notes="Do not export beyond the engagement workspace; summarize only.",
+            ),
+        ]
+    )
+    evidence_storage_path: str = Field(
+        default="/workspace/<engagement>/evidence/",
+        description="Engagement-workspace-relative path where collected evidence is stored",
+    )
+    chain_of_custody: bool = Field(
+        default=True,
+        description="If True, every evidence file gets a SHA-256 hash recorded in the Finding",
+    )
+    purge_after_days: int = Field(
+        default=90,
+        description=(
+            "Hard cap — every artifact in evidence/ older than this is purged "
+            "regardless of data_class.retention_days"
+        ),
+        ge=0,
+    )
+    compliance_frameworks: list[str] = Field(
+        default_factory=list,
+        description="Frameworks that bind this engagement: GDPR / HIPAA / PCI-DSS / SOC2 / etc.",
+    )
+
+    version: str = "1.0"
+    last_updated: str = Field(default_factory=lambda: datetime.now().isoformat())
+
+
 # ── Engagement Bundle ─────────────────────────────────────────────────
 
 
 class EngagementBundle(BaseModel):
     """Complete engagement document set.
 
-    The planning agent generates all four documents as a unit.
-    The ralph loop reads roe + opplan each iteration.
+    Soundwave generates the three baseline documents (``roe``, ``conops``,
+    ``deconfliction``) plus the five expansion documents introduced for
+    the AI-autonomous red-team flow (``threat_profile``, ``cleanup``,
+    ``abort``, ``contact``, ``data_handling``). The orchestrator
+    (Decepticon) generates ``opplan`` separately by reading the
+    expansion docs — Soundwave does not write opplan.
+
+    The ralph loop reads roe + opplan each iteration; the operations
+    agents consult ``cleanup`` (to record artifacts) and ``abort``
+    (for halt-trigger evaluation) during execution.
     """
 
     roe: RoE
     conops: CONOPS
     opplan: OPPLAN
     deconfliction: DeconflictionPlan
+    # ── Expansion documents (Soundwave writes; orchestrator + ops consume) ──
+    threat_profile: ThreatProfile | None = None
+    cleanup: CleanupPlan | None = None
+    abort: AbortPlan | None = None
+    contact: ContactPlan | None = None
+    data_handling: DataHandlingPlan | None = None
 
     def save(self, engagement_dir: str) -> dict[str, str]:
         """Save all documents to an engagement workspace directory.
@@ -574,12 +1046,25 @@ class EngagementBundle(BaseModel):
         plan_dir.mkdir(parents=True, exist_ok=True)
 
         files = {}
-        for name, doc in [
+        # Baseline four + the expansion five (optional). The four
+        # baseline docs always serialize even when their content is
+        # default; the expansion docs only serialize when populated so
+        # legacy callers writing only roe/conops/opplan/deconfliction
+        # remain compatible.
+        baseline = [
             ("roe", self.roe),
             ("conops", self.conops),
             ("opplan", self.opplan),
             ("deconfliction", self.deconfliction),
-        ]:
+        ]
+        expansion = [
+            ("threat-profile", self.threat_profile),
+            ("cleanup", self.cleanup),
+            ("abort", self.abort),
+            ("contact", self.contact),
+            ("data-handling", self.data_handling),
+        ]
+        for name, doc in [*baseline, *[(n, d) for n, d in expansion if d is not None]]:
             path = plan_dir / f"{name}.json"
             path.write_text(
                 json.dumps(doc.model_dump(), indent=2, ensure_ascii=False),

--- a/skills/standard/soundwave/abort-template/SKILL.md
+++ b/skills/standard/soundwave/abort-template/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: abort-template
+description: "Abort / crisis plan generator — halt triggers, response actions, AI-aware safety gates (hallucination threshold, destructive-action gate, output validation)."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "create abort plan, emergency halt, crisis procedure, AI safety gate, hallucination guard, destructive action gate"
+  tags: abort, halt, crisis, safety, ai-safety, owasp-agentic
+  mitre_attack: []
+---
+
+# Abort / Crisis Plan Generator
+
+The abort plan defines **when the agent stops**. Without it, the autonomous loop runs through real-incident alerts, scope violations, and production-data exposures as if they were normal operations.
+
+AI-specific gates address the failure modes documented in **OWASP Top 10 for Agentic Applications (2025.12)** — hallucination, prompt injection, unverified destructive actions.
+
+## When to Use
+
+- After CONOPS + Threat Profile + Data Handling are written (the kill chain shapes which triggers are relevant)
+- User says "create abort plan", "halt triggers", "emergency stop", "safety gates"
+
+## Workflow
+
+### Step 1: Keep the Three Default Triggers
+
+The `AbortPlan` schema seeds three default halt triggers. Keep all three; do not remove unless the engagement is explicitly read-only:
+
+1. `EMERGENCY` — Real-incident alert from blue team / SOC
+2. `CRITICAL` — Production data observed in collected evidence
+3. `CRITICAL` — Scope boundary violation detected
+
+### Step 2: Add Engagement-Specific Triggers
+
+Based on the interview answers, add custom `AbortTrigger` entries. Common additions:
+
+| Engagement signal | Severity | Response |
+|---|---|---|
+| Tier-3+ adversary emulation against critical infrastructure | `EMERGENCY` | Halt + operator-page + 1hr cooldown |
+| Compliance-bound data class encountered (GDPR / HIPAA) | `CRITICAL` | Halt; redact; await operator |
+| Network outage or latency spike on target | `WARNING` | Pause active scanning; resume after 5min |
+| LLM cost-per-objective threshold exceeded | `WARNING` | Pause; ask operator to approve budget |
+| C2 beacon lost for > 30 minutes during active phase | `WARNING` | Pause; re-establish C2 before continuing |
+
+### Step 3: Set AI Safety Gates
+
+- `hallucination_threshold` — default 3 (after 3 unverified-success claims, force evidence-collection mode). Lower (2) for high-stakes engagements; never set 0.
+- `destructive_action_gate` — default True. Set False only for read-only / recon-only engagements where no `rm`, `drop`, `format`, `delete-policy` commands will run.
+- `output_validation` — default `"verify-evidence-hash"`. Override to `"second-tool-confirm"` for engagements where evidence cannot be hashed (e.g. real-time API responses).
+
+### Step 4: Set Abort Signal Channel + Recovery Procedure
+
+- `abort_signal_channel` — operator's out-of-band channel for forcing halt (HTTP endpoint, file marker, ask_user_question). Leave empty only if Ctrl+C-via-CLI is the only abort path.
+- `recovery_procedure` — default text covers the standard flow (snapshot → export evidence → run cleanup → operator approval). Override for engagements with custom recovery semantics.
+
+## Validation Checklist
+
+Before writing `plan/abort.json`:
+
+- [ ] At least one `EMERGENCY`-severity trigger exists
+- [ ] All custom triggers have non-empty `condition` and `response_action`
+- [ ] `hallucination_threshold` ≥ 1
+- [ ] `output_validation` matches one of the documented methods
+- [ ] `abort_signal_channel` is set OR explicitly marked "CLI Ctrl+C only"
+
+## Anti-patterns
+
+- Removing the EMERGENCY default — guarantees the agent runs through a SOC real-incident alert
+- Setting `destructive_action_gate=False` for engagements that include post-exploit or cleanup phases
+- Conflating WARNING and CRITICAL — WARNING pauses one step; CRITICAL halts the active objective
+
+## Output
+
+Write to `plan/abort.json` validating against `decepticon.core.schemas.AbortPlan`.

--- a/skills/standard/soundwave/cleanup-template/SKILL.md
+++ b/skills/standard/soundwave/cleanup-template/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cleanup-template
+description: "Cleanup & restoration plan generator — artifact inventory, persistence removal commands, pre-engagement baseline, post-engagement verification."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "create cleanup plan, artifact inventory, persistence removal, post-engagement teardown, restoration plan"
+  tags: cleanup, restoration, persistence, post-engagement, hygiene
+  mitre_attack: []
+---
+
+# Cleanup & Restoration Plan Generator
+
+The cleanup plan is the **anti-foothold roster** — every artifact the kill chain will create must have a concrete removal command and a verifier, or dummy accounts / scheduled tasks / beacons routinely outlive the engagement.
+
+## When to Use
+
+- After CONOPS is written (the kill chain phases dictate what artifacts will exist)
+- User says "create cleanup plan", "list what we'll leave behind", "post-engagement teardown"
+
+## Workflow
+
+### Step 1: Map Kill Chain Phases → Expected Artifact Types
+
+For every phase in CONOPS.kill_chain, infer which `CleanupArtifact.artifact_type` entries will be produced:
+
+| Kill Chain Phase | Likely artifact_types |
+|---|---|
+| recon | `tool` (installed scanners), `network-rule` (firewall whitelist) |
+| initial-access | `account` (test users), `file` (uploaded payloads), `tool` (web shells) |
+| post-exploit | `persistence-mechanism` (scheduled-task / service / registry-run), `account` (created backdoor users), `file` (dropped binaries) |
+| c2 | `beacon` (C2 implants), `network-rule` (egress allow), `tool` (sliver / cobalt-strike payloads) |
+| exfiltration | `file` (staged exfil archives), `network-rule` (DNS tunneling) |
+
+### Step 2: Seed CleanupArtifact entries
+
+For each expected artifact, set:
+- `artifact_type` — category above
+- `host` — placeholder (e.g. ``"<initial-access target>"``) — operations agents replace at run time
+- `path` — likely filesystem / registry / account-name location
+- `persistence_mech` — concrete mechanism if applicable
+- `removal_command` — idempotent shell or API call to remove
+- `verifier_command` — zero-exit on success
+- `created_by_objective` — left blank; operations agents fill on creation
+- `removed=False`, `removed_at=""`
+
+### Step 3: Pre-engagement Baseline
+
+Set `pre_engagement_baseline` to whatever snapshot reference the operator gives during the interview (volume ID, AWS AMI, hypervisor snapshot, manual filesystem hash list). If no baseline is available, record that explicitly — it's a critical risk signal for the engagement owner.
+
+### Step 4: Completion Criteria
+
+Default schema text covers most engagements. Override only when the engagement specifies different completion semantics (e.g. "leave honeyfile FILE_X in place for blue team training" — note as a cancellation_reason on that artifact later).
+
+## Validation Checklist
+
+Before writing `plan/cleanup.json`:
+
+- [ ] Every CONOPS phase that creates persistence has a matching artifact entry
+- [ ] Every artifact has a non-empty `removal_command`
+- [ ] No artifact's `path` references an out-of-scope host
+- [ ] `pre_engagement_baseline` is either set or explicitly marked "no baseline available"
+
+## Anti-patterns
+
+- Leaving `removal_command` empty — operations agents will skip the artifact entirely
+- Putting absolute paths from the operator's machine (engagement workspace is `/workspace/<eng>` inside the sandbox; cleanup runs on TARGETS not the workspace)
+- Forgetting C2 beacons — the kill chain's c2 phase is the most common omission
+
+## Output
+
+Write to `plan/cleanup.json` validating against `decepticon.core.schemas.CleanupPlan`.

--- a/skills/standard/soundwave/contact-template/SKILL.md
+++ b/skills/standard/soundwave/contact-template/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: contact-template
+description: "Contact / communications plan generator — primary operator, escalation chain, abort signal recipient, external SOC endpoint, blackout windows."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "create contact plan, communications plan, escalation chain, operator contacts, SOC notification, blackout window"
+  tags: contact, communications, escalation, soc, deconfliction, blackout
+  mitre_attack: []
+---
+
+# Contact / Communications Plan Generator
+
+Slim version of the traditional white-cell/blue-cell/red-cell matrix tailored for autonomous-AI engagements. The agent itself is the "red cell"; only humans staff the white / blue cells. Full multi-cell rosters belong in an external comms doc, not here.
+
+## When to Use
+
+- After RoE is written (escalation_contacts seed the primary operator)
+- User says "create contact plan", "communications", "who do we notify", "escalation chain"
+
+## Workflow
+
+### Step 1: Identify Primary Operator
+
+This is the single human responsible for the engagement on the operator side. Resolve from the RoE `escalation_contacts`:
+
+- If exactly one contact has the role "engagement lead" or "primary operator" — use that
+- Otherwise ask via `ask_user_question` who the primary is
+
+Fields: `name`, `role`, `channel` (resolvable — Signal, email, PagerDuty service-key, Slack channel), `availability`
+
+### Step 2: Build Escalation Chain
+
+Ordered list of fallbacks. The agent walks this chain when the primary is unreachable past the abort plan's response window (default 15 minutes).
+
+Typical chain:
+1. Primary operator
+2. Engagement owner (lead pentester / red team manager)
+3. Client SOC lead (only contacted on deconfliction events)
+
+### Step 3: Abort Signal Recipient
+
+The contact paged on EMERGENCY-severity abort triggers. Usually = primary operator but can differ (e.g., engagements with a dedicated on-call rotation).
+
+Optional — leave `None` only if the engagement explicitly opts out of EMERGENCY paging (rare).
+
+### Step 4: External SOC Endpoint (Optional)
+
+If the client has an integration endpoint for deconfliction (HTTP webhook, Splunk HEC token, internal ticketing API), record the URL here. The agent POSTs before active scanning begins so the SOC can pre-allowlist red-team activity.
+
+Empty = no external integration; deconfliction happens via the primary operator only.
+
+### Step 5: Blackout Windows
+
+ISO 8601 datetime ranges during which the agent must not run **active** operations (passive recon — DNS, public WHOIS — is usually OK). Format: `"<start>/<duration-or-end>"`, e.g.:
+
+- `"2026-05-22T22:00:00+09:00/PT8H"` — 8 hours starting May 22 22:00 KST
+- `"2026-05-25T00:00:00Z/2026-05-26T00:00:00Z"` — full day UTC
+
+Common blackouts:
+- Production change-management freeze windows
+- Client business-critical events (earnings, product launch)
+- Holidays / weekends (if RoE forbids weekend testing)
+
+## Validation Checklist
+
+Before writing `plan/contact.json`:
+
+- [ ] `primary_operator` is set with a resolvable channel
+- [ ] Escalation chain is ordered (no duplicates, primary listed only once if at all)
+- [ ] `abort_signal_recipient` is set OR `None` with an explicit reason
+- [ ] Blackout windows are valid ISO 8601 ranges
+
+## Anti-patterns
+
+- Listing the primary operator twice (once as `primary_operator`, once in chain) — redundant
+- Using non-resolvable channels ("call John") — the agent can't dial; require a concrete `tel:` / `signal:` / `mailto:` style
+- Blackout windows without timezone — agent will misinterpret in UTC
+
+## Output
+
+Write to `plan/contact.json` validating against `decepticon.core.schemas.ContactPlan`.

--- a/skills/standard/soundwave/data-handling-template/SKILL.md
+++ b/skills/standard/soundwave/data-handling-template/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: data-handling-template
+description: "Data handling plan generator — evidence retention, encryption, chain-of-custody, compliance frameworks (GDPR / HIPAA / PCI-DSS / SOC2)."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "create data handling plan, evidence retention, chain-of-custody, GDPR, HIPAA, PCI-DSS, compliance, PII handling"
+  tags: data-handling, evidence, retention, encryption, chain-of-custody, compliance, gdpr, hipaa
+  mitre_attack: []
+---
+
+# Data Handling Plan Generator
+
+The data handling plan defines **what evidence the agent collects, where it lives, how long it's kept, and who can read it**. Replaces the deprecated free-form `RoE.data_handling` string with structured per-class fields.
+
+## When to Use
+
+- After RoE is written (RoE constraints + scope drive which data classes appear)
+- User says "create data handling", "retention policy", "evidence storage", "PII handling", "compliance"
+
+## Workflow
+
+### Step 1: Start From the Schema Defaults
+
+The `DataHandlingPlan` schema seeds four default classes — credentials, pii, source-code, business-data — with conservative retention. **Keep these by default**; override only when the engagement requires stricter or looser rules.
+
+### Step 2: Add Engagement-Specific Classes
+
+Based on the interview:
+
+| Engagement type | Likely additional classes |
+|---|---|
+| Healthcare client | `health-records` (classification: secret, retention: 7 days, framework: HIPAA) |
+| Financial client | `cardholder-data` (classification: secret, retention: 0 days — never store, framework: PCI-DSS) |
+| EU client / data subjects | Mark existing `pii` with framework: GDPR; consider `personal-data-eu` for stricter handling |
+| Defense / classified | `controlled-unclassified` (classification: secret, retention: 0 days off-network) |
+
+### Step 3: Set Evidence Storage Path
+
+Default `"/workspace/<engagement>/evidence/"` works for sandbox-isolated engagements. Override only when:
+- Engagement requires an external-bucket destination (S3 / Azure Blob with client KMS)
+- Multiple engagement workspaces share an evidence repository
+
+### Step 4: Compliance Frameworks
+
+Set `compliance_frameworks` from the interview. Common entries: GDPR, HIPAA, PCI-DSS, SOC2, NIST 800-53, FedRAMP, ISO 27001.
+
+The orchestrator (Decepticon) reads this list and refuses to start objectives that violate the matching framework's evidence-handling rules.
+
+### Step 5: Purge Hard Cap
+
+`purge_after_days` is the GLOBAL upper bound — every artifact older than this is deleted regardless of per-class retention. Default 90 days; reduce for engagements with tighter regulatory exposure.
+
+## Validation Checklist
+
+Before writing `plan/data-handling.json`:
+
+- [ ] At least one `data_class` is `credentials`-equivalent
+- [ ] Every class has `retention_days >= 0`
+- [ ] `purge_after_days >= max(class.retention_days)` (otherwise classes get cut short)
+- [ ] If `compliance_frameworks` includes HIPAA / GDPR / PCI-DSS, matching data classes exist
+- [ ] `chain_of_custody=True` for any engagement that may produce findings
+
+## Anti-patterns
+
+- Setting `retention_days=0` for `credentials` without explicit operator approval — agent then can't reference creds across phases
+- Disabling `encryption_at_rest` for any restricted+ class — straight compliance violation
+- Listing HIPAA in `compliance_frameworks` without a `health-records` class — orchestrator will refuse objectives that touch PHI
+
+## Output
+
+Write to `plan/data-handling.json` validating against `decepticon.core.schemas.DataHandlingPlan`.

--- a/skills/standard/soundwave/roe-template/SKILL.md
+++ b/skills/standard/soundwave/roe-template/SKILL.md
@@ -23,20 +23,21 @@ The RoE is the **legally binding** foundation of every red team engagement. All 
 
 ### Step 1: Interview the User
 
-Ask these questions in **two rounds** (batch related questions to minimize back-and-forth):
+Drive each dimension through one `ask_user_question` call (per CRITICAL_RULES #8 — every operator-facing question goes through the tool). Cover these roughly in order, never bundling multiple questions in one turn:
 
-**Round 1 — Identity & Scope:**
-1. Engagement name and client organization
-2. Engagement type: `external` / `internal` / `hybrid` / `assumed-breach` / `physical`
-3. Start date, end date, testing window (with timezone)
-4. In-scope targets (domains, IP ranges, cloud resources, applications)
-5. Out-of-scope targets (explicit exclusions)
+**Identity & Scope**
+1. Engagement name (free-form, `allow_other=true` with sensible guesses)
+2. Client organization (free-form, `allow_other=true`)
+3. Engagement type — single-select: `external` / `internal` / `hybrid` / `assumed-breach` / `physical`
+4. Start date / end date / testing window with timezone (free-form, `allow_other=true` — suggest defaults like "Mon-Fri 09:00-18:00 client TZ")
+5. In-scope targets (free-form, `allow_other=true` — domains, IP ranges, cloud resources, applications)
+6. Out-of-scope targets (free-form, `allow_other=true`)
 
-**Round 2 — Boundaries & Escalation:**
-6. Additional prohibited actions beyond defaults
-7. Special permitted actions (phishing, password spraying, etc.)
-8. Escalation contacts (minimum 2: client + red team lead) — name, role, channel
-9. Authorization reference (contract #, signed letter)
+**Boundaries & Escalation**
+7. Additional prohibited actions beyond schema defaults (multi-select with sensible options + `allow_other=true`)
+8. Special permitted actions — phishing, password spraying, raw-socket scans (multi-select)
+9. Escalation contacts — minimum 2 (client + red team lead). One ask per contact slot covering name, role, channel
+10. Authorization reference / contract # (free-form, `allow_other=true`)
 
 ### Step 2: Generate roe.json
 

--- a/skills/standard/soundwave/threat-profile/SKILL.md
+++ b/skills/standard/soundwave/threat-profile/SKILL.md
@@ -56,14 +56,28 @@ The profile must be consistent with what the RoE allows. There's no point emulat
 
 ### Step 4: Output
 
-Generate a `ThreatActor` JSON object for inclusion in `conops.json`:
+Generate **two** payloads:
+
+**(a) Standalone `plan/threat-profile.json`** — full `ThreatProfile` schema:
 
 ```json
 {
-  "name": "APT29-like (Cozy Bear)",
+  "engagement_name": "...",
+  "actor_name": "APT29-like (Cozy Bear)",
+  "actor_aliases": ["Cozy Bear", "The Dukes"],
+  "group_id": "G0050",
+  "tier": "tier-3",
   "sophistication": "nation-state",
   "motivation": "espionage",
   "initial_access": ["T1195.002", "T1566.001", "T1078"],
-  "ttps": ["T1059.001", "T1053.005", "T1071.001", "T1048.003", "T1550.001"]
+  "key_ttps": ["T1059.001", "T1053.005", "T1071.001", "T1048.003", "T1550.001"],
+  "tools": ["Cobalt Strike", "Mimikatz", "WMI Event Subscription"],
+  "infrastructure": ["Compromised SaaS", "Domain fronting via CDN"],
+  "recent_cti_delta": "Q1 2026 reports show shift toward OAuth abuse and CI/CD supply-chain",
+  "confidence": "probable"
 }
 ```
+
+`tier` is the StrEnum value: `"tier-1"` (opportunistic), `"tier-2"` (targeted cybercrime), `"tier-3"` (APT / nation-state), `"tier-4"` (insider). Map to `sophistication` informally — `tier-3` ↔ "nation-state", `tier-2` ↔ "high", `tier-1` ↔ "low/medium".
+
+**(b) Embedded summary** — one-entry `threat_actors` list inside `conops.json` for backward-compat (the legacy `ThreatActor` shape: `name` + `sophistication` + `motivation` + `initial_access` + `ttps`). Skip `tier`/`group_id`/`tools`/`infrastructure` here — those live only in the standalone profile.

--- a/skills/standard/soundwave/workflow.md
+++ b/skills/standard/soundwave/workflow.md
@@ -10,7 +10,18 @@ metadata:
 
 ## Role
 
-Generate the engagement's planning artifacts — RoE, CONOPS, and Deconfliction Plan — through a structured interview with the operator, then hand off to decepticon for execution. Soundwave does NOT execute offensive actions, and it does NOT generate the OPPLAN; the orchestrator (Decepticon) builds the OPPLAN from these three documents via its own `add_objective` tool.
+Generate the engagement's eight planning artifacts through a structured interview with the operator, then hand off to decepticon for execution. The eight artifacts are:
+
+1. **RoE** — legal scope + boundaries
+2. **Threat Profile** — MITRE-mapped adversary persona
+3. **CONOPS** — threat model + kill chain
+4. **Deconfliction Plan** — identifiers separating red-team from real-threat activity
+5. **Contact Plan** — operator + escalation + abort recipients
+6. **Data Handling Plan** — evidence retention + encryption + chain-of-custody
+7. **Abort Plan** — halt triggers + AI-aware safety gates
+8. **Cleanup Plan** — artifact inventory + removal commands
+
+Soundwave does NOT execute offensive actions, and it does NOT generate the OPPLAN; the orchestrator (Decepticon) builds the OPPLAN from this bundle via its own `add_objective` tool.
 
 ## The Loop
 
@@ -28,11 +39,16 @@ Load `load_skill("/skills/standard/soundwave/structured-questions/SKILL.md")` an
 
 ### Phase 2 — Generate Planning Artifacts (continuous, no approval gates)
 
-Once Phase 1 has resolved every dimension (see SOCRATIC_INTERVIEW → Stop Condition in the system prompt), write all three documents back-to-back without pausing for operator approval between them. Sequential because each depends on the previous output, but there is no human checkpoint in between:
+Once Phase 1 has resolved every dimension (see SOCRATIC_INTERVIEW → Stop Condition in the system prompt), write all eight documents back-to-back without pausing for operator approval between them. Sequential because each depends on the previous output, but there is no human checkpoint in between:
 
-1. **RoE** (`load_skill("/skills/standard/soundwave/roe-template/SKILL.md")`) — produce `plan/roe.json`.
-2. **CONOPS** (`load_skill("/skills/standard/soundwave/conops-template/SKILL.md")` + `threat-profile`) — produce `plan/conops.json` with kill chain phases scoped to the RoE.
-3. **Deconfliction** — produce `plan/deconfliction.json` covering every active phase in the CONOPS kill chain.
+1. **RoE** (`load_skill("/skills/standard/soundwave/roe-template/SKILL.md")`) — `plan/roe.json`.
+2. **Threat Profile** (`load_skill("/skills/standard/soundwave/threat-profile/SKILL.md")`) — `plan/threat-profile.json` with `ThreatTier`, `group_id`, `key_ttps`.
+3. **CONOPS** (`load_skill("/skills/standard/soundwave/conops-template/SKILL.md")`) — `plan/conops.json` with kill chain phases scoped to the RoE; embed a one-entry `threat_actors` summary of the standalone profile.
+4. **Deconfliction** — `plan/deconfliction.json` covering every active CONOPS phase.
+5. **Contact Plan** (`load_skill("/skills/standard/soundwave/contact-template/SKILL.md")`) — `plan/contact.json`.
+6. **Data Handling** (`load_skill("/skills/standard/soundwave/data-handling-template/SKILL.md")`) — `plan/data-handling.json`; the schema's default `data_classes` cover most engagements.
+7. **Abort Plan** (`load_skill("/skills/standard/soundwave/abort-template/SKILL.md")`) — `plan/abort.json`; keep the three default halt triggers and add engagement-specific ones.
+8. **Cleanup Plan** (`load_skill("/skills/standard/soundwave/cleanup-template/SKILL.md")`) — `plan/cleanup.json` seeded with artifact types implied by the CONOPS kill chain.
 
 If a validation failure is detected mid-bundle, fix the failing document in place and continue — do NOT bounce back to the operator for re-confirmation.
 
@@ -40,10 +56,13 @@ If a validation failure is detected mid-bundle, fix the failing document in plac
 
 Before handing off to decepticon, confirm:
 
-- [ ] `plan/roe.json` exists and validates against `decepticon.core.schemas.RoE`.
-- [ ] `plan/conops.json` exists, validates against `decepticon.core.schemas.CONOPS`, kill-chain phases reference RoE-in-scope assets only.
-- [ ] `plan/deconfliction.json` exists, validates against `decepticon.core.schemas.DeconflictionPlan`, covers every active CONOPS phase.
-- [ ] All three documents cross-reference each other consistently (target IDs, scope language, threat profile).
+- [ ] All eight `plan/*.json` files exist and validate against their schemas in `decepticon.core.schemas`.
+- [ ] Threat Profile `initial_access` techniques are permitted under RoE.
+- [ ] CONOPS `kill_chain` phases reference RoE-in-scope assets only.
+- [ ] Cleanup `artifacts` cover every persistence-leaving phase.
+- [ ] Abort `halt_triggers` includes at least one EMERGENCY-severity trigger.
+- [ ] Data Handling `compliance_frameworks` matches RoE constraints.
+- [ ] Contact Plan `primary_operator` is set; `abort_signal_recipient` is paged on EMERGENCY.
 
 Any failed check loops back to the relevant Phase 2 step — fix the document in place, do not re-interview.
 
@@ -62,11 +81,16 @@ Any failed check loops back to the relevant Phase 2 step — fix the document in
 
 ## Handoff Format (output files)
 
-Soundwave writes exactly three documents. Decepticon (the orchestrator) generates `opplan.json` itself from these three; soundwave does NOT touch it.
+Soundwave writes exactly eight documents. Decepticon (the orchestrator) generates `opplan.json` itself from this bundle; soundwave does NOT touch it.
 
 ```
 /workspace/plan/
-├── roe.json                  # Rules of Engagement (Soundwave writes)
-├── conops.json               # Concept of Operations — threat model, kill chain (Soundwave writes)
-└── deconfliction.json        # Deconfliction identifiers + procedures (Soundwave writes)
+├── roe.json                  # Rules of Engagement
+├── threat-profile.json       # MITRE-mapped adversary persona
+├── conops.json               # Concept of Operations — kill chain
+├── deconfliction.json        # Deconfliction identifiers + procedures
+├── contact.json              # Operator + escalation + abort recipients
+├── data-handling.json        # Evidence retention + chain-of-custody
+├── abort.json                # Halt triggers + AI-aware safety gates
+└── cleanup.json              # Artifact inventory + removal commands
 ```

--- a/tests/unit/core/test_schemas.py
+++ b/tests/unit/core/test_schemas.py
@@ -1,0 +1,287 @@
+"""Smoke tests for the eight engagement-planning schemas.
+
+The five new schemas (ThreatProfile, CleanupPlan, AbortPlan, ContactPlan,
+DataHandlingPlan) shipped alongside the existing three (RoE, CONOPS,
+DeconflictionPlan). These tests pin their default shapes, round-trip
+JSON, and the EngagementBundle.save() expansion so soundwave's bundle
+generation stays wire-compatible across refactors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from decepticon.core.schemas import (
+    AbortPlan,
+    AbortTrigger,
+    CleanupArtifact,
+    CleanupPlan,
+    CONOPS,
+    Contact,
+    ContactPlan,
+    DataClass,
+    DataHandlingPlan,
+    DeconflictionPlan,
+    EngagementBundle,
+    EngagementType,
+    FindingConfidence,
+    OPPLAN,
+    RoE,
+    ThreatProfile,
+    ThreatTier,
+    TriggerSeverity,
+)
+
+
+# ── ThreatProfile ─────────────────────────────────────────────────────
+
+
+def test_threat_profile_minimum_construction() -> None:
+    """Required fields only — the rest carry defaults."""
+    tp = ThreatProfile(
+        engagement_name="acme-q2",
+        actor_name="APT29-like",
+        tier=ThreatTier.TIER_3,
+        sophistication="nation-state",
+        motivation="espionage",
+    )
+
+    assert tp.actor_aliases == []
+    assert tp.group_id == ""
+    assert tp.confidence == FindingConfidence.PROBABLE
+    assert tp.version == "1.0"
+    assert tp.last_updated  # default factory ran
+
+
+def test_threat_profile_round_trips_through_json() -> None:
+    tp = ThreatProfile(
+        engagement_name="acme-q2",
+        actor_name="APT29-like",
+        actor_aliases=["Cozy Bear"],
+        group_id="G0050",
+        tier=ThreatTier.TIER_3,
+        sophistication="nation-state",
+        motivation="espionage",
+        initial_access=["T1566.001"],
+        key_ttps=["T1059.001", "T1071.001"],
+        recent_cti_delta="2026 CTI: OAuth abuse",
+    )
+
+    encoded = json.dumps(tp.model_dump())
+    rehydrated = ThreatProfile.model_validate_json(encoded)
+
+    assert rehydrated.tier == ThreatTier.TIER_3
+    assert rehydrated.group_id == "G0050"
+    assert rehydrated.key_ttps == ["T1059.001", "T1071.001"]
+
+
+# ── CleanupPlan ───────────────────────────────────────────────────────
+
+
+def test_cleanup_plan_defaults_to_empty_inventory() -> None:
+    cp = CleanupPlan(engagement_name="acme-q2")
+    assert cp.artifacts == []
+    assert "removed=True" in cp.completion_criteria
+
+
+def test_cleanup_artifact_required_fields() -> None:
+    art = CleanupArtifact(
+        artifact_type="beacon",
+        host="10.1.2.3",
+        path="/tmp/.sliver-implant",
+        removal_command="rm -f /tmp/.sliver-implant",
+    )
+    assert art.removed is False
+    assert art.verifier_command == ""
+
+
+# ── AbortPlan ─────────────────────────────────────────────────────────
+
+
+def test_abort_plan_seeds_three_default_triggers() -> None:
+    """The schema default seeds the three baseline triggers. Removing
+    the EMERGENCY default would let the agent run through a real
+    blue-team incident alert — pin the count so a future refactor that
+    drops them fails this test."""
+    ap = AbortPlan(engagement_name="acme-q2")
+    assert len(ap.halt_triggers) == 3
+    assert any(t.severity == TriggerSeverity.EMERGENCY for t in ap.halt_triggers)
+
+
+def test_abort_plan_ai_safety_gates_defaults() -> None:
+    ap = AbortPlan(engagement_name="acme-q2")
+    assert ap.hallucination_threshold >= 1
+    assert ap.destructive_action_gate is True
+    assert ap.output_validation == "verify-evidence-hash"
+
+
+def test_abort_trigger_can_be_custom() -> None:
+    trig = AbortTrigger(
+        condition="Network outage on target",
+        severity=TriggerSeverity.WARNING,
+        response_action="Pause scanning for 5min, resume on healthcheck",
+        auto_halt=False,
+    )
+    assert trig.severity == TriggerSeverity.WARNING
+
+
+def test_abort_plan_hallucination_threshold_rejects_zero() -> None:
+    """``ge=1`` validator on hallucination_threshold prevents a zero
+    that would silently disable the gate."""
+    with pytest.raises(ValueError):
+        AbortPlan(engagement_name="acme-q2", hallucination_threshold=0)
+
+
+# ── ContactPlan ───────────────────────────────────────────────────────
+
+
+def test_contact_plan_minimum_construction() -> None:
+    operator = Contact(name="Op", role="Primary Operator", channel="signal:+10000000000")
+    cp = ContactPlan(engagement_name="acme-q2", primary_operator=operator)
+    assert cp.escalation_chain == []
+    assert cp.abort_signal_recipient is None
+    assert cp.blackout_windows == []
+
+
+def test_contact_plan_with_escalation_chain() -> None:
+    op = Contact(name="Op", role="Primary", channel="email:op@x")
+    owner = Contact(name="Eng Lead", role="Engagement Owner", channel="pagerduty:svc-key")
+    cp = ContactPlan(
+        engagement_name="acme-q2",
+        primary_operator=op,
+        escalation_chain=[owner],
+        abort_signal_recipient=op,
+    )
+    assert len(cp.escalation_chain) == 1
+    assert cp.abort_signal_recipient is op
+
+
+# ── DataHandlingPlan ──────────────────────────────────────────────────
+
+
+def test_data_handling_plan_seeds_four_default_classes() -> None:
+    """Defaults cover credentials / pii / source-code / business-data
+    so engagements without explicit overrides still get conservative
+    retention."""
+    dh = DataHandlingPlan(engagement_name="acme-q2")
+    names = {dc.name for dc in dh.data_classes}
+    assert {"credentials", "pii", "source-code", "business-data"} <= names
+    assert dh.purge_after_days == 90
+    assert dh.chain_of_custody is True
+
+
+def test_data_handling_plan_compliance_frameworks() -> None:
+    dh = DataHandlingPlan(engagement_name="acme-q2", compliance_frameworks=["GDPR", "HIPAA"])
+    assert "GDPR" in dh.compliance_frameworks
+
+
+def test_data_class_retention_rejects_negative() -> None:
+    with pytest.raises(ValueError):
+        DataClass(name="x", classification="internal", retention_days=-1)
+
+
+# ── EngagementBundle.save() expansion ─────────────────────────────────
+
+
+def _minimal_baseline() -> tuple[RoE, CONOPS, OPPLAN, DeconflictionPlan]:
+    """The original four required docs — minimal valid values so the
+    save() bundle tests aren't gated on RoE/CONOPS schema validation."""
+    roe = RoE(
+        engagement_name="acme-q2",
+        client="Acme",
+        start_date="2026-05-21",
+        end_date="2026-05-28",
+        engagement_type=EngagementType.EXTERNAL,
+        testing_window="Mon-Fri 09:00-18:00 KST",
+    )
+    conops = CONOPS(engagement_name="acme-q2", executive_summary="Quarterly external test.")
+    opplan = OPPLAN(engagement_name="acme-q2", threat_profile="APT29-like (Cozy Bear)")
+    deconfliction = DeconflictionPlan(engagement_name="acme-q2")
+    return roe, conops, opplan, deconfliction
+
+
+def test_bundle_save_writes_only_baseline_when_expansion_absent(tmp_path: Path) -> None:
+    """Backward-compat: callers that don't populate the five expansion
+    docs still get the original four files written."""
+    roe, conops, opplan, deconfliction = _minimal_baseline()
+    bundle = EngagementBundle(roe=roe, conops=conops, opplan=opplan, deconfliction=deconfliction)
+
+    files = bundle.save(str(tmp_path))
+
+    plan_dir = tmp_path / "plan"
+    assert sorted(files) == ["conops", "deconfliction", "opplan", "roe"]
+    assert {p.name for p in plan_dir.iterdir()} == {
+        "roe.json",
+        "conops.json",
+        "opplan.json",
+        "deconfliction.json",
+    }
+
+
+def test_bundle_save_writes_expansion_docs_when_populated(tmp_path: Path) -> None:
+    """When the operator supplies the five expansion docs alongside the
+    baseline four, save() writes nine files total (the four baseline
+    plus all five expansion files with hyphenated names)."""
+    roe, conops, opplan, deconfliction = _minimal_baseline()
+    operator = Contact(name="Op", role="Primary", channel="email:op@x")
+
+    bundle = EngagementBundle(
+        roe=roe,
+        conops=conops,
+        opplan=opplan,
+        deconfliction=deconfliction,
+        threat_profile=ThreatProfile(
+            engagement_name="acme-q2",
+            actor_name="APT29-like",
+            tier=ThreatTier.TIER_3,
+            sophistication="nation-state",
+            motivation="espionage",
+        ),
+        cleanup=CleanupPlan(engagement_name="acme-q2"),
+        abort=AbortPlan(engagement_name="acme-q2"),
+        contact=ContactPlan(engagement_name="acme-q2", primary_operator=operator),
+        data_handling=DataHandlingPlan(engagement_name="acme-q2"),
+    )
+
+    files = bundle.save(str(tmp_path))
+    plan_dir = tmp_path / "plan"
+
+    expected = {
+        "roe.json",
+        "conops.json",
+        "opplan.json",
+        "deconfliction.json",
+        "threat-profile.json",
+        "cleanup.json",
+        "abort.json",
+        "contact.json",
+        "data-handling.json",
+    }
+    assert {p.name for p in plan_dir.iterdir()} == expected
+    assert "threat-profile" in files
+    assert "data-handling" in files
+
+
+def test_bundle_save_skips_only_absent_expansion_docs(tmp_path: Path) -> None:
+    """Per-doc independence — populating only some expansion fields
+    writes only those files, not all-or-nothing."""
+    roe, conops, opplan, deconfliction = _minimal_baseline()
+    bundle = EngagementBundle(
+        roe=roe,
+        conops=conops,
+        opplan=opplan,
+        deconfliction=deconfliction,
+        cleanup=CleanupPlan(engagement_name="acme-q2"),
+        # threat_profile / abort / contact / data_handling left None
+    )
+
+    files = bundle.save(str(tmp_path))
+    plan_dir = tmp_path / "plan"
+
+    assert "cleanup" in files
+    assert "threat-profile" not in files
+    assert not (plan_dir / "threat-profile.json").exists()
+    assert (plan_dir / "cleanup.json").exists()

--- a/tests/unit/core/test_schemas.py
+++ b/tests/unit/core/test_schemas.py
@@ -15,11 +15,12 @@ from pathlib import Path
 import pytest
 
 from decepticon.core.schemas import (
+    CONOPS,
+    OPPLAN,
     AbortPlan,
     AbortTrigger,
     CleanupArtifact,
     CleanupPlan,
-    CONOPS,
     Contact,
     ContactPlan,
     DataClass,
@@ -28,13 +29,11 @@ from decepticon.core.schemas import (
     EngagementBundle,
     EngagementType,
     FindingConfidence,
-    OPPLAN,
     RoE,
     ThreatProfile,
     ThreatTier,
     TriggerSeverity,
 )
-
 
 # ── ThreatProfile ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Brings Soundwave's pre-engagement output into line with the document set 2026 industry standards (MITRE ATT&CK / CTID, CREST 2025, NIST SP 800-115, OWASP Top 10 for Agentic Applications 2025.12) flag as the minimum for autonomous red-team operations.

The three baseline docs (RoE / CONOPS / Deconfliction) stay; **five expansion docs** join the bundle:

- **Threat Profile** — MITRE-mapped adversary persona (group_id, ThreatTier 1-4, key TTPs, recent CTI delta) that Decepticon's OPPLAN builder consults to pick TTP sequences.
- **Cleanup Plan** — artifact inventory + concrete removal commands. Replaces the deprecated ``RoE.cleanup_required`` bool flag.
- **Abort Plan** — halt-trigger roster seeded with three baseline EMERGENCY / CRITICAL triggers + AI-aware safety gates (``hallucination_threshold``, ``destructive_action_gate``, ``output_validation``). Replaces the deprecated ``RoE.incident_procedure`` free-form string.
- **Contact Plan** — slim operator + escalation + abort-recipient roster tailored for autonomous-AI engagements where the agent is the red cell.
- **Data Handling Plan** — per-class evidence retention + encryption + chain-of-custody. Defaults cover credentials / pii / source-code / business-data; HIPAA / GDPR / PCI-DSS engagements override.

## Operator-flagged behaviour fixes (in scope)
- **Mandatory completion call**: new CRITICAL_RULES #11 makes ``complete_engagement_planning`` non-negotiable. Without it the active assistant stays on Soundwave and the operator cannot reach Decepticon — the prompt spells out the consequence and the exact when (after all eight files validate, before any closing prose).

## Commit structure
1. ``feat(schemas): five planning-doc schemas for autonomous red-team bundle`` — ThreatProfile / CleanupPlan / AbortPlan / ContactPlan / DataHandlingPlan + helper types + EngagementBundle.save() expansion. Existing string fields (``RoE.data_handling`` etc.) marked DEPRECATED but kept for backward-compat.
2. ``feat(soundwave): 8-doc bundle generation with mandatory completion call`` — system prompt updates (CRITICAL_RULES, SOCRATIC_INTERVIEW dimensions 5→9, WORKFLOW Phase 2 sequence, SCHEMA_REFERENCE matrix, Completion Signal hardening), four new skill templates, threat-profile + roe-template + workflow.md updates.
3. ``test(schemas): pin shapes + bundle behaviour for the eight planning docs`` — 16 smoke tests pinning required-field shapes, JSON round-trip, default triggers / classes, validator boundaries, and the three EngagementBundle.save() flows (baseline-only, fully populated, partial expansion).

## Test plan
- [x] ``uv run ruff check .`` / ``ruff format --check`` — pass
- [x] ``uv run basedpyright --level error`` — 0 errors / 0 warnings / 0 notes
- [x] ``uv run pytest -n auto -q -m "not slow"`` — **916 passed** (900 → 916, +16 from new test_schemas.py)
- [x] Schema import + default-instance smoke confirms all five new types instantiate with their seeded defaults (3 abort triggers, 4 data classes)

## Sources for the new doc set
- [NIST SP 800-115 — Technical Guide to Information Security Testing](https://csrc.nist.gov/pubs/sp/800/115/final)
- [MITRE CTID — Adversary Emulation Library](https://ctid.mitre.org/resources/adversary-emulation-library/)
- [CREST Certified Red Team Specialist Syllabus v2.1 (2024)](https://www.crest-approved.org/wp-content/uploads/2024/12/CREST-Certified-Red-Team-Specialist-Syllabus-v2.1.pdf)
- [OWASP Top 10 for Agentic Applications (2025.12)](https://www.trydeepteam.com/docs/frameworks-owasp-top-10-for-agentic-applications)
- [TrustedSec — Red Team Engagement Guide](https://trustedsec.com/blog/red-team-engagement-guide-how-an-organization-should-react)

## Follow-up (out of scope)
- ``skills/standard/soundwave/opplan-converter/SKILL.md`` is mislocated — describes orchestrator (Decepticon) behaviour but lives under soundwave's skill tree.
- OPSEC 2D matrix upgrade (axis + posture + direction) — P2 follow-up.
- AI Autonomy Safety Annex (full Hallucination Audit / Prompt Injection / Tool Boundary fields) — P3 follow-up.
- Live LLM smoke against a fresh ``make smoke`` stack — gated on the OAuth credential mount available in the worktree's docker env.