### PR TITLE
feat(telemetry): optional OpenTelemetry exporter alongside LangSmith

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -425,6 +425,27 @@ services:
     profiles:
       - c2-sliver
 
+  # ─── Optional: OpenTelemetry collector for self-hosted traces ──────────
+  # Uncomment to receive Decepticon spans locally (Jaeger all-in-one).
+  # Decepticon stays default-off; set OTEL_ENABLED=1 plus the env vars below
+  # in the langgraph service to actually emit spans.
+  #
+  # jaeger:
+  #   image: jaegertracing/all-in-one:1.60
+  #   container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-jaeger
+  #   environment:
+  #     - COLLECTOR_OTLP_ENABLED=true
+  #   ports:
+  #     - "127.0.0.1:${JAEGER_UI_PORT:-16686}:16686"
+  #     - "127.0.0.1:${OTEL_HTTP_PORT:-4318}:4318"
+  #   networks:
+  #     - decepticon-net
+  #
+  # To export Decepticon spans to this service, set on the langgraph service:
+  #   - OTEL_ENABLED=1
+  #   - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318/v1/traces
+  #   - OTEL_SERVICE_NAME=decepticon
+
 volumes:
   postgres_data:
   sliver_data:

--- a/packages/decepticon/decepticon/telemetry/__init__.py
+++ b/packages/decepticon/decepticon/telemetry/__init__.py
@@ -1,0 +1,29 @@
+"""Optional OpenTelemetry helpers for Decepticon.
+
+Default off. When ``OTEL_ENABLED`` is set and the ``opentelemetry`` packages
+are installed, helpers emit OTLP spans for engagement / agent / tool / LLM
+activity. Otherwise every helper is a no-op so the library remains safe to
+import in any process without the optional extra installed.
+"""
+
+from decepticon.telemetry.otel import (
+    init_otel,
+    record_llm_cost,
+    record_llm_token_usage,
+    set_current_objective_id,
+    start_agent_span,
+    start_engagement_span,
+    start_llm_span,
+    start_tool_span,
+)
+
+__all__ = [
+    "init_otel",
+    "record_llm_cost",
+    "record_llm_token_usage",
+    "set_current_objective_id",
+    "start_agent_span",
+    "start_engagement_span",
+    "start_llm_span",
+    "start_tool_span",
+]

--- a/packages/decepticon/decepticon/telemetry/otel.py
+++ b/packages/decepticon/decepticon/telemetry/otel.py
@@ -33,12 +33,8 @@ _current_engagement_id: ContextVar[str | None] = ContextVar(
     "decepticon_engagement_id", default=None
 )
 _current_agent: ContextVar[str | None] = ContextVar("decepticon_agent", default=None)
-_current_objective_id: ContextVar[str | None] = ContextVar(
-    "decepticon_objective_id", default=None
-)
-_active_llm_span: ContextVar[Any | None] = ContextVar(
-    "decepticon_active_llm_span", default=None
-)
+_current_objective_id: ContextVar[str | None] = ContextVar("decepticon_objective_id", default=None)
+_active_llm_span: ContextVar[Any | None] = ContextVar("decepticon_active_llm_span", default=None)
 _active_engagement_span: ContextVar[Any | None] = ContextVar(
     "decepticon_active_engagement_span", default=None
 )
@@ -80,9 +76,7 @@ def init_otel() -> bool:
         _INITIALIZED = True
         return False
 
-    provider = TracerProvider(
-        resource=Resource.create({"service.name": _service_name()})
-    )
+    provider = TracerProvider(resource=Resource.create({"service.name": _service_name()}))
     endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None
     exporter = OTLPSpanExporter(endpoint=endpoint) if endpoint else OTLPSpanExporter()
     provider.add_span_processor(BatchSpanProcessor(exporter))
