### PR TITLE
fix(llm): wrap acompletion in asyncio.wait_for with configurable timeout

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -88,9 +88,7 @@ async def call_with_timeout(coro: Awaitable[Any], timeout: float) -> Any:
     try:
         return await asyncio.wait_for(coro, timeout=timeout)
     except asyncio.TimeoutError as exc:
-        raise LLMTimeoutError(
-            f"LLM request timed out after {timeout:g} seconds"
-        ) from exc
+        raise LLMTimeoutError(f"LLM request timed out after {timeout:g} seconds") from exc
 
 
 # Default ordering when DECEPTICON_AUTH_PRIORITY is not set. OAuth methods

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -19,8 +19,10 @@ ordering AuthMethods in the fallback chain.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+from collections.abc import Awaitable
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -43,6 +45,52 @@ from decepticon_core.types.llm import (
 from decepticon_core.utils.logging import get_logger
 
 log = get_logger("llm.factory")
+
+
+DEFAULT_LLM_REQUEST_TIMEOUT_SECONDS = 600
+LLM_TIMEOUT_ENV = "DECEPTICON_LLM_TIMEOUT_SECONDS"
+
+
+class LLMTimeoutError(RuntimeError):
+    """Raised when an async LLM request exceeds the configured per-call timeout.
+
+    Distinct from generic ``asyncio.TimeoutError`` so middleware and retry
+    layers can identify request-timeout failures without catching every
+    cancellation in the loop. The timeout is whole-coroutine, not transport-
+    level (``ProxyConfig.timeout`` already covers transport).
+    """
+
+
+def _resolve_llm_timeout_seconds() -> float:
+    """Resolve the per-call LLM request timeout.
+
+    Precedence: ``DECEPTICON_LLM_TIMEOUT_SECONDS`` env > default ``600``.
+    Rejects non-positive or non-numeric env values with ``ValueError`` so
+    misconfiguration fails loudly rather than silently disabling the guard.
+    """
+    raw = os.getenv(LLM_TIMEOUT_ENV, "").strip()
+    if raw:
+        value = float(raw)
+    else:
+        value = float(DEFAULT_LLM_REQUEST_TIMEOUT_SECONDS)
+    if value <= 0:
+        raise ValueError(f"{LLM_TIMEOUT_ENV} must be greater than 0")
+    return value
+
+
+async def call_with_timeout(coro: Awaitable[Any], timeout: float) -> Any:
+    """Wrap ``coro`` in :func:`asyncio.wait_for` and re-raise as :class:`LLMTimeoutError`.
+
+    The translation preserves the original ``asyncio.TimeoutError`` via
+    ``__cause__`` so debugging traces remain intact, while letting upstream
+    code distinguish provider-stall timeouts from generic cancellation.
+    """
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        raise LLMTimeoutError(
+            f"LLM request timed out after {timeout:g} seconds"
+        ) from exc
 
 
 # Default ordering when DECEPTICON_AUTH_PRIORITY is not set. OAuth methods
@@ -509,7 +557,12 @@ class _ProxiedChatOpenAI(ChatOpenAI):
 
     async def ainvoke(self, *args, **kwargs):
         try:
-            return await super().ainvoke(*args, **kwargs)
+            return await call_with_timeout(
+                super().ainvoke(*args, **kwargs),
+                _resolve_llm_timeout_seconds(),
+            )
+        except LLMTimeoutError:
+            raise
         except Exception as exc:
             _reraise_with_actionable_message(exc, self.model_name)
             raise
@@ -640,7 +693,10 @@ class _DeepSeekThinkingChatOpenAI(_ProxiedChatOpenAI):
 
     async def _agenerate(self, messages: list[BaseMessage], *args: Any, **kwargs: Any) -> Any:
         """Wrap _agenerate to preserve reasoning_content in the response."""
-        result = await super()._agenerate(messages, *args, **kwargs)
+        result = await call_with_timeout(
+            super()._agenerate(messages, *args, **kwargs),
+            _resolve_llm_timeout_seconds(),
+        )
         return result
 
     def _convert_chunk_to_generation_chunk(

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -1235,34 +1235,26 @@ class TestLLMTimeout:
         monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "3")
         assert _resolve_llm_timeout_seconds() == 3.0
 
-    def test_default_timeout_is_600_when_env_absent(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_default_timeout_is_600_when_env_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from decepticon.llm.factory import _resolve_llm_timeout_seconds
 
         monkeypatch.delenv("DECEPTICON_LLM_TIMEOUT_SECONDS", raising=False)
         assert _resolve_llm_timeout_seconds() == 600.0
 
-    def test_blank_env_falls_back_to_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_blank_env_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from decepticon.llm.factory import _resolve_llm_timeout_seconds
 
         monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "   ")
         assert _resolve_llm_timeout_seconds() == 600.0
 
-    def test_invalid_env_raises_value_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_invalid_env_raises_value_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from decepticon.llm.factory import _resolve_llm_timeout_seconds
 
         monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "not-a-number")
         with pytest.raises(ValueError):
             _resolve_llm_timeout_seconds()
 
-    def test_non_positive_env_raises_value_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_non_positive_env_raises_value_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from decepticon.llm.factory import _resolve_llm_timeout_seconds
 
         monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "0")

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -1176,3 +1176,99 @@ class TestResolveCredentialsForLlamacpp:
 
         creds = _resolve_credentials()
         assert creds.methods == [AuthMethod.LLAMACPP_LOCAL, AuthMethod.ANTHROPIC_API]
