### PR TITLE
fix(docker): install neo4j extra in langgraph image so KG works after neo4j→extra

### DIFF
--- a/containers/langgraph.Dockerfile
+++ b/containers/langgraph.Dockerfile
@@ -30,7 +30,12 @@ RUN sed -i 's/^version = "[^"]*"/version = "'"$VERSION"'"/' pyproject.toml
 # always gets the same versions that were locked at commit time. The editable
 # install uses --no-deps because all dependencies are already installed; source
 # changes via docker compose watch are still reflected without reinstall.
-RUN uv export --no-dev --frozen -o /tmp/requirements.txt && \
+#
+# ``--extra neo4j`` is required here: neo4j is an optional extra so the PyPI SDK
+# (``pip install decepticon``) stays lean, but the full langgraph image runs the
+# Neo4j knowledge-graph feature and needs the driver. Without it the KG health
+# check fails (no ``neo4j`` module in the container).
+RUN uv export --no-dev --extra neo4j --frozen -o /tmp/requirements.txt && \
     uv pip install --system -r /tmp/requirements.txt && \
     uv pip install --system -e "." --no-deps
 


### PR DESCRIPTION
## Summary
PR #273 moved `neo4j` to an optional extra (`decepticon[neo4j]`) to keep the PyPI SDK lean. But the langgraph image installs deps via `uv export --no-dev --frozen`, which **excludes extras** — so the langgraph container lost the `neo4j` driver and the Neo4j knowledge-graph (KG) feature broke in the full Docker stack.

`make smoke` caught it: all images built, all containers **Healthy**, but the `kg` health check **FAILED** (`neo4j installed: False` inside `decepticon-langgraph`). Unit tests didn't catch it because they only assert the base SDK imports fine *without* neo4j (the lazy-import contract) — they don't exercise the full stack's KG.

## Fix
Add `--extra neo4j` to the langgraph Dockerfile's `uv export`. Design intent holds: the PyPI SDK stays lean (neo4j optional), while the full langgraph **image** installs the extra it actually uses for the KG.

```diff
- RUN uv export --no-dev --frozen -o /tmp/requirements.txt && \
+ RUN uv export --no-dev --extra neo4j --frozen -o /tmp/requirements.txt && \
```

## Verification
Rebuilt langgraph + re-ran `make health` against the live stack:
- `neo4j installed: True` (was `False`)
- `kg: OK` · `neo4j: OK` · `web: OK`

## Note
This must land before tagging `v1.1.1` (otherwise the v1.1.1 langgraph image ships a broken KG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)