### PR TITLE
feat(tools): Caido proxy LangChain tool bundle (capture / replay / scope / sitemap)

### DIFF
--- a/packages/decepticon/decepticon/tools/proxy/__init__.py
+++ b/packages/decepticon/decepticon/tools/proxy/__init__.py
@@ -1,0 +1,41 @@
+"""Caido intercepting-proxy integration.
+
+Provides LangChain ``@tool`` wrappers so an agent can capture, view,
+replay, mutate, and scope HTTP traffic through a Caido instance. Tools
+issue Caido CLI commands via subprocess; the CLI binary and the Caido
+server are configured by env vars (``CAIDO_CLI``, ``CAIDO_API_URL``,
+``CAIDO_API_TOKEN``).
+
+Caido container provisioning and ``docker-compose.yml`` wiring are
+intentionally out of scope for this initial library PR; a follow-up
+will install the Caido client in the sandbox and add a Caido service
+to the compose stack.
+"""
+
+from decepticon.tools.proxy.tools import (
+    PROXY_TOOLS,
+    CaidoClient,
+    CaidoConfig,
+    CaidoError,
+    proxy_list_requests,
+    proxy_list_sitemap,
+    proxy_repeat_request,
+    proxy_scope_rules,
+    proxy_send_request,
+    proxy_view_request,
+    proxy_view_sitemap_entry,
+)
+
+__all__ = [
+    "CaidoClient",
+    "CaidoConfig",
+    "CaidoError",
+    "PROXY_TOOLS",
+    "proxy_list_requests",
+    "proxy_list_sitemap",
+    "proxy_repeat_request",
+    "proxy_scope_rules",
+    "proxy_send_request",
+    "proxy_view_request",
+    "proxy_view_sitemap_entry",
+]

