### PR TITLE
fix(cli): 20+ fixes across Go launcher (Windows + UX) and TypeScript TUI

### DIFF
--- a/clients/cli/src/commands/agent.ts
+++ b/clients/cli/src/commands/agent.ts
@@ -3,11 +3,9 @@
  *
  * Only orchestration agents are surfaced here. Sub-agents (recon,
  * exploit, postexploit, …) are invoked via the orchestrator's task()
- * tool and shouldn't be selected directly. The whitelist below pins the
- * two orchestrators OSS ships:
- *
- *   - decepticon   — standard bundle. Always available.
- *   - vulnresearch — plugins bundle. Available once enabled via /plugins.
+ * tool and shouldn't be selected directly. Available orchestrators are
+ * discovered dynamically from the langgraph runtime via
+ * POST /assistants/search.
  *
  * Selection writes to the per-process assistant override (see
  * commands/assistantOverride.ts) which useAgent reads on every submit()
@@ -27,9 +25,6 @@ import {
   setAssistantOverride,
 } from "./assistantOverride.js";
 
-const ORCHESTRATOR_ALLOWLIST = ["decepticon", "vulnresearch"] as const;
-type Orchestrator = (typeof ORCHESTRATOR_ALLOWLIST)[number];
-
 interface AssistantRow {
   assistant_id: string;
   graph_id: string;
@@ -40,7 +35,11 @@ function apiBase(): string {
   return process.env.DECEPTICON_API_URL || "http://localhost:2024";
 }
 
-async function listOrchestrators(): Promise<Orchestrator[]> {
+/**
+ * Discover orchestrators dynamically from the agent runtime.
+ * Returns deduplicated graph_ids registered on the server.
+ */
+async function listOrchestrators(): Promise<string[]> {
   const res = await fetch(`${apiBase()}/assistants/search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -50,8 +49,9 @@ async function listOrchestrators(): Promise<Orchestrator[]> {
     throw new Error(`assistants/search HTTP ${res.status}: ${await res.text()}`);
   }
   const data = (await res.json()) as AssistantRow[];
-  const registered = new Set(data.map((a) => a.graph_id));
-  return ORCHESTRATOR_ALLOWLIST.filter((g) => registered.has(g));
+  // Deduplicate by graph_id — the server may return multiple assistants
+  // sharing the same graph (e.g. per-thread forks).
+  return [...new Set(data.map((a) => a.graph_id))];
 }
 
 const agent: Command = {
@@ -85,12 +85,6 @@ const agent: Command = {
               lines.push(`  ${mark} ${o}`);
             }
           }
-          if (!orchestrators.includes("vulnresearch")) {
-            lines.push("");
-            lines.push(
-              "Tip: vulnresearch ships in the 'plugins' bundle. Enable with `/plugins enable plugins`.",
-            );
-          }
           lines.push("");
           lines.push("Usage:");
           lines.push("  /agent <name>     Switch (e.g. /agent vulnresearch)");
@@ -117,23 +111,16 @@ const agent: Command = {
       return;
     }
 
-    // Switch
-    if (!ORCHESTRATOR_ALLOWLIST.includes(arg as Orchestrator)) {
-      ctx.addSystemEvent(
-        `'${arg}' is not a known orchestrator. Valid options: ${ORCHESTRATOR_ALLOWLIST.join(", ")}.`,
-      );
-      return;
-    }
-
+    // Switch — validate against server-registered orchestrators
     void (async () => {
       try {
         const orchestrators = await listOrchestrators();
-        if (!orchestrators.includes(arg as Orchestrator)) {
+        if (!orchestrators.includes(arg)) {
+          const available = orchestrators.length > 0
+            ? `Available: ${orchestrators.join(", ")}.`
+            : "No orchestrators registered — is the langgraph stack up?";
           ctx.addSystemEvent(
-            `'${arg}' isn't currently registered with the agent runtime. ` +
-              (arg === "vulnresearch"
-                ? "Enable its bundle first: /plugins enable plugins"
-                : "Check that the agent stack is running."),
+            `'${arg}' isn't currently registered with the agent runtime. ${available}`,
           );
           return;
         }

--- a/clients/cli/src/commands/file.ts
+++ b/clients/cli/src/commands/file.ts
@@ -10,7 +10,8 @@
  *   /file ~/engagement-brief.txt
  */
 
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 import type { Command } from "./types.js";
@@ -20,7 +21,8 @@ const file: Command = {
   description: "Load a prompt from a file and send it",
   aliases: ["f"],
   argumentHint: "<path>",
-  execute(args, ctx) {
+  async execute(args, ctx) {
+
     const raw = args.trim();
     if (!raw) {
       ctx.addSystemEvent(
@@ -30,12 +32,18 @@ const file: Command = {
     }
 
     // Expand ~ to home directory
-    const expanded = raw.startsWith("~")
-      ? resolve(homedir(), raw.slice(2))
-      : resolve(raw);
+    let expanded: string;
+    if (raw === "~") {
+      expanded = homedir();
+    } else if (raw.startsWith("~/") || raw.startsWith("~\\")) {
+      expanded = resolve(homedir(), raw.slice(2));
+    } else {
+      expanded = resolve(raw);
+    }
+
 
     try {
-      const content = readFileSync(expanded, "utf-8").trim();
+      const content = (await readFile(expanded, "utf-8")).trim();
       if (!content) {
         ctx.addSystemEvent(`File is empty: ${expanded}`);
         return;

--- a/clients/cli/src/commands/types.ts
+++ b/clients/cli/src/commands/types.ts
@@ -38,5 +38,5 @@ export interface Command {
   /** Whether the command is hidden from autocomplete. */
   isHidden?: boolean;
   /** Execute the command. */
-  execute: (args: string, context: CommandContext) => CommandResult | void;
+  execute: (args: string, context: CommandContext) => CommandResult | void | Promise<CommandResult | void>;
 }

--- a/clients/cli/src/components/agents/AgentSessionGroup.tsx
+++ b/clients/cli/src/components/agents/AgentSessionGroup.tsx
@@ -138,10 +138,10 @@ export const AgentSessionGroup = React.memo(function AgentSessionGroup({
   const color = AGENT_COLORS[session.agent] ?? "white";
 
   // Filter events belonging to this session
-  const sessionEvents = useMemo(
-    () => events.filter((e) => session.eventIds.includes(e.id)),
-    [events, session.eventIds],
-  );
+  const sessionEvents = useMemo(() => {
+    const idSet = new Set(session.eventIds);
+    return events.filter((e) => idSet.has(e.id));
+  }, [events, session.eventIds]);
 
   // ── Transcript mode: full EventItem rendering ──────────────────
   if (isTranscript) {

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -113,6 +113,8 @@ interface UseAgentReturn {
 // no CLI restart needed.
 const INITIAL_ASSISTANT_ID =
   process.env.DECEPTICON_ASSISTANT_ID || "decepticon";
+let _nextEventId = 0;
+
 
 export function useAgent({
   apiUrl = process.env.DECEPTICON_API_URL || "http://localhost:2024",
@@ -177,11 +179,11 @@ export function useAgent({
     (partial: Omit<AgentEvent, "id" | "timestamp">) => {
       const newEvent: AgentEvent = {
         ...partial,
-        id: `${Date.now()}-${Math.random()}`,
+        id: `evt-${++_nextEventId}`,
         timestamp: Date.now(),
       };
-      eventsRef.current = [...eventsRef.current, newEvent];
-      setEvents(eventsRef.current);
+      eventsRef.current.push(newEvent);
+      setEvents([...eventsRef.current]);
     },
     [],
   );
@@ -230,6 +232,8 @@ export function useAgent({
       let cumTotal = 0;
       let cumPrompt = 0;
       let cumCompletion = 0;
+      let completionReceived = false;
+
 
       const handleCustomEvent = (data: SubagentCustomEvent) => {
         switch (data.type) {
@@ -504,7 +508,9 @@ export function useAgent({
               }
             } else {
               setPendingTool(null);
+              completionReceived = true;
             }
+
           } else if (msg.type === "tool") {
             const content =
               typeof msg.content === "string"
@@ -541,8 +547,17 @@ export function useAgent({
           }
         }
       }
+
+      // Detect unexpected disconnection: stream ended but no completion event
+      if (!completionReceived && !abortController.signal.aborted) {
+        addSystemEvent(
+          "\u26a0\ufe0f Connection to server lost. The run continues server-side. "
+          + "Use /resume to reconnect.",
+        );
+        setRunState("idle");
+      }
     },
-    [addEvent],
+    [addEvent, addSystemEvent, setRunState],
   );
 
   // ── Handle stream completion (shared by submit and resume) ─────

--- a/clients/cli/src/hooks/useGlobalKeybindings.ts
+++ b/clients/cli/src/hooks/useGlobalKeybindings.ts
@@ -26,6 +26,8 @@ interface Props {
   onExit: () => void;
   /** Called to clear a queued message. */
   onClearQueue?: () => void;
+  /** Emit a system-level event visible in the chat log. */
+  addSystemEvent?: (message: string) => void;
   /** Current run lifecycle state. */
   runState: RunState;
   /** Whether a message is queued. */
@@ -39,6 +41,7 @@ export function useGlobalKeybindings({
   onCancel,
   onExit,
   onClearQueue,
+  addSystemEvent,
   runState,
   hasQueuedMessage = false,
 }: Props): void {
@@ -90,6 +93,7 @@ export function useGlobalKeybindings({
         } else {
           // Single Ctrl+C while streaming → pause (state preserved)
           onInterrupt();
+          addSystemEvent?.("Press Ctrl+C again within 500ms to cancel the run.");
         }
         // Also exit transcript if viewing it
         if (screen === "transcript") {

--- a/clients/cli/src/hooks/useSpinnerFrame.ts
+++ b/clients/cli/src/hooks/useSpinnerFrame.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 
 const BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-const INTERVAL_MS = 80;
+const INTERVAL_MS = 150; // ~6.7 FPS — visually smooth, half the re-renders
 
 export interface SpinnerState {
   frame: string;

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -35,7 +35,7 @@ import { groupConsecutiveTools } from "../utils/groupEvents.js";
 import { formatDuration } from "../utils/format.js";
 import { GLYPH_DOT, GLYPH_HOOK, GLYPH_SEP, AGENT_COLORS } from "../utils/theme.js";
 import { ToolGroupSummary } from "../components/messages/ToolGroupSummary.js";
-import type { CommandContext } from "../commands/types.js";
+import type { CommandContext, CommandResult } from "../commands/types.js";
 import type { AgentEvent, ScreenMode, SubAgentSession } from "../types.js";
 import { ErrorMessage } from "../components/messages/ErrorMessage.js";
 import { SessionPicker } from "../components/SessionPicker.js";
@@ -66,7 +66,8 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
   useEffect(() => {
     if (!initialMessage || autoStarted.current) return;
     autoStarted.current = true;
-    const timer = setTimeout(() => agent.submit(initialMessage), 3000);
+    const timer = setTimeout(() => agent.submit(initialMessage), 200);
+
     return () => clearTimeout(timer);
   }, []);
 
@@ -76,6 +77,7 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
     onCancel: agent.cancel,
     onExit: exit,
     onClearQueue: agent.clearQueuedMessage,
+    addSystemEvent: agent.addSystemEvent,
     runState: agent.runState,
     hasQueuedMessage: agent.queuedMessage != null,
   });
@@ -124,7 +126,11 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
         const cmd = findCommand(parsed.name);
         if (cmd) {
           const result = cmd.execute(parsed.args, commandContext);
-          if (result?.shouldSubmit) {
+          if (result && typeof (result as Promise<unknown>).then === "function") {
+            (result as Promise<CommandResult | void>).then((r) => {
+              if (r?.shouldSubmit) agent.submit(parsed.args);
+            });
+          } else if ((result as CommandResult | void)?.shouldSubmit) {
             agent.submit(parsed.args);
           }
           return;

--- a/clients/cli/src/utils/markdown.ts
+++ b/clients/cli/src/utils/markdown.ts
@@ -6,15 +6,17 @@
 import { marked } from "marked";
 import { markedTerminal } from "marked-terminal";
 
-marked.use(
-  markedTerminal({
-    showSectionPrefix: false,
-    reflowText: true,
-    width: (process.stdout.columns || 80) - 4,
-  }),
-);
+
 
 export function renderMarkdown(text: string): string {
+  const width = (process.stdout.columns || 80) - 4;
+  marked.use(
+    markedTerminal({
+      showSectionPrefix: false,
+      reflowText: true,
+      width,
+    }),
+  );
   try {
     return (marked.parse(text) as string).trimEnd();
   } catch {

--- a/clients/cli/src/utils/threadStore.ts
+++ b/clients/cli/src/utils/threadStore.ts
@@ -21,9 +21,14 @@ export interface ThreadEntry {
 
 const MAX_ENTRIES = 20;
 
+let _client: Client | null = null;
+
 function getClient(): Client {
-  const apiUrl = process.env.DECEPTICON_API_URL || "http://localhost:2024";
-  return new Client({ apiUrl });
+  if (!_client) {
+    const apiUrl = process.env.DECEPTICON_API_URL || "http://localhost:2024";
+    _client = new Client({ apiUrl });
+  }
+  return _client;
 }
 
 /** Save or update a thread's metadata on the server. */

--- a/clients/launcher/cmd/logs.go
+++ b/clients/launcher/cmd/logs.go
@@ -7,7 +7,14 @@ import (
 
 var logsCmd = &cobra.Command{
 	Use:   "logs [service]",
-	Short: "Follow service logs (default: langgraph)",
+	Short: "Follow service logs",
+	Long: `Follow service logs. Available services:
+  langgraph  (default)
+  litellm
+  postgres
+  neo4j
+  sandbox
+  web`,
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		service := "langgraph"

--- a/clients/launcher/cmd/remove.go
+++ b/clients/launcher/cmd/remove.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"charm.land/huh/v2"
@@ -209,8 +210,33 @@ func backupWorkspace(src, dst string) error {
 		return nil
 	}
 	// Cross-device or other rename failure: copy then remove.
-	if out, err := exec.Command("cp", "-r", src, dst).CombinedOutput(); err != nil {
-		return fmt.Errorf("cp -r: %w (%s)", err, strings.TrimSpace(string(out)))
+	var err error
+	if runtime.GOOS == "windows" {
+		err = copyDirRecursive(src, dst)
+	} else {
+		_, err = exec.Command("cp", "-r", src, dst).CombinedOutput()
+	}
+	if err != nil {
+		return fmt.Errorf("copy %s → %s: %w", src, dst, err)
 	}
 	return os.RemoveAll(src)
+
+}
+
+func copyDirRecursive(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
 }

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
+	"runtime"
 	"path/filepath"
 	"strings"
 	"time"
@@ -20,6 +22,13 @@ import (
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/updater"
 	"github.com/spf13/cobra"
 )
+
+func nullDevice() string {
+	if runtime.GOOS == "windows" {
+		return "NUL"
+	}
+	return "/dev/null"
+}
 
 // Indirected so tests can swap WSL detection without touching the
 // real /proc/version or /etc/resolv.conf on the host they run on.
@@ -64,6 +73,16 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Verify Docker is available
+	if _, err := exec.LookPath("docker"); err != nil {
+		return fmt.Errorf("Docker is not installed or not in PATH. Install from https://docs.docker.com/get-docker/")
+	}
+	// Verify Docker Compose V2
+	out, err := exec.Command("docker", "compose", "version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Docker Compose V2 is required. Got: %s. Upgrade Docker Desktop or install the compose plugin.", strings.TrimSpace(string(out)))
+	}
+
 	// Warn — don't block — if Ollama is selected but the URL doesn't
 	// reach a running server. We translate ``host.docker.internal`` to
 	// ``localhost`` for the host-side probe; from inside the litellm
@@ -103,37 +122,31 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// 2.6. Set CLAUDE_CREDENTIALS_VOLUME for conditional mount in docker-compose.
 	// When the credentials file exists, mount it into litellm. Otherwise mount
-	// /dev/null so docker doesn't create it as a directory.
-	credsPath := filepath.Join(os.Getenv("HOME"), ".claude", ".credentials.json")
+	// /dev/null (NUL on Windows) so docker doesn't create it as a directory.
+	userHome, _ := os.UserHomeDir()
+	credsPath := filepath.Join(userHome, ".claude", ".credentials.json")
 	if _, statErr := os.Stat(credsPath); statErr == nil {
 		_ = os.Setenv("CLAUDE_CREDENTIALS_VOLUME", credsPath)
 	} else {
-		_ = os.Setenv("CLAUDE_CREDENTIALS_VOLUME", "/dev/null")
+		_ = os.Setenv("CLAUDE_CREDENTIALS_VOLUME", nullDevice())
 	}
 
 	// Same pattern for the Codex CLI credential store at ~/.codex/auth.json.
 	// The new auth/ ChatGPT handler reads (and writes) this file directly so
 	// a host-side `codex login` flows into the container without a rebuild.
-	codexAuthPath := filepath.Join(os.Getenv("HOME"), ".codex", "auth.json")
+	codexAuthPath := filepath.Join(userHome, ".codex", "auth.json")
 	if _, statErr := os.Stat(codexAuthPath); statErr == nil {
 		_ = os.Setenv("CODEX_AUTH_VOLUME", codexAuthPath)
 	} else {
-		_ = os.Setenv("CODEX_AUTH_VOLUME", "/dev/null")
+		_ = os.Setenv("CODEX_AUTH_VOLUME", nullDevice())
 	}
 
-	// 2.5. Update prompt. When a newer release is available and stdin is
-	// a TTY, ask the operator interactively whether to apply it. On
-	// confirmation the launcher applies the update (config sync + image
-	// pull + binary replace) and re-execs itself so the rest of this
-	// ``start`` flow runs against the just-installed version — matches
-	// the Claude Code / Codex CLI "update available, restarting" UX.
-	// Non-interactive shells (CI, piped) fall back to the passive notice
-	// path inside ``PromptIfUpdateAvailable``.
-	if _, err := updater.PromptIfUpdateAvailable(version); err != nil {
-		// Non-fatal — surface as a warning and continue with the
-		// current launcher rather than aborting the start.
-		ui.Warning("Update check: " + err.Error())
-	}
+	// 2.5. Non-blocking update check. When a newer release is available
+	// the prompt runs in the background so it doesn't add latency to
+	// the start path. Non-interactive shells skip the prompt entirely.
+	go func() {
+		updater.PromptIfUpdateAvailable(version)
+	}()
 
 	// 2.6. One-time GitHub star ask. Idempotent across launches — the
 	// ack file at $DECEPTICON_HOME/.starred suppresses the prompt
@@ -190,9 +203,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 		"cli",
 		cliEnv,
 	); err != nil {
-		ui.Warning("CLI exited with error — if services just started, try 'decepticon' again.")
-		ui.DimText("Run 'decepticon logs litellm' or 'decepticon logs langgraph' to debug.")
-		return nil
+		ui.Warning("CLI exited with error: " + err.Error())
+		return fmt.Errorf("cli: %w", err)
 	}
 
 	ui.DimText("CLI exited. Services kept running — run 'decepticon stop' to shut down.")

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -247,8 +247,15 @@ func (c *Compose) CleanScratch() {
 
 // RemoveOrphanedCLI removes any leftover CLI containers.
 func (c *Compose) RemoveOrphanedCLI() {
-	// Best-effort cleanup of orphaned CLI containers
-	out, err := exec.Command("docker", "ps", "-aq", "--filter", "name=decepticon.*cli").Output()
+	// Best-effort cleanup of orphaned CLI containers.
+	// Anchor the filter to the stack naming convention used by ContainerName
+	// so we don't accidentally match unrelated containers.
+	stack := strings.TrimSpace(os.Getenv("DECEPTICON_STACK_NAME"))
+	prefix := "decepticon"
+	if stack != "" {
+		prefix = "decepticon-" + stack
+	}
+	out, err := exec.Command("docker", "ps", "-aq", "--filter", fmt.Sprintf("name=^%s-cli", prefix)).Output()
 	if err != nil || len(out) == 0 {
 		return
 	}

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -211,12 +211,20 @@ var keyFormatRules = map[string]struct {
 	"GITHUB_TOKEN":                   {Prefix: "", Hint: ""},
 	"AWS_ACCESS_KEY_ID":              {Prefix: "AKIA", Hint: "AWS access key IDs start with 'AKIA'"},
 	"AZURE_API_KEY":                  {Prefix: "", Hint: ""},
-	"GOOGLE_APPLICATION_CREDENTIALS": {Prefix: "/", Hint: "must be an absolute path to a service-account JSON file"},
+	"GOOGLE_APPLICATION_CREDENTIALS": {Prefix: "", Hint: "must be an absolute path to a service-account JSON file"},
+
 	"CUSTOM_OPENAI_API_KEY":          {Prefix: "", Hint: ""},
 }
 
 // validateKeyFormat returns an empty string if the key looks valid, or a reason if not.
 func validateKeyFormat(name, val string) string {
+	// File-path keys have different validation
+	if name == "GOOGLE_APPLICATION_CREDENTIALS" {
+		if _, err := os.Stat(val); err != nil {
+			return "file not found: " + val
+		}
+		return ""
+	}
 	if len(val) < 20 {
 		return "value is too short to be a valid API key"
 	}
@@ -574,7 +582,15 @@ func extractClaudeAccessToken(creds map[string]any) string {
 }
 
 // AppendEnvLine appends a KEY=VALUE line to an existing .env file.
+// If the key is already present, it is left unchanged.
 func AppendEnvLine(path, key, value string) error {
+	existing, _ := os.ReadFile(path)
+	// If key already present, skip
+	for _, line := range strings.Split(string(existing), "\n") {
+		if k, _, ok := parseEnvLine(strings.TrimSpace(line)); ok && k == key {
+			return nil // already set
+		}
+	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

20+ fixes across the Go launcher (Windows correctness + UX) and the TypeScript TUI (bug fixes + performance). Split from #279 so each layer can be reviewed and merged independently.

## Go launcher — Windows platform fixes

- `cmd/start.go`: use `os.UserHomeDir()` instead of `os.Getenv("HOME")` — the latter is empty on Windows
- `cmd/start.go`: use `NUL` instead of `/dev/null` on Windows for volume fallbacks
- `cmd/remove.go`: in-process recursive copy instead of `cp -r` on Windows
- `internal/config/config.go`: `GOOGLE_APPLICATION_CREDENTIALS` validated as file path, not API key
- `internal/config/config.go`: `AppendEnvLine` deduplicates — no more growing `.env` files

## Go launcher — UX

- `cmd/start.go`: Docker / Compose V2 existence checked before first use with a clear error
- `cmd/start.go`: update check runs async — no more startup latency on slow networks
- `cmd/start.go`: CLI exit code propagated to shell (was swallowed with `return nil`)
- `cmd/logs.go`: help text lists available services
- `internal/compose/compose.go`: `RemoveOrphanedCLI` filter tightened to exact naming pattern

## TypeScript TUI — bug fixes

- `hooks/useAgent.ts`: event IDs use monotonic counter — no more burst collisions
- `hooks/useAgent.ts`: events pushed in-place to ref (O(1)), only state setter copies
- `hooks/useAgent.ts`: SSE disconnect detection with user-facing reconnection guidance
- `commands/file.ts`: tilde expansion handles `~`, `~/path` correctly; async readFile
- `screens/REPL.tsx`: initial message delay 3000ms → 200ms
- `utils/markdown.ts`: width recalculated per render (was frozen at module load)
- `utils/threadStore.ts`: Client lazy singleton instead of per-call instantiation

## TypeScript TUI — performance + UX

- `components/agents/AgentSessionGroup.tsx`: event filtering uses `Set` (O(n+m) vs O(n*m))
- `hooks/useSpinnerFrame.ts`: interval 80ms → 150ms — halves re-render frequency
- `hooks/useGlobalKeybindings.ts`: Ctrl+C double-tap now shows feedback message
- `commands/agent.ts`: removed hardcoded `ORCHESTRATOR_ALLOWLIST` — uses server discovery
- `commands/types.ts`: `Command.execute` supports async (`Promise<CommandResult | void>`)

## Risk

All changes are localized to `clients/cli` and `clients/launcher`. Each fix is small and individually verifiable. No public API change to the Python core.