+
+
+class TestLLMTimeout:
+    """Whole-coroutine LLM request timeout (DECEPTICON_LLM_TIMEOUT_SECONDS)."""
+
+    def test_call_with_timeout_raises_typed_exception(self) -> None:
+        from decepticon.llm.factory import LLMTimeoutError, call_with_timeout
+
+        async def slow_call() -> str:
+            await asyncio.sleep(10)
+            return "done"
+
+        with pytest.raises(LLMTimeoutError, match="timed out after 0.01 seconds"):
+            asyncio.run(call_with_timeout(slow_call(), 0.01))
+
+    def test_call_with_timeout_preserves_original_timeout_as_cause(self) -> None:
+        from decepticon.llm.factory import LLMTimeoutError, call_with_timeout
+
+        async def slow_call() -> None:
+            await asyncio.sleep(10)
+
+        try:
+            asyncio.run(call_with_timeout(slow_call(), 0.01))
+        except LLMTimeoutError as exc:
+            assert isinstance(exc.__cause__, asyncio.TimeoutError)
+        else:
+            raise AssertionError("expected LLMTimeoutError")
+
+    def test_call_with_timeout_returns_successful_result(self) -> None:
+        from decepticon.llm.factory import call_with_timeout
+
+        async def fast_call() -> str:
+            await asyncio.sleep(0)
+            return "ok"
+
+        assert asyncio.run(call_with_timeout(fast_call(), 1)) == "ok"
+
+    def test_call_with_timeout_propagates_non_timeout_exceptions(self) -> None:
+        from decepticon.llm.factory import LLMTimeoutError, call_with_timeout
+
+        async def failing_call() -> None:
+            raise RuntimeError("upstream 500")
+
+        with pytest.raises(RuntimeError, match="upstream 500"):
+            asyncio.run(call_with_timeout(failing_call(), 1))
+        # And not as a timeout error
+        try:
+            asyncio.run(call_with_timeout(failing_call(), 1))
+        except LLMTimeoutError:
+            raise AssertionError("non-timeout exception was retyped")
+        except RuntimeError:
+            pass
+
+    def test_env_override_takes_effect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "3")
+        assert _resolve_llm_timeout_seconds() == 3.0
+
+    def test_default_timeout_is_600_when_env_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.delenv("DECEPTICON_LLM_TIMEOUT_SECONDS", raising=False)
+        assert _resolve_llm_timeout_seconds() == 600.0
+
+    def test_blank_env_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "   ")
+        assert _resolve_llm_timeout_seconds() == 600.0
+
+    def test_invalid_env_raises_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "not-a-number")
+        with pytest.raises(ValueError):
+            _resolve_llm_timeout_seconds()
+
+    def test_non_positive_env_raises_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "0")
+        with pytest.raises(ValueError, match="greater than 0"):
+            _resolve_llm_timeout_seconds()
+
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "-5")
+        with pytest.raises(ValueError, match="greater than 0"):
+            _resolve_llm_timeout_seconds()


### PR DESCRIPTION
## Summary

Async LLM call paths in `decepticon.llm.factory` previously had no whole-coroutine timeout. A stalled provider / proxy / network call could hang the agent loop indefinitely — `ProxyConfig.timeout` is transport-level only and does not bound the awaited coroutine end-to-end.

## What changes

Three additions to `packages/decepticon/decepticon/llm/factory.py`:

| Symbol | Purpose |
|---|---|
| `LLMTimeoutError` | Typed exception so middleware / retry can distinguish request-timeout from generic cancellation. |
| `call_with_timeout(coro, timeout)` | Single `asyncio.wait_for` helper; re-raises as `LLMTimeoutError` with `__cause__` preserved. |
| `_resolve_llm_timeout_seconds()` | Env precedence: `DECEPTICON_LLM_TIMEOUT_SECONDS` > default `600`. Non-numeric / non-positive → `ValueError`. |

Two wrap sites — the only `await super()...` async network calls in the file:

- `_ProxiedChatOpenAI.ainvoke`
- `_DeepSeekThinkingChatOpenAI._agenerate`

Streaming chunk post-processing (`_convert_chunk_to_generation_chunk`) is untouched: it has no awaited network call.

## Configuration

| Source | Default |
|---|---|
| `DECEPTICON_LLM_TIMEOUT_SECONDS` env | (overrides everything) |
| hard default | `600` seconds |

Per-model granularity (`ModelAssignment.request_timeout_seconds`) is intentionally **out of scope** here to keep this PR free of cross-package coupling with `decepticon-core`. The env + 600s default fully resolves the indefinite-hang failure mode; per-model can be a follow-up.

## Files touched

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/llm/factory.py` | +58 lines (constants, exception, helpers, two wrap sites) |
| `packages/decepticon/tests/unit/llm/test_factory.py` | +96 lines (new `TestLLMTimeout` class) |

## Verification

- `uv run pytest packages/decepticon/tests/unit/llm/test_factory.py::TestLLMTimeout -q` → **9 passed**
- `uv run pytest packages/decepticon/tests/unit/llm/test_factory.py -q` → **73 passed** (no regressions)
- `uv run ruff check packages/decepticon/decepticon/llm/factory.py packages/decepticon/tests/unit/llm/test_factory.py` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

`TestLLMTimeout` covers: raise on timeout, `__cause__` preservation, fast-path return, non-timeout exception propagation, env override, default-600, blank-env fallback, invalid-env `ValueError`, non-positive-env `ValueError`.
