### PR TITLE
refactor: split prompts module + extract helpers + fix silent-swallow + retire docker-exec dead code (re-merge of #289)

### DIFF
--- a/packages/decepticon/decepticon/agents/prompts/__init__.py
+++ b/packages/decepticon/decepticon/agents/prompts/__init__.py
@@ -1,476 +1,77 @@
 """Agent system prompt assembly pipeline.
 
-Structured prompt composition with:
+Re-export shim. The implementation lives in two sibling modules:
 
-1. **Static/dynamic section separation** — static sections (identity, rules, environment)
-   are stable and cacheable; dynamic sections (skills metadata, engagement context) vary
-   per invocation. A cache boundary marker separates them for Anthropic prompt caching.
+- :mod:`decepticon.agents.prompts.builder` — the prompt-assembly engine:
+  fragment readers, :class:`PromptBuilder`, :func:`load_prompt`, the
+  cross-cutting pattern constants, and the cache-boundary constant.
+- :mod:`decepticon.agents.prompts.registry` — language / locale data and
+  policy: the country→language and language-name maps, and
+  :func:`build_language_policy`.
 
-2. **Tool prompt co-location** — tool prompts live with their tool code (e.g.,
-   decepticon/tools/bash/prompt.py) and are injected here with role-specific variations.
+``builder`` depends on ``registry`` (one-directional — no cycle). Every name
+previously defined at the top level of this module is re-exported here so
+``from decepticon.agents.prompts import X`` keeps working unchanged. The
+redundant ``X as X`` import aliases mark these as intentional re-exports; the
+original module defined no ``__all__``, so none is added here and ``import *``
+behaviour is preserved.
 
-3. **Cross-cutting patterns** — faithful reporting, verification gates, output discipline
-   are injected consistently across all operational agents.
-
-4. **Section registry** — prompts are composed from named sections, making it easy to
-   add, remove, or reorder sections without touching the assembly logic.
-
-Usage:
-    # Simple (backward-compatible)
-    load_prompt("recon", shared=["bash"])
-
-    # Builder API (structured)
-    prompt = (
-        PromptBuilder("recon")
-        .with_tool_prompts(["bash"])
-        .with_shared(["language"])
-        .build()
-    )
+See :mod:`decepticon.agents.prompts.builder` for the assembly design notes
+(static/dynamic section separation, tool-prompt co-location, cross-cutting
+patterns, section registry) and the :func:`load_prompt` / :class:`PromptBuilder`
+usage examples.
 """
 
 from __future__ import annotations
 
-import os
-from datetime import datetime, timezone
-from functools import lru_cache
-from pathlib import Path
-
-_PROMPTS_DIR = Path(__file__).parent
-
-# Search order for prompt fragment lookup. ``_read_fragment(name)`` tries
-# each base directory in order, returning the first ``<base>/<name>.md``
-# that exists. The top-level dir holds cross-cutting fragments
-# (``language.md``); ``standard/`` and ``plugins/`` hold per-agent
-# prompts mirroring the bundle split applied to ``decepticon/agents/``
-# and ``skills/``. External plugin packages ship their own prompts via
-# their own ``importlib.resources`` lookups; this list is OSS-internal.
-_PROMPT_SEARCH_PATHS: tuple[Path, ...] = (
-    _PROMPTS_DIR,
-    _PROMPTS_DIR / "standard",
-    _PROMPTS_DIR / "plugins",
+from decepticon.agents.prompts.builder import (
+    _ANALYST_MINDSET as _ANALYST_MINDSET,
 )
-
-# ── Cache boundary marker ────────────────────────────────────────────────────
-# Inserted between static and dynamic sections. Anthropic's prompt caching
-# heuristic uses this to determine the cacheable prefix boundary.
-# Everything above this marker is stable across invocations and can be cached.
-CACHE_BOUNDARY = "\n\n---\n\n"
-
-# ── Cross-cutting prompt patterns ─────────────────────────────────────────────
-
-_FAITHFUL_REPORTING = """\
-<FAITHFUL_REPORTING>
-Report findings exactly as observed. Do NOT:
-- Speculate about vulnerabilities that scans did not confirm
-- Inflate severity to appear more productive
-- Omit negative results — "no findings" is a valid and valuable result
-- Assume a service is vulnerable without evidence
-
-If a tool returns empty output or no results, report that explicitly. The operator
-needs ground truth to make decisions, not optimistic guesses. A false positive
-wastes more time than a missed finding — the operator will direct further investigation.
-</FAITHFUL_REPORTING>"""
-
-_VERIFICATION_GATE = """\
-<VERIFICATION_GATE>
-Before declaring any finding CRITICAL or HIGH severity:
-1. Verify with at least one additional method (different tool, manual confirmation, or secondary evidence)
-2. Confirm the target is in scope (re-check roe.json if uncertain)
-3. Document the evidence chain: what tool reported it, what confirmed it
-
-Do NOT skip verification to save time. Unverified findings that turn out to be
-false positives erode operator trust and waste downstream effort.
-</VERIFICATION_GATE>"""
-
-_OUTPUT_DISCIPLINE = """\
-<OUTPUT_DISCIPLINE>
-## Response Length Rules
-
-- **Between tool calls**: Keep text to 1-2 sentences. State what you found and what you're doing next. No summaries, no analysis paragraphs — save those for the report.
-- **Final report / handoff**: Be thorough and structured. Use the full format from RESPONSE_RULES.
-- **When the operator asks a question**: Answer directly and concisely. Lead with the answer, not the reasoning.
-
-Do NOT narrate your thought process ("Let me now check...", "I'll proceed to...").
-Just execute. The operator can see your tool calls.
-</OUTPUT_DISCIPLINE>"""
-
-_FINDING_PROTOCOL_POINTER = """\
-<FINDING_PROTOCOL>
-Before recording findings, load the finding-protocol skill:
-`load_skill("/skills/shared/finding-protocol/SKILL.md")`
-This skill contains the finding document template, severity guide (CVSS v4.0),
-naming conventions, and post-creation checklist. Load it before creating any
-finding files.
-</FINDING_PROTOCOL>"""
-
-_ANALYST_MINDSET = """\
-<ANALYST_MINDSET>
-You are an analyst and collaborator, not just a tool executor. This means:
-- **Interpret results**: Don't just dump output — highlight what matters and why
-- **Suggest next steps**: Based on findings, recommend the logical next action
-- **Challenge assumptions**: If the current approach isn't yielding results, say so and propose alternatives
-- **Connect the dots**: Relate new findings to previous discoveries across the engagement
-</ANALYST_MINDSET>"""
-
-
-@lru_cache(maxsize=32)
-def _read_fragment(name: str) -> str:
-    """Read and cache a prompt fragment file from any configured search path."""
-    for base in _PROMPT_SEARCH_PATHS:
-        path = base / f"{name}.md"
-        if path.exists():
-            return path.read_text(encoding="utf-8")
-    searched = ", ".join(str(p / f"{name}.md") for p in _PROMPT_SEARCH_PATHS)
-    msg = f"Prompt fragment not found: {name}.md (searched: {searched})"
-    raise FileNotFoundError(msg)
-
-
-def _get_tool_prompt(tool_name: str, role: str | None = None) -> str:
-    """Get a tool's prompt from its co-located prompt module.
-
-    Tool prompts live with their tool code (e.g., tools/bash/prompt.py).
-    This allows each tool to own its documentation and provide role-specific
-    variations.
-    """
-    if tool_name == "bash":
-        from decepticon.tools.bash.prompt import BASH_PROMPT
-
-        return BASH_PROMPT
-
-    # Fallback: try reading from the prompts directory (backward compat)
-    return _read_fragment(tool_name)
-
-
-# ── Roles that get cross-cutting prompt patterns ─────────────────────────────
-# The orchestrator (decepticon) and soundwave don't do direct tool execution,
-# so they get a subset of the patterns.
-_OPERATIONAL_ROLES = {
-    "recon",
-    "exploit",
-    "postexploit",
-    "analyst",
-    "reverser",
-    "contract_auditor",
-    "cloud_hunter",
-    "ad_operator",
-}
-
-
-class PromptBuilder:
-    """Structured prompt assembly with static/dynamic section separation.
-
-    Structured prompt assembly with static/dynamic section separation:
-    - Static sections are loaded from .md files and tool prompt modules
-    - Cross-cutting patterns are injected based on agent role
-    - A cache boundary marker separates static from dynamic content
-    - Dynamic sections (skills metadata, context) are appended last
-
-    Example:
-        prompt = (
-            PromptBuilder("recon")
-            .with_tool_prompts(["bash"])
-            .with_shared(["language"])
-            .with_dynamic("Current engagement: acme-corp-2026")
-            .build()
-        )
-    """
-
-    def __init__(self, role: str) -> None:
-        self._role = role
-        self._tool_prompts: list[str] = []
-        self._shared: list[str] = []
-        self._dynamic_sections: list[str] = []
-
-    def with_tool_prompts(self, tools: list[str]) -> PromptBuilder:
-        """Add tool prompts (co-located with tool code)."""
-        self._tool_prompts = tools
-        return self
-
-    def with_shared(self, fragments: list[str]) -> PromptBuilder:
-        """Add shared prompt fragments."""
-        self._shared = fragments
-        return self
-
-    def with_dynamic(self, section: str) -> PromptBuilder:
-        """Add a dynamic section (varies per invocation, not cached)."""
-        self._dynamic_sections.append(section)
-        return self
-
-    def build(self) -> str:
-        """Assemble the complete system prompt.
-
-        Layout:
-            [Agent identity + rules + environment]  ← from .md file (static)
-            [Cross-cutting patterns]                ← faithful reporting, etc. (static)
-            [Tool prompts]                          ← from tool prompt modules (static)
-            --- cache boundary ---
-            [Shared fragments]                      ← skills metadata (semi-dynamic)
-            [Dynamic sections]                      ← engagement context (dynamic)
-        """
-        parts: list[str] = []
-
-        # 1. Agent-specific prompt (identity, rules, environment, workflow)
-        parts.append(_read_fragment(self._role))
-
-        # 2. Cross-cutting prompt patterns
-        if self._role in _OPERATIONAL_ROLES:
-            parts.append(_FAITHFUL_REPORTING)
-            parts.append(_VERIFICATION_GATE)
-            parts.append(_FINDING_PROTOCOL_POINTER)
-            parts.append(_OUTPUT_DISCIPLINE)
-            parts.append(_ANALYST_MINDSET)
-        elif self._role == "decepticon":
-            # Orchestrator gets reporting + output discipline but not verification gate
-            parts.append(_FAITHFUL_REPORTING)
-            parts.append(_FINDING_PROTOCOL_POINTER)
-            parts.append(_OUTPUT_DISCIPLINE)
-            parts.append(_ANALYST_MINDSET)
-
-        # 3. Tool prompts (co-located with tool code, role-specific)
-        for tool_name in self._tool_prompts:
-            parts.append(_get_tool_prompt(tool_name, self._role))
-
-        # ── Cache boundary ──
-        # Everything above is static and cacheable by Anthropic prompt caching.
-        # Everything below may change between invocations.
-        parts.append(CACHE_BOUNDARY)
-
-        # 4. Current date/time (prevents model from assuming training cutoff date)
-        now = datetime.now(timezone.utc)
-        parts.append(
-            f"<CURRENT_DATE>Today is {now.strftime('%Y-%m-%d')} "
-            f"(UTC {now.strftime('%H:%M')}). "
-            f"Use this date for all reporting and timestamps.</CURRENT_DATE>"
-        )
-
-        # 5. Shared fragments (skills metadata — semi-dynamic, changes with skill updates)
-        for fragment_name in self._shared:
-            parts.append(_read_fragment(fragment_name))
-
-        # 6. Dynamic sections (engagement context, runtime state)
-        for section in self._dynamic_sections:
-            parts.append(section)
-
-        return "\n\n".join(parts)
-
-
-# Country-code aliases → ISO 639-1 language codes. Users naturally type
-# "dk" (Denmark), "se" (Sweden), "jp" (Japan), "cn" (China) instead of
-# the ISO 639-1 "da", "sv", "ja", "zh". Shared between the env-based
-# prompt-time path (CLI) and the runtime config path (web SaaS).
-_COUNTRY_TO_LANG = {
-    "dk": "da",
-    "se": "sv",
-    "jp": "ja",
-    "cn": "zh",
-    "br": "pt-br",
-    "tw": "zh-tw",
-}
-
-_LANG_NAMES = {
-    # East Asian
-    "ko": "Korean",
-    "ja": "Japanese",
-    "zh": "Chinese",
-    "zh-cn": "Simplified Chinese",
-    "zh-tw": "Traditional Chinese",
-    # Nordic / Scandinavian
-    "no": "Norwegian",
-    "nb": "Norwegian Bokmål",
-    "nn": "Norwegian Nynorsk",
-    "sv": "Swedish",
-    "da": "Danish",
-    "fi": "Finnish",
-    "is": "Icelandic",
-    # Western European
-    "de": "German",
-    "fr": "French",
-    "es": "Spanish",
-    "pt": "Portuguese",
-    "pt-br": "Brazilian Portuguese",
-    "it": "Italian",
-    "nl": "Dutch",
-    "ca": "Catalan",
-    # Eastern European / Slavic
-    "ru": "Russian",
-    "pl": "Polish",
-    "cs": "Czech",
-    "sk": "Slovak",
-    "uk": "Ukrainian",
-    "bg": "Bulgarian",
-    "hr": "Croatian",
-    "sr": "Serbian",
-    "sl": "Slovenian",
-    "ro": "Romanian",
-    # South / Southeast Asian
-    "hi": "Hindi",
-    "bn": "Bengali",
-    "ta": "Tamil",
-    "te": "Telugu",
-    "th": "Thai",
-    "vi": "Vietnamese",
-    "id": "Indonesian",
-    "ms": "Malay",
-    "tl": "Filipino",
-    # Middle Eastern
-    "ar": "Arabic",
-    "fa": "Persian",
-    "he": "Hebrew",
-    "tr": "Turkish",
-    # Other
-    "el": "Greek",
-    "hu": "Hungarian",
-    "et": "Estonian",
-    "lv": "Latvian",
-    "lt": "Lithuanian",
-    "sw": "Swahili",
-    "af": "Afrikaans",
-}
-
-
-def build_language_policy(language: str) -> str | None:
-    """Build the LANGUAGE_POLICY block for a given ISO 639-1 code.
-
-    Returns the policy text, or None when the code is empty / English (no
-    override needed — the prompt's default language.md fragment applies).
-    Shared between the prompt builder (env-based) and the
-    EngagementContextMiddleware runtime path (config-based).
-    """
-    lang = (language or "").strip()
-    if not lang or lang.lower() == "en":
-        return None
-
-    resolved = _COUNTRY_TO_LANG.get(lang.lower(), lang.lower())
-
-    if resolved == "wenyan":
-        return (
-            "<LANGUAGE_POLICY>\n"
-            "You MUST respond in 文言文 (wenyan-full) — Classical Chinese literary\n"
-            "prose with English technical terms preserved verbatim.\n"
-            "\n"
-            "Rules:\n"
-            "- Maximum classical terseness. 80-90% character reduction vs normal prose.\n"
-            "- Classical sentence patterns: verbs precede objects, subjects often omitted,\n"
-            "  use classical particles (之/乃/為/其/則/而/以/故).\n"
-            "- ALL technical terms stay in English exactly as-is: function names, API names,\n"
-            "  code symbols, error strings, file paths, command flags, tool names, config\n"
-            "  keys, variable names. NEVER transliterate these into Chinese.\n"
-            "- Code blocks, tool calls, JSON, structured payloads: completely unchanged.\n"
-            "- Mix freely: Classical Chinese for explanation, English for technical nouns.\n"
-            "\n"
-            "Examples:\n"
-            "- '物出新參照，致重繪。useMemo Wrap之。'\n"
-            "- '池reuse open connection。不每req新開。skip handshake overhead。'\n"
-            "- 'Bug在auth middleware。Token expiry check用 `<` 非 `<=`。Fix:'\n"
-            "\n"
-            "Drop caveman for: security warnings, irreversible action confirmations,\n"
-            "cases where compression creates technical ambiguity. Resume after.\n"
-            "</LANGUAGE_POLICY>"
-        )
-
-    lang_name = _LANG_NAMES.get(resolved, lang)
-    return (
-        "<LANGUAGE_POLICY>\n"
-        f"You MUST respond in {lang_name} for all operator-facing prose.\n"
-        f"\n"
-        f"- All operator-facing prose (interview questions, menu options, explanations,\n"
-        f"  summaries, status updates, error messages) MUST be in {lang_name}.\n"
-        f"- Tool calls, tool arguments, and structured payloads (JSON fields, code\n"
-        f"  blocks, file paths, command output) stay in their original technical\n"
-        f"  form — do not translate identifiers, file names, command flags, or\n"
-        f"  schema field names.\n"
-        f"</LANGUAGE_POLICY>"
-    )
-
-
-def load_prompt(
-    name: str,
-    *,
-    shared: list[str] | None = None,
-    override: str | dict[str, str] | None = None,
-) -> str:
-    """Load an agent system prompt with structured assembly.
-
-    Static identity/rules/environment load from ``<name>.md`` and combine
-    with cross-cutting patterns (faithful reporting, verification gate,
-    output discipline) and tool prompts. The Anthropic prompt-caching
-    boundary separates the cacheable static prefix from per-invocation
-    dynamic content.
-
-    Plugin prompt overrides (``PluginBundle(prompts={...})`` under the
-    ``decepticon.bundles`` entry-point group) apply automatically. Library
-    callers can supply an explicit ``override`` — ``str`` for full
-    replace, ``dict`` with ``prepend`` / ``append`` / ``replace`` keys.
-    Explicit overrides win over plugin overrides on conflict.
-
-    Args:
-        name: Prompt filename without extension (e.g., "recon", "exploit").
-        shared: Shared fragment names to append (e.g., ["bash", "skills"]).
-            "bash" is special-cased to use the co-located tool prompt module.
-        override: Optional explicit prompt override. ``None`` (default) =
-            only plugin overrides apply.
-
-    Returns:
-        Assembled system prompt string.
-    """
-    shared = shared or []
-
-    # Separate tool prompts from shared fragments
-    tool_prompts = [s for s in shared if s == "bash"]
-    fragments = [s for s in shared if s != "bash"]
-
-    # Cross-cutting language policy — applies to every agent. Prepended once
-    # so every prompt picks up the same operator-language directive without
-    # per-agent edits.
-    #
-    # DECEPTICON_LANGUAGE env var pins the output language (e.g. "en", "ko",
-    # "no"). When set, auto-detect is disabled and the agent always responds
-    # in the pinned language. When unset, the language.md fragment's
-    # auto-detect logic applies.
-    if "language" not in fragments:
-        fragments = ["language", *fragments]
-
-    prompt = PromptBuilder(name).with_tool_prompts(tool_prompts).with_shared(fragments).build()
-
-    # Runtime language pin: when DECEPTICON_LANGUAGE is set, replace the
-    # default English policy with a pinned-language directive so every agent
-    # replies in the configured locale regardless of input language. The
-    # env-based path is the CLI / single-tenant convention; multi-tenant
-    # launchers (SaaS web) override per-run via config.configurable.language
-    # which EngagementContextMiddleware injects as a later SystemMessage.
-    pinned_lang = os.environ.get("DECEPTICON_LANGUAGE", "").strip()
-    lang_policy = build_language_policy(pinned_lang)
-    if lang_policy is not None:
-        import re
-
-        prompt = re.sub(
-            r"<LANGUAGE_POLICY>.*?</LANGUAGE_POLICY>",
-            lang_policy,
-            prompt,
-            flags=re.DOTALL,
-        )
-
-    # Apply Claude 4.x compatibility shim (no-op for other model families).
-    # See decepticon/agents/prompts/claude4_compat.py and docs/model-compatibility.md.
-    try:
-        from decepticon.agents.prompts.claude4_compat import apply_compat_for_role
-
-        prompt = apply_compat_for_role(prompt, name)
-    except Exception:
-        # Fail soft: never break prompt loading because of the compat shim.
-        pass
-
-    # Plugin + explicit prompt overrides apply last so prepend/append wrap
-    # the fully-assembled prompt (language policy + compat shim included).
-    # Lazy import avoids a circular dependency between assembly and prompts.
-    from decepticon.agents.build import resolve_prompt_overrides
-
-    merged = resolve_prompt_overrides(name, override=override)
-    if "replace" in merged:
-        prompt = merged["replace"]
-    if merged.get("prepend"):
-        prompt = f"{merged['prepend']}\n\n{prompt}"
-    if merged.get("append"):
-        prompt = f"{prompt}\n\n{merged['append']}"
-
-    return prompt
+from decepticon.agents.prompts.builder import (
+    _FAITHFUL_REPORTING as _FAITHFUL_REPORTING,
+)
+from decepticon.agents.prompts.builder import (
+    _FINDING_PROTOCOL_POINTER as _FINDING_PROTOCOL_POINTER,
+)
+from decepticon.agents.prompts.builder import (
+    _OPERATIONAL_ROLES as _OPERATIONAL_ROLES,
+)
+from decepticon.agents.prompts.builder import (
+    _OUTPUT_DISCIPLINE as _OUTPUT_DISCIPLINE,
+)
+from decepticon.agents.prompts.builder import (
+    _PROMPT_SEARCH_PATHS as _PROMPT_SEARCH_PATHS,
+)
+from decepticon.agents.prompts.builder import (
+    _PROMPTS_DIR as _PROMPTS_DIR,
+)
+from decepticon.agents.prompts.builder import (
+    _VERIFICATION_GATE as _VERIFICATION_GATE,
+)
+from decepticon.agents.prompts.builder import (
+    CACHE_BOUNDARY as CACHE_BOUNDARY,
+)
+from decepticon.agents.prompts.builder import (
+    PromptBuilder as PromptBuilder,
+)
+from decepticon.agents.prompts.builder import (
+    _get_tool_prompt as _get_tool_prompt,
+)
+from decepticon.agents.prompts.builder import (
+    _read_fragment as _read_fragment,
+)
+from decepticon.agents.prompts.builder import (
+    load_prompt as load_prompt,
+)
+from decepticon.agents.prompts.builder import (
+    log as log,
+)
+from decepticon.agents.prompts.registry import (
+    _COUNTRY_TO_LANG as _COUNTRY_TO_LANG,
+)
+from decepticon.agents.prompts.registry import (
+    _LANG_NAMES as _LANG_NAMES,
+)
+from decepticon.agents.prompts.registry import (
+    build_language_policy as build_language_policy,
+)

--- a/packages/decepticon/decepticon/agents/prompts/builder.py
+++ b/packages/decepticon/decepticon/agents/prompts/builder.py
@@ -1,0 +1,352 @@
+"""Agent system prompt assembly pipeline.
+
+Structured prompt composition with:
+
+1. **Static/dynamic section separation** — static sections (identity, rules, environment)
+   are stable and cacheable; dynamic sections (skills metadata, engagement context) vary
+   per invocation. A cache boundary marker separates them for Anthropic prompt caching.
+
+2. **Tool prompt co-location** — tool prompts live with their tool code (e.g.,
+   decepticon/tools/bash/prompt.py) and are injected here with role-specific variations.
+
+3. **Cross-cutting patterns** — faithful reporting, verification gates, output discipline
+   are injected consistently across all operational agents.
+
+4. **Section registry** — prompts are composed from named sections, making it easy to
+   add, remove, or reorder sections without touching the assembly logic.
+
+Usage:
+    # Simple (backward-compatible)
+    load_prompt("recon", shared=["bash"])
+
+    # Builder API (structured)
+    prompt = (
+        PromptBuilder("recon")
+        .with_tool_prompts(["bash"])
+        .with_shared(["language"])
+        .build()
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+
+from decepticon.agents.prompts.registry import build_language_policy
+
+log = logging.getLogger(__name__)
+
+_PROMPTS_DIR = Path(__file__).parent
+
+# Search order for prompt fragment lookup. ``_read_fragment(name)`` tries
+# each base directory in order, returning the first ``<base>/<name>.md``
+# that exists. The top-level dir holds cross-cutting fragments
+# (``language.md``); ``standard/`` and ``plugins/`` hold per-agent
+# prompts mirroring the bundle split applied to ``decepticon/agents/``
+# and ``skills/``. External plugin packages ship their own prompts via
+# their own ``importlib.resources`` lookups; this list is OSS-internal.
+_PROMPT_SEARCH_PATHS: tuple[Path, ...] = (
+    _PROMPTS_DIR,
+    _PROMPTS_DIR / "standard",
+    _PROMPTS_DIR / "plugins",
+)
+
+# ── Cache boundary marker ────────────────────────────────────────────────────
+# Inserted between static and dynamic sections. Anthropic's prompt caching
+# heuristic uses this to determine the cacheable prefix boundary.
+# Everything above this marker is stable across invocations and can be cached.
+CACHE_BOUNDARY = "\n\n---\n\n"
+
+# ── Cross-cutting prompt patterns ─────────────────────────────────────────────
+
+_FAITHFUL_REPORTING = """\
+<FAITHFUL_REPORTING>
+Report findings exactly as observed. Do NOT:
+- Speculate about vulnerabilities that scans did not confirm
+- Inflate severity to appear more productive
+- Omit negative results — "no findings" is a valid and valuable result
+- Assume a service is vulnerable without evidence
+
+If a tool returns empty output or no results, report that explicitly. The operator
+needs ground truth to make decisions, not optimistic guesses. A false positive
+wastes more time than a missed finding — the operator will direct further investigation.
+</FAITHFUL_REPORTING>"""
+
+_VERIFICATION_GATE = """\
+<VERIFICATION_GATE>
+Before declaring any finding CRITICAL or HIGH severity:
+1. Verify with at least one additional method (different tool, manual confirmation, or secondary evidence)
+2. Confirm the target is in scope (re-check roe.json if uncertain)
+3. Document the evidence chain: what tool reported it, what confirmed it
+
+Do NOT skip verification to save time. Unverified findings that turn out to be
+false positives erode operator trust and waste downstream effort.
+</VERIFICATION_GATE>"""
+
+_OUTPUT_DISCIPLINE = """\
+<OUTPUT_DISCIPLINE>
+## Response Length Rules
+
+- **Between tool calls**: Keep text to 1-2 sentences. State what you found and what you're doing next. No summaries, no analysis paragraphs — save those for the report.
+- **Final report / handoff**: Be thorough and structured. Use the full format from RESPONSE_RULES.
+- **When the operator asks a question**: Answer directly and concisely. Lead with the answer, not the reasoning.
+
+Do NOT narrate your thought process ("Let me now check...", "I'll proceed to...").
+Just execute. The operator can see your tool calls.
+</OUTPUT_DISCIPLINE>"""
+
+_FINDING_PROTOCOL_POINTER = """\
+<FINDING_PROTOCOL>
+Before recording findings, load the finding-protocol skill:
+`load_skill("/skills/shared/finding-protocol/SKILL.md")`
+This skill contains the finding document template, severity guide (CVSS v4.0),
+naming conventions, and post-creation checklist. Load it before creating any
+finding files.
+</FINDING_PROTOCOL>"""
+
+_ANALYST_MINDSET = """\
+<ANALYST_MINDSET>
+You are an analyst and collaborator, not just a tool executor. This means:
+- **Interpret results**: Don't just dump output — highlight what matters and why
+- **Suggest next steps**: Based on findings, recommend the logical next action
+- **Challenge assumptions**: If the current approach isn't yielding results, say so and propose alternatives
+- **Connect the dots**: Relate new findings to previous discoveries across the engagement
+</ANALYST_MINDSET>"""
+
+
+@lru_cache(maxsize=32)
+def _read_fragment(name: str) -> str:
+    """Read and cache a prompt fragment file from any configured search path."""
+    for base in _PROMPT_SEARCH_PATHS:
+        path = base / f"{name}.md"
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+    searched = ", ".join(str(p / f"{name}.md") for p in _PROMPT_SEARCH_PATHS)
+    msg = f"Prompt fragment not found: {name}.md (searched: {searched})"
+    raise FileNotFoundError(msg)
+
+
+def _get_tool_prompt(tool_name: str, role: str | None = None) -> str:
+    """Get a tool's prompt from its co-located prompt module.
+
+    Tool prompts live with their tool code (e.g., tools/bash/prompt.py).
+    This allows each tool to own its documentation and provide role-specific
+    variations.
+    """
+    if tool_name == "bash":
+        from decepticon.tools.bash.prompt import BASH_PROMPT
+
+        return BASH_PROMPT
+
+    # Fallback: try reading from the prompts directory (backward compat)
+    return _read_fragment(tool_name)
+
+
+# ── Roles that get cross-cutting prompt patterns ─────────────────────────────
+# The orchestrator (decepticon) and soundwave don't do direct tool execution,
+# so they get a subset of the patterns.
+_OPERATIONAL_ROLES = {
+    "recon",
+    "exploit",
+    "postexploit",
+    "analyst",
+    "reverser",
+    "contract_auditor",
+    "cloud_hunter",
+    "ad_operator",
+}
+
+
+class PromptBuilder:
+    """Structured prompt assembly with static/dynamic section separation.
+
+    Structured prompt assembly with static/dynamic section separation:
+    - Static sections are loaded from .md files and tool prompt modules
+    - Cross-cutting patterns are injected based on agent role
+    - A cache boundary marker separates static from dynamic content
+    - Dynamic sections (skills metadata, context) are appended last
+
+    Example:
+        prompt = (
+            PromptBuilder("recon")
+            .with_tool_prompts(["bash"])
+            .with_shared(["language"])
+            .with_dynamic("Current engagement: acme-corp-2026")
+            .build()
+        )
+    """
+
+    def __init__(self, role: str) -> None:
+        self._role = role
+        self._tool_prompts: list[str] = []
+        self._shared: list[str] = []
+        self._dynamic_sections: list[str] = []
+
+    def with_tool_prompts(self, tools: list[str]) -> PromptBuilder:
+        """Add tool prompts (co-located with tool code)."""
+        self._tool_prompts = tools
+        return self
+
+    def with_shared(self, fragments: list[str]) -> PromptBuilder:
+        """Add shared prompt fragments."""
+        self._shared = fragments
+        return self
+
+    def with_dynamic(self, section: str) -> PromptBuilder:
+        """Add a dynamic section (varies per invocation, not cached)."""
+        self._dynamic_sections.append(section)
+        return self
+
+    def build(self) -> str:
+        """Assemble the complete system prompt.
+
+        Layout:
+            [Agent identity + rules + environment]  ← from .md file (static)
+            [Cross-cutting patterns]                ← faithful reporting, etc. (static)
+            [Tool prompts]                          ← from tool prompt modules (static)
+            --- cache boundary ---
+            [Shared fragments]                      ← skills metadata (semi-dynamic)
+            [Dynamic sections]                      ← engagement context (dynamic)
+        """
+        parts: list[str] = []
+
+        # 1. Agent-specific prompt (identity, rules, environment, workflow)
+        parts.append(_read_fragment(self._role))
+
+        # 2. Cross-cutting prompt patterns
+        if self._role in _OPERATIONAL_ROLES:
+            parts.append(_FAITHFUL_REPORTING)
+            parts.append(_VERIFICATION_GATE)
+            parts.append(_FINDING_PROTOCOL_POINTER)
+            parts.append(_OUTPUT_DISCIPLINE)
+            parts.append(_ANALYST_MINDSET)
+        elif self._role == "decepticon":
+            # Orchestrator gets reporting + output discipline but not verification gate
+            parts.append(_FAITHFUL_REPORTING)
+            parts.append(_FINDING_PROTOCOL_POINTER)
+            parts.append(_OUTPUT_DISCIPLINE)
+            parts.append(_ANALYST_MINDSET)
+
+        # 3. Tool prompts (co-located with tool code, role-specific)
+        for tool_name in self._tool_prompts:
+            parts.append(_get_tool_prompt(tool_name, self._role))
+
+        # ── Cache boundary ──
+        # Everything above is static and cacheable by Anthropic prompt caching.
+        # Everything below may change between invocations.
+        parts.append(CACHE_BOUNDARY)
+
+        # 4. Current date/time (prevents model from assuming training cutoff date)
+        now = datetime.now(timezone.utc)
+        parts.append(
+            f"<CURRENT_DATE>Today is {now.strftime('%Y-%m-%d')} "
+            f"(UTC {now.strftime('%H:%M')}). "
+            f"Use this date for all reporting and timestamps.</CURRENT_DATE>"
+        )
+
+        # 5. Shared fragments (skills metadata — semi-dynamic, changes with skill updates)
+        for fragment_name in self._shared:
+            parts.append(_read_fragment(fragment_name))
+
+        # 6. Dynamic sections (engagement context, runtime state)
+        for section in self._dynamic_sections:
+            parts.append(section)
+
+        return "\n\n".join(parts)
+
+
+def load_prompt(
+    name: str,
+    *,
+    shared: list[str] | None = None,
+    override: str | dict[str, str] | None = None,
+) -> str:
+    """Load an agent system prompt with structured assembly.
+
+    Static identity/rules/environment load from ``<name>.md`` and combine
+    with cross-cutting patterns (faithful reporting, verification gate,
+    output discipline) and tool prompts. The Anthropic prompt-caching
+    boundary separates the cacheable static prefix from per-invocation
+    dynamic content.
+
+    Plugin prompt overrides (``PluginBundle(prompts={...})`` under the
+    ``decepticon.bundles`` entry-point group) apply automatically. Library
+    callers can supply an explicit ``override`` — ``str`` for full
+    replace, ``dict`` with ``prepend`` / ``append`` / ``replace`` keys.
+    Explicit overrides win over plugin overrides on conflict.
+
+    Args:
+        name: Prompt filename without extension (e.g., "recon", "exploit").
+        shared: Shared fragment names to append (e.g., ["bash", "skills"]).
+            "bash" is special-cased to use the co-located tool prompt module.
+        override: Optional explicit prompt override. ``None`` (default) =
+            only plugin overrides apply.
+
+    Returns:
+        Assembled system prompt string.
+    """
+    shared = shared or []
+
+    # Separate tool prompts from shared fragments
+    tool_prompts = [s for s in shared if s == "bash"]
+    fragments = [s for s in shared if s != "bash"]
+
+    # Cross-cutting language policy — applies to every agent. Prepended once
+    # so every prompt picks up the same operator-language directive without
+    # per-agent edits.
+    #
+    # DECEPTICON_LANGUAGE env var pins the output language (e.g. "en", "ko",
+    # "no"). When set, auto-detect is disabled and the agent always responds
+    # in the pinned language. When unset, the language.md fragment's
+    # auto-detect logic applies.
+    if "language" not in fragments:
+        fragments = ["language", *fragments]
+
+    prompt = PromptBuilder(name).with_tool_prompts(tool_prompts).with_shared(fragments).build()
+
+    # Runtime language pin: when DECEPTICON_LANGUAGE is set, replace the
+    # default English policy with a pinned-language directive so every agent
+    # replies in the configured locale regardless of input language. The
+    # env-based path is the CLI / single-tenant convention; multi-tenant
+    # launchers (SaaS web) override per-run via config.configurable.language
+    # which EngagementContextMiddleware injects as a later SystemMessage.
+    pinned_lang = os.environ.get("DECEPTICON_LANGUAGE", "").strip()
+    lang_policy = build_language_policy(pinned_lang)
+    if lang_policy is not None:
+        import re
+
+        prompt = re.sub(
+            r"<LANGUAGE_POLICY>.*?</LANGUAGE_POLICY>",
+            lang_policy,
+            prompt,
+            flags=re.DOTALL,
+        )
+
+    # Apply Claude 4.x compatibility shim (no-op for other model families).
+    # See decepticon/agents/prompts/claude4_compat.py and docs/model-compatibility.md.
+    try:
+        from decepticon.agents.prompts.claude4_compat import apply_compat_for_role
+
+        prompt = apply_compat_for_role(prompt, name)
+    except Exception as exc:
+        # Fail soft: never break prompt loading because of the compat shim.
+        log.debug("Claude 4.x compat shim skipped (swallowed): %s", exc)
+
+    # Plugin + explicit prompt overrides apply last so prepend/append wrap
+    # the fully-assembled prompt (language policy + compat shim included).
+    # Lazy import avoids a circular dependency between assembly and prompts.
+    from decepticon.agents.build import resolve_prompt_overrides
+
+    merged = resolve_prompt_overrides(name, override=override)
+    if "replace" in merged:
+        prompt = merged["replace"]
+    if merged.get("prepend"):
+        prompt = f"{merged['prepend']}\n\n{prompt}"
+    if merged.get("append"):
+        prompt = f"{prompt}\n\n{merged['append']}"
+
+    return prompt

--- a/packages/decepticon/decepticon/agents/prompts/registry.py
+++ b/packages/decepticon/decepticon/agents/prompts/registry.py
@@ -1,0 +1,138 @@
+"""Language / locale registry and operator-language policy.
+
+Holds the country-code → ISO 639-1 alias map, the ISO 639-1 → language-name
+map, and :func:`build_language_policy`, which renders the ``<LANGUAGE_POLICY>``
+block injected into every agent prompt. Kept separate from the prompt-assembly
+engine (:mod:`decepticon.agents.prompts.builder`) so the assembly engine can
+depend on this data without the reverse — one-directional, no cycle.
+"""
+
+from __future__ import annotations
+
+# Country-code aliases → ISO 639-1 language codes. Users naturally type
+# "dk" (Denmark), "se" (Sweden), "jp" (Japan), "cn" (China) instead of
+# the ISO 639-1 "da", "sv", "ja", "zh". Shared between the env-based
+# prompt-time path (CLI) and the runtime config path (web SaaS).
+_COUNTRY_TO_LANG = {
+    "dk": "da",
+    "se": "sv",
+    "jp": "ja",
+    "cn": "zh",
+    "br": "pt-br",
+    "tw": "zh-tw",
+}
+
+_LANG_NAMES = {
+    # East Asian
+    "ko": "Korean",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "zh-cn": "Simplified Chinese",
+    "zh-tw": "Traditional Chinese",
+    # Nordic / Scandinavian
+    "no": "Norwegian",
+    "nb": "Norwegian Bokmål",
+    "nn": "Norwegian Nynorsk",
+    "sv": "Swedish",
+    "da": "Danish",
+    "fi": "Finnish",
+    "is": "Icelandic",
+    # Western European
+    "de": "German",
+    "fr": "French",
+    "es": "Spanish",
+    "pt": "Portuguese",
+    "pt-br": "Brazilian Portuguese",
+    "it": "Italian",
+    "nl": "Dutch",
+    "ca": "Catalan",
+    # Eastern European / Slavic
+    "ru": "Russian",
+    "pl": "Polish",
+    "cs": "Czech",
+    "sk": "Slovak",
+    "uk": "Ukrainian",
+    "bg": "Bulgarian",
+    "hr": "Croatian",
+    "sr": "Serbian",
+    "sl": "Slovenian",
+    "ro": "Romanian",
+    # South / Southeast Asian
+    "hi": "Hindi",
+    "bn": "Bengali",
+    "ta": "Tamil",
+    "te": "Telugu",
+    "th": "Thai",
+    "vi": "Vietnamese",
+    "id": "Indonesian",
+    "ms": "Malay",
+    "tl": "Filipino",
+    # Middle Eastern
+    "ar": "Arabic",
+    "fa": "Persian",
+    "he": "Hebrew",
+    "tr": "Turkish",
+    # Other
+    "el": "Greek",
+    "hu": "Hungarian",
+    "et": "Estonian",
+    "lv": "Latvian",
+    "lt": "Lithuanian",
+    "sw": "Swahili",
+    "af": "Afrikaans",
+}
+
+
+def build_language_policy(language: str) -> str | None:
+    """Build the LANGUAGE_POLICY block for a given ISO 639-1 code.
+
+    Returns the policy text, or None when the code is empty / English (no
+    override needed — the prompt's default language.md fragment applies).
+    Shared between the prompt builder (env-based) and the
+    EngagementContextMiddleware runtime path (config-based).
+    """
+    lang = (language or "").strip()
+    if not lang or lang.lower() == "en":
+        return None
+
+    resolved = _COUNTRY_TO_LANG.get(lang.lower(), lang.lower())
+
+    if resolved == "wenyan":
+        return (
+            "<LANGUAGE_POLICY>\n"
+            "You MUST respond in 文言文 (wenyan-full) — Classical Chinese literary\n"
+            "prose with English technical terms preserved verbatim.\n"
+            "\n"
+            "Rules:\n"
+            "- Maximum classical terseness. 80-90% character reduction vs normal prose.\n"
+            "- Classical sentence patterns: verbs precede objects, subjects often omitted,\n"
+            "  use classical particles (之/乃/為/其/則/而/以/故).\n"
+            "- ALL technical terms stay in English exactly as-is: function names, API names,\n"
+            "  code symbols, error strings, file paths, command flags, tool names, config\n"
+            "  keys, variable names. NEVER transliterate these into Chinese.\n"
+            "- Code blocks, tool calls, JSON, structured payloads: completely unchanged.\n"
+            "- Mix freely: Classical Chinese for explanation, English for technical nouns.\n"
+            "\n"
+            "Examples:\n"
+            "- '物出新參照，致重繪。useMemo Wrap之。'\n"
+            "- '池reuse open connection。不每req新開。skip handshake overhead。'\n"
+            "- 'Bug在auth middleware。Token expiry check用 `<` 非 `<=`。Fix:'\n"
+            "\n"
+            "Drop caveman for: security warnings, irreversible action confirmations,\n"
+            "cases where compression creates technical ambiguity. Resume after.\n"
+            "</LANGUAGE_POLICY>"
+        )
+
+    lang_name = _LANG_NAMES.get(resolved, lang)
+    return (
+        "<LANGUAGE_POLICY>\n"
+        f"You MUST respond in {lang_name} for all operator-facing prose.\n"
+        f"\n"
+        f"- All operator-facing prose (interview questions, menu options, explanations,\n"
+        f"  summaries, status updates, error messages) MUST be in {lang_name}.\n"
+        f"- Tool calls, tool arguments, and structured payloads (JSON fields, code\n"
+        f"  blocks, file paths, command output) stay in their original technical\n"
+        f"  form — do not translate identifiers, file names, command flags, or\n"
+        f"  schema field names.\n"
+        f"</LANGUAGE_POLICY>"
+    )

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -325,23 +325,13 @@ def _is_truthy(value: str) -> bool:
     return value.strip().lower() in ("true", "1", "yes", "on")
 
 
-def _resolve_credentials() -> Credentials:
-    """Build Credentials from environment variables.
+def _parse_auth_priority() -> tuple[list[AuthMethod], bool]:
+    """Parse ``DECEPTICON_AUTH_PRIORITY`` into an ordered AuthMethod list.
 
-    Walks ``DECEPTICON_AUTH_PRIORITY`` (comma-separated AuthMethod
-    values; defaults to ``_DEFAULT_AUTH_PRIORITY``) and includes only
-    methods whose detection rule passes:
-
-      - API methods: their key env var is set to a non-placeholder
-      - OAuth methods: their boolean env var is set truthy
-
-    When **nothing** is detected — typical of CI / dev shells where
-    onboard hasn't run — falls back to all four API methods. This keeps
-    module-level ``graph = create_X_agent()`` calls importable so the
-    test suite (and tools like langgraph Studio) can load agents
-    without API keys present. Real LLM calls under that fallback will
-    fail at request time with a provider 401, which is the correct
-    surface for that misconfiguration.
+    Returns ``(priority, priority_explicit)``: the ordered method list and a
+    flag for whether the env var was set non-empty. When it is unset/blank
+    the default ordering (``_DEFAULT_AUTH_PRIORITY``) is returned. Unknown
+    tokens are logged and skipped.
     """
     priority_raw = os.getenv("DECEPTICON_AUTH_PRIORITY", "")
     priority_explicit = bool(priority_raw.strip())
@@ -357,7 +347,17 @@ def _resolve_credentials() -> Credentials:
                 log.warning("Unknown method in DECEPTICON_AUTH_PRIORITY: %s", token)
     else:
         priority = list(_DEFAULT_AUTH_PRIORITY)
+    return priority, priority_explicit
 
+
+def _detect_available_methods(priority: list[AuthMethod]) -> list[AuthMethod]:
+    """Return the subset of ``priority`` whose credential-detection rule passes.
+
+    - API methods: their key env var is set to a non-placeholder
+    - OAuth methods: their boolean env var is truthy AND the credential
+      file is present
+    - Local methods: their own env signal is configured
+    """
     methods: list[AuthMethod] = []
     for method in priority:
         if method in _API_METHOD_ENV:
@@ -388,60 +388,95 @@ def _resolve_credentials() -> Credentials:
         elif method == AuthMethod.CUSTOM_OPENAI_API:
             if _custom_openai_configured():
                 methods.append(method)
+    return methods
+
+
+def _fallback_credentials(*, priority_explicit: bool) -> Credentials:
+    """Build the fallback Credentials when no priority method was detected.
+
+    A user who wired only a local/cloud OpenAI-compatible endpoint (Ollama,
+    LM Studio, llama.cpp, custom) but authored no priority list gets a
+    single-method chain for it. Otherwise falls back to all API methods so
+    module-level agent constructors stay importable; ``priority_explicit``
+    only changes the log severity (ERROR vs INFO).
+    """
+    # Local-only or cloud-only OSS path: a user who set Ollama env vars
+    # but didn't write a priority list gets a single-method Ollama chain.
+    if _ollama_local_configured():
+        log.info(
+            "Only OLLAMA_API_BASE/OLLAMA_MODEL detected; running against local Ollama exclusively"
+        )
+        return Credentials(methods=[AuthMethod.OLLAMA_LOCAL])
+    if _ollama_cloud_configured():
+        log.info(
+            "Only OLLAMA_CLOUD_API_BASE/OLLAMA_CLOUD_MODEL detected; "
+            "running against Ollama Cloud exclusively"
+        )
+        return Credentials(methods=[AuthMethod.OLLAMA_CLOUD])
+    if _lmstudio_local_configured():
+        log.info("Only LMSTUDIO_API_BASE/LMSTUDIO_MODEL detected; using LM Studio")
+        return Credentials(methods=[AuthMethod.LMSTUDIO_LOCAL])
+    if _llamacpp_local_configured():
+        log.info("Only LLAMACPP_API_BASE/LLAMACPP_MODEL detected; using llama.cpp")
+        return Credentials(methods=[AuthMethod.LLAMACPP_LOCAL])
+    if _custom_openai_configured():
+        log.info("Only CUSTOM_OPENAI_* detected; using custom OpenAI-compatible endpoint")
+        return Credentials(methods=[AuthMethod.CUSTOM_OPENAI_API])
+    if priority_explicit:
+        # User expressed clear intent (set DECEPTICON_AUTH_PRIORITY) but
+        # every listed method failed detection. Surface the root cause
+        # at ERROR level — otherwise the silent fallback to
+        # all_api_methods() runs through providers the user doesn't
+        # have, producing a confusing 401 cascade (often masked as a
+        # downstream "rate limit (429)" once the routed-to provider
+        # cools down). Return behavior preserved so module imports
+        # stay green; real model calls still surface a remediation
+        # hint via _reraise_with_actionable_message.
+        log.error(
+            "DECEPTICON_AUTH_PRIORITY=%r set but no listed method has "
+            "detectable credentials. Verify: (1) API keys are "
+            "non-placeholder (e.g. ANTHROPIC_API_KEY starts with "
+            "'sk-ant-'), (2) OAuth flag matches credential file "
+            "(e.g. DECEPTICON_AUTH_CLAUDE_CODE=true requires "
+            "~/.claude/.credentials.json to exist and contain a valid "
+            "JSON object — a /dev/null mount fails this check). "
+            "Falling back to all-API-methods so module imports "
+            "remain importable; every model call will 401 until "
+            "the priority chain is fixed.",
+            os.getenv("DECEPTICON_AUTH_PRIORITY", ""),
+        )
+    else:
+        log.info(
+            "No credentials detected in environment; using all-API-methods "
+            "fallback so module-level agent constructors stay importable"
+        )
+    return Credentials.all_api_methods()
+
+
+def _resolve_credentials() -> Credentials:
+    """Build Credentials from environment variables.
+
+    Walks ``DECEPTICON_AUTH_PRIORITY`` (comma-separated AuthMethod
+    values; defaults to ``_DEFAULT_AUTH_PRIORITY``) and includes only
+    methods whose detection rule passes:
+
+      - API methods: their key env var is set to a non-placeholder
+      - OAuth methods: their boolean env var is set truthy
+
+    When **nothing** is detected — typical of CI / dev shells where
+    onboard hasn't run — falls back to all four API methods. This keeps
+    module-level ``graph = create_X_agent()`` calls importable so the
+    test suite (and tools like langgraph Studio) can load agents
+    without API keys present. Real LLM calls under that fallback will
+    fail at request time with a provider 401, which is the correct
+    surface for that misconfiguration.
+    """
+    priority, priority_explicit = _parse_auth_priority()
+
+    methods = _detect_available_methods(priority)
 
     if not methods:
-        # Local-only or cloud-only OSS path: a user who set Ollama env vars
-        # but didn't write a priority list gets a single-method Ollama chain.
-        if _ollama_local_configured():
-            log.info(
-                "Only OLLAMA_API_BASE/OLLAMA_MODEL detected; "
-                "running against local Ollama exclusively"
-            )
-            return Credentials(methods=[AuthMethod.OLLAMA_LOCAL])
-        if _ollama_cloud_configured():
-            log.info(
-                "Only OLLAMA_CLOUD_API_BASE/OLLAMA_CLOUD_MODEL detected; "
-                "running against Ollama Cloud exclusively"
-            )
-            return Credentials(methods=[AuthMethod.OLLAMA_CLOUD])
-        if _lmstudio_local_configured():
-            log.info("Only LMSTUDIO_API_BASE/LMSTUDIO_MODEL detected; using LM Studio")
-            return Credentials(methods=[AuthMethod.LMSTUDIO_LOCAL])
-        if _llamacpp_local_configured():
-            log.info("Only LLAMACPP_API_BASE/LLAMACPP_MODEL detected; using llama.cpp")
-            return Credentials(methods=[AuthMethod.LLAMACPP_LOCAL])
-        if _custom_openai_configured():
-            log.info("Only CUSTOM_OPENAI_* detected; using custom OpenAI-compatible endpoint")
-            return Credentials(methods=[AuthMethod.CUSTOM_OPENAI_API])
-        if priority_explicit:
-            # User expressed clear intent (set DECEPTICON_AUTH_PRIORITY) but
-            # every listed method failed detection. Surface the root cause
-            # at ERROR level — otherwise the silent fallback to
-            # all_api_methods() runs through providers the user doesn't
-            # have, producing a confusing 401 cascade (often masked as a
-            # downstream "rate limit (429)" once the routed-to provider
-            # cools down). Return behavior preserved so module imports
-            # stay green; real model calls still surface a remediation
-            # hint via _reraise_with_actionable_message.
-            log.error(
-                "DECEPTICON_AUTH_PRIORITY=%r set but no listed method has "
-                "detectable credentials. Verify: (1) API keys are "
-                "non-placeholder (e.g. ANTHROPIC_API_KEY starts with "
-                "'sk-ant-'), (2) OAuth flag matches credential file "
-                "(e.g. DECEPTICON_AUTH_CLAUDE_CODE=true requires "
-                "~/.claude/.credentials.json to exist and contain a valid "
-                "JSON object — a /dev/null mount fails this check). "
-                "Falling back to all-API-methods so module imports "
-                "remain importable; every model call will 401 until "
-                "the priority chain is fixed.",
-                priority_raw,
-            )
-        else:
-            log.info(
-                "No credentials detected in environment; using all-API-methods "
-                "fallback so module-level agent constructors stay importable"
-            )
-        return Credentials.all_api_methods()
+        return _fallback_credentials(priority_explicit=priority_explicit)
 
     return Credentials(methods=methods)
 

--- a/packages/decepticon/decepticon/sandbox_kernel/__init__.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/__init__.py
@@ -1,34 +1,38 @@
-"""Shared sandbox kernel — utilities used by BOTH the agent-side transport
-backends and the in-container HTTP daemon.
+"""Shared sandbox kernel — utilities used by the agent-side HTTP client
+and the in-container HTTP daemon.
 
 Layering: this package is the lowest layer of the sandbox stack. It
 contains the tmux session manager, the background-job tracker, and the
-docker-less ``DaemonSandbox`` class. Everything else hangs off of it:
-
-  ``decepticon.backends.docker_sandbox.DockerSandbox`` — agent-side,
-      uses ``docker exec`` as transport. Imports ``TmuxSessionManager``
-      from this package via the ``exec_prefix=["docker", "exec", ...]``
-      configuration knob.
+``DaemonSandbox`` class that the daemon wraps. Two consumers hang off it:
 
   ``decepticon.backends.http_sandbox.HTTPSandbox`` — agent-side,
       uses HTTP as transport. Imports ``BackgroundJob`` and
       ``BackgroundJobTracker`` from this package so the
-      ``SandboxNotificationMiddleware`` mirror pattern works
-      identically across the two backends.
+      ``SandboxNotificationMiddleware`` mirror pattern works against
+      the remote daemon's state.
 
   ``decepticon.sandbox_server.app`` — sandbox-side, FastAPI daemon.
       Imports ``DaemonSandbox`` from this package and exposes its
-      methods over HTTP.
+      methods over HTTP. Instantiates ``DaemonSandbox(exec_prefix=[])``
+      so tmux is driven by local subprocesses inside the container.
+
+Historical note: an earlier ``DockerSandbox`` ran the same machinery
+from the agent host via ``exec_prefix=["docker", "exec", <ctn>]``. That
+transport was retired in favor of ``HTTPSandbox`` + the in-container
+daemon (see ``backends/factory.py`` — "there is no longer a docker-exec
+transport"). ``TmuxSessionManager`` still accepts a non-empty
+``exec_prefix`` for parity with the old wire format, but no production
+caller exercises that branch.
 
 Why a separate package: the OSS sandbox container image is a *passive*
 container (Kali Linux + red-team tools + tmux); historically it shipped
-zero decepticon Python code. Adding the daemon to the same image
-required *some* in-container Python, but the agent-side transport
-classes (``DockerSandbox``, ``HTTPSandbox``, ``factory``) have no
-business inside the sandbox. Splitting the shared utilities out keeps
-the original "agent has everything, sandbox has nothing" boundary
-intact: the sandbox image now ships only ``sandbox_kernel`` + ``sandbox_server``,
-the agent (langgraph image) keeps ``backends`` + everything else.
+zero decepticon Python code. Adding the daemon required *some* in-
+container Python, but the agent-side transport (``HTTPSandbox``,
+``factory``) has no business inside the sandbox. Splitting the shared
+utilities out keeps the original "agent has everything, sandbox has
+nothing" boundary intact: the sandbox image ships only
+``sandbox_kernel`` + ``sandbox_server``; the agent (langgraph image)
+keeps ``backends`` + everything else.
 """
 
 from decepticon.sandbox_kernel.jobs import BackgroundJob, BackgroundJobTracker

--- a/packages/decepticon/decepticon/sandbox_kernel/base.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/base.py
@@ -71,15 +71,12 @@ class SandboxBase(BaseSandbox):
         self._workspace_path = self._normalize_workspace_path(workspace_path)
         self._managers: dict[str, TmuxSessionManager] = {}
         self._managers_lock = threading.RLock()
-        # When None: keep the default `docker exec <ctn>` prefix so
-        # nothing changes for existing callers. The HTTP sandbox daemon
-        # — which runs *inside* the sandbox container — passes
-        # `exec_prefix=[]` (or instantiates LocalSandbox) so the
-        # same tmux/exec/upload code path is reused without a nested
-        # docker daemon.
-        self._exec_prefix: list[str] = (
-            list(exec_prefix) if exec_prefix is not None else ["docker", "exec", container_name]
-        )
+        # Default to `[]` (local execution): the HTTP sandbox daemon runs
+        # *inside* the sandbox container and drives tmux/exec directly.
+        # The old `["docker", "exec", container_name]` default served the
+        # retired DockerSandbox transport and is no longer reachable from
+        # any production caller (HTTPSandbox is the agent-side client).
+        self._exec_prefix: list[str] = list(exec_prefix) if exec_prefix is not None else []
 
     @staticmethod
     def _normalize_workspace_path(workspace_path: str | None) -> str:
@@ -343,11 +340,11 @@ class SandboxBase(BaseSandbox):
         try:
             mgr = self._get_manager(session, effective_workspace)
             try:
-                mgr._docker_tmux(["send-keys", "-t", mgr.session, "C-c"])
+                mgr._tmux(["send-keys", "-t", mgr.session, "C-c"])
             except RuntimeError as e:
                 log.debug("send-keys C-c failed for '%s': %s", _safe_log(session), _safe_log(e))
             try:
-                mgr._docker_tmux(["kill-session", "-t", mgr.session])
+                mgr._tmux(["kill-session", "-t", mgr.session])
             except RuntimeError as e:
                 log.warning("kill-session failed for '%s': %s", _safe_log(session), _safe_log(e))
         finally:

--- a/packages/decepticon/decepticon/sandbox_kernel/daemon.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/daemon.py
@@ -39,9 +39,11 @@ validation to ``upload_files`` / ``download_files`` before shipping.
       heavy bash tool path is reserved for silo plane.
 
   Dev (single-machine docker compose)
-      ``SANDBOX_DAEMON=0`` by default — the OSS path is unchanged
-      (``DockerSandbox`` + ``docker exec``). Enabling the daemon on
-      a shared dev machine voids the trust model; don't.
+      The sandbox container's entrypoint starts the daemon
+      (``SANDBOX_DAEMON=1``) so the local stack uses the same HTTP
+      transport as production. The historical no-daemon path
+      (``DockerSandbox`` + ``docker exec`` from the agent host) has
+      been retired; ``HTTPSandbox`` is the only agent-side client now.
 
 Class-level state inheritance
 -----------------------------

--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -234,14 +234,13 @@ class TmuxSessionManager:
 
     # ── session lifecycle ──
 
-    def initialize(self) -> None:
-        """Create session if needed and inject PS1 marker (once per session)."""
-        with TmuxSessionManager._init_lock:
-            if self._cached_pane_is_alive():
-                return
-            TmuxSessionManager._initialized.discard(self.session)
-            self._pane_id = None
+    def _ensure_session(self) -> bool:
+        """Ensure the tmux session exists, creating it if needed.
 
+        Returns ``True`` when the session already existed before this call
+        (so the caller can skip first-run-only setup like pipe-pane logging).
+        Sets ``self._pane_id`` as a side effect.
+        """
         session_exists = False
         try:
             self._docker_tmux(["has-session", "-t", self.session], timeout=5)
@@ -285,40 +284,59 @@ class TmuxSessionManager:
         else:
             self._pane_id = self._resolve_pane_id()
 
-        # Inject PS1 marker + disable PS2 + clear screen
+        return session_exists
+
+    def _inject_ps1_marker(self) -> None:
+        """Inject the PS1 completion marker, disable PS2, and clear the screen."""
         ps1_cmd = "export PROMPT_COMMAND='export PS1=\"[DCPTN:$?:$PWD] \"'; export PS2=''; clear"
         self._send(ps1_cmd)
         time.sleep(0.5)
         self._clear_screen()
         time.sleep(0.2)
 
+    def _setup_pipe_pane_logging(self) -> None:
+        """Wire ``pipe-pane`` so the session's output streams to a host-tailable log."""
+        log_path = f"{self._workspace_path}/.sessions/{self._log_name}.log"
+        try:
+            # Idempotent — the directory is bind-mounted to the host so
+            # operators can tail the same file the agent reads. Use
+            # the configured exec_prefix instead of a hardcoded
+            # ``docker exec`` so this works both when the manager
+            # wraps a sibling docker container AND when it runs
+            # in-process inside the HTTP sandbox daemon (where
+            # exec_prefix is empty and no docker socket is reachable).
+            subprocess.run(
+                [*self._exec_prefix, "mkdir", "-p", f"{self._workspace_path}/.sessions"],
+                capture_output=True,
+                timeout=5,
+                check=True,
+            )
+            self._docker_tmux(
+                [
+                    "pipe-pane",
+                    "-t",
+                    self.session,
+                    "-o",
+                    f"cat >> {log_path}",
+                ]
+            )
+        except Exception as e:
+            log.warning("pipe-pane setup failed for session '%s': %s", self.session, e)
+
+    def initialize(self) -> None:
+        """Create session if needed and inject PS1 marker (once per session)."""
+        with TmuxSessionManager._init_lock:
+            if self._cached_pane_is_alive():
+                return
+            TmuxSessionManager._initialized.discard(self.session)
+            self._pane_id = None
+
+        session_exists = self._ensure_session()
+
+        self._inject_ps1_marker()
+
         if not session_exists and self._workspace_path != "/workspace":
-            log_path = f"{self._workspace_path}/.sessions/{self._log_name}.log"
-            try:
-                # Idempotent — the directory is bind-mounted to the host so
-                # operators can tail the same file the agent reads. Use
-                # the configured exec_prefix instead of a hardcoded
-                # ``docker exec`` so this works both when the manager
-                # wraps a sibling docker container AND when it runs
-                # in-process inside the HTTP sandbox daemon (where
-                # exec_prefix is empty and no docker socket is reachable).
-                subprocess.run(
-                    [*self._exec_prefix, "mkdir", "-p", f"{self._workspace_path}/.sessions"],
-                    capture_output=True,
-                    timeout=5,
-                    check=True,
-                )
-                self._docker_tmux(
-                    [
-                        "pipe-pane",
-                        "-t",
-                        self.session,
-                        "-o",
-                        f"cat >> {log_path}",
-                    ]
-                )
-            except Exception as e:
-                log.warning("pipe-pane setup failed for session '%s': %s", self.session, e)
+            self._setup_pipe_pane_logging()
 
         with TmuxSessionManager._init_lock:
             TmuxSessionManager._initialized.add(self.session)

--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -1,15 +1,17 @@
-"""TmuxSessionManager + execution helpers — shared between DockerSandbox
-(agent-side, via `exec_prefix=["docker", "exec", <ctn>]`) and the in-
-container HTTP daemon (sandbox-side, via `exec_prefix=[]`).
+"""TmuxSessionManager + execution helpers — drives tmux from inside the
+sandbox container via `exec_prefix=[]` (local subprocess). The HTTP
+sandbox daemon (`sandbox_server/`) is the only production caller.
 
-Extracted from `decepticon/backends/docker_sandbox.py` so the daemon
-can import the tmux machinery without pulling in agent-side transport
-classes. See `sandbox_kernel/__init__.py` for the layering rationale.
+Historical note: the original implementation lived in
+`decepticon/backends/docker_sandbox.py` and ran from the agent host via
+`exec_prefix=["docker", "exec", <ctn>]`. That `DockerSandbox` transport
+has been retired in favor of `HTTPSandbox` + the in-container daemon,
+so the docker-exec branch is no longer reachable from any production
+caller (`exec_prefix` defaults to `[]`).
 
 The semantics — PS1 marker parsing, polling cadence, stall detection,
 size watchdog, output truncation, auto-background after 60 s — are
-unchanged from the docker_sandbox.py original. Only the import site
-moved.
+unchanged from the docker_sandbox.py original.
 """
 
 from __future__ import annotations
@@ -87,10 +89,13 @@ def _interpret_exit_code(code: int) -> str:
 
 
 class TmuxSessionManager:
-    """Manages a single named tmux session inside the Docker container.
+    """Manages a single named tmux session inside the sandbox container.
 
-    Transplanted from tools/bash/tool.py; docker exec calls now go directly
-    through subprocess instead of the old run_in_sandbox() helper.
+    Runs tmux subcommands via ``subprocess.run([*self._exec_prefix, "tmux", …])``.
+    In production ``_exec_prefix`` is empty — the daemon process lives in
+    the sandbox container, next to tmux — so subprocess invokes tmux
+    directly. The arg supports a non-empty prefix for parity with the
+    retired DockerSandbox transport, which is no longer used in production.
 
     Thread-safety: ``_initialized`` is process-wide shared state. The
     ``_init_lock`` (threading.RLock) guards add/discard/clear so concurrent
@@ -113,24 +118,23 @@ class TmuxSessionManager:
         self._workspace_path = workspace_path.rstrip("/") or "/workspace"
         self._log_name = log_name or session
         self._pane_id: str | None = None
-        # When None, default to the existing docker-exec pattern so
-        # nothing changes for DockerSandbox callers. The HTTP sandbox
-        # daemon (which runs *inside* the sandbox container and talks
-        # to the local tmux directly) passes `exec_prefix=[]` so the
-        # same TmuxSessionManager logic is reused without spawning a
-        # nested docker daemon.
-        self._exec_prefix: list[str] = (
-            list(exec_prefix) if exec_prefix is not None else ["docker", "exec", container_name]
-        )
+        # Default to `[]` (local execution): the HTTP sandbox daemon runs
+        # *inside* the sandbox container and drives tmux directly. The old
+        # `["docker", "exec", container_name]` default served the
+        # retired DockerSandbox transport and is no longer reachable from
+        # any production caller (HTTPSandbox is the agent-side client).
+        self._exec_prefix: list[str] = list(exec_prefix) if exec_prefix is not None else []
 
-    # ── docker / tmux helpers ──
+    # ── tmux helpers ──
 
-    def _docker_tmux(self, args: list[str], timeout: int = 10) -> str:
+    def _tmux(self, args: list[str], timeout: int = 10) -> str:
         """Run a tmux subcommand against the session's target.
 
-        The prefix in `_exec_prefix` is the only thing that distinguishes
-        in-container (host-side, via `docker exec`) from inside-container
-        (no prefix) execution — every other tmux semantic is identical.
+        Production prefixes the command with an empty list — tmux runs as
+        a local subprocess inside the sandbox container (the daemon's
+        process tree). A non-empty `_exec_prefix` would route through a
+        remote transport instead; that branch existed for the retired
+        DockerSandbox path and is no longer reachable in production.
         """
         result = subprocess.run(
             [*self._exec_prefix, "tmux", "-L", self.session, *args],
@@ -156,14 +160,14 @@ class TmuxSessionManager:
 
     def _resolve_pane_id(self) -> str:
         try:
-            return self._docker_tmux(
+            return self._tmux(
                 ["display-message", "-p", "-t", self.session, "#{pane_id}"],
                 timeout=5,
             ).strip()
         except subprocess.TimeoutExpired:
             self._forget_cached_state()
             time.sleep(1.0)
-            return self._docker_tmux(
+            return self._tmux(
                 ["display-message", "-p", "-t", self.session, "#{pane_id}"],
                 timeout=10,
             ).strip()
@@ -178,7 +182,7 @@ class TmuxSessionManager:
                 self._forget_cached_state()
                 return False
         try:
-            self._docker_tmux(
+            self._tmux(
                 ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
                 timeout=5,
             )
@@ -187,7 +191,7 @@ class TmuxSessionManager:
             self._forget_cached_state()
             time.sleep(1.0)
             try:
-                self._docker_tmux(
+                self._tmux(
                     ["display-message", "-p", "-t", self._pane_id, "#{pane_id}"],
                     timeout=10,
                 )
@@ -204,21 +208,21 @@ class TmuxSessionManager:
     def _send(self, text: str, enter: bool = True) -> None:
         """Send keystrokes using -l (literal) to prevent tmux escaping bugs."""
         target = self._target()
-        self._docker_tmux(["send-keys", "-t", target, "-l", text])
+        self._tmux(["send-keys", "-t", target, "-l", text])
         if enter:
-            self._docker_tmux(["send-keys", "-t", target, "Enter"])
+            self._tmux(["send-keys", "-t", target, "Enter"])
 
     def _clear_screen(self) -> None:
         target = self._target()
         try:
-            self._docker_tmux(["send-keys", "-t", target, "C-l"])
+            self._tmux(["send-keys", "-t", target, "C-l"])
             time.sleep(0.1)
-            self._docker_tmux(["clear-history", "-t", target])
+            self._tmux(["clear-history", "-t", target])
         except (TmuxCommandError, subprocess.TimeoutExpired, OSError) as e:
             log.warning("_clear_screen failed for '%s': %s", target, e)
 
     def _capture(self) -> str:
-        return self._docker_tmux(
+        return self._tmux(
             [
                 "capture-pane",
                 "-J",
@@ -243,7 +247,7 @@ class TmuxSessionManager:
         """
         session_exists = False
         try:
-            self._docker_tmux(["has-session", "-t", self.session], timeout=5)
+            self._tmux(["has-session", "-t", self.session], timeout=5)
             session_exists = True
         except RuntimeError:
             session_exists = False
@@ -258,7 +262,7 @@ class TmuxSessionManager:
                         timeout=5,
                         check=True,
                     )
-                pane_id = self._docker_tmux(
+                pane_id = self._tmux(
                     [
                         "new-session",
                         "-d",
@@ -274,7 +278,7 @@ class TmuxSessionManager:
                 self._pane_id = pane_id or self.session
             except RuntimeError:
                 try:
-                    self._docker_tmux(["has-session", "-t", self.session], timeout=5)
+                    self._tmux(["has-session", "-t", self.session], timeout=5)
                     self._pane_id = self._resolve_pane_id()
                     session_exists = True
                     log.debug("Session %s already exists (race), reusing", self.session)
@@ -311,7 +315,7 @@ class TmuxSessionManager:
                 timeout=5,
                 check=True,
             )
-            self._docker_tmux(
+            self._tmux(
                 [
                     "pipe-pane",
                     "-t",
@@ -385,7 +389,7 @@ class TmuxSessionManager:
             try:
                 if is_input:
                     if command in ("C-c", "C-z", "C-d"):
-                        self._docker_tmux(["send-keys", "-t", self._target(), command])
+                        self._tmux(["send-keys", "-t", self._target(), command])
                     else:
                         self._send(command, enter=True)
                 else:
@@ -443,7 +447,7 @@ class TmuxSessionManager:
                     _safe_log(command[:50]),
                 )
                 try:
-                    self._docker_tmux(["send-keys", "-t", self._target(), "C-c"])
+                    self._tmux(["send-keys", "-t", self._target(), "C-c"])
                 except RuntimeError as interrupt_err:
                     log.debug("Failed to interrupt oversized tmux command: %s", interrupt_err)
                 output = _extract_interactive_output(screen, baseline)
@@ -542,7 +546,7 @@ class TmuxSessionManager:
                 if is_input:
                     if command in ("C-c", "C-z", "C-d"):
                         await asyncio.to_thread(
-                            self._docker_tmux, ["send-keys", "-t", self._target(), command]
+                            self._tmux, ["send-keys", "-t", self._target(), command]
                         )
                     else:
                         await asyncio.to_thread(self._send, command, True)
@@ -601,9 +605,7 @@ class TmuxSessionManager:
                     _safe_log(command[:50]),
                 )
                 try:
-                    await asyncio.to_thread(
-                        self._docker_tmux, ["send-keys", "-t", self._target(), "C-c"]
-                    )
+                    await asyncio.to_thread(self._tmux, ["send-keys", "-t", self._target(), "C-c"])
                 except RuntimeError as interrupt_err:
                     log.debug("Failed to interrupt oversized tmux command: %s", interrupt_err)
                 output = _extract_interactive_output(screen, baseline)

--- a/packages/decepticon/decepticon/tools/research/_state.py
+++ b/packages/decepticon/decepticon/tools/research/_state.py
@@ -38,8 +38,9 @@ def close_store() -> None:
     if _store is not None:
         try:
             _store.close()
-        except Exception:
-            pass  # Neo4j not configured — no-op
+        except Exception as exc:
+            # Neo4j not configured — no-op
+            log.debug("Neo4j store close failed (swallowed): %s", exc)
         _store = None
 
 

--- a/packages/decepticon/decepticon/tools/research/chain.py
+++ b/packages/decepticon/decepticon/tools/research/chain.py
@@ -207,8 +207,9 @@ def plan_chains(
 
     try:
         rows = store.query_custom(apoc_query, params)
-    except Exception:
+    except Exception as exc:
         log.info("APOC dijkstra unavailable, falling back to shortestPath")
+        log.debug("APOC dijkstra error (swallowed): %s", exc)
         try:
             rows = store.query_custom(fallback_query, params)
         except Exception as exc:
@@ -342,8 +343,9 @@ def critical_path_score(chain: Chain) -> float:
                     score = 0.0
                 if score > worst_sev:
                     worst_sev = score
-        except Exception:
-            pass  # APOC unavailable — fall back to shortestPath
+        except Exception as exc:
+            # APOC unavailable — fall back to shortestPath
+            log.debug("Worst-severity lookup failed (swallowed): %s", exc)
 
     inv_cost = 1.0 / max(chain.total_cost, 0.1)
     return round(0.6 * inv_cost * 10 + 0.4 * worst_sev, 2)

--- a/packages/decepticon/decepticon/tools/research/scanner_tools.py
+++ b/packages/decepticon/decepticon/tools/research/scanner_tools.py
@@ -406,34 +406,15 @@ def scan_shard(
     )
 
 
-@tool
-def rank_candidates(shard_results: str, top_k: int = 50) -> str:
-    """Merge shard outputs, dedupe by ``(path,line,sink_kind)``, return top-k.
+def _parse_shard_blobs(raw: str) -> list[dict[str, Any]]:
+    """Parse ``rank_candidates`` input into a list of shard-output dicts.
 
-    WHEN TO USE: After fanning out N :func:`scan_shard` calls, pass the
-    concatenated JSON (newline- or comma-separated list of shard JSON
-    blobs, or a single JSON array) here to get a clean, ranked candidate
-    list for the detector stage.
-
-    The ranker does **not** write to the knowledge graph. Call
-    :func:`kg_add_candidate` per returned hit once the detector has
-    decided which ones to investigate.
-
-    Args:
-        shard_results: JSON array of shard outputs, OR a newline-separated
-            list of shard JSON blobs (the format ``scan_shard`` returns).
-        top_k: Max candidates to return (default 50).
-
-    Returns:
-        JSON with ``total_hits``, ``unique_hits``, and a ``candidates``
-        array sorted by descending score.
+    Three accepted shapes:
+      1. A single JSON object (one shard)
+      2. A JSON array of shard objects
+      3. Several JSON objects concatenated back-to-back
     """
-    raw = shard_results.strip()
     blobs: list[dict[str, Any]] = []
-    # Three accepted shapes:
-    #   1. A single JSON object (one shard)
-    #   2. A JSON array of shard objects
-    #   3. Several JSON objects concatenated back-to-back
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError:
@@ -464,7 +445,15 @@ def rank_candidates(shard_results: str, top_k: int = 50) -> str:
                     except json.JSONDecodeError:
                         pass
                     start = -1
+    return blobs
 
+
+def _dedupe_hits(blobs: list[dict[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    """Merge hits across shard blobs, deduping by ``(path,line,sink_kind)``.
+
+    Returns ``(total_hits, unique_hits_sorted)`` — the raw hit count and the
+    deduped hits sorted by descending score (highest score wins on collision).
+    """
     seen: dict[tuple[str, int, str], dict[str, Any]] = {}
     total = 0
     for blob in blobs:
@@ -482,6 +471,33 @@ def rank_candidates(shard_results: str, top_k: int = 50) -> str:
                 seen[key] = hit
 
     uniq = sorted(seen.values(), key=lambda h: h.get("score", 0), reverse=True)
+    return total, uniq
+
+
+@tool
+def rank_candidates(shard_results: str, top_k: int = 50) -> str:
+    """Merge shard outputs, dedupe by ``(path,line,sink_kind)``, return top-k.
+
+    WHEN TO USE: After fanning out N :func:`scan_shard` calls, pass the
+    concatenated JSON (newline- or comma-separated list of shard JSON
+    blobs, or a single JSON array) here to get a clean, ranked candidate
+    list for the detector stage.
+
+    The ranker does **not** write to the knowledge graph. Call
+    :func:`kg_add_candidate` per returned hit once the detector has
+    decided which ones to investigate.
+
+    Args:
+        shard_results: JSON array of shard outputs, OR a newline-separated
+            list of shard JSON blobs (the format ``scan_shard`` returns).
+        top_k: Max candidates to return (default 50).
+
+    Returns:
+        JSON with ``total_hits``, ``unique_hits``, and a ``candidates``
+        array sorted by descending score.
+    """
+    blobs = _parse_shard_blobs(shard_results.strip())
+    total, uniq = _dedupe_hits(blobs)
     return _json(
         {
             "total_hits": total,

--- a/packages/decepticon/decepticon/tools/skills.py
+++ b/packages/decepticon/decepticon/tools/skills.py
@@ -88,6 +88,60 @@ def _list_dir_via_backend(backend: Any, dir_path: str) -> list[str]:
     return sorted(n for n in names if n.endswith(".md"))
 
 
+def _validate_skill_path(skill_path: Any, sources: list[str]) -> str | None:
+    """Validate a ``load_skill`` path against the format + allowlist rules.
+
+    Returns an ``[load_skill error] ...`` string when the path is rejected,
+    or ``None`` when it passes every check. Mirrors the checks the tool
+    surfaced inline so ``load_skill`` keeps returning the exact same error
+    strings (it never raises).
+    """
+    if not isinstance(skill_path, str) or not skill_path:
+        return "[load_skill error] skill_path must be a non-empty string."
+    if not skill_path.startswith(_SKILL_PATH_PREFIX):
+        return (
+            "[load_skill error] Path must start with /skills/. "
+            "For non-skill files use read_file. "
+            f"Got: {skill_path!r}"
+        )
+    if not skill_path.endswith(".md"):
+        return f"[load_skill error] Skill files must be markdown (.md). Got: {skill_path!r}"
+    # Reject path traversal — disallow ".." segments
+    if ".." in skill_path.split("/"):
+        return f"[load_skill error] Path traversal not allowed: {skill_path!r}"
+    # Enforce agent's skill source allowlist
+    if sources and not any(skill_path.startswith(src.rstrip("/")) for src in sources):
+        allowed = ", ".join(sources)
+        return (
+            f"[load_skill error] This agent may only load skills from: {allowed}. "
+            f"Got: {skill_path!r}"
+        )
+    return None
+
+
+def _format_skill_body(skill_path: str, raw: str) -> tuple[list[str], str, str]:
+    """Build the header + body sections for a loaded skill file.
+
+    Strips frontmatter, derives the base-directory header (skill name +
+    description), and seeds the section list. Returns ``(sections, base_dir,
+    basename)`` so the caller can append the backend-dependent references /
+    siblings index.
+    """
+    body, frontmatter = _strip_frontmatter(raw)
+
+    path_parts = skill_path.rsplit("/", 1)
+    base_dir = path_parts[0] if len(path_parts) == 2 else "/"
+    stem = path_parts[-1].rsplit(".", 1)[0]
+    header_lines = [f"Base directory for this skill: {base_dir}"]
+    name = frontmatter.get("name") or stem
+    description = frontmatter.get("description", "").strip()
+    header_lines.append(f"Skill: {name}" + (f" — {description}" if description else ""))
+    header = "\n".join(header_lines)
+
+    sections: list[str] = [header, "", body.rstrip(), ""]
+    return sections, base_dir, path_parts[-1]
+
+
 def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-untyped-def]
     """Construct the ``load_skill`` LangChain tool.
 
@@ -124,43 +178,15 @@ def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-
             The skill body with a header + references index. Errors are
             returned as ``[load_skill error] ...`` strings (never raised).
         """
-        if not isinstance(skill_path, str) or not skill_path:
-            return "[load_skill error] skill_path must be a non-empty string."
-        if not skill_path.startswith(_SKILL_PATH_PREFIX):
-            return (
-                "[load_skill error] Path must start with /skills/. "
-                "For non-skill files use read_file. "
-                f"Got: {skill_path!r}"
-            )
-        if not skill_path.endswith(".md"):
-            return f"[load_skill error] Skill files must be markdown (.md). Got: {skill_path!r}"
-        # Reject path traversal — disallow ".." segments
-        if ".." in skill_path.split("/"):
-            return f"[load_skill error] Path traversal not allowed: {skill_path!r}"
-        # Enforce agent's skill source allowlist
-        if sources and not any(skill_path.startswith(src.rstrip("/")) for src in sources):
-            allowed = ", ".join(sources)
-            return (
-                f"[load_skill error] This agent may only load skills from: {allowed}. "
-                f"Got: {skill_path!r}"
-            )
+        path_error = _validate_skill_path(skill_path, sources)
+        if path_error is not None:
+            return path_error
 
         raw, err = _read_via_backend(backend, skill_path)
         if raw is None:
             return f"[load_skill error] Skill not found: {skill_path} ({err})"
 
-        body, frontmatter = _strip_frontmatter(raw)
-
-        path_parts = skill_path.rsplit("/", 1)
-        base_dir = path_parts[0] if len(path_parts) == 2 else "/"
-        stem = path_parts[-1].rsplit(".", 1)[0]
-        header_lines = [f"Base directory for this skill: {base_dir}"]
-        name = frontmatter.get("name") or stem
-        description = frontmatter.get("description", "").strip()
-        header_lines.append(f"Skill: {name}" + (f" — {description}" if description else ""))
-        header = "\n".join(header_lines)
-
-        sections: list[str] = [header, "", body.rstrip(), ""]
+        sections, base_dir, basename = _format_skill_body(skill_path, raw)
 
         refs_dir = base_dir.rstrip("/") + "/references"
         refs = _list_dir_via_backend(backend, refs_dir)
@@ -171,7 +197,7 @@ def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-
             sections.append("")
 
         if include_siblings:
-            sibs = [s for s in _list_dir_via_backend(backend, base_dir) if s != path_parts[-1]]
+            sibs = [s for s in _list_dir_via_backend(backend, base_dir) if s != basename]
             if sibs:
                 sections.append("---")
                 sections.append("Related sub-skills in this directory (load with `load_skill`):")

--- a/packages/decepticon/tests/unit/backends/test_background_jobs.py
+++ b/packages/decepticon/tests/unit/backends/test_background_jobs.py
@@ -183,7 +183,7 @@ def test_auto_background_path_registers_job():
         mgr._capture.side_effect = captures + ["[DCPTN:0:/workspace] sleep 99999\nrunning\n"] * 5
         mgr.initialize = MagicMock()
         mgr._send = MagicMock()
-        mgr._docker_tmux = MagicMock()
+        mgr._tmux = MagicMock()
         mgr._clear_screen = MagicMock()
         mock_get.return_value = mgr
 

--- a/packages/decepticon/tests/unit/backends/test_session_log.py
+++ b/packages/decepticon/tests/unit/backends/test_session_log.py
@@ -17,7 +17,7 @@ def test_initialize_does_not_create_root_workspace_sessions_log():
     TmuxSessionManager._initialized.discard("scan-1")
 
     with (
-        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch.object(mgr, "_tmux") as mock_tmux,
         patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
@@ -47,7 +47,7 @@ def test_initialize_pipes_pane_to_engagement_scoped_sessions_log():
     TmuxSessionManager._initialized.discard("dcptn_test-main")
 
     with (
-        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch.object(mgr, "_tmux") as mock_tmux,
         patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
@@ -83,7 +83,7 @@ def test_initialize_creates_sessions_directory_inside_engagement_workspace():
     TmuxSessionManager._initialized.discard("dcptn_test-scan-2")
 
     with (
-        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch.object(mgr, "_tmux") as mock_tmux,
         patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
@@ -116,7 +116,7 @@ def test_initialize_warns_when_mkdir_fails(caplog):
     decepticon_logger.propagate = True
     try:
         with (
-            patch.object(mgr, "_docker_tmux") as mock_tmux,
+            patch.object(mgr, "_tmux") as mock_tmux,
             patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
             patch("time.sleep"),
         ):
@@ -292,7 +292,7 @@ def test_kill_session_sends_ctrl_c_then_kill_session_then_clears_caches():
     mgr = sandbox._get_manager("scan")  # populate the cache
     TmuxSessionManager._initialized.add("scan")
 
-    with patch.object(mgr, "_docker_tmux") as mock_tmux:
+    with patch.object(mgr, "_tmux") as mock_tmux:
         sandbox.kill_session("scan")
 
     sent_calls = [c.args[0] for c in mock_tmux.call_args_list]
@@ -316,7 +316,7 @@ def test_kill_session_swallows_errors():
     mgr = sandbox._get_manager("flaky")
     TmuxSessionManager._initialized.add("flaky")
 
-    with patch.object(mgr, "_docker_tmux", side_effect=RuntimeError("boom")):
+    with patch.object(mgr, "_tmux", side_effect=RuntimeError("boom")):
         sandbox.kill_session("flaky")  # must not raise
 
     # Caches still cleared even when tmux ops failed
@@ -436,7 +436,7 @@ def test_initialize_recreates_stale_cached_pane_without_error_string_matching():
     TmuxSessionManager._initialized.add("stale")
 
     with (
-        patch.object(mgr, "_docker_tmux") as mock_tmux,
+        patch.object(mgr, "_tmux") as mock_tmux,
         patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):


### PR DESCRIPTION
Re-applies #289 on current main (clean 3-way merge — no conflicts with #281/#309) plus a dead-code cleanup. Authorship preserved via cherry-pick. Original PR: #289

## From #289 — structural refactor (no public API change)
- **`agents/prompts/__init__.py`** (533 → 70-line shim): split into `builder.py` (+352, prompt-assembly engine: fragment readers, `PromptBuilder`, `load_prompt`, pattern constants, cache-boundary marker) and `registry.py` (+138, language/locale data + `build_language_policy`). 17+ explicit re-exports preserve every `from decepticon.agents.prompts import X` path. builder→registry one-directional, no cycle.
- **`llm/factory.py`** (±171): oversized factory split into 15+ named helpers (per-provider config checks, credential resolution, model-flag checks, error helpers). `create_llm()` unchanged as entry point.
- **`sandbox_kernel/tmux.py`** (±86): `initialize()` split into `_ensure_session()` (lifecycle) + `_inject_ps1_marker()` (per-session-once) + a thin `initialize()` orchestrator.
- **`tools/skills.py`** (±92): `_validate_skill_path()` + `_format_skill_body()` extracted from the `load_skill` tool body. Validation logic unchanged (the `..`-traversal reject already existed — it moved, it's not new).
- **`tools/research/{_state,chain}.py`**: 3 silent `except: pass` → `log.debug(..., exc_info)` (swallow intent preserved, visibility added).
- **`tools/research/scanner_tools.py`**: `rank_candidates` split into `_parse_shard_blobs` + `_dedupe_hits` helpers.

## Added before merge — retire dead docker-exec path
While reviewing the tmux refactor we confirmed the **DockerSandbox transport is already retired** (backends/factory.py: "there is no longer a docker-exec transport"). Production runs `HTTPSandbox` (agent side) → in-container `DaemonSandbox(exec_prefix=[])`. The docker-exec branch in the tmux/exec layer was unreachable dead code:
- Rename `_docker_tmux` → `_tmux` (method drives tmux via subprocess regardless of prefix; "docker" was a stale-transport artifact). Updated `SandboxBase` callers + the two test files that patch it.
- Default `exec_prefix` to `[]` instead of `["docker","exec",container_name]` in `TmuxSessionManager` + `SandboxBase`. Behavior-identical — every production caller already passes `exec_prefix=[]`; only the unreachable fallback changes.
- Refresh docstrings (tmux.py, base.py, __init__.py, daemon.py) that still described docker-exec as the live transport.

## Verification
shim imports resolve (`PromptBuilder`, `load_prompt`, `build_language_policy`); **1159 tests pass**; ruff + format + basedpyright clean. No mojibake/CRLF. The auto-merge against #309 (SIZE_WATCHDOG_INTERVAL removal) and #281 (skills docstring path) was verified correct.

Co-authored-by: VoidChecksum <halvorsentech@gmail.com>