### PR TITLE
feat(reverser): Ghidra 12.1 integration (re-merge of #288, scope-trimmed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,4 +262,8 @@ DECEPTICON_STACK_NAME=
 #
 # Special:
 #   wenyan   文言文 Classical Chinese prose + English technical terms
+# --- Reverse Engineering ---
+# Ghidra 12.1 is baked into the sandbox container (GHIDRA_INSTALL_DIR=/opt/ghidra).
+# The Ghidra MCP bridge runs as a sidecar — enable with: COMPOSE_PROFILES=reversing
+
 DECEPTICON_LANGUAGE=en

--- a/containers/sandbox.Dockerfile
+++ b/containers/sandbox.Dockerfile
@@ -59,8 +59,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=sandbox-apt-cache
         # ── C2 client (connects to the separate c2-sliver server container) ──
         sliver
 
-# Configure tmux: 50K line scrollback buffer to prevent output truncation
-RUN echo "set-option -g history-limit 50000" > /root/.tmux.conf
+# Configure tmux: 20K line scrollback buffer. The Python-side output
+# truncation (MAX_OUTPUT_CHARS = 30_000 chars) means the agent reads at
+# most ~500 lines, but the tmux PS1-marker detection
+# (TmuxSessionManager._wait_for_completion) counts ALL markers in the
+# scrollback via capture-pane. Commands that produce >N lines cause old
+# markers to scroll off, which breaks the count check. 20K handles
+# realistic red-team tool output (nmap /24 ≈ 5–25K lines) while cutting
+# per-session RSS by ~60% vs the previous 50K.
+RUN echo "set-option -g history-limit 20000" > /root/.tmux.conf
 
 # Optional HTTP sandbox daemon — see decepticon/sandbox_server/.
 #
@@ -80,6 +87,54 @@ RUN pip3 install --break-system-packages --no-cache-dir \
     "fastapi>=0.115.0" \
     "uvicorn>=0.30.0" \
     "deepagents>=0.5.0"
+
+# ── Reverse Engineering: Ghidra 12.1 + radare2 + binwalk (opt-in) ──
+#
+# Gated by a build ARG so the default sandbox image stays lean
+# (~500 MB lighter without JDK 21 + Ghidra). Enable with:
+#   docker build --build-arg INSTALL_REVERSING=true ...
+# or, via docker-compose, set INSTALL_REVERSING=true in .env when running
+# with COMPOSE_PROFILES=reversing. The ghidra-mcp sidecar service in
+# docker-compose.yml builds this image with the ARG set to true.
+#
+# When disabled (default), ghidra_available() returns False and the
+# tools/reversing/tools.py @tool wrappers surface a clean "Ghidra not
+# installed — enable the reversing profile" error to the agent rather
+# than crashing. The MCP path (http://ghidra-mcp:8089) is still wired
+# up — agents can use the sidecar without the host sandbox having
+# Ghidra installed locally.
+#
+# Pinned to the 20260513 build of Ghidra 12.1 so the image is
+# reproducible. To upgrade: bump the URL + verify the SHA-256 against
+# the GitHub release page, then bump GHIDRA_SHA256 below.
+ARG INSTALL_REVERSING=false
+ARG GHIDRA_VERSION=12.1
+ARG GHIDRA_BUILD_DATE=20260513
+ARG GHIDRA_SHA256=""
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=sandbox-apt-cache \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=sandbox-apt-lists \
+    if [ "$INSTALL_REVERSING" = "true" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends --no-install-suggests \
+            openjdk-21-jdk-headless \
+            radare2 \
+            binwalk \
+            unzip && \
+        curl -fsSL -o /tmp/ghidra.zip \
+            "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${GHIDRA_VERSION}_build/ghidra_${GHIDRA_VERSION}_PUBLIC_${GHIDRA_BUILD_DATE}.zip" && \
+        if [ -n "$GHIDRA_SHA256" ]; then \
+            echo "$GHIDRA_SHA256  /tmp/ghidra.zip" | sha256sum -c - ; \
+        fi && \
+        unzip -q /tmp/ghidra.zip -d /opt && \
+        mv "/opt/ghidra_${GHIDRA_VERSION}_PUBLIC" /opt/ghidra && \
+        rm /tmp/ghidra.zip ; \
+    else \
+        echo "INSTALL_REVERSING=false — skipping JDK 21 + Ghidra + radare2 + binwalk" ; \
+    fi
+
+ENV GHIDRA_INSTALL_DIR=/opt/ghidra \
+    GHIDRA_MCP_URL=http://ghidra-mcp:8089 \
+    JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 # Ship only the modules the daemon actually imports:
 #   - decepticon/__init__.py     — package marker (light-weight, just reads __version__)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,6 @@ services:
       - "host.docker.internal:host-gateway"
     networks:
       - decepticon-net
-    mem_limit: 1g
-    cpus: 1.0
     restart: unless-stopped
 
   # PostgreSQL — Persistent storage for LiteLLM
@@ -88,8 +86,6 @@ services:
       - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     networks:
       - decepticon-net
-    mem_limit: 512m
-    cpus: 0.5
     restart: unless-stopped
 
     healthcheck:
@@ -129,8 +125,6 @@ services:
       timeout: 5s
       retries: 12
       start_period: 90s
-    mem_limit: 768m
-    cpus: 1.0
     restart: unless-stopped
 
 
@@ -181,8 +175,6 @@ services:
       # ``containers/langgraph.Dockerfile``) and are read in-process by
       # ``FilesystemBackend`` via ``CompositeBackend``. The sandbox only
       # owns ``/workspace/`` from here on.
-    mem_limit: 4g
-    cpus: 2.0
     pids_limit: 1024
     depends_on:
       neo4j:
@@ -312,8 +304,6 @@ services:
       # keeping the sandbox itself isolated from the infra plane.
       - decepticon-net
       - sandbox-net
-    mem_limit: 2g
-    cpus: 2.0
     restart: unless-stopped
 
 
@@ -358,8 +348,6 @@ services:
       start_period: 90s
     networks:
       - decepticon-net
-    mem_limit: 1g
-    cpus: 1.0
     restart: unless-stopped
 
   # Ink CLI — Interactive terminal UI
@@ -405,8 +393,6 @@ services:
       - NET_BIND_SERVICE
     volumes:
       - sliver_data:/home/sliver/.sliver
-    mem_limit: 2g
-    cpus: 1.0
     pids_limit: 512
     restart: unless-stopped
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,10 @@ services:
       - "host.docker.internal:host-gateway"
     networks:
       - decepticon-net
+    mem_limit: 1g
+    cpus: 1.0
     restart: unless-stopped
+
   # PostgreSQL — Persistent storage for LiteLLM
   # Stores: virtual keys, spend logs, user budgets, rate limits
   postgres:
@@ -60,6 +63,22 @@ services:
       POSTGRES_DB: litellm
       POSTGRES_USER: decepticon
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-decepticon}
+      # Keep shared_buffers small — Decepticon stores only LiteLLM spend
+      # logs and web dashboard state; the working set fits in 32MB.
+      # Default (128MB) wastes RAM in this context. work_mem is lowered
+      # from the 4MB default because queries are simple key-value lookups.
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=32MB"
+      - "-c"
+      - "work_mem=2MB"
+      - "-c"
+      - "effective_cache_size=128MB"
+      - "-c"
+      - "maintenance_work_mem=32MB"
+
     volumes:
       - postgres_data:/var/lib/postgresql/data
       # Auto-create decepticon_web DB on first startup (empty volume only).
@@ -69,7 +88,10 @@ services:
       - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     networks:
       - decepticon-net
+    mem_limit: 512m
+    cpus: 0.5
     restart: unless-stopped
+
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U decepticon -d litellm"]
       interval: 10s
@@ -84,9 +106,10 @@ services:
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-neo4j
     environment:
       NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-decepticon-graph}
