### PR TITLE
fix(ci): skip docker-bound slow tests on macOS python lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,9 +226,18 @@ jobs:
         # timeout cases) so PR feedback stays under a minute. Main coverage
         # lane below still runs them.
         run: uv run pytest -n auto -q -m "not slow"
-      - name: Pytest with coverage (main — enforces threshold)
-        if: github.event_name == 'push'
+      - name: Pytest with coverage (Linux push — full suite, enforces threshold)
+        if: github.event_name == 'push' && runner.os == 'Linux'
         run: uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=30
+      - name: Pytest cross-platform sanity (macOS push — skip docker-bound slow tests)
+        # macOS GitHub runners don't have Docker installed; the harness's
+        # `slow` tests call `docker compose restart sandbox` directly and
+        # fail there. The PR fast lane already deselects `slow`; mirror
+        # that on push so macOS validates cross-platform Python without
+        # blocking main on Docker availability. Linux remains the canonical
+        # coverage lane (full suite + threshold).
+        if: github.event_name == 'push' && runner.os == 'macOS'
+        run: uv run pytest -n auto -q -m "not slow"
       - name: Upload coverage artifact
         if: github.event_name == 'push' && always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why

Main has been red since #281 merged. Symptom: \`Python (macos-latest)\` fails every push with
\`subprocess.run(['docker', 'compose', 'restart', 'sandbox'])\` returning 255 — macOS GitHub runners
don't ship Docker, but the harness's \`pytest.mark.slow\` tests call \`docker compose\` directly.

PR-time CI passed because the PR lane already deselects \`slow\` (\`pytest -m \"not slow\"\`).
The main-push coverage lane (\`pytest -n auto --cov ... --cov-fail-under=30\`) didn't apply
that filter, so every push to main has hit the docker-bound tests on macOS.

Reproduces in https://github.com/PurpleAILAB/Decepticon/actions/runs/26430082578 onward.

## Fix

Split the push-time pytest step by \`runner.os\`:

- **Linux push** — full suite + coverage threshold (canonical coverage lane, unchanged).
- **macOS push** — \`pytest -n auto -q -m \"not slow\"\` (cross-platform sanity; no docker needed).

Mirrors the PR fast lane's behavior so macOS still validates Python correctness without
blocking main on a runner-image gap.

## Verification

\`uv run pytest -n auto -q -m \"not slow\"\` → **1119 passed** locally.
Ruff lint + format clean.

## Scope

One CI step replaced with two conditional steps. No production code or test logic changed.