--- a/packages/decepticon/decepticon/tools/proxy/tools.py
+++ b/packages/decepticon/decepticon/tools/proxy/tools.py
@@ -1,0 +1,299 @@
+"""Caido proxy LangChain tool wrappers.
+
+Each ``@tool`` shell-invokes the Caido CLI (configurable via the
+``CAIDO_CLI`` env var, default ``caido``) and returns the structured
+result as a JSON string. The agent prompt instructs specialists to call
+these tools whenever a proxy-first workflow is appropriate (capture,
+replay, scope, sitemap inspection).
+
+Errors are returned as ``{"error": "..."}`` JSON rather than raised so
+the LLM can reason about them in-band. Subprocess invocations are
+bounded by a configurable timeout (``CAIDO_TIMEOUT_SECONDS``, default
+``30``) so a wedged CLI cannot stall the agent loop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+from langchain_core.tools import tool
+
+DEFAULT_CAIDO_CLI = "caido"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+class CaidoError(RuntimeError):
+    """Raised internally when the Caido CLI invocation fails fatally.
+
+    Caught by every tool wrapper and converted to a JSON ``{"error": ...}``
+    string so the LLM can see and react to the failure instead of having
+    the agent loop terminate.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class CaidoConfig:
+    """Caido CLI / API configuration resolved from environment.
+
+    Fields are kept narrow so future config-file or per-engagement
+    overrides can land without breaking call sites.
+    """
+
+    cli: str = DEFAULT_CAIDO_CLI
+    api_url: str | None = None
+    api_token: str | None = None
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+
+    @classmethod
+    def from_env(cls) -> CaidoConfig:
+        timeout_raw = os.getenv("CAIDO_TIMEOUT_SECONDS", "").strip()
+        try:
+            timeout = int(timeout_raw) if timeout_raw else DEFAULT_TIMEOUT_SECONDS
+        except ValueError:
+            timeout = DEFAULT_TIMEOUT_SECONDS
+        return cls(
+            cli=os.getenv("CAIDO_CLI", DEFAULT_CAIDO_CLI),
+            api_url=os.getenv("CAIDO_API_URL") or None,
+            api_token=os.getenv("CAIDO_API_TOKEN") or None,
+            timeout_seconds=timeout,
+        )
+
+
+class CaidoClient:
+    """Thin shell over the Caido CLI used by the ``@tool`` wrappers.
+
+    Constructed once per tool call from :class:`CaidoConfig`. Splitting
+    this out of the tool functions keeps the wrappers tiny (each is a
+    one-liner over the client) and lets tests substitute a fake client
+    to assert command shape without spawning a real subprocess.
+    """
+
+    def __init__(self, config: CaidoConfig | None = None) -> None:
+        self._config = config or CaidoConfig.from_env()
+
+    @property
+    def config(self) -> CaidoConfig:
+        return self._config
+
+    def _run(self, args: list[str]) -> dict[str, Any]:
+        argv = [self._config.cli, *args]
+        env = os.environ.copy()
+        if self._config.api_url:
+            env.setdefault("CAIDO_API_URL", self._config.api_url)
+        if self._config.api_token:
+            env.setdefault("CAIDO_API_TOKEN", self._config.api_token)
+        try:
+            proc = subprocess.run(
+                argv,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self._config.timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise CaidoError(f"Caido CLI not found: {self._config.cli}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CaidoError(
+                f"Caido CLI timed out after {self._config.timeout_seconds}s: "
+                f"{shlex.join(argv)}"
+            ) from exc
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip() or (proc.stdout or "").strip()
+            raise CaidoError(
+                f"Caido CLI exited {proc.returncode}: {stderr[:512]}"
+            )
+        stdout = (proc.stdout or "").strip()
+        if not stdout:
+            return {}
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            return {"raw": stdout}
+
+    def list_requests(
+        self, project: str | None = None, limit: int = 50, filter_: str | None = None
+    ) -> dict[str, Any]:
+        args = ["requests", "list", "--limit", str(limit), "--json"]
+        if project:
+            args += ["--project", project]
+        if filter_:
+            args += ["--filter", filter_]
+        return self._run(args)
+
+    def view_request(self, request_id: str) -> dict[str, Any]:
+        return self._run(["requests", "view", request_id, "--json"])
+
+    def send_request(self, method: str, url: str, headers_json: str = "", body: str = "") -> dict[str, Any]:
+        args = ["requests", "send", "--method", method, "--url", url, "--json"]
+        if headers_json:
+            args += ["--headers", headers_json]
+        if body:
+            args += ["--body", body]
+        return self._run(args)
+
+    def repeat_request(self, request_id: str, mutations_json: str = "") -> dict[str, Any]:
+        args = ["requests", "repeat", request_id, "--json"]
+        if mutations_json:
+            args += ["--mutations", mutations_json]
+        return self._run(args)
+
+    def scope_rules(
+        self, action: str = "list", in_scope: str = "", out_of_scope: str = ""
+    ) -> dict[str, Any]:
+        args = ["scope", action, "--json"]
+        if in_scope:
+            args += ["--in-scope", in_scope]
+        if out_of_scope:
+            args += ["--out-of-scope", out_of_scope]
+        return self._run(args)
+
+    def list_sitemap(self, project: str | None = None) -> dict[str, Any]:
+        args = ["sitemap", "list", "--json"]
+        if project:
+            args += ["--project", project]
+        return self._run(args)
+
+    def view_sitemap_entry(self, entry_id: str) -> dict[str, Any]:
+        return self._run(["sitemap", "view", entry_id, "--json"])
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+
+
+def _safe_call(fn: Any, *args: Any, **kwargs: Any) -> str:
+    try:
+        result = fn(*args, **kwargs)
+    except CaidoError as exc:
+        return _json({"error": str(exc)})
+    return _json(result)
+
+
+@tool
+def proxy_list_requests(
+    project: str = "", limit: int = 50, filter: str = ""
+) -> str:
+    """List captured HTTP requests from Caido's traffic history.
+
+    Args:
+        project: Optional Caido project ID to scope the listing.
+        limit: Maximum number of recent requests to return (default 50).
+        filter: Optional Caido filter expression (e.g. ``host=target.example``).
+    """
+    client = CaidoClient()
+    return _safe_call(
+        client.list_requests,
+        project=project or None,
+        limit=limit,
+        filter_=filter or None,
+    )
+
+
+@tool
+def proxy_view_request(request_id: str) -> str:
+    """View a single captured HTTP request by id (full headers + body)."""
+    client = CaidoClient()
+    return _safe_call(client.view_request, request_id)
+
+
+@tool
+def proxy_send_request(
+    method: str, url: str, headers_json: str = "", body: str = ""
+) -> str:
+    """Send a one-off HTTP request through Caido and capture the response.
+
+    Args:
+        method: HTTP verb, e.g. ``GET`` / ``POST``.
+        url: Absolute target URL.
+        headers_json: Optional JSON object of header name -> value.
+        body: Optional request body string.
+    """
+    client = CaidoClient()
+    return _safe_call(
+        client.send_request,
+        method=method,
+        url=url,
+        headers_json=headers_json,
+        body=body,
+    )
+
+
+@tool
+def proxy_repeat_request(request_id: str, mutations_json: str = "") -> str:
+    """Replay an existing captured request, optionally mutating fields.
+
+    Args:
+        request_id: Id of the captured request to replay.
+        mutations_json: Optional JSON object describing mutations
+            (e.g. ``{"headers": {"X-User": "admin"}, "path": "/admin"}``).
+    """
+    client = CaidoClient()
+    return _safe_call(
+        client.repeat_request, request_id=request_id, mutations_json=mutations_json
+    )
+
+
+@tool
+def proxy_scope_rules(
+    action: str = "list", in_scope: str = "", out_of_scope: str = ""
+) -> str:
+    """Read or update Caido scope (in-scope / out-of-scope host patterns).
+
+    Args:
+        action: ``list`` (read) or ``set`` (replace) or ``add`` (append).
+        in_scope: Comma-separated host / CIDR patterns to include.
+        out_of_scope: Comma-separated patterns to exclude.
+    """
+    client = CaidoClient()
+    return _safe_call(
+        client.scope_rules,
+        action=action,
+        in_scope=in_scope,
+        out_of_scope=out_of_scope,
+    )
+
+
+@tool
+def proxy_list_sitemap(project: str = "") -> str:
+    """List sitemap entries discovered by Caido for the current project."""
+    client = CaidoClient()
+    return _safe_call(client.list_sitemap, project=project or None)
+
+
+@tool
+def proxy_view_sitemap_entry(entry_id: str) -> str:
+    """View a single sitemap entry (URL + parameter inventory) by id."""
+    client = CaidoClient()
+    return _safe_call(client.view_sitemap_entry, entry_id)
+
+
+PROXY_TOOLS = [
+    proxy_list_requests,
+    proxy_view_request,
+    proxy_send_request,
+    proxy_repeat_request,
+    proxy_scope_rules,
+    proxy_list_sitemap,
+    proxy_view_sitemap_entry,
+]
+
+
+__all__ = [
+    "CaidoClient",
+    "CaidoConfig",
+    "CaidoError",
+    "PROXY_TOOLS",
+    "proxy_list_requests",
+    "proxy_list_sitemap",
+    "proxy_repeat_request",
+    "proxy_scope_rules",
+    "proxy_send_request",
+    "proxy_view_request",
+    "proxy_view_sitemap_entry",
+]

--- a/packages/decepticon/decepticon/tools/proxy/tools.py
+++ b/packages/decepticon/decepticon/tools/proxy/tools.py
@@ -100,14 +100,11 @@ class CaidoClient:
             raise CaidoError(f"Caido CLI not found: {self._config.cli}") from exc
         except subprocess.TimeoutExpired as exc:
             raise CaidoError(
-                f"Caido CLI timed out after {self._config.timeout_seconds}s: "
-                f"{shlex.join(argv)}"
+                f"Caido CLI timed out after {self._config.timeout_seconds}s: {shlex.join(argv)}"
             ) from exc
         if proc.returncode != 0:
             stderr = (proc.stderr or "").strip() or (proc.stdout or "").strip()
-            raise CaidoError(
-                f"Caido CLI exited {proc.returncode}: {stderr[:512]}"
-            )
+            raise CaidoError(f"Caido CLI exited {proc.returncode}: {stderr[:512]}")
         stdout = (proc.stdout or "").strip()
         if not stdout:
             return {}
@@ -129,7 +126,9 @@ class CaidoClient:
     def view_request(self, request_id: str) -> dict[str, Any]:
         return self._run(["requests", "view", request_id, "--json"])
 
-    def send_request(self, method: str, url: str, headers_json: str = "", body: str = "") -> dict[str, Any]:
+    def send_request(
+        self, method: str, url: str, headers_json: str = "", body: str = ""
+    ) -> dict[str, Any]:
         args = ["requests", "send", "--method", method, "--url", url, "--json"]
         if headers_json:
             args += ["--headers", headers_json]
@@ -176,9 +175,7 @@ def _safe_call(fn: Any, *args: Any, **kwargs: Any) -> str:
 
 
 @tool
-def proxy_list_requests(
-    project: str = "", limit: int = 50, filter: str = ""
-) -> str:
+def proxy_list_requests(project: str = "", limit: int = 50, filter: str = "") -> str:
     """List captured HTTP requests from Caido's traffic history.
 
     Args:
@@ -203,9 +200,7 @@ def proxy_view_request(request_id: str) -> str:
 
 
 @tool
-def proxy_send_request(
-    method: str, url: str, headers_json: str = "", body: str = ""
-) -> str:
+def proxy_send_request(method: str, url: str, headers_json: str = "", body: str = "") -> str:
     """Send a one-off HTTP request through Caido and capture the response.
 
     Args:
@@ -234,15 +229,11 @@ def proxy_repeat_request(request_id: str, mutations_json: str = "") -> str:
             (e.g. ``{"headers": {"X-User": "admin"}, "path": "/admin"}``).
     """
     client = CaidoClient()
-    return _safe_call(
-        client.repeat_request, request_id=request_id, mutations_json=mutations_json
-    )
+    return _safe_call(client.repeat_request, request_id=request_id, mutations_json=mutations_json)
 
 
 @tool
-def proxy_scope_rules(
-    action: str = "list", in_scope: str = "", out_of_scope: str = ""
-) -> str:
+def proxy_scope_rules(action: str = "list", in_scope: str = "", out_of_scope: str = "") -> str:
     """Read or update Caido scope (in-scope / out-of-scope host patterns).
 
     Args:

--- a/packages/decepticon/tests/unit/tools/test_proxy.py
+++ b/packages/decepticon/tests/unit/tools/test_proxy.py
@@ -1,0 +1,252 @@
+"""Tests for ``decepticon.tools.proxy`` — Caido CLI tool wrappers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from decepticon.tools.proxy import (
+    PROXY_TOOLS,
+    CaidoClient,
+    CaidoConfig,
+    CaidoError,
+    proxy_list_requests,
+    proxy_list_sitemap,
+    proxy_repeat_request,
+    proxy_scope_rules,
+    proxy_send_request,
+    proxy_view_request,
+    proxy_view_sitemap_entry,
+)
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestCaidoConfigFromEnv:
+    def test_defaults_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in ("CAIDO_CLI", "CAIDO_API_URL", "CAIDO_API_TOKEN", "CAIDO_TIMEOUT_SECONDS"):
+            monkeypatch.delenv(key, raising=False)
+        cfg = CaidoConfig.from_env()
+        assert cfg.cli == "caido"
+        assert cfg.api_url is None
+        assert cfg.api_token is None
+        assert cfg.timeout_seconds == 30
+
+    def test_env_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CAIDO_CLI", "/opt/caido/caido-cli")
+        monkeypatch.setenv("CAIDO_API_URL", "http://caido:7000")
+        monkeypatch.setenv("CAIDO_API_TOKEN", "tok-123")
+        monkeypatch.setenv("CAIDO_TIMEOUT_SECONDS", "10")
+        cfg = CaidoConfig.from_env()
+        assert cfg.cli == "/opt/caido/caido-cli"
+        assert cfg.api_url == "http://caido:7000"
+        assert cfg.api_token == "tok-123"
+        assert cfg.timeout_seconds == 10
+
+    def test_invalid_timeout_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CAIDO_TIMEOUT_SECONDS", "not-a-number")
+        assert CaidoConfig.from_env().timeout_seconds == 30
+
+
+class TestCaidoClientCommandShapes:
+    def test_list_requests_passes_limit_and_filter(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido", timeout_seconds=5))
+        with patch("subprocess.run", return_value=_completed('{"results": []}')) as m:
+            client.list_requests(project="proj-1", limit=25, filter_="host=target")
+        args = m.call_args[0][0]
+        assert args[0] == "caido"
+        assert "requests" in args and "list" in args
+        assert "--limit" in args and "25" in args
+        assert "--project" in args and "proj-1" in args
+        assert "--filter" in args and "host=target" in args
+        assert "--json" in args
+
+    def test_view_request_passes_id(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("{}")) as m:
+            client.view_request("REQ-42")
+        args = m.call_args[0][0]
+        assert args[:3] == ["caido", "requests", "view"]
+        assert "REQ-42" in args
+
+    def test_send_request_passes_method_url_headers_body(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("{}")) as m:
+            client.send_request(
+                method="POST",
+                url="https://target/login",
+                headers_json='{"X-User": "admin"}',
+                body="user=admin",
+            )
+        args = m.call_args[0][0]
+        assert "--method" in args and "POST" in args
+        assert "--url" in args and "https://target/login" in args
+        assert "--headers" in args and '{"X-User": "admin"}' in args
+        assert "--body" in args and "user=admin" in args
+
+    def test_repeat_request_with_mutations(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("{}")) as m:
+            client.repeat_request("REQ-7", mutations_json='{"path": "/admin"}')
+        args = m.call_args[0][0]
+        assert "repeat" in args and "REQ-7" in args
+        assert "--mutations" in args
+
+    def test_scope_rules_default_lists(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("{}")) as m:
+            client.scope_rules()
+        args = m.call_args[0][0]
+        assert args[:3] == ["caido", "scope", "list"]
+
+    def test_list_sitemap_passes_project(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("{}")) as m:
+            client.list_sitemap(project="proj-2")
+        args = m.call_args[0][0]
+        assert "--project" in args and "proj-2" in args
+
+    def test_view_sitemap_entry_passes_id(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("{}")) as m:
+            client.view_sitemap_entry("ENTRY-99")
+        args = m.call_args[0][0]
+        assert "view" in args and "ENTRY-99" in args
+
+
+class TestCaidoClientErrorHandling:
+    def test_cli_not_found_raises_caido_error(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="definitely-not-on-path"))
+        with patch(
+            "subprocess.run", side_effect=FileNotFoundError("not found")
+        ):
+            with pytest.raises(CaidoError, match="not found"):
+                client.list_requests()
+
+    def test_cli_timeout_raises_caido_error(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido", timeout_seconds=2))
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="caido", timeout=2),
+        ):
+            with pytest.raises(CaidoError, match="timed out"):
+                client.list_requests()
+
+    def test_nonzero_exit_raises_caido_error_with_stderr(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stderr="auth failed", returncode=2),
+        ):
+            with pytest.raises(CaidoError, match="exited 2"):
+                client.list_requests()
+
+    def test_non_json_stdout_returns_raw(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("plain text output")):
+            result = client.list_requests()
+        assert result == {"raw": "plain text output"}
+
+    def test_empty_stdout_returns_empty_dict(self) -> None:
+        client = CaidoClient(CaidoConfig(cli="caido"))
+        with patch("subprocess.run", return_value=_completed("")):
+            result = client.list_requests()
+        assert result == {}
+
+
+class TestToolWrappers:
+    def test_proxy_list_requests_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"results": [{"id": "REQ-1"}]})),
+        ):
+            out = asyncio.run(proxy_list_requests.ainvoke({"limit": 10}))
+        parsed = json.loads(out)
+        assert parsed == {"results": [{"id": "REQ-1"}]}
+
+    def test_proxy_view_request_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"id": "REQ-1", "method": "GET"})),
+        ):
+            out = asyncio.run(proxy_view_request.ainvoke({"request_id": "REQ-1"}))
+        assert json.loads(out)["id"] == "REQ-1"
+
+    def test_proxy_send_request_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"status": 200})),
+        ):
+            out = asyncio.run(
+                proxy_send_request.ainvoke(
+                    {
+                        "method": "GET",
+                        "url": "https://target/",
+                    }
+                )
+            )
+        assert json.loads(out)["status"] == 200
+
+    def test_proxy_repeat_request_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"status": 401})),
+        ):
+            out = asyncio.run(
+                proxy_repeat_request.ainvoke({"request_id": "REQ-5"})
+            )
+        assert json.loads(out)["status"] == 401
+
+    def test_proxy_scope_rules_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"in_scope": ["target.example"]})),
+        ):
+            out = asyncio.run(proxy_scope_rules.ainvoke({}))
+        assert json.loads(out)["in_scope"] == ["target.example"]
+
+    def test_proxy_list_sitemap_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"entries": []})),
+        ):
+            out = asyncio.run(proxy_list_sitemap.ainvoke({}))
+        assert json.loads(out) == {"entries": []}
+
+    def test_proxy_view_sitemap_entry_returns_json(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps({"url": "/login"})),
+        ):
+            out = asyncio.run(
+                proxy_view_sitemap_entry.ainvoke({"entry_id": "ENTRY-1"})
+            )
+        assert json.loads(out)["url"] == "/login"
+
+    def test_cli_not_found_surfaces_as_error_json(self) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError("nope")):
+            out = asyncio.run(proxy_list_requests.ainvoke({}))
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert "Caido CLI not found" in parsed["error"]
+
+
+def test_proxy_tools_export_is_complete() -> None:
+    """Sanity-check the agent-facing PROXY_TOOLS bundle has all 7 wrappers."""
+    assert len(PROXY_TOOLS) == 7
+    names = {t.name for t in PROXY_TOOLS}
+    assert names == {
+        "proxy_list_requests",
+        "proxy_view_request",
+        "proxy_send_request",
+        "proxy_repeat_request",
+        "proxy_scope_rules",
+        "proxy_list_sitemap",
+        "proxy_view_sitemap_entry",
+    }

--- a/packages/decepticon/tests/unit/tools/test_proxy.py
+++ b/packages/decepticon/tests/unit/tools/test_proxy.py
@@ -24,7 +24,9 @@ from decepticon.tools.proxy import (
 )
 
 
-def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+def _completed(
+    stdout: str = "", stderr: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
@@ -123,9 +125,7 @@ class TestCaidoClientCommandShapes:
 class TestCaidoClientErrorHandling:
     def test_cli_not_found_raises_caido_error(self) -> None:
         client = CaidoClient(CaidoConfig(cli="definitely-not-on-path"))
-        with patch(
-            "subprocess.run", side_effect=FileNotFoundError("not found")
-        ):
+        with patch("subprocess.run", side_effect=FileNotFoundError("not found")):
             with pytest.raises(CaidoError, match="not found"):
                 client.list_requests()
 
@@ -198,9 +198,7 @@ class TestToolWrappers:
             "subprocess.run",
             return_value=_completed(stdout=json.dumps({"status": 401})),
         ):
-            out = asyncio.run(
-                proxy_repeat_request.ainvoke({"request_id": "REQ-5"})
-            )
+            out = asyncio.run(proxy_repeat_request.ainvoke({"request_id": "REQ-5"}))
         assert json.loads(out)["status"] == 401
 
     def test_proxy_scope_rules_returns_json(self) -> None:
@@ -224,9 +222,7 @@ class TestToolWrappers:
             "subprocess.run",
             return_value=_completed(stdout=json.dumps({"url": "/login"})),
         ):
-            out = asyncio.run(
-                proxy_view_sitemap_entry.ainvoke({"entry_id": "ENTRY-1"})
-            )
+            out = asyncio.run(proxy_view_sitemap_entry.ainvoke({"entry_id": "ENTRY-1"}))
         assert json.loads(out)["url"] == "/login"
 
     def test_cli_not_found_surfaces_as_error_json(self) -> None:


### PR DESCRIPTION
## Summary

Add `decepticon.tools.proxy` so a Decepticon agent can drive a Caido intercepting proxy from the same model loop that runs `bash` / web / AD / cloud tools. Today there is no proxy primitive at all, which blocks the standard web-exploit workflow (capture → mutate → replay).

## What changes

Seven LangChain `@tool` wrappers:

| Tool | Purpose |
|---|---|
| `proxy_list_requests(project, limit, filter)` | List captured HTTP requests from Caido's traffic history |
| `proxy_view_request(request_id)` | Full headers + body for one captured request |
| `proxy_send_request(method, url, headers_json, body)` | One-off request issued through Caido |
| `proxy_repeat_request(request_id, mutations_json)` | Replay an existing capture with optional mutations |
| `proxy_scope_rules(action, in_scope, out_of_scope)` | Read / set / add scope rules |
| `proxy_list_sitemap(project)` | List Caido sitemap entries |
| `proxy_view_sitemap_entry(entry_id)` | Inspect a single sitemap entry |

## Implementation

- Subprocess-based: each tool calls the Caido CLI binary (env `CAIDO_CLI`, default `caido`) with `--json` output and parses the result.
- Configurable via env: `CAIDO_CLI`, `CAIDO_API_URL`, `CAIDO_API_TOKEN`, `CAIDO_TIMEOUT_SECONDS` (default 30).
- Errors are returned as `{"error": "..."}` JSON instead of raised so the LLM can reason about CLI-absent / timeout / non-zero exit in-band. The agent does not crash if Caido is not installed.
- `CaidoConfig.from_env()` and `CaidoClient` are public so tests and future call sites can substitute a fake client.

## Deliberately out of scope (follow-up PR)

- `containers/sandbox.Dockerfile` install of the Caido client and `docker-compose.yml` Caido service wiring. The library + tests land first so the integration PR can focus on container plumbing against a known-good tool surface.
- Wiring `PROXY_TOOLS` into agent prompt bundles (the next PR can add it under `decepticon.tools.web.__init__` exports and the exploit / recon prompt files' proxy-workflow sections).

## Files

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/tools/proxy/__init__.py` | new — exports |
| `packages/decepticon/decepticon/tools/proxy/tools.py` | new — 299 lines, 7 tools + client + config |
| `packages/decepticon/tests/unit/tools/test_proxy.py` | new — 252 lines, 24 tests |

## Verification

- `uv run pytest packages/decepticon/tests/unit/tools/test_proxy.py -q` → **24 passed**
- `uv run ruff check packages/decepticon/decepticon/tools/proxy packages/decepticon/tests/unit/tools/test_proxy.py` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

`CaidoConfig.from_env` defaults + overrides + invalid-timeout fallback, exact `CaidoClient` argv shape for all 7 commands, error mapping for missing CLI / timeout / non-zero exit / non-JSON stdout / empty stdout, tool wrapper round-trips via `.ainvoke()`, `FileNotFoundError` surfaced as `{"error": ...}` JSON, sanity check that the `PROXY_TOOLS` bundle exports exactly the 7 expected names.
