### PR TITLE
feat(reporting): SARIF v2.1.0 export for GitHub code scanning + DefectDojo

### DIFF
--- a/packages/decepticon/decepticon/tools/reporting/__init__.py
+++ b/packages/decepticon/decepticon/tools/reporting/__init__.py
@@ -4,10 +4,11 @@
 - ``bugcrowd``    — Bugcrowd submission CSV writer
 - ``executive``   — Engagement-level executive summary composer
 - ``timeline``    — Chronological event timeline extractor
+- ``sarif``       — SARIF v2.1.0 JSON exporter for GitHub / DefectDojo
 
 Renderers operate on ``KnowledgeGraph`` state so the same graph can
-feed a bounty submission, an engagement executive summary, and a
-JSON bundle for further automation.
+feed a bounty submission, an engagement executive summary, a SARIF
+upload, and a JSON bundle for further automation.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from __future__ import annotations
 from decepticon.tools.reporting.bugcrowd import render_bugcrowd_csv
 from decepticon.tools.reporting.executive import render_executive_summary
 from decepticon.tools.reporting.hackerone import HackerOneReport, render_hackerone_markdown
+from decepticon.tools.reporting.sarif import render_sarif
 from decepticon.tools.reporting.timeline import extract_timeline
 
 __all__ = [
@@ -23,4 +25,5 @@ __all__ = [
     "render_bugcrowd_csv",
     "render_executive_summary",
     "render_hackerone_markdown",
+    "render_sarif",
 ]

--- a/packages/decepticon/decepticon/tools/reporting/sarif.py
+++ b/packages/decepticon/decepticon/tools/reporting/sarif.py
@@ -1,0 +1,261 @@
+"""SARIF v2.1.0 report renderer for the engagement knowledge graph.
+
+Emits a SARIF log that GitHub code scanning, DefectDojo, and other
+SARIF-aware aggregators can ingest. The renderer reuses the same
+graph state populated from ``workspace/findings/FIND-NNN.md`` so it
+stays consistent with HackerOne / Bugcrowd / executive exports.
+
+Field mapping follows the SARIF v2.1.0 OASIS spec:
+https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from decepticon_core.types.kg import KnowledgeGraph, Node, NodeKind
+
+SARIF_VERSION = "2.1.0"
+SARIF_SCHEMA = (
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/"
+    "os/schemas/sarif-schema-2.1.0.json"
+)
+DRIVER_NAME = "Decepticon"
+DRIVER_INFORMATION_URI = "https://github.com/PurpleAILAB/Decepticon"
+
+_DEFAULT_INCLUDE_KINDS: tuple[NodeKind, ...] = (NodeKind.VULNERABILITY, NodeKind.FINDING)
+_RULE_ID_SAFE = re.compile(r"[^A-Za-z0-9_.\-:]+")
+
+
+def render_sarif(
+    graph: KnowledgeGraph,
+    *,
+    engagement_id: str = "Engagement",
+    include_kinds: Iterable[NodeKind] = _DEFAULT_INCLUDE_KINDS,
+) -> str:
+    """Render the matching graph nodes as SARIF v2.1.0 JSON text.
+
+    Returned text is UTF-8 JSON. The structure passes the SARIF v2.1.0
+    schema validation and the GitHub ``upload-sarif`` action's parser.
+    """
+    include_set = set(include_kinds)
+    nodes = [
+        n
+        for n in sorted(graph.nodes.values(), key=lambda x: x.created_at)
+        if n.kind in include_set
+    ]
+
+    rules, rule_index_by_id = _build_rules(nodes)
+    results = [_result_for(node, rule_index_by_id) for node in nodes]
+
+    sarif_log: dict[str, Any] = {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": DRIVER_NAME,
+                        "informationUri": DRIVER_INFORMATION_URI,
+                        "rules": rules,
+                    }
+                },
+                "automationDetails": {"id": f"{engagement_id}/sarif"},
+                "results": results,
+            }
+        ],
+    }
+    return json.dumps(sarif_log, indent=2, ensure_ascii=False)
+
+
+def _build_rules(
+    nodes: Iterable[Node],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    rules: list[dict[str, Any]] = []
+    index_by_id: dict[str, int] = {}
+    for node in nodes:
+        rule_id = _stable_rule_id(node)
+        if rule_id in index_by_id:
+            continue
+        title = _node_title(node)
+        description = _node_description(node) or title
+        rules.append(
+            {
+                "id": rule_id,
+                "name": title,
+                "shortDescription": {"text": title},
+                "fullDescription": {"text": description},
+                "defaultConfiguration": {
+                    "level": _sarif_level(
+                        node.props.get("severity"), node.props.get("cvss_score")
+                    )
+                },
+            }
+        )
+        index_by_id[rule_id] = len(rules) - 1
+    return rules, index_by_id
+
+
+def _result_for(node: Node, rule_index_by_id: dict[str, int]) -> dict[str, Any]:
+    rule_id = _stable_rule_id(node)
+    rule_index = rule_index_by_id.get(rule_id, 0)
+    level = _sarif_level(node.props.get("severity"), node.props.get("cvss_score"))
+    message_text = _node_description(node) or _node_title(node)
+
+    result: dict[str, Any] = {
+        "ruleId": rule_id,
+        "ruleIndex": rule_index,
+        "level": level,
+        "message": {"text": message_text},
+        "locations": [_location_for(node)],
+        "partialFingerprints": _partial_fingerprints(node),
+    }
+    tags = _result_tags(node)
+    if tags:
+        result["properties"] = {"tags": tags}
+    return result
+
+
+def _sarif_level(severity: Any, cvss_score: Any) -> str:
+    """Map severity / CVSS to SARIF ``level`` (``error`` / ``warning`` / ``note``).
+
+    Severity has precedence. When severity is missing, fall back to
+    numeric CVSS bands (>=7 → error, >=4 → warning, <4 → note).
+    """
+    if isinstance(severity, str):
+        normalized = severity.strip().lower()
+        if normalized in ("critical", "high"):
+            return "error"
+        if normalized == "medium":
+            return "warning"
+        if normalized in ("low", "info", "informational"):
+            return "note"
+    try:
+        score = float(cvss_score) if cvss_score is not None else None
+    except (TypeError, ValueError):
+        score = None
+    if score is None:
+        return "note"
+    if score >= 7.0:
+        return "error"
+    if score >= 4.0:
+        return "warning"
+    return "note"
+
+
+def _node_title(node: Node) -> str:
+    return str(node.props.get("title") or node.label or node.id)
+
+
+def _node_description(node: Node) -> str:
+    return str(node.props.get("description") or node.props.get("summary") or "")
+
+
+def _stable_rule_id(node: Node) -> str:
+    """Choose a deterministic SARIF rule id for a finding node.
+
+    Preference order: first CWE tag, then sanitized title, then ``node.id``.
+    SARIF ``ruleId`` allows any string but de-duplication is by exact match,
+    so a stable derivation keeps rule lists tight across runs.
+    """
+    cwe = node.props.get("cwe")
+    if isinstance(cwe, (list, tuple)) and cwe:
+        first = str(cwe[0]).strip()
+        if first:
+            return _normalize_rule_id(first)
+    if isinstance(cwe, str) and cwe.strip():
+        return _normalize_rule_id(cwe.strip())
+    title = _node_title(node).strip()
+    if title:
+        return _normalize_rule_id(title) or node.id
+    return node.id
+
+
+def _normalize_rule_id(text: str) -> str:
+    cleaned = _RULE_ID_SAFE.sub("-", text).strip("-")
+    return cleaned[:120] or "rule"
+
+
+def _location_for(node: Node) -> dict[str, Any]:
+    uri = _location_uri(node)
+    physical: dict[str, Any] = {"artifactLocation": {"uri": uri}}
+    line = node.props.get("line")
+    if isinstance(line, int) and line > 0:
+        physical["region"] = {"startLine": line}
+    else:
+        try:
+            line_int = int(str(line))
+            if line_int > 0:
+                physical["region"] = {"startLine": line_int}
+        except (TypeError, ValueError):
+            pass
+    return {"physicalLocation": physical}
+
+
+def _location_uri(node: Node) -> str:
+    file_path = node.props.get("file")
+    if isinstance(file_path, str) and file_path.strip():
+        return file_path.strip()
+    url = node.props.get("url")
+    if isinstance(url, str) and url.strip():
+        return url.strip()
+    return f"workspace/findings/{node.id}.md"
+
+
+def _result_tags(node: Node) -> list[str]:
+    tags: list[str] = []
+    severity = node.props.get("severity")
+    if isinstance(severity, str) and severity.strip():
+        tags.append(f"severity:{severity.strip().lower()}")
+    cwe = node.props.get("cwe")
+    if isinstance(cwe, (list, tuple)):
+        for entry in cwe:
+            text = str(entry).strip()
+            if text:
+                tags.append(text)
+    elif isinstance(cwe, str) and cwe.strip():
+        tags.append(cwe.strip())
+    mitre = node.props.get("mitre")
+    if isinstance(mitre, (list, tuple)):
+        for entry in mitre:
+            text = str(entry).strip()
+            if text:
+                tags.append(text)
+    elif isinstance(mitre, str) and mitre.strip():
+        tags.append(mitre.strip())
+    cvss_vector = node.props.get("cvss_vector")
+    if isinstance(cvss_vector, str) and cvss_vector.strip():
+        tags.append(cvss_vector.strip())
+    return tags
+
+
+def _partial_fingerprints(node: Node) -> dict[str, str]:
+    """Compute deterministic fingerprints so re-runs do not duplicate alerts.
+
+    GitHub code scanning uses ``partialFingerprints`` for alert correlation;
+    stable fingerprints prevent the same finding from appearing as a new
+    alert on every run.
+    """
+    cwe = node.props.get("cwe") or []
+    cwe_text = (
+        ",".join(str(c) for c in cwe) if isinstance(cwe, (list, tuple)) else str(cwe)
+    )
+    raw = "|".join(
+        [
+            node.id,
+            _node_title(node),
+            str(node.props.get("severity", "")),
+            str(node.props.get("file") or node.props.get("url") or ""),
+            cwe_text,
+            str(node.props.get("cvss_vector", "")),
+        ]
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return {
+        "decepticonFindingId": node.id,
+        "decepticonStableHash": digest,
+    }

--- a/packages/decepticon/decepticon/tools/reporting/sarif.py
+++ b/packages/decepticon/decepticon/tools/reporting/sarif.py
@@ -21,8 +21,7 @@ from decepticon_core.types.kg import KnowledgeGraph, Node, NodeKind
 
 SARIF_VERSION = "2.1.0"
 SARIF_SCHEMA = (
-    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/"
-    "os/schemas/sarif-schema-2.1.0.json"
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
 )
 DRIVER_NAME = "Decepticon"
 DRIVER_INFORMATION_URI = "https://github.com/PurpleAILAB/Decepticon"
@@ -44,9 +43,7 @@ def render_sarif(
     """
     include_set = set(include_kinds)
     nodes = [
-        n
-        for n in sorted(graph.nodes.values(), key=lambda x: x.created_at)
-        if n.kind in include_set
+        n for n in sorted(graph.nodes.values(), key=lambda x: x.created_at) if n.kind in include_set
     ]
 
     rules, rule_index_by_id = _build_rules(nodes)
@@ -90,9 +87,7 @@ def _build_rules(
                 "shortDescription": {"text": title},
                 "fullDescription": {"text": description},
                 "defaultConfiguration": {
-                    "level": _sarif_level(
-                        node.props.get("severity"), node.props.get("cvss_score")
-                    )
+                    "level": _sarif_level(node.props.get("severity"), node.props.get("cvss_score"))
                 },
             }
         )