-      NEO4J_server_memory_heap_initial__size: 128m
-      NEO4J_server_memory_heap_max__size: 384m
-      NEO4J_server_memory_pagecache_size: 128m
+      NEO4J_server_memory_heap_initial__size: 64m
+      NEO4J_server_memory_heap_max__size: 256m
+      NEO4J_server_memory_pagecache_size: 64m
+
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
       NEO4J_apoc_export_file_enabled: "true"
@@ -106,7 +129,10 @@ services:
       timeout: 5s
       retries: 12
       start_period: 90s
+    mem_limit: 768m
+    cpus: 1.0
     restart: unless-stopped
+
 
   # Evasive Red Team Sandbox
   # Isolated container for executing red-team tools (nmap, whois, etc.)
@@ -141,6 +167,8 @@ services:
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-decepticon-graph}
+      - GHIDRA_INSTALL_DIR=/opt/ghidra
+      - GHIDRA_MCP_URL=http://ghidra-mcp:8089
     volumes:
       # Bind is engagement-scoped. The launcher sets DECEPTICON_ENGAGEMENT_WORKSPACE
       # to <home>/workspace/<slug> after the engagement picker, so the agent only
@@ -160,6 +188,60 @@ services:
       neo4j:
         condition: service_started
     restart: unless-stopped
+
+
+  # Ghidra MCP — optional 245-tool reverse engineering bridge for the
+  # Reverser agent. Only built and started when the `reversing` profile is
+  # active. The headless backend in decepticon/tools/reversing/ghidra.py
+  # works inside the sandbox container without this sidecar; the sidecar
+  # adds richer real-time queries (xrefs, batch decompile, P-code) via the
+  # bethington/ghidra-mcp plugin.
+  #
+  # Building this service builds the sandbox image with INSTALL_REVERSING=
+  # true (adds JDK 21 + Ghidra 12.1 + radare2 + binwalk, ~500 MB) so it
+  # has the analyzeHeadless binary needed below.
+  #
+  # NOTE: the bethington/ghidra-mcp plugin install is intentionally NOT
+  # baked into sandbox.Dockerfile yet — the plugin's release-artifact
+  # layout is not stable across Ghidra versions and the integration needs
+  # a follow-up PR to pin both sides together. Until then, this service
+  # boots Ghidra in headless mode but the MCP HTTP listener will not bind;
+  # ghidra_available() will report mcp=false and the tools will fall back
+  # to the headless-only path. Tracked separately from #279.
+  ghidra-mcp:
+    build:
+      context: .
+      dockerfile: containers/sandbox.Dockerfile
+      args:
+        INSTALL_REVERSING: "true"
+        # SHA-256 pin for the Ghidra 12.1 / 20260513 release. Set this on
+        # the build-arg side rather than baking it into the Dockerfile so
+        # an upgrade is a single-line change here. To verify, see
+        # https://github.com/NationalSecurityAgency/ghidra/releases.
+        GHIDRA_SHA256: ""
+    image: decepticon-sandbox-reversing:${DECEPTICON_VERSION:-latest}
+    container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-ghidra-mcp
+    # Keep the container alive with a long-running analyzeHeadless that
+    # imports a placeholder binary. The MCP plugin (when installed) auto-
+    # starts its HTTP listener on import.
+    entrypoint:
+      - /opt/ghidra/support/analyzeHeadless
+      - /tmp/ghidra_project
+      - dcp
+      - -import
+      - /bin/true
+      - -deleteProject
+      - -noanalysis
+    environment:
+      - GHIDRA_MCP_PORT=8089
+      - JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+    networks:
+      - sandbox-net
+    mem_limit: 4g
+    cpus: 2.0
+    restart: unless-stopped
+    profiles:
+      - reversing
 
   # LangGraph Platform — Agent API Server
   # Exposes all agents (decepticon, soundwave, recon, exploit, postexploit)
@@ -230,7 +312,10 @@ services:
       # keeping the sandbox itself isolated from the infra plane.
       - decepticon-net
       - sandbox-net
+    mem_limit: 2g
+    cpus: 2.0
     restart: unless-stopped
+
 
   # Web Dashboard — Next.js UI
   # Migrations run automatically at startup via web-entrypoint.sh (prisma migrate deploy).
@@ -273,6 +358,8 @@ services:
       start_period: 90s
     networks:
       - decepticon-net
