### PR TITLE
feat(runtime): append-only engagement events.jsonl event log

### DIFF
--- a/packages/decepticon/decepticon/runtime/__init__.py
+++ b/packages/decepticon/decepticon/runtime/__init__.py
@@ -1,19 +1,35 @@
 """Runtime infrastructure for the Decepticon orchestrator process.
 
-Currently exposes the append-only engagement event log; future
-primitives (graceful shutdown, resume) will live alongside it.
+Each runtime module (event log, graceful shutdown, future resume, ...)
+ships in its own PR. This package init imports every known module
+best-effort so each PR can land in any order without colliding on
+this file.
 """
 
-from decepticon.runtime.event_log import (
-    EngagementEvent,
-    EventLog,
-    EventType,
-    read_events,
-)
+_exports: list[str] = []
 
-__all__ = [
-    "EngagementEvent",
-    "EventLog",
-    "EventType",
-    "read_events",
-]
+try:
+    from decepticon.runtime.event_log import (  # noqa: F401  # re-exported via __all__
+        EngagementEvent,
+        EventLog,
+        EventType,
+        read_events,
+    )
+
+    _exports += ["EngagementEvent", "EventLog", "EventType", "read_events"]
+except ImportError:
+    # event log module not present — another runtime PR may be mid-merge
+    pass
+
+try:
+    from decepticon.runtime.shutdown import (  # noqa: F401  # re-exported via __all__
+        LangGraphState,
+        install_shutdown_handlers,
+    )
+
+    _exports += ["LangGraphState", "install_shutdown_handlers"]
+except ImportError:
+    # shutdown module not present — another runtime PR may be mid-merge
+    pass
+
+__all__ = _exports

--- a/packages/decepticon/decepticon/runtime/__init__.py
+++ b/packages/decepticon/decepticon/runtime/__init__.py
@@ -1,0 +1,19 @@
+"""Runtime infrastructure for the Decepticon orchestrator process.
+
+Currently exposes the append-only engagement event log; future
+primitives (graceful shutdown, resume) will live alongside it.
+"""
+
+from decepticon.runtime.event_log import (
+    EngagementEvent,
+    EventLog,
+    EventType,
+    read_events,
+)
+
+__all__ = [
+    "EngagementEvent",
+    "EventLog",
+    "EventType",
+    "read_events",
+]