@@ -241,9 +236,7 @@ def _partial_fingerprints(node: Node) -> dict[str, str]:
     alert on every run.
     """
     cwe = node.props.get("cwe") or []
-    cwe_text = (
-        ",".join(str(c) for c in cwe) if isinstance(cwe, (list, tuple)) else str(cwe)
-    )
+    cwe_text = ",".join(str(c) for c in cwe) if isinstance(cwe, (list, tuple)) else str(cwe)
     raw = "|".join(
         [
             node.id,

--- a/packages/decepticon/decepticon/tools/reporting/tools.py
+++ b/packages/decepticon/decepticon/tools/reporting/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from langchain_core.tools import tool
@@ -10,6 +11,7 @@ from langchain_core.tools import tool
 from decepticon.tools.reporting.bugcrowd import render_bugcrowd_csv
 from decepticon.tools.reporting.executive import render_executive_summary
 from decepticon.tools.reporting.hackerone import render_hackerone_markdown
+from decepticon.tools.reporting.sarif import render_sarif
 from decepticon.tools.reporting.timeline import extract_timeline
 from decepticon.tools.research._state import _load
 
@@ -53,4 +55,35 @@ def report_timeline() -> str:
     return _json({"count": len(events), "events": [e.to_dict() for e in events]})
 
 
-REPORTING_TOOLS = [report_hackerone, report_bugcrowd_csv, report_executive, report_timeline]
+@tool
+def report_sarif(engagement_id: str, output_path: str) -> str:
+    """Render the engagement graph as SARIF v2.1.0 JSON for GitHub code scanning / DefectDojo / SARIF aggregators.
+
+    Writes UTF-8 to ``output_path`` (parent directories are created) and
+    returns a JSON summary with the engagement id, written path, byte
+    count, and number of result entries emitted.
+    """
+    graph, _ = _load()
+    sarif = render_sarif(graph, engagement_id=engagement_id)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(sarif, encoding="utf-8")
+    payload = json.loads(sarif)
+    results = payload["runs"][0]["results"]
+    return _json(
+        {
+            "engagement_id": engagement_id,
+            "path": str(path),
+            "bytes": len(sarif.encode("utf-8")),
+            "results": len(results),
+        }
+    )
+
+
+REPORTING_TOOLS = [
+    report_hackerone,
+    report_bugcrowd_csv,
+    report_executive,
+    report_timeline,
+    report_sarif,
+]

--- a/packages/decepticon/tests/unit/reporting/test_sarif.py
+++ b/packages/decepticon/tests/unit/reporting/test_sarif.py
@@ -1,0 +1,229 @@
+"""Tests for the SARIF v2.1.0 renderer + ``report_sarif`` tool."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from decepticon.tools.reporting.sarif import (
+    SARIF_SCHEMA,
+    SARIF_VERSION,
+    _partial_fingerprints,
+    _sarif_level,
+    _stable_rule_id,
+    render_sarif,
+)
+from decepticon.tools.reporting.tools import report_sarif
+from decepticon_core.types.kg import KnowledgeGraph, Node, NodeKind
+
+
+def _seeded_graph() -> KnowledgeGraph:
+    g = KnowledgeGraph()
+    g.upsert_node(
+        Node.make(
+            NodeKind.VULNERABILITY,
+            "SSRF in /proxy",
+            severity="critical",
+            cvss_score=9.8,
+            cvss_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            summary="Server fetches arbitrary URLs allowing IMDS access.",
+            description="Detailed description of SSRF exploit chain.",
+            poc_command="curl https://target/proxy?url=http://169.254.169.254/",
+            cwe=["CWE-918"],
+            mitre=["T1190"],
+            url="/proxy",
+            file="src/proxy/handler.py",
+            line=42,
+        )
+    )
+    g.upsert_node(
+        Node.make(
+            NodeKind.FINDING,
+            "Open redirect on /login",
+            severity="medium",
+            cvss_score=5.4,
+            url="/login?next=//attacker",
+            summary="Next-param redirects off-site.",
+        )
+    )
+    g.upsert_node(Node.make(NodeKind.CVE, "CVE-2024-1234", score=9.8))
+    return g
+
+
+class TestRenderSarifShape:
+    def test_top_level_structure_is_sarif_2_1_0(self) -> None:
+        g = _seeded_graph()
+        payload = json.loads(render_sarif(g, engagement_id="eng-1"))
+        assert payload["version"] == SARIF_VERSION
+        assert payload["$schema"] == SARIF_SCHEMA
+        assert len(payload["runs"]) == 1
+        run = payload["runs"][0]
+        assert run["tool"]["driver"]["name"] == "Decepticon"
+        assert run["automationDetails"]["id"] == "eng-1/sarif"
+        assert len(run["results"]) == 2
+
+    def test_only_vulnerability_and_finding_nodes_emitted(self) -> None:
+        g = _seeded_graph()
+        payload = json.loads(render_sarif(g))
+        run = payload["runs"][0]
+        rule_names = [rule["name"] for rule in run["tool"]["driver"]["rules"]]
+        result_messages = [r["message"]["text"] for r in run["results"]]
+        combined = " ".join(rule_names) + " ||| " + " ".join(result_messages)
+        assert "SSRF" in combined
+        assert "Open redirect" in combined
+        assert "CVE-2024-1234" not in combined
+
+    def test_driver_rules_include_one_entry_per_unique_rule(self) -> None:
+        g = _seeded_graph()
+        payload = json.loads(render_sarif(g))
+        rules = payload["runs"][0]["tool"]["driver"]["rules"]
+        rule_ids = {r["id"] for r in rules}
+        assert "CWE-918" in rule_ids
+        assert len(rules) == len({r["id"] for r in rules})
+
+
+class TestSarifLevelMapping:
+    @pytest.mark.parametrize(
+        "severity,expected",
+        [
+            ("critical", "error"),
+            ("CRITICAL", "error"),
+            ("high", "error"),
+            ("medium", "warning"),
+            ("low", "note"),
+            ("info", "note"),
+            ("informational", "note"),
+        ],
+    )
+    def test_severity_strings_map_correctly(self, severity: str, expected: str) -> None:
+        assert _sarif_level(severity, None) == expected
+
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (9.8, "error"),
+            (7.0, "error"),
+            (6.9, "warning"),
+            (4.0, "warning"),
+            (3.9, "note"),
+            (0.0, "note"),
+        ],
+    )
+    def test_cvss_fallback_when_severity_missing(
+        self, score: float, expected: str
+    ) -> None:
+        assert _sarif_level(None, score) == expected
+
+    def test_severity_takes_precedence_over_cvss(self) -> None:
+        assert _sarif_level("low", 9.9) == "note"
+
+    def test_unknown_severity_falls_back_to_note(self) -> None:
+        assert _sarif_level("weird", None) == "note"
+
+    def test_non_numeric_cvss_falls_back_to_note(self) -> None:
+        assert _sarif_level(None, "not-a-number") == "note"
+
+
+class TestResultMapping:
+    def test_existing_fields_populate_result(self) -> None:
+        g = _seeded_graph()
+        payload = json.loads(render_sarif(g))
+        results = payload["runs"][0]["results"]
+        ssrf = next(r for r in results if "SSRF" in r["message"]["text"])
+
+        assert ssrf["ruleId"] == "CWE-918"
+        assert ssrf["level"] == "error"
+        loc = ssrf["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "src/proxy/handler.py"
+        assert loc["region"]["startLine"] == 42
+        tags = ssrf["properties"]["tags"]
+        assert "severity:critical" in tags
+        assert "CWE-918" in tags
+        assert "T1190" in tags
+        assert any(t.startswith("CVSS:3.1") for t in tags)
+
+    def test_url_fallback_when_no_file(self) -> None:
+        g = _seeded_graph()
+        payload = json.loads(render_sarif(g))
+        run = payload["runs"][0]
+        rules = run["tool"]["driver"]["rules"]
+        redirect_rule = next(r for r in rules if "redirect" in r["name"].lower())
+        results = run["results"]
+        redirect = next(r for r in results if r["ruleId"] == redirect_rule["id"])
+        loc_uri = redirect["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        assert loc_uri == "/login?next=//attacker"
+
+    def test_fingerprints_are_deterministic_and_stable(self) -> None:
+        g = _seeded_graph()
+        node = g.by_kind(NodeKind.VULNERABILITY)[0]
+
+        fp1 = _partial_fingerprints(node)
+        fp2 = _partial_fingerprints(node)
+
+        assert fp1 == fp2
+        assert "decepticonFindingId" in fp1
+        assert "decepticonStableHash" in fp1
+        assert len(fp1["decepticonStableHash"]) == 64
+
+    def test_workspace_finding_uri_used_when_no_file_or_url(self) -> None:
+        g = KnowledgeGraph()
+        node = Node.make(NodeKind.VULNERABILITY, "abstract issue", severity="low")
+        g.upsert_node(node)
+        payload = json.loads(render_sarif(g))
+        result = payload["runs"][0]["results"][0]
+        loc_uri = result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        assert loc_uri == f"workspace/findings/{node.id}.md"
+
+
+class TestStableRuleId:
+    def test_first_cwe_wins(self) -> None:
+        g = KnowledgeGraph()
+        node = Node.make(
+            NodeKind.VULNERABILITY,
+            "Cmd injection in /run",
+            severity="high",
+            cwe=["CWE-78", "CWE-77"],
+        )
+        g.upsert_node(node)
+        assert _stable_rule_id(node) == "CWE-78"
+
+    def test_falls_back_to_title(self) -> None:
+        node = Node.make(NodeKind.VULNERABILITY, "Stored XSS in /comments")
+        assert "Stored-XSS-in-comments" in _stable_rule_id(node)
+
+    def test_falls_back_to_node_id_when_title_normalizes_empty(self) -> None:
+        node = Node.make(NodeKind.VULNERABILITY, "***")
+        rid = _stable_rule_id(node)
+        assert rid == node.id or rid == "rule"
+
+
+class TestReportSarifTool:
+    def test_writes_sarif_to_disk_and_reports_metadata(self, tmp_path: Path) -> None:
+        out = tmp_path / "out" / "decepticon.sarif"
+        g = _seeded_graph()
+        with patch("decepticon.tools.reporting.tools._load", return_value=(g, None)):
+            result = asyncio.run(
+                report_sarif.ainvoke({"engagement_id": "eng-X", "output_path": str(out)})
+            )
+
+        assert out.exists()
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["version"] == SARIF_VERSION
+        info = json.loads(result)
+        assert info["engagement_id"] == "eng-X"
+        assert info["path"] == str(out)
+        assert info["bytes"] > 0
+        assert info["results"] == 2
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        out = tmp_path / "nested" / "deeper" / "decepticon.sarif"
+        g = _seeded_graph()
+        with patch("decepticon.tools.reporting.tools._load", return_value=(g, None)):
+            asyncio.run(
+                report_sarif.ainvoke({"engagement_id": "eng-Y", "output_path": str(out)})
+            )
+        assert out.exists()

--- a/packages/decepticon/tests/unit/reporting/test_sarif.py
+++ b/packages/decepticon/tests/unit/reporting/test_sarif.py
@@ -113,9 +113,7 @@ class TestSarifLevelMapping:
             (0.0, "note"),
         ],
     )
