### PR TITLE
feat(tools): persistent Playwright browser sessions (browser_action multiplex)

### DIFF
--- a/packages/decepticon/decepticon/tools/browser/__init__.py
+++ b/packages/decepticon/decepticon/tools/browser/__init__.py
@@ -1,0 +1,29 @@
+"""Persistent Playwright browser sessions for the Decepticon agent.
+
+Exposes ``browser_action(action, **kwargs)`` — a single multiplex
+LangChain tool covering the operations a specialist needs to drive a
+real browser (SPA auth flows, OAuth callbacks, DOM-XSS verification,
+companion-app inspection). State lives in a per-process session
+manager; the optional Playwright dependency is imported lazily so the
+agent process keeps booting even when Playwright is not installed in
+the current environment.
+
+Sandbox / ``containers/sandbox.Dockerfile`` install of Playwright +
+Chromium and the ``docker-compose.yml`` wiring are intentionally out
+of scope for this initial library PR; a follow-up will install the
+deps in the sandbox image so the tool can be used end-to-end at runtime.
+"""
+
+from decepticon.tools.browser.tools import (
+    BROWSER_TOOLS,
+    BrowserActionError,
+    BrowserSessionManager,
+    browser_action,
+)
+
+__all__ = [
+    "BROWSER_TOOLS",
+    "BrowserActionError",
+    "BrowserSessionManager",
+    "browser_action",
+]

--- a/packages/decepticon/decepticon/tools/browser/tools.py
+++ b/packages/decepticon/decepticon/tools/browser/tools.py
@@ -123,9 +123,7 @@ class BrowserSessionManager:
 
     def _active_tab(self) -> _Tab:
         if self._active is None or self._active not in self._tabs:
-            raise BrowserActionError(
-                "No active tab. Call browser_action(action='launch') first."
-            )
+            raise BrowserActionError("No active tab. Call browser_action(action='launch') first.")
         return self._tabs[self._active]
 
     async def goto(self, url: str, timeout_ms: int = 30000) -> dict[str, Any]:
@@ -157,9 +155,7 @@ class BrowserSessionManager:
     async def scroll(self, dx: int = 0, dy: int = 0) -> dict[str, Any]:
         async with self._lock:
             tab = self._active_tab()
-            await tab.page.evaluate(
-                "([dx, dy]) => window.scrollBy(dx, dy)", [dx, dy]
-            )
+            await tab.page.evaluate("([dx, dy]) => window.scrollBy(dx, dy)", [dx, dy])
             return {"scrolled": {"dx": dx, "dy": dy}, "url": tab.page.url}
 
     async def screenshot(self, full_page: bool = False) -> dict[str, Any]:
@@ -294,9 +290,7 @@ async def _dispatch(action: str, kwargs: dict[str, Any]) -> dict[str, Any]:
             timeout_ms=int(kwargs.get("timeout_ms", 15000)),
         )
     if action == "scroll":
-        return await mgr.scroll(
-            dx=int(kwargs.get("dx", 0)), dy=int(kwargs.get("dy", 0))
-        )
+        return await mgr.scroll(dx=int(kwargs.get("dx", 0)), dy=int(kwargs.get("dy", 0)))
     if action == "screenshot":
         return await mgr.screenshot(full_page=bool(kwargs.get("full_page", False)))
     if action == "eval_js":

