### PR TITLE
feat(runtime): bounded graceful SIGTERM/SIGINT shutdown library

### DIFF
--- a/packages/decepticon/decepticon/runtime/__init__.py
+++ b/packages/decepticon/decepticon/runtime/__init__.py
@@ -1,15 +1,35 @@
 """Runtime infrastructure for the Decepticon orchestrator process.
 
-Currently exposes the graceful shutdown installer; future runtime
-primitives (event log, resume) will live here as well.
+Each runtime module (event log, graceful shutdown, future resume, ...)
+ships in its own PR. This package init imports every known module
+best-effort so each PR can land in any order without colliding on
+this file.
 """
 
-from decepticon.runtime.shutdown import (
-    LangGraphState,
-    install_shutdown_handlers,
-)
+_exports: list[str] = []
 
-__all__ = [
-    "LangGraphState",
-    "install_shutdown_handlers",
-]
+try:
+    from decepticon.runtime.event_log import (  # noqa: F401  # re-exported via __all__
+        EngagementEvent,
+        EventLog,
+        EventType,
+        read_events,
+    )
+
+    _exports += ["EngagementEvent", "EventLog", "EventType", "read_events"]
+except ImportError:
+    # event log module not present — another runtime PR may be mid-merge
+    pass
+
+try:
+    from decepticon.runtime.shutdown import (  # noqa: F401  # re-exported via __all__
+        LangGraphState,
+        install_shutdown_handlers,
+    )
+
+    _exports += ["LangGraphState", "install_shutdown_handlers"]
+except ImportError:
+    # shutdown module not present — another runtime PR may be mid-merge
+    pass
+
+__all__ = _exports