--- a/packages/decepticon/decepticon/runtime/event_log.py
+++ b/packages/decepticon/decepticon/runtime/event_log.py
@@ -1,0 +1,229 @@
+"""Append-only engagement event log with cross-platform file locking.
+
+The orchestrator (and the future ``resume <engagement_id>`` command) needs
+a durable, line-oriented record of what happened during a run that
+survives crash or Ctrl-C. This module defines that contract:
+
+* one ``events.jsonl`` file per engagement under
+  ``engagements/<id>/events.jsonl``,
+* append-only writes with platform-appropriate exclusive file locking
+  (``fcntl.flock`` on POSIX, ``msvcrt.locking`` on Windows) so concurrent
+  writers cannot interleave a single event's JSON line,
+* a small enum of event types so consumers can dispatch without
+  string-matching free-form payloads,
+* a ``read_events()`` helper that yields events in order and gracefully
+  skips malformed lines (so a torn final line does not break replay).
+
+The CLI ``--resume <id>`` wiring (Go launcher + TS REPL + Python
+middleware) is intentionally out of scope for this PR; the Python event
+log lands first as a clean dependency-free unit that the CLI layer can
+adopt next.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("decepticon.runtime.event_log")
+
+
+_WINDOWS = sys.platform == "win32"
+
+if _WINDOWS:
+    import msvcrt
+else:
+    import fcntl
+
+
+class EventType(str, Enum):
+    """All engagement event types the orchestrator may emit."""
+
+    ENGAGEMENT_START = "engagement.start"
+    ENGAGEMENT_END = "engagement.end"
+    ENGAGEMENT_CHECKPOINT = "engagement.checkpoint"
+    AGENT_TURN = "agent.turn"
+    TOOL_CALL = "tool.call"
+    TOOL_RESULT = "tool.result"
+    LLM_CALL = "llm.call"
+    LLM_RESPONSE = "llm.response"
+    FINDING_CREATED = "finding.created"
+    OPPLAN_UPDATE = "opplan.update"
+
+
+@dataclass(frozen=True, slots=True)
+class EngagementEvent:
+    """One line in an engagement's ``events.jsonl``.
+
+    Fields:
+
+    * ``ts`` — wall-clock timestamp (seconds since epoch).
+    * ``type`` — one of :class:`EventType` (kept as ``str`` on disk so the
+      file remains parseable even if a new type is added in a later
+      version).
+    * ``agent`` — emitting agent name, when known.
+    * ``payload`` — type-specific data (kept untyped to keep the schema
+      forward-compatible).
+    """
+
+    ts: float
+    type: str
+    agent: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_json_line(self) -> str:
+        obj: dict[str, Any] = {
+            "ts": self.ts,
+            "type": self.type,
+            "payload": self.payload,
+        }
+        if self.agent is not None:
+            obj["agent"] = self.agent
+        return json.dumps(obj, default=str, ensure_ascii=False)
+
+    @classmethod
+    def from_json_line(cls, line: str) -> EngagementEvent | None:
+        line = line.strip()
+        if not line:
+            return None
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(obj, dict):
+            return None
+        try:
+            return cls(
+                ts=float(obj.get("ts", 0.0)),
+                type=str(obj.get("type", "")),
+                agent=obj.get("agent"),
+                payload=obj.get("payload") or {},
+            )
+        except (TypeError, ValueError):
+            return None
+
+
+def _engagement_events_path(workspace_root: Path, engagement_id: str) -> Path:
+    return workspace_root / "engagements" / engagement_id / "events.jsonl"
+
+
+def _acquire_lock(fd: int) -> None:
+    if _WINDOWS:
+        while True:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                time.sleep(0.01)
+    else:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+
+
+def _release_lock(fd: int) -> None:
+    if _WINDOWS:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    else:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+class EventLog:
+    """Append-only events.jsonl writer for one engagement.
+
+    Instances are cheap; create one per engagement and reuse it for the
+    lifetime of the run. ``append()`` is safe under concurrent threads
+    (via the in-process ``_lock``) and concurrent processes (via the
+    platform file lock). A torn write attempt (process killed
+    mid-write) cannot corrupt earlier events — the lock blocks any
+    second writer until the current line is fully flushed and the lock
+    released.
+    """
+
+    def __init__(self, workspace_root: str | os.PathLike[str], engagement_id: str) -> None:
+        self._engagement_id = engagement_id
+        self._path = _engagement_events_path(Path(workspace_root), engagement_id)
+        self._lock = threading.RLock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def engagement_id(self) -> str:
+        return self._engagement_id
+
+    def append(
+        self,
+        event_type: str | EventType,
+        payload: dict[str, Any] | None = None,
+        *,
+        agent: str | None = None,
+        ts: float | None = None,
+    ) -> EngagementEvent:
+        """Append one event line atomically. Returns the rendered event."""
+        if isinstance(event_type, EventType):
+            type_str = event_type.value
+        else:
+            type_str = str(event_type)
+        event = EngagementEvent(
+            ts=ts if ts is not None else time.time(),
+            type=type_str,
+            agent=agent,
+            payload=payload or {},
+        )
+        line = event.to_json_line() + "\n"
+        with self._lock:
+            with open(self._path, "ab") as fh:
+                fd = fh.fileno()
+                _acquire_lock(fd)
+                try:
+                    fh.write(line.encode("utf-8"))
+                    fh.flush()
+                    os.fsync(fd)
+                finally:
+                    _release_lock(fd)
+        return event
+
+    def read(self) -> Iterator[EngagementEvent]:
+        """Iterate events in the order they were appended.
+
+        Malformed or torn lines are skipped silently so a process killed
+        mid-write cannot make the entire log unreadable.
+        """
+        yield from read_events(self._path)
+
+
+def read_events(path: str | os.PathLike[str]) -> Iterator[EngagementEvent]:
+    """Yield :class:`EngagementEvent` objects from ``path`` in order."""
+    p = Path(path)
+    if not p.exists():
+        return
+    with open(p, "rb") as fh:
+        for raw in fh:
+            try:
+                line = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            event = EngagementEvent.from_json_line(line)
+            if event is not None:
+                yield event
+
+
+__all__ = [
+    "EngagementEvent",
+    "EventLog",
+    "EventType",
+    "read_events",
+]

--- a/packages/decepticon/decepticon/runtime/event_log.py
+++ b/packages/decepticon/decepticon/runtime/event_log.py
@@ -37,12 +37,6 @@ from typing import Any
 log = logging.getLogger("decepticon.runtime.event_log")
 
 
-if sys.platform == "win32":
-    import msvcrt
-else:
-    import fcntl
-
-
 class EventType(str, Enum):
     """All engagement event types the orchestrator may emit."""
 
@@ -116,6 +110,8 @@ def _engagement_events_path(workspace_root: Path, engagement_id: str) -> Path:
 
 def _acquire_lock(fd: int) -> None:
     if sys.platform == "win32":
+        import msvcrt
+
         while True:
             try:
                 msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
@@ -123,16 +119,22 @@ def _acquire_lock(fd: int) -> None:
             except OSError:
                 time.sleep(0.01)
     else:
+        import fcntl
+
         fcntl.flock(fd, fcntl.LOCK_EX)
 
 
 def _release_lock(fd: int) -> None:
     if sys.platform == "win32":
+        import msvcrt
+
         try:
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
         except OSError:
             pass
     else:
+        import fcntl
+
         fcntl.flock(fd, fcntl.LOCK_UN)
 
 

--- a/packages/decepticon/decepticon/runtime/event_log.py
+++ b/packages/decepticon/decepticon/runtime/event_log.py
@@ -37,9 +37,7 @@ from typing import Any
 log = logging.getLogger("decepticon.runtime.event_log")
 
 
-_WINDOWS = sys.platform == "win32"
-
-if _WINDOWS:
+if sys.platform == "win32":
     import msvcrt
 else:
     import fcntl
@@ -117,7 +115,7 @@ def _engagement_events_path(workspace_root: Path, engagement_id: str) -> Path:
 
 
 def _acquire_lock(fd: int) -> None:
-    if _WINDOWS:
+    if sys.platform == "win32":
         while True:
             try:
                 msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
@@ -129,7 +127,7 @@ def _acquire_lock(fd: int) -> None:
 
 
 def _release_lock(fd: int) -> None:
-    if _WINDOWS:
+    if sys.platform == "win32":
         try:
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
         except OSError:

--- a/packages/decepticon/tests/unit/runtime/test_event_log.py
+++ b/packages/decepticon/tests/unit/runtime/test_event_log.py
@@ -1,0 +1,137 @@
+"""Tests for ``decepticon.runtime.event_log`` — append-only engagement log."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import time
+from pathlib import Path
+
+from decepticon.runtime.event_log import (
+    EngagementEvent,
+    EventLog,
+    EventType,
+    read_events,
+)
+
+
+def test_append_writes_one_jsonl_line_per_event(tmp_path: Path) -> None:
+    log = EventLog(workspace_root=tmp_path, engagement_id="eng-1")
+    log.append(EventType.ENGAGEMENT_START, {"name": "demo"})
+    log.append(EventType.AGENT_TURN, {"turn": 1}, agent="decepticon")
+    log.append(EventType.ENGAGEMENT_END, {})
+
+    lines = log.path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    parsed = [json.loads(ln) for ln in lines]
+    assert parsed[0]["type"] == "engagement.start"
+    assert parsed[1]["type"] == "agent.turn"
+    assert parsed[1]["agent"] == "decepticon"
+    assert parsed[2]["type"] == "engagement.end"
+
+
+def test_read_returns_events_in_order(tmp_path: Path) -> None:
+    log = EventLog(workspace_root=tmp_path, engagement_id="eng-2")
+    log.append(EventType.ENGAGEMENT_START, {"i": 0})
+    log.append(EventType.TOOL_CALL, {"i": 1}, agent="recon")
+    log.append(EventType.TOOL_RESULT, {"i": 2}, agent="recon")
+    log.append(EventType.ENGAGEMENT_END, {"i": 3})
+
+    events = list(log.read())
+    assert [e.payload["i"] for e in events] == [0, 1, 2, 3]
+    assert events[1].agent == "recon"
+    assert events[2].type == "tool.result"
+
+
+def test_append_returns_rendered_event(tmp_path: Path) -> None:
+    log = EventLog(workspace_root=tmp_path, engagement_id="eng-3")
+    before = time.time()
+    event = log.append(EventType.FINDING_CREATED, {"id": "FIND-001"}, agent="exploit")
+    after = time.time()
+    assert event.type == "finding.created"
+    assert event.agent == "exploit"
+    assert event.payload == {"id": "FIND-001"}
+    assert before <= event.ts <= after
+
+
+def test_event_type_accepts_str(tmp_path: Path) -> None:
+    log = EventLog(workspace_root=tmp_path, engagement_id="eng-4")
+    log.append("custom.event", {"x": 1})
+    events = list(log.read())
+    assert events[0].type == "custom.event"
+
+
+def test_read_events_skips_malformed_lines(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    path.write_text(
+        '{"ts": 1.0, "type": "agent.turn", "payload": {}}\n'
+        "not valid json\n"
+        '{"ts": 2.0, "type": "tool.call", "payload": {"a": 1}}\n'
+        "\n"
+        '{"ts": 3.0, "type": "finding.created", "payload": {"id": "FIND-001"}}\n',
+        encoding="utf-8",
+    )
+    events = list(read_events(path))
+    assert len(events) == 3
+    assert [e.type for e in events] == ["agent.turn", "tool.call", "finding.created"]
+
+
+def test_read_events_handles_missing_file(tmp_path: Path) -> None:
+    assert list(read_events(tmp_path / "nope.jsonl")) == []
+
+
+def test_engagement_event_from_json_line_round_trips(tmp_path: Path) -> None:
+    event = EngagementEvent(ts=1.5, type="agent.turn", agent="decepticon", payload={"k": "v"})
+    line = event.to_json_line()
+    parsed = EngagementEvent.from_json_line(line)
+    assert parsed is not None
+    assert parsed.ts == 1.5
+    assert parsed.type == "agent.turn"
+    assert parsed.agent == "decepticon"
+    assert parsed.payload == {"k": "v"}
+
+
+def test_engagement_event_from_invalid_json_returns_none() -> None:
+    assert EngagementEvent.from_json_line("not json") is None
+    assert EngagementEvent.from_json_line("") is None
+    assert EngagementEvent.from_json_line("   ") is None
+    assert EngagementEvent.from_json_line("123") is None
+
+
+def test_path_lives_under_engagement_id(tmp_path: Path) -> None:
+    log = EventLog(workspace_root=tmp_path, engagement_id="eng-A")
+    expected = tmp_path / "engagements" / "eng-A" / "events.jsonl"
+    assert log.path == expected
+
+
+def test_concurrent_threads_do_not_interleave(tmp_path: Path) -> None:
+    """Atomicity smoke test: many threads appending must produce intact JSON lines."""
+    log = EventLog(workspace_root=tmp_path, engagement_id="concurrent")
+    total = 200
+
+    def _worker(i: int) -> None:
+        log.append(EventType.TOOL_CALL, {"i": i, "blob": "x" * 200})
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=12) as ex:
+        list(ex.map(_worker, range(total)))
+
+    events = list(log.read())
+    assert len(events) == total
+    assert sorted(e.payload["i"] for e in events) == list(range(total))
+
+
+def test_event_log_appends_to_existing_file(tmp_path: Path) -> None:
+    log_a = EventLog(workspace_root=tmp_path, engagement_id="eng-X")
+    log_a.append(EventType.ENGAGEMENT_START, {})
+    log_a.append(EventType.AGENT_TURN, {"turn": 1})
+
+    log_b = EventLog(workspace_root=tmp_path, engagement_id="eng-X")
+    log_b.append(EventType.AGENT_TURN, {"turn": 2})
+    log_b.append(EventType.ENGAGEMENT_END, {})
+
+    events = list(log_b.read())
+    assert len(events) == 4
+    assert events[0].type == "engagement.start"
+    assert events[1].payload["turn"] == 1
+    assert events[2].payload["turn"] == 2
+    assert events[3].type == "engagement.end"