+    mem_limit: 1g
+    cpus: 1.0
     restart: unless-stopped
 
   # Ink CLI — Interactive terminal UI

--- a/packages/decepticon/decepticon/agents/prompts/plugins/exploiter.md
+++ b/packages/decepticon/decepticon/agents/prompts/plugins/exploiter.md
@@ -63,7 +63,7 @@ For each exploit objective:
 If the target is a binary (ELF / PE / Mach-O / firmware) and the chain
 requires ROP, heap massaging, or anti-exploit bypasses, call
 ``kg_triage_binary(path)`` to load packer/symbol/gadget inventory into
-the graph. For deep RE work (Ghidra scripts, IDA decomp), signal to the
+the graph. For deep RE work (Ghidra decompilation, xrefs), signal to the
 orchestrator that the Reverser agent should handle it — do not try to
 decompile manually.
 </BINARY_HANDOFF>

--- a/packages/decepticon/decepticon/agents/prompts/standard/reverser.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/reverser.md
@@ -2,19 +2,23 @@
 You are the Decepticon Reverser — a binary analysis specialist. You
 take opaque ELF / PE / Mach-O / firmware blobs and turn them into
 structured intelligence: dangerous imports, embedded secrets, packer
-signatures, ROP gadget inventories, and Ghidra/r2 recon scripts.
+signatures, ROP gadget inventories, Ghidra deep analysis (decompilation,
+xrefs, P-code emulation), and r2 recon scripts.
 
 Your operating loop is:
   1. TRIAGE  — bin_identify to get format/arch/bits/NX/PIE
   2. UNPACK  — bin_packer; if entropy > 7, unpack before further work
   3. HARVEST — bin_strings (url, ip, crypto, secret, version, import)
   4. RISK    — bin_symbols_report on the import table
-  5. DEEPEN  — bin_ghidra_script or bin_r2_script, run under bash
-  6. EXPLOIT — bin_rop for gadget inventory if memory corruption suspected
-  7. PERSIST — every observation → kg_add_node, chain with kg_add_edge
+  5. DEEPEN  — ghidra_analyze for full analysis; ghidra_decompile for pseudocode
+  6. XREFS   — ghidra_xrefs to trace dangerous-import callers
+  7. EXPLOIT — bin_rop for gadget inventory if memory corruption suspected
+  8. PERSIST — every observation → kg_add_node, chain with kg_add_edge
 </IDENTITY>
 
 <CRITICAL_RULES>
+- Start with ghidra_status to confirm the Ghidra MCP bridge is live.
+  If MCP is unavailable, fall back to bin_ghidra_script + bash.
 - Record every binary you look at as a FILE node. Link secrets, imports,
   crashes to it with appropriate edges.
 - Version strings from bin_strings feed cve_lookup / cve_by_package —
@@ -25,6 +29,9 @@ Your operating loop is:
   symbol analysis on a UPX-packed binary wastes the whole iteration.
 - For firmware: extract with binwalk first (via bash), then analyse
   each squashfs/cramfs/jffs2 partition as an independent target.
+- ghidra_decompile is expensive — don't decompile every function.
+  Target: entry points, dangerous-import callers, functions flagged
+  by bin_symbols_report.
 </CRITICAL_RULES>
 
 <HUNTING_LANES>
@@ -41,7 +48,7 @@ Focus: hardcoded credentials, crypto key leakage, unsafe imports.
    (bin_strings category=crypto, secret).
 
 ## Lane C — Malware triage (defensive)
-1. bin_packer first. If packed → manual unpack via x64dbg/Ghidra.
+1. bin_packer first. If packed → manual unpack via Ghidra.
 2. bin_symbols_report on post-unpack binary.
 3. bin_strings with category=url, ip to find C2 infrastructure.
 4. Graph the C2 as ENTRYPOINT for incident-response chain analysis.
@@ -55,9 +62,13 @@ After memory-corruption bug is identified (e.g. from a fuzzer crash):
 </HUNTING_LANES>
 
 <ENVIRONMENT>
-You run inside the Decepticon Kali sandbox. Recommended tools (install
-via apt as needed):
-- ghidra, radare2, binwalk, nm, objdump, readelf, strings, file
+You run inside the Decepticon Kali sandbox with Ghidra 12.1 pre-installed.
+
+Reverse engineering stack:
+- Ghidra MCP bridge at $GHIDRA_MCP_URL — 245 tools: decompile, xrefs,
+  batch analysis, P-code emulation, convention enforcement, scripting
+- ghidra analyzeHeadless — headless fallback when MCP is down
+- radare2, binwalk, nm, objdump, readelf, strings, file
 - capstone-tools, ROPgadget
 - python3-lief, python3-pefile for deeper analysis
 </ENVIRONMENT>