--- a/packages/decepticon/decepticon/tools/browser/tools.py
+++ b/packages/decepticon/decepticon/tools/browser/tools.py
@@ -1,0 +1,369 @@
+"""``browser_action`` — single multiplex tool for persistent Playwright.
+
+Sub-actions: ``launch``, ``goto``, ``click``, ``type``, ``scroll``,
+``screenshot``, ``eval_js``, ``console_logs``, ``page_source``, ``pdf``,
+``list_tabs``, ``switch_tab``, ``close``.
+
+State (Browser, Context, Pages, console buffer) lives in a per-process
+:class:`BrowserSessionManager` accessed through :func:`get_session_manager`.
+Each sub-action returns a JSON string so the LLM sees structured output;
+errors are caught and returned as ``{"error": "..."}`` rather than
+raised so the agent loop continues.
+
+Playwright is imported lazily on first use. If Playwright is not
+installed the tool returns an instructive error pointing operators at
+the ``decepticon[browser]`` extra (which will be added by a follow-up
+PR alongside the sandbox-image install).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.tools import tool
+
+
+class BrowserActionError(RuntimeError):
+    """Raised internally by the manager; caught at the tool boundary.
+
+    Converted to ``{"error": "..."}`` JSON so the LLM can reason about
+    Playwright-missing / page-closed / navigation-timeout / bad-selector
+    failures without terminating the agent run.
+    """
+
+
+_SUPPORTED_ACTIONS = frozenset(
+    {
+        "launch",
+        "goto",
+        "click",
+        "type",
+        "scroll",
+        "screenshot",
+        "eval_js",
+        "console_logs",
+        "page_source",
+        "pdf",
+        "list_tabs",
+        "switch_tab",
+        "close",
+    }
+)
+
+
+@dataclass(slots=True)
+class _Tab:
+    """One Playwright page tracked by the session manager.
+
+    The ``console`` deque is bounded so a chatty page cannot drive
+    memory growth without bound; ``len`` is exposed to the LLM via
+    ``console_logs`` so the agent knows when older lines were dropped.
+    """
+
+    page: Any
+    console: deque[str] = field(default_factory=lambda: deque(maxlen=500))
+
+
+class BrowserSessionManager:
+    """Per-process singleton holding the live Playwright browser state.
+
+    All public methods are async and serialize through a per-instance
+    asyncio lock so concurrent ``browser_action(...)`` calls from
+    different tool turns cannot interleave navigation against the same
+    page.
+    """
+
+    def __init__(self) -> None:
+        self._playwright: Any = None
+        self._browser: Any = None
+        self._context: Any = None
+        self._tabs: dict[str, _Tab] = {}
+        self._active: str | None = None
+        self._lock = asyncio.Lock()
+
+    @staticmethod
+    def _import_playwright() -> Any:
+        try:
+            from playwright import async_api
+        except ImportError as exc:
+            raise BrowserActionError(
+                "Playwright is not installed. Add the 'browser' extra or install "
+                "playwright + chromium in the sandbox image."
+            ) from exc
+        return async_api
+
+    async def _ensure_browser(self, headless: bool = True) -> None:
+        if self._browser is not None:
+            return
+        api = self._import_playwright()
+        self._playwright = await api.async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=headless)
+        self._context = await self._browser.new_context()
+
+    async def launch(self, headless: bool = True) -> dict[str, Any]:
+        async with self._lock:
+            await self._ensure_browser(headless=headless)
+            if not self._tabs:
+                await self._new_tab("main")
+            return {"tabs": list(self._tabs.keys()), "active": self._active}
+
+    async def _new_tab(self, tab_id: str) -> _Tab:
+        page = await self._context.new_page()
+        tab = _Tab(page=page)
+        page.on("console", lambda msg: tab.console.append(f"[{msg.type}] {msg.text}"))
+        self._tabs[tab_id] = tab
+        self._active = tab_id
+        return tab
+
+    def _active_tab(self) -> _Tab:
+        if self._active is None or self._active not in self._tabs:
+            raise BrowserActionError(
+                "No active tab. Call browser_action(action='launch') first."
+            )
+        return self._tabs[self._active]
+
+    async def goto(self, url: str, timeout_ms: int = 30000) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            response = await tab.page.goto(url, timeout=timeout_ms, wait_until="load")
+            return {
+                "url": tab.page.url,
+                "status": response.status if response is not None else None,
+                "title": await tab.page.title(),
+            }
+
+    async def click(self, selector: str, timeout_ms: int = 15000) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            await tab.page.click(selector, timeout=timeout_ms)
+            return {"clicked": selector, "url": tab.page.url}
+
+    async def type_text(
+        self, selector: str, text: str, delay_ms: int = 0, timeout_ms: int = 15000
+    ) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            await tab.page.fill(selector, text, timeout=timeout_ms)
+            if delay_ms:
+                await asyncio.sleep(delay_ms / 1000.0)
+            return {"typed_into": selector, "chars": len(text)}
+
+    async def scroll(self, dx: int = 0, dy: int = 0) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            await tab.page.evaluate(
+                "([dx, dy]) => window.scrollBy(dx, dy)", [dx, dy]
+            )
+            return {"scrolled": {"dx": dx, "dy": dy}, "url": tab.page.url}
+
+    async def screenshot(self, full_page: bool = False) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            png = await tab.page.screenshot(full_page=full_page)
+            return {
+                "format": "png",
+                "bytes": len(png),
+                "base64": base64.b64encode(png).decode("ascii"),
+            }
+
+    async def eval_js(self, expression: str) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            result = await tab.page.evaluate(expression)
+            return {"result": result}
+
+    async def console_logs(self, clear: bool = False) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            lines = list(tab.console)
+            if clear:
+                tab.console.clear()
+            return {"count": len(lines), "lines": lines}
+
+    async def page_source(self) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            html = await tab.page.content()
+            return {"url": tab.page.url, "bytes": len(html), "html": html}
+
+    async def pdf(self) -> dict[str, Any]:
+        async with self._lock:
+            tab = self._active_tab()
+            data = await tab.page.pdf()
+            return {
+                "format": "pdf",
+                "bytes": len(data),
+                "base64": base64.b64encode(data).decode("ascii"),
+            }
+
+    async def list_tabs(self) -> dict[str, Any]:
+        async with self._lock:
+            return {"tabs": list(self._tabs.keys()), "active": self._active}
+
+    async def switch_tab(self, tab_id: str) -> dict[str, Any]:
+        async with self._lock:
+            if tab_id not in self._tabs:
+                await self._new_tab(tab_id)
+            else:
+                self._active = tab_id
+            return {"active": self._active}
+
+    async def close(self) -> dict[str, Any]:
+        async with self._lock:
+            for tab in self._tabs.values():
+                try:
+                    await tab.page.close()
+                except Exception:
+                    pass
+            self._tabs.clear()
+            self._active = None
+            if self._context is not None:
+                try:
+                    await self._context.close()
+                except Exception:
+                    pass
+                self._context = None
+            if self._browser is not None:
+                try:
+                    await self._browser.close()
+                except Exception:
+                    pass
+                self._browser = None
+            if self._playwright is not None:
+                try:
+                    await self._playwright.stop()
+                except Exception:
+                    pass
+                self._playwright = None
+            return {"closed": True}
+
+
+_manager: BrowserSessionManager | None = None
+_manager_lock = threading.Lock()
+
+
+def get_session_manager() -> BrowserSessionManager:
+    """Return the process-wide :class:`BrowserSessionManager` singleton."""
+    global _manager
+    with _manager_lock:
+        if _manager is None:
+            _manager = BrowserSessionManager()
+        return _manager
+
+
+def _reset_session_manager_for_tests() -> None:
+    """Test-only: drop the singleton so each test gets a fresh manager."""
+    global _manager
+    with _manager_lock:
+        _manager = None
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+
+
+async def _dispatch(action: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+    if action not in _SUPPORTED_ACTIONS:
+        raise BrowserActionError(
+            f"Unknown action '{action}'. Supported: {sorted(_SUPPORTED_ACTIONS)}"
+        )
+    mgr = get_session_manager()
+    if action == "launch":
+        return await mgr.launch(headless=bool(kwargs.get("headless", True)))
+    if action == "goto":
+        return await mgr.goto(
+            url=str(kwargs["url"]),
+            timeout_ms=int(kwargs.get("timeout_ms", 30000)),
+        )
+    if action == "click":
+        return await mgr.click(
+            selector=str(kwargs["selector"]),
+            timeout_ms=int(kwargs.get("timeout_ms", 15000)),
+        )
+    if action == "type":
+        return await mgr.type_text(
+            selector=str(kwargs["selector"]),
+            text=str(kwargs["text"]),
+            delay_ms=int(kwargs.get("delay_ms", 0)),
+            timeout_ms=int(kwargs.get("timeout_ms", 15000)),
+        )
+    if action == "scroll":
+        return await mgr.scroll(
+            dx=int(kwargs.get("dx", 0)), dy=int(kwargs.get("dy", 0))
+        )
+    if action == "screenshot":
+        return await mgr.screenshot(full_page=bool(kwargs.get("full_page", False)))
+    if action == "eval_js":
+        return await mgr.eval_js(expression=str(kwargs["expression"]))
+    if action == "console_logs":
+        return await mgr.console_logs(clear=bool(kwargs.get("clear", False)))
+    if action == "page_source":
+        return await mgr.page_source()
+    if action == "pdf":
+        return await mgr.pdf()
+    if action == "list_tabs":
+        return await mgr.list_tabs()
+    if action == "switch_tab":
+        return await mgr.switch_tab(tab_id=str(kwargs["tab_id"]))
+    if action == "close":
+        return await mgr.close()
+    raise BrowserActionError(f"unreachable: {action}")
+
+
+@tool
+async def browser_action(action: str, params_json: str = "{}") -> str:
+    """Drive a persistent Playwright browser session for SPA / auth / DOM work.
+
+    Supported actions (pass parameters as a JSON string via ``params_json``):
+
+    * ``launch`` — open the browser; optional ``headless`` (default true).
+    * ``goto`` — navigate; requires ``url``; optional ``timeout_ms``.
+    * ``click`` — click a CSS selector; requires ``selector``.
+    * ``type`` — type into a selector; requires ``selector`` + ``text``.
+    * ``scroll`` — scroll the active page by ``dx`` / ``dy`` pixels.
+    * ``screenshot`` — return base64 PNG; optional ``full_page``.
+    * ``eval_js`` — evaluate JS; requires ``expression``.
+    * ``console_logs`` — return captured console messages; optional ``clear``.
+    * ``page_source`` — return the active page's HTML.
+    * ``pdf`` — render the page as PDF (base64).
+    * ``list_tabs`` — list tracked tabs and the active tab id.
+    * ``switch_tab`` — switch to / create tab; requires ``tab_id``.
+    * ``close`` — close the browser and reset state.
+
+    Returns a JSON string. Errors are returned as ``{"error": "..."}``
+    rather than raised so the LLM can handle them in-band.
+    """
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError as exc:
+        return _json({"error": f"params_json is not valid JSON: {exc}"})
+    if not isinstance(params, dict):
+        return _json({"error": "params_json must decode to a JSON object."})
+
+    try:
+        result = await _dispatch(action, params)
+    except BrowserActionError as exc:
+        return _json({"error": str(exc)})
+    except KeyError as exc:
+        return _json({"error": f"missing required parameter: {exc!s}"})
+    except Exception as exc:  # noqa: BLE001
+        return _json({"error": f"{type(exc).__name__}: {exc}"})
+    return _json(result)
+
+
+BROWSER_TOOLS = [browser_action]
+
+
+__all__ = [
+    "BROWSER_TOOLS",
+    "BrowserActionError",
+    "BrowserSessionManager",
+    "browser_action",
+    "get_session_manager",
+]

--- a/packages/decepticon/tests/unit/tools/test_browser.py
+++ b/packages/decepticon/tests/unit/tools/test_browser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,7 +21,7 @@ from decepticon.tools.browser.tools import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_singleton() -> None:
+def _reset_singleton() -> Iterator[None]:
     _reset_session_manager_for_tests()
     yield
     _reset_session_manager_for_tests()

--- a/packages/decepticon/tests/unit/tools/test_browser.py
+++ b/packages/decepticon/tests/unit/tools/test_browser.py
@@ -87,17 +87,13 @@ def test_dispatcher_rejects_unknown_action() -> None:
 
 
 def test_dispatcher_rejects_bad_params_json() -> None:
-    out = asyncio.run(
-        browser_action.ainvoke({"action": "launch", "params_json": "{not json"})
-    )
+    out = asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{not json"}))
     parsed = json.loads(out)
     assert "not valid JSON" in parsed["error"]
 
 
 def test_dispatcher_rejects_non_object_params() -> None:
-    out = asyncio.run(
-        browser_action.ainvoke({"action": "launch", "params_json": "[1, 2]"})
-    )
+    out = asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "[1, 2]"}))
     parsed = json.loads(out)
     assert "must decode to a JSON object" in parsed["error"]
 
@@ -106,9 +102,7 @@ def test_missing_required_parameter_surfaces_as_error_json() -> None:
     api, _, _ = _fake_browser_chain()
     with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
         asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
-        out = asyncio.run(
-            browser_action.ainvoke({"action": "goto", "params_json": "{}"})
-        )
+        out = asyncio.run(browser_action.ainvoke({"action": "goto", "params_json": "{}"}))
     parsed = json.loads(out)
     assert "missing required parameter" in parsed["error"]
 
@@ -119,9 +113,7 @@ def test_missing_playwright_surfaces_install_hint() -> None:
             "Playwright is not installed. Add the 'browser' extra or install playwright + chromium in the sandbox image."
         )
 
-    with patch.object(
-        BrowserSessionManager, "_import_playwright", side_effect=lambda: _raise()
-    ):
+    with patch.object(BrowserSessionManager, "_import_playwright", side_effect=lambda: _raise()):
         out = asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
     parsed = json.loads(out)
     assert "Playwright is not installed" in parsed["error"]
@@ -182,9 +174,7 @@ def test_type_invokes_page_fill() -> None:
             browser_action.ainvoke(
                 {
                     "action": "type",
-                    "params_json": json.dumps(
-                        {"selector": "input[name=user]", "text": "admin"}
-                    ),
+                    "params_json": json.dumps({"selector": "input[name=user]", "text": "admin"}),
                 }
             )
         )
@@ -199,9 +189,7 @@ def test_screenshot_returns_base64_png() -> None:
     api, _, _ = _fake_browser_chain(pages=[page])
     with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
         asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
-        out = asyncio.run(
-            browser_action.ainvoke({"action": "screenshot", "params_json": "{}"})
-        )
+        out = asyncio.run(browser_action.ainvoke({"action": "screenshot", "params_json": "{}"}))
     parsed = json.loads(out)
     assert parsed["format"] == "png"
     assert parsed["bytes"] == len(b"PNGDATA")
@@ -233,9 +221,7 @@ def test_console_logs_returns_captured_messages() -> None:
         for _event, fn in handlers:
             fn(MagicMock(type="log", text="hello"))
             fn(MagicMock(type="error", text="boom"))
-        out = asyncio.run(
-            browser_action.ainvoke({"action": "console_logs", "params_json": "{}"})
-        )
+        out = asyncio.run(browser_action.ainvoke({"action": "console_logs", "params_json": "{}"}))
     parsed = json.loads(out)
     assert parsed["count"] == 2
     assert any("hello" in line for line in parsed["lines"])
@@ -247,9 +233,7 @@ def test_page_source_returns_html_and_url() -> None:
     api, _, _ = _fake_browser_chain(pages=[page])
     with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
         asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
-        out = asyncio.run(
-            browser_action.ainvoke({"action": "page_source", "params_json": "{}"})
-        )
+        out = asyncio.run(browser_action.ainvoke({"action": "page_source", "params_json": "{}"}))
     parsed = json.loads(out)
     assert parsed["url"] == "https://target/"
     assert parsed["html"].startswith("<html>")
@@ -266,9 +250,7 @@ def test_list_tabs_and_switch_tab() -> None:
                 {"action": "switch_tab", "params_json": json.dumps({"tab_id": "second"})}
             )
         )
-        out = asyncio.run(
-            browser_action.ainvoke({"action": "list_tabs", "params_json": "{}"})
-        )
+        out = asyncio.run(browser_action.ainvoke({"action": "list_tabs", "params_json": "{}"}))
     parsed = json.loads(out)
     assert "main" in parsed["tabs"]
     assert "second" in parsed["tabs"]
@@ -280,9 +262,7 @@ def test_close_resets_session_state() -> None:
     api, _, context = _fake_browser_chain(pages=[page])
     with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
         asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
-        out = asyncio.run(
-            browser_action.ainvoke({"action": "close", "params_json": "{}"})
-        )
+        out = asyncio.run(browser_action.ainvoke({"action": "close", "params_json": "{}"}))
     parsed = json.loads(out)
     assert parsed["closed"] is True
 
@@ -294,9 +274,7 @@ def test_browser_tools_export() -> None:
 
 def test_active_tab_required_for_navigation() -> None:
     out = asyncio.run(
-        browser_action.ainvoke(
-            {"action": "goto", "params_json": json.dumps({"url": "https://x/"})}
-        )
+        browser_action.ainvoke({"action": "goto", "params_json": json.dumps({"url": "https://x/"})})
     )
     parsed = json.loads(out)
     assert "active tab" in parsed["error"].lower()

--- a/packages/decepticon/tests/unit/tools/test_browser.py
+++ b/packages/decepticon/tests/unit/tools/test_browser.py
@@ -1,0 +1,302 @@
+"""Tests for ``decepticon.tools.browser`` — Playwright session manager + multiplex tool."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from decepticon.tools.browser.tools import (
+    BROWSER_TOOLS,
+    BrowserActionError,
+    BrowserSessionManager,
+    _reset_session_manager_for_tests,
+    browser_action,
+    get_session_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> None:
+    _reset_session_manager_for_tests()
+    yield
+    _reset_session_manager_for_tests()
+
+
+def _async_mock(return_value: Any = None) -> AsyncMock:
+    m = AsyncMock()
+    m.return_value = return_value
+    return m
+
+
+def _fake_page(
+    *,
+    url: str = "https://target/",
+    title: str = "target",
+    content_html: str = "<html></html>",
+    goto_status: int = 200,
+) -> MagicMock:
+    page = MagicMock()
+    page.url = url
+    page.goto = _async_mock(MagicMock(status=goto_status))
+    page.click = _async_mock()
+    page.fill = _async_mock()
+    page.evaluate = _async_mock("ok")
+    page.screenshot = _async_mock(b"PNGDATA")
+    page.pdf = _async_mock(b"PDFDATA")
+    page.title = _async_mock(title)
+    page.content = _async_mock(content_html)
+    page.close = _async_mock()
+    page.on = MagicMock()
+    return page
+
+
+def _fake_browser_chain(pages: list[Any] | None = None):
+    page_iter = iter(pages or [_fake_page()])
+    context = MagicMock()
+    context.new_page = AsyncMock(side_effect=lambda: next(page_iter))
+    context.close = _async_mock()
+    browser = MagicMock()
+    browser.new_context = _async_mock(context)
+    browser.close = _async_mock()
+    chromium = MagicMock()
+    chromium.launch = _async_mock(browser)
+    pw_instance = MagicMock()
+    pw_instance.chromium = chromium
+    pw_instance.stop = _async_mock()
+    pw_factory = MagicMock()
+    pw_factory.start = _async_mock(pw_instance)
+    api = MagicMock()
+    api.async_playwright = MagicMock(return_value=pw_factory)
+    return api, browser, context
+
+
+def test_get_session_manager_is_singleton() -> None:
+    a = get_session_manager()
+    b = get_session_manager()
+    assert a is b
+
+
+def test_dispatcher_rejects_unknown_action() -> None:
+    out = asyncio.run(browser_action.ainvoke({"action": "nope", "params_json": "{}"}))
+    parsed = json.loads(out)
+    assert "Unknown action" in parsed["error"]
+
+
+def test_dispatcher_rejects_bad_params_json() -> None:
+    out = asyncio.run(
+        browser_action.ainvoke({"action": "launch", "params_json": "{not json"})
+    )
+    parsed = json.loads(out)
+    assert "not valid JSON" in parsed["error"]
+
+
+def test_dispatcher_rejects_non_object_params() -> None:
+    out = asyncio.run(
+        browser_action.ainvoke({"action": "launch", "params_json": "[1, 2]"})
+    )
+    parsed = json.loads(out)
+    assert "must decode to a JSON object" in parsed["error"]
+
+
+def test_missing_required_parameter_surfaces_as_error_json() -> None:
+    api, _, _ = _fake_browser_chain()
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke({"action": "goto", "params_json": "{}"})
+        )
+    parsed = json.loads(out)
+    assert "missing required parameter" in parsed["error"]
+
+
+def test_missing_playwright_surfaces_install_hint() -> None:
+    def _raise() -> None:
+        raise BrowserActionError(
+            "Playwright is not installed. Add the 'browser' extra or install playwright + chromium in the sandbox image."
+        )
+
+    with patch.object(
+        BrowserSessionManager, "_import_playwright", side_effect=lambda: _raise()
+    ):
+        out = asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+    parsed = json.loads(out)
+    assert "Playwright is not installed" in parsed["error"]
+
+
+def test_launch_starts_browser_and_creates_main_tab() -> None:
+    api, _, _ = _fake_browser_chain()
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        out = asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+    parsed = json.loads(out)
+    assert parsed["tabs"] == ["main"]
+    assert parsed["active"] == "main"
+
+
+def test_goto_returns_url_status_title() -> None:
+    page = _fake_page(url="https://target/login", title="login", goto_status=302)
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke(
+                {
+                    "action": "goto",
+                    "params_json": json.dumps({"url": "https://target/login"}),
+                }
+            )
+        )
+    parsed = json.loads(out)
+    assert parsed["url"] == "https://target/login"
+    assert parsed["status"] == 302
+    assert parsed["title"] == "login"
+
+
+def test_click_invokes_page_click() -> None:
+    page = _fake_page()
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke(
+                {
+                    "action": "click",
+                    "params_json": json.dumps({"selector": "#submit"}),
+                }
+            )
+        )
+    parsed = json.loads(out)
+    assert parsed["clicked"] == "#submit"
+    page.click.assert_called_once()
+
+
+def test_type_invokes_page_fill() -> None:
+    page = _fake_page()
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke(
+                {
+                    "action": "type",
+                    "params_json": json.dumps(
+                        {"selector": "input[name=user]", "text": "admin"}
+                    ),
+                }
+            )
+        )
+    parsed = json.loads(out)
+    assert parsed["typed_into"] == "input[name=user]"
+    assert parsed["chars"] == 5
+    page.fill.assert_called_once()
+
+
+def test_screenshot_returns_base64_png() -> None:
+    page = _fake_page()
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke({"action": "screenshot", "params_json": "{}"})
+        )
+    parsed = json.loads(out)
+    assert parsed["format"] == "png"
+    assert parsed["bytes"] == len(b"PNGDATA")
+    assert parsed["base64"]
+
+
+def test_eval_js_returns_result() -> None:
+    page = _fake_page()
+    page.evaluate = _async_mock("evaluated-ok")
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke(
+                {"action": "eval_js", "params_json": json.dumps({"expression": "1+1"})}
+            )
+        )
+    parsed = json.loads(out)
+    assert parsed["result"] == "evaluated-ok"
+
+
+def test_console_logs_returns_captured_messages() -> None:
+    page = _fake_page()
+    handlers: list[Any] = []
+    page.on = MagicMock(side_effect=lambda event, fn: handlers.append((event, fn)))
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        for _event, fn in handlers:
+            fn(MagicMock(type="log", text="hello"))
+            fn(MagicMock(type="error", text="boom"))
+        out = asyncio.run(
+            browser_action.ainvoke({"action": "console_logs", "params_json": "{}"})
+        )
+    parsed = json.loads(out)
+    assert parsed["count"] == 2
+    assert any("hello" in line for line in parsed["lines"])
+    assert any("boom" in line for line in parsed["lines"])
+
+
+def test_page_source_returns_html_and_url() -> None:
+    page = _fake_page(content_html="<html><body>x</body></html>")
+    api, _, _ = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke({"action": "page_source", "params_json": "{}"})
+        )
+    parsed = json.loads(out)
+    assert parsed["url"] == "https://target/"
+    assert parsed["html"].startswith("<html>")
+
+
+def test_list_tabs_and_switch_tab() -> None:
+    page1 = _fake_page(url="https://target/")
+    page2 = _fake_page(url="https://target/admin")
+    api, _, _ = _fake_browser_chain(pages=[page1, page2])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        asyncio.run(
+            browser_action.ainvoke(
+                {"action": "switch_tab", "params_json": json.dumps({"tab_id": "second"})}
+            )
+        )
+        out = asyncio.run(
+            browser_action.ainvoke({"action": "list_tabs", "params_json": "{}"})
+        )
+    parsed = json.loads(out)
+    assert "main" in parsed["tabs"]
+    assert "second" in parsed["tabs"]
+    assert parsed["active"] == "second"
+
+
+def test_close_resets_session_state() -> None:
+    page = _fake_page()
+    api, _, context = _fake_browser_chain(pages=[page])
+    with patch.object(BrowserSessionManager, "_import_playwright", return_value=api):
+        asyncio.run(browser_action.ainvoke({"action": "launch", "params_json": "{}"}))
+        out = asyncio.run(
+            browser_action.ainvoke({"action": "close", "params_json": "{}"})
+        )
+    parsed = json.loads(out)
+    assert parsed["closed"] is True
+
+
+def test_browser_tools_export() -> None:
+    assert len(BROWSER_TOOLS) == 1
+    assert BROWSER_TOOLS[0].name == "browser_action"
+
+
+def test_active_tab_required_for_navigation() -> None:
+    out = asyncio.run(
+        browser_action.ainvoke(
+            {"action": "goto", "params_json": json.dumps({"url": "https://x/"})}
+        )
+    )
+    parsed = json.loads(out)
+    assert "active tab" in parsed["error"].lower()


