### PR TITLE
perf(orchestrator): SubAgentTaskSpec data contract for scoped child dispatch

### DIFF
--- a/packages/decepticon/decepticon/agents/task_spec.py
+++ b/packages/decepticon/decepticon/agents/task_spec.py
@@ -1,0 +1,154 @@
+"""Scoped sub-agent task specification.
+
+This module defines the data contract the orchestrator uses to hand a
+single discrete task to a specialist sub-agent without copying the
+parent conversation history into the child ``messages`` state.
+
+The motivation is two-fold: copying the parent transcript inflates
+child token counts (and breaks LangChain's prompt cache) and it leaks
+parent reasoning that is rarely relevant to the child task. The child
+should receive only:
+
+1. its own system prompt (built by ``load_prompt`` for its role),
+2. a compact, deterministic task spec (this module),
+3. file references to parent artifacts when reading them is useful.
+
+Integration (replacing the stock dispatch payload with
+:func:`scoped_dispatch_payload`) is intentionally not in this PR — the
+data contract lands first so it can be reviewed independently of the
+LangGraph middleware surgery.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SUBAGENT_TASK_SYSTEM_PROMPT = (
+    "You are executing a scoped child task for Decepticon.\n"
+    "Use only this task spec, your own system prompt, current engagement\n"
+    "middleware context, and referenced parent artifacts. Do not assume\n"
+    "access to the parent's private reasoning or full transcript. Return\n"
+    "results using the existing specialist handoff format."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SubAgentTaskSpec:
+    """Compact handoff payload for a specialist sub-agent invocation.
+
+    Fields:
+
+    * ``objective`` — one-sentence statement of what the child must do.
+    * ``scope`` — engagement scope (in-scope hosts/CIDRs, RoE limits).
+    * ``inputs`` — tool-arg-shaped key/value bundle the parent already
+      gathered (e.g. ``target_url``, ``credential_id``).
+    * ``expected_outputs`` — names of artifacts/keys the parent expects
+      back so the child can self-check before returning.
+    * ``parent_artifacts`` — paths on the engagement workspace the child
+      may read (findings, screenshots, captures). Never inline content.
+    * ``engagement_id`` — parent's engagement identifier.
+    * ``parent_agent`` — name of the dispatching agent (typically
+      ``"decepticon"``).
+    """
+
+    objective: str
+    scope: Mapping[str, Any] = field(default_factory=dict)
+    inputs: Mapping[str, Any] = field(default_factory=dict)
+    expected_outputs: tuple[str, ...] = field(default_factory=tuple)
+    parent_artifacts: tuple[Path, ...] = field(default_factory=tuple)
+    engagement_id: str = ""
+    parent_agent: str = ""
+
+    def render(self) -> str:
+        """Render a deterministic markdown handoff.
+
+        Dict keys are sorted so identical inputs produce identical text,
+        which is what makes prompt caching effective for the child run.
+        """
+        lines: list[str] = ["# Sub-agent task", ""]
+        lines.append(f"**Objective:** {self.objective.strip()}")
+        if self.engagement_id:
+            lines.append(f"**Engagement:** {self.engagement_id}")
+        if self.parent_agent:
+            lines.append(f"**Dispatched by:** {self.parent_agent}")
+        lines.append("")
+
+        lines.append("## Scope")
+        lines.append("```json")
+        lines.append(json.dumps(dict(self.scope), indent=2, sort_keys=True, default=str))
+        lines.append("```")
+        lines.append("")
+
+        lines.append("## Inputs")
+        lines.append("```json")
+        lines.append(json.dumps(dict(self.inputs), indent=2, sort_keys=True, default=str))
+        lines.append("```")
+        lines.append("")
+
+        lines.append("## Expected outputs")
+        if self.expected_outputs:
+            for item in self.expected_outputs:
+                lines.append(f"- {item}")
+        else:
+            lines.append("- (none specified)")
+        lines.append("")
+
+        lines.append("## Parent artifacts (file references — read on demand)")
+        if self.parent_artifacts:
+            for path in self.parent_artifacts:
+                lines.append(f"- {Path(path).as_posix()}")
+        else:
+            lines.append("- (none)")
+        lines.append("")
+
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def scoped_dispatch_payload(task_spec: SubAgentTaskSpec) -> list[Mapping[str, Any]]:
+    """Build the LangGraph child ``messages`` list from a task spec.
+
+    Returns a two-message list (system + human) the dispatch wrapper can
+    pass to the specialist's runnable in place of the parent's message
+    history. Returned dicts mirror the shape LangChain's converters
+    expect so callers can ``BaseMessage``-deserialize them without
+    importing this module from the LangChain side.
+    """
+    return [
+        {"role": "system", "content": SUBAGENT_TASK_SYSTEM_PROMPT},
+        {"role": "user", "content": task_spec.render()},
+    ]
+
+
+def estimate_token_savings(
+    parent_message_chars: int, task_spec: SubAgentTaskSpec
+) -> int:
+    """Estimate the character delta between full-history vs scoped dispatch.
+
+    Used by tests to assert the scoped dispatch is materially smaller
+    than what the parent would have sent before this refactor. Uses raw
+    character count as a coarse proxy for tokens; the actual tokenizer
+    ratio varies per model but the relative savings hold.
+    """
+    scoped_chars = len(SUBAGENT_TASK_SYSTEM_PROMPT) + len(task_spec.render())
+    return parent_message_chars - scoped_chars
+
+
+__all__ = [
+    "SUBAGENT_TASK_SYSTEM_PROMPT",
+    "SubAgentTaskSpec",
+    "estimate_token_savings",
+    "scoped_dispatch_payload",
+]
+
+
+def _coerce_paths(paths: Iterable[Any]) -> tuple[Path, ...]:
+    """Convert a heterogeneous iterable into a tuple of ``Path``.
+
+    Used by tests and integration code that builds a task spec from
+    string-or-Path mixes coming out of LangGraph state.
+    """
+    return tuple(p if isinstance(p, Path) else Path(str(p)) for p in paths)

--- a/packages/decepticon/decepticon/agents/task_spec.py
+++ b/packages/decepticon/decepticon/agents/task_spec.py
@@ -123,9 +123,7 @@ def scoped_dispatch_payload(task_spec: SubAgentTaskSpec) -> list[Mapping[str, An
     ]
 
 
-def estimate_token_savings(
-    parent_message_chars: int, task_spec: SubAgentTaskSpec
-) -> int:
+def estimate_token_savings(parent_message_chars: int, task_spec: SubAgentTaskSpec) -> int:
     """Estimate the character delta between full-history vs scoped dispatch.
 
     Used by tests to assert the scoped dispatch is materially smaller