--- a/packages/decepticon/decepticon/agents/standard/reverser.py
+++ b/packages/decepticon/decepticon/agents/standard/reverser.py
@@ -180,7 +180,9 @@ SUBAGENT_SPEC = SubAgentSpec(
     description=(
         "Binary reversing specialist. Use for ELF/PE/Mach-O/firmware triage, "
         "packer detection, classified string extraction, symbol risk reports, "
-        "ROP gadget inventories, and Ghidra/radare2 recon script generation. "
+        "ROP gadget inventories, Ghidra/radare2 recon script generation, "
+        "and deep analysis via Ghidra headless + MCP bridge (decompilation, "
+        "cross-references, P-code emulation, batch analysis, 245 tools). "
         "Ideal for thick clients, IoT firmware, game cheats, malware triage, "
         "and exploit dev hand-offs."
     ),

--- a/packages/decepticon/decepticon/skills/standard/reverser/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reverser-overview
-description: Root pointer for the binary reversing lane. Covers triage, string extraction, packer unpacking, symbol risk, ROP, Ghidra/r2 recon, and firmware extraction.
+description: Root pointer for the binary reversing lane. Covers triage, string extraction, packer unpacking, symbol risk, ROP, Ghidra deep analysis, and firmware extraction.
 ---
 
 # Reverser Skill Catalog
@@ -13,13 +13,16 @@ description: Root pointer for the binary reversing lane. Covers triage, string e
 | `/skills/standard/reverser/packer-unpacking/SKILL.md`  | UPX / ASPack / Themida / VMProtect |
 | `/skills/standard/reverser/rop-chain/SKILL.md`         | Gadget hunting for exploit dev |
 | `/skills/standard/reverser/anti-debug-bypass/SKILL.md` | IsDebuggerPresent, ptrace, NtGlobalFlag |
+| `/skills/standard/reverser/ghidra/SKILL.md`            | Deep Ghidra analysis — decompile, xrefs, imports, P-code |
 
 ## Workflow
-1. `bin_identify` — format, arch, NX/PIE
-2. `bin_packer` — entropy + signature
-3. If packed → follow the packer-unpacking skill, re-identify after unpack
-4. `bin_strings` — category=url/ip/crypto/secret/version to seed the graph
-5. `bin_symbols_report` — risk bucket classification
-6. Version strings → `cve_lookup` + `cve_by_package`
-7. For deeper analysis: `bin_ghidra_script` or `bin_r2_script`, write to disk, run via bash
-8. Record every observation in the knowledge graph
+1. `ghidra_status` — check Ghidra MCP bridge and headless availability
+2. `bin_identify` — format, arch, NX/PIE
+3. `bin_packer` — entropy + signature
+4. If packed → follow the packer-unpacking skill, re-identify after unpack
+5. `bin_strings` — category=url/ip/crypto/secret/version to seed the graph
+6. `bin_symbols_report` — risk bucket classification
+7. Version strings → `cve_lookup` + `cve_by_package`
+8. `ghidra_analyze` for full analysis, or `bin_ghidra_script` / `bin_r2_script` as fallback
+9. `ghidra_decompile` on interesting functions, `ghidra_xrefs` on dangerous imports
+10. Record every observation in the knowledge graph

--- a/packages/decepticon/decepticon/skills/standard/reverser/ghidra/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/ghidra/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: reverser-ghidra
+description: Deep binary analysis via Ghidra — headless analyzeHeadless or live MCP bridge with 245 tools. Decompilation, xrefs, function listing, batch operations, P-code emulation, convention enforcement.
+---
+
+# Ghidra Deep Analysis
+
+Ghidra is the primary reverse engineering backend. Two modes:
+- **MCP bridge** (preferred) — 245 tools via HTTP at `$GHIDRA_MCP_URL`
+- **Headless** (fallback) — `analyzeHeadless` + postScript for JSON output
+
+## Prerequisites
+```
+ghidra_status()
+```
+Check if Ghidra headless and/or MCP bridge are available.
+
+## 1. Full Analysis
+```
+ghidra_analyze(binary="/workspace/target.exe")
+```
+Returns: functions (up to 500), imports, exports, language, image base.
+Auto-selects MCP if running, headless otherwise.
+
+## 2. Decompile a Function
+```
+ghidra_decompile(binary="/workspace/target.exe", function="main")
+ghidra_decompile(binary="/workspace/target.exe", function="0x401000")
+```
+Accepts symbol name or hex address. Returns C pseudocode.
+
+## 3. Cross-References (MCP)
+```
+ghidra_xrefs(binary="/workspace/target.exe", address="0x401000")
+```
+Returns up to 200 xrefs with source function context.
+
+## 4. Fallback: Script Generation
+If headless/MCP are unavailable, generate a recon script and run via bash:
+```
+bin_ghidra_script(binary="/workspace/target.exe")
+```
+
+## MCP Bridge — Full 245-Tool Coverage
+When the Ghidra MCP bridge is running, the reverser also has access to
+the complete bethington/ghidra-mcp tool surface via bash + curl:
+
+- **Function analysis** — decompilation, call graphs, completeness scoring
+- **Data flow** — PCode-graph value propagation (forward / backward)
+- **Structure discovery** — struct/union/enum creation, field analysis
+- **String extraction** — regex search, quality filtering
+- **Import/export analysis** — symbol tables, ordinal resolution
+- **Memory inspection** — raw reads, byte pattern search
+- **Cross-binary documentation** — SHA-256 function hash matching
+- **P-code emulation** — run functions in isolation, brute-force API hashes
+- **Batch operations** — bulk rename, comment, type (93% fewer API calls)
+- **Script management** — create, run, update Ghidra scripts via MCP
+- **Convention enforcement** — auto-fix naming, type safety, documentation
+
+## Workflow
+1. `ghidra_status()` → check availability
+2. `ghidra_analyze()` → full triage
+3. Pick interesting functions → `ghidra_decompile()` each
+4. For xref hunting → `ghidra_xrefs()` on dangerous imports
+5. Record all findings in the knowledge graph

--- a/packages/decepticon/decepticon/tools/reversing/__init__.py
+++ b/packages/decepticon/decepticon/tools/reversing/__init__.py
@@ -8,6 +8,7 @@ Pure-Python implementations that run without Ghidra / radare2 installed:
 - ``rop``     — ROP gadget finder operating on raw bytes via a tiny x86 disassembler
 - ``symbols`` — import/export table walker + sanitizer-symbol detection
 - ``scripts`` — Ghidra + r2 script generators the agent can drop on disk and run
+- ``ghidra``  — Ghidra headless + MCP bridge integration (decompile, xrefs, analysis)
 
 The agent can escalate to a real disassembler via bash (radare2,
 ghidra_headless, objdump) — this package is the fast first pass.
@@ -16,6 +17,16 @@ ghidra_headless, objdump) — this package is the fast first pass.
 from __future__ import annotations
 
 from decepticon.tools.reversing.binary import BinaryInfo, identify_binary
+from decepticon.tools.reversing.ghidra import (
+    GhidraAnalysis,
+    GhidraDecompilation,
+    GhidraFunction,
+    GhidraXref,
+    ghidra_analyze_binary,
+    ghidra_available,
+    ghidra_decompile_function,
+    ghidra_get_xrefs,
+)
 from decepticon.tools.reversing.packer import PackerVerdict, detect_packer
 from decepticon.tools.reversing.rop import RopGadget, find_rop_gadgets
 from decepticon.tools.reversing.scripts import ghidra_recon_script, r2_recon_script
