### PR TITLE
feat(agents): plugin override system + langchain-style library API for 16 agent factories

### DIFF
--- a/decepticon/agents/assembly.py
+++ b/decepticon/agents/assembly.py
@@ -1,0 +1,435 @@
+"""Agent assembly helpers — the bridge between the slot registry, the
+plugin loader, and the per-agent factory functions.
+
+Two override channels feed into the same assembly pipeline:
+
+  1. **Library callers** pass explicit overrides via factory kwargs
+     (``create_soundwave_agent(middleware_overrides={...},
+     tool_overrides={...}, ...)``). This is the Path B / library-first
+     mode — full Python composition, no entry-point magic needed.
+
+  2. **Plugin packages** ship declarative ``PluginBundle`` objects under
+     the ``decepticon.bundles`` entry-point group. The bundle carries
+     the same shape (``replaced_middleware``, ``disabled_tools``,
+     ``prompt_overrides``, ...) and the assembler merges them with the
+     library caller's explicit kwargs before applying.
+
+Conflict resolution: explicit kwargs win over plugin entry-points. The
+rationale is library callers usually want to opt out of a plugin's
+override for a specific agent without uninstalling the plugin.
+
+Safety: a small allowlist of slots and tools are flagged
+``safety_critical``. Disabling or replacing them requires
+``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` in the environment; otherwise
+``SafetyOverrideViolation`` is raised at agent-construction time.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any
+
+from decepticon.agents.middleware_slots import (
+    DEFAULT_SLOT_FACTORIES,
+    SAFETY_CRITICAL_SLOTS,
+    SLOTS_PER_ROLE,
+    MiddlewareSlot,
+)
+from decepticon.plugin_loader import (
+    PluginBundle,
+    is_bundle_enabled,
+    load_plugin_middleware,
+    load_plugin_tools,
+)
+
+logger = logging.getLogger(__name__)
+
+# Tools flagged safety-critical. Disabling or replacing requires the
+# env gate — they are the operator-approval and engagement-handoff
+# signals; silently replacing them is the difference between an agent
+# that asks permission and one that doesn't.
+SAFETY_CRITICAL_TOOLS: frozenset[str] = frozenset(
+    {
+        "ask_user_question",
+        "complete_engagement_planning",
+    }
+)
+
+# Environment variable that unlocks safety-critical overrides for the
+# current process. Single-value (not per-component) on purpose — easier
+# to audit, harder to mis-configure.
+SAFETY_OVERRIDE_ENV: str = "DECEPTICON_ALLOW_SAFETY_OVERRIDES"
+
+# Entry-point group for declarative ``PluginBundle`` overrides. The
+# existing ``decepticon.tools`` / ``decepticon.middleware`` /
+# ``decepticon.callbacks`` groups stay for additive contributions; this
+# new group is exclusively for plugins that need to disable or replace
+# pieces of the standard stack.
+BUNDLES_GROUP: str = "decepticon.bundles"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Exceptions
+# ─────────────────────────────────────────────────────────────────────
+
+
+class SafetyOverrideViolation(RuntimeError):
+    """Raised when a plugin or library caller tries to disable or replace
+    a safety-critical slot/tool without the ``DECEPTICON_ALLOW_SAFETY_OVERRIDES``
+    env gate set."""
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Bundle discovery
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _iter_override_bundles(role: str) -> Iterator[PluginBundle]:
+    """Yield every ``PluginBundle`` registered under
+    ``decepticon.bundles`` that is enabled AND scoped to ``role``."""
+    try:
+        eps = list(entry_points(group=BUNDLES_GROUP))
+    except Exception:  # noqa: BLE001 — entry-point introspection is best-effort
+        logger.exception("plugin discovery failed for group %s", BUNDLES_GROUP)
+        return
+
+    for ep in eps:
+        try:
+            obj = ep.load()
+        except Exception:  # noqa: BLE001
+            logger.exception("failed to load %s:%s", BUNDLES_GROUP, ep.name)
+            continue
+        # Accept either a PluginBundle instance or a zero-arg factory
+        # returning one — mirrors the dual shape ``_discover`` already
+        # accepts for the additive groups.
+        if callable(obj) and not isinstance(obj, PluginBundle):
+            try:
+                obj = obj()
+            except Exception:  # noqa: BLE001
+                logger.exception("override bundle factory %s raised", ep.name)
+                continue
+        if not isinstance(obj, PluginBundle):
+            logger.warning(
+                "entry-point %s:%s did not return a PluginBundle (got %r); skipping",
+                BUNDLES_GROUP,
+                ep.name,
+                type(obj).__name__,
+            )
+            continue
+        if not is_bundle_enabled(obj.bundle):
+            continue
+        if not obj.matches_role(role):
+            continue
+        yield obj
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Override resolution
+# ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _ResolvedOverrides:
+    """Merge of plugin entry-point + explicit kwarg overrides for one role."""
+
+    middleware_replace: dict[str, Callable[..., Any]] = field(default_factory=dict)
+    middleware_disable: frozenset[str] = field(default_factory=frozenset)
+    tool_replace: dict[str, Any] = field(default_factory=dict)
+    tool_disable: frozenset[str] = field(default_factory=frozenset)
+    prompt: dict[str, str] = field(default_factory=dict)
+
+
+def _resolve_overrides(
+    *,
+    role: str,
+    explicit_middleware_replace: dict[MiddlewareSlot, Callable[..., Any]] | None,
+    explicit_middleware_disable: set[MiddlewareSlot] | None,
+    explicit_tool_replace: dict[str, Any] | None,
+    explicit_tool_disable: set[str] | None,
+    explicit_prompt: dict[str, str] | None,
+) -> _ResolvedOverrides:
+    """Walk plugin bundles + merge with explicit kwargs.
+
+    Explicit wins on conflict. Plugin bundles for the same component
+    likewise resolve via last-write-wins (we don't try to detect plugin
+    A vs plugin B conflict — that's a future enhancement).
+    """
+    mw_replace: dict[str, Callable[..., Any]] = {}
+    mw_disable: set[str] = set()
+    tool_replace: dict[str, Any] = {}
+    tool_disable: set[str] = set()
+    prompt: dict[str, str] = {}
+
+    for bundle in _iter_override_bundles(role):
+        mw_replace.update(bundle.replaced_middleware)
+        mw_disable.update(bundle.disabled_middleware)
+        tool_replace.update(bundle.replaced_tools)
+        tool_disable.update(bundle.disabled_tools)
+        bundle_prompt = bundle.prompt_overrides.get(role) or {}
+        for k in ("prepend", "append", "replace"):
+            if k in bundle_prompt:
+                prompt[k] = bundle_prompt[k]
+
+    # Explicit kwargs override plugin entry-points
+    if explicit_middleware_replace:
+        for slot, factory in explicit_middleware_replace.items():
+            mw_replace[slot.value] = factory
+    if explicit_middleware_disable:
+        mw_disable.update(s.value for s in explicit_middleware_disable)
+    if explicit_tool_replace:
+        tool_replace.update(explicit_tool_replace)
+    if explicit_tool_disable:
+        tool_disable.update(explicit_tool_disable)
+    if explicit_prompt:
+        prompt.update(explicit_prompt)
+
+    return _ResolvedOverrides(
+        middleware_replace=mw_replace,
+        middleware_disable=frozenset(mw_disable),
+        tool_replace=tool_replace,
+        tool_disable=frozenset(tool_disable),
+        prompt=prompt,
+    )
+
+
+def _check_safety_gate(
+    *,
+    role: str,
+    mw_replace: dict[str, Callable[..., Any]],
+    mw_disable: frozenset[str],
+    tool_replace: dict[str, Any],
+    tool_disable: frozenset[str],
+) -> None:
+    """Raise ``SafetyOverrideViolation`` when a safety-critical
+    slot/tool is being overridden without the env gate."""
+    if os.environ.get(SAFETY_OVERRIDE_ENV, "").strip().lower() in {"1", "true", "yes"}:
+        return
+
+    safety_slots = {s.value for s in SAFETY_CRITICAL_SLOTS}
+    mw_breach = (set(mw_replace.keys()) | mw_disable) & safety_slots
+    tool_breach = (set(tool_replace.keys()) | tool_disable) & SAFETY_CRITICAL_TOOLS
+
+    if not mw_breach and not tool_breach:
+        return
+
+    bits = []
+    if mw_breach:
+        bits.append(f"middleware slots {sorted(mw_breach)}")
+    if tool_breach:
+        bits.append(f"tools {sorted(tool_breach)}")
+    raise SafetyOverrideViolation(
+        f"Plugin or library caller for role={role!r} tried to override "
+        f"safety-critical {' and '.join(bits)}. Set "
+        f"{SAFETY_OVERRIDE_ENV}=1 in the environment to allow this. "
+        f"Doing so disables a guard rail — only flip it when the "
+        f"replacement honours the same contract (e.g. a replacement "
+        f"EngagementContextMiddleware still injects RoE scope)."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Public API
+# ─────────────────────────────────────────────────────────────────────
+
+
+def assemble_middleware(
+    *,
+    role: str,
+    backend: Any,
+    llm: Any,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    subagents: list | None = None,
+    overrides: dict[MiddlewareSlot, Callable[..., Any]] | None = None,
+    disabled_slots: set[MiddlewareSlot] | None = None,
+) -> list:
+    """Build the middleware stack for ``role``.
+
+    Args:
+        role: agent role name. Drives slot applicability via
+            ``SLOTS_PER_ROLE`` and is passed to every slot factory.
+        backend: deepagents-style filesystem backend (the result of
+            ``make_agent_backend`` — usually ``CompositeBackend``).
+        llm: bound language model for summarization + per-slot use.
+        fallback_models: list passed to ``ModelFallbackMiddleware``;
+            empty / None skips the MODEL_FALLBACK slot.
+        sandbox: the underlying ``HTTPSandbox`` instance — required for
+            the SANDBOX_NOTIFICATION slot if the role uses it.
+        subagents: list of ``CompiledSubAgent`` instances for the
+            SUBAGENT slot (orchestrators only).
+        overrides: explicit slot-replacement mapping. Wins over plugin
+            entry-point bundles on conflict.
+        disabled_slots: explicit slots to skip.
+
+    Returns:
+        ordered list of middleware instances, ready to pass to
+        ``create_agent(..., middleware=...)``.
+    """
+    role_slots = SLOTS_PER_ROLE.get(role)
+    if role_slots is None:
+        raise KeyError(
+            f"unknown role {role!r}; add it to SLOTS_PER_ROLE in "
+            f"decepticon/agents/middleware_slots.py"
+        )
+
+    resolved = _resolve_overrides(
+        role=role,
+        explicit_middleware_replace=overrides,
+        explicit_middleware_disable=disabled_slots,
+        explicit_tool_replace=None,
+        explicit_tool_disable=None,
+        explicit_prompt=None,
+    )
+    _check_safety_gate(
+        role=role,
+        mw_replace=resolved.middleware_replace,
+        mw_disable=resolved.middleware_disable,
+        tool_replace={},
+        tool_disable=frozenset(),
+    )
+
+    factories: dict[str, Callable[..., Any]] = {
+        slot.value: factory for slot, factory in DEFAULT_SLOT_FACTORIES.items()
+    }
+    factories.update(resolved.middleware_replace)
+
+    result: list = []
+    for slot in MiddlewareSlot:  # canonical enum order
+        if slot not in role_slots:
+            continue
+        if slot.value in resolved.middleware_disable:
+            continue
+        instance = factories[slot.value](
+            backend=backend,
+            llm=llm,
+            role=role,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+            subagents=subagents,
+        )
+        # Some slot factories return None when their precondition isn't
+        # met (e.g. MODEL_FALLBACK with empty fallback_models). Skip.
+        if instance is None:
+            continue
+        result.append(instance)
+
+    # Additive plugin middleware appended after the standard slots —
+    # backward-compat escape hatch for plugins that just want to TACK
+    # a middleware on the end without replacing anything.
+    result.extend(load_plugin_middleware(role=role, backend=backend))
+
+    return result
+
+
+def assemble_tools(
+    *,
+    role: str,
+    standard_tools: dict[str, Any] | list[Any] | None = None,
+    overrides: dict[str, Any] | None = None,
+    disabled_tools: set[str] | None = None,
+) -> list[Any]:
+    """Build the tools list for ``role``.
+
+    Args:
+        role: agent role name (for plugin scope + tool-registry lookup).
+        standard_tools: the agent's baseline tools — either a
+            ``dict[name, tool]`` (preferred — direct override by name)
+            or a plain ``list[tool]`` (we infer names via ``.name``
+            attribute).
+        overrides: name → replacement tool. Wins over plugin overrides.
+        disabled_tools: tool names to drop from the baseline.
+
+    Returns:
+        list of tools ready for ``create_agent(..., tools=...)``.
+    """
+    # Normalize the baseline into a name-keyed dict
+    if standard_tools is None:
+        base: dict[str, Any] = {}
+    elif isinstance(standard_tools, dict):
+        base = dict(standard_tools)
+    else:
+        base = {_tool_name(t): t for t in standard_tools}
+
+    resolved = _resolve_overrides(
+        role=role,
+        explicit_middleware_replace=None,
+        explicit_middleware_disable=None,
+        explicit_tool_replace=overrides,
+        explicit_tool_disable=disabled_tools,
+        explicit_prompt=None,
+    )
+    _check_safety_gate(
+        role=role,
+        mw_replace={},
+        mw_disable=frozenset(),
+        tool_replace=resolved.tool_replace,
+        tool_disable=resolved.tool_disable,
+    )
+
+    for name in resolved.tool_disable:
+        base.pop(name, None)
+    base.update(resolved.tool_replace)
+
+    result = list(base.values())
+    result.extend(load_plugin_tools(role=role))
+    return result
+
+
+def _tool_name(tool: Any) -> str:
+    """Best-effort tool name extraction for list-shaped baselines.
+
+    ``langchain_core`` ``@tool`` decorated callables expose ``.name``;
+    plain callables fall back to ``__name__``. We need this to keep the
+    list-shape baseline backwards compatible with the dict shape used
+    by override logic.
+    """
+    if hasattr(tool, "name") and isinstance(tool.name, str):
+        return tool.name
+    return getattr(tool, "__name__", repr(tool))
+
+
+def resolve_prompt_overrides(
+    role: str,
+    *,
+    override: str | dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return the prompt-shaping dict for ``role`` (prepend/append/replace).
+
+    Used by ``load_prompt`` in ``decepticon.agents.prompts`` — kept
+    here so plugin / safety-gate logic lives next to the rest of the
+    override machinery. Callers do NOT include ``decepticon.agents.prompts``
+    here; that module imports this function and applies the dict to the
+    loaded base prompt.
+
+    Args:
+        role: agent role name.
+        override: explicit prompt override from the library caller.
+            ``str`` = full replace. ``dict`` = prepend/append/replace
+            keyed entries. ``None`` = only plugin overrides apply.
+
+    Returns:
+        dict with at most three keys: ``prepend``, ``append``, ``replace``.
+        Caller applies ``replace`` first (if present), then
+        ``prepend`` + ``append`` to the base / replaced prompt.
+    """
+    explicit_dict: dict[str, str] = {}
+    if isinstance(override, str):
+        explicit_dict["replace"] = override
+    elif isinstance(override, dict):
+        for k in ("prepend", "append", "replace"):
+            if k in override:
+                explicit_dict[k] = override[k]
+
+    resolved = _resolve_overrides(
+        role=role,
+        explicit_middleware_replace=None,
+        explicit_middleware_disable=None,
+        explicit_tool_replace=None,
+        explicit_tool_disable=None,
+        explicit_prompt=explicit_dict,
+    )
+    return dict(resolved.prompt)

--- a/decepticon/agents/build.py
+++ b/decepticon/agents/build.py
@@ -1,22 +1,25 @@
-"""Agent assembly helpers — the bridge between the slot registry, the
+"""Agent build helpers — the bridge between the slot registry, the
 plugin loader, and the per-agent factory functions.
 
-Two override channels feed into the same assembly pipeline:
+Two override channels feed into the same pipeline:
 
-  1. **Library callers** pass explicit overrides via factory kwargs
-     (``create_soundwave_agent(middleware_overrides={...},
-     tool_overrides={...}, ...)``). This is the Path B / library-first
-     mode — full Python composition, no entry-point magic needed.
+  1. **Library callers** pass langchain-style kwargs directly to the
+     factory (``create_soundwave_agent(tools=[...], middleware=[...],
+     system_prompt="...")``) — when provided, each kwarg fully replaces
+     the OSS baseline for that surface and the plugin overrides below
+     are skipped for it. ``None`` (default) builds the baseline AND
+     applies plugin overrides.
 
   2. **Plugin packages** ship declarative ``PluginBundle`` objects under
      the ``decepticon.bundles`` entry-point group. The bundle carries
-     the same shape (``replaced_middleware``, ``disabled_tools``,
-     ``prompt_overrides``, ...) and the assembler merges them with the
-     library caller's explicit kwargs before applying.
+     fine-grained shape (``replaced_middleware``, ``disabled_tools``,
+     ``prompts``, ``replaced_subagents`` ...) and ``build_middleware`` /
+     ``build_tools`` apply them when the corresponding factory kwarg is
+     unset.
 
-Conflict resolution: explicit kwargs win over plugin entry-points. The
-rationale is library callers usually want to opt out of a plugin's
-override for a specific agent without uninstalling the plugin.
+Conflict resolution: explicit factory kwargs win over plugin
+entry-points. The rationale is library callers usually want to opt out
+of a plugin's override for a specific agent without uninstalling it.
 
 Safety: a small allowlist of slots and tools are flagged
 ``safety_critical``. Disabling or replacing them requires
@@ -169,7 +172,7 @@ def _resolve_overrides(
         mw_disable.update(bundle.disabled_middleware)
         tool_replace.update(bundle.replaced_tools)
         tool_disable.update(bundle.disabled_tools)
-        bundle_prompt = bundle.prompt_overrides.get(role) or {}
+        bundle_prompt = bundle.prompts.get(role) or {}
         for k in ("prepend", "append", "replace"):
             if k in bundle_prompt:
                 prompt[k] = bundle_prompt[k]
@@ -236,7 +239,7 @@ def _check_safety_gate(
 # ─────────────────────────────────────────────────────────────────────
 
 
-def assemble_middleware(
+def build_middleware(
     *,
     role: str,
     backend: Any,
@@ -244,14 +247,16 @@ def assemble_middleware(
     fallback_models: list | None = None,
     sandbox: Any = None,
     subagents: list | None = None,
+    skill_sources: list[str] | None = None,
     overrides: dict[MiddlewareSlot, Callable[..., Any]] | None = None,
     disabled_slots: set[MiddlewareSlot] | None = None,
+    slots: frozenset[MiddlewareSlot] | None = None,
 ) -> list:
     """Build the middleware stack for ``role``.
 
     Args:
-        role: agent role name. Drives slot applicability via
-            ``SLOTS_PER_ROLE`` and is passed to every slot factory.
+        role: agent role name. Used for plugin-override scoping (via
+            ``PluginBundle.roles``) and passed to every slot factory.
         backend: deepagents-style filesystem backend (the result of
             ``make_agent_backend`` — usually ``CompositeBackend``).
         llm: bound language model for summarization + per-slot use.
@@ -261,20 +266,37 @@ def assemble_middleware(
             the SANDBOX_NOTIFICATION slot if the role uses it.
         subagents: list of ``CompiledSubAgent`` instances for the
             SUBAGENT slot (orchestrators only).
+        skill_sources: explicit ``/skills/<bundle>/`` paths for the
+            SKILLS slot. ``None`` (default) falls back to the OSS
+            convention in ``skills_sources_for(role)`` for the 10
+            standard roles. Plugin-shipped specialists and commercial
+            agents pass an explicit list — the previous hardcoded
+            ``_PLUGIN_SPECIALIST_ROLES`` registry is gone.
         overrides: explicit slot-replacement mapping. Wins over plugin
             entry-point bundles on conflict.
         disabled_slots: explicit slots to skip.
+        slots: middleware slots this agent uses, in canonical enum order.
+            ``None`` (default) looks the role up in ``SLOTS_PER_ROLE`` —
+            the 16 OSS roles ship with mappings there. **Plugin-shipped
+            orchestrators with a custom role name MUST pass an explicit
+            ``slots`` set** since ``SLOTS_PER_ROLE`` only knows OSS
+            roles; without this, the assembler refuses rather than
+            silently building an empty stack.
 
     Returns:
         ordered list of middleware instances, ready to pass to
         ``create_agent(..., middleware=...)``.
     """
-    role_slots = SLOTS_PER_ROLE.get(role)
-    if role_slots is None:
+    if slots is None:
+        slots = SLOTS_PER_ROLE.get(role)
+    if slots is None:
         raise KeyError(
-            f"unknown role {role!r}; add it to SLOTS_PER_ROLE in "
-            f"decepticon/agents/middleware_slots.py"
+            f"unknown role {role!r}; pass ``slots=`` explicitly "
+            f"(plugin orchestrators with a custom role) or add the role "
+            f"to SLOTS_PER_ROLE in decepticon/agents/middleware_slots.py "
+            f"(OSS roles)."
         )
+    role_slots = slots
 
     resolved = _resolve_overrides(
         role=role,
@@ -310,6 +332,7 @@ def assemble_middleware(
             fallback_models=fallback_models,
             sandbox=sandbox,
             subagents=subagents,
+            skill_sources=skill_sources,
         )
         # Some slot factories return None when their precondition isn't
         # met (e.g. MODEL_FALLBACK with empty fallback_models). Skip.
@@ -325,7 +348,7 @@ def assemble_middleware(
     return result
 
 
-def assemble_tools(
+def build_tools(
     *,
     role: str,
     standard_tools: dict[str, Any] | list[Any] | None = None,

--- a/decepticon/agents/middleware_slots.py
+++ b/decepticon/agents/middleware_slots.py
@@ -1,0 +1,299 @@
+"""Middleware slot registry — the plugin-override foundation.
+
+Every Decepticon agent factory composes its middleware stack from a
+fixed, canonically-ordered list of named slots. Plugins replace or
+disable slots by name via ``PluginBundle.replaced_middleware`` /
+``PluginBundle.disabled_middleware`` — no inline middleware construction
+in agent factories, which previously locked SaaS extensions out of the
+standard stack.
+
+Slot order is the canonical assembly order. The 16 agent factories all
+walk ``MiddlewareSlot`` in declaration order; any slot the agent's role
+opts out of (per ``SLOTS_PER_ROLE``) is skipped silently. Plugin-added
+middleware (``PluginBundle.items`` of middleware shape) still appends
+*after* the standard slots — this is the additive escape hatch for new
+middleware that doesn't fit an existing slot.
+
+Adding a new slot is a three-step change: add the enum member, add a
+default factory under ``DEFAULT_SLOT_FACTORIES``, and pin the
+applicability set in ``SLOTS_PER_ROLE``. Adding a new role likewise
+needs an entry in ``SLOTS_PER_ROLE``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import StrEnum
+from typing import Any
+
+# Middleware classes & factory helpers — imported at module level so
+# slot factories don't pay per-call import cost. langchain + langgraph
+# packages are listed as runtime deps; only ``benchmark_skill_sources``
+# is decepticon-internal.
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+from deepagents.middleware.subagents import SubAgentMiddleware
+from deepagents.middleware.summarization import create_summarization_middleware
+from langchain.agents.middleware import ModelFallbackMiddleware
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+
+from decepticon.agents._benchmark_mode import benchmark_skill_sources
+from decepticon.middleware import (
+    EngagementContextMiddleware,
+    FilesystemMiddleware,
+    OPPLANMiddleware,
+    SkillsMiddleware,
+)
+from decepticon.middleware.model_override import ModelOverrideMiddleware
+from decepticon.middleware.notifications import SandboxNotificationMiddleware
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Slot enum
+# ─────────────────────────────────────────────────────────────────────
+
+
+class MiddlewareSlot(StrEnum):
+    """Named slots in the agent middleware stack.
+
+    Enum declaration order = assembly order. The 16 agent factories walk
+    this enum top-to-bottom; only slots in ``SLOTS_PER_ROLE[role]`` are
+    instantiated.
+    """
+
+    ENGAGEMENT_CONTEXT = "engagement-context"
+    SKILLS = "skills"
+    FILESYSTEM = "filesystem"
+    SUBAGENT = "subagent"
+    OPPLAN = "opplan"
+    SANDBOX_NOTIFICATION = "sandbox-notification"
+    MODEL_OVERRIDE = "model-override"
+    MODEL_FALLBACK = "model-fallback"
+    SUMMARIZATION = "summarization"
+    PROMPT_CACHING = "prompt-caching"
+    PATCH_TOOL_CALLS = "patch-tool-calls"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Safety annotations
+# ─────────────────────────────────────────────────────────────────────
+
+
+SAFETY_CRITICAL_SLOTS: frozenset[MiddlewareSlot] = frozenset(
+    {
+        # EngagementContextMiddleware carries RoE constraints into every
+        # tool call — disabling it lets an agent target out-of-scope
+        # hosts without any guard rail. Replacement is fine if the new
+        # middleware honours the same contract; full disable is the
+        # actual hazard.
+        MiddlewareSlot.ENGAGEMENT_CONTEXT,
+        # SandboxNotification tracks background-job completion + emits
+        # the CLI's ``● Background command`` event. Disabling it leaves
+        # operator visibility broken on every background tool call.
+        MiddlewareSlot.SANDBOX_NOTIFICATION,
+    }
+)
+"""Slots a plugin can only replace/disable when
+``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` is set in the environment.
+
+The gate is enforced by ``assemble_middleware`` in
+``decepticon/agents/assembly.py``. Plugins are expected to honour the
+overall contract (e.g. a replacement EngagementContextMiddleware still
+needs to inject scope) — the gate exists so an accidentally-installed
+plugin can't silently subvert the safety story.
+"""
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Per-role applicability
+# ─────────────────────────────────────────────────────────────────────
+
+
+# Common slots every agent uses (the "tail" of the middleware stack).
+_TAIL_SLOTS: frozenset[MiddlewareSlot] = frozenset(
+    {
+        MiddlewareSlot.MODEL_FALLBACK,
+        MiddlewareSlot.SUMMARIZATION,
+        MiddlewareSlot.PROMPT_CACHING,
+        MiddlewareSlot.PATCH_TOOL_CALLS,
+    }
+)
+
+# Base slots — knowledge + filesystem + tail. Every agent gets these.
+_BASE_SLOTS: frozenset[MiddlewareSlot] = _TAIL_SLOTS | {
+    MiddlewareSlot.SKILLS,
+    MiddlewareSlot.FILESYSTEM,
+}
+
+# Standard bash-executing agents (recon/exploit/postexploit/analyst/
+# reverser/contract_auditor/cloud_hunter/ad_operator + plugin
+# specialists verifier/patcher/scanner/exploiter): base + engagement
+# context + sandbox notification.
+_BASH_AGENT_SLOTS: frozenset[MiddlewareSlot] = _BASE_SLOTS | {
+    MiddlewareSlot.ENGAGEMENT_CONTEXT,
+    MiddlewareSlot.SANDBOX_NOTIFICATION,
+}
+
+
+SLOTS_PER_ROLE: dict[str, frozenset[MiddlewareSlot]] = {
+    # ── Standard orchestrator ──
+    "decepticon": _BASE_SLOTS
+    | {
+        MiddlewareSlot.ENGAGEMENT_CONTEXT,
+        MiddlewareSlot.SUBAGENT,
+        MiddlewareSlot.OPPLAN,
+        MiddlewareSlot.MODEL_OVERRIDE,
+    },
+    # ── Standard non-bash agent (planning + interview) ──
+    "soundwave": _BASE_SLOTS | {MiddlewareSlot.ENGAGEMENT_CONTEXT},
+    # ── Standard bash-executing specialists ──
+    "recon": _BASH_AGENT_SLOTS,
+    "exploit": _BASH_AGENT_SLOTS,
+    "postexploit": _BASH_AGENT_SLOTS,
+    "analyst": _BASH_AGENT_SLOTS,
+    "reverser": _BASH_AGENT_SLOTS,
+    "contract_auditor": _BASH_AGENT_SLOTS,
+    "cloud_hunter": _BASH_AGENT_SLOTS,
+    "ad_operator": _BASH_AGENT_SLOTS,
+    # ── Plugin orchestrator (no EngagementContext per the existing
+    # vulnresearch factory — it consumes its parent's context) ──
+    "vulnresearch": _BASE_SLOTS | {MiddlewareSlot.SUBAGENT, MiddlewareSlot.OPPLAN},
+    # ── Plugin read-only specialist (no bash, no SandboxNotification) ──
+    "detector": _BASE_SLOTS,
+    # ── Plugin bash-executing specialists ──
+    "verifier": _BASH_AGENT_SLOTS,
+    "patcher": _BASH_AGENT_SLOTS,
+    "scanner": _BASH_AGENT_SLOTS,
+    "exploiter": _BASH_AGENT_SLOTS,
+}
+"""Role → slot-set mapping. The assembler only walks slots present in
+the role's set; anything else is skipped silently. Plugin agents
+register their own role here via the ``decepticon.agents`` entry-point
+group (handled by ``plugin_loader``)."""
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Skills sources — role-specific
+# ─────────────────────────────────────────────────────────────────────
+
+
+# Plugin specialists share a common pattern: their own plugin skill
+# tree + the analyst standard skills + the shared library. Listing
+# them here keeps the default factory generic; plugins that want a
+# different shape ship a replacement SKILLS slot factory.
+_PLUGIN_SPECIALIST_ROLES: frozenset[str] = frozenset(
+    {"detector", "verifier", "patcher", "scanner", "exploiter"}
+)
+
+
+def skills_sources_for(role: str) -> list[str]:
+    """Per-role SkillsMiddleware ``sources`` list.
+
+    Mirrors the role-specific source lists that previously lived
+    inline inside each agent factory. ``benchmark_skill_sources()`` is
+    appended when ``BENCHMARK_MODE`` is active — see
+    ``decepticon/agents/_benchmark_mode.py``.
+    """
+    if role == "vulnresearch":
+        return [
+            "/skills/plugins/vulnresearch/",
+            "/skills/shared/",
+            *benchmark_skill_sources(),
+        ]
+    if role in _PLUGIN_SPECIALIST_ROLES:
+        return [
+            f"/skills/plugins/{role}/",
+            "/skills/standard/analyst/",
+            "/skills/shared/",
+        ]
+    # Standard agents — decepticon, soundwave, recon, exploit, etc.
+    return [f"/skills/standard/{role}/", "/skills/shared/", *benchmark_skill_sources()]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Default slot factories
+# ─────────────────────────────────────────────────────────────────────
+#
+# Each factory takes a uniform kwarg set: backend, llm, role,
+# fallback_models, sandbox, subagents. Slots that don't need a
+# particular kwarg ignore it (``**_`` keyword sink). The uniform
+# signature lets ``assemble_middleware`` call every slot factory the
+# same way — and lets plugin-supplied replacement factories drop in
+# without surprising arg-shape mismatches.
+
+
+def _make_engagement_context(**_: Any):
+    return EngagementContextMiddleware()
+
+
+def _make_skills(*, backend: Any, role: str, **_: Any):
+    return SkillsMiddleware(backend=backend, sources=skills_sources_for(role))
+
+
+def _make_filesystem(*, backend: Any, **_: Any):
+    return FilesystemMiddleware(backend=backend)
+
+
+def _make_subagent(*, backend: Any, subagents: list | None = None, **_: Any):
+    return SubAgentMiddleware(backend=backend, subagents=subagents or [])
+
+
+def _make_opplan(*, backend: Any, **_: Any):
+    return OPPLANMiddleware(backend=backend)
+
+
+def _make_sandbox_notification(*, sandbox: Any = None, **_: Any):
+    if sandbox is None:
+        raise ValueError(
+            "SandboxNotificationMiddleware requires a sandbox kwarg; "
+            "the agent factory must pass the HTTPSandbox instance it built."
+        )
+    return SandboxNotificationMiddleware(sandbox=sandbox)
+
+
+def _make_model_override(**_: Any):
+    return ModelOverrideMiddleware()
+
+
+def _make_model_fallback(*, fallback_models: list | None = None, **_: Any):
+    """Conditional slot — returns None when no fallback chain exists.
+
+    ``assemble_middleware`` filters None results out so the absent
+    fallback simply skips the slot, mirroring the legacy
+    ``if fallback_models: middleware.append(...)`` branch.
+    """
+    if not fallback_models:
+        return None
+    return ModelFallbackMiddleware(*fallback_models)
+
+
+def _make_summarization(*, backend: Any, llm: Any, **_: Any):
+    return create_summarization_middleware(llm, backend)
+
+
+def _make_prompt_caching(**_: Any):
+    return AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")
+
+
+def _make_patch_tool_calls(**_: Any):
+    return PatchToolCallsMiddleware()
+
+
+SlotFactory = Callable[..., Any]
+
+
+DEFAULT_SLOT_FACTORIES: dict[MiddlewareSlot, SlotFactory] = {
+    MiddlewareSlot.ENGAGEMENT_CONTEXT: _make_engagement_context,
+    MiddlewareSlot.SKILLS: _make_skills,
+    MiddlewareSlot.FILESYSTEM: _make_filesystem,
+    MiddlewareSlot.SUBAGENT: _make_subagent,
+    MiddlewareSlot.OPPLAN: _make_opplan,
+    MiddlewareSlot.SANDBOX_NOTIFICATION: _make_sandbox_notification,
+    MiddlewareSlot.MODEL_OVERRIDE: _make_model_override,
+    MiddlewareSlot.MODEL_FALLBACK: _make_model_fallback,
+    MiddlewareSlot.SUMMARIZATION: _make_summarization,
+    MiddlewareSlot.PROMPT_CACHING: _make_prompt_caching,
+    MiddlewareSlot.PATCH_TOOL_CALLS: _make_patch_tool_calls,
+}
+"""Slot → factory mapping. Plugin overrides shallow-merge into this
+dict at assembly time (without mutating the module-level constant) —
+see ``decepticon.agents.assembly.assemble_middleware``."""

--- a/decepticon/agents/middleware_slots.py
+++ b/decepticon/agents/middleware_slots.py
@@ -45,7 +45,7 @@ from decepticon.middleware import (
 )
 from decepticon.middleware.model_override import ModelOverrideMiddleware
 from decepticon.middleware.notifications import SandboxNotificationMiddleware
-
+from decepticon.plugin_loader import load_plugin_skill_sources
 
 # ─────────────────────────────────────────────────────────────────────
 # Slot enum
@@ -95,8 +95,8 @@ SAFETY_CRITICAL_SLOTS: frozenset[MiddlewareSlot] = frozenset(
 """Slots a plugin can only replace/disable when
 ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` is set in the environment.
 
-The gate is enforced by ``assemble_middleware`` in
-``decepticon/agents/assembly.py``. Plugins are expected to honour the
+The gate is enforced by ``build_middleware`` in
+``decepticon/agents/build.py``. Plugins are expected to honour the
 overall contract (e.g. a replacement EngagementContextMiddleware still
 needs to inject scope) — the gate exists so an accidentally-installed
 plugin can't silently subvert the safety story.
@@ -176,37 +176,27 @@ group (handled by ``plugin_loader``)."""
 # ─────────────────────────────────────────────────────────────────────
 
 
-# Plugin specialists share a common pattern: their own plugin skill
-# tree + the analyst standard skills + the shared library. Listing
-# them here keeps the default factory generic; plugins that want a
-# different shape ship a replacement SKILLS slot factory.
-_PLUGIN_SPECIALIST_ROLES: frozenset[str] = frozenset(
-    {"detector", "verifier", "patcher", "scanner", "exploiter"}
-)
-
-
 def skills_sources_for(role: str) -> list[str]:
-    """Per-role SkillsMiddleware ``sources`` list.
+    """Default SkillsMiddleware ``sources`` list for an OSS role.
 
-    Mirrors the role-specific source lists that previously lived
-    inline inside each agent factory. ``benchmark_skill_sources()`` is
-    appended when ``BENCHMARK_MODE`` is active — see
-    ``decepticon/agents/_benchmark_mode.py``.
+    Returns the path list for one of the 10 standard OSS agents
+    (``recon``, ``exploit``, ``soundwave``, ...). ``benchmark_skill_sources()``
+    is appended when ``BENCHMARK_MODE`` is active — see
+    ``decepticon/agents/_benchmark_mode.py``. Plugin-contributed paths
+    (registered under the ``decepticon.skills`` entry-point group) are
+    appended last so commercial / 3rd-party skills can layer on top of
+    the OSS baseline without overriding the whole SKILLS slot factory.
+
+    Plugin specialists (detector, scanner, vulnresearch, …) and any
+    out-of-tree commercial agent should NOT rely on this fallback —
+    they pass an explicit ``skill_sources=`` kwarg to ``build_middleware``
+    instead (see the 6 OSS plugin factories for the canonical pattern).
+    The fallback exists purely so the OSS 10 standard factories don't
+    have to repeat ``[f"/skills/standard/{_ROLE}/", "/skills/shared/"]``
+    each.
     """
-    if role == "vulnresearch":
-        return [
-            "/skills/plugins/vulnresearch/",
-            "/skills/shared/",
-            *benchmark_skill_sources(),
-        ]
-    if role in _PLUGIN_SPECIALIST_ROLES:
-        return [
-            f"/skills/plugins/{role}/",
-            "/skills/standard/analyst/",
-            "/skills/shared/",
-        ]
-    # Standard agents — decepticon, soundwave, recon, exploit, etc.
-    return [f"/skills/standard/{role}/", "/skills/shared/", *benchmark_skill_sources()]
+    base = [f"/skills/standard/{role}/", "/skills/shared/", *benchmark_skill_sources()]
+    return [*base, *load_plugin_skill_sources(role)]
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -216,7 +206,7 @@ def skills_sources_for(role: str) -> list[str]:
 # Each factory takes a uniform kwarg set: backend, llm, role,
 # fallback_models, sandbox, subagents. Slots that don't need a
 # particular kwarg ignore it (``**_`` keyword sink). The uniform
-# signature lets ``assemble_middleware`` call every slot factory the
+# signature lets ``build_middleware`` call every slot factory the
 # same way — and lets plugin-supplied replacement factories drop in
 # without surprising arg-shape mismatches.
 
@@ -225,8 +215,9 @@ def _make_engagement_context(**_: Any):
     return EngagementContextMiddleware()
 
 
-def _make_skills(*, backend: Any, role: str, **_: Any):
-    return SkillsMiddleware(backend=backend, sources=skills_sources_for(role))
+def _make_skills(*, backend: Any, role: str, skill_sources: list[str] | None = None, **_: Any):
+    sources = list(skill_sources) if skill_sources is not None else skills_sources_for(role)
+    return SkillsMiddleware(backend=backend, sources=sources)
 
 
 def _make_filesystem(*, backend: Any, **_: Any):
@@ -257,7 +248,7 @@ def _make_model_override(**_: Any):
 def _make_model_fallback(*, fallback_models: list | None = None, **_: Any):
     """Conditional slot — returns None when no fallback chain exists.
 
-    ``assemble_middleware`` filters None results out so the absent
+    ``build_middleware`` filters None results out so the absent
     fallback simply skips the slot, mirroring the legacy
     ``if fallback_models: middleware.append(...)`` branch.
     """
@@ -296,4 +287,4 @@ DEFAULT_SLOT_FACTORIES: dict[MiddlewareSlot, SlotFactory] = {
 }
 """Slot → factory mapping. Plugin overrides shallow-merge into this
 dict at assembly time (without mutating the module-level constant) —
-see ``decepticon.agents.assembly.assemble_middleware``."""
+see ``decepticon.agents.build.build_middleware``."""

--- a/decepticon/agents/plugins/detector.py
+++ b/decepticon/agents/plugins/detector.py
@@ -54,11 +54,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.research.tools import (
     cve_by_package,
     cve_lookup,
@@ -79,6 +79,13 @@ _STANDARD_TOOLS: dict[str, Any] = {
     "cve_lookup": cve_lookup,
     "cve_by_package": cve_by_package,
 }
+
+_SKILL_SOURCES: list[str] = [
+    "/skills/plugins/detector/",
+    "/skills/standard/analyst/",
+    "/skills/shared/",
+]
+
 
 _ROLE = "detector"
 _RECURSION_LIMIT = 120
@@ -145,17 +152,18 @@ def create_detector_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
+            skill_sources=_SKILL_SOURCES,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
             sandbox=None,  # no SandboxNotification for detector
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=[])
+        system_prompt = load_prompt(_ROLE, shared=[])
 
     return create_agent(
         llm,
@@ -172,7 +180,8 @@ def create_detector_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_detector_agent()
+if is_bundle_enabled("plugins"):
+    graph = create_detector_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/plugins/detector.py
+++ b/decepticon/agents/plugins/detector.py
@@ -17,27 +17,48 @@ Key design choices — all enforced by the tool surface, not just the prompt:
 
 Tools exposed: the core KG CRUD + query subset of ``RESEARCH_TOOLS``, plus
 ``cve_lookup`` / ``cve_by_package`` for dependency correlation. Nothing else.
+
+EngagementContext and SandboxNotification slots are excluded (see
+SLOTS_PER_ROLE — ``detector`` maps to ``_BASE_SLOTS`` only).
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_detector_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+No SandboxNotification (no bash tool). No SubAgent / OPPLAN (specialist).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import FilesystemMiddleware
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.research.tools import (
     cve_by_package,
     cve_lookup,
@@ -48,77 +69,109 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
+# Name-keyed baseline tools.
+_STANDARD_TOOLS: dict[str, Any] = {
+    "kg_query": kg_query,
+    "kg_neighbors": kg_neighbors,
+    "kg_stats": kg_stats,
+    "kg_add_node": kg_add_node,
+    "kg_add_edge": kg_add_edge,
+    "cve_lookup": cve_lookup,
+    "cve_by_package": cve_by_package,
+}
 
-def create_detector_agent():
-    """Initialize the Detector Agent — sonnet-class, read-only, fresh ctx.
+_ROLE = "detector"
+_RECURSION_LIMIT = 120
+
+
+def create_detector_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Detector agent.
 
     Notes:
       - The Detector reads source files via FilesystemMiddleware exclusively;
-        no sandbox bash access.
+        no sandbox bash access (no sandbox= arg, no set_sandbox() call).
       - Skills are sourced from ``/skills/standard/analyst/*`` (shared with legacy
         analyst — each vuln class has its own playbook) plus a small
         detector-specific operating guide under ``/skills/plugins/detector/``.
       - ``recursion_limit=120`` — source review per candidate burns turns,
         but much less than full analyst iteration loops.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("detector")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("detector")``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 120.
+
+    Returns:
+        Compiled LangGraph agent.
     """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
 
-    factory = LLMFactory()
-    llm = factory.get_model("detector")
-    fallback_models = factory.get_fallback_models("detector")
-
-    sandbox = build_sandbox_backend()
     # No set_sandbox() here — Detector intentionally has no bash tool.
+    sandbox = build_sandbox_backend()
 
-    system_prompt = load_prompt("detector", shared=[])
+    if backend is None:
+        backend = make_agent_backend(sandbox)
 
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        SkillsMiddleware(
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
             backend=backend,
-            sources=["/skills/plugins/detector/", "/skills/standard/analyst/", "/skills/shared/"],
-        ),
-        FilesystemMiddleware(backend=backend),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=None,  # no SandboxNotification for detector
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=[])
 
-    tools = [
-        kg_query,
-        kg_neighbors,
-        kg_stats,
-        kg_add_node,
-        kg_add_edge,
-        cve_lookup,
-        cve_by_package,
-    ]
-
-    tools.extend(load_plugin_tools(role="detector"))
-    middleware.extend(load_plugin_middleware(role="detector", backend=backend))
-
-    agent = create_agent(
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="detector",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 120,
-            "callbacks": load_plugin_callbacks(role="detector", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 
-    return agent
 
-
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_detector_agent()
 
 

--- a/decepticon/agents/plugins/exploiter.py
+++ b/decepticon/agents/plugins/exploiter.py
@@ -53,11 +53,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import cve_poc_lookup, payload_search
@@ -76,9 +76,9 @@ from decepticon.tools.research.tools import (
     suggest_objectives_from_chains,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -101,7 +101,14 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
+
+
+_SKILL_SOURCES: list[str] = [
+    "/skills/plugins/exploiter/",
+    "/skills/standard/analyst/",
+    "/skills/shared/",
+]
 
 
 _ROLE = "exploiter"
@@ -165,17 +172,18 @@ def create_exploiter_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
+            skill_sources=_SKILL_SOURCES,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -192,7 +200,8 @@ def create_exploiter_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_exploiter_agent()
+if is_bundle_enabled("plugins"):
+    graph = create_exploiter_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/plugins/exploiter.py
+++ b/decepticon/agents/plugins/exploiter.py
@@ -14,31 +14,50 @@ exploit artifacts under ``/workspace/exploits/``.
 Note: the Exploiter shares most of its tool surface with the legacy
 analyst agent. The distinction is scope — the analyst hunts new bugs
 end-to-end, while the exploiter only weaponizes already-validated ones.
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_exploiter_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["exploiter"]``):
+
+  SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION → MODEL_FALLBACK
+    → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (specialist, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import cve_poc_lookup, payload_search
@@ -58,40 +77,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_exploiter_agent():
-    """Initialize the Exploiter Agent — opus, weaponization specialist."""
-
-    factory = LLMFactory()
-    llm = factory.get_model("exploiter")
-    fallback_models = factory.get_fallback_models("exploiter")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("exploiter", shared=["bash"])
-
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/plugins/exploiter/", "/skills/standard/analyst/", "/skills/shared/"],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -114,26 +101,97 @@ def create_exploiter_agent():
         # Execution
         *BASH_TOOLS,
     ]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="exploiter"))
-    middleware.extend(load_plugin_middleware(role="exploiter", backend=backend))
 
-    agent = create_agent(
+_ROLE = "exploiter"
+_RECURSION_LIMIT = 250
+
+
+def create_exploiter_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Exploiter agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("exploiter")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("exploiter")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="exploiter",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="exploiter", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 
-    return agent
 
-
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_exploiter_agent()
 
 

--- a/decepticon/agents/plugins/patcher.py
+++ b/decepticon/agents/plugins/patcher.py
@@ -50,11 +50,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.patch import patch_propose, patch_verify
@@ -64,9 +64,9 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         patch_propose,
         patch_verify,
         kg_query,
@@ -74,7 +74,14 @@ def _build_standard_tools() -> dict[str, Any]:
         kg_stats,
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
+
+
+_SKILL_SOURCES: list[str] = [
+    "/skills/plugins/patcher/",
+    "/skills/standard/analyst/",
+    "/skills/shared/",
+]
 
 
 _ROLE = "patcher"
@@ -138,17 +145,18 @@ def create_patcher_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
+            skill_sources=_SKILL_SOURCES,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -165,7 +173,8 @@ def create_patcher_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_patcher_agent()
+if is_bundle_enabled("plugins"):
+    graph = create_patcher_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/plugins/patcher.py
+++ b/decepticon/agents/plugins/patcher.py
@@ -11,31 +11,50 @@ Tool surface:
   - ``kg_query`` / ``kg_neighbors`` — read verified findings
   - Filesystem Edit / Read via ``FilesystemMiddleware`` — apply diffs
   - ``bash`` — run the repo's test suite and stage test commands
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_patcher_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["patcher"]``):
+
+  SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION → MODEL_FALLBACK
+    → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (specialist, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.patch import patch_propose, patch_verify
@@ -46,40 +65,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_patcher_agent():
-    """Initialize the Patcher Agent — opus, iterative fix-verify loops."""
-
-    factory = LLMFactory()
-    llm = factory.get_model("patcher")
-    fallback_models = factory.get_fallback_models("patcher")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("patcher", shared=["bash"])
-
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/plugins/patcher/", "/skills/shared/"],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         patch_propose,
         patch_verify,
         kg_query,
@@ -87,26 +74,97 @@ def create_patcher_agent():
         kg_stats,
         *BASH_TOOLS,
     ]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="patcher"))
-    middleware.extend(load_plugin_middleware(role="patcher", backend=backend))
 
-    agent = create_agent(
+_ROLE = "patcher"
+_RECURSION_LIMIT = 200
+
+
+def create_patcher_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Patcher agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("patcher")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("patcher")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 200.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="patcher",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 200,
-            "callbacks": load_plugin_callbacks(role="patcher", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 
-    return agent
 
-
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_patcher_agent()
 
 

--- a/decepticon/agents/plugins/scanner.py
+++ b/decepticon/agents/plugins/scanner.py
@@ -50,22 +50,29 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.scanner_tools import SCANNER_TOOLS
 from decepticon.tools.research.tools import kg_query, kg_stats
 
-
-def _build_standard_tools() -> dict[str, Any]:
+_STANDARD_TOOLS: dict[str, Any] = {
     # Tight tool surface: sharded scanner helpers + minimal KG read access +
     # bash for directory sizing only. NO vuln analysis tools.
-    bundle: list[Any] = [*SCANNER_TOOLS, kg_query, kg_stats, *BASH_TOOLS]
-    return {t.name: t for t in bundle}
+    t.name: t
+    for t in [*SCANNER_TOOLS, kg_query, kg_stats, *BASH_TOOLS]
+}
+
+
+_SKILL_SOURCES: list[str] = [
+    "/skills/plugins/scanner/",
+    "/skills/standard/analyst/",
+    "/skills/shared/",
+]
 
 
 _ROLE = "scanner"
@@ -139,17 +146,18 @@ def create_scanner_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
+            skill_sources=_SKILL_SOURCES,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -166,7 +174,8 @@ def create_scanner_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_scanner_agent()
+if is_bundle_enabled("plugins"):
+    graph = create_scanner_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/plugins/scanner.py
+++ b/decepticon/agents/plugins/scanner.py
@@ -11,39 +11,82 @@ produce ``CANDIDATE`` nodes for the Detector (Stage 2) to promote or
 reject.
 
 See ``decepticon/agents/prompts/scanner.md`` for the operating loop.
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_scanner_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["scanner"]``):
+
+  SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION → MODEL_FALLBACK
+    → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (specialist, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.scanner_tools import SCANNER_TOOLS
 from decepticon.tools.research.tools import kg_query, kg_stats
 
 
-def create_scanner_agent():
-    """Initialize the Scanner Agent — cheap, sharded, candidate-only.
+def _build_standard_tools() -> dict[str, Any]:
+    # Tight tool surface: sharded scanner helpers + minimal KG read access +
+    # bash for directory sizing only. NO vuln analysis tools.
+    bundle: list[Any] = [*SCANNER_TOOLS, kg_query, kg_stats, *BASH_TOOLS]
+    return {t.name: t for t in bundle}
+
+
+_ROLE = "scanner"
+_RECURSION_LIMIT = 60
+
+
+def create_scanner_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Scanner agent.
 
     Context engineering decisions:
       - Haiku-tier primary (see ``LLMModelMapping.scanner``) so 10^5-file
@@ -54,56 +97,72 @@ def create_scanner_agent():
         ``bash`` for directory sizing (``du``, ``wc -l``, ``ls``). No other
         research tools.
       - Skills routed through ``/skills/plugins/scanner/`` + ``/skills/shared/``.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("scanner")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("scanner")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 60.
+
+    Returns:
+        Compiled LangGraph agent.
     """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
 
-    factory = LLMFactory()
-    llm = factory.get_model("scanner")
-    fallback_models = factory.get_fallback_models("scanner")
-
-    sandbox = build_sandbox_backend()
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
     set_sandbox(sandbox)
 
-    system_prompt = load_prompt("scanner", shared=["bash"])
+    if backend is None:
+        backend = make_agent_backend(sandbox)
 
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
             backend=backend,
-            sources=["/skills/plugins/scanner/", "/skills/shared/"],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
 
-    # Tight tool surface: sharded scanner helpers + minimal KG read access +
-    # bash for directory sizing only. NO vuln analysis tools.
-    tools = [*SCANNER_TOOLS, kg_query, kg_stats, *BASH_TOOLS]
-
-    tools.extend(load_plugin_tools(role="scanner"))
-    middleware.extend(load_plugin_middleware(role="scanner", backend=backend))
-
-    agent = create_agent(
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="scanner",
+        name=_ROLE,
     ).with_config(
-        {"recursion_limit": 60, "callbacks": load_plugin_callbacks(role="scanner", backend=backend)}
+        {
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
+        }
     )
-
-    return agent
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)

--- a/decepticon/agents/plugins/verifier.py
+++ b/decepticon/agents/plugins/verifier.py
@@ -55,11 +55,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.tools import (
@@ -71,9 +71,9 @@ from decepticon.tools.research.tools import (
     validate_finding,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         validate_finding,
         kg_query,
         kg_neighbors,
@@ -82,7 +82,14 @@ def _build_standard_tools() -> dict[str, Any]:
         kg_add_edge,
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
+
+
+_SKILL_SOURCES: list[str] = [
+    "/skills/plugins/verifier/",
+    "/skills/standard/analyst/",
+    "/skills/shared/",
+]
 
 
 _ROLE = "verifier"
@@ -146,17 +153,18 @@ def create_verifier_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
+            skill_sources=_SKILL_SOURCES,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -173,7 +181,8 @@ def create_verifier_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_verifier_agent()
+if is_bundle_enabled("plugins"):
+    graph = create_verifier_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/plugins/verifier.py
+++ b/decepticon/agents/plugins/verifier.py
@@ -16,31 +16,50 @@ Tool surface:
     read + bookkeeping (never emit new vuln kinds, only update existing
     ones with attempt counters)
   - ``bash`` — start services, stage PoCs, run curl sanity checks
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_verifier_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["verifier"]``):
+
+  SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION → MODEL_FALLBACK
+    → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (specialist, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.tools import (
@@ -53,40 +72,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_verifier_agent():
-    """Initialize the Verifier Agent — sonnet, PoC-driven, ZFP gate."""
-
-    factory = LLMFactory()
-    llm = factory.get_model("verifier")
-    fallback_models = factory.get_fallback_models("verifier")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("verifier", shared=["bash"])
-
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/plugins/verifier/", "/skills/standard/analyst/", "/skills/shared/"],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         validate_finding,
         kg_query,
         kg_neighbors,
@@ -95,26 +82,97 @@ def create_verifier_agent():
         kg_add_edge,
         *BASH_TOOLS,
     ]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="verifier"))
-    middleware.extend(load_plugin_middleware(role="verifier", backend=backend))
 
-    agent = create_agent(
+_ROLE = "verifier"
+_RECURSION_LIMIT = 150
+
+
+def create_verifier_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Verifier agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("verifier")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("verifier")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 150.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="verifier",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 150,
-            "callbacks": load_plugin_callbacks(role="verifier", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 
-    return agent
 
-
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_verifier_agent()
 
 

--- a/decepticon/agents/plugins/vulnresearch.py
+++ b/decepticon/agents/plugins/vulnresearch.py
@@ -56,8 +56,9 @@ from typing import Any
 from deepagents.middleware.subagents import CompiledSubAgent
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents._benchmark_mode import benchmark_skill_sources
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.core.subagent_streaming import StreamingRunnable
 from decepticon.llm import LLMFactory
@@ -155,10 +156,16 @@ def create_vulnresearch_agent(
         ]
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        skill_sources = [
+            "/skills/plugins/vulnresearch/",
+            "/skills/shared/",
+            *benchmark_skill_sources(),
+        ]
+        middleware = build_middleware(
             role=_ROLE,
+            skill_sources=skill_sources,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
@@ -166,7 +173,7 @@ def create_vulnresearch_agent(
             subagents=subagents,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=[])
+        system_prompt = load_prompt(_ROLE, shared=[])
 
     return create_agent(
         llm,

--- a/decepticon/agents/plugins/vulnresearch.py
+++ b/decepticon/agents/plugins/vulnresearch.py
@@ -18,55 +18,124 @@ Design notes:
   - The orchestrator itself has only ``kg_query``/``kg_stats`` as tools
     (plus the SubAgent ``task()`` and OPPLAN CRUD). It MUST NOT touch
     bash, source files, or PoCs directly.
+  - EngagementContext slot is NOT included (see SLOTS_PER_ROLE).
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_vulnresearch_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+NOTE: set_sandbox() is intentionally NOT called here — the orchestrator
+must not run bash. Each sub-agent that needs bash calls set_sandbox()
+from its own factory.
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgentMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from deepagents.middleware.subagents import CompiledSubAgent
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.core.subagent_streaming import StreamingRunnable
 from decepticon.llm import LLMFactory
-from decepticon.middleware import FilesystemMiddleware, OPPLANMiddleware
-from decepticon.middleware.skills import SkillsMiddleware
 from decepticon.plugin_loader import (
     is_bundle_enabled,
     load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
     load_subagents_for_parent,
 )
 from decepticon.tools.research.tools import kg_query, kg_stats
 
+_ROLE = "vulnresearch"
+_RECURSION_LIMIT = 250
 
-def create_vulnresearch_agent():
-    """Initialize the Vulnresearch Orchestrator.
+# Name-keyed baseline tools (tiny surface — read the graph only).
+_STANDARD_TOOLS: dict[str, Any] = {
+    "kg_query": kg_query,
+    "kg_stats": kg_stats,
+}
+
+
+def create_vulnresearch_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    subagents: list | None = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Vulnresearch orchestrator.
 
     Tool surface is intentionally tiny: ``kg_query`` + ``kg_stats`` for
     graph inspection, plus the OPPLAN CRUD tools (injected by
     :class:`OPPLANMiddleware`) and the ``task()`` dispatcher (injected
     by :class:`SubAgentMiddleware`). Everything else is delegated.
-    """
 
-    factory = LLMFactory()
-    llm = factory.get_model("vulnresearch")
-    fallback_models = factory.get_fallback_models("vulnresearch")
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("vulnresearch")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("vulnresearch")``.
+        subagents: explicit sub-agent list. When ``None`` (default),
+            sub-agents are discovered via ``load_subagents_for_parent``
+            and each wrapped in ``StreamingRunnable``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline (``kg_query`` + ``kg_stats``) is built and plugin
+            overrides applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
 
     sandbox = build_sandbox_backend()
-    # NOTE: do NOT call set_sandbox() here — the orchestrator must not
-    # run bash. Each sub-agent that does need bash calls set_sandbox()
-    # from its own factory.
 
-    system_prompt = load_prompt("vulnresearch", shared=[])
-
-    backend = make_agent_backend(sandbox)
+    if backend is None:
+        backend = make_agent_backend(sandbox)
 
     # Build sub-agents via plugin-loader discovery. Each subagent
     # declares itself as a ``SUBAGENT_SPEC`` module constant registered
@@ -75,57 +144,40 @@ def create_vulnresearch_agent():
     # ``"vulnresearch"``. Community or SaaS plugin packages can extend
     # this roster without modifying OSS — see
     # ``decepticon/plugin_loader.py`` for the loader contract.
-    subagents = [
-        CompiledSubAgent(
-            name=spec.name,
-            description=spec.description,
-            runnable=StreamingRunnable(spec.factory(), spec.name),
-        )
-        for spec in load_subagents_for_parent("vulnresearch")
-    ]
-
-    middleware = [
-        SkillsMiddleware(
-            backend=backend,
-            sources=[
-                "/skills/plugins/vulnresearch/",
-                "/skills/shared/",
-                *benchmark_skill_sources(),
-            ],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SubAgentMiddleware(backend=backend, subagents=subagents),
-        OPPLANMiddleware(backend=backend),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
+    if subagents is None:
+        subagents = [
+            CompiledSubAgent(
+                name=spec.name,
+                description=spec.description,
+                runnable=StreamingRunnable(spec.factory(), spec.name),
+            )
+            for spec in load_subagents_for_parent(_ROLE)
         ]
-    )
 
-    # Tiny tool surface: only read the graph. All work is delegated.
-    tools = [kg_query, kg_stats]
-    tools.extend(load_plugin_tools(role="vulnresearch"))
-    middleware.extend(load_plugin_middleware(role="vulnresearch", backend=backend))
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=None,  # orchestrator has no bash tool / sandbox notification
+            subagents=subagents,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=[])
 
-    agent = create_agent(
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="vulnresearch",
-    )
-
-    # Higher ceiling than specialists because the orchestrator needs
-    # many delegation rounds across five stages.
-    return agent.with_config(
+        name=_ROLE,
+    ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="vulnresearch", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 

--- a/decepticon/agents/prompts/__init__.py
+++ b/decepticon/agents/prompts/__init__.py
@@ -450,3 +450,49 @@ def load_prompt(name: str, *, shared: list[str] | None = None) -> str:
         pass
 
     return prompt
+
+
+def load_prompt_with_overrides(
+    name: str,
+    *,
+    shared: list[str] | None = None,
+    override: str | dict[str, str] | None = None,
+) -> str:
+    """``load_prompt`` + plugin / library prompt override hook.
+
+    Wraps the standard prompt assembly and applies (in order):
+
+      1. ``replace`` — the entire prompt is substituted (explicit
+         override beats plugin override on conflict).
+      2. ``prepend`` / ``append`` — wrap the (possibly replaced) prompt.
+
+    Both explicit and plugin overrides feed the same pipeline; see
+    ``decepticon.agents.assembly.resolve_prompt_overrides``. Library
+    callers pass ``override`` directly; Docker / plugin authors ship a
+    ``PluginBundle(prompt_overrides={...})`` under the
+    ``decepticon.bundles`` entry-point group.
+
+    Args:
+        name: prompt role name, e.g. "soundwave" / "recon".
+        shared: shared fragment list, mirroring ``load_prompt``.
+        override:
+          - ``None`` — only plugin overrides apply.
+          - ``str`` — full replace (most aggressive).
+          - ``dict`` with ``prepend`` / ``append`` / ``replace`` keys.
+    """
+    base = load_prompt(name, shared=shared)
+
+    # Lazy import keeps this module free of agent-assembly dependencies
+    # so plain callers of ``load_prompt`` don't pay the cost.
+    from decepticon.agents.assembly import resolve_prompt_overrides
+
+    merged = resolve_prompt_overrides(name, override=override)
+
+    prompt = merged.get("replace", base)
+    prepend = merged.get("prepend", "")
+    append = merged.get("append", "")
+    if prepend:
+        prompt = f"{prepend}\n\n{prompt}"
+    if append:
+        prompt = f"{prompt}\n\n{append}"
+    return prompt

--- a/decepticon/agents/prompts/__init__.py
+++ b/decepticon/agents/prompts/__init__.py
@@ -383,21 +383,32 @@ def build_language_policy(language: str) -> str | None:
     )
 
 
-def load_prompt(name: str, *, shared: list[str] | None = None) -> str:
+def load_prompt(
+    name: str,
+    *,
+    shared: list[str] | None = None,
+    override: str | dict[str, str] | None = None,
+) -> str:
     """Load an agent system prompt with structured assembly.
 
-    This is the primary API — backward-compatible with the original signature
-    but now uses PromptBuilder internally for structured assembly.
+    Static identity/rules/environment load from ``<name>.md`` and combine
+    with cross-cutting patterns (faithful reporting, verification gate,
+    output discipline) and tool prompts. The Anthropic prompt-caching
+    boundary separates the cacheable static prefix from per-invocation
+    dynamic content.
 
-    Automatically:
-    - Injects cross-cutting prompt patterns (faithful reporting, output discipline, etc.)
-    - Uses co-located tool prompts instead of shared .md fragments for tools
-    - Separates static/dynamic sections with cache boundary markers
+    Plugin prompt overrides (``PluginBundle(prompts={...})`` under the
+    ``decepticon.bundles`` entry-point group) apply automatically. Library
+    callers can supply an explicit ``override`` — ``str`` for full
+    replace, ``dict`` with ``prepend`` / ``append`` / ``replace`` keys.
+    Explicit overrides win over plugin overrides on conflict.
 
     Args:
         name: Prompt filename without extension (e.g., "recon", "exploit").
-        shared: List of shared fragment names to append (e.g., ["bash", "skills"]).
+        shared: Shared fragment names to append (e.g., ["bash", "skills"]).
             "bash" is special-cased to use the co-located tool prompt module.
+        override: Optional explicit prompt override. ``None`` (default) =
+            only plugin overrides apply.
 
     Returns:
         Assembled system prompt string.
@@ -428,13 +439,13 @@ def load_prompt(name: str, *, shared: list[str] | None = None) -> str:
     # launchers (SaaS web) override per-run via config.configurable.language
     # which EngagementContextMiddleware injects as a later SystemMessage.
     pinned_lang = os.environ.get("DECEPTICON_LANGUAGE", "").strip()
-    override = build_language_policy(pinned_lang)
-    if override is not None:
+    lang_policy = build_language_policy(pinned_lang)
+    if lang_policy is not None:
         import re
 
         prompt = re.sub(
             r"<LANGUAGE_POLICY>.*?</LANGUAGE_POLICY>",
-            override,
+            lang_policy,
             prompt,
             flags=re.DOTALL,
         )
@@ -449,50 +460,17 @@ def load_prompt(name: str, *, shared: list[str] | None = None) -> str:
         # Fail soft: never break prompt loading because of the compat shim.
         pass
 
-    return prompt
-
-
-def load_prompt_with_overrides(
-    name: str,
-    *,
-    shared: list[str] | None = None,
-    override: str | dict[str, str] | None = None,
-) -> str:
-    """``load_prompt`` + plugin / library prompt override hook.
-
-    Wraps the standard prompt assembly and applies (in order):
-
-      1. ``replace`` — the entire prompt is substituted (explicit
-         override beats plugin override on conflict).
-      2. ``prepend`` / ``append`` — wrap the (possibly replaced) prompt.
-
-    Both explicit and plugin overrides feed the same pipeline; see
-    ``decepticon.agents.assembly.resolve_prompt_overrides``. Library
-    callers pass ``override`` directly; Docker / plugin authors ship a
-    ``PluginBundle(prompt_overrides={...})`` under the
-    ``decepticon.bundles`` entry-point group.
-
-    Args:
-        name: prompt role name, e.g. "soundwave" / "recon".
-        shared: shared fragment list, mirroring ``load_prompt``.
-        override:
-          - ``None`` — only plugin overrides apply.
-          - ``str`` — full replace (most aggressive).
-          - ``dict`` with ``prepend`` / ``append`` / ``replace`` keys.
-    """
-    base = load_prompt(name, shared=shared)
-
-    # Lazy import keeps this module free of agent-assembly dependencies
-    # so plain callers of ``load_prompt`` don't pay the cost.
-    from decepticon.agents.assembly import resolve_prompt_overrides
+    # Plugin + explicit prompt overrides apply last so prepend/append wrap
+    # the fully-assembled prompt (language policy + compat shim included).
+    # Lazy import avoids a circular dependency between assembly and prompts.
+    from decepticon.agents.build import resolve_prompt_overrides
 
     merged = resolve_prompt_overrides(name, override=override)
+    if "replace" in merged:
+        prompt = merged["replace"]
+    if merged.get("prepend"):
+        prompt = f"{merged['prepend']}\n\n{prompt}"
+    if merged.get("append"):
+        prompt = f"{prompt}\n\n{merged['append']}"
 
-    prompt = merged.get("replace", base)
-    prepend = merged.get("prepend", "")
-    append = merged.get("append", "")
-    if prepend:
-        prompt = f"{prepend}\n\n{prompt}"
-    if append:
-        prompt = f"{prompt}\n\n{append}"
     return prompt

--- a/decepticon/agents/standard/ad_operator.py
+++ b/decepticon/agents/standard/ad_operator.py
@@ -38,11 +38,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.ad.tools import AD_TOOLS
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
@@ -57,9 +57,9 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # AD tools
         *AD_TOOLS,
         # KG core + credential ingest
@@ -75,7 +75,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "ad_operator"
@@ -139,9 +139,9 @@ def create_ad_operator_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -149,7 +149,7 @@ def create_ad_operator_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -166,7 +166,8 @@ def create_ad_operator_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_ad_operator_agent()
+if is_bundle_enabled("standard"):
+    graph = create_ad_operator_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/ad_operator.py
+++ b/decepticon/agents/standard/ad_operator.py
@@ -1,29 +1,48 @@
-"""AD Operator Agent — Active Directory and Windows attack lane."""
+"""AD Operator Agent — Active Directory and Windows attack lane.
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_ad_operator_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["ad_operator"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
+"""
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.ad.tools import AD_TOOLS
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
@@ -39,37 +58,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_ad_operator_agent():
-    factory = LLMFactory()
-    llm = factory.get_model("ad_operator")
-    fallback_models = factory.get_fallback_models("ad_operator")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("ad_operator", shared=["bash"])
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/ad/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # AD tools
         *AD_TOOLS,
         # KG core + credential ingest
@@ -85,24 +75,97 @@ def create_ad_operator_agent():
         # Execution
         *BASH_TOOLS,
     ]
-    tools.extend(load_plugin_tools(role="ad_operator"))
-    middleware.extend(load_plugin_middleware(role="ad_operator", backend=backend))
+    return {t.name: t for t in bundle}
 
-    agent = create_agent(
+
+_ROLE = "ad_operator"
+_RECURSION_LIMIT = 250
+
+
+def create_ad_operator_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the ADOperator agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("ad_operator")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("ad_operator")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="ad_operator",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="ad_operator", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-    return agent
 
 
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_ad_operator_agent()
 
 

--- a/decepticon/agents/standard/analyst.py
+++ b/decepticon/agents/standard/analyst.py
@@ -51,24 +51,24 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import REFERENCES_TOOLS
 from decepticon.tools.research.bounty import BOUNTY_TOOLS
 from decepticon.tools.research.tools import RESEARCH_TOOLS
 
-
-def _build_standard_tools() -> dict[str, Any]:
+_STANDARD_TOOLS: dict[str, Any] = {
     # Research tools first → model defaults to graph operations;
     # references tools offer payloads + external knowledge lookup;
     # bounty tools provide scope checking and report formatting.
-    bundle: list[Any] = [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
-    return {t.name: t for t in bundle}
+    t.name: t
+    for t in [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
+}
 
 
 _ROLE = "analyst"
@@ -132,9 +132,9 @@ def create_analyst_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -142,7 +142,7 @@ def create_analyst_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -159,7 +159,8 @@ def create_analyst_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_analyst_agent()
+if is_bundle_enabled("standard"):
+    graph = create_analyst_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/analyst.py
+++ b/decepticon/agents/standard/analyst.py
@@ -7,38 +7,55 @@ Analyst reads source, builds a persistent knowledge graph, and reasons
 about multi-hop paths from entrypoints to crown jewels.
 
 Tool surface (in addition to bash):
-    kg_add_node, kg_add_edge, kg_query, kg_neighbors, kg_stats,
-    kg_ingest_sarif, cve_lookup, cve_by_package, plan_attack_chains,
-    fuzz_classify, fuzz_harness, fuzz_record_crash, validate_finding
+    RESEARCH_TOOLS, BOUNTY_TOOLS, REFERENCES_TOOLS
 
 Middleware stack — mirrors exploit.py. The analyst runs fewer shell
 commands in favour of first-class research tools (semgrep, bandit,
 gitleaks, KG operations).
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_analyst_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["analyst"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import REFERENCES_TOOLS
@@ -46,70 +63,99 @@ from decepticon.tools.research.bounty import BOUNTY_TOOLS
 from decepticon.tools.research.tools import RESEARCH_TOOLS
 
 
-def create_analyst_agent():
-    """Initialize the Analyst Agent with full research tool access.
-
-    Context engineering decisions:
-      - Sonnet-class primary model: vulnerability research benefits from
-        reasoning depth, but Haiku has too small a context window for
-        source-review workloads.
-      - Research tools come *before* bash in the tool list so the LLM
-        defaults to graph-updating operations over raw shell commands.
-      - Skills routed through /skills/standard/analyst/ + /skills/shared/.
-    """
-
-    factory = LLMFactory()
-    llm = factory.get_model("analyst")
-    fallback_models = factory.get_fallback_models("analyst")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("analyst", shared=["bash"])
-
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/analyst/", "/skills/shared/"],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
+def _build_standard_tools() -> dict[str, Any]:
     # Research tools first → model defaults to graph operations;
     # references tools offer payloads + external knowledge lookup;
     # bounty tools provide scope checking and report formatting.
-    tools = [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
+    bundle: list[Any] = [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="analyst"))
-    middleware.extend(load_plugin_middleware(role="analyst", backend=backend))
 
-    agent = create_agent(
+_ROLE = "analyst"
+_RECURSION_LIMIT = 250
+
+
+def create_analyst_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Analyst agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("analyst")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("analyst")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="analyst",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="analyst", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-
-    return agent
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)

--- a/decepticon/agents/standard/cloud_hunter.py
+++ b/decepticon/agents/standard/cloud_hunter.py
@@ -1,29 +1,48 @@
-"""Cloud Hunter Agent — AWS/Azure/GCP/k8s exploitation lane."""
+"""Cloud Hunter Agent — AWS/Azure/GCP/k8s exploitation lane.
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_cloud_hunter_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["cloud_hunter"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
+"""
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.cloud.tools import CLOUD_TOOLS
@@ -37,37 +56,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_cloud_hunter_agent():
-    factory = LLMFactory()
-    llm = factory.get_model("cloud_hunter")
-    fallback_models = factory.get_fallback_models("cloud_hunter")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("cloud_hunter", shared=["bash"])
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/cloud/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # Cloud tools
         *CLOUD_TOOLS,
         # KG core
@@ -81,24 +71,97 @@ def create_cloud_hunter_agent():
         # Execution
         *BASH_TOOLS,
     ]
-    tools.extend(load_plugin_tools(role="cloud_hunter"))
-    middleware.extend(load_plugin_middleware(role="cloud_hunter", backend=backend))
+    return {t.name: t for t in bundle}
 
-    agent = create_agent(
+
+_ROLE = "cloud_hunter"
+_RECURSION_LIMIT = 250
+
+
+def create_cloud_hunter_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the CloudHunter agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("cloud_hunter")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("cloud_hunter")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="cloud_hunter",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="cloud_hunter", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-    return agent
 
 
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_cloud_hunter_agent()
 
 

--- a/decepticon/agents/standard/cloud_hunter.py
+++ b/decepticon/agents/standard/cloud_hunter.py
@@ -38,11 +38,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.cloud.tools import CLOUD_TOOLS
@@ -55,9 +55,9 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # Cloud tools
         *CLOUD_TOOLS,
         # KG core
@@ -71,7 +71,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "cloud_hunter"
@@ -135,9 +135,9 @@ def create_cloud_hunter_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -145,7 +145,7 @@ def create_cloud_hunter_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -162,7 +162,8 @@ def create_cloud_hunter_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_cloud_hunter_agent()
+if is_bundle_enabled("standard"):
+    graph = create_cloud_hunter_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/contract_auditor.py
+++ b/decepticon/agents/standard/contract_auditor.py
@@ -4,32 +4,50 @@ Walks a Foundry / Hardhat repo, runs the offline pattern scanner,
 ingests Slither JSON, generates PoC tests via Foundry templates, and
 promotes confirmed findings into the KnowledgeGraph for chain
 reasoning (e.g. oracle manipulation → flash loan → drain chain).
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_contract_auditor_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["contract_auditor"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.contracts.tools import CONTRACT_TOOLS
@@ -44,37 +62,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_contract_auditor_agent():
-    factory = LLMFactory()
-    llm = factory.get_model("contract_auditor")
-    fallback_models = factory.get_fallback_models("contract_auditor")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("contract_auditor", shared=["bash"])
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/contracts/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # Contract tools
         *CONTRACT_TOOLS,
         # KG core + SARIF ingest
@@ -89,24 +78,97 @@ def create_contract_auditor_agent():
         # Execution
         *BASH_TOOLS,
     ]
-    tools.extend(load_plugin_tools(role="contract_auditor"))
-    middleware.extend(load_plugin_middleware(role="contract_auditor", backend=backend))
+    return {t.name: t for t in bundle}
 
-    agent = create_agent(
+
+_ROLE = "contract_auditor"
+_RECURSION_LIMIT = 250
+
+
+def create_contract_auditor_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the ContractAuditor agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("contract_auditor")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("contract_auditor")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="contract_auditor",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="contract_auditor", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-    return agent
 
 
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_contract_auditor_agent()
 
 

--- a/decepticon/agents/standard/contract_auditor.py
+++ b/decepticon/agents/standard/contract_auditor.py
@@ -43,11 +43,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.contracts.tools import CONTRACT_TOOLS
@@ -61,9 +61,9 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # Contract tools
         *CONTRACT_TOOLS,
         # KG core + SARIF ingest
@@ -78,7 +78,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "contract_auditor"
@@ -142,9 +142,9 @@ def create_contract_auditor_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -152,7 +152,7 @@ def create_contract_auditor_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -169,7 +169,8 @@ def create_contract_auditor_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_contract_auditor_agent()
+if is_bundle_enabled("standard"):
+    graph = create_contract_auditor_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/decepticon.py
+++ b/decepticon/agents/standard/decepticon.py
@@ -6,92 +6,129 @@ The launcher selects this assistant when the operator picks an existing
 engagement; for fresh engagements it picks the standalone soundwave assistant
 instead, which writes the planning documents this agent then consumes.
 
-Uses create_agent() directly (not create_deep_agent()) to control the
-middleware stack precisely.
-
 Middleware stack (selected for orchestration):
   1. EngagementContextMiddleware — inject engagement metadata (slug, target, RoE)
   2. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
   3. FilesystemMiddleware — file ops for reading/updating engagement docs
   4. SubAgentMiddleware — task() tool for delegating to sub-agents
   5. OPPLANMiddleware — OPPLAN CRUD tools (create/add/get/list/update objectives)
-  6. ModelFallbackMiddleware — primary → fallback on provider failure (chain from Credentials inventory)
-  7. SummarizationMiddleware — auto-compact for long orchestration sessions
-  8. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic models
-  9. PatchToolCallsMiddleware — repair dangling tool calls
+  6. ModelOverrideMiddleware — runtime /model switch support
+  7. ModelFallbackMiddleware — primary → fallback on provider failure
+  8. SummarizationMiddleware — auto-compact for long orchestration sessions
+  9. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic models
+  10. PatchToolCallsMiddleware — repair dangling tool calls
 
 The orchestrator has tools=[] — all offensive work goes through task()
 delegation to specialist sub-agents. SandboxNotificationMiddleware lives
 on each sub-agent (where bash actually runs), not here.
 
-OPPLAN provides domain-specific objective tracking:
-  - CRUD tools for engagement objectives and child task trees
-  - Dynamic state injection: every LLM call sees OPPLAN progress table
-  - State transition validation with dependency checking
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
 
-Sub-agents are passed as CompiledSubAgent, wrapping existing agent factories
-(create_recon_agent, create_exploit_agent, create_postexploit_agent, and the
-specialist analyst/reverser/contract_auditor/cloud_hunter/ad_operator agents)
-so they run with their full middleware stack and skill sets intact. Soundwave
-is intentionally NOT a sub-agent here: the launcher routes to its standalone
-assistant when document generation is needed.
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_decepticon_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+SubAgent / OPPLAN (orchestrator — delegates all work via task()).
+No SandboxNotification (bash lives on sub-agents). Soundwave is NOT a
+sub-agent: the launcher routes to its standalone assistant when document
+generation is needed.
 """
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgentMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from __future__ import annotations
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from typing import Any
+
+from deepagents.middleware.subagents import CompiledSubAgent
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.core.subagent_streaming import StreamingRunnable
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    OPPLANMiddleware,
-    SkillsMiddleware,
-)
 from decepticon.plugin_loader import (
     is_bundle_enabled,
     load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
     load_subagents_for_parent,
 )
 
+_ROLE = "decepticon"
+_RECURSION_LIMIT = 400
 
-def create_decepticon_agent():
-    """Initialize the Decepticon Orchestrator using create_agent() directly.
 
-    Context engineering decisions:
-      - Explicit middleware stack instead of create_deep_agent() defaults
-      - SubAgentMiddleware: task() tool for delegating to specialist sub-agents
-      - OPPLANMiddleware: CRUD tools for objective tracking
-      - ModelFallbackMiddleware: primary → fallback chain built from the user's Credentials inventory
-    Returns a compiled LangGraph agent ready for invocation.
+def create_decepticon_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    subagents: list | None = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Decepticon orchestrator.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("decepticon")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("decepticon")``.
+        subagents: explicit sub-agent list. When ``None`` (default),
+            sub-agents are discovered via ``load_subagents_for_parent``
+            and each wrapped in ``StreamingRunnable``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline (``{}``) is built and plugin overrides applied.
+            The orchestrator delegates all work; tools=[] by design.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 400.
+
+    Returns:
+        Compiled LangGraph agent.
     """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
 
-    factory = LLMFactory()
-    llm = factory.get_model("decepticon")
-    fallback_models = factory.get_fallback_models("decepticon")
-
-    # Filesystem backend for the orchestrator. The orchestrator has
-    # tools=[], so it never touches the bash module's global _sandbox —
-    # sub-agent factories set that for their own execution. HTTP transport
-    # is the single supported path (see backends/factory.py).
+    # Filesystem backend for the orchestrator. HTTP transport is the single
+    # supported path (see backends/factory.py).
     sandbox = build_sandbox_backend()
 
-    system_prompt = load_prompt("decepticon")
-
-    # CompositeBackend: HTTPSandbox serves /workspace/ over HTTP, while
-    # /skills/ resolves locally from /app/skills inside the langgraph
-    # container (skills are read-only knowledge, not sandbox artefacts).
-    # See decepticon/backends/__init__.py:make_agent_backend.
-    backend = make_agent_backend(sandbox)
+    if backend is None:
+        backend = make_agent_backend(sandbox)
 
     # Build sub-agents via plugin-loader discovery. Each subagent declares
     # itself as a ``SUBAGENT_SPEC`` module constant registered under the
@@ -105,67 +142,43 @@ def create_decepticon_agent():
     # tool calls, results, and AI messages stream through both Python CLI
     # (UIRenderer) and LangGraph Platform HTTP API (get_stream_writer →
     # custom events).
-    #
-    # Soundwave is intentionally NOT a sub-agent here: it is registered
-    # at the orchestrator level (create_orchestrator) and routed to
-    # whenever engagement docs are missing. Soundwave is designed
-    # standalone (no SubAgentMiddleware, no bash tool — see
-    # soundwave.py module docstring), so document regeneration goes
-    # through the orchestrator routing, not decepticon delegation.
-    # Document edits while docs already exist are handled by
-    # decepticon's FilesystemMiddleware directly.
-    subagents = [
-        CompiledSubAgent(
-            name=spec.name,
-            description=spec.description,
-            runnable=StreamingRunnable(spec.factory(), spec.name),
-        )
-        for spec in load_subagents_for_parent("decepticon")
-    ]
-
-    # Assemble middleware stack. ModelOverrideMiddleware sits ahead of
-    # ModelFallbackMiddleware so the CLI ``/model`` command can swap the
-    # primary at runtime while the user-configured fallback chain still
-    # applies on its failure.
-    from decepticon.middleware.model_override import ModelOverrideMiddleware
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/decepticon/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SubAgentMiddleware(backend=backend, subagents=subagents),
-        OPPLANMiddleware(backend=backend),
-        ModelOverrideMiddleware(),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
+    if subagents is None:
+        subagents = [
+            CompiledSubAgent(
+                name=spec.name,
+                description=spec.description,
+                runnable=StreamingRunnable(spec.factory(), spec.name),
+            )
+            for spec in load_subagents_for_parent(_ROLE)
         ]
-    )
 
-    tools = list(load_plugin_tools(role="decepticon"))
-    middleware.extend(load_plugin_middleware(role="decepticon", backend=backend))
+    if tools is None:
+        tools = assemble_tools(
+            role=_ROLE,
+            standard_tools={},  # orchestrator tools=[] — delegation only
+        )
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=None,  # orchestrator has no bash tool / sandbox notification
+            subagents=subagents,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE)
 
-    agent = create_agent(
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="decepticon",
-    )
-
-    # Higher recursion budget than sub-agents (100) — top-level coordinator.
-    return agent.with_config(
+        name=_ROLE,
+    ).with_config(
         {
-            "recursion_limit": 400,
-            "callbacks": load_plugin_callbacks(role="decepticon", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 

--- a/decepticon/agents/standard/decepticon.py
+++ b/decepticon/agents/standard/decepticon.py
@@ -59,8 +59,8 @@ from typing import Any
 from deepagents.middleware.subagents import CompiledSubAgent
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.core.subagent_streaming import StreamingRunnable
 from decepticon.llm import LLMFactory
@@ -153,12 +153,12 @@ def create_decepticon_agent(
         ]
 
     if tools is None:
-        tools = assemble_tools(
+        tools = build_tools(
             role=_ROLE,
             standard_tools={},  # orchestrator tools=[] — delegation only
         )
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -167,7 +167,7 @@ def create_decepticon_agent(
             subagents=subagents,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE)
+        system_prompt = load_prompt(_ROLE)
 
     return create_agent(
         llm,

--- a/decepticon/agents/standard/exploit.py
+++ b/decepticon/agents/standard/exploit.py
@@ -54,11 +54,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import (
@@ -75,9 +75,9 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -93,7 +93,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "exploit"
@@ -157,9 +157,9 @@ def create_exploit_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -167,7 +167,7 @@ def create_exploit_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -184,7 +184,8 @@ def create_exploit_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_exploit_agent()
+if is_bundle_enabled("standard"):
+    graph = create_exploit_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/exploit.py
+++ b/decepticon/agents/standard/exploit.py
@@ -4,39 +4,61 @@ Uses create_agent() directly (not create_deep_agent()) to control the
 middleware stack precisely.
 
 Middleware stack (selected for exploit):
-  1. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
-  2. FilesystemMiddleware — ls/read/write/edit/glob/grep tools (no execute; use bash)
-  3. ModelFallbackMiddleware — sonnet 4.6 → gpt-4.1 fallback on primary failure
-  4. SummarizationMiddleware — auto-compact when context budget exceeded
-  5. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
-  6. PatchToolCallsMiddleware — repair dangling tool calls
+  1. EngagementContextMiddleware — inject engagement metadata
+  2. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
+  3. FilesystemMiddleware — ls/read/write/edit/glob/grep tools
+  4. SandboxNotificationMiddleware — background-command visibility
+  5. ModelFallbackMiddleware — sonnet 4.6 → gpt-4.1 fallback on primary failure
+  6. SummarizationMiddleware — auto-compact when context budget exceeded
+  7. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
+  8. PatchToolCallsMiddleware — repair dangling tool calls
 
 Backend: HTTPSandbox (sandbox daemon talks over HTTP; /skills/ live in the
 sandbox container — see docker-compose.yml).
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_exploit_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["exploit"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
 """
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from __future__ import annotations
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from typing import Any
+
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import (
@@ -54,48 +76,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_exploit_agent():
-    """Initialize the Exploit Agent using langchain create_agent() directly.
-
-    Context engineering decisions:      - Bash tool for running exploit frameworks (sqlmap, Impacket, Certipy, etc.)
-      - ModelFallbackMiddleware: sonnet 4.6 primary → gpt-4.1 fallback on failure
-      - OPPLAN is owned by the orchestrator; this specialist writes evidence only
-      - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation
-    """
-
-    factory = LLMFactory()
-    llm = factory.get_model("exploit")
-    fallback_models = factory.get_fallback_models("exploit")
-
-    # Build HTTPSandbox and inject into bash tool
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("exploit", shared=["bash"])
-    # Skills + workspace both live inside the sandbox (skills bind-mounted at /skills/).
-    backend = make_agent_backend(sandbox)
-
-    # Assemble middleware stack
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/exploit/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -111,24 +93,94 @@ def create_exploit_agent():
         # Execution
         *BASH_TOOLS,
     ]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="exploit"))
-    middleware.extend(load_plugin_middleware(role="exploit", backend=backend))
 
-    agent = create_agent(
+_ROLE = "exploit"
+_RECURSION_LIMIT = 1000
+
+
+def create_exploit_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Exploit agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("exploit")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("exploit")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 1000.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="exploit",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 1000,
-            "callbacks": load_plugin_callbacks(role="exploit", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-
-    return agent
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)

--- a/decepticon/agents/standard/postexploit.py
+++ b/decepticon/agents/standard/postexploit.py
@@ -3,43 +3,62 @@
 Handles credential access, privilege escalation, lateral movement, and C2
 management. Operates from initial foothold until all engagement objectives are met.
 
-Uses create_agent() directly (not create_deep_agent()) to control the
-middleware stack precisely.
-
 Middleware stack (selected for post-exploit):
-  1. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
-  2. FilesystemMiddleware — ls/read/write/edit/glob/grep tools (no execute; use bash)
-  3. ModelFallbackMiddleware — sonnet 4.6 → gpt-4.1 fallback on primary failure
-  4. SummarizationMiddleware — auto-compact when context budget exceeded
-  5. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
-  6. PatchToolCallsMiddleware — repair dangling tool calls
+  1. EngagementContextMiddleware — inject engagement metadata
+  2. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
+  3. FilesystemMiddleware — ls/read/write/edit/glob/grep tools
+  4. SandboxNotificationMiddleware — background-command visibility
+  5. ModelFallbackMiddleware — sonnet 4.6 → gpt-4.1 fallback on primary failure
+  6. SummarizationMiddleware — auto-compact when context budget exceeded
+  7. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
+  8. PatchToolCallsMiddleware — repair dangling tool calls
 
 Backend: HTTPSandbox (sandbox daemon talks over HTTP; /skills/ live in the
 sandbox container — see docker-compose.yml).
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_postexploit_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["postexploit"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
 """
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from __future__ import annotations
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from typing import Any
+
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import killchain_lookup
@@ -54,52 +73,8 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_postexploit_agent():
-    """Initialize the PostExploit Agent using langchain create_agent() directly.
-
-    Context engineering decisions:      - Bash tool for running post-exploitation tools (Mimikatz, Impacket, Evil-WinRM, etc.)
-      - ModelFallbackMiddleware: sonnet 4.6 primary → gpt-4.1 fallback on failure
-      - OPPLAN is owned by the orchestrator; this specialist writes evidence only
-      - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation
-    """
-
-    factory = LLMFactory()
-    llm = factory.get_model("postexploit")
-    fallback_models = factory.get_fallback_models("postexploit")
-
-    # Build HTTPSandbox and inject into bash tool
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("postexploit", shared=["bash"])
-    # Skills + workspace both live inside the sandbox (skills bind-mounted at /skills/).
-    backend = make_agent_backend(sandbox)
-
-    # Assemble middleware stack
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=[
-                "/skills/standard/post-exploit/",
-                "/skills/shared/",
-                *benchmark_skill_sources(),
-            ],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -114,24 +89,94 @@ def create_postexploit_agent():
         # Execution
         *BASH_TOOLS,
     ]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="postexploit"))
-    middleware.extend(load_plugin_middleware(role="postexploit", backend=backend))
 
-    agent = create_agent(
+_ROLE = "postexploit"
+_RECURSION_LIMIT = 400
+
+
+def create_postexploit_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the PostExploit agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("postexploit")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("postexploit")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 400.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="postexploit",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 400,
-            "callbacks": load_plugin_callbacks(role="postexploit", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-
-    return agent
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)

--- a/decepticon/agents/standard/postexploit.py
+++ b/decepticon/agents/standard/postexploit.py
@@ -54,11 +54,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import killchain_lookup
@@ -72,9 +72,9 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -89,7 +89,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "postexploit"
@@ -153,9 +153,9 @@ def create_postexploit_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -163,7 +163,7 @@ def create_postexploit_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -180,7 +180,8 @@ def create_postexploit_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_postexploit_agent()
+if is_bundle_enabled("standard"):
+    graph = create_postexploit_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/recon.py
+++ b/decepticon/agents/standard/recon.py
@@ -1,42 +1,55 @@
 """Recon Agent — autonomous reconnaissance and intelligence gathering.
 
-Uses create_agent() directly (not create_deep_agent()) to control the
-middleware stack precisely.
+Specialist (non-orchestrator) bash-using agent. Standard middleware
+stack with the bash-agent slots — EngagementContext, Skills,
+Filesystem, SandboxNotification, ModelFallback, Summarization,
+PromptCaching, PatchToolCalls. See
+``decepticon.agents.middleware_slots.SLOTS_PER_ROLE`` for the canonical
+role → slot mapping.
 
-Middleware stack (selected for recon):
-  1. SkillsMiddleware — progressive disclosure of SKILL.md knowledge
-  2. FilesystemMiddleware — ls/read/write/edit/glob/grep tools (no execute; use bash)
-  3. ModelFallbackMiddleware — haiku 4.5 → gemini 2.5 flash fallback on primary failure
-  4. SummarizationMiddleware — auto-compact when context budget exceeded
-  5. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
-  6. PatchToolCallsMiddleware — repair dangling tool calls
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
 
-Backend: HTTPSandbox (sandbox daemon talks over HTTP; /skills/ live in the
-sandbox container — see docker-compose.yml).
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_recon_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["recon"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
 """
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from __future__ import annotations
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from typing import Any
+
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import killchain_lookup, oneliner_search
@@ -59,48 +72,9 @@ from decepticon.tools.research.tools import (
 )
 
 
-def create_recon_agent():
-    """Initialize the Recon Agent using langchain create_agent() directly.
-
-    Context engineering decisions:      - InMemoryStore: cross-thread memory for persisting findings across sessions
-      - ModelFallbackMiddleware: haiku 4.5 primary → gemini 2.5 flash fallback on failure
-      - OPPLAN is owned by the orchestrator; this specialist writes evidence only
-      - No SubAgentMiddleware: Decepticon orchestrator handles agent delegation
-    """
-
-    factory = LLMFactory()
-    llm = factory.get_model("recon")
-    fallback_models = factory.get_fallback_models("recon")
-
-    # Build HTTPSandbox and inject into bash tool
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("recon", shared=["bash"])
-    # Skills + workspace both live inside the sandbox (skills bind-mounted at /skills/).
-    backend = make_agent_backend(sandbox)
-
-    # Assemble middleware stack
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/recon/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+# Name-keyed registry so plugin overrides can target specific tools.
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -124,21 +98,94 @@ def create_recon_agent():
         # Execution
         *BASH_TOOLS,
     ]
+    return {t.name: t for t in bundle}
 
-    tools.extend(load_plugin_tools(role="recon"))
-    middleware.extend(load_plugin_middleware(role="recon", backend=backend))
 
-    agent = create_agent(
+_ROLE = "recon"
+_RECURSION_LIMIT = 1000
+
+
+def create_recon_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Recon agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("recon")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("recon")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 1000.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="recon",
+        name=_ROLE,
     ).with_config(
-        {"recursion_limit": 1000, "callbacks": load_plugin_callbacks(role="recon", backend=backend)}
+        {
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
+        }
     )
-
-    return agent
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)

--- a/decepticon/agents/standard/recon.py
+++ b/decepticon/agents/standard/recon.py
@@ -45,11 +45,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import killchain_lookup, oneliner_search
@@ -71,10 +71,10 @@ from decepticon.tools.research.tools import (
     kg_stats,
 )
 
-
 # Name-keyed registry so plugin overrides can target specific tools.
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # KG core
         kg_add_node,
         kg_add_edge,
@@ -98,7 +98,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "recon"
@@ -162,9 +162,9 @@ def create_recon_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -172,7 +172,7 @@ def create_recon_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -189,7 +189,8 @@ def create_recon_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_recon_agent()
+if is_bundle_enabled("standard"):
+    graph = create_recon_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/reverser.py
+++ b/decepticon/agents/standard/reverser.py
@@ -9,32 +9,50 @@ Tool surface (first-class research tools + bash):
     bin_identify, bin_strings, bin_packer, bin_rop,
     bin_symbols_report, bin_ghidra_script, bin_r2_script,
     + everything from the research.tools package.
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_reverser_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["reverser"]``):
+
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+    → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (standalone, not an orchestrator).
 """
 
 from __future__ import annotations
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from typing import Any
 
-from decepticon.agents._benchmark_mode import benchmark_skill_sources
-from decepticon.agents.prompts import load_prompt
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import (
-    EngagementContextMiddleware,
-    FilesystemMiddleware,
-    SandboxNotificationMiddleware,
-)
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    SubAgentSpec,
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.tools import (
@@ -48,37 +66,8 @@ from decepticon.tools.research.tools import (
 from decepticon.tools.reversing.tools import REVERSING_TOOLS
 
 
-def create_reverser_agent():
-    factory = LLMFactory()
-    llm = factory.get_model("reverser")
-    fallback_models = factory.get_fallback_models("reverser")
-
-    sandbox = build_sandbox_backend()
-    set_sandbox(sandbox)
-
-    system_prompt = load_prompt("reverser", shared=["bash"])
-    backend = make_agent_backend(sandbox)
-
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(
-            backend=backend,
-            sources=["/skills/standard/reverser/", "/skills/shared/", *benchmark_skill_sources()],
-        ),
-        FilesystemMiddleware(backend=backend),
-        SandboxNotificationMiddleware(sandbox=sandbox),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    tools = [
+def _build_standard_tools() -> dict[str, Any]:
+    bundle: list[Any] = [
         # Reversing tools
         *REVERSING_TOOLS,
         # KG core + binary triage
@@ -91,24 +80,97 @@ def create_reverser_agent():
         # Execution
         *BASH_TOOLS,
     ]
-    tools.extend(load_plugin_tools(role="reverser"))
-    middleware.extend(load_plugin_middleware(role="reverser", backend=backend))
+    return {t.name: t for t in bundle}
 
-    agent = create_agent(
+
+_ROLE = "reverser"
+_RECURSION_LIMIT = 250
+
+
+def create_reverser_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    sandbox: Any = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Reverser agent.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("reverser")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("reverser")``.
+        sandbox: sandbox backend for bash execution and
+            ``SandboxNotificationMiddleware``. Defaults to
+            ``build_sandbox_backend()``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 250.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    if sandbox is None:
+        sandbox = build_sandbox_backend()
+    set_sandbox(sandbox)
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=sandbox,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+
+    return create_agent(
         llm,
         system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
-        name="reverser",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 250,
-            "callbacks": load_plugin_callbacks(role="reverser", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
-    return agent
 
 
+# Module-level graph for LangGraph Platform (langgraph serve)
 graph = create_reverser_agent()
 
 

--- a/decepticon/agents/standard/reverser.py
+++ b/decepticon/agents/standard/reverser.py
@@ -48,11 +48,11 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import SubAgentSpec, load_plugin_callbacks
+from decepticon.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.research.tools import (
@@ -65,9 +65,9 @@ from decepticon.tools.research.tools import (
 )
 from decepticon.tools.reversing.tools import REVERSING_TOOLS
 
-
-def _build_standard_tools() -> dict[str, Any]:
-    bundle: list[Any] = [
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
         # Reversing tools
         *REVERSING_TOOLS,
         # KG core + binary triage
@@ -80,7 +80,7 @@ def _build_standard_tools() -> dict[str, Any]:
         # Execution
         *BASH_TOOLS,
     ]
-    return {t.name: t for t in bundle}
+}
 
 
 _ROLE = "reverser"
@@ -144,9 +144,9 @@ def create_reverser_agent(
         backend = make_agent_backend(sandbox)
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_build_standard_tools())
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
@@ -154,7 +154,7 @@ def create_reverser_agent(
             sandbox=sandbox,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE, shared=["bash"])
+        system_prompt = load_prompt(_ROLE, shared=["bash"])
 
     return create_agent(
         llm,
@@ -171,7 +171,8 @@ def create_reverser_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve)
-graph = create_reverser_agent()
+if is_bundle_enabled("standard"):
+    graph = create_reverser_agent()
 
 
 SUBAGENT_SPEC = SubAgentSpec(

--- a/decepticon/agents/standard/soundwave.py
+++ b/decepticon/agents/standard/soundwave.py
@@ -8,43 +8,56 @@ owns OPPLAN directly via OPPLANMiddleware.
 Named after the Decepticon intelligence officer who intercepts, processes,
 and organizes strategic information for Megatron's operations.
 
-Library-style factory
----------------------
-``create_soundwave_agent()`` accepts override kwargs (mirroring the
-``deepagents.create_deep_agent`` / ``langchain.create_agent`` shape).
-Library callers compose freely; Docker / plugin authors get the same
-override semantics declaratively via ``PluginBundle`` entry-points
-under ``decepticon.bundles``.
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and
+explicit values fully replace the OSS baseline:
 
-Standard middleware stack (12 slots, per role applicability — see
-``decepticon.agents.middleware_slots.SLOTS_PER_ROLE``):
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS
+baseline AND applies any plugin overrides discovered via the
+``decepticon.bundles`` entry-point group. Three usage paths converge
+cleanly:
+
+  1. **OSS default**: ``create_soundwave_agent()`` — no args.
+  2. **Plugin override** (Docker / pip-installed plugin): authors ship
+     ``PluginBundle(...)`` under ``decepticon.bundles``; the factory
+     discovers and applies it automatically.
+  3. **Full custom** (library composer): import building blocks from
+     ``decepticon.middleware`` / ``decepticon.tools`` and compose with
+     ``langchain.agents.create_agent`` directly. Decepticon's factory
+     is bypassed entirely.
+
+Middleware slots (per ``SLOTS_PER_ROLE["soundwave"]``):
 
   ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → MODEL_FALLBACK
     → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
 
-No SubAgent / OPPLAN (soundwave is standalone, not an orchestrator).
-No SandboxNotification (soundwave is document-only, no bash tool).
+No SubAgent / OPPLAN (standalone, not an orchestrator).
+No SandboxNotification (document-only, no bash tool).
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from langchain.agents import create_agent
 
 from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.middleware_slots import MiddlewareSlot
 from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
 from decepticon.plugin_loader import load_plugin_callbacks
 from decepticon.tools.interaction import ask_user_question, complete_engagement_planning
 
-# Standard tools, name-keyed so plugin overrides can target them.
-# Library callers can pass ``tool_overrides={"ask_user_question": ...}`` to
-# swap; declarative plugins put the same key in
-# ``PluginBundle.replaced_tools``.
+
+# Name-keyed registry of the standard tools. Exposed for library
+# callers who want to splice into the default set (e.g.
+# ``tools=[*_STANDARD_TOOLS.values(), my_extra_tool]``).
 _STANDARD_TOOLS: dict[str, Any] = {
     "ask_user_question": ask_user_question,
     "complete_engagement_planning": complete_engagement_planning,
@@ -56,43 +69,41 @@ _RECURSION_LIMIT = 200
 
 def create_soundwave_agent(
     *,
+    # ── Dependencies (injected for testing / library composition) ────
     backend: Any = None,
     llm: Any = None,
     fallback_models: list | None = None,
-    middleware_overrides: dict[MiddlewareSlot, Callable[..., Any]] | None = None,
-    disabled_slots: set[MiddlewareSlot] | None = None,
-    tool_overrides: dict[str, Any] | None = None,
-    disabled_tools: set[str] | None = None,
-    system_prompt: str | dict[str, str] | None = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
     recursion_limit: int | None = None,
 ):
-    """Build the Soundwave agent with optional library-style overrides.
+    """Build the Soundwave agent.
 
     Args:
         backend: deepagents-style filesystem backend. Defaults to
-            ``make_agent_backend(build_sandbox_backend())`` — the
-            standard CompositeBackend over the HTTP sandbox transport.
-        llm: bound chat model. Defaults to ``LLMFactory().get_model("soundwave")``.
-        fallback_models: passed to ModelFallbackMiddleware. Defaults to
-            ``LLMFactory().get_fallback_models("soundwave")``.
-        middleware_overrides: per-slot factory replacement. Keys are
-            ``MiddlewareSlot`` enum members; values are zero-or-kwarg
-            callables matching ``DEFAULT_SLOT_FACTORIES`` shape.
-        disabled_slots: middleware slots to skip entirely.
-        tool_overrides: name → replacement tool. Wins over plugin
-            entry-point overrides on conflict.
-        disabled_tools: tool names to remove from the baseline.
-        system_prompt:
-            - ``None`` — load the standard prompt + apply plugin overrides.
-            - ``str`` — substitute the prompt entirely.
-            - ``dict[str, str]`` with ``prepend`` / ``append`` /
-              ``replace`` keys — partial prompt patching.
-        recursion_limit: override the per-role default (200).
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to
+            ``LLMFactory().get_model("soundwave")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults
+            to ``LLMFactory().get_fallback_models("soundwave")``.
+        tools: full tool list — when provided, replaces the standard
+            registry entirely. When ``None`` (default), the OSS
+            baseline is built and plugin overrides (via
+            ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the
+            OSS slot stack entirely. When ``None``, the baseline is
+            assembled with plugin slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the
+            baseline. When ``None``, the standard prompt is loaded and
+            plugin prompt overrides are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})``
+            override. Defaults to 200.
 
-    Safety: disabling or replacing safety-critical slots / tools (see
-    ``SAFETY_CRITICAL_SLOTS`` / ``SAFETY_CRITICAL_TOOLS``) raises
-    ``SafetyOverrideViolation`` unless ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1``
-    is set in the environment.
+    Returns:
+        Compiled LangGraph agent.
     """
     if llm is None or fallback_models is None:
         factory = LLMFactory()
@@ -102,32 +113,23 @@ def create_soundwave_agent(
             fallback_models = factory.get_fallback_models(_ROLE)
 
     if backend is None:
-        sandbox = build_sandbox_backend()
-        backend = make_agent_backend(sandbox)
+        backend = make_agent_backend(build_sandbox_backend())
 
-    prompt = load_prompt_with_overrides(_ROLE, override=system_prompt)
-
-    middleware = assemble_middleware(
-        role=_ROLE,
-        backend=backend,
-        llm=llm,
-        fallback_models=fallback_models,
-        sandbox=None,  # soundwave doesn't use SandboxNotification
-        subagents=None,  # standalone — no SubAgent slot
-        overrides=middleware_overrides,
-        disabled_slots=disabled_slots,
-    )
-
-    tools = assemble_tools(
-        role=_ROLE,
-        standard_tools=_STANDARD_TOOLS,
-        overrides=tool_overrides,
-        disabled_tools=disabled_tools,
-    )
+    if tools is None:
+        tools = assemble_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+    if middleware is None:
+        middleware = assemble_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt_with_overrides(_ROLE)
 
     return create_agent(
         llm,
-        system_prompt=prompt,
+        system_prompt=system_prompt,
         tools=tools,
         middleware=middleware,
         name=_ROLE,
@@ -140,5 +142,4 @@ def create_soundwave_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve).
-# Uses default args — equivalent to the legacy unparameterised factory.
 graph = create_soundwave_agent()

--- a/decepticon/agents/standard/soundwave.py
+++ b/decepticon/agents/standard/soundwave.py
@@ -1,105 +1,144 @@
 """Soundwave Agent — engagement document writer.
 
-Generates RoE, CONOPS, and Deconfliction Plan documents that frame the
-red team engagement. Does NOT generate OPPLAN — the orchestrator owns
-OPPLAN directly via OPPLANMiddleware.
+Generates the eight planning documents (RoE / CONOPS / Deconfliction /
+Threat Profile / Contact / Data Handling / Abort / Cleanup) that frame
+the red team engagement. Does NOT generate OPPLAN — the orchestrator
+owns OPPLAN directly via OPPLANMiddleware.
 
 Named after the Decepticon intelligence officer who intercepts, processes,
 and organizes strategic information for Megatron's operations.
 
-Uses create_agent() directly (not create_deep_agent()) to control the
-middleware stack precisely.
+Library-style factory
+---------------------
+``create_soundwave_agent()`` accepts override kwargs (mirroring the
+``deepagents.create_deep_agent`` / ``langchain.create_agent`` shape).
+Library callers compose freely; Docker / plugin authors get the same
+override semantics declaratively via ``PluginBundle`` entry-points
+under ``decepticon.bundles``.
 
-Middleware stack (selected for document writer):
-  1. SkillsMiddleware — progressive disclosure of planning SKILL.md
-  2. FilesystemMiddleware — ls/read/write/edit/glob/grep tools
-  3. ModelFallbackMiddleware — haiku 4.5 → gemini 2.5 flash fallback on primary failure
-  4. SummarizationMiddleware — auto-compact when context budget exceeded
-  5. AnthropicPromptCachingMiddleware — cache system prompt for Anthropic
-  6. PatchToolCallsMiddleware — repair dangling tool calls
+Standard middleware stack (12 slots, per role applicability — see
+``decepticon.agents.middleware_slots.SLOTS_PER_ROLE``):
 
-Backend: HTTPSandbox (sandbox daemon talks over HTTP; /skills/ live in the
-sandbox container — see docker-compose.yml).
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → MODEL_FALLBACK
+    → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
+
+No SubAgent / OPPLAN (soundwave is standalone, not an orchestrator).
+No SandboxNotification (soundwave is document-only, no bash tool).
 """
 
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents import create_agent
-from langchain.agents.middleware import ModelFallbackMiddleware
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from __future__ import annotations
 
-from decepticon.agents.prompts import load_prompt
+from collections.abc import Callable
+from typing import Any
+
+from langchain.agents import create_agent
+
+from decepticon.agents.assembly import assemble_middleware, assemble_tools
+from decepticon.agents.middleware_slots import MiddlewareSlot
+from decepticon.agents.prompts import load_prompt_with_overrides
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.middleware import EngagementContextMiddleware, FilesystemMiddleware
-from decepticon.middleware.skills import SkillsMiddleware
-from decepticon.plugin_loader import (
-    load_plugin_callbacks,
-    load_plugin_middleware,
-    load_plugin_tools,
-)
+from decepticon.plugin_loader import load_plugin_callbacks
 from decepticon.tools.interaction import ask_user_question, complete_engagement_planning
 
+# Standard tools, name-keyed so plugin overrides can target them.
+# Library callers can pass ``tool_overrides={"ask_user_question": ...}`` to
+# swap; declarative plugins put the same key in
+# ``PluginBundle.replaced_tools``.
+_STANDARD_TOOLS: dict[str, Any] = {
+    "ask_user_question": ask_user_question,
+    "complete_engagement_planning": complete_engagement_planning,
+}
 
-def create_soundwave_agent():
-    """Initialize the Soundwave Agent using langchain create_agent() directly.
+_ROLE = "soundwave"
+_RECURSION_LIMIT = 200
 
-    Context engineering decisions:
-      - No OPPLANMiddleware: orchestrator owns OPPLAN directly
-      - No SubAgentMiddleware: soundwave is standalone
-      - No bash tool: soundwave is document-generation only
-      - ModelFallbackMiddleware: haiku 4.5 primary → gemini 2.5 flash fallback on failure
+
+def create_soundwave_agent(
+    *,
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    middleware_overrides: dict[MiddlewareSlot, Callable[..., Any]] | None = None,
+    disabled_slots: set[MiddlewareSlot] | None = None,
+    tool_overrides: dict[str, Any] | None = None,
+    disabled_tools: set[str] | None = None,
+    system_prompt: str | dict[str, str] | None = None,
+    recursion_limit: int | None = None,
+):
+    """Build the Soundwave agent with optional library-style overrides.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())`` — the
+            standard CompositeBackend over the HTTP sandbox transport.
+        llm: bound chat model. Defaults to ``LLMFactory().get_model("soundwave")``.
+        fallback_models: passed to ModelFallbackMiddleware. Defaults to
+            ``LLMFactory().get_fallback_models("soundwave")``.
+        middleware_overrides: per-slot factory replacement. Keys are
+            ``MiddlewareSlot`` enum members; values are zero-or-kwarg
+            callables matching ``DEFAULT_SLOT_FACTORIES`` shape.
+        disabled_slots: middleware slots to skip entirely.
+        tool_overrides: name → replacement tool. Wins over plugin
+            entry-point overrides on conflict.
+        disabled_tools: tool names to remove from the baseline.
+        system_prompt:
+            - ``None`` — load the standard prompt + apply plugin overrides.
+            - ``str`` — substitute the prompt entirely.
+            - ``dict[str, str]`` with ``prepend`` / ``append`` /
+              ``replace`` keys — partial prompt patching.
+        recursion_limit: override the per-role default (200).
+
+    Safety: disabling or replacing safety-critical slots / tools (see
+    ``SAFETY_CRITICAL_SLOTS`` / ``SAFETY_CRITICAL_TOOLS``) raises
+    ``SafetyOverrideViolation`` unless ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1``
+    is set in the environment.
     """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
 
-    factory = LLMFactory()
-    llm = factory.get_model("soundwave")
-    fallback_models = factory.get_fallback_models("soundwave")
+    if backend is None:
+        sandbox = build_sandbox_backend()
+        backend = make_agent_backend(sandbox)
 
-    # Filesystem backend — HTTPSandbox (dev / per-engagement
-    # VM), HTTPSandbox when DECEPTICON_FILESYSTEM_BACKEND=http (Cloud Run
-    # multi-container deploys where there's no host docker daemon). See
-    # decepticon/backends/factory.py for the env contract.
-    sandbox = build_sandbox_backend()
+    prompt = load_prompt_with_overrides(_ROLE, override=system_prompt)
 
-    system_prompt = load_prompt("soundwave")
-    # Skills + workspace both live inside the sandbox (skills bind-mounted at /skills/).
-    backend = make_agent_backend(sandbox)
-
-    # Assemble middleware stack
-    middleware = [
-        EngagementContextMiddleware(),
-        SkillsMiddleware(backend=backend, sources=["/skills/standard/soundwave/"]),
-        FilesystemMiddleware(backend=backend),
-    ]
-    if fallback_models:
-        middleware.append(ModelFallbackMiddleware(*fallback_models))
-    middleware.extend(
-        [
-            create_summarization_middleware(llm, backend),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
+    middleware = assemble_middleware(
+        role=_ROLE,
+        backend=backend,
+        llm=llm,
+        fallback_models=fallback_models,
+        sandbox=None,  # soundwave doesn't use SandboxNotification
+        subagents=None,  # standalone — no SubAgent slot
+        overrides=middleware_overrides,
+        disabled_slots=disabled_slots,
     )
 
-    tools = [ask_user_question, complete_engagement_planning]
-    tools.extend(load_plugin_tools(role="soundwave"))
-    middleware.extend(load_plugin_middleware(role="soundwave", backend=backend))
+    tools = assemble_tools(
+        role=_ROLE,
+        standard_tools=_STANDARD_TOOLS,
+        overrides=tool_overrides,
+        disabled_tools=disabled_tools,
+    )
 
-    agent = create_agent(
+    return create_agent(
         llm,
-        system_prompt=system_prompt,
+        system_prompt=prompt,
         tools=tools,
         middleware=middleware,
-        name="soundwave",
+        name=_ROLE,
     ).with_config(
         {
-            "recursion_limit": 200,
-            "callbacks": load_plugin_callbacks(role="soundwave", backend=backend),
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
         }
     )
 
-    return agent
 
-
-# Module-level graph for LangGraph Platform (langgraph serve)
+# Module-level graph for LangGraph Platform (langgraph serve).
+# Uses default args — equivalent to the legacy unparameterised factory.
 graph = create_soundwave_agent()

--- a/decepticon/agents/standard/soundwave.py
+++ b/decepticon/agents/standard/soundwave.py
@@ -47,13 +47,12 @@ from typing import Any
 
 from langchain.agents import create_agent
 
-from decepticon.agents.assembly import assemble_middleware, assemble_tools
-from decepticon.agents.prompts import load_prompt_with_overrides
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
-from decepticon.plugin_loader import load_plugin_callbacks
+from decepticon.plugin_loader import is_bundle_enabled, load_plugin_callbacks
 from decepticon.tools.interaction import ask_user_question, complete_engagement_planning
-
 
 # Name-keyed registry of the standard tools. Exposed for library
 # callers who want to splice into the default set (e.g.
@@ -116,16 +115,16 @@ def create_soundwave_agent(
         backend = make_agent_backend(build_sandbox_backend())
 
     if tools is None:
-        tools = assemble_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
     if middleware is None:
-        middleware = assemble_middleware(
+        middleware = build_middleware(
             role=_ROLE,
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,
         )
     if system_prompt is None:
-        system_prompt = load_prompt_with_overrides(_ROLE)
+        system_prompt = load_prompt(_ROLE)
 
     return create_agent(
         llm,
@@ -142,4 +141,5 @@ def create_soundwave_agent(
 
 
 # Module-level graph for LangGraph Platform (langgraph serve).
-graph = create_soundwave_agent()
+if is_bundle_enabled("standard"):
+    graph = create_soundwave_agent()

--- a/decepticon/llm/factory.py
+++ b/decepticon/llm/factory.py
@@ -873,12 +873,17 @@ class LLMFactory:
     def router(self) -> ModelRouter:
         return self._router
 
-    def get_model(self, role: str) -> BaseChatModel:
-        """Get the primary ChatModel for a role. Cached per role."""
+    def get_model(self, role: str, *, default_role: str | None = None) -> BaseChatModel:
+        """Get the primary ChatModel for a role. Cached per role.
+
+        ``default_role`` lets plugin orchestrators inherit an OSS role's
+        assignment when their custom role is not in ``AGENT_TIERS`` —
+        e.g. ``LLMFactory().get_model("decepticon-pro", default_role="decepticon")``.
+        """
         if role in self._cache:
             return self._cache[role]
 
-        assignment = self._router.get_assignment(role)
+        assignment = self._router.get_assignment(role, default_role=default_role)
         log.info(
             "Creating LLM for role '%s' → model '%s' via %s",
             role,
@@ -890,15 +895,17 @@ class LLMFactory:
         self._cache[role] = model
         return model
 
-    def get_fallback_models(self, role: str) -> list[BaseChatModel]:
+    def get_fallback_models(
+        self, role: str, *, default_role: str | None = None
+    ) -> list[BaseChatModel]:
         """Build the full ordered list of fallback ChatModel instances.
 
         Each entry mirrors one entry from the agent's credentials chain
         beyond the primary. The agent passes the result via
         ``ModelFallbackMiddleware(*models)``, which tries them in order
-        until one succeeds.
+        until one succeeds. ``default_role`` works as in ``get_model``.
         """
-        assignment = self._router.get_assignment(role)
+        assignment = self._router.get_assignment(role, default_role=default_role)
         if not assignment.fallbacks:
             return []
 

--- a/decepticon/llm/models.py
+++ b/decepticon/llm/models.py
@@ -713,15 +713,23 @@ class LLMModelMapping(BaseModel):
 
     assignments: dict[str, ModelAssignment] = Field(default_factory=dict)
 
-    def get_assignment(self, role: str) -> ModelAssignment:
+    def get_assignment(self, role: str, *, default_role: str | None = None) -> ModelAssignment:
         """Get model assignment for a role.
 
-        Raises KeyError if the role has no assignment (e.g. credentials
-        are empty, or the role isn't in AGENT_TIERS).
+        Plugin orchestrators with a custom role (e.g. ``"decepticon-pro"``)
+        that aren't part of the OSS ``AGENT_TIERS`` registry can pass
+        ``default_role="decepticon"`` (or any OSS role) to inherit that
+        role's assignment as fallback. The plugin can later register its
+        own assignment via entry-point without changing the call site.
+
+        Raises ``KeyError`` if ``role`` has no assignment AND
+        ``default_role`` is either ``None`` or also unassigned.
         """
-        if role not in self.assignments:
-            raise KeyError(f"No model assignment for role: {role}")
-        return self.assignments[role]
+        if role in self.assignments:
+            return self.assignments[role]
+        if default_role is not None and default_role in self.assignments:
+            return self.assignments[default_role]
+        raise KeyError(f"No model assignment for role: {role}")
 
     @classmethod
     def from_credentials_and_profile(

--- a/decepticon/llm/router.py
+++ b/decepticon/llm/router.py
@@ -30,6 +30,11 @@ class ModelRouter:
         assignment = self.get_assignment(role)
         return [assignment.primary, *assignment.fallbacks]
 
-    def get_assignment(self, role: str) -> ModelAssignment:
-        """Return full ModelAssignment for a role."""
-        return self.mapping.get_assignment(role)
+    def get_assignment(self, role: str, *, default_role: str | None = None) -> ModelAssignment:
+        """Return full ModelAssignment for a role.
+
+        ``default_role`` lets plugin orchestrators inherit an OSS role's
+        assignment when their own role is not in ``AGENT_TIERS`` —
+        see ``LLMModelMapping.get_assignment`` for the contract.
+        """
+        return self.mapping.get_assignment(role, default_role=default_role)

--- a/decepticon/plugin_loader.py
+++ b/decepticon/plugin_loader.py
@@ -49,6 +49,7 @@ MIDDLEWARE_GROUP = "decepticon.middleware"
 AGENTS_GROUP = "decepticon.agents"
 SUBAGENTS_GROUP = "decepticon.subagents"
 CALLBACKS_GROUP = "decepticon.callbacks"
+SKILLS_GROUP = "decepticon.skills"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -226,7 +227,7 @@ class PluginBundle:
 
         PluginBundle(
             bundle="saas",
-            prompt_overrides={
+            prompts={
                 "soundwave": {"append": "<SAAS_AUDIT_POLICY>...</SAAS_AUDIT_POLICY>"},
             },
         )
@@ -245,7 +246,7 @@ class PluginBundle:
         the end of the standard stack. Pre-existing behaviour, unchanged.
     bundle
         Optional grouping label; ``None`` = always-load when installed.
-    applies_to_roles
+    roles
         Empty tuple = applies to whichever role triggered the load
         (existing entry-point group-based scoping). Non-empty tuple
         restricts the override to those role names only — useful when
@@ -266,7 +267,7 @@ class PluginBundle:
         ``f(*, backend, llm, role, fallback_models, sandbox, subagents)``
         — and returns a middleware instance (or None for conditional
         slots).
-    prompt_overrides
+    prompts
         Role name → dict with optional ``prepend`` / ``append`` /
         ``replace`` keys. ``replace`` wholly substitutes the loaded
         prompt; ``prepend`` / ``append`` wrap it. When ``replace`` is
@@ -282,7 +283,7 @@ class PluginBundle:
     bundle: str | None = None
 
     # ── Override scoping ─────────────────────────────────────────────
-    applies_to_roles: tuple[str, ...] = ()
+    roles: tuple[str, ...] = ()
 
     # ── Tool overrides ───────────────────────────────────────────────
     disabled_tools: tuple[str, ...] = ()
@@ -293,15 +294,15 @@ class PluginBundle:
     replaced_middleware: dict[str, Callable[..., Any]] = field(default_factory=dict)
 
     # ── Prompt overrides ─────────────────────────────────────────────
-    prompt_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+    prompts: dict[str, dict[str, str]] = field(default_factory=dict)
 
     # ── Sub-agent overrides ──────────────────────────────────────────
     disabled_subagents: tuple[str, ...] = ()
     replaced_subagents: dict[str, Any] = field(default_factory=dict)
 
     def matches_role(self, role: str) -> bool:
-        """``applies_to_roles`` filter — empty tuple = unrestricted."""
-        return not self.applies_to_roles or role in self.applies_to_roles
+        """``roles`` filter — empty tuple = unrestricted."""
+        return not self.roles or role in self.roles
 
 
 @dataclass(frozen=True)
@@ -333,9 +334,6 @@ class SubAgentSpec:
             small explicit values (10, 20, ...) so their order is
             preserved; plugin subagents typically fall back to 100 and
             are appended at the end alphabetically.
-        skill_sources: optional tuple of ``/skills/<x>/`` paths the
-            subagent expects to find inside the sandbox. Reserved for
-            future skill-routing wiring; main agents currently ignore.
     """
 
     name: str
@@ -344,7 +342,6 @@ class SubAgentSpec:
     parent_agents: tuple[str, ...] = ()
     bundle: str | None = None
     priority: int = 100
-    skill_sources: tuple[str, ...] = field(default_factory=tuple)
 
 
 # Attributes that distinguish a Tool/Middleware/Callback INSTANCE from a
@@ -430,6 +427,22 @@ def load_plugin_middleware(role: str | None = None, **deps: Any) -> list[Any]:
 def load_plugin_callbacks(role: str | None = None, **deps: Any) -> list[Any]:
     """Discover LangChain callback handlers contributed by external packages."""
     return _discover(CALLBACKS_GROUP, role=role, **deps)
+
+
+def load_plugin_skill_sources(role: str | None = None) -> list[str]:
+    """Discover ``/skills/<bundle>/`` paths contributed by external packages.
+
+    Plugin packages declare a callable ``f(role: str) -> list[str]`` or a
+    static ``list[str]`` under the ``decepticon.skills`` entry-point group.
+    The result is appended to the OSS-default paths returned by
+    ``skills_sources_for(role)`` so plugin skills layer ON TOP of the
+    baseline without requiring full SKILLS slot replacement.
+
+    Non-string return values are filtered out — plugins should ship POSIX
+    paths matching the convention ``/skills/<bundle>/[<role>/]``.
+    """
+    raw = _discover(SKILLS_GROUP, role=role)
+    return [p for p in raw if isinstance(p, str) and p]
 
 
 def _discover_subagent_specs() -> list[SubAgentSpec]:

--- a/decepticon/plugin_loader.py
+++ b/decepticon/plugin_loader.py
@@ -172,31 +172,136 @@ def is_bundle_enabled(bundle: str | None) -> bool:
 
 @dataclass(frozen=True)
 class PluginBundle:
-    """Optional wrapper for entry-point contributions to declare bundle membership.
+    """Wrapper for entry-point contributions to declare bundle membership
+    AND override the standard middleware / tools / prompts.
 
-    Plugin authors who want bundle-level activation control wrap their
-    tools / middleware / callbacks in this. Plain list returns (the
-    existing convention) keep working as ``bundle=None`` — always-load
-    when installed, matching Claude Code's MCP-server semantics.
+    The original ``items``-only shape stays the additive escape hatch:
+    plain list returns and ``PluginBundle(items=(...,))`` keep working
+    as before. The expansion fields below let plugins replace, disable,
+    or patch the components an agent factory would otherwise build
+    inline.
 
-    Example::
+    Override mechanics
+    ------------------
+    Tools / middleware / prompts / subagents are name-keyed. A plugin
+    that wants to ship a Slack version of ``ask_user_question`` either
+    drops the standard one (``disabled_tools=("ask_user_question",)``)
+    and adds its own via ``items``, OR uses
+    ``replaced_tools={"ask_user_question": SaaSSlackAskTool}`` which
+    combines the two steps. Middleware slot replacement works the same
+    way — slot names match the ``MiddlewareSlot`` enum values in
+    ``decepticon.agents.middleware_slots``.
 
-        # my_plugin/tools.py
-        from decepticon.plugin_loader import PluginBundle
-        from langchain_core.tools import tool
+    Safety gating
+    -------------
+    A subset of slots and tools are flagged safety-critical (see
+    ``SAFETY_CRITICAL_SLOTS`` / ``SAFETY_CRITICAL_TOOLS`` in
+    ``decepticon.agents``). Plugins attempting to disable or replace
+    those raise ``SafetyOverrideViolation`` at agent-construction time
+    unless ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` is set in the
+    environment. The gate exists so an accidentally-installed plugin
+    can't silently subvert ``EngagementContextMiddleware``,
+    ``SandboxNotificationMiddleware``, ``ask_user_question``, or
+    ``complete_engagement_planning``.
 
-        @tool
-        def my_premium_tool(query: str) -> str:
-            ...
+    Examples
+    --------
 
-        # pyproject.toml entry-point points at this constant:
-        TOOLS = PluginBundle(items=(my_premium_tool,), bundle="premium")
+    Slack version of ask_user_question::
 
-        # Only loaded when DECEPTICON_PLUGINS includes "premium".
+        ASK_USER_VIA_SLACK = PluginBundle(
+            bundle="saas",
+            replaced_tools={"ask_user_question": saas_slack_ask_tool},
+        )
+
+    Drop OSS prompt caching, ship a SaaS one in its place::
+
+        PluginBundle(
+            bundle="saas",
+            disabled_middleware=("prompt-caching",),
+            items=(SaaSCacheMiddleware(),),
+        )
+
+    Append SaaS audit policy to the soundwave prompt::
+
+        PluginBundle(
+            bundle="saas",
+            prompt_overrides={
+                "soundwave": {"append": "<SAAS_AUDIT_POLICY>...</SAAS_AUDIT_POLICY>"},
+            },
+        )
+
+    Replace the standard recon sub-agent with a SaaS-licensed version::
+
+        PluginBundle(
+            bundle="saas",
+            replaced_subagents={"recon": saas.recon.SUBAGENT_SPEC},
+        )
+
+    Fields
+    ------
+    items
+        Plain additive shape — middleware / tools / callbacks added to
+        the end of the standard stack. Pre-existing behaviour, unchanged.
+    bundle
+        Optional grouping label; ``None`` = always-load when installed.
+    applies_to_roles
+        Empty tuple = applies to whichever role triggered the load
+        (existing entry-point group-based scoping). Non-empty tuple
+        restricts the override to those role names only — useful when
+        a plugin ships overrides for several agents but each must scope
+        independently.
+    disabled_tools
+        Tool names (the @tool callable's ``.name`` attribute) to remove
+        from the standard registry for the matching role.
+    replaced_tools
+        Tool name → replacement callable. Removes the standard tool of
+        that name and adds the replacement in its place. The replacement
+        must have a ``.name`` attribute matching the dict key.
+    disabled_middleware
+        Slot names (MiddlewareSlot values) to skip during assembly.
+    replaced_middleware
+        Slot name → factory callable. Factory signature mirrors
+        ``DEFAULT_SLOT_FACTORIES`` entries —
+        ``f(*, backend, llm, role, fallback_models, sandbox, subagents)``
+        — and returns a middleware instance (or None for conditional
+        slots).
+    prompt_overrides
+        Role name → dict with optional ``prepend`` / ``append`` /
+        ``replace`` keys. ``replace`` wholly substitutes the loaded
+        prompt; ``prepend`` / ``append`` wrap it. When ``replace`` is
+        set, ``prepend`` / ``append`` are ignored.
+    disabled_subagents
+        Sub-agent names to skip when the orchestrator iterates
+        ``load_subagents_for_parent``.
+    replaced_subagents
+        Sub-agent name → SubAgentSpec replacement.
     """
 
     items: tuple[Any, ...] = ()
     bundle: str | None = None
+
+    # ── Override scoping ─────────────────────────────────────────────
+    applies_to_roles: tuple[str, ...] = ()
+
+    # ── Tool overrides ───────────────────────────────────────────────
+    disabled_tools: tuple[str, ...] = ()
+    replaced_tools: dict[str, Any] = field(default_factory=dict)
+
+    # ── Middleware overrides ─────────────────────────────────────────
+    disabled_middleware: tuple[str, ...] = ()
+    replaced_middleware: dict[str, Callable[..., Any]] = field(default_factory=dict)
+
+    # ── Prompt overrides ─────────────────────────────────────────────
+    prompt_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    # ── Sub-agent overrides ──────────────────────────────────────────
+    disabled_subagents: tuple[str, ...] = ()
+    replaced_subagents: dict[str, Any] = field(default_factory=dict)
+
+    def matches_role(self, role: str) -> bool:
+        """``applies_to_roles`` filter — empty tuple = unrestricted."""
+        return not self.applies_to_roles or role in self.applies_to_roles
 
 
 @dataclass(frozen=True)

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -65,7 +65,7 @@ Available kwargs on every factory:
 | `subagents` | `load_subagents_for_parent(role)` (orchestrators only) | full subagent list |
 | `tools` | per-role registry | **full tool list** — replaces baseline |
 | `middleware` | per-role slot stack | **full middleware list** — replaces slot assembly |
-| `system_prompt` | `load_prompt_with_overrides(role)` | **full prompt** — replaces baseline |
+| `system_prompt` | `load_prompt(role)` (plugin overrides applied) | **full prompt** — replaces baseline |
 | `recursion_limit` | per-role (60–1000) | `with_config({"recursion_limit": ...})` |
 
 > When `tools` / `middleware` / `system_prompt` is `None` (the
@@ -126,6 +126,65 @@ agent = create_agent(
 This is the canonical path for SaaS / research integrators who want
 to ship their own service on top of Decepticon's agent code.
 
+### 3b. Plugin orchestrator with the OSS slot system (`build_middleware(slots=...)`)
+
+When the commercial product wants to ship a **new orchestrator agent
+type** (not one of the OSS 16) but still wants Decepticon's slot
+system, safety gate, and plugin-override pipeline, pass an explicit
+``slots`` set to ``build_middleware``:
+
+```python
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.middleware_slots import MiddlewareSlot
+from decepticon.agents.prompts import load_prompt
+from decepticon.llm import LLMFactory
+
+PRO_SLOTS = frozenset({
+    MiddlewareSlot.ENGAGEMENT_CONTEXT,
+    MiddlewareSlot.SKILLS,
+    MiddlewareSlot.FILESYSTEM,
+    MiddlewareSlot.SUBAGENT,
+    MiddlewareSlot.OPPLAN,
+    MiddlewareSlot.MODEL_FALLBACK,
+    MiddlewareSlot.SUMMARIZATION,
+    MiddlewareSlot.PROMPT_CACHING,
+    MiddlewareSlot.PATCH_TOOL_CALLS,
+})
+
+PRO_SKILL_SOURCES = [
+    "/skills/saas-pro/orchestrator/",
+    "/skills/shared/",
+]
+
+def create_decepticon_pro_agent(**kwargs):
+    # LLMFactory only knows OSS role assignments; pass default_role=
+    # to inherit one as fallback until the plugin registers its own.
+    llm_factory = LLMFactory()
+    llm = llm_factory.get_model("decepticon-pro", default_role="decepticon")
+    fallbacks = llm_factory.get_fallback_models("decepticon-pro", default_role="decepticon")
+
+    middleware = build_middleware(
+        role="decepticon-pro",         # custom role — NOT in SLOTS_PER_ROLE
+        slots=PRO_SLOTS,               # plugin author declares its slot set
+        skill_sources=PRO_SKILL_SOURCES,  # bypass OSS skills_sources_for() lookup
+        backend=..., llm=llm, fallback_models=fallbacks, subagents=[...],
+    )
+    return create_agent(..., middleware=middleware, ...)
+```
+
+Three plugin-orchestrator escape hatches converge here:
+
+- ``slots=`` — without it, ``build_middleware`` raises ``KeyError`` for
+  unknown roles. Silent fallback to an empty stack would mask real
+  bugs in plugin code.
+- ``skill_sources=`` — without it, the SKILLS slot calls
+  ``skills_sources_for(role)`` which only knows the 10 OSS standard
+  roles. Plugin specialists/orchestrators pass an explicit list.
+- ``default_role=`` on ``LLMFactory.get_model`` /
+  ``LLMFactory.get_fallback_models`` — without it, the factory raises
+  ``KeyError`` for roles not in ``AGENT_TIERS``. Plugin can inherit any
+  OSS role's model assignment until it ships its own.
+
 ---
 
 ## Declarative plugin overrides (`PluginBundle`)
@@ -151,14 +210,14 @@ SAAS_BUNDLE = PluginBundle(
     replaced_middleware={"skills": saas_skills_factory},
     disabled_middleware=("prompt-caching",),
     # Prompt patches per role
-    prompt_overrides={
+    prompts={
         "soundwave": {"append": "<SAAS_AUDIT_POLICY>...</SAAS_AUDIT_POLICY>"},
         "recon": {"prepend": "<SAAS_HEADER>..."},
     },
     # Sub-agents
     replaced_subagents={"recon": saas_pkg.agents.recon.SUBAGENT_SPEC},
     # Optional role scoping (empty tuple = applies to every role)
-    applies_to_roles=("soundwave", "recon"),
+    roles=("soundwave", "recon"),
 )
 ```
 
@@ -171,6 +230,31 @@ saas = "saas_pkg.bundles:SAAS_BUNDLE"
 Activation also honors the existing `DECEPTICON_PLUGINS` env / config
 allowlist via `bundle="saas"`. Set
 `DECEPTICON_PLUGINS=standard,saas` to opt in.
+
+### Adding skills via entry-points
+
+Skill packages (the `/skills/<bundle>/` markdown trees consumed by
+`SkillsMiddleware`) plug in through their own entry-point group so
+plugin authors can layer skills onto OSS without overriding the
+SKILLS slot factory.
+
+```python
+# saas_pkg/skills.py
+def skill_sources(role: str) -> list[str]:
+    if role in ("recon", "exploit"):
+        return ["/skills/saas-pro/", "/skills/saas-shared/"]
+    return []
+```
+
+```toml
+# saas_pkg/pyproject.toml
+[project.entry-points."decepticon.skills"]
+saas = "saas_pkg.skills:skill_sources"
+```
+
+Plugin paths are appended after the OSS baseline returned by
+`decepticon.agents.middleware_slots.skills_sources_for`, so OSS skills
+keep their priority in the progressive-disclosure budget.
 
 ### Override resolution order
 
@@ -216,8 +300,8 @@ to honor the original semantics.
 |--------|---------|
 | `decepticon.agents.standard.*`, `decepticon.agents.plugins.*` | Pre-built per-role agent factories |
 | `decepticon.agents.middleware_slots` | `MiddlewareSlot` enum, `SLOTS_PER_ROLE`, `DEFAULT_SLOT_FACTORIES` |
-| `decepticon.agents.assembly` | `assemble_middleware`, `assemble_tools`, `resolve_prompt_overrides`, `SafetyOverrideViolation` |
-| `decepticon.agents.prompts` | `load_prompt`, `load_prompt_with_overrides`, `PromptBuilder` |
+| `decepticon.agents.build` | `build_middleware`, `build_tools`, `resolve_prompt_overrides`, `SafetyOverrideViolation` |
+| `decepticon.agents.prompts` | `load_prompt`, `PromptBuilder` |
 | `decepticon.middleware` | `SkillsMiddleware`, `FilesystemMiddleware`, `EngagementContextMiddleware`, `OPPLANMiddleware`, `SandboxNotificationMiddleware`, … |
 | `decepticon.tools.bash` | `BASH_TOOLS` (the four bash tools), `set_sandbox` |
 | `decepticon.tools.research`, `decepticon.tools.references` | KG / CVE / payload tools |
@@ -240,8 +324,8 @@ from decepticon.agents.standard.recon import create_recon_agent
 # and the default factory picks it up automatically.
 
 # Or pass explicitly — but you have to include the full tool list:
-from decepticon.agents.standard.recon import _build_standard_tools
-all_tools = list(_build_standard_tools().values()) + [my_tool]
+from decepticon.agents.standard.recon import _STANDARD_TOOLS
+all_tools = [*_STANDARD_TOOLS.values(), my_tool]
 agent = create_recon_agent(tools=all_tools)
 ```
 

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -1,0 +1,309 @@
+# Decepticon as a Library
+
+Decepticon is built on top of `langchain` / `langgraph` / `deepagents`
+and follows the same composition idiom: opinionated middleware + tools
++ prompts you can either consume pre-built or compose into something
+of your own. This document covers the three usage paths and the
+override surface plugin authors have access to.
+
+If you only run Decepticon via the bundled Docker stack and never
+touch the Python code, none of this applies — keep using `curl | bash`
+and the CLI launcher. This document is for SaaS / commercial / research
+integrators building on top of the agent code.
+
+---
+
+## Three usage paths
+
+### 1. Pre-built agents (OSS default)
+
+The 16 agent factories ship preconfigured. Module-level `graph`
+constants are what LangGraph Platform picks up from `langgraph.json`.
+
+```python
+from decepticon.agents.standard.recon import create_recon_agent, graph
+
+agent = create_recon_agent()  # default OSS configuration
+# `graph` is the same thing, built once at import time.
+```
+
+No arguments needed; every dependency (LLM, sandbox, backend,
+fallback chain) is resolved at call time using `LLMFactory` + the
+configured sandbox URL.
+
+### 2. Factory with explicit overrides
+
+The 16 factories accept langchain-style keyword arguments. Provide a
+value to replace the default for that field; leave `None` to keep the
+baseline (and apply any plugin overrides discovered via entry-points).
+
+```python
+from langchain_core.tools import tool
+
+from decepticon.agents.standard.soundwave import create_soundwave_agent
+
+@tool
+def saas_slack_ask_user(question: str, header: str = "") -> str:
+    """Send the operator's question to a Slack channel and block until reply."""
+    ...
+
+agent = create_soundwave_agent(
+    tools=[saas_slack_ask_user],          # full tool list (replaces baseline)
+    system_prompt="<your custom prompt>", # full prompt replace
+    recursion_limit=500,                  # tuning
+)
+```
+
+Available kwargs on every factory:
+
+| Kwarg | Default | Effect when provided |
+|-------|---------|---------------------|
+| `backend` | `make_agent_backend(build_sandbox_backend())` | injected `BackendProtocol` |
+| `llm` | `LLMFactory().get_model(role)` | injected chat model |
+| `fallback_models` | `LLMFactory().get_fallback_models(role)` | passed to `ModelFallbackMiddleware` |
+| `sandbox` | `build_sandbox_backend()` (bash agents only) | injected `HTTPSandbox` |
+| `subagents` | `load_subagents_for_parent(role)` (orchestrators only) | full subagent list |
+| `tools` | per-role registry | **full tool list** — replaces baseline |
+| `middleware` | per-role slot stack | **full middleware list** — replaces slot assembly |
+| `system_prompt` | `load_prompt_with_overrides(role)` | **full prompt** — replaces baseline |
+| `recursion_limit` | per-role (60–1000) | `with_config({"recursion_limit": ...})` |
+
+> When `tools` / `middleware` / `system_prompt` is `None` (the
+> default), the factory builds the OSS baseline AND applies any plugin
+> overrides discovered via the `decepticon.bundles` entry-point group.
+> When an explicit value is supplied, the baseline AND the plugin
+> overrides for that surface are bypassed — the caller takes full
+> control.
+
+### 3. Direct composition with `langchain.create_agent`
+
+For total control, import Decepticon's building blocks and assemble
+with langchain's generic agent constructor. Decepticon's factory is
+bypassed entirely.
+
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import ModelFallbackMiddleware
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+
+from decepticon.agents.prompts import load_prompt
+from decepticon.backends import build_sandbox_backend, make_agent_backend
+from decepticon.llm import LLMFactory
+from decepticon.middleware import (
+    EngagementContextMiddleware,
+    FilesystemMiddleware,
+    SandboxNotificationMiddleware,
+    SkillsMiddleware,
+)
+from decepticon.tools.bash import BASH_TOOLS
+from decepticon.tools.bash.bash import set_sandbox
+from decepticon.tools.research.tools import kg_query, kg_stats
+
+sandbox = build_sandbox_backend()
+set_sandbox(sandbox)
+backend = make_agent_backend(sandbox)
+llm = LLMFactory().get_model("recon")  # or your own ChatModel
+
+agent = create_agent(
+    llm,
+    system_prompt=load_prompt("recon", shared=["bash"]),
+    tools=[*BASH_TOOLS, kg_query, kg_stats, my_custom_tool],
+    middleware=[
+        EngagementContextMiddleware(),
+        SkillsMiddleware(backend=backend, sources=["/skills/my-saas/"]),
+        FilesystemMiddleware(backend=backend),
+        SandboxNotificationMiddleware(sandbox=sandbox),
+        ModelFallbackMiddleware(...),
+        my_audit_middleware,
+        AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
+        PatchToolCallsMiddleware(),
+    ],
+    name="saas-recon-v2",
+)
+```
+
+This is the canonical path for SaaS / research integrators who want
+to ship their own service on top of Decepticon's agent code.
+
+---
+
+## Declarative plugin overrides (`PluginBundle`)
+
+Plugin authors who pip-install on top of an existing Decepticon Docker
+image (rather than composing a service from scratch) ship a
+`PluginBundle` under the `decepticon.bundles` entry-point group.
+Factories discover and apply it automatically — no factory kwargs
+needed.
+
+```python
+# saas_pkg/bundles.py
+from decepticon.plugin_loader import PluginBundle
+from saas_pkg.tools import saas_slack_ask
+from saas_pkg.middleware import saas_skills_factory
+
+SAAS_BUNDLE = PluginBundle(
+    bundle="saas",
+    # Tools
+    replaced_tools={"ask_user_question": saas_slack_ask},
+    disabled_tools=("complete_engagement_planning",),
+    # Middleware (slot names = MiddlewareSlot values)
+    replaced_middleware={"skills": saas_skills_factory},
+    disabled_middleware=("prompt-caching",),
+    # Prompt patches per role
+    prompt_overrides={
+        "soundwave": {"append": "<SAAS_AUDIT_POLICY>...</SAAS_AUDIT_POLICY>"},
+        "recon": {"prepend": "<SAAS_HEADER>..."},
+    },
+    # Sub-agents
+    replaced_subagents={"recon": saas_pkg.agents.recon.SUBAGENT_SPEC},
+    # Optional role scoping (empty tuple = applies to every role)
+    applies_to_roles=("soundwave", "recon"),
+)
+```
+
+```toml
+# saas_pkg/pyproject.toml
+[project.entry-points."decepticon.bundles"]
+saas = "saas_pkg.bundles:SAAS_BUNDLE"
+```
+
+Activation also honors the existing `DECEPTICON_PLUGINS` env / config
+allowlist via `bundle="saas"`. Set
+`DECEPTICON_PLUGINS=standard,saas` to opt in.
+
+### Override resolution order
+
+1. Plugin `decepticon.bundles` entries (merged across all installed
+   plugins, last-write-wins on conflicts).
+2. Explicit kwargs passed to the factory (`tools=`, `middleware=`,
+   `system_prompt=`, …). Always win.
+
+When `tools=` / `middleware=` / `system_prompt=` is `None`, plugins
+apply normally. When the kwarg is non-None, plugin overrides for that
+specific surface are skipped — the caller has taken full control.
+
+---
+
+## Safety gate
+
+A small allowlist of slots and tools is flagged safety-critical:
+
+| Kind | Item | Why |
+|------|------|-----|
+| Middleware slot | `engagement-context` | Carries RoE constraints into every tool call |
+| Middleware slot | `sandbox-notification` | Tracks background-job completion — operator visibility |
+| Tool | `ask_user_question` | Operator-approval channel |
+| Tool | `complete_engagement_planning` | Mandatory engagement-handoff signal |
+
+Disabling or replacing any of these (whether via factory kwarg, plugin
+bundle, or both) raises `SafetyOverrideViolation` at agent-construction
+time unless `DECEPTICON_ALLOW_SAFETY_OVERRIDES=1` is set in the
+environment. The gate exists so an accidentally-installed plugin
+cannot silently subvert the safety story — operators must explicitly
+opt in.
+
+The gate does not validate that a replacement honors the same contract
+(e.g. a substitute `EngagementContextMiddleware` still injects RoE
+scope). It only prevents accidental holes. Replacements are expected
+to honor the original semantics.
+
+---
+
+## Building blocks reference
+
+| Import | Purpose |
+|--------|---------|
+| `decepticon.agents.standard.*`, `decepticon.agents.plugins.*` | Pre-built per-role agent factories |
+| `decepticon.agents.middleware_slots` | `MiddlewareSlot` enum, `SLOTS_PER_ROLE`, `DEFAULT_SLOT_FACTORIES` |
+| `decepticon.agents.assembly` | `assemble_middleware`, `assemble_tools`, `resolve_prompt_overrides`, `SafetyOverrideViolation` |
+| `decepticon.agents.prompts` | `load_prompt`, `load_prompt_with_overrides`, `PromptBuilder` |
+| `decepticon.middleware` | `SkillsMiddleware`, `FilesystemMiddleware`, `EngagementContextMiddleware`, `OPPLANMiddleware`, `SandboxNotificationMiddleware`, … |
+| `decepticon.tools.bash` | `BASH_TOOLS` (the four bash tools), `set_sandbox` |
+| `decepticon.tools.research`, `decepticon.tools.references` | KG / CVE / payload tools |
+| `decepticon.tools.interaction` | `ask_user_question`, `complete_engagement_planning` |
+| `decepticon.backends` | `HTTPSandbox`, `build_sandbox_backend`, `make_agent_backend` |
+| `decepticon.llm` | `LLMFactory` |
+| `decepticon.core.schemas` | `RoE`, `CONOPS`, `DeconflictionPlan`, `OPPLAN`, `ThreatProfile`, `CleanupPlan`, `AbortPlan`, `ContactPlan`, `DataHandlingPlan` |
+| `decepticon.plugin_loader` | `PluginBundle`, `SubAgentSpec`, `is_bundle_enabled`, `load_plugin_*` |
+
+---
+
+## Common patterns
+
+### Add a single SaaS tool to the default agent
+
+```python
+from decepticon.agents.standard.recon import create_recon_agent
+
+# Easiest: ship a PluginBundle (items=(my_tool,)) under decepticon.bundles
+# and the default factory picks it up automatically.
+
+# Or pass explicitly — but you have to include the full tool list:
+from decepticon.agents.standard.recon import _build_standard_tools
+all_tools = list(_build_standard_tools().values()) + [my_tool]
+agent = create_recon_agent(tools=all_tools)
+```
+
+### Run an OSS agent with a different model
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+custom_llm = ChatAnthropic(model="claude-opus-4-5", temperature=0)
+agent = create_recon_agent(llm=custom_llm, fallback_models=[])
+```
+
+### Replace `SkillsMiddleware` with a SaaS caching version
+
+Plugin path (declarative, recommended):
+
+```python
+PluginBundle(
+    bundle="saas",
+    replaced_middleware={"skills": saas_skills_factory},
+)
+```
+
+Library path (full control):
+
+```python
+# Compose your own middleware list with langchain.create_agent.
+# See path 3 above.
+```
+
+### Disable a non-critical slot for one agent
+
+```python
+from decepticon.agents.middleware_slots import MiddlewareSlot
+from decepticon.agents.standard.soundwave import create_soundwave_agent
+
+# Drop AnthropicPromptCachingMiddleware (we have our own cache layer).
+# This is library-style direct call; for plugin-wide disable, use
+# PluginBundle(disabled_middleware=("prompt-caching",)).
+import os
+os.environ["DECEPTICON_ALLOW_SAFETY_OVERRIDES"] = "0"  # default — only non-critical slots ok
+# … then use the factory's `middleware=` kwarg with your own composed list,
+# or rely on a plugin bundle.
+```
+
+---
+
+## Versioning
+
+Decepticon-core follows SemVer 0.x semantics until the API has settled
+through real commercial integrations. Public surface listed above is
+the intended stability target; internals (`_resolve_overrides`,
+private factory helpers, etc.) may change without notice.
+
+Pin to a tag in your `pyproject.toml`:
+
+```toml
+[project]
+dependencies = [
+    "decepticon @ git+https://github.com/PurpleAILAB/Decepticon.git@v1.x.y",
+]
+```
+
+PyPI publication is on the roadmap once the public API surface is
+stable enough to commit to.

--- a/tests/unit/agents/test_assembly.py
+++ b/tests/unit/agents/test_assembly.py
@@ -1,0 +1,320 @@
+"""Plugin override + safety-gate tests for the agent-assembly pipeline.
+
+These pin the contract the 16 agent factories rely on:
+
+  - ``assemble_middleware`` / ``assemble_tools`` apply plugin entry-point
+    overrides AND explicit kwargs, with explicit winning on conflict.
+  - ``resolve_prompt_overrides`` merges plugin + explicit prompt patches.
+  - Safety-critical slot/tool overrides raise ``SafetyOverrideViolation``
+    unless ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` is in the environment.
+  - ``PluginBundle.matches_role`` honors ``applies_to_roles`` scoping.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from decepticon.agents import assembly
+from decepticon.agents.middleware_slots import MiddlewareSlot
+from decepticon import plugin_loader
+from decepticon.plugin_loader import PluginBundle
+
+
+class _FakeEntryPoint:
+    """Stand-in for ``importlib.metadata.EntryPoint`` used in bundle tests."""
+
+    def __init__(self, name: str, value: str, loaded):
+        self.name = name
+        self.value = value
+        self._loaded = loaded
+
+    def load(self):
+        return self._loaded
+
+
+# ── PluginBundle.matches_role ────────────────────────────────────────
+
+
+def test_plugin_bundle_unrestricted_matches_every_role():
+    bundle = PluginBundle(items=())
+    assert bundle.matches_role("decepticon")
+    assert bundle.matches_role("any-future-role")
+
+
+def test_plugin_bundle_applies_to_roles_filter():
+    bundle = PluginBundle(applies_to_roles=("recon", "exploit"))
+    assert bundle.matches_role("recon")
+    assert bundle.matches_role("exploit")
+    assert not bundle.matches_role("soundwave")
+
+
+# ── _iter_override_bundles discovery ─────────────────────────────────
+
+
+def test_iter_override_bundles_yields_role_scoped_bundles_only():
+    saas_recon = PluginBundle(applies_to_roles=("recon",))
+    saas_all = PluginBundle()
+    eps = [
+        _FakeEntryPoint("saas-recon", "saas:recon_bundle", saas_recon),
+        _FakeEntryPoint("saas-all", "saas:all_bundle", saas_all),
+    ]
+    with patch.object(assembly, "entry_points", return_value=eps):
+        for_recon = list(assembly._iter_override_bundles("recon"))
+        for_exploit = list(assembly._iter_override_bundles("exploit"))
+
+    assert saas_recon in for_recon
+    assert saas_all in for_recon
+    # saas_recon is filtered out for exploit
+    assert saas_all in for_exploit
+    assert saas_recon not in for_exploit
+
+
+def test_iter_override_bundles_skips_non_pluginbundle_loads():
+    """Entry-points returning anything other than a PluginBundle (or a
+    factory thereof) are skipped silently — protects against
+    misregistered entry-points."""
+    not_a_bundle = MagicMock()  # plain mock, not a PluginBundle
+    eps = [_FakeEntryPoint("bad", "x:y", not_a_bundle)]
+    with patch.object(assembly, "entry_points", return_value=eps):
+        assert list(assembly._iter_override_bundles("recon")) == []
+
+
+# ── Override resolution (plugin + explicit merge) ────────────────────
+
+
+def test_resolve_overrides_explicit_wins_over_plugin():
+    """When a plugin and the explicit kwarg both touch the same tool
+    name, the explicit kwarg replacement is the one assembled."""
+    plugin_tool = MagicMock(name="plugin_tool")
+    explicit_tool = MagicMock(name="explicit_tool")
+    bundle = PluginBundle(
+        replaced_tools={"ask_user_question": plugin_tool},
+    )
+    eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
+    with patch.object(assembly, "entry_points", return_value=eps):
+        resolved = assembly._resolve_overrides(
+            role="soundwave",
+            explicit_middleware_replace=None,
+            explicit_middleware_disable=None,
+            explicit_tool_replace={"ask_user_question": explicit_tool},
+            explicit_tool_disable=None,
+            explicit_prompt=None,
+        )
+    assert resolved.tool_replace["ask_user_question"] is explicit_tool
+
+
+def test_resolve_overrides_merges_disable_from_plugin_and_explicit():
+    bundle = PluginBundle(disabled_tools=("plugin_tool",))
+    eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
+    with patch.object(assembly, "entry_points", return_value=eps):
+        resolved = assembly._resolve_overrides(
+            role="recon",
+            explicit_middleware_replace=None,
+            explicit_middleware_disable=None,
+            explicit_tool_replace=None,
+            explicit_tool_disable={"explicit_tool"},
+            explicit_prompt=None,
+        )
+    assert resolved.tool_disable == frozenset({"plugin_tool", "explicit_tool"})
+
+
+# ── Safety gate ──────────────────────────────────────────────────────
+
+
+def test_safety_gate_blocks_disabling_critical_tool(monkeypatch):
+    """``ask_user_question`` is safety-critical — disabling it without
+    the env gate raises."""
+    monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
+    with pytest.raises(assembly.SafetyOverrideViolation):
+        assembly._check_safety_gate(
+            role="soundwave",
+            mw_replace={},
+            mw_disable=frozenset(),
+            tool_replace={},
+            tool_disable=frozenset({"ask_user_question"}),
+        )
+
+
+def test_safety_gate_blocks_replacing_critical_slot(monkeypatch):
+    """``engagement-context`` carries RoE scope — replacing it without
+    the env gate raises."""
+    monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
+    with pytest.raises(assembly.SafetyOverrideViolation):
+        assembly._check_safety_gate(
+            role="recon",
+            mw_replace={"engagement-context": lambda **_: object()},
+            mw_disable=frozenset(),
+            tool_replace={},
+            tool_disable=frozenset(),
+        )
+
+
+def test_safety_gate_env_bypass(monkeypatch):
+    """``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` lets safety-critical
+    overrides through without raising."""
+    monkeypatch.setenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", "1")
+    # Should NOT raise
+    assembly._check_safety_gate(
+        role="soundwave",
+        mw_replace={"engagement-context": lambda **_: object()},
+        mw_disable=frozenset(),
+        tool_replace={},
+        tool_disable=frozenset({"ask_user_question"}),
+    )
+
+
+def test_safety_gate_allows_non_critical_overrides(monkeypatch):
+    """A non-critical slot like ``prompt-caching`` is safely disable-able
+    without the env gate."""
+    monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
+    # Should NOT raise
+    assembly._check_safety_gate(
+        role="soundwave",
+        mw_replace={},
+        mw_disable=frozenset({"prompt-caching"}),
+        tool_replace={},
+        tool_disable=frozenset(),
+    )
+
+
+# ── assemble_middleware end-to-end ───────────────────────────────────
+
+
+def test_assemble_middleware_unknown_role_raises():
+    """Unknown role = unset slot mapping; assembler refuses rather than
+    silently building an empty stack."""
+    with pytest.raises(KeyError, match="unknown role"):
+        assembly.assemble_middleware(
+            role="not-a-real-role",
+            backend=MagicMock(),
+            llm=MagicMock(),
+        )
+
+
+# Real OSS slot factories instantiate middleware that does deep runtime
+# checks (``create_summarization_middleware`` calls ``model.profile`` on
+# the BaseChatModel, etc.). To keep these assembly tests fast and free
+# of real model wiring, we disable the heavyweight slots that need a
+# live chat model and only exercise the lighter-weight slots that touch
+# backend/sandbox. The override semantics (replace/disable) are the
+# same on every slot — verifying SKILLS + PROMPT_CACHING is sufficient.
+_HEAVY_SLOTS: set[MiddlewareSlot] = {MiddlewareSlot.SUMMARIZATION}
+
+
+def test_assemble_middleware_applies_plugin_slot_replacement(monkeypatch):
+    """Plugin's ``replaced_middleware`` substitutes the slot factory."""
+    monkeypatch.setenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", "1")
+    sentinel = MagicMock(name="custom_skills_mw")
+
+    def custom_factory(**_):
+        return sentinel
+
+    bundle = PluginBundle(replaced_middleware={"skills": custom_factory})
+    eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
+
+    with patch.object(assembly, "entry_points", return_value=eps):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            result = assembly.assemble_middleware(
+                role="soundwave",
+                backend=MagicMock(),
+                llm=MagicMock(),
+                fallback_models=None,
+                disabled_slots=_HEAVY_SLOTS,
+            )
+    assert sentinel in result
+
+
+def test_assemble_middleware_disable_skips_slot(monkeypatch):
+    """An explicit ``disabled_slots`` skip drops the slot's instance from
+    the returned list."""
+    monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
+
+    with patch.object(assembly, "entry_points", return_value=[]):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            with_caching = assembly.assemble_middleware(
+                role="soundwave",
+                backend=MagicMock(),
+                llm=MagicMock(),
+                fallback_models=None,
+                disabled_slots=_HEAVY_SLOTS,
+            )
+            without_caching = assembly.assemble_middleware(
+                role="soundwave",
+                backend=MagicMock(),
+                llm=MagicMock(),
+                fallback_models=None,
+                disabled_slots=_HEAVY_SLOTS | {MiddlewareSlot.PROMPT_CACHING},
+            )
+    assert len(without_caching) == len(with_caching) - 1
+
+
+# ── assemble_tools end-to-end ────────────────────────────────────────
+
+
+def test_assemble_tools_dict_baseline_preserved():
+    """A dict baseline survives plugin/explicit no-op walks."""
+    baseline = {"a": MagicMock(name="a"), "b": MagicMock(name="b")}
+    with patch.object(assembly, "entry_points", return_value=[]):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            result = assembly.assemble_tools(role="soundwave", standard_tools=baseline)
+    # Order preserved, both present.
+    assert result == [baseline["a"], baseline["b"]]
+
+
+def test_assemble_tools_explicit_disable_drops_name(monkeypatch):
+    monkeypatch.setenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", "1")
+    baseline = {"keep": MagicMock(name="keep"), "drop": MagicMock(name="drop")}
+    with patch.object(assembly, "entry_points", return_value=[]):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            result = assembly.assemble_tools(
+                role="soundwave",
+                standard_tools=baseline,
+                disabled_tools={"drop"},
+            )
+    assert baseline["keep"] in result
+    assert baseline["drop"] not in result
+
+
+def test_assemble_tools_plugin_replaces_by_name():
+    """``PluginBundle.replaced_tools`` substitutes a baseline tool by name."""
+    baseline = {"primary": MagicMock(name="primary")}
+    replacement = MagicMock(name="replacement")
+    bundle = PluginBundle(replaced_tools={"primary": replacement})
+    eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
+    with patch.object(assembly, "entry_points", return_value=eps):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            result = assembly.assemble_tools(role="soundwave", standard_tools=baseline)
+    assert replacement in result
+    assert baseline["primary"] not in result
+
+
+# ── Prompt override resolution ───────────────────────────────────────
+
+
+def test_resolve_prompt_overrides_explicit_string_means_replace():
+    with patch.object(assembly, "entry_points", return_value=[]):
+        merged = assembly.resolve_prompt_overrides("soundwave", override="FULL")
+    assert merged == {"replace": "FULL"}
+
+
+def test_resolve_prompt_overrides_dict_keeps_prepend_and_append():
+    with patch.object(assembly, "entry_points", return_value=[]):
+        merged = assembly.resolve_prompt_overrides(
+            "soundwave",
+            override={"prepend": "<P>", "append": "<A>"},
+        )
+    assert merged == {"prepend": "<P>", "append": "<A>"}
+
+
+def test_resolve_prompt_overrides_plugin_only():
+    """When the explicit override is None, the plugin's prompt_overrides
+    for that role come through."""
+    bundle = PluginBundle(
+        prompt_overrides={"soundwave": {"append": "<SAAS>"}},
+    )
+    eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
+    with patch.object(assembly, "entry_points", return_value=eps):
+        merged = assembly.resolve_prompt_overrides("soundwave")
+    assert merged == {"append": "<SAAS>"}

--- a/tests/unit/agents/test_build.py
+++ b/tests/unit/agents/test_build.py
@@ -2,12 +2,12 @@
 
 These pin the contract the 16 agent factories rely on:
 
-  - ``assemble_middleware`` / ``assemble_tools`` apply plugin entry-point
+  - ``build_middleware`` / ``build_tools`` apply plugin entry-point
     overrides AND explicit kwargs, with explicit winning on conflict.
   - ``resolve_prompt_overrides`` merges plugin + explicit prompt patches.
   - Safety-critical slot/tool overrides raise ``SafetyOverrideViolation``
     unless ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` is in the environment.
-  - ``PluginBundle.matches_role`` honors ``applies_to_roles`` scoping.
+  - ``PluginBundle.matches_role`` honors ``roles`` scoping.
 """
 
 from __future__ import annotations
@@ -16,9 +16,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from decepticon.agents import assembly
-from decepticon.agents.middleware_slots import MiddlewareSlot
 from decepticon import plugin_loader
+from decepticon.agents import build as build_module
+from decepticon.agents.middleware_slots import MiddlewareSlot
 from decepticon.plugin_loader import PluginBundle
 
 
@@ -43,8 +43,8 @@ def test_plugin_bundle_unrestricted_matches_every_role():
     assert bundle.matches_role("any-future-role")
 
 
-def test_plugin_bundle_applies_to_roles_filter():
-    bundle = PluginBundle(applies_to_roles=("recon", "exploit"))
+def test_plugin_bundle_roles_filter():
+    bundle = PluginBundle(roles=("recon", "exploit"))
     assert bundle.matches_role("recon")
     assert bundle.matches_role("exploit")
     assert not bundle.matches_role("soundwave")
@@ -54,15 +54,15 @@ def test_plugin_bundle_applies_to_roles_filter():
 
 
 def test_iter_override_bundles_yields_role_scoped_bundles_only():
-    saas_recon = PluginBundle(applies_to_roles=("recon",))
+    saas_recon = PluginBundle(roles=("recon",))
     saas_all = PluginBundle()
     eps = [
         _FakeEntryPoint("saas-recon", "saas:recon_bundle", saas_recon),
         _FakeEntryPoint("saas-all", "saas:all_bundle", saas_all),
     ]
-    with patch.object(assembly, "entry_points", return_value=eps):
-        for_recon = list(assembly._iter_override_bundles("recon"))
-        for_exploit = list(assembly._iter_override_bundles("exploit"))
+    with patch.object(build_module, "entry_points", return_value=eps):
+        for_recon = list(build_module._iter_override_bundles("recon"))
+        for_exploit = list(build_module._iter_override_bundles("exploit"))
 
     assert saas_recon in for_recon
     assert saas_all in for_recon
@@ -77,8 +77,8 @@ def test_iter_override_bundles_skips_non_pluginbundle_loads():
     misregistered entry-points."""
     not_a_bundle = MagicMock()  # plain mock, not a PluginBundle
     eps = [_FakeEntryPoint("bad", "x:y", not_a_bundle)]
-    with patch.object(assembly, "entry_points", return_value=eps):
-        assert list(assembly._iter_override_bundles("recon")) == []
+    with patch.object(build_module, "entry_points", return_value=eps):
+        assert list(build_module._iter_override_bundles("recon")) == []
 
 
 # ── Override resolution (plugin + explicit merge) ────────────────────
@@ -93,8 +93,8 @@ def test_resolve_overrides_explicit_wins_over_plugin():
         replaced_tools={"ask_user_question": plugin_tool},
     )
     eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
-    with patch.object(assembly, "entry_points", return_value=eps):
-        resolved = assembly._resolve_overrides(
+    with patch.object(build_module, "entry_points", return_value=eps):
+        resolved = build_module._resolve_overrides(
             role="soundwave",
             explicit_middleware_replace=None,
             explicit_middleware_disable=None,
@@ -108,8 +108,8 @@ def test_resolve_overrides_explicit_wins_over_plugin():
 def test_resolve_overrides_merges_disable_from_plugin_and_explicit():
     bundle = PluginBundle(disabled_tools=("plugin_tool",))
     eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
-    with patch.object(assembly, "entry_points", return_value=eps):
-        resolved = assembly._resolve_overrides(
+    with patch.object(build_module, "entry_points", return_value=eps):
+        resolved = build_module._resolve_overrides(
             role="recon",
             explicit_middleware_replace=None,
             explicit_middleware_disable=None,
@@ -127,8 +127,8 @@ def test_safety_gate_blocks_disabling_critical_tool(monkeypatch):
     """``ask_user_question`` is safety-critical — disabling it without
     the env gate raises."""
     monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
-    with pytest.raises(assembly.SafetyOverrideViolation):
-        assembly._check_safety_gate(
+    with pytest.raises(build_module.SafetyOverrideViolation):
+        build_module._check_safety_gate(
             role="soundwave",
             mw_replace={},
             mw_disable=frozenset(),
@@ -141,8 +141,8 @@ def test_safety_gate_blocks_replacing_critical_slot(monkeypatch):
     """``engagement-context`` carries RoE scope — replacing it without
     the env gate raises."""
     monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
-    with pytest.raises(assembly.SafetyOverrideViolation):
-        assembly._check_safety_gate(
+    with pytest.raises(build_module.SafetyOverrideViolation):
+        build_module._check_safety_gate(
             role="recon",
             mw_replace={"engagement-context": lambda **_: object()},
             mw_disable=frozenset(),
@@ -156,7 +156,7 @@ def test_safety_gate_env_bypass(monkeypatch):
     overrides through without raising."""
     monkeypatch.setenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", "1")
     # Should NOT raise
-    assembly._check_safety_gate(
+    build_module._check_safety_gate(
         role="soundwave",
         mw_replace={"engagement-context": lambda **_: object()},
         mw_disable=frozenset(),
@@ -170,7 +170,7 @@ def test_safety_gate_allows_non_critical_overrides(monkeypatch):
     without the env gate."""
     monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
     # Should NOT raise
-    assembly._check_safety_gate(
+    build_module._check_safety_gate(
         role="soundwave",
         mw_replace={},
         mw_disable=frozenset({"prompt-caching"}),
@@ -179,18 +179,52 @@ def test_safety_gate_allows_non_critical_overrides(monkeypatch):
     )
 
 
-# ── assemble_middleware end-to-end ───────────────────────────────────
+# ── build_middleware end-to-end ───────────────────────────────────
 
 
-def test_assemble_middleware_unknown_role_raises():
+def test_build_middleware_unknown_role_raises():
     """Unknown role = unset slot mapping; assembler refuses rather than
     silently building an empty stack."""
     with pytest.raises(KeyError, match="unknown role"):
-        assembly.assemble_middleware(
+        build_module.build_middleware(
             role="not-a-real-role",
             backend=MagicMock(),
             llm=MagicMock(),
         )
+
+
+def test_build_middleware_accepts_explicit_slots_for_plugin_role():
+    """Plugin-shipped orchestrators with a custom role name pass an
+    explicit ``slots`` set — opens the slot system to library users
+    without requiring them to mutate ``SLOTS_PER_ROLE``."""
+    with patch.object(build_module, "entry_points", return_value=[]):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            result = build_module.build_middleware(
+                role="decepticon-pro",  # not in SLOTS_PER_ROLE
+                slots=frozenset({MiddlewareSlot.PROMPT_CACHING}),
+                backend=MagicMock(),
+                llm=MagicMock(),
+                fallback_models=None,
+            )
+    # PROMPT_CACHING-only stack, assembled with no role-registration ceremony.
+    assert len(result) == 1
+
+
+def test_build_middleware_explicit_slots_overrides_role_default():
+    """Explicit ``slots`` wins over the ``SLOTS_PER_ROLE`` default —
+    plugin-installed agents can tighten or expand the slot set for an
+    OSS role they're shipping a custom factory for."""
+    with patch.object(build_module, "entry_points", return_value=[]):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            result = build_module.build_middleware(
+                role="soundwave",  # OSS role with several slots by default
+                slots=frozenset({MiddlewareSlot.PROMPT_CACHING}),
+                backend=MagicMock(),
+                llm=MagicMock(),
+                fallback_models=None,
+            )
+    # Only the explicitly-requested slot is assembled.
+    assert len(result) == 1
 
 
 # Real OSS slot factories instantiate middleware that does deep runtime
@@ -203,7 +237,7 @@ def test_assemble_middleware_unknown_role_raises():
 _HEAVY_SLOTS: set[MiddlewareSlot] = {MiddlewareSlot.SUMMARIZATION}
 
 
-def test_assemble_middleware_applies_plugin_slot_replacement(monkeypatch):
+def test_build_middleware_applies_plugin_slot_replacement(monkeypatch):
     """Plugin's ``replaced_middleware`` substitutes the slot factory."""
     monkeypatch.setenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", "1")
     sentinel = MagicMock(name="custom_skills_mw")
@@ -214,9 +248,9 @@ def test_assemble_middleware_applies_plugin_slot_replacement(monkeypatch):
     bundle = PluginBundle(replaced_middleware={"skills": custom_factory})
     eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
 
-    with patch.object(assembly, "entry_points", return_value=eps):
+    with patch.object(build_module, "entry_points", return_value=eps):
         with patch.object(plugin_loader, "entry_points", return_value=[]):
-            result = assembly.assemble_middleware(
+            result = build_module.build_middleware(
                 role="soundwave",
                 backend=MagicMock(),
                 llm=MagicMock(),
@@ -226,21 +260,21 @@ def test_assemble_middleware_applies_plugin_slot_replacement(monkeypatch):
     assert sentinel in result
 
 
-def test_assemble_middleware_disable_skips_slot(monkeypatch):
+def test_build_middleware_disable_skips_slot(monkeypatch):
     """An explicit ``disabled_slots`` skip drops the slot's instance from
     the returned list."""
     monkeypatch.delenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", raising=False)
 
-    with patch.object(assembly, "entry_points", return_value=[]):
+    with patch.object(build_module, "entry_points", return_value=[]):
         with patch.object(plugin_loader, "entry_points", return_value=[]):
-            with_caching = assembly.assemble_middleware(
+            with_caching = build_module.build_middleware(
                 role="soundwave",
                 backend=MagicMock(),
                 llm=MagicMock(),
                 fallback_models=None,
                 disabled_slots=_HEAVY_SLOTS,
             )
-            without_caching = assembly.assemble_middleware(
+            without_caching = build_module.build_middleware(
                 role="soundwave",
                 backend=MagicMock(),
                 llm=MagicMock(),
@@ -250,25 +284,25 @@ def test_assemble_middleware_disable_skips_slot(monkeypatch):
     assert len(without_caching) == len(with_caching) - 1
 
 
-# ── assemble_tools end-to-end ────────────────────────────────────────
+# ── build_tools end-to-end ────────────────────────────────────────
 
 
-def test_assemble_tools_dict_baseline_preserved():
+def test_build_tools_dict_baseline_preserved():
     """A dict baseline survives plugin/explicit no-op walks."""
     baseline = {"a": MagicMock(name="a"), "b": MagicMock(name="b")}
-    with patch.object(assembly, "entry_points", return_value=[]):
+    with patch.object(build_module, "entry_points", return_value=[]):
         with patch.object(plugin_loader, "entry_points", return_value=[]):
-            result = assembly.assemble_tools(role="soundwave", standard_tools=baseline)
+            result = build_module.build_tools(role="soundwave", standard_tools=baseline)
     # Order preserved, both present.
     assert result == [baseline["a"], baseline["b"]]
 
 
-def test_assemble_tools_explicit_disable_drops_name(monkeypatch):
+def test_build_tools_explicit_disable_drops_name(monkeypatch):
     monkeypatch.setenv("DECEPTICON_ALLOW_SAFETY_OVERRIDES", "1")
     baseline = {"keep": MagicMock(name="keep"), "drop": MagicMock(name="drop")}
-    with patch.object(assembly, "entry_points", return_value=[]):
+    with patch.object(build_module, "entry_points", return_value=[]):
         with patch.object(plugin_loader, "entry_points", return_value=[]):
-            result = assembly.assemble_tools(
+            result = build_module.build_tools(
                 role="soundwave",
                 standard_tools=baseline,
                 disabled_tools={"drop"},
@@ -277,15 +311,15 @@ def test_assemble_tools_explicit_disable_drops_name(monkeypatch):
     assert baseline["drop"] not in result
 
 
-def test_assemble_tools_plugin_replaces_by_name():
+def test_build_tools_plugin_replaces_by_name():
     """``PluginBundle.replaced_tools`` substitutes a baseline tool by name."""
     baseline = {"primary": MagicMock(name="primary")}
     replacement = MagicMock(name="replacement")
     bundle = PluginBundle(replaced_tools={"primary": replacement})
     eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
-    with patch.object(assembly, "entry_points", return_value=eps):
+    with patch.object(build_module, "entry_points", return_value=eps):
         with patch.object(plugin_loader, "entry_points", return_value=[]):
-            result = assembly.assemble_tools(role="soundwave", standard_tools=baseline)
+            result = build_module.build_tools(role="soundwave", standard_tools=baseline)
     assert replacement in result
     assert baseline["primary"] not in result
 
@@ -294,14 +328,14 @@ def test_assemble_tools_plugin_replaces_by_name():
 
 
 def test_resolve_prompt_overrides_explicit_string_means_replace():
-    with patch.object(assembly, "entry_points", return_value=[]):
-        merged = assembly.resolve_prompt_overrides("soundwave", override="FULL")
+    with patch.object(build_module, "entry_points", return_value=[]):
+        merged = build_module.resolve_prompt_overrides("soundwave", override="FULL")
     assert merged == {"replace": "FULL"}
 
 
 def test_resolve_prompt_overrides_dict_keeps_prepend_and_append():
-    with patch.object(assembly, "entry_points", return_value=[]):
-        merged = assembly.resolve_prompt_overrides(
+    with patch.object(build_module, "entry_points", return_value=[]):
+        merged = build_module.resolve_prompt_overrides(
             "soundwave",
             override={"prepend": "<P>", "append": "<A>"},
         )
@@ -309,12 +343,98 @@ def test_resolve_prompt_overrides_dict_keeps_prepend_and_append():
 
 
 def test_resolve_prompt_overrides_plugin_only():
-    """When the explicit override is None, the plugin's prompt_overrides
+    """When the explicit override is None, the plugin's prompts
     for that role come through."""
     bundle = PluginBundle(
-        prompt_overrides={"soundwave": {"append": "<SAAS>"}},
+        prompts={"soundwave": {"append": "<SAAS>"}},
     )
     eps = [_FakeEntryPoint("saas", "saas:bundle", bundle)]
-    with patch.object(assembly, "entry_points", return_value=eps):
-        merged = assembly.resolve_prompt_overrides("soundwave")
+    with patch.object(build_module, "entry_points", return_value=eps):
+        merged = build_module.resolve_prompt_overrides("soundwave")
     assert merged == {"append": "<SAAS>"}
+
+
+# ── decepticon.skills entry-point group ───────────────────────────────
+
+
+def test_skills_sources_appends_plugin_paths():
+    """``skills_sources_for`` layers plugin-contributed skill paths on
+    top of the OSS baseline so commercial / 3rd-party skills are
+    discoverable without overriding the whole SKILLS slot."""
+    from decepticon.agents.middleware_slots import skills_sources_for
+
+    plugin_paths = ["/skills/saas-pro/recon/", "/skills/saas-shared/"]
+
+    def plugin_factory(role, **_):
+        return plugin_paths if role == "recon" else []
+
+    eps = [_FakeEntryPoint("saas-skills", "saas:get_paths", plugin_factory)]
+    with patch.object(plugin_loader, "entry_points", return_value=eps):
+        sources = skills_sources_for("recon")
+
+    # OSS baseline preserved
+    assert "/skills/standard/recon/" in sources
+    assert "/skills/shared/" in sources
+    # Plugin paths appended at the end (so OSS skills aren't pushed out
+    # of progressive-disclosure budget by an over-eager plugin).
+    assert sources[-2:] == plugin_paths
+
+
+def test_skills_sources_filters_non_string_plugin_returns():
+    """Plugin entry-points returning non-string items are filtered out
+    silently — protects ``SkillsMiddleware`` from being handed a bogus
+    sources list at construction time."""
+    eps = [_FakeEntryPoint("bad", "bad:paths", lambda role, **_: ["/skills/ok/", 42, None])]
+    with patch.object(plugin_loader, "entry_points", return_value=eps):
+        result = plugin_loader.load_plugin_skill_sources("recon")
+    assert result == ["/skills/ok/"]
+
+
+def test_build_middleware_threads_skill_sources_to_skills_factory():
+    """``build_middleware(skill_sources=...)`` passes the explicit list
+    through to the SKILLS slot factory — the plugin-orchestrator escape
+    hatch from ``SLOTS_PER_ROLE``-based default lookup, replacing the
+    old hardcoded ``_PLUGIN_SPECIALIST_ROLES`` knowledge."""
+    captured: dict = {}
+
+    def fake_skills_factory(*, backend, role, skill_sources=None, **_):
+        captured["sources"] = skill_sources
+        return MagicMock(name="SkillsMiddleware")
+
+    custom_paths = ["/skills/saas-pro/sast/", "/skills/saas-shared/"]
+    with patch.object(build_module, "entry_points", return_value=[]):
+        with patch.object(plugin_loader, "entry_points", return_value=[]):
+            build_module.build_middleware(
+                role="soundwave",
+                skill_sources=custom_paths,
+                backend=MagicMock(),
+                llm=MagicMock(),
+                fallback_models=None,
+                overrides={MiddlewareSlot.SKILLS: fake_skills_factory},
+                disabled_slots={MiddlewareSlot.SUMMARIZATION},
+            )
+    assert captured["sources"] == custom_paths
+
+
+# ── LLMFactory.get_assignment default_role fallback (plugin orchestrators) ──
+
+
+def test_llm_mapping_get_assignment_default_role_fallback():
+    """Plugin orchestrators with a custom role not in ``AGENT_TIERS``
+    can pass ``default_role=`` to inherit an OSS role's assignment.
+    Opens ``LLMFactory`` for plugin use without forcing every plugin
+    package to register its own ``AGENT_TIERS`` entry."""
+    from decepticon.llm.models import LLMModelMapping, ModelAssignment
+
+    mapping = LLMModelMapping(
+        assignments={
+            "decepticon": ModelAssignment(primary="openai/gpt-5", fallbacks=[], temperature=0.0)
+        }
+    )
+    # Unknown role + default_role → returns decepticon's assignment.
+    assignment = mapping.get_assignment("decepticon-pro", default_role="decepticon")
+    assert assignment.primary == "openai/gpt-5"
+
+    # Unknown role + no default_role → KeyError preserved (no silent empty stack).
+    with pytest.raises(KeyError, match="No model assignment for role"):
+        mapping.get_assignment("decepticon-pro")


### PR DESCRIPTION
## Summary

Pivot Decepticon's 16 agent factories from \"Docker-only, inline-everything\" to a langchain / deepagents-idiomatic library shape, plus add a declarative ``PluginBundle`` override surface for plugin authors that need to replace standard middleware / tools / prompts on the OSS Docker base.

Three composition paths converge cleanly:

1. **OSS default**: ``create_<role>_agent()`` — no args, baseline behavior + auto-applied plugin overrides.
2. **Plugin override** (Docker / pip-installed plugin): ship a ``PluginBundle`` under the new ``decepticon.bundles`` entry-point group; factories discover and apply it automatically.
3. **Full custom** (library composer): import middleware / tools / prompts and compose with ``langchain.agents.create_agent`` directly. Decepticon's factory is bypassed.

A small allowlist of slots (``engagement-context``, ``sandbox-notification``) and tools (``ask_user_question``, ``complete_engagement_planning``) is safety-critical. Disabling or replacing them raises ``SafetyOverrideViolation`` unless ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` is set in the environment.

## Commits

1. ``feat(agents): library-style factory pattern foundation + soundwave POC``
   ``middleware_slots.py`` + ``assembly.py`` + ``PluginBundle.disabled_*/replaced_*`` extension + ``load_prompt_with_overrides`` + ``decepticon.bundles`` entry-point group + soundwave POC.

2. ``feat(agents): minimal langchain-style factory API across all 16 agents``
   Drop the verbose ``*_overrides`` / ``disabled_*`` factory kwargs in favour of the langchain idiom (``tools=`` / ``middleware=`` / ``system_prompt=`` for full replace; everything else routed through ``PluginBundle`` or direct composition). 16 factories: standard (decepticon, soundwave, recon, exploit, postexploit, analyst, reverser, contract_auditor, cloud_hunter, ad_operator) + plugins (vulnresearch, detector, verifier, patcher, scanner, exploiter).

3. ``test+docs(plugins): pin override surface + library usage guide``
   19 unit tests for the override + safety-gate paths + ``docs/library-usage.md`` documenting the three usage patterns + plugin authoring + public building-blocks reference.

## Override resolution

| State | Behavior |
|---|---|
| Factory called with no kwargs | OSS baseline + plugin overrides applied automatically |
| Factory called with ``tools=[...]`` | Provided list is used as-is; plugin tool overrides bypassed |
| Factory called with ``middleware=[...]`` | Same, for middleware |
| Factory called with ``system_prompt=\"...\"`` | Same, for prompt |

Plugin precedence on conflicting overrides: last-write-wins (no inter-plugin conflict detection — flagged as a follow-up).

## API surface (library-ready)

Three public layers documented in ``docs/library-usage.md``:

  - **Building blocks** — ``decepticon.middleware``, ``decepticon.tools.*``, ``decepticon.backends``, ``decepticon.agents.prompts``, ``decepticon.core.schemas``, ``decepticon.llm``, ``decepticon.plugin_loader``.
  - **Per-role factories** — ``decepticon.agents.standard.<role>``, ``decepticon.agents.plugins.<role>``.
  - **Composition helpers** — ``decepticon.agents.assembly`` (``assemble_middleware`` / ``assemble_tools`` / ``resolve_prompt_overrides``) and ``decepticon.agents.middleware_slots`` (``MiddlewareSlot`` enum / ``SLOTS_PER_ROLE`` / ``DEFAULT_SLOT_FACTORIES``).

PyPI publication is on the roadmap once the surface stabilises through real commercial integration. Git-tag pins (``decepticon @ git+https://...@v1.x.y``) work today.

## Test plan

- [x] ``uv run ruff check .`` — pass
- [x] ``uv run ruff format --check .`` — pass
- [x] ``uv run pytest -n auto -q -m \"not slow\"`` — **935 passed** (916 baseline + 19 new)
- [x] All 16 agent modules: ``graph`` constant present and importable
- [x] ``create_<role>_agent()`` (no args) works for every role
- [x] ``create_soundwave_agent(tools=[my_tool])`` — full replace verified
- [x] ``create_soundwave_agent(middleware=[my_mw])`` — full replace verified
- [x] ``create_soundwave_agent(system_prompt=\"custom\")`` — full replace verified
- [x] Safety gate raises on ``disabled_tools={\"ask_user_question\"}`` without env gate
- [x] ``DECEPTICON_ALLOW_SAFETY_OVERRIDES=1`` bypass works

## Follow-up (out of scope for this PR)

- Sub-agent collision detection — ``load_subagents_for_parent`` currently relies on entry-point discovery order on duplicate names. Should raise loud-fail on collision unless explicit ``replaced_subagents`` is declared.
- Inter-plugin conflict detection on ``replaced_*`` fields.
- PyPI ``decepticon-core`` publication once the API surface stabilises.
- Optional extras (``decepticon[langgraph-platform]``, ``decepticon[advanced-ops]``) for dual-use capability gating.