--- a/packages/decepticon/tests/unit/agents/test_task_spec.py
+++ b/packages/decepticon/tests/unit/agents/test_task_spec.py
@@ -1,0 +1,137 @@
+"""Tests for ``decepticon.agents.task_spec`` — scoped sub-agent handoff."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from decepticon.agents.task_spec import (
+    SUBAGENT_TASK_SYSTEM_PROMPT,
+    SubAgentTaskSpec,
+    estimate_token_savings,
+    scoped_dispatch_payload,
+)
+
+
+def _full_spec() -> SubAgentTaskSpec:
+    return SubAgentTaskSpec(
+        objective="Identify SQL injection on /search endpoint",
+        scope={
+            "in_scope": ["target.example", "api.target.example"],
+            "out_of_scope": ["billing.target.example"],
+        },
+        inputs={"target_url": "https://target.example/search", "credential_id": "test-1"},
+        expected_outputs=("FIND-NNN.md if exploitable", "scan log"),
+        parent_artifacts=(
+            Path("/workspace/eng-1/findings/FIND-001.md"),
+            Path("/workspace/eng-1/recon/sitemap.json"),
+        ),
+        engagement_id="eng-1",
+        parent_agent="decepticon",
+    )
+
+
+def test_render_includes_objective_engagement_dispatcher() -> None:
+    body = _full_spec().render()
+    assert "# Sub-agent task" in body
+    assert "Identify SQL injection on /search endpoint" in body
+    assert "**Engagement:** eng-1" in body
+    assert "**Dispatched by:** decepticon" in body
+
+
+def test_render_uses_sorted_json_for_dicts() -> None:
+    spec = SubAgentTaskSpec(
+        objective="x",
+        scope={"z_last": 1, "a_first": 2, "m_mid": 3},
+        inputs={"y": "Y", "x": "X"},
+    )
+    body = spec.render()
+    scope_json = body.split("## Scope\n```json\n", 1)[1].split("\n```", 1)[0]
+    parsed = json.loads(scope_json)
+    assert list(parsed.keys()) == ["a_first", "m_mid", "z_last"]
+    inputs_json = body.split("## Inputs\n```json\n", 1)[1].split("\n```", 1)[0]
+    parsed_inputs = json.loads(inputs_json)
+    assert list(parsed_inputs.keys()) == ["x", "y"]
+
+
+def test_render_is_deterministic_across_identical_specs() -> None:
+    a = _full_spec().render()
+    b = _full_spec().render()
+    assert a == b
+
+
+def test_render_lists_expected_outputs_and_artifacts() -> None:
+    body = _full_spec().render()
+    assert "- FIND-NNN.md if exploitable" in body
+    assert "- scan log" in body
+    assert "/workspace/eng-1/findings/FIND-001.md" in body
+    assert "/workspace/eng-1/recon/sitemap.json" in body
+
+
+def test_render_with_no_expected_outputs_shows_placeholder() -> None:
+    spec = SubAgentTaskSpec(objective="x")
+    body = spec.render()
+    assert "## Expected outputs\n- (none specified)" in body
+
+
+def test_render_with_no_artifacts_shows_placeholder() -> None:
+    spec = SubAgentTaskSpec(objective="x")
+    body = spec.render()
+    assert "(none)" in body
+
+
+def test_scoped_dispatch_payload_has_two_messages() -> None:
+    spec = _full_spec()
+    payload = scoped_dispatch_payload(spec)
+    assert len(payload) == 2
+    assert payload[0]["role"] == "system"
+    assert payload[0]["content"] == SUBAGENT_TASK_SYSTEM_PROMPT
+    assert payload[1]["role"] == "user"
+    assert payload[1]["content"] == spec.render()
+
+
+def test_scoped_dispatch_is_smaller_than_full_history() -> None:
+    spec = _full_spec()
+    fake_parent_history_chars = 80_000
+
+    savings = estimate_token_savings(
+        parent_message_chars=fake_parent_history_chars, task_spec=spec
+    )
+
+    scoped_chars = len(SUBAGENT_TASK_SYSTEM_PROMPT) + len(spec.render())
+    assert savings == fake_parent_history_chars - scoped_chars
+    assert savings > 70_000
+
+
+def test_dataclass_is_frozen() -> None:
+    spec = _full_spec()
+    raised = False
+    try:
+        spec.objective = "tampered"  # type: ignore[misc]
+    except Exception:
+        raised = True
+    assert raised
+
+
+def test_task_spec_is_serializable_via_render() -> None:
+    spec = _full_spec()
+    body = spec.render()
+    assert isinstance(body, str)
+    assert body.startswith("# Sub-agent task")
+    assert body.endswith("\n")
+
+
+def test_path_objects_render_as_posix() -> None:
+    spec = SubAgentTaskSpec(
+        objective="x",
+        parent_artifacts=(Path("C:/Users/x/findings/FIND-001.md"),),
+    )
+    body = spec.render()
+    assert "C:/Users/x/findings/FIND-001.md" in body
+
+
+def test_empty_engagement_and_parent_agent_are_omitted() -> None:
+    spec = SubAgentTaskSpec(objective="x")
+    body = spec.render()
+    assert "**Engagement:**" not in body
+    assert "**Dispatched by:**" not in body

--- a/packages/decepticon/tests/unit/agents/test_task_spec.py
+++ b/packages/decepticon/tests/unit/agents/test_task_spec.py
@@ -94,9 +94,7 @@ def test_scoped_dispatch_is_smaller_than_full_history() -> None:
     spec = _full_spec()
     fake_parent_history_chars = 80_000
 
-    savings = estimate_token_savings(
-        parent_message_chars=fake_parent_history_chars, task_spec=spec
-    )
+    savings = estimate_token_savings(parent_message_chars=fake_parent_history_chars, task_spec=spec)
 
     scoped_chars = len(SUBAGENT_TASK_SYSTEM_PROMPT) + len(spec.render())
     assert savings == fake_parent_history_chars - scoped_chars


### PR DESCRIPTION
## Summary

Add `decepticon.agents.task_spec` so a future orchestrator change can hand each specialist sub-agent a scoped task spec instead of copying the parent conversation history into the child `messages` state.

## Why

Copying the parent transcript today:
- inflates child token counts,
- breaks LangChain's prompt cache for the child's static prompt,
- leaks parent reasoning that is rarely relevant to the child task.

## Public surface

| Symbol | Purpose |
|---|---|
| `SubAgentTaskSpec` (frozen dataclass) | objective, scope, inputs, expected_outputs, parent_artifacts (file references — never inline transcript), engagement_id, parent_agent |
| `SubAgentTaskSpec.render()` | deterministic markdown handoff with **sorted-key JSON** for scope/inputs so identical specs render identically (prompt-cache friendly) |
| `scoped_dispatch_payload(task_spec)` | returns the two-message `[system, user]` list a future dispatch wrapper hands to a specialist runnable in place of parent history |
| `SUBAGENT_TASK_SYSTEM_PROMPT` | fixed system instruction documenting the contract for the child |
| `estimate_token_savings(parent_chars, task_spec)` | coarse helper used in tests to assert scoped dispatch is materially smaller |

## Deliberately deferred (follow-up PR)

Wiring `scoped_dispatch_payload` into the LangGraph sub-agent dispatch middleware in `decepticon.agents.standard.decepticon` / `decepticon.agents.middleware_slots`. The data contract lands first so it can be reviewed independently of the higher-blast-radius middleware surgery. The integration PR can ship next and will replace `_make_subagent()`'s payload construction.

## Files

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/agents/task_spec.py` | new — 154 lines |
| `packages/decepticon/tests/unit/agents/test_task_spec.py` | new — 137 lines, 12 tests |

## Verification

- `uv run pytest packages/decepticon/tests/unit/agents/test_task_spec.py -q` → **12 passed**
- `uv run ruff check packages/decepticon/decepticon/agents/task_spec.py packages/decepticon/tests/unit/agents/test_task_spec.py` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

Objective / engagement / dispatcher rendering, sorted-key JSON for scope/inputs, deterministic output across identical specs, expected-outputs and artifacts listing, placeholder handling when optional collections are empty, `scoped_dispatch_payload` shape and content, `estimate_token_savings` math, dataclass frozenness, `Path` POSIX rendering on Windows, omitted-when-empty engagement/dispatcher fields.