@@ -25,12 +36,20 @@ from decepticon.tools.reversing.symbols import SymbolReport, summarize_symbols
 __all__ = [
     "BinaryInfo",
     "ExtractedString",
+    "GhidraAnalysis",
+    "GhidraDecompilation",
+    "GhidraFunction",
+    "GhidraXref",
     "PackerVerdict",
     "RopGadget",
     "SymbolReport",
     "detect_packer",
     "extract_strings",
     "find_rop_gadgets",
+    "ghidra_analyze_binary",
+    "ghidra_available",
+    "ghidra_decompile_function",
+    "ghidra_get_xrefs",
     "ghidra_recon_script",
     "identify_binary",
     "r2_recon_script",

--- a/packages/decepticon/decepticon/tools/reversing/ghidra.py
+++ b/packages/decepticon/decepticon/tools/reversing/ghidra.py
@@ -1,0 +1,483 @@
+"""Ghidra headless integration for deep binary analysis.
+
+Drives ``analyzeHeadless`` and the Ghidra MCP bridge to give the
+reverser agent real decompilation, cross-references, and function
+listings without leaving the sandbox.
+
+Two backends:
+  1. **Headless** ΓÇö ``analyzeHeadless`` + a postScript that dumps JSON.
+     Works everywhere Ghidra is installed.  Env: ``GHIDRA_INSTALL_DIR``.
+  2. **MCP bridge** ΓÇö HTTP calls to a running ghidra-mcp server.
+     Env: ``GHIDRA_MCP_URL`` (default ``http://127.0.0.1:8089``).
+
+The tools auto-select: MCP when reachable, headless otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+GHIDRA_INSTALL_DIR: str = os.environ.get("GHIDRA_INSTALL_DIR", "/opt/ghidra")
+GHIDRA_MCP_URL: str = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089")
+_HEADLESS_TIMEOUT: int = int(os.environ.get("GHIDRA_HEADLESS_TIMEOUT", "300"))
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GhidraFunction:
+    name: str
+    address: str
+    size: int = 0
+    calling_convention: str = ""
+    signature: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v}
+
+
+@dataclass
+class GhidraDecompilation:
+    function_name: str
+    address: str
+    source: str
+    return_type: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v}
+
+
+@dataclass
+class GhidraAnalysis:
+    program_name: str
+    language: str
+    image_base: str
+    function_count: int
+    functions: list[GhidraFunction] = field(default_factory=list)
+    imports: list[str] = field(default_factory=list)
+    exports: list[str] = field(default_factory=list)
+    strings_count: int = 0
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "program_name": self.program_name,
+            "language": self.language,
+            "image_base": self.image_base,
+            "function_count": self.function_count,
+        }
+        if self.functions:
+            d["functions"] = [f.to_dict() for f in self.functions]
+        if self.imports:
+            d["imports"] = self.imports
+        if self.exports:
+            d["exports"] = self.exports
+        if self.strings_count:
+            d["strings_count"] = self.strings_count
+        if self.error:
+            d["error"] = self.error
+        return d
+
+
+@dataclass
+class GhidraXref:
+    from_address: str
+    to_address: str
+    ref_type: str
+    from_function: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v}
+
+
+# ---------------------------------------------------------------------------
+# MCP bridge helpers
+# ---------------------------------------------------------------------------
+
+
+def _mcp_available() -> bool:
+    """Check if the Ghidra MCP server is reachable."""
+    try:
+        req = Request(f"{GHIDRA_MCP_URL}/mcp/health", method="GET")
+        with urlopen(req, timeout=3) as resp:
+            data = json.loads(resp.read())
+            return data.get("status") == "ok"
+    except (URLError, OSError, json.JSONDecodeError, KeyError):
+        return False
+
+
+def _mcp_post(endpoint: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """POST to the Ghidra MCP bridge and return parsed JSON."""
+    url = f"{GHIDRA_MCP_URL}{endpoint}"
+    body = json.dumps(payload or {}).encode()
+    req = Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    with urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read())
+
+
+def _mcp_get(endpoint: str) -> dict[str, Any]:
+    """GET from the Ghidra MCP bridge."""
+    url = f"{GHIDRA_MCP_URL}{endpoint}"
+    req = Request(url, method="GET")
+    with urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read())
+
+
+# ---------------------------------------------------------------------------
+# Headless scripts that dump structured JSON
+# ---------------------------------------------------------------------------
+#
+# The scripts write their result to a path supplied via the ``DCP_GHIDRA_OUT``
+# environment variable. We use a file rather than stdout-with-markers because:
+#   1. Ghidra's logger interleaves with stdout under contention — marker-based
+#      extraction was fragile and broke on long analyses.
+#   2. A binary containing the marker string in its data would otherwise
+#      corrupt the parse.
+# The decompile script reads its target argument via ``getScriptArgs()``, which
+# Ghidra populates from the positional args after ``-postScript script.py``.
+# This eliminates the format-substitution attack surface that the previous
+# version exposed (a function name containing ``"`` or newline could escape
+# the Python string literal and execute arbitrary code in the Ghidra Jython
+# interpreter).
+
+_HEADLESS_ANALYSIS_SCRIPT = '''\
+"""Ghidra postScript: dump analysis results as JSON to DCP_GHIDRA_OUT."""
+import json
+import os
+
+OUT_PATH = os.environ.get("DCP_GHIDRA_OUT", "dcp_out.json")
+
+program = currentProgram  # noqa: F821 - injected by Ghidra
+fm = program.getFunctionManager()
+st = program.getSymbolTable()
+
+functions = []
+for f in fm.getFunctions(True):
+    functions.append({
+        "name": f.getName(),
+        "address": str(f.getEntryPoint()),
+        "size": int(f.getBody().getNumAddresses()),
+        "calling_convention": str(f.getCallingConventionName() or ""),
+        "signature": str(f.getPrototypeString(False, False)),
+    })
+
+imports = [str(sym.getName()) for sym in st.getExternalSymbols()]
+
+exports = []
+for sym in st.getAllSymbols(True):
+    if sym.isExternalEntryPoint():
+        exports.append(str(sym.getName()))
+
+result = {
+    "program_name": str(program.getName()),
+    "language": str(program.getLanguageID()),
+    "image_base": "0x{:x}".format(program.getImageBase().getOffset()),
+    "function_count": int(fm.getFunctionCount()),
+    "functions": functions[:500],
+    "imports": imports[:500],
+    "exports": exports[:200],
+}
+
+with open(OUT_PATH, "w") as out:
+    json.dump(result, out)
+'''
+
+_HEADLESS_DECOMPILE_SCRIPT = '''\
+"""Ghidra postScript: decompile a function (target passed as script arg)."""
+import json
+import os
+
+OUT_PATH = os.environ.get("DCP_GHIDRA_OUT", "dcp_out.json")
+
+# getScriptArgs() is the Ghidra-supported way to receive arguments — Ghidra
+# splits the postScript line into [script_path, *argv] and exposes argv here.
+# This is the surface that replaces the previous .format()-based injection.
+args = getScriptArgs()  # noqa: F821 - injected by Ghidra
+target = args[0] if args else ""
+
+from ghidra.app.decompiler import DecompInterface  # noqa: F821
+
+program = currentProgram  # noqa: F821
+fm = program.getFunctionManager()
+
+decomp = DecompInterface()
+decomp.openProgram(program)
+
+func = None
+# Try by name first
+for f in fm.getFunctions(True):
+    if f.getName() == target:
+        func = f
+        break
+
+# Try by address
+if func is None:
+    try:
+        addr = program.getAddressFactory().getAddress(target)
+        if addr is not None:
+            func = fm.getFunctionContaining(addr)
+    except Exception:
+        pass
+
+if func is None:
+    payload = {"error": "function not found: " + target}
+else:
+    res = decomp.decompileFunction(func, 60, monitor)  # noqa: F821
+    source = str(res.getDecompiledFunction().getC()) if res.decompileCompleted() else ""
+    payload = {
+        "function_name": func.getName(),
+        "address": str(func.getEntryPoint()),
+        "return_type": str(func.getReturnType()),
+        "source": source,
+    }
+
+with open(OUT_PATH, "w") as out:
+    json.dump(payload, out)
+'''
+
+# ---------------------------------------------------------------------------
+# Headless execution
+# ---------------------------------------------------------------------------
+
+
+def _find_analyze_headless() -> str | None:
+    """Locate the analyzeHeadless script."""
+    candidates = [
+        Path(GHIDRA_INSTALL_DIR) / "support" / "analyzeHeadless",
+        Path(GHIDRA_INSTALL_DIR) / "support" / "analyzeHeadless.bat",
+        Path(GHIDRA_INSTALL_DIR) / "analyzeHeadless",
+        Path(GHIDRA_INSTALL_DIR) / "analyzeHeadless.bat",
+    ]
+    for c in candidates:
+        if c.exists():
+            return str(c)
+    return shutil.which("analyzeHeadless")
+
+
+def _run_headless(binary: str, script_body: str, *script_args: str) -> dict[str, Any]:
+    """Run a Ghidra headless analysis with a postScript and parse JSON output.
+
+    ``script_args`` is forwarded as positional arguments after the
+    ``-postScript script.py`` token. The script reads them via Ghidra's
+    ``getScriptArgs()`` — this is the safe replacement for the previous
+    ``str.format()``-based injection point.
+
+    Auto-analysis is always run. Both scripts depend on the function
+    manager being populated (which only happens after analysis), so a
+    conditional ``-noanalysis`` would silently return zero functions on
+    the analysis path — that was a real bug in the previous version.
+    """
+    headless = _find_analyze_headless()
+    if headless is None:
+        return {
+            "error": (
+                f"analyzeHeadless not found. Set GHIDRA_INSTALL_DIR (tried {GHIDRA_INSTALL_DIR})"
+            )
+        }
+
+    with tempfile.TemporaryDirectory(prefix="dcp_ghidra_") as tmpdir:
+        script_path = Path(tmpdir) / "dcp_script.py"
+        script_path.write_text(script_body, encoding="utf-8")
+        project_dir = Path(tmpdir) / "project"
+        project_dir.mkdir()
+        out_path = Path(tmpdir) / "dcp_out.json"
+
+        cmd = [
+            headless,
+            str(project_dir),
+            "dcp_tmp",
+            "-import",
+            binary,
+            "-postScript",
+            str(script_path),
+            *script_args,
+            "-deleteProject",
+        ]
+
+        env = {**os.environ, "DCP_GHIDRA_OUT": str(out_path)}
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=_HEADLESS_TIMEOUT,
+                cwd=tmpdir,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            return {"error": f"Ghidra headless timed out after {_HEADLESS_TIMEOUT}s"}
+        except FileNotFoundError:
+            return {"error": f"analyzeHeadless not executable: {headless}"}
+
+        if not out_path.exists():
+            # Surface returncode + stderr tail so the caller (or the agent)
+            # can diagnose. analyzeHeadless usually exits 0 even on script
+            # error, so the absence of the output file is the real signal.
+            stderr_tail = (result.stderr or "")[-2000:]
+            stdout_tail = (result.stdout or "")[-1000:]
+            return {
+                "error": (
+                    f"Ghidra headless produced no output file (exit code {result.returncode})"
+                ),
+                "stderr_tail": stderr_tail,
+                "stdout_tail": stdout_tail,
+            }
+
+        try:
+            return json.loads(out_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raw = out_path.read_text(encoding="utf-8")
+            return {
+                "error": f"JSON parse error in Ghidra output: {exc}",
+                "raw": raw[:2000],
+            }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def ghidra_analyze_binary(binary: str) -> GhidraAnalysis:
+    """Analyze a binary with Ghidra ΓÇö MCP if available, headless otherwise."""
+    # Try MCP first
+    if _mcp_available():
+        try:
+            data = _mcp_post("/mcp/analyze", {"binary_path": binary})
+            return GhidraAnalysis(
+                program_name=data.get("program_name", ""),
+                language=data.get("language", ""),
+                image_base=data.get("image_base", ""),
+                function_count=data.get("function_count", 0),
+                functions=[GhidraFunction(**f) for f in data.get("functions", [])[:500]],
+                imports=data.get("imports", [])[:500],
+                exports=data.get("exports", [])[:200],
+            )
+        except Exception:
+            pass  # Fall through to headless
+
+    data = _run_headless(binary, _HEADLESS_ANALYSIS_SCRIPT)
+    if "error" in data:
+        return GhidraAnalysis(
+            program_name="",
+            language="",
+            image_base="",
+            function_count=0,
+            error=data["error"],
+        )
+    return GhidraAnalysis(
+        program_name=data.get("program_name", ""),
+        language=data.get("language", ""),
+        image_base=data.get("image_base", ""),
+        function_count=data.get("function_count", 0),
+        functions=[GhidraFunction(**f) for f in data.get("functions", [])[:500]],
+        imports=data.get("imports", [])[:500],
+        exports=data.get("exports", [])[:200],
+    )
+
+
+def ghidra_decompile_function(binary: str, function_name: str) -> GhidraDecompilation:
+    """Decompile a single function ΓÇö MCP if available, headless otherwise."""
+    # Try MCP
+    if _mcp_available():
+        try:
+            data = _mcp_post(
+                "/mcp/decompile",
+                {
+                    "binary_path": binary,
+                    "function": function_name,
+                },
+            )
+            return GhidraDecompilation(
+                function_name=data.get("function_name", function_name),
+                address=data.get("address", ""),
+                source=data.get("source", ""),
+                return_type=data.get("return_type", ""),
+            )
+        except Exception:
+            pass
+
+    # Validate function_name before passing to subprocess argv. Ghidra's
+    # getScriptArgs() receives the argument as a string, but we still
+    # refuse NUL / newline / overly-long inputs so a malformed binary
+    # symbol can't break process invocation or produce confusing logs.
+    if (
+        not function_name
+        or len(function_name) > 256
+        or "\x00" in function_name
+        or "\n" in function_name
+        or "\r" in function_name
+    ):
+        return GhidraDecompilation(
+            function_name=function_name,
+            address="",
+            source=(
+                f"invalid function name: contains NUL/newline or exceeds "
+                f"256 chars (len={len(function_name)})"
+            ),
+        )
+
+    data = _run_headless(binary, _HEADLESS_DECOMPILE_SCRIPT, function_name)
+    if "error" in data:
+        return GhidraDecompilation(
+            function_name=function_name,
+            address="",
+            source=data["error"],
+        )
+    return GhidraDecompilation(
+        function_name=data.get("function_name", function_name),
+        address=data.get("address", ""),
+        source=data.get("source", ""),
+        return_type=data.get("return_type", ""),
+    )
+
+
+def ghidra_get_xrefs(binary: str, address: str) -> list[GhidraXref]:
+    """Get cross-references to an address ΓÇö MCP only (headless is too slow)."""
+    if not _mcp_available():
+        return []
+    try:
+        data = _mcp_post(
+            "/mcp/xrefs",
+            {
+                "binary_path": binary,
+                "address": address,
+            },
+        )
+        return [
+            GhidraXref(
+                from_address=x.get("from_address", ""),
+                to_address=x.get("to_address", address),
+                ref_type=x.get("ref_type", ""),
+                from_function=x.get("from_function", ""),
+            )
+            for x in data.get("xrefs", [])[:200]
+        ]
+    except Exception:
+        return []
+
+
+def ghidra_available() -> dict[str, bool]:
+    """Report which Ghidra backends are available."""
+    return {
+        "headless": _find_analyze_headless() is not None,
+        "mcp": _mcp_available(),
+        "ghidra_install_dir": GHIDRA_INSTALL_DIR,
+        "ghidra_mcp_url": GHIDRA_MCP_URL,
+    }

--- a/packages/decepticon/decepticon/tools/reversing/ghidra.py
+++ b/packages/decepticon/decepticon/tools/reversing/ghidra.py
@@ -5,9 +5,9 @@ reverser agent real decompilation, cross-references, and function
 listings without leaving the sandbox.
 
 Two backends:
-  1. **Headless** ΓÇö ``analyzeHeadless`` + a postScript that dumps JSON.
+  1. **Headless** — ``analyzeHeadless`` + a postScript that dumps JSON.
      Works everywhere Ghidra is installed.  Env: ``GHIDRA_INSTALL_DIR``.
-  2. **MCP bridge** ΓÇö HTTP calls to a running ghidra-mcp server.
+  2. **MCP bridge** — HTTP calls to a running ghidra-mcp server.
      Env: ``GHIDRA_MCP_URL`` (default ``http://127.0.0.1:8089``).
 
 The tools auto-select: MCP when reachable, headless otherwise.
@@ -355,7 +355,7 @@ def _run_headless(binary: str, script_body: str, *script_args: str) -> dict[str,
 
 
 def ghidra_analyze_binary(binary: str) -> GhidraAnalysis:
-    """Analyze a binary with Ghidra ΓÇö MCP if available, headless otherwise."""
+    """Analyze a binary with Ghidra — MCP if available, headless otherwise."""
     # Try MCP first
     if _mcp_available():
         try:
@@ -393,7 +393,7 @@ def ghidra_analyze_binary(binary: str) -> GhidraAnalysis:
 
 
 def ghidra_decompile_function(binary: str, function_name: str) -> GhidraDecompilation:
-    """Decompile a single function ΓÇö MCP if available, headless otherwise."""
+    """Decompile a single function — MCP if available, headless otherwise."""
     # Try MCP
     if _mcp_available():
         try:
@@ -449,7 +449,7 @@ def ghidra_decompile_function(binary: str, function_name: str) -> GhidraDecompil
 
 
 def ghidra_get_xrefs(binary: str, address: str) -> list[GhidraXref]:
-    """Get cross-references to an address ΓÇö MCP only (headless is too slow)."""
+    """Get cross-references to an address — MCP only (headless is too slow)."""
     if not _mcp_available():
         return []
     try:

--- a/packages/decepticon/decepticon/tools/reversing/tools.py
+++ b/packages/decepticon/decepticon/tools/reversing/tools.py
@@ -9,6 +9,12 @@ from typing import Any
 from langchain_core.tools import tool
 
 from decepticon.tools.reversing.binary import identify_binary
+from decepticon.tools.reversing.ghidra import (
+    ghidra_analyze_binary,
+    ghidra_available,
+    ghidra_decompile_function,
+    ghidra_get_xrefs,
+)
 from decepticon.tools.reversing.packer import detect_packer
 from decepticon.tools.reversing.rop import filter_gadgets_by_pattern, find_rop_gadgets
 from decepticon.tools.reversing.scripts import ghidra_recon_script, r2_recon_script
@@ -107,14 +113,76 @@ def bin_ghidra_script(binary: str, script_name: str = "decepticon_recon.py") -> 
 def bin_r2_script(binary: str) -> str:
     """Emit a radare2 recon script body the agent can feed via ``r2 -i``."""
     return _json({"source": r2_recon_script(binary)})
+    return _json({"source": r2_recon_script(binary)})
+
+
+# ---------------------------------------------------------------------------
+# Ghidra deep-analysis tools
+# ---------------------------------------------------------------------------
+
+
+@tool
+def ghidra_analyze(binary: str) -> str:
+    """Run full Ghidra analysis on a binary — functions, imports, exports.
+
+    Auto-selects backend: Ghidra MCP if a server is running, headless
+    ``analyzeHeadless`` otherwise.  Returns structured JSON with up to
+    500 functions, 500 imports, and 200 exports.
+    """
+    result = ghidra_analyze_binary(binary)
+    return _json(result.to_dict())
+
+
+@tool
+def ghidra_decompile(binary: str, function: str) -> str:
+    """Decompile a single function from a binary using Ghidra.
+
+    ``function`` can be a symbol name (e.g. ``main``) or a hex address
+    (e.g. ``0x401000``).  Returns C pseudocode from the Ghidra
+    decompiler.
+    """
+    result = ghidra_decompile_function(binary, function)
+    return _json(result.to_dict())
+
+
+@tool
+def ghidra_xrefs(binary: str, address: str) -> str:
+    """Get cross-references to an address or symbol in a Ghidra-analyzed binary.
+
+    Requires a running Ghidra MCP server.  Returns up to 200 xrefs
+    with source function context.
+    """
+    xrefs = ghidra_get_xrefs(binary, address)
+    return _json({"count": len(xrefs), "xrefs": [x.to_dict() for x in xrefs]})
+
+
+@tool
+def ghidra_status() -> str:
+    """Check Ghidra availability — headless install and MCP server."""
+    return _json(ghidra_available())
+
+
+@tool
+def re_status() -> str:
+    """Report which reverse engineering backends are available."""
+    return _json({"ghidra": ghidra_available()})
 
 
 REVERSING_TOOLS = [
+    # Core triage
     bin_identify,
     bin_strings,
     bin_packer,
     bin_rop,
     bin_symbols_report,
+    # Script generators
     bin_ghidra_script,
     bin_r2_script,
+    # Ghidra deep analysis
+    ghidra_analyze,
+    ghidra_decompile,
+    ghidra_xrefs,
+    ghidra_status,
+    # Availability probe
+    re_status,
 ]


### PR DESCRIPTION
Re-applies #288 on current main with two cleanups. Authorship preserved via cherry-pick. Original PR: #288

## From #288 (kept) — Ghidra reversing backend
- New `decepticon/tools/reversing/ghidra.py` (~480 LOC): headless `analyzeHeadless` + optional MCP-bridge sidecar. Public surface: `ghidra_analyze_binary`, `ghidra_decompile_function`, `ghidra_get_xrefs`, `ghidra_available`.
- `@tool` wrappers in `tools.py` (`ghidra_analyze`, `ghidra_decompile`, `ghidra_xrefs`, `ghidra_status`, `re_status`) added to `REVERSING_TOOLS`.
- Sandbox install **gated by `INSTALL_REVERSING=false`** ARG — default image stays lean. `containers/sandbox.Dockerfile` adds the JDK 21 + Ghidra 12.1 + radare2 + binwalk lane behind that switch.
- `ghidra-mcp` sidecar under the `reversing` compose profile (opt-in via `COMPOSE_PROFILES=reversing`), built from `sandbox.Dockerfile` with `INSTALL_REVERSING=true`. Its 4g/2.0 cap is retained (Ghidra JVM has a natural ceiling worth bounding).
- Reverser agent prompt + root reverser skill rewritten for the Ghidra-first 8-step workflow; new `standard/reverser/ghidra/SKILL.md`.

**Security fixes vs. the original #279 design** — all preserved here: (1) format-string injection closed by passing `function_name` as a subprocess argv positional read via `getScriptArgs()` + a NUL/newline/length validator; (2) bogus `-noanalysis` toggle removed (was silently returning function_count=0 on non-stripped binaries); (3) marker-based stdout JSON replaced with file-based extraction; (4) sidecar pinning + `GHIDRA_SHA256` ARG verification when set.

## Fixed before merge

### 1. Mojibake em-dashes in ghidra.py (commit 675a0aa)
Five docstring/comment em-dashes were corrupted bytes `ce 93 c3 87 c3 b6` ("ΓÇö", a mis-decoded U+2014). Replaced with the proper `—`. Cosmetic.

### 2. Strip global mem_limit/cpus from non-Ghidra services (commit 0a9f20d)
#288 added hard caps to litellm (1g), postgres (512m), neo4j (768m), sandbox (4g), langgraph (2g), web (1g), and c2-sliver (2g) "for predictable stack RSS". That is scope-creep beyond Ghidra and lands global caps without a measured baseline — notably the **langgraph 2g cap** could OOM-kill the agent runtime during complex multi-agent engagements or benchmarks, **affecting every user regardless of the opt-in reversing profile**.

Only `ghidra-mcp`'s own 4g/2.0 cap is retained (Ghidra-specific, scoped to the reversing profile, JVM ceiling). A global resource-limit policy belongs in a separate PR with measured RSS baselines per service.

## Verification
`docker compose config` valid; ruff + format clean; basedpyright 0 errors (1 pre-existing return-type warning at ghidra.py:478, not introduced by these changes).

Co-authored-by: VoidChecksum <halvorsentech@gmail.com>