### PR DESCRIPTION
## Summary

Add `decepticon.runtime.event_log` so the orchestrator (and a future `resume <engagement_id>` command) can durably record what happens during a run. The log survives crashes / Ctrl-C and is structured as a line-oriented append-only file under `engagements/<id>/events.jsonl`.

## Public surface

| Symbol | Purpose |
|---|---|
| `EventType` (str-enum) | engagement.start / .end / .checkpoint, agent.turn, tool.call / .result, llm.call / .response, finding.created, opplan.update |
| `EngagementEvent` (frozen dataclass) | ts / type / agent / payload + JSON round-trip |
| `EventLog(workspace_root, engagement_id)` | per-engagement writer; safe under concurrent threads + processes |
| `read_events(path)` | yields events in order; silently skips malformed / torn lines |

## Atomicity / durability

- `append()` is safe under concurrent threads (in-process `threading.RLock`) **and** concurrent processes (cross-platform file lock: `fcntl.flock` on POSIX, `msvcrt.locking` on Windows).
- Each write is followed by `flush()` + `os.fsync()` before the lock is released.
- A torn write by a killed process cannot corrupt earlier events — the lock blocks any second writer until the current line is fully flushed.
- `read_events()` silently skips malformed lines so a process killed mid-write cannot make the whole log unreadable.
- Event types are stored as `str` on disk so a newer Decepticon can add a type without breaking older readers.

