### PR TITLE
fix: green up local test suite (posixpath + pytest-n-auto isolation) — re-merge of #286

### DIFF
--- a/packages/decepticon/decepticon/middleware/filesystem.py
+++ b/packages/decepticon/decepticon/middleware/filesystem.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import posixpath
 from dataclasses import replace
 from typing import Any
 
@@ -51,7 +51,9 @@ def _normalize_engagement_workspace(workspace_path: str | None) -> str | None:
     if not path.startswith(f"{WORKSPACE}/"):
         return None
     expected = path.rstrip("/")
-    if os.path.normpath(expected) != expected:
+    # posixpath, not os.path: these are virtual POSIX paths. os.path.normpath
+    # rewrites "/" to "\" on Windows, which would reject every valid workspace.
+    if posixpath.normpath(expected) != expected:
         return None
     normalized = SandboxBase._normalize_workspace_path(path)
     return normalized if normalized == expected else None

--- a/packages/decepticon/tests/unit/backends/conftest.py
+++ b/packages/decepticon/tests/unit/backends/conftest.py
@@ -1,6 +1,6 @@
 """Per-test isolation for process-wide sandbox class state.
 
-``SandboxBase._log_offsets`` and ``_jobs`` are deliberately class-level ΓÇö
+``SandboxBase._log_offsets`` and ``_jobs`` are deliberately class-level —
 shared by every agent factory in a process (see ``SandboxBase``'s docstring).
 That contract is correct for production but leaks across tests: one test's
 ``read_session_log_diff`` call populates ``_log_offsets``, and a later test

--- a/packages/decepticon/tests/unit/backends/conftest.py
+++ b/packages/decepticon/tests/unit/backends/conftest.py
@@ -1,0 +1,35 @@
+"""Per-test isolation for process-wide sandbox class state.
+
+``SandboxBase._log_offsets`` and ``_jobs`` are deliberately class-level ΓÇö
+shared by every agent factory in a process (see ``SandboxBase``'s docstring).
+That contract is correct for production but leaks across tests: one test's
+``read_session_log_diff`` call populates ``_log_offsets``, and a later test
+that asserts a pristine offset map then fails. Under ``pytest -n auto`` the
+victim test varies with execution order. Resetting the state around every
+test makes each one start from the documented clean baseline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from decepticon.sandbox_kernel import BackgroundJobTracker, TmuxSessionManager
+from decepticon.sandbox_kernel.base import SandboxBase
+from decepticon.sandbox_kernel.daemon import DaemonSandbox
+
+
+@pytest.fixture(autouse=True)
+def _reset_sandbox_class_state() -> Iterator[None]:
+    """Reset shared sandbox ClassVar state before and after each test."""
+
+    def _reset() -> None:
+        for cls in (SandboxBase, DaemonSandbox):
+            cls._log_offsets.clear()
+            cls._jobs = BackgroundJobTracker()
+        TmuxSessionManager._initialized.clear()
+
+    _reset()
+    yield
+    _reset()

--- a/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
@@ -87,6 +87,7 @@ def test_read_json_file_returns_none_when_top_level_is_not_dict(tmp_path: Path) 
 # ── write_json_atomic ──────────────────────────────────────────────────
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode 0o600 is not enforced on Windows")
 def test_write_json_atomic_writes_payload_with_secure_mode(tmp_path: Path) -> None:
     path = tmp_path / "tokens.json"
     payload = {"access": "abc"}
@@ -110,6 +111,7 @@ def test_write_json_atomic_uses_atomic_temp_then_rename(tmp_path: Path) -> None:
     assert json.loads(path.read_text()) == {"v": "second"}
 
 
+@pytest.mark.skipif(os.name == "nt", reason="chmod-based directory locking is a no-op on Windows")
 def test_write_json_atomic_returns_false_when_target_dir_unwritable(tmp_path: Path) -> None:
     locked = tmp_path / "locked"
     locked.mkdir()


### PR DESCRIPTION
Re-applies #286 on current main + fixes a mojibake. Authorship preserved via cherry-pick. Original PR: #286

Note: #286's stated motivation was unlocking `windows-latest` for the Python CI matrix, but we've since decided the Python lane is **ubuntu-only by design** (the backend runs in the langgraph Linux container; see #311). The changes still stand on their own merit — two of the three are platform-agnostic correctness/reliability fixes:

## Changes
1. **`filesystem.py`: `os.path.normpath` → `posixpath.normpath`** — `_normalize_engagement_workspace` validates virtual `/workspace/...` paths, which are always POSIX. `os.path.normpath` rewrites `/`→`\` on Windows. Behavior-identical on Linux/macOS (where `os.path` *is* `posixpath`); a latent-correctness fix for the virtual-path domain.
2. **`tests/unit/backends/conftest.py`: autouse fixture** resets the shared `SandboxBase._log_offsets` / `_jobs` / `TmuxSessionManager._initialized` ClassVars around every test. These are deliberately process-wide for production but leak across tests; under `pytest -n auto` the victim varies with execution order. **Helps every platform**, not just Windows — this class of leak can flake ubuntu CI too.
3. **`test_oauth_token_store.py`: two `skipif(os.name == "nt")`** for POSIX file-mode `0o600` + chmod-based locking assertions. No-op on Linux/macOS; a local-dev nicety for Windows.

## Fixed before merge
The cherry-picked conftest docstring had a corrupted em-dash (`ΓÇö`, a mis-decoded U+2014). Replaced with a proper `—`.

## Verification
basedpyright (CI gate) 0 errors on conftest; ruff + format clean; affected tests 99 passed.

## Risk
Three small changes; Linux/macOS behavior preserved. No public API change.

Co-authored-by: VoidChecksum <halvorsentech@gmail.com>