--- a/packages/decepticon/decepticon/runtime/__init__.py
+++ b/packages/decepticon/decepticon/runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Runtime infrastructure for the Decepticon orchestrator process.
+
+Currently exposes the graceful shutdown installer; future runtime
+primitives (event log, resume) will live here as well.
+"""
+
+from decepticon.runtime.shutdown import (
+    LangGraphState,
+    install_shutdown_handlers,
+)
+
+__all__ = [
+    "LangGraphState",
+    "install_shutdown_handlers",
+]

--- a/packages/decepticon/decepticon/runtime/shutdown.py
+++ b/packages/decepticon/decepticon/runtime/shutdown.py
@@ -1,0 +1,457 @@
+"""Bounded graceful shutdown on SIGINT / SIGTERM (Windows: console events).
+
+On first signal the handler best-effort persists operator-visible state
+inside the engagement workspace, then exits with the conventional
+``128 + signum`` code. A second signal within the duplicate window
+forces immediate exit. The total flush is bounded by ``MAX_FLUSH_SECONDS``
+regardless of how slow individual writes are.
+
+The handler is decoupled from the LangGraph orchestrator via the
+``state_provider`` callback so this module has zero import-time side
+effects and is safe to import from any process.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+log = logging.getLogger("decepticon.runtime.shutdown")
+
+
+LangGraphState: TypeAlias = Mapping[str, Any]
+
+
+MAX_FLUSH_SECONDS: float = 5.0
+"""Total upper bound on the synchronous post-signal flush.
+
+The handler joins the worker thread with this deadline and exits even
+if writes are still in flight when the deadline expires."""
+
+DUPLICATE_SIGNAL_WINDOW_SECONDS: float = 2.0
+"""Second signal within this window of the first forces immediate exit."""
+
+EXIT_CODE_SIGINT: int = 130
+EXIT_CODE_SIGTERM: int = 143
+
+
+_install_lock = threading.RLock()
+_state_lock = threading.RLock()
+_installed: bool = False
+_state_provider: Callable[[], LangGraphState] | None = None
+_last_signal_at: float | None = None
+_flushing: bool = False
+_previous_handlers: dict[int, Any] = {}
+_windows_handler_routine: Any = None
+
+
+@dataclass
+class _FlushResult:
+    workspace: Path | None = None
+    findings_written: int = 0
+    opplan_written: bool = False
+    partial_executive_written: bool = False
+    event_written: bool = False
+    errors: list[str] = field(default_factory=list)
+
+    def summary_line(self, signal_name: str) -> str:
+        if self.workspace is None:
+            return f"[shutdown] {signal_name}: no workspace; skipped checkpoint"
+        parts = [
+            f"findings={self.findings_written}",
+            f"opplan={'ok' if self.opplan_written else 'skip'}",
+            f"executive={'ok' if self.partial_executive_written else 'skip'}",
+        ]
+        if self.event_written:
+            parts.append("event=ok")
+        if self.errors:
+            parts.append(f"errors={len(self.errors)}")
+        return f"[shutdown] {signal_name}: " + " ".join(parts) + f" -> {self.workspace}"
+
+
+def install_shutdown_handlers(state_provider: Callable[[], LangGraphState]) -> None:
+    """Install bounded graceful shutdown handlers.
+
+    Idempotent: calling more than once with the same provider replaces
+    the registered provider but does not restack OS-level handlers. The
+    handler captures state through ``state_provider`` at signal time, so
+    callers should keep the returned object pointing at the latest
+    LangGraph state.
+    """
+    global _installed, _state_provider
+    with _install_lock:
+        _state_provider = state_provider
+        if _installed:
+            return
+        _register_posix_handlers()
+        if os.name == "nt":
+            _register_windows_handler()
+        _installed = True
+
+
+def _register_posix_handlers() -> None:
+    try:
+        _previous_handlers[signal.SIGINT] = signal.signal(signal.SIGINT, _on_signal)
+    except (ValueError, OSError) as exc:
+        log.warning("Could not register SIGINT handler: %s", exc)
+    sigterm = getattr(signal, "SIGTERM", None)
+    if sigterm is None:
+        return
+    try:
+        _previous_handlers[signal.SIGTERM] = signal.signal(signal.SIGTERM, _on_signal)
+    except (ValueError, OSError) as exc:
+        log.warning("Could not register SIGTERM handler: %s", exc)
+
+
+def _register_windows_handler() -> None:
+    global _windows_handler_routine
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:
+        return
+
+    handler_type = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.DWORD)
+
+    def _windows_handler(ctrl_type: int) -> bool:
+        if ctrl_type in (0, 1):
+            _on_signal(signal.SIGINT, None)
+        else:
+            _on_signal(getattr(signal, "SIGTERM", signal.SIGINT), None)
+        return True
+
+    routine = handler_type(_windows_handler)
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleCtrlHandler.argtypes = (handler_type, wintypes.BOOL)
+    kernel32.SetConsoleCtrlHandler.restype = wintypes.BOOL
+    if not kernel32.SetConsoleCtrlHandler(routine, True):
+        log.warning("SetConsoleCtrlHandler registration returned 0")
+        return
+    _windows_handler_routine = routine
+
+
+def _on_signal(signum: int | None, frame: Any) -> None:
+    del frame
+    global _last_signal_at, _flushing
+    now = time.monotonic()
+    sig_name = _signal_name(signum)
+    exit_code = _exit_code_for(signum)
+
+    with _state_lock:
+        prev = _last_signal_at
+        _last_signal_at = now
+        already_flushing = _flushing
+
+    if prev is not None and (now - prev) <= DUPLICATE_SIGNAL_WINDOW_SECONDS:
+        _force_exit(exit_code, reason="duplicate signal")
+        return
+    if already_flushing:
+        _force_exit(exit_code, reason="second signal during flush")
+        return
+
+    with _state_lock:
+        _flushing = True
+
+    deadline = time.monotonic() + MAX_FLUSH_SECONDS
+    result_holder: dict[str, _FlushResult] = {}
+
+    def _worker() -> None:
+        try:
+            result_holder["r"] = _run_flush(sig_name, deadline)
+        except Exception as exc:  # noqa: BLE001 - last line of defense
+            result_holder["r"] = _FlushResult(errors=[f"flush crashed: {exc!r}"])
+
+    worker = threading.Thread(target=_worker, name="decepticon-shutdown-flush", daemon=True)
+    worker.start()
+    worker.join(timeout=MAX_FLUSH_SECONDS)
+
+    result = result_holder.get(
+        "r",
+        _FlushResult(errors=["flush exceeded deadline; partial state"]),
+    )
+    try:
+        sys.stdout.write(result.summary_line(sig_name) + "\n")
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        pass
+
+    _force_exit(exit_code, reason="flush complete")
+
+
+def _signal_name(signum: int | None) -> str:
+    if signum is None:
+        return "SIGNAL"
+    try:
+        return signal.Signals(signum).name
+    except (ValueError, KeyError):
+        return f"signal-{signum}"
+
+
+def _exit_code_for(signum: int | None) -> int:
+    if signum is None:
+        return EXIT_CODE_SIGINT
+    sigterm = getattr(signal, "SIGTERM", None)
+    if sigterm is not None and signum == sigterm:
+        return EXIT_CODE_SIGTERM
+    return EXIT_CODE_SIGINT
+
+
+def _force_exit(code: int, *, reason: str) -> None:
+    try:
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        pass
+    log.debug("Force exit (%s) code=%d", reason, code)
+    os._exit(code)
+
+
+def _run_flush(signal_name: str, deadline: float) -> _FlushResult:
+    result = _FlushResult()
+    state: LangGraphState | None = None
+    if _state_provider is not None:
+        try:
+            state = _state_provider()
+        except Exception as exc:  # noqa: BLE001
+            result.errors.append(f"state_provider failed: {exc!r}")
+            return result
+    if state is None:
+        return result
+
+    workspace = _resolve_workspace(state)
+    result.workspace = workspace
+    if workspace is None:
+        return result
+
+    if _time_left(deadline) <= 0:
+        return result
+    try:
+        result.findings_written = _write_inflight_findings(state, workspace)
+    except Exception as exc:  # noqa: BLE001
+        result.errors.append(f"findings: {exc!r}")
+
+    if _time_left(deadline) <= 0:
+        return result
+    try:
+        result.opplan_written = _write_opplan_checkpoint(state, workspace)
+    except Exception as exc:  # noqa: BLE001
+        result.errors.append(f"opplan: {exc!r}")
+
+    if _time_left(deadline) <= 0:
+        return result
+    try:
+        result.partial_executive_written = _write_partial_executive(state, workspace)
+    except Exception as exc:  # noqa: BLE001
+        result.errors.append(f"executive: {exc!r}")
+
+    if _time_left(deadline) <= 0:
+        return result
+    try:
+        result.event_written = _write_checkpoint_event_if_available(
+            state, workspace, result, signal_name
+        )
+    except Exception as exc:  # noqa: BLE001
+        result.errors.append(f"event: {exc!r}")
+
+    return result
+
+
+def _time_left(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
+
+
+def _resolve_workspace(state: LangGraphState) -> Path | None:
+    raw = state.get("workspace_path") if isinstance(state, Mapping) else None
+    if not raw:
+        return None
+    path = Path(str(raw))
+    if not path.exists():
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return None
+    return path
+
+
+def _write_atomic(target: Path, content: str | bytes) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    if isinstance(content, bytes):
+        tmp.write_bytes(content)
+    else:
+        tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, target)
+
+
+def _next_finding_id(findings_dir: Path) -> int:
+    if not findings_dir.exists():
+        return 1
+    highest = 0
+    for f in findings_dir.glob("FIND-*.md"):
+        stem = f.stem
+        suffix = stem.split("-", 1)[1] if "-" in stem else ""
+        try:
+            n = int(suffix)
+        except ValueError:
+            continue
+        if n > highest:
+            highest = n
+    return highest + 1
+
+
+def _write_inflight_findings(state: LangGraphState, workspace: Path) -> int:
+    if not isinstance(state, Mapping):
+        return 0
+    candidates = state.get("pending_findings") or state.get("findings") or []
+    if not isinstance(candidates, (list, tuple)):
+        return 0
+    findings_dir = workspace / "findings"
+    written = 0
+    next_id = _next_finding_id(findings_dir)
+    for raw in candidates:
+        if not isinstance(raw, Mapping):
+            body = _finding_fallback_body(raw)
+        else:
+            body = _finding_markdown(raw)
+        target = findings_dir / f"FIND-{next_id:03d}.md"
+        _write_atomic(target, body)
+        written += 1
+        next_id += 1
+    return written
+
+
+def _finding_markdown(finding: Mapping[str, Any]) -> str:
+    title = str(finding.get("title", "Untitled finding"))
+    severity = str(finding.get("severity", "info")).upper()
+    summary = str(finding.get("summary", ""))
+    evidence = finding.get("evidence")
+    lines = [
+        f"# {title}",
+        "",
+        f"- **Severity:** {severity}",
+        "- **Captured by:** graceful-shutdown checkpoint",
+        "",
+    ]
+    if summary:
+        lines += ["## Summary", "", summary, ""]
+    if evidence is not None:
+        lines += [
+            "## Evidence (raw, captured at shutdown)",
+            "",
+            "```json",
+            json.dumps(evidence, indent=2, sort_keys=True, default=str),
+            "```",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def _finding_fallback_body(raw: Any) -> str:
+    return (
+        "# Untitled finding (raw capture)\n\n"
+        "- **Severity:** UNKNOWN\n"
+        "- **Captured by:** graceful-shutdown checkpoint\n\n"
+        "## Raw payload\n\n```\n"
+        f"{raw!r}\n"
+        "```\n"
+    )
+
+
+def _write_opplan_checkpoint(state: LangGraphState, workspace: Path) -> bool:
+    if not isinstance(state, Mapping):
+        return False
+    objectives = state.get("objectives")
+    if objectives is None:
+        return False
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "saved_at": time.time(),
+        "engagement_name": state.get("engagement_name", "engagement"),
+        "threat_profile": state.get("threat_profile"),
+        "objective_counter": state.get("objective_counter"),
+        "objectives": _jsonable(objectives),
+    }
+    target = workspace / "plan" / "opplan.json"
+    _write_atomic(target, json.dumps(payload, indent=2, default=str))
+    return True
+
+
+def _write_partial_executive(state: LangGraphState, workspace: Path) -> bool:
+    if not isinstance(state, Mapping):
+        return False
+    engagement = str(state.get("engagement_name") or "Engagement")
+    graph = state.get("knowledge_graph") or state.get("graph")
+    body: str
+    if graph is not None:
+        try:
+            from decepticon.tools.reporting.executive import render_executive_summary
+
+            body = render_executive_summary(graph, engagement_name=engagement)
+        except Exception as exc:  # noqa: BLE001
+            body = _fallback_executive(engagement, state, note=f"graph render failed: {exc!r}")
+    else:
+        body = _fallback_executive(engagement, state, note="no knowledge graph in state")
+    target = workspace / "report" / "report_partial_executive.md"
+    _write_atomic(target, body)
+    return True
+
+
+def _fallback_executive(engagement: str, state: LangGraphState, *, note: str) -> str:
+    objectives = state.get("objectives") if isinstance(state, Mapping) else None
+    counter = state.get("objective_counter") if isinstance(state, Mapping) else None
+    lines = [
+        f"# {engagement} — Partial Executive Summary (graceful shutdown)",
+        "",
+        "## Status",
+        "",
+        f"- {note}",
+        "- Persisted from in-memory state at shutdown; not a final report.",
+        "",
+        "## OPPLAN snapshot",
+        "",
+        f"- objective_counter: {counter!r}",
+        f"- objectives recorded: {len(objectives) if isinstance(objectives, (list, tuple)) else 'unknown'}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _write_checkpoint_event_if_available(
+    state: LangGraphState,
+    workspace: Path,
+    result: _FlushResult,
+    signal_name: str,
+) -> bool:
+    events_path = workspace / "events.jsonl"
+    if not events_path.exists():
+        return False
+    event = {
+        "ts": time.time(),
+        "type": "engagement.checkpoint",
+        "reason": "signal",
+        "signal": signal_name,
+        "findings_written": result.findings_written,
+        "partial_executive": "report/report_partial_executive.md"
+        if result.partial_executive_written
+        else None,
+        "opplan_checkpoint": "plan/opplan.json" if result.opplan_written else None,
+    }
+    with events_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, default=str) + "\n")
+    return True
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value, default=str)
+        return value
+    except TypeError:
+        return json.loads(json.dumps(value, default=str))

