### PR TITLE
fix(sdk): read __version__ from installed metadata + drop typer[all] extra

### DIFF
--- a/packages/decepticon-sdk/decepticon_sdk/__init__.py
+++ b/packages/decepticon-sdk/decepticon_sdk/__init__.py
@@ -24,6 +24,9 @@ Deferred from Phase 3 (follow-up commits):
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
 # Re-export the decepticon-core contracts so plugin authors only need
 # a single import line:
 #
@@ -68,7 +71,13 @@ from decepticon_core.registry import (
     SkillSourceRegistry,
 )
 
-__version__ = "0.0.0"
+# Read the installed distribution version — release.yml stamps the git
+# tag into wheel metadata at build time; local checkouts read 0.0.0.
+# Mirrors decepticon-core / decepticon so all three report consistently.
+try:
+    __version__ = _version("decepticon-sdk")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 __all__ = [
     # Protocols (decepticon_core.protocols)

--- a/packages/decepticon-sdk/pyproject.toml
+++ b/packages/decepticon-sdk/pyproject.toml
@@ -27,7 +27,10 @@ classifiers = [
 
 dependencies = [
     "decepticon-core",
-    "typer[all]>=0.9.0",
+    # Modern typer (>=0.12) bundles rich + shellingham by default and
+    # dropped the ``[all]`` extra; depending on ``typer[all]`` only emits
+    # a "no extra named all" warning at install time.
+    "typer>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ requires-dist = [
     { name = "decepticon-core", editable = "packages/decepticon-core" },
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=0.23.0" },
-    { name = "typer", extras = ["all"], specifier = ">=0.9.0" },
+    { name = "typer", specifier = ">=0.9.0" },
 ]
 provides-extras = ["testing", "fixtures"]
 


### PR DESCRIPTION
## Summary
- `decepticon-sdk` hardcoded `__version__ = "0.0.0"` instead of following the decepticon / decepticon-core pattern of reading the installed distribution version via `importlib.metadata`. Installed 1.1.2 wheels reported `decepticon_sdk.__version__ == "0.0.0"` while core/framework correctly reported 1.1.2. Now mirrors the try/except `_version("decepticon-sdk")` pattern.
- Drop the obsolete `typer[all]` extra — modern typer (>=0.12) bundles rich + shellingham by default and only emits a "no extra named all" warning at install time.

Scope: `__version__` attribute + install-time warning only. Distribution version, dependency resolution, and imports were all already correct. Targets the next release (1.1.3).

## Test plan
- [ ] CI ruff + basedpyright + pytest green
- [ ] After 1.1.3 publish: `pip install decepticon-sdk` → `decepticon_sdk.__version__` matches the installed version (not 0.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)