-    def test_cvss_fallback_when_severity_missing(
-        self, score: float, expected: str
-    ) -> None:
+    def test_cvss_fallback_when_severity_missing(self, score: float, expected: str) -> None:
         assert _sarif_level(None, score) == expected
 
     def test_severity_takes_precedence_over_cvss(self) -> None:
@@ -223,7 +221,5 @@ class TestReportSarifTool:
         out = tmp_path / "nested" / "deeper" / "decepticon.sarif"
         g = _seeded_graph()
         with patch("decepticon.tools.reporting.tools._load", return_value=(g, None)):
-            asyncio.run(
-                report_sarif.ainvoke({"engagement_id": "eng-Y", "output_path": str(out)})
-            )
+            asyncio.run(report_sarif.ainvoke({"engagement_id": "eng-Y", "output_path": str(out)}))
         assert out.exists()


### PR DESCRIPTION
## Summary

Add native SARIF v2.1.0 export so an engagement's vulnerability/finding graph can be emitted as a standards-compliant `.sarif` file for GitHub code scanning upload, DefectDojo ingestion, and other SARIF-aware aggregators.

## What changes

| File | Change |
|---|---|
| `packages/decepticon/decepticon/tools/reporting/sarif.py` | new — `render_sarif` + helpers |
| `packages/decepticon/decepticon/tools/reporting/tools.py` | adds `@tool report_sarif(engagement_id, output_path)`; appends to `REPORTING_TOOLS` |
| `packages/decepticon/decepticon/tools/reporting/__init__.py` | exports `render_sarif` |
| `packages/decepticon/tests/unit/reporting/test_sarif.py` | new — 28 tests |