### PR DESCRIPTION
## Summary

Add `decepticon.tools.browser` so a Decepticon agent can drive a real headless browser for SPA / auth / OAuth-callback / DOM-XSS / companion-app flows from the same model loop that runs `bash` / web / proxy tools. Today there is no headless-browser primitive, which blocks any test that needs JavaScript execution or DOM inspection.

## What changes

Single multiplex LangChain tool `browser_action(action, params_json)` covering 13 sub-actions:

| Action | Purpose |
|---|---|
| `launch` | Open the (headless) browser and create a `main` tab. |
| `goto` | Navigate; returns final URL, status, title. |
| `click` | Click a CSS selector. |
| `type` | Fill an input with text. |
| `scroll` | Scroll the active page by dx/dy pixels. |
| `screenshot` | Return base64 PNG (`full_page` optional). |
| `eval_js` | Evaluate JS and return the result. |
| `console_logs` | Return up to 500 captured console messages. |
| `page_source` | Return the active page's HTML. |
| `pdf` | Render the page as PDF (base64). |
| `list_tabs` | List tracked tabs + active id. |
| `switch_tab` | Switch to / create tab. |
| `close` | Close the browser and reset state. |

## Implementation

- `BrowserSessionManager` is a per-process singleton holding the Playwright instance + browser + context + tabs. All operations are async and serialize through an `asyncio.Lock` so concurrent `browser_action` calls cannot interleave navigation against the same page.
- Playwright is imported lazily on first `launch`. If Playwright is not installed the tool returns a JSON error pointing operators at the `decepticon[browser]` extra.
- Each sub-action returns a JSON string; errors are caught and returned as `{"error": "..."}` rather than raised so the agent loop continues.
- Console messages are bounded to **500 entries per tab** so a chatty page cannot drive memory growth without bound.