## Deliberately deferred (follow-up PRs)

- Wiring `EventLog` into `decepticon.middleware.opplan` / `agents.standard.decepticon` so emit sites actually call `append()` at the natural boundaries.
- The `--resume <id>` CLI plumbing across the Go launcher (`clients/launcher/`), TS REPL (`clients/cli/`), and the Python middleware. Multi-layer wiring is its own PR.
- `engagement.checkpoint` emission from the graceful-shutdown handler (already lands in a separate PR; it appends to events.jsonl iff the file exists, so dependency ordering is forward-only).

The Python library + tests land first as the clean, dependency-free ground truth the integration PRs can adopt.

## Files

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/runtime/__init__.py` | exports public API |
| `packages/decepticon/decepticon/runtime/event_log.py` | new — 229 lines |
| `packages/decepticon/tests/unit/runtime/__init__.py` | empty package marker |
| `packages/decepticon/tests/unit/runtime/test_event_log.py` | new — 137 lines, 11 tests |

## Verification

- `uv run pytest packages/decepticon/tests/unit/runtime/test_event_log.py -q` → **11 passed**
- `uv run ruff check packages/decepticon/decepticon/runtime packages/decepticon/tests/unit/runtime` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

One-line-per-event JSONL output, in-order read, `append()` return value, `str`-typed event names accepted, malformed-line skipping during read, missing-file handling, `EngagementEvent` JSON round-trip, invalid-JSON returns `None`, per-engagement path layout, two `EventLog` instances appending to the same file in sequence, and a **200-thread concurrent atomicity smoke test** that asserts every line parses and no events were lost or interleaved.
