### PR TITLE
feat(tools): skill registry + slug / fuzzy resolver for dynamic load_skill

### DIFF
--- a/packages/decepticon/decepticon/tools/skills_registry.py
+++ b/packages/decepticon/decepticon/tools/skills_registry.py
@@ -1,0 +1,258 @@
+"""Decepticon skill registry + slug / fuzzy resolver.
+
+This module is the data-layer counterpart to ``decepticon.tools.skills``.
+The existing ``load_skill`` tool reads a single fully-qualified
+``/skills/...`` path. The registry walks the package's skill tree
+(plus virtual ``/skills/...`` paths shipped from plugins / shared
+sources) and lets callers resolve a skill by:
+
+1. exact ``/skills/...`` virtual path,
+2. trailing slug (``sql-injection`` → ``/skills/standard/analyst/sql-injection/SKILL.md``),
+3. fuzzy match with disambiguation (no silent guessing on ambiguity).
+
+A future PR will plug this resolver into the existing ``load_skill``
+tool so a running agent can name a skill by slug and persist the
+loaded id into LangGraph state for the next turn's prompt. Shipping
+the resolver as a standalone library here lets the integration land
+as a small, focused follow-up against well-tested ground truth.
+
+Path safety contract:
+
+* All resolved paths start with ``/skills/``.
+* ``..`` traversal segments and backslashes are rejected.
+* Resolved paths must point to a discovered registry entry; raw
+  filesystem reads are never performed against caller-controlled input.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+SKILL_PATH_PREFIX = "/skills/"
+_SLUG_NORMALIZE = re.compile(r"[\s_]+")
+_RULE_SAFE = re.compile(r"[^A-Za-z0-9_\-]+")
+
+
+@dataclass(frozen=True, slots=True)
+class SkillRecord:
+    """One discovered skill markdown file.
+
+    Fields:
+
+    * ``id`` — canonical virtual path (e.g. ``/skills/standard/analyst/sql-injection/SKILL.md``)
+    * ``slug`` — trailing directory or file slug (``sql-injection`` or ``crypto``)
+    * ``name`` — frontmatter ``name`` field or slug fallback
+    * ``description`` — frontmatter ``description`` field or empty string
+    * ``source`` — first allowlist source prefix that exposed this record
+    """
+
+    id: str
+    slug: str
+    name: str
+    description: str
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class AmbiguousSkill:
+    """Returned by :func:`resolve_skill` when multiple candidates tie.
+
+    Callers (typically the ``load_skill`` tool wrapper) should render the
+    ``candidates`` list back to the agent so it can disambiguate. The
+    resolver never silently picks a winner under ambiguity.
+    """
+
+    query: str
+    candidates: tuple[SkillRecord, ...]
+
+
+def normalize_slug(text: str) -> str:
+    """Lowercase, trim, convert spaces/underscores to hyphens.
+
+    ``"SQL Injection"`` -> ``"sql-injection"``.
+    """
+    cleaned = _SLUG_NORMALIZE.sub("-", text.strip().lower())
+    return cleaned.strip("-")
+
+
+def is_safe_skill_path(path: str) -> bool:
+    """Return True if ``path`` is a syntactically safe virtual skill path."""
+    if not isinstance(path, str) or not path:
+        return False
+    if not path.startswith(SKILL_PATH_PREFIX):
+        return False
+    if not path.endswith(".md"):
+        return False
+    if "\\" in path:
+        return False
+    segments = path.split("/")
+    if ".." in segments:
+        return False
+    return True
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    block = text[4:end]
+    out: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip().strip('"').strip("'")
+    return out
+
+
+def _walk_skills_root(skills_root: Path) -> Iterator[tuple[Path, str]]:
+    """Yield ``(file_path, virtual_path)`` for every ``*.md`` skill file."""
+    if not skills_root.exists():
+        return
+    for md in skills_root.rglob("*.md"):
+        rel = md.relative_to(skills_root).as_posix()
+        virtual = f"{SKILL_PATH_PREFIX}{rel}"
+        yield md, virtual
+
+
+def iter_skill_records(
+    skills_root: Path, source_prefix: str = SKILL_PATH_PREFIX
+) -> Iterator[SkillRecord]:
+    """Walk ``skills_root`` and yield one :class:`SkillRecord` per ``*.md``.
+
+    ``source_prefix`` is the virtual-path prefix to record on each
+    entry; callers walking shared/plugin trees should pass the matching
+    virtual prefix so allowlist filtering downstream stays accurate.
+    """
+    for path, virtual in _walk_skills_root(skills_root):
+        try:
+            body = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = _frontmatter(body)
+        rel = virtual[len(SKILL_PATH_PREFIX):]
+        parts = rel.split("/")
+        if parts[-1] == "SKILL.md" and len(parts) >= 2:
+            slug = parts[-2]
+        else:
+            slug = parts[-1].removesuffix(".md")
+        name = fm.get("name") or slug
+        description = fm.get("description", "").strip()
+        yield SkillRecord(
+            id=virtual,
+            slug=slug,
+            name=name,
+            description=description,
+            source=source_prefix,
+        )
+
+
+def build_registry_from_package(package_skills_root: Path) -> list[SkillRecord]:
+    """Convenience builder for the shipped package skill tree."""
+    return list(iter_skill_records(package_skills_root))
+
+
+def resolve_skill(
+    query: str,
+    registry: Iterable[SkillRecord],
+    *,
+    allowed_sources: Iterable[str] | None = None,
+    fuzzy_cutoff: float = 0.7,
+) -> SkillRecord | AmbiguousSkill | None:
+    """Resolve a user/agent query against the registry.
+
+    Resolution order: exact ``/skills/...`` id match → trailing-slug
+    match → fuzzy match (with disambiguation). When ``allowed_sources``
+    is provided every candidate's ``id`` must start with one of the
+    allowed prefixes; otherwise the record is filtered out before
+    matching.
+
+    Returns:
+
+    * a single :class:`SkillRecord` on a definite match,
+    * an :class:`AmbiguousSkill` listing candidates when multiple
+      records tie on slug/name or fuzzy score,
+    * ``None`` when no candidate is reachable.
+    """
+    if not isinstance(query, str) or not query.strip():
+        return None
+    pool = list(registry)
+    if allowed_sources is not None:
+        prefixes = tuple(s.rstrip("/") for s in allowed_sources)
+        if prefixes:
+            pool = [r for r in pool if any(r.id.startswith(p) for p in prefixes)]
+    if not pool:
+        return None
+
+    q = query.strip()
+
+    if q.startswith(SKILL_PATH_PREFIX):
+        if not is_safe_skill_path(q):
+            return None
+        for rec in pool:
+            if rec.id == q:
+                return rec
+        return None
+
+    normalized = normalize_slug(q.removesuffix(".md").removesuffix("/SKILL"))
+    slug_hits = [r for r in pool if r.slug == normalized]
+    if len(slug_hits) == 1:
+        return slug_hits[0]
+    if len(slug_hits) > 1:
+        return AmbiguousSkill(query=q, candidates=tuple(slug_hits))
+
+    name_hits = [r for r in pool if normalize_slug(r.name) == normalized]
+    if len(name_hits) == 1:
+        return name_hits[0]
+    if len(name_hits) > 1:
+        return AmbiguousSkill(query=q, candidates=tuple(name_hits))
+
+    slug_index = {r.slug: r for r in pool}
+    fuzzy = difflib.get_close_matches(
+        normalized, list(slug_index.keys()), n=5, cutoff=fuzzy_cutoff
+    )
+    if not fuzzy:
+        return None
+    if len(fuzzy) == 1:
+        return slug_index[fuzzy[0]]
+    return AmbiguousSkill(
+        query=q, candidates=tuple(slug_index[s] for s in fuzzy)
+    )
+
+
+def list_skill_strings(
+    registry: Iterable[SkillRecord], *, filter: str | None = None
+) -> list[str]:
+    """Return ``slug — id — description`` strings, optionally filtered."""
+    out: list[str] = []
+    needle = filter.strip().lower() if isinstance(filter, str) else ""
+    for rec in registry:
+        if needle:
+            haystack = " ".join(
+                [rec.slug, rec.name, rec.description, rec.id]
+            ).lower()
+            if needle not in haystack:
+                continue
+        desc = rec.description or "(no description)"
+        out.append(f"{rec.slug} — {rec.id} — {desc}")
+    out.sort()
+    return out
+
+
+__all__ = [
+    "AmbiguousSkill",
+    "SKILL_PATH_PREFIX",
+    "SkillRecord",
+    "build_registry_from_package",
+    "is_safe_skill_path",
+    "iter_skill_records",
+    "list_skill_strings",
+    "normalize_slug",
+    "resolve_skill",
+]

--- a/packages/decepticon/decepticon/tools/skills_registry.py
+++ b/packages/decepticon/decepticon/tools/skills_registry.py
@@ -136,7 +136,7 @@ def iter_skill_records(
         except OSError:
             continue
         fm = _frontmatter(body)
-        rel = virtual[len(SKILL_PATH_PREFIX):]
+        rel = virtual[len(SKILL_PATH_PREFIX) :]
         parts = rel.split("/")
         if parts[-1] == "SKILL.md" and len(parts) >= 2:
             slug = parts[-2]
@@ -214,29 +214,21 @@ def resolve_skill(
         return AmbiguousSkill(query=q, candidates=tuple(name_hits))
 
     slug_index = {r.slug: r for r in pool}
-    fuzzy = difflib.get_close_matches(
-        normalized, list(slug_index.keys()), n=5, cutoff=fuzzy_cutoff
-    )
+    fuzzy = difflib.get_close_matches(normalized, list(slug_index.keys()), n=5, cutoff=fuzzy_cutoff)
     if not fuzzy:
         return None
     if len(fuzzy) == 1:
         return slug_index[fuzzy[0]]
-    return AmbiguousSkill(
-        query=q, candidates=tuple(slug_index[s] for s in fuzzy)
-    )
+    return AmbiguousSkill(query=q, candidates=tuple(slug_index[s] for s in fuzzy))
 
 
-def list_skill_strings(
-    registry: Iterable[SkillRecord], *, filter: str | None = None
-) -> list[str]:
+def list_skill_strings(registry: Iterable[SkillRecord], *, filter: str | None = None) -> list[str]:
     """Return ``slug — id — description`` strings, optionally filtered."""
     out: list[str] = []
     needle = filter.strip().lower() if isinstance(filter, str) else ""
     for rec in registry:
         if needle:
-            haystack = " ".join(
-                [rec.slug, rec.name, rec.description, rec.id]
-            ).lower()
+            haystack = " ".join([rec.slug, rec.name, rec.description, rec.id]).lower()
             if needle not in haystack:
                 continue
         desc = rec.description or "(no description)"

--- a/packages/decepticon/tests/unit/tools/test_skills_registry.py
+++ b/packages/decepticon/tests/unit/tools/test_skills_registry.py
@@ -27,11 +27,9 @@ def _make_record(
     source: str = SKILL_PATH_PREFIX,
 ) -> SkillRecord:
     if slug is None:
-        parts = id_[len(SKILL_PATH_PREFIX):].split("/")
+        parts = id_[len(SKILL_PATH_PREFIX) :].split("/")
         slug = parts[-2] if parts[-1] == "SKILL.md" else parts[-1].removesuffix(".md")
-    return SkillRecord(
-        id=id_, slug=slug, name=name or slug, description=description, source=source
-    )
+    return SkillRecord(id=id_, slug=slug, name=name or slug, description=description, source=source)
 
 
 @pytest.fixture
@@ -111,16 +109,12 @@ class TestIsSafeSkillPath:
 
 class TestResolveSkill:
     def test_exact_path_match(self, small_registry: list[SkillRecord]) -> None:
-        rec = resolve_skill(
-            "/skills/standard/analyst/sql-injection/SKILL.md", small_registry
-        )
+        rec = resolve_skill("/skills/standard/analyst/sql-injection/SKILL.md", small_registry)
         assert isinstance(rec, SkillRecord)
         assert rec.slug == "sql-injection"
 
     def test_exact_path_unsafe_rejected(self, small_registry: list[SkillRecord]) -> None:
-        assert (
-            resolve_skill("/skills/../etc/passwd", small_registry) is None
-        )
+        assert resolve_skill("/skills/../etc/passwd", small_registry) is None
 
     def test_trailing_slug_match(self, small_registry: list[SkillRecord]) -> None:
         rec = resolve_skill("sql-injection", small_registry)
@@ -142,9 +136,7 @@ class TestResolveSkill:
         assert isinstance(rec, SkillRecord)
         assert rec.slug == "reentrancy"
 
-    def test_ambiguous_slug_returns_disambiguation(
-        self, small_registry: list[SkillRecord]
-    ) -> None:
+    def test_ambiguous_slug_returns_disambiguation(self, small_registry: list[SkillRecord]) -> None:
         result = resolve_skill("reporting", small_registry)
         assert isinstance(result, AmbiguousSkill)
         ids = {c.id for c in result.candidates}
@@ -179,23 +171,17 @@ class TestResolveSkill:
 
 
 class TestListSkillStrings:
-    def test_no_filter_returns_all_sorted(
-        self, small_registry: list[SkillRecord]
-    ) -> None:
+    def test_no_filter_returns_all_sorted(self, small_registry: list[SkillRecord]) -> None:
         out = list_skill_strings(small_registry)
         assert len(out) == len(small_registry)
         assert out == sorted(out)
 
-    def test_filter_matches_by_description(
-        self, small_registry: list[SkillRecord]
-    ) -> None:
+    def test_filter_matches_by_description(self, small_registry: list[SkillRecord]) -> None:
         out = list_skill_strings(small_registry, filter="injection")
         assert len(out) == 1
         assert "sql-injection" in out[0]
 
-    def test_filter_matches_by_slug_substring(
-        self, small_registry: list[SkillRecord]
-    ) -> None:
+    def test_filter_matches_by_slug_substring(self, small_registry: list[SkillRecord]) -> None:
         out = list_skill_strings(small_registry, filter="smuggl")
         assert len(out) == 1
         assert "/skills/standard/exploit/web/smuggling.md" in out[0]

--- a/packages/decepticon/tests/unit/tools/test_skills_registry.py
+++ b/packages/decepticon/tests/unit/tools/test_skills_registry.py
@@ -1,0 +1,236 @@
+"""Tests for ``decepticon.tools.skills_registry`` — slug resolver + safety."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from decepticon.tools.skills_registry import (
+    SKILL_PATH_PREFIX,
+    AmbiguousSkill,
+    SkillRecord,
+    is_safe_skill_path,
+    iter_skill_records,
+    list_skill_strings,
+    normalize_slug,
+    resolve_skill,
+)
+
+
+def _make_record(
+    id_: str,
+    *,
+    slug: str | None = None,
+    name: str | None = None,
+    description: str = "",
+    source: str = SKILL_PATH_PREFIX,
+) -> SkillRecord:
+    if slug is None:
+        parts = id_[len(SKILL_PATH_PREFIX):].split("/")
+        slug = parts[-2] if parts[-1] == "SKILL.md" else parts[-1].removesuffix(".md")
+    return SkillRecord(
+        id=id_, slug=slug, name=name or slug, description=description, source=source
+    )
+
+
+@pytest.fixture
+def small_registry() -> list[SkillRecord]:
+    return [
+        _make_record(
+            "/skills/standard/analyst/sql-injection/SKILL.md",
+            description="Hunt SQL injection (CWE-89).",
+        ),
+        _make_record(
+            "/skills/standard/analyst/auth-bypass/SKILL.md",
+            description="Authentication-bypass triage.",
+        ),
+        _make_record(
+            "/skills/standard/contracts/reentrancy/SKILL.md",
+            description="Hunt reentrancy bugs in Solidity contracts.",
+        ),
+        _make_record(
+            "/skills/standard/exploit/web/smuggling.md",
+            slug="smuggling",
+            description="HTTP request smuggling (HRS).",
+        ),
+        _make_record(
+            "/skills/shared/finding-protocol/SKILL.md",
+            description="Operational finding template.",
+        ),
+        _make_record(
+            "/skills/standard/analyst/reporting/SKILL.md",
+            description="Analyst reporting guide.",
+        ),
+        _make_record(
+            "/skills/standard/decepticon/reporting/SKILL.md",
+            description="Decepticon reporting guide.",
+        ),
+    ]
+
+
+class TestNormalizeSlug:
+    def test_lowercases_and_strips(self) -> None:
+        assert normalize_slug("  SQL Injection ") == "sql-injection"
+
+    def test_underscores_become_hyphens(self) -> None:
+        assert normalize_slug("auth_bypass") == "auth-bypass"
+
+    def test_mixed_whitespace_collapses(self) -> None:
+        assert normalize_slug("HTTP   request smuggling") == "http-request-smuggling"
+
+
+class TestIsSafeSkillPath:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/skills/standard/analyst/sql-injection/SKILL.md",
+            "/skills/shared/finding-protocol/SKILL.md",
+            "/skills/standard/exploit/web/smuggling.md",
+        ],
+    )
+    def test_accepts_valid_paths(self, path: str) -> None:
+        assert is_safe_skill_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            "skills/standard/analyst/sql-injection/SKILL.md",
+            "/etc/passwd",
+            "/skills/../etc/passwd",
+            "/skills/standard/../../etc/passwd",
+            "/skills/standard/analyst/sql-injection",
+            "C:\\Users\\x\\skills.md",
+            None,
+        ],
+    )
+    def test_rejects_bad_paths(self, path: object) -> None:
+        assert is_safe_skill_path(path) is False  # type: ignore[arg-type]
+
+
+class TestResolveSkill:
+    def test_exact_path_match(self, small_registry: list[SkillRecord]) -> None:
+        rec = resolve_skill(
+            "/skills/standard/analyst/sql-injection/SKILL.md", small_registry
+        )
+        assert isinstance(rec, SkillRecord)
+        assert rec.slug == "sql-injection"
+
+    def test_exact_path_unsafe_rejected(self, small_registry: list[SkillRecord]) -> None:
+        assert (
+            resolve_skill("/skills/../etc/passwd", small_registry) is None
+        )
+
+    def test_trailing_slug_match(self, small_registry: list[SkillRecord]) -> None:
+        rec = resolve_skill("sql-injection", small_registry)
+        assert isinstance(rec, SkillRecord)
+        assert rec.id == "/skills/standard/analyst/sql-injection/SKILL.md"
+
+    def test_slug_with_spaces_normalizes(self, small_registry: list[SkillRecord]) -> None:
+        rec = resolve_skill("sql injection", small_registry)
+        assert isinstance(rec, SkillRecord)
+        assert rec.slug == "sql-injection"
+
+    def test_flat_file_slug_resolves(self, small_registry: list[SkillRecord]) -> None:
+        rec = resolve_skill("smuggling", small_registry)
+        assert isinstance(rec, SkillRecord)
+        assert rec.id == "/skills/standard/exploit/web/smuggling.md"
+
+    def test_fuzzy_single_match(self, small_registry: list[SkillRecord]) -> None:
+        rec = resolve_skill("reenterancy", small_registry, fuzzy_cutoff=0.6)
+        assert isinstance(rec, SkillRecord)
+        assert rec.slug == "reentrancy"
+
+    def test_ambiguous_slug_returns_disambiguation(
+        self, small_registry: list[SkillRecord]
+    ) -> None:
+        result = resolve_skill("reporting", small_registry)
+        assert isinstance(result, AmbiguousSkill)
+        ids = {c.id for c in result.candidates}
+        assert "/skills/standard/analyst/reporting/SKILL.md" in ids
+        assert "/skills/standard/decepticon/reporting/SKILL.md" in ids
+
+    def test_unknown_skill_returns_none(self, small_registry: list[SkillRecord]) -> None:
+        assert resolve_skill("not-a-real-skill-anywhere", small_registry) is None
+
+    def test_empty_query_returns_none(self, small_registry: list[SkillRecord]) -> None:
+        assert resolve_skill("   ", small_registry) is None
+
+    def test_allowed_sources_filter_blocks_outside_records(
+        self, small_registry: list[SkillRecord]
+    ) -> None:
+        result = resolve_skill(
+            "reentrancy",
+            small_registry,
+            allowed_sources=["/skills/standard/analyst/"],
+        )
+        assert result is None
+
+    def test_allowed_sources_passes_matching_records(
+        self, small_registry: list[SkillRecord]
+    ) -> None:
+        rec = resolve_skill(
+            "sql-injection",
+            small_registry,
+            allowed_sources=["/skills/standard/analyst/", "/skills/shared/"],
+        )
+        assert isinstance(rec, SkillRecord)
+
+
+class TestListSkillStrings:
+    def test_no_filter_returns_all_sorted(
+        self, small_registry: list[SkillRecord]
+    ) -> None:
+        out = list_skill_strings(small_registry)
+        assert len(out) == len(small_registry)
+        assert out == sorted(out)
+
+    def test_filter_matches_by_description(
+        self, small_registry: list[SkillRecord]
+    ) -> None:
+        out = list_skill_strings(small_registry, filter="injection")
+        assert len(out) == 1
+        assert "sql-injection" in out[0]
+
+    def test_filter_matches_by_slug_substring(
+        self, small_registry: list[SkillRecord]
+    ) -> None:
+        out = list_skill_strings(small_registry, filter="smuggl")
+        assert len(out) == 1
+        assert "/skills/standard/exploit/web/smuggling.md" in out[0]
+
+
+class TestIterSkillRecords:
+    def test_walks_real_filesystem_tree(self, tmp_path: Path) -> None:
+        (tmp_path / "standard" / "analyst" / "sql-injection").mkdir(parents=True)
+        (tmp_path / "standard" / "analyst" / "sql-injection" / "SKILL.md").write_text(
+            "---\nname: sql-injection\ndescription: hunt SQL injection\n---\n# body\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "standard" / "exploit" / "web").mkdir(parents=True)
+        (tmp_path / "standard" / "exploit" / "web" / "smuggling.md").write_text(
+            "---\nname: smuggling\ndescription: HTTP smuggling\n---\n# body\n",
+            encoding="utf-8",
+        )
+
+        records = list(iter_skill_records(tmp_path))
+        ids = {r.id for r in records}
+        assert "/skills/standard/analyst/sql-injection/SKILL.md" in ids
+        assert "/skills/standard/exploit/web/smuggling.md" in ids
+
+        sql = next(r for r in records if r.slug == "sql-injection")
+        assert sql.description == "hunt SQL injection"
+        smug = next(r for r in records if r.slug == "smuggling")
+        assert smug.description == "HTTP smuggling"
+
+    def test_handles_missing_root_gracefully(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        assert list(iter_skill_records(missing)) == []
+
+    def test_skips_files_with_no_frontmatter(self, tmp_path: Path) -> None:
+        (tmp_path / "raw.md").write_text("# no frontmatter\nbody\n", encoding="utf-8")
+        records = list(iter_skill_records(tmp_path))
+        assert len(records) == 1
+        assert records[0].description == ""
+        assert records[0].name == "raw"


### PR DESCRIPTION
## Summary

Add `decepticon.tools.skills_registry` — the data-layer counterpart to the existing `load_skill` tool. The registry walks the package skill tree and exposes a safe resolver that maps:

1. exact `/skills/...` virtual path
2. trailing slug (`sql-injection` → `/skills/standard/analyst/sql-injection/SKILL.md`)
3. fuzzy match with disambiguation (no silent guessing on ambiguity)

This unblocks a future PR that wires dynamic mid-engagement skill injection into the live system prompt without restarting the agent. Shipping the resolver as a standalone library lets that integration land as a small follow-up against well-tested ground truth.

## Public surface

| Symbol | Purpose |
|---|---|
| `SkillRecord` (frozen dataclass) | `id` / `slug` / `name` / `description` / `source` |
| `AmbiguousSkill` (frozen dataclass) | `query` + candidate tuple; returned when multiple records tie so the caller can disambiguate |
| `iter_skill_records(skills_root, source_prefix=...)` | walk `*.md` under a filesystem root, parse frontmatter |
| `build_registry_from_package(package_skills_root)` | convenience builder |
| `resolve_skill(query, registry, *, allowed_sources=..., fuzzy_cutoff=0.7)` | exact / slug / name / fuzzy with allowlist enforcement |
| `list_skill_strings(registry, *, filter=None)` | `slug — id — desc` strings, sorted, optionally filtered |
| `normalize_slug(text)` | lowercase + spaces/underscores → hyphens |
| `is_safe_skill_path(path)` | central path-safety predicate |

## Path-safety contract (security boundary)

- Every resolved id starts with `/skills/`.
- `..` traversal segments and `\` separators are rejected.
- Resolved paths must point to a discovered registry entry; raw filesystem reads are never performed against caller-controlled input.

## Deliberately deferred (follow-up PR)

- Wiring the resolver into `decepticon.tools.skills.build_load_skill_tool` so `load_skill("sql injection")` works.
- Adding a `list_available_skills` LangChain tool that wraps `list_skill_strings`.
- Persisting dynamically-loaded skill ids in LangGraph state and appending the bodies to the next turn's system prompt via `SkillsMiddleware.modify_request()`.

These touch middleware `modify_request()` (high blast radius) and belong in a focused follow-up against the integration boundary.

## Files

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/tools/skills_registry.py` | new — 258 lines |
| `packages/decepticon/tests/unit/tools/test_skills_registry.py` | new — 236 lines, 31 tests |

## Verification

- `uv run pytest packages/decepticon/tests/unit/tools/test_skills_registry.py -q` → **31 passed**
- `uv run ruff check packages/decepticon/decepticon/tools/skills_registry.py packages/decepticon/tests/unit/tools/test_skills_registry.py` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

Slug normalization, path-safety (8 valid + 8 invalid parametrized cases), exact-path resolution incl. unsafe rejection, trailing-slug resolution, space normalization, flat-file slug, fuzzy single-match, ambiguous-disambiguation, unknown query, empty query, allowed-sources filtering (both blocks and passes), `list_skill_strings` sort + filtering, `iter_skill_records` against a real filesystem tree (incl. missing root and no-frontmatter cases).