## Deliberately out of scope (follow-up PR)

- `containers/sandbox.Dockerfile` Playwright + Chromium install and the `decepticon[browser]` optional dep. The library + tests land first so the integration PR can focus on container plumbing.
- Wiring `BROWSER_TOOLS` into agent prompt bundles and `recon` / `exploit` / `analyst` prompt sections.

## Files

| File | Δ |
|---|---|
| `packages/decepticon/decepticon/tools/browser/__init__.py` | new — exports |
| `packages/decepticon/decepticon/tools/browser/tools.py` | new — 369 lines |
| `packages/decepticon/tests/unit/tools/test_browser.py` | new — 302 lines, 18 tests |

## Verification

- `uv run pytest packages/decepticon/tests/unit/tools/test_browser.py -q` → **18 passed**
- `uv run ruff check packages/decepticon/decepticon/tools/browser packages/decepticon/tests/unit/tools/test_browser.py` → All checks passed
- LSP diagnostics on changed files: clean

## Test coverage

Singleton identity, unknown-action rejection, malformed `params_json`, non-object `params_json`, missing required parameters, missing-Playwright install hint, `launch` creating the main tab, `goto` status/url/title, `click` / `type` / scroll delegation, screenshot base64 PNG, `eval_js` result passthrough, console-log capture across the registered event handler, page-source return, multi-tab list/switch, `close` reset, `BROWSER_TOOLS` export, and the active-tab-required guard. Playwright is mocked via `_import_playwright` patching so the test suite runs without the optional extra installed.