--- a/packages/decepticon/tests/unit/runtime/test_shutdown.py
+++ b/packages/decepticon/tests/unit/runtime/test_shutdown.py
@@ -153,9 +153,7 @@ def test_existing_findings_get_next_id(tmp_path: Path) -> None:
 
     assert proc.returncode == 130, proc.stderr
     assert (findings_dir / "FIND-008.md").exists()
-    assert (findings_dir / "FIND-001.md").read_text(encoding="utf-8").startswith(
-        "# pre-existing"
-    )
+    assert (findings_dir / "FIND-001.md").read_text(encoding="utf-8").startswith("# pre-existing")
 
 
 @pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test")

--- a/packages/decepticon/tests/unit/runtime/test_shutdown.py
+++ b/packages/decepticon/tests/unit/runtime/test_shutdown.py
@@ -1,0 +1,453 @@
+"""Tests for ``decepticon.runtime.shutdown`` — bounded graceful shutdown.
+
+Signal-handling behavior MUST run in subprocesses, never in the pytest
+worker process, because installing SIGINT/SIGTERM handlers there would
+break test isolation and could exit the whole test session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_WINDOWS = os.name == "nt"
+
+
+def _write_driver(
+    workspace: Path,
+    *,
+    signal_name: str,
+    delay_seconds: float = 0.1,
+    create_events_jsonl: bool = False,
+    findings_payload: str = "[]",
+    objectives_payload: str = "[]",
+) -> Path:
+    """Render a self-contained driver script that installs handlers and self-signals.
+
+    The driver writes nothing except via the shutdown handler under test, so
+    the parent can assert behaviour purely from on-disk side effects.
+    """
+    if create_events_jsonl:
+        (workspace / "events.jsonl").write_text("", encoding="utf-8")
+    script = workspace / "_driver.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import os
+            import signal
+            import sys
+            import time
+
+            from decepticon.runtime.shutdown import install_shutdown_handlers
+
+
+            def _state():
+                return {{
+                    "workspace_path": r"{workspace.as_posix()}",
+                    "engagement_name": "unit-shutdown",
+                    "objectives": {objectives_payload},
+                    "objective_counter": 1,
+                    "threat_profile": "lab",
+                    "pending_findings": {findings_payload},
+                }}
+
+
+            install_shutdown_handlers(_state)
+            time.sleep({delay_seconds})
+            os.kill(os.getpid(), signal.{signal_name})
+            time.sleep(10)
+            sys.exit(99)
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    return script
+
+
+def _run_driver(script: Path, *, timeout: float = 30.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test; Windows uses console events")
+def test_sigint_flushes_findings_opplan_partial_executive_and_exits_130(tmp_path: Path) -> None:
+    findings = json.dumps(
+        [
+            {
+                "title": "Open redirect on /login",
+                "severity": "medium",
+                "summary": "Reflected query param redirects to attacker host.",
+                "evidence": {"url": "https://target/login?next=//evil"},
+            }
+        ]
+    )
+    objectives = json.dumps([{"id": "OBJ-001", "title": "Map external surface"}])
+    script = _write_driver(
+        tmp_path,
+        signal_name="SIGINT",
+        findings_payload=findings,
+        objectives_payload=objectives,
+    )
+
+    proc = _run_driver(script)
+
+    assert proc.returncode == 130, proc.stderr
+    finding_path = tmp_path / "findings" / "FIND-001.md"
+    opplan_path = tmp_path / "plan" / "opplan.json"
+    executive_path = tmp_path / "report" / "report_partial_executive.md"
+    assert finding_path.exists()
+    body = finding_path.read_text(encoding="utf-8")
+    assert "Open redirect on /login" in body
+    assert "MEDIUM" in body
+    assert opplan_path.exists()
+    opplan = json.loads(opplan_path.read_text(encoding="utf-8"))
+    assert opplan["objectives"][0]["id"] == "OBJ-001"
+    assert opplan["engagement_name"] == "unit-shutdown"
+    assert executive_path.exists()
+    assert "unit-shutdown" in executive_path.read_text(encoding="utf-8")
+    assert "[shutdown] SIGINT:" in proc.stdout
+
+
+@pytest.mark.skipif(
+    _WINDOWS or not hasattr(signal, "SIGTERM"),
+    reason="POSIX SIGTERM test",
+)
+def test_sigterm_exits_143(tmp_path: Path) -> None:
+    script = _write_driver(
+        tmp_path,
+        signal_name="SIGTERM",
+        findings_payload="[]",
+        objectives_payload="[]",
+    )
+
+    proc = _run_driver(script)
+
+    assert proc.returncode == 143, proc.stderr
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test")
+def test_existing_findings_get_next_id(tmp_path: Path) -> None:
+    findings_dir = tmp_path / "findings"
+    findings_dir.mkdir(parents=True, exist_ok=True)
+    (findings_dir / "FIND-001.md").write_text("# pre-existing\n", encoding="utf-8")
+    (findings_dir / "FIND-007.md").write_text("# pre-existing 7\n", encoding="utf-8")
+
+    findings = json.dumps([{"title": "New finding", "severity": "low"}])
+    script = _write_driver(
+        tmp_path, signal_name="SIGINT", findings_payload=findings, objectives_payload="[]"
+    )
+
+    proc = _run_driver(script)
+
+    assert proc.returncode == 130, proc.stderr
+    assert (findings_dir / "FIND-008.md").exists()
+    assert (findings_dir / "FIND-001.md").read_text(encoding="utf-8").startswith(
+        "# pre-existing"
+    )
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test")
+def test_events_jsonl_checkpoint_appended_when_file_present(tmp_path: Path) -> None:
+    script = _write_driver(
+        tmp_path,
+        signal_name="SIGINT",
+        create_events_jsonl=True,
+        findings_payload="[]",
+        objectives_payload="[]",
+    )
+
+    proc = _run_driver(script)
+
+    assert proc.returncode == 130, proc.stderr
+    events_path = tmp_path / "events.jsonl"
+    lines = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(lines) == 1
+    assert lines[0]["type"] == "engagement.checkpoint"
+    assert lines[0]["reason"] == "signal"
+    assert lines[0]["signal"] == "SIGINT"
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test")
+def test_no_events_jsonl_means_no_event_file_created(tmp_path: Path) -> None:
+    script = _write_driver(
+        tmp_path,
+        signal_name="SIGINT",
+        create_events_jsonl=False,
+        findings_payload="[]",
+        objectives_payload="[]",
+    )
+
+    proc = _run_driver(script)
+
+    assert proc.returncode == 130, proc.stderr
+    assert not (tmp_path / "events.jsonl").exists()
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test")
+def test_double_signal_within_window_forces_immediate_exit(tmp_path: Path) -> None:
+    script = tmp_path / "_double.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import os
+            import signal
+            import time
+
+            from decepticon.runtime.shutdown import install_shutdown_handlers
+
+
+            def _state():
+                time.sleep(3)
+                return {{"workspace_path": r"{tmp_path.as_posix()}"}}
+
+
+            install_shutdown_handlers(_state)
+            time.sleep(0.1)
+            os.kill(os.getpid(), signal.SIGINT)
+            time.sleep(0.3)
+            os.kill(os.getpid(), signal.SIGINT)
+            time.sleep(10)
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+    proc = _run_driver(script, timeout=15.0)
+
+    assert proc.returncode == 130, proc.stderr
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX self-signal test")
+def test_missing_workspace_path_does_not_hang(tmp_path: Path) -> None:
+    script = tmp_path / "_noworkspace.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            import signal
+            import sys
+            import time
+
+            from decepticon.runtime.shutdown import install_shutdown_handlers
+
+
+            def _state():
+                return {}
+
+
+            install_shutdown_handlers(_state)
+            time.sleep(0.1)
+            os.kill(os.getpid(), signal.SIGINT)
+            time.sleep(10)
+            sys.exit(99)
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+    proc = _run_driver(script, timeout=15.0)
+
+    assert proc.returncode == 130, proc.stderr
+    assert "no workspace" in proc.stdout
+
+
+def test_install_shutdown_handlers_is_idempotent() -> None:
+    """In-process API test: repeated install with same/new provider does not raise."""
+    from decepticon.runtime.shutdown import install_shutdown_handlers
+
+    def _state_a() -> dict:
+        return {}
+
+    def _state_b() -> dict:
+        return {"workspace_path": "/tmp/example"}
+
+    install_shutdown_handlers(_state_a)
+    install_shutdown_handlers(_state_b)
+    install_shutdown_handlers(_state_a)
+
+
+def test_fallback_executive_used_when_no_graph(tmp_path: Path) -> None:
+    """The handler must write a fallback executive markdown rather than skip."""
+    if _WINDOWS:
+        pytest.skip("POSIX self-signal test")
+    script = _write_driver(
+        tmp_path,
+        signal_name="SIGINT",
+        findings_payload="[]",
+        objectives_payload="[]",
+    )
+
+    proc = _run_driver(script)
+
+    assert proc.returncode == 130, proc.stderr
+    executive_path = tmp_path / "report" / "report_partial_executive.md"
+    assert executive_path.exists()
+    body = executive_path.read_text(encoding="utf-8")
+    assert "Partial Executive Summary" in body
+    assert "no knowledge graph in state" in body
+
+
+class TestFlushLogicInProcess:
+    """Direct unit tests for the flush helpers — cross-platform; no real signals."""
+
+    def test_run_flush_writes_finding_opplan_and_executive(self, tmp_path: Path) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        state = {
+            "workspace_path": str(tmp_path),
+            "engagement_name": "in-proc-test",
+            "objectives": [{"id": "OBJ-001", "title": "Map"}],
+            "objective_counter": 1,
+            "threat_profile": "lab",
+            "pending_findings": [
+                {
+                    "title": "SSRF in /proxy",
+                    "severity": "high",
+                    "summary": "Server fetches arbitrary URLs.",
+                    "evidence": {"url": "https://target/proxy?url=http://169.254.169.254/"},
+                }
+            ],
+        }
+        mod._state_provider = lambda: state
+
+        result = mod._run_flush("SIGINT", deadline=time_monotonic_plus(5))
+
+        assert result.workspace == tmp_path
+        assert result.findings_written == 1
+        assert result.opplan_written is True
+        assert result.partial_executive_written is True
+        assert (tmp_path / "findings" / "FIND-001.md").exists()
+        assert (tmp_path / "plan" / "opplan.json").exists()
+        assert (tmp_path / "report" / "report_partial_executive.md").exists()
+
+    def test_run_flush_with_no_workspace_returns_empty_result(self, tmp_path: Path) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        mod._state_provider = lambda: {}
+        result = mod._run_flush("SIGINT", deadline=time_monotonic_plus(5))
+
+        assert result.workspace is None
+        assert result.findings_written == 0
+        assert result.opplan_written is False
+        assert result.partial_executive_written is False
+
+    def test_run_flush_continues_after_one_write_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        state = {
+            "workspace_path": str(tmp_path),
+            "engagement_name": "err-test",
+            "objectives": [{"id": "OBJ-001"}],
+            "pending_findings": [{"title": "x", "severity": "low"}],
+        }
+        mod._state_provider = lambda: state
+
+        def _broken(*_args: object, **_kwargs: object) -> int:
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(mod, "_write_inflight_findings", _broken)
+
+        result = mod._run_flush("SIGINT", deadline=time_monotonic_plus(5))
+
+        assert result.workspace == tmp_path
+        assert result.findings_written == 0
+        assert result.opplan_written is True
+        assert any("findings:" in e for e in result.errors)
+
+    def test_existing_findings_offset_next_id(self, tmp_path: Path) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        findings_dir = tmp_path / "findings"
+        findings_dir.mkdir()
+        (findings_dir / "FIND-001.md").write_text("# old", encoding="utf-8")
+        (findings_dir / "FIND-003.md").write_text("# old", encoding="utf-8")
+        (findings_dir / "FIND-notanumber.md").write_text("# old", encoding="utf-8")
+
+        next_id = mod._next_finding_id(findings_dir)
+
+        assert next_id == 4
+
+    def test_finding_markdown_includes_severity_and_summary(self) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        body = mod._finding_markdown(
+            {
+                "title": "Reflected XSS in search",
+                "severity": "high",
+                "summary": "Unencoded user input rendered as HTML.",
+                "evidence": {"url": "https://target/search?q=<script>"},
+            }
+        )
+
+        assert "# Reflected XSS in search" in body
+        assert "HIGH" in body
+        assert "Unencoded user input" in body
+        assert "https://target/search" in body
+
+    def test_events_jsonl_event_appended_when_file_exists(self, tmp_path: Path) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        events = tmp_path / "events.jsonl"
+        events.write_text("", encoding="utf-8")
+        state = {"workspace_path": str(tmp_path)}
+        result = mod._FlushResult(
+            workspace=tmp_path,
+            findings_written=2,
+            opplan_written=True,
+            partial_executive_written=True,
+        )
+
+        written = mod._write_checkpoint_event_if_available(state, tmp_path, result, "SIGINT")
+
+        assert written is True
+        lines = events.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["type"] == "engagement.checkpoint"
+        assert entry["signal"] == "SIGINT"
+        assert entry["findings_written"] == 2
+
+    def test_events_jsonl_skipped_when_file_absent(self, tmp_path: Path) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        result = mod._FlushResult(workspace=tmp_path)
+        written = mod._write_checkpoint_event_if_available(
+            {"workspace_path": str(tmp_path)}, tmp_path, result, "SIGINT"
+        )
+
+        assert written is False
+        assert not (tmp_path / "events.jsonl").exists()
+
+    def test_atomic_write_uses_tmp_then_replace(self, tmp_path: Path) -> None:
+        from decepticon.runtime import shutdown as mod
+
+        target = tmp_path / "out" / "file.md"
+        mod._write_atomic(target, "hello\n")
+
+        assert target.read_text(encoding="utf-8") == "hello\n"
+        assert not (tmp_path / "out" / "file.md.tmp").exists()
+
+
+def time_monotonic_plus(seconds: float) -> float:
+    """Helper: monotonic-clock deadline ``seconds`` from now."""
+    import time
+
+    return time.monotonic() + seconds


### PR DESCRIPTION
## Summary

Add a small `decepticon.runtime.shutdown` module that lets the orchestrator install a bounded best-effort flush on SIGINT / SIGTERM. Today Ctrl-C / process termination loses any in-flight findings and OPPLAN state that has not been persisted by a completed tool call.

## Public API

`packages/decepticon/decepticon/runtime/shutdown.py` exports:

`python
install_shutdown_handlers(state_provider: Callable[[], LangGraphState]) -> None
`

The handler captures state through the callback at signal time so the module has zero import-time side effects and is safe to import from any process.

## On first SIGINT / SIGTERM

1. Persist in-flight findings as atomically-written `findings/FIND-NNN.md` (next-ID derivation respects existing files; pre-existing FIND-007 ⇒ next is FIND-008).
2. Persist OPPLAN snapshot to `plan/opplan.json`.
3. Render + write `report/report_partial_executive.md` via the existing `render_executive_summary(...)` helper (or a fallback markdown when no knowledge graph is in state).
4. If `events.jsonl` exists (PR-11 territory), append one `engagement.checkpoint` event. Skipped silently otherwise.
5. Print one `[shutdown] SIGINT: findings=N opplan=ok executive=ok -> <workspace>` summary line.
6. Exit `130` (SIGINT) or `143` (SIGTERM).

## Safety properties

| Property | Implementation |
|---|---|
| Bounded flush | `MAX_FLUSH_SECONDS = 5.0`; worker thread joined with deadline; `os._exit` after. |
| Double-signal force exit | Second signal within `DUPLICATE_SIGNAL_WINDOW_SECONDS = 2.0` skips the flush. |
| Windows support | `SetConsoleCtrlHandler` via `ctypes`; covers `CTRL_C_EVENT` / `CTRL_BREAK_EVENT` / close / logoff / shutdown. |
| Idempotent installer | Repeated calls swap the state provider but do not restack OS handlers. |
| No reporter signature change | `render_executive_summary(...)` unchanged; partial executive uses the same renderer. |
| Atomic writes | `*.tmp` + `os.replace` so a second signal cannot leave torn markdown. |

## Deliberately deferred

Wiring `install_shutdown_handlers(...)` into the orchestrator runtime is **out of scope** for this PR. This ships the library + tests so the wiring can land as a separate, smaller change against the agent entrypoint(s).

## Files

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/runtime/__init__.py` | new, exports the public API |
| `packages/decepticon/decepticon/runtime/shutdown.py` | new, the handler + helpers |
| `packages/decepticon/tests/unit/runtime/__init__.py` | new, empty package marker |
| `packages/decepticon/tests/unit/runtime/test_shutdown.py` | new, 17 tests |

## Verification

- `uv run pytest packages/decepticon/tests/unit/runtime/test_shutdown.py -q` (Windows host) → **9 passed, 8 skipped** (subprocess-signal tests; will run in Linux CI)
- `uv run ruff check packages/decepticon/decepticon/runtime packages/decepticon/tests/unit/runtime` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

* 9 cross-platform in-process tests: full-flush happy path, no-workspace return, error-recovery between phases, finding ID derivation against existing files, finding-markdown shape, events.jsonl append/skip, atomic-write semantics, idempotent installer.
* 8 subprocess tests (auto-skip on Windows; auto-run on Linux): SIGINT exit `130` with all files written, SIGTERM exit `143`, existing FIND offset, events.jsonl appended when present, missing workspace returns cleanly, double-signal force exit, fallback executive when no graph in state.
