### PR TITLE
fix: green up the local test suite on Windows (9 failures)

### DIFF
--- a/packages/decepticon/decepticon/middleware/filesystem.py
+++ b/packages/decepticon/decepticon/middleware/filesystem.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import posixpath
 from dataclasses import replace
 from typing import Any
 
@@ -51,7 +51,9 @@ def _normalize_engagement_workspace(workspace_path: str | None) -> str | None:
     if not path.startswith(f"{WORKSPACE}/"):
         return None
     expected = path.rstrip("/")
-    if os.path.normpath(expected) != expected:
+    # posixpath, not os.path: these are virtual POSIX paths. os.path.normpath
+    # rewrites "/" to "\" on Windows, which would reject every valid workspace.
+    if posixpath.normpath(expected) != expected:
         return None
     normalized = SandboxBase._normalize_workspace_path(path)
     return normalized if normalized == expected else None

--- a/packages/decepticon/tests/unit/backends/conftest.py
+++ b/packages/decepticon/tests/unit/backends/conftest.py
@@ -1,0 +1,35 @@
+"""Per-test isolation for process-wide sandbox class state.
+
+``SandboxBase._log_offsets`` and ``_jobs`` are deliberately class-level ΓÇö
+shared by every agent factory in a process (see ``SandboxBase``'s docstring).
+That contract is correct for production but leaks across tests: one test's
+``read_session_log_diff`` call populates ``_log_offsets``, and a later test
+that asserts a pristine offset map then fails. Under ``pytest -n auto`` the
+victim test varies with execution order. Resetting the state around every
+test makes each one start from the documented clean baseline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from decepticon.sandbox_kernel import BackgroundJobTracker, TmuxSessionManager
+from decepticon.sandbox_kernel.base import SandboxBase
+from decepticon.sandbox_kernel.daemon import DaemonSandbox
+
+
+@pytest.fixture(autouse=True)
+def _reset_sandbox_class_state() -> Iterator[None]:
+    """Reset shared sandbox ClassVar state before and after each test."""
+
+    def _reset() -> None:
+        for cls in (SandboxBase, DaemonSandbox):
+            cls._log_offsets.clear()
+            cls._jobs = BackgroundJobTracker()
+        TmuxSessionManager._initialized.clear()
+
+    _reset()
+    yield
+    _reset()

--- a/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
@@ -87,6 +87,7 @@ def test_read_json_file_returns_none_when_top_level_is_not_dict(tmp_path: Path) 
 # ── write_json_atomic ──────────────────────────────────────────────────
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode 0o600 is not enforced on Windows")
 def test_write_json_atomic_writes_payload_with_secure_mode(tmp_path: Path) -> None:
     path = tmp_path / "tokens.json"
     payload = {"access": "abc"}
@@ -110,6 +111,7 @@ def test_write_json_atomic_uses_atomic_temp_then_rename(tmp_path: Path) -> None:
     assert json.loads(path.read_text()) == {"v": "second"}
 
 
+@pytest.mark.skipif(os.name == "nt", reason="chmod-based directory locking is a no-op on Windows")
 def test_write_json_atomic_returns_false_when_target_dir_unwritable(tmp_path: Path) -> None:
     locked = tmp_path / "locked"
     locked.mkdir()


### PR DESCRIPTION
## Summary

Fixes the 9 `make test-local` failures on Windows. All three root causes confirmed by systematic debugging; all three are minimal, surgical changes.

## Failures fixed

### 1. `filesystem.py`: `os.path.normpath` corrupts virtual POSIX paths on Windows

`_normalize_engagement_workspace` validates virtual `/workspace/...` paths with `os.path.normpath`. On Windows that rewrites `/` to `\\`, so every engagement workspace resolves to `not set` and **5 EngagementFilesystemBackend tests fail**.

**Fix:** switch to `posixpath.normpath`. Behavior-identical on Linux/macOS; correct for the virtual POSIX path domain on Windows.

### 2. `test_session_log.py`: race on shared `SandboxBase` class state under `pytest -n auto`

`SandboxBase._log_offsets` and `_jobs` are deliberately shared `ClassVar`s — that contract is correct for production but leaks across tests. One test's `read_session_log_diff` populates `_log_offsets`; a later test asserts a pristine offset map and fails. Under `pytest -n auto` the victim varies with execution order.

**Fix:** new `packages/decepticon/tests/unit/backends/conftest.py` with an autouse fixture that resets `_log_offsets`, `_jobs`, and `TmuxSessionManager._initialized` around every test.

### 3. `test_oauth_token_store.py`: POSIX-only file mode + chmod assertions

Two tests assert POSIX file mode `0o600` and chmod-based directory locking. Neither is enforced on Windows.

**Fix:** mark both `pytest.skipif(os.name == "nt", ...)` with a documented reason.

## Why this is split from #279

PR #279 stacked 9 unrelated commits under a "Ghidra integration" title. These three Windows fixes are independent, surgical, and unblock the next step (#281 currently defers `windows-latest` for the Python and CLI CI matrices "until the Windows test-suite fixes land — track in #279"; merging this PR is that unlock).

## After this PR merges

Open a follow-up to add `windows-latest` to the python and cli CI matrices in `.github/workflows/ci.yml`. (Launcher Windows runner additionally needs fixes in `internal/config` and `internal/compose` for OAuth-credential test fixtures — separate scope.)

## Risk

Three small, localized changes. Linux + macOS behavior is preserved.