@@ -237,9 +231,7 @@ def record_llm_token_usage(
             pass
     if completion_tokens is not None:
         try:
-            span.set_attribute(
-                "decepticon.llm.completion_tokens", int(completion_tokens)
-            )
+            span.set_attribute("decepticon.llm.completion_tokens", int(completion_tokens))
         except Exception:
             pass
 

--- a/packages/decepticon/decepticon/telemetry/otel.py
+++ b/packages/decepticon/decepticon/telemetry/otel.py
@@ -1,0 +1,266 @@
+"""OpenTelemetry trace helpers (opt-in, no-op when disabled).
+
+Every public helper degrades gracefully through two failure modes:
+
+1. ``OTEL_ENABLED`` env var is not truthy -> all helpers are no-ops.
+2. ``opentelemetry`` packages are not installed (the ``telemetry`` extra is
+   optional) -> all helpers are no-ops and emit one debug log line.
+
+The library therefore stays safe to import from any process without the
+optional extra, and trace cardinality is bounded to stable identifiers
+(engagement id, agent name, tool name, model name, objective id, token
+counts, cost). Prompt text, tool outputs, credentials, and target URLs
+are never recorded as span attributes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+log = logging.getLogger("decepticon.telemetry.otel")
+
+_TRUE = frozenset({"1", "true", "yes", "on"})
+
+_INITIALIZED: bool = False
+_TRACER: Any = None
+
+_current_engagement_id: ContextVar[str | None] = ContextVar(
+    "decepticon_engagement_id", default=None
+)
+_current_agent: ContextVar[str | None] = ContextVar("decepticon_agent", default=None)
+_current_objective_id: ContextVar[str | None] = ContextVar(
+    "decepticon_objective_id", default=None
+)
+_active_llm_span: ContextVar[Any | None] = ContextVar(
+    "decepticon_active_llm_span", default=None
+)
+_active_engagement_span: ContextVar[Any | None] = ContextVar(
+    "decepticon_active_engagement_span", default=None
+)
+
+
+def _enabled() -> bool:
+    raw = os.getenv("OTEL_ENABLED", "").strip().lower()
+    return raw in _TRUE
+
+
+def _service_name() -> str:
+    return os.getenv("OTEL_SERVICE_NAME", "decepticon")
+
+
+def init_otel() -> bool:
+    """Lazy-init the global TracerProvider + OTLP exporter.
+
+    Returns ``True`` if a tracer is available after the call (either freshly
+    initialized or previously initialized in this process), ``False`` if the
+    feature is disabled or the optional packages are missing.
+    """
+    global _INITIALIZED, _TRACER
+
+    if not _enabled():
+        return False
+    if _INITIALIZED:
+        return _TRACER is not None
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        log.debug("OpenTelemetry packages not installed; telemetry disabled")
+        _INITIALIZED = True
+        return False
+
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": _service_name()})
+    )
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None
+    exporter = OTLPSpanExporter(endpoint=endpoint) if endpoint else OTLPSpanExporter()
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    _TRACER = trace.get_tracer("decepticon")
+    _INITIALIZED = True
+    return True
+
+
+def _reset_for_tests() -> None:
+    """Test-only: forget initialization so a fresh provider can be installed."""
+    global _INITIALIZED, _TRACER
+    _INITIALIZED = False
+    _TRACER = None
+
+
+def _get_tracer() -> Any | None:
+    if not _enabled():
+        return None
+    init_otel()
+    return _TRACER
+
+
+@contextmanager
+def _noop() -> Iterator[Any]:
+    yield None
+
+
+@contextmanager
+def start_engagement_span(engagement_id: str) -> Iterator[Any]:
+    """Start the top-level engagement span and set engagement-id context."""
+    tracer = _get_tracer()
+    eng_token = _current_engagement_id.set(engagement_id)
+    if tracer is None:
+        try:
+            yield None
+        finally:
+            _current_engagement_id.reset(eng_token)
+        return
+
+    with tracer.start_as_current_span("decepticon.engagement") as span:
+        span.set_attribute("decepticon.engagement_id", engagement_id)
+        span_token = _active_engagement_span.set(span)
+        try:
+            yield span
+        finally:
+            _active_engagement_span.reset(span_token)
+            _current_engagement_id.reset(eng_token)
+
+
+@contextmanager
+def start_agent_span(agent_name: str) -> Iterator[Any]:
+    """Start an agent-run span as a child of the active engagement (if any)."""
+    tracer = _get_tracer()
+    agent_token = _current_agent.set(agent_name)
+    if tracer is None:
+        try:
+            yield None
+        finally:
+            _current_agent.reset(agent_token)
+        return
+
+    with tracer.start_as_current_span("decepticon.agent_run") as span:
+        span.set_attribute("decepticon.agent", agent_name)
+        eng_id = _current_engagement_id.get()
+        if eng_id:
+            span.set_attribute("decepticon.engagement_id", eng_id)
+        try:
+            yield span
+        finally:
+            _current_agent.reset(agent_token)
+
+
+@contextmanager
+def start_tool_span(tool_name: str) -> Iterator[Any]:
+    """Start a tool-call span as a sibling of llm_call under agent_run."""
+    tracer = _get_tracer()
+    if tracer is None:
+        yield None
+        return
+
+    with tracer.start_as_current_span("decepticon.tool_call") as span:
+        span.set_attribute("decepticon.tool", tool_name)
+        eng_id = _current_engagement_id.get()
+        if eng_id:
+            span.set_attribute("decepticon.engagement_id", eng_id)
+        agent = _current_agent.get()
+        if agent:
+            span.set_attribute("decepticon.agent", agent)
+        objective = _current_objective_id.get()
+        if objective:
+            span.set_attribute("decepticon.opplan.objective_id", objective)
+        yield span
+
+
+@contextmanager
+def start_llm_span(model: str) -> Iterator[Any]:
+    """Start an LLM-call span; cost / token attrs land on the active span."""
+    tracer = _get_tracer()
+    if tracer is None:
+        yield None
+        return
+
+    with tracer.start_as_current_span("decepticon.llm_call") as span:
+        span.set_attribute("decepticon.llm.model", model)
+        eng_id = _current_engagement_id.get()
+        if eng_id:
+            span.set_attribute("decepticon.engagement_id", eng_id)
+        agent = _current_agent.get()
+        if agent:
+            span.set_attribute("decepticon.agent", agent)
+        objective = _current_objective_id.get()
+        if objective:
+            span.set_attribute("decepticon.opplan.objective_id", objective)
+        llm_token = _active_llm_span.set(span)
+        try:
+            yield span
+        finally:
+            _active_llm_span.reset(llm_token)
+
+
+def record_llm_cost(cost_usd: float | None) -> None:
+    """Attach cost to the active llm_call span, or to engagement as fallback."""
+    if cost_usd is None:
+        return
+    llm_span = _active_llm_span.get()
+    if llm_span is not None:
+        try:
+            llm_span.set_attribute("decepticon.llm.cost_usd", float(cost_usd))
+            return
+        except Exception:
+            pass
+    eng_span = _active_engagement_span.get()
+    if eng_span is not None:
+        try:
+            eng_span.set_attribute("decepticon.llm.cost_usd", float(cost_usd))
+        except Exception:
+            pass
+
+
+def record_llm_token_usage(
+    prompt_tokens: int | None = None, completion_tokens: int | None = None
+) -> None:
+    """Attach prompt / completion token counts to the active llm_call span."""
+    span = _active_llm_span.get()
+    if span is None:
+        return
+    if prompt_tokens is not None:
+        try:
+            span.set_attribute("decepticon.llm.prompt_tokens", int(prompt_tokens))
+        except Exception:
+            pass
+    if completion_tokens is not None:
+        try:
+            span.set_attribute(
+                "decepticon.llm.completion_tokens", int(completion_tokens)
+            )
+        except Exception:
+            pass
+
+
+def set_current_objective_id(objective_id: str | None) -> object | None:
+    """Bind an OPPLAN objective id into the current context.
+
+    Returns a token that the caller can pass to
+    :func:`reset_current_objective_id` to unbind. Returns ``None`` when the
+    feature is disabled so callers can no-op the unbind step.
+    """
+    if not _enabled():
+        return None
+    return _current_objective_id.set(objective_id)
+
+
+def reset_current_objective_id(token: object | None) -> None:
+    """Unbind a previously-set OPPLAN objective id."""
+    if token is None:
+        return
+    try:
+        _current_objective_id.reset(token)
+    except (ValueError, LookupError):
+        pass

--- a/packages/decepticon/pyproject.toml
+++ b/packages/decepticon/pyproject.toml
@@ -74,7 +74,12 @@ dependencies = [
 # driver is imported lazily (decepticon/tools/research/neo4j_store.py), so
 # the base install imports and runs everything except the KG graph tools.
 neo4j = ["neo4j>=5.0"]
-all = ["decepticon[neo4j]"]
+telemetry = [
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp>=1.27",
+]
+all = ["decepticon[neo4j,telemetry]"]
 
 [project.scripts]
 decepticon-kg-health = "decepticon.tools.research.health:main"

--- a/packages/decepticon/tests/unit/telemetry/test_otel.py
+++ b/packages/decepticon/tests/unit/telemetry/test_otel.py
@@ -9,17 +9,37 @@ exercise the real OpenTelemetry SDK without hitting the network.
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
+from typing import Any
+
 import pytest
 
 opentelemetry = pytest.importorskip("opentelemetry")
 
 from opentelemetry import trace  # noqa: E402
 from opentelemetry.sdk.resources import Resource  # noqa: E402
-from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider  # noqa: E402
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
     InMemorySpanExporter,
 )
+
+
+def _attrs(span: ReadableSpan) -> Mapping[str, Any]:
+    """Return ``span.attributes`` after asserting it is populated.
+
+    ``ReadableSpan.attributes`` is ``Optional[Mapping]`` in the SDK type
+    stubs; narrow it once here so the per-attribute asserts below stay
+    readable and basedpyright sees the non-None refinement.
+    """
+    assert span.attributes is not None, f"{span.name} has no attributes"
+    return span.attributes
+
+
+def _parent_span_id(span: ReadableSpan) -> int:
+    assert span.parent is not None, f"{span.name} has no parent"
+    return span.parent.span_id
+
 
 from decepticon.telemetry import otel as otel_module  # noqa: E402
 from decepticon.telemetry.otel import (  # noqa: E402
@@ -40,7 +60,7 @@ trace.set_tracer_provider(_SHARED_PROVIDER)
 
 
 @pytest.fixture
-def memory_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+def memory_exporter(monkeypatch: pytest.MonkeyPatch) -> Iterator[InMemorySpanExporter]:
     """Reuse the module-level TracerProvider; OTel refuses post-init swaps."""
     monkeypatch.setenv("OTEL_ENABLED", "1")
     _SHARED_EXPORTER.clear()
@@ -82,9 +102,9 @@ def test_engagement_agent_tool_llm_hierarchy(memory_exporter: InMemorySpanExport
     agent = spans["decepticon.agent_run"]
     tool = spans["decepticon.tool_call"]
     llm = spans["decepticon.llm_call"]
-    assert agent.parent.span_id == engagement.context.span_id
-    assert tool.parent.span_id == agent.context.span_id
-    assert llm.parent.span_id == agent.context.span_id
+    assert _parent_span_id(agent) == engagement.context.span_id
+    assert _parent_span_id(tool) == agent.context.span_id
+    assert _parent_span_id(llm) == agent.context.span_id
 
 
 def test_attributes_are_set(memory_exporter: InMemorySpanExporter) -> None:
@@ -101,21 +121,21 @@ def test_attributes_are_set(memory_exporter: InMemorySpanExporter) -> None:
                 reset_current_objective_id(token)
 
     spans = {span.name: span for span in memory_exporter.get_finished_spans()}
-    engagement = spans["decepticon.engagement"]
-    agent = spans["decepticon.agent_run"]
-    tool = spans["decepticon.tool_call"]
-    llm = spans["decepticon.llm_call"]
-    assert engagement.attributes["decepticon.engagement_id"] == "eng-1"
-    assert agent.attributes["decepticon.agent"] == "decepticon"
-    assert agent.attributes["decepticon.engagement_id"] == "eng-1"
-    assert tool.attributes["decepticon.tool"] == "update_objective"
-    assert tool.attributes["decepticon.opplan.objective_id"] == "OBJ-001"
-    assert tool.attributes["decepticon.engagement_id"] == "eng-1"
-    assert llm.attributes["decepticon.llm.model"] == "anthropic/claude-haiku-4-5"
-    assert llm.attributes["decepticon.llm.prompt_tokens"] == 120
-    assert llm.attributes["decepticon.llm.completion_tokens"] == 45
-    assert llm.attributes["decepticon.llm.cost_usd"] == pytest.approx(0.123456)
-    assert llm.attributes["decepticon.opplan.objective_id"] == "OBJ-001"
+    engagement = _attrs(spans["decepticon.engagement"])
+    agent = _attrs(spans["decepticon.agent_run"])
+    tool = _attrs(spans["decepticon.tool_call"])
+    llm = _attrs(spans["decepticon.llm_call"])
+    assert engagement["decepticon.engagement_id"] == "eng-1"
+    assert agent["decepticon.agent"] == "decepticon"
+    assert agent["decepticon.engagement_id"] == "eng-1"
+    assert tool["decepticon.tool"] == "update_objective"
+    assert tool["decepticon.opplan.objective_id"] == "OBJ-001"
+    assert tool["decepticon.engagement_id"] == "eng-1"
+    assert llm["decepticon.llm.model"] == "anthropic/claude-haiku-4-5"
+    assert llm["decepticon.llm.prompt_tokens"] == 120
+    assert llm["decepticon.llm.completion_tokens"] == 45
+    assert llm["decepticon.llm.cost_usd"] == pytest.approx(0.123456)
+    assert llm["decepticon.opplan.objective_id"] == "OBJ-001"
 
 
 def test_record_llm_cost_falls_back_to_engagement_span(
@@ -124,7 +144,7 @@ def test_record_llm_cost_falls_back_to_engagement_span(
     with start_engagement_span("eng-2"):
         record_llm_cost(2.5)
     eng = next(s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.engagement")
-    assert eng.attributes["decepticon.llm.cost_usd"] == pytest.approx(2.5)
+    assert _attrs(eng)["decepticon.llm.cost_usd"] == pytest.approx(2.5)
 
 
 def test_record_llm_cost_ignores_none(memory_exporter: InMemorySpanExporter) -> None:
@@ -132,7 +152,7 @@ def test_record_llm_cost_ignores_none(memory_exporter: InMemorySpanExporter) -> 
         with start_llm_span("model-x"):
             record_llm_cost(None)
     llm = next(s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.llm_call")
-    assert "decepticon.llm.cost_usd" not in llm.attributes
+    assert "decepticon.llm.cost_usd" not in _attrs(llm)
 
 
 def test_set_current_objective_id_returns_none_when_disabled(

--- a/packages/decepticon/tests/unit/telemetry/test_otel.py
+++ b/packages/decepticon/tests/unit/telemetry/test_otel.py
@@ -34,9 +34,7 @@ from decepticon.telemetry.otel import (  # noqa: E402
 )
 
 _SHARED_EXPORTER = InMemorySpanExporter()
-_SHARED_PROVIDER = TracerProvider(
-    resource=Resource.create({"service.name": "decepticon-test"})
-)
+_SHARED_PROVIDER = TracerProvider(resource=Resource.create({"service.name": "decepticon-test"}))
 _SHARED_PROVIDER.add_span_processor(SimpleSpanProcessor(_SHARED_EXPORTER))
 trace.set_tracer_provider(_SHARED_PROVIDER)
 
@@ -125,9 +123,7 @@ def test_record_llm_cost_falls_back_to_engagement_span(
 ) -> None:
     with start_engagement_span("eng-2"):
         record_llm_cost(2.5)
-    eng = next(
-        s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.engagement"
-    )
+    eng = next(s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.engagement")
     assert eng.attributes["decepticon.llm.cost_usd"] == pytest.approx(2.5)
 
 
@@ -135,9 +131,7 @@ def test_record_llm_cost_ignores_none(memory_exporter: InMemorySpanExporter) -> 
     with start_engagement_span("eng-3"):
         with start_llm_span("model-x"):
             record_llm_cost(None)
-    llm = next(
-        s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.llm_call"
-    )
+    llm = next(s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.llm_call")
     assert "decepticon.llm.cost_usd" not in llm.attributes
 
 
@@ -167,14 +161,20 @@ def test_helpers_are_safe_when_otel_packages_missing(
     monkeypatch.setenv("OTEL_ENABLED", "1")
     otel_module._reset_for_tests()
 
-    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    real_import = (
+        __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    )
 
     def _no_otel_imports(name: str, *args: object, **kwargs: object) -> object:
         if name.startswith("opentelemetry."):
             raise ImportError("simulated missing otel extra")
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__, "__import__", _no_otel_imports)
+    monkeypatch.setitem(
+        __builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__,
+        "__import__",
+        _no_otel_imports,
+    )
 
     assert otel_module.init_otel() is False
     with start_engagement_span("eng-no-otel"):

--- a/packages/decepticon/tests/unit/telemetry/test_otel.py
+++ b/packages/decepticon/tests/unit/telemetry/test_otel.py
@@ -41,6 +41,11 @@ def _parent_span_id(span: ReadableSpan) -> int:
     return span.parent.span_id
 
 
+def _span_id(span: ReadableSpan) -> int:
+    assert span.context is not None, f"{span.name} has no context"
+    return span.context.span_id
+
+
 from decepticon.telemetry import otel as otel_module  # noqa: E402
 from decepticon.telemetry.otel import (  # noqa: E402
     record_llm_cost,
@@ -102,9 +107,9 @@ def test_engagement_agent_tool_llm_hierarchy(memory_exporter: InMemorySpanExport
     agent = spans["decepticon.agent_run"]
     tool = spans["decepticon.tool_call"]
     llm = spans["decepticon.llm_call"]
-    assert _parent_span_id(agent) == engagement.context.span_id
-    assert _parent_span_id(tool) == agent.context.span_id
-    assert _parent_span_id(llm) == agent.context.span_id
+    assert _parent_span_id(agent) == _span_id(engagement)
+    assert _parent_span_id(tool) == _span_id(agent)
+    assert _parent_span_id(llm) == _span_id(agent)
 
 
 def test_attributes_are_set(memory_exporter: InMemorySpanExporter) -> None:

--- a/packages/decepticon/tests/unit/telemetry/test_otel.py
+++ b/packages/decepticon/tests/unit/telemetry/test_otel.py
@@ -1,0 +1,186 @@
+"""Tests for ``decepticon.telemetry.otel`` — opt-in OTLP trace export.
+
+When ``OTEL_ENABLED`` is unset the helpers must produce zero spans. When
+set, they must emit the engagement -> agent_run -> (tool_call | llm_call)
+hierarchy with the documented Decepticon attributes. Tests install an
+``InMemorySpanExporter`` directly on the global TracerProvider so we
+exercise the real OpenTelemetry SDK without hitting the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+opentelemetry = pytest.importorskip("opentelemetry")
+
+from opentelemetry import trace  # noqa: E402
+from opentelemetry.sdk.resources import Resource  # noqa: E402
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
+    InMemorySpanExporter,
+)
+
+from decepticon.telemetry import otel as otel_module  # noqa: E402
+from decepticon.telemetry.otel import (  # noqa: E402
+    record_llm_cost,
+    record_llm_token_usage,
+    reset_current_objective_id,
+    set_current_objective_id,
+    start_agent_span,
+    start_engagement_span,
+    start_llm_span,
+    start_tool_span,
+)
+
+_SHARED_EXPORTER = InMemorySpanExporter()
+_SHARED_PROVIDER = TracerProvider(
+    resource=Resource.create({"service.name": "decepticon-test"})
+)
+_SHARED_PROVIDER.add_span_processor(SimpleSpanProcessor(_SHARED_EXPORTER))
+trace.set_tracer_provider(_SHARED_PROVIDER)
+
+
+@pytest.fixture
+def memory_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    """Reuse the module-level TracerProvider; OTel refuses post-init swaps."""
+    monkeypatch.setenv("OTEL_ENABLED", "1")
+    _SHARED_EXPORTER.clear()
+    otel_module._INITIALIZED = True
+    otel_module._TRACER = trace.get_tracer("decepticon")
+    yield _SHARED_EXPORTER
+    _SHARED_EXPORTER.clear()
+
+
+def test_disabled_by_default_emits_no_spans(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_ENABLED", raising=False)
+    _SHARED_EXPORTER.clear()
+    otel_module._reset_for_tests()
+
+    with start_engagement_span("eng-x"):
+        with start_agent_span("decepticon"):
+            with start_tool_span("update_objective"):
+                pass
+            with start_llm_span("anthropic/claude-haiku-4-5"):
+                record_llm_cost(0.42)
+
+    assert _SHARED_EXPORTER.get_finished_spans() == ()
+
+
+def test_engagement_agent_tool_llm_hierarchy(memory_exporter: InMemorySpanExporter) -> None:
+    with start_engagement_span("eng-1"):
+        with start_agent_span("decepticon"):
+            with start_tool_span("update_objective"):
+                pass
+            with start_llm_span("anthropic/claude-haiku-4-5"):
+                pass
+
+    spans = {span.name: span for span in memory_exporter.get_finished_spans()}
+    assert "decepticon.engagement" in spans
+    assert "decepticon.agent_run" in spans
+    assert "decepticon.tool_call" in spans
+    assert "decepticon.llm_call" in spans
+    engagement = spans["decepticon.engagement"]
+    agent = spans["decepticon.agent_run"]
+    tool = spans["decepticon.tool_call"]
+    llm = spans["decepticon.llm_call"]
+    assert agent.parent.span_id == engagement.context.span_id
+    assert tool.parent.span_id == agent.context.span_id
+    assert llm.parent.span_id == agent.context.span_id
+
+
+def test_attributes_are_set(memory_exporter: InMemorySpanExporter) -> None:
+    with start_engagement_span("eng-1"):
+        with start_agent_span("decepticon"):
+            token = set_current_objective_id("OBJ-001")
+            try:
+                with start_tool_span("update_objective"):
+                    pass
+                with start_llm_span("anthropic/claude-haiku-4-5"):
+                    record_llm_token_usage(prompt_tokens=120, completion_tokens=45)
+                    record_llm_cost(0.123456)
+            finally:
+                reset_current_objective_id(token)
+
+    spans = {span.name: span for span in memory_exporter.get_finished_spans()}
+    engagement = spans["decepticon.engagement"]
+    agent = spans["decepticon.agent_run"]
+    tool = spans["decepticon.tool_call"]
+    llm = spans["decepticon.llm_call"]
+    assert engagement.attributes["decepticon.engagement_id"] == "eng-1"
+    assert agent.attributes["decepticon.agent"] == "decepticon"
+    assert agent.attributes["decepticon.engagement_id"] == "eng-1"
+    assert tool.attributes["decepticon.tool"] == "update_objective"
+    assert tool.attributes["decepticon.opplan.objective_id"] == "OBJ-001"
+    assert tool.attributes["decepticon.engagement_id"] == "eng-1"
+    assert llm.attributes["decepticon.llm.model"] == "anthropic/claude-haiku-4-5"
+    assert llm.attributes["decepticon.llm.prompt_tokens"] == 120
+    assert llm.attributes["decepticon.llm.completion_tokens"] == 45
+    assert llm.attributes["decepticon.llm.cost_usd"] == pytest.approx(0.123456)
+    assert llm.attributes["decepticon.opplan.objective_id"] == "OBJ-001"
+
+
+def test_record_llm_cost_falls_back_to_engagement_span(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    with start_engagement_span("eng-2"):
+        record_llm_cost(2.5)
+    eng = next(
+        s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.engagement"
+    )
+    assert eng.attributes["decepticon.llm.cost_usd"] == pytest.approx(2.5)
+
+
+def test_record_llm_cost_ignores_none(memory_exporter: InMemorySpanExporter) -> None:
+    with start_engagement_span("eng-3"):
+        with start_llm_span("model-x"):
+            record_llm_cost(None)
+    llm = next(
+        s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.llm_call"
+    )
+    assert "decepticon.llm.cost_usd" not in llm.attributes
+
+
+def test_set_current_objective_id_returns_none_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OTEL_ENABLED", raising=False)
+    assert set_current_objective_id("OBJ-1") is None
+    reset_current_objective_id(None)
+
+
+def test_init_otel_returns_false_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_ENABLED", raising=False)
+    otel_module._reset_for_tests()
+    assert otel_module.init_otel() is False
+
+
+def test_init_otel_is_idempotent(memory_exporter: InMemorySpanExporter) -> None:
+    assert otel_module.init_otel() is True
+    assert otel_module.init_otel() is True
+
+
+def test_helpers_are_safe_when_otel_packages_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate missing optional packages by forcing the import path to fail."""
+    monkeypatch.setenv("OTEL_ENABLED", "1")
+    otel_module._reset_for_tests()
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _no_otel_imports(name: str, *args: object, **kwargs: object) -> object:
+        if name.startswith("opentelemetry."):
+            raise ImportError("simulated missing otel extra")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__, "__import__", _no_otel_imports)
+
+    assert otel_module.init_otel() is False
+    with start_engagement_span("eng-no-otel"):
+        with start_agent_span("decepticon"):
+            with start_tool_span("update_objective"):
+                pass
+            with start_llm_span("model-x"):
+                record_llm_cost(1.0)
+                record_llm_token_usage(prompt_tokens=10, completion_tokens=5)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [manifest]
 members = [
@@ -395,14 +399,22 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "neo4j" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
 ]
 neo4j = [
     { name = "neo4j" },
 ]
+telemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "decepticon", extras = ["neo4j"], marker = "extra == 'all'", editable = "packages/decepticon" },
+    { name = "decepticon", extras = ["neo4j", "telemetry"], marker = "extra == 'all'", editable = "packages/decepticon" },
     { name = "decepticon-core", editable = "packages/decepticon-core" },
     { name = "deepagents", specifier = ">=0.5.0" },
     { name = "defusedxml", specifier = ">=0.7.0" },
@@ -415,6 +427,9 @@ requires-dist = [
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.2.0" },
     { name = "langgraph-sdk", specifier = ">=0.1.0" },
     { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.0" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'telemetry'", specifier = ">=1.27" },
+    { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.27" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -423,7 +438,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["neo4j", "all"]
+provides-extras = ["neo4j", "telemetry", "all"]
 
 [[package]]
 name = "decepticon-core"
@@ -1241,6 +1256,19 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/94/8637919a5d01f81dacf510234bc0110b944f4687a6e96b0a02adf2f6bdce/opentelemetry_exporter_otlp-1.42.1.tar.gz", hash = "sha256:2d9ebaed714377a67d224d46795ddcc11d2c877fa5de35fda70b6f3b010729a9", size = 6086, upload-time = "2026-05-21T16:32:51.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/4d/c26080295a36fd22e201fefd7cb9c22cd203189b1af8cd73b158382b7ad8/opentelemetry_exporter_otlp-1.42.1-py3-none-any.whl", hash = "sha256:aedd54545bb0587cd45210abdc8be545af9c01413f3307786e276df1e3c83bee", size = 6733, upload-time = "2026-05-21T16:32:31.261Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1250,6 +1278,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/2b/28ba5b128f47fe8c3bab541000d6feb4b5a9bd26623ca013406f01c0fb60/opentelemetry_exporter_otlp_proto_grpc-1.42.1-py3-none-any.whl", hash = "sha256:0ae1177e2038b18a929b3098215243631ef91136cba26b7e2b12790ceb7e87cc", size = 19617, upload-time = "2026-05-21T16:32:34.278Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a small `decepticon.telemetry.otel` module that emits OTLP spans for the engagement → agent → (tool | LLM) hierarchy. **Default off**: when `OTEL_ENABLED` is unset, or when the optional `opentelemetry` packages are not installed, every helper is a no-op. LangSmith tracing is untouched; OTEL is a sibling observability path users can self-host (Jaeger / Tempo / any OTLP collector).

## Public API

`packages/decepticon/decepticon/telemetry/otel.py`:

| Symbol | Purpose |
|---|---|
| `init_otel()` | Lazy idempotent provider + OTLP exporter setup. |
| `start_engagement_span(engagement_id)` | Top-level span; sets engagement context. |
| `start_agent_span(agent_name)` | Child of engagement; sets agent context. |
| `start_tool_span(tool_name)` | Sibling of llm_call under agent_run. |
| `start_llm_span(model)` | Sibling of tool_call; cost / token attrs land here. |
| `record_llm_cost(cost_usd)` | Active llm_call span; falls back to engagement. |
| `record_llm_token_usage(prompt_tokens, completion_tokens)` | Active llm_call span. |
| `set_current_objective_id` / `reset_current_objective_id` | OPPLAN context binding. |

## Attribute schema (low-cardinality, no PII)

- `decepticon.engagement_id`, `decepticon.agent`, `decepticon.tool`
- `decepticon.llm.model`, `decepticon.llm.cost_usd`
- `decepticon.llm.prompt_tokens`, `decepticon.llm.completion_tokens`
- `decepticon.opplan.objective_id`

**Never recorded as attributes**: prompt bodies, tool outputs, credentials, target URLs, raw findings.

## Configuration (all default OFF)

| Env var | Default |
|---|---|
| `OTEL_ENABLED` | unset → no-op; truthy values: `1`, `true`, `yes`, `on` |
| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset → SDK default |
| `OTEL_EXPORTER_OTLP_HEADERS` | unset |
| `OTEL_SERVICE_NAME` | `decepticon` |

## Packaging

- `packages/decepticon/pyproject.toml` gains a `telemetry` optional extra:
  ```
  telemetry = [
      "opentelemetry-api>=1.27",
      "opentelemetry-sdk>=1.27",
      "opentelemetry-exporter-otlp>=1.27",
  ]
  ```
  The `all` bundle now includes `neo4j,telemetry`.

- `docker-compose.yml` gains a commented-out Jaeger all-in-one service + example env vars so operators can self-host with one uncomment.

## Deliberately out of scope (follow-up)

Wiring the helpers into `benchmark/harness.py`, `llm/factory.py`, `middleware/opplan.py`, and `tools/opplan.py`. The library + packaging land first as a clean, low-blast-radius unit; integration edits can land as a focused follow-up against the agent boundary.

## Files

| File | Change |
|---|---|
| `packages/decepticon/decepticon/telemetry/__init__.py` | new — exports public API |
| `packages/decepticon/decepticon/telemetry/otel.py` | new — 266 lines, the module |
| `packages/decepticon/tests/unit/telemetry/__init__.py` | new — empty package marker |
| `packages/decepticon/tests/unit/telemetry/test_otel.py` | new — 9 tests |
| `packages/decepticon/pyproject.toml` | adds `telemetry` extra |
| `docker-compose.yml` | adds commented Jaeger service block |
| `uv.lock` | refreshed for the new optional dep |

## Verification

- `uv run pytest packages/decepticon/tests/unit/telemetry/test_otel.py -q` → **9 passed**
- `uv run ruff check packages/decepticon/decepticon/telemetry packages/decepticon/tests/unit/telemetry` → All checks passed
- LSP diagnostics on changed files: clean
- Test file uses `pytest.importorskip("opentelemetry")` so it skips cleanly in CI installs that don't include the optional extra.

## Test coverage

Disabled-by-default emission, full engagement → agent → (tool | llm) hierarchy, all required attributes including cost / tokens / objective id, cost fallback to engagement span, `None` cost ignored, `set_current_objective_id` no-op when disabled, `init_otel` idempotency, `init_otel` returns `False` when disabled, graceful no-op when the `opentelemetry` extra is uninstalled (simulated via `__import__` monkeypatch).