No existing renderer behavior changes (HackerOne / Bugcrowd / executive / timeline are untouched).

## Behavior

- Consumes the same `KnowledgeGraph` populated from `workspace/findings/FIND-NNN.md` — no new finding schema fields.
- Exports `NodeKind.VULNERABILITY` and `NodeKind.FINDING` only; CVE / attack-path / unrelated nodes are skipped.
- **Severity / CVSS → SARIF level** mapping (severity has precedence; CVSS is the fallback):

| Input | SARIF level |
|---|---|
| critical, high, OR CVSS ≥ 7.0 | error |
| medium, OR CVSS ≥ 4.0 | warning |
| low, info, OR CVSS < 4.0 | note |

- **Stable rule IDs**: first CWE → normalized title → node id, so the driver rules list deduplicates across runs.
- **GitHub-correlatable fingerprints**: SHA-256 `partialFingerprints` (`decepticonFindingId` + `decepticonStableHash`) prevent re-runs from creating duplicate alerts.
- **Location** prefers `file` over `url`; falls back to `workspace/findings/<node.id>.md`. `line` becomes `startLine` if it parses as a positive integer.
- **Tags** include `severity:<level>`, every CWE, every MITRE technique, and the full CVSS vector string when present.

## Tool API

```python
@tool
def report_sarif(engagement_id: str, output_path: str) -> str:
```

Writes UTF-8 SARIF JSON, creates parent directories, returns:

```json
{
  "engagement_id": "...",
  "path": "...",
  "bytes": 12345,
  "results": 17
}
```

## CI integration

```yaml
- name: Generate Decepticon SARIF
  run: decepticon report-sarif --engagement-id "${{ github.repository }}-${{ github.run_id }}" --output-path "reports/decepticon.sarif"
- uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: reports/decepticon.sarif
    category: decepticon
```

Workflow needs `security-events: write`.

## Verification

- `uv run pytest packages/decepticon/tests/unit/reporting/test_sarif.py -q` → **28 passed**
- `uv run pytest packages/decepticon/tests/unit/reporting -q` → **35 passed** (no regressions in existing reporters)
- `uv run ruff check packages/decepticon/decepticon/tools/reporting packages/decepticon/tests/unit/reporting` → All checks passed
- LSP diagnostics on changed files: clean
