### PR TITLE
feat: Podman + nerdctl runtime support + PR-time arm64 docker smoke (re-merge of #292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,48 @@ jobs:
           path: trivy-${{ matrix.image }}.sarif
           if-no-files-found: ignore
 
+  # Cross-architecture (linux/arm64) smoke build for Raspberry Pi /
+  # Apple Silicon targets. Releases already build multi-arch images, but
+  # we want PR-time signal so an arm64 break doesn't only surface at
+  # release time. Limited to the two images that are smallest under
+  # QEMU (cli + langgraph build in ~3-5 min; sandbox/web take 20+ min
+  # under QEMU and would dominate PR CI wall time — they're validated
+  # via the release pipeline only).
+  #
+  # No Trivy step here: `load: false` means the foreign-arch image stays
+  # in the buildx cache and isn't materialized into the host Docker, so
+  # there's nothing for Trivy to scan. The release pipeline scans the
+  # arm64 images post-push.
+  docker-build-arm64:
+    name: Docker arm64 smoke (${{ matrix.image }})
+    needs: changes
+    if: needs.changes.outputs.docker-images != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [cli, langgraph]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Build linux/arm64 image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: containers/${{ matrix.image }}.Dockerfile
+          push: false
+          # `load: false` with --platform linux/arm64 keeps the image in
+          # the buildx cache without trying to load a foreign-arch image
+          # into the host's local Docker (which would error on amd64
+          # runners). The build itself still validates the entire
+          # Dockerfile path on the target arch.
+          load: false
+          platforms: linux/arm64
+          tags: decepticon-${{ matrix.image }}:ci-arm64
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=${{ github.event_name == 'push' && 'max' || 'min' }},scope=arm64
+
   # Security scans always run regardless of which paths changed —
   # vulnerability databases update independently of repo state.
   security:

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/runtime"
 )
 
 // Compose wraps Docker Compose commands for Decepticon services.
@@ -16,15 +17,32 @@ type Compose struct {
 	Home        string
 	ComposeFile string
 	EnvFile     string
+	// Runtime is the container runtime selected at construction time
+	// (docker / podman / nerdctl). Stored so every call uses the same
+	// binary + socket and we don't re-probe on every invocation.
+	Runtime runtime.Runtime
 }
 
 // New creates a Compose instance using the Decepticon home directory.
+// The container runtime is detected at construction time so every
+// subsequent call uses the same binary. Falls back to "docker" if no
+// runtime is reachable so existing tests and dev workflows that don't
+// have Podman installed keep working unchanged.
 func New() *Compose {
 	home := config.DecepticonHome()
+	rt, err := runtime.Detect()
+	if err != nil {
+		// No runtime available right now — fall back to assuming
+		// docker. The user will get a clear error from the first
+		// `docker` exec if it's really missing, and the onboard
+		// System Check surfaces it well before reaching here.
+		rt = runtime.Runtime{Name: "docker", Bin: "docker", ComposeArgs: []string{"compose"}}
+	}
 	return &Compose{
 		Home:        home,
 		ComposeFile: filepath.Join(home, "docker-compose.yml"),
 		EnvFile:     filepath.Join(home, ".env"),
+		Runtime:     rt,
 	}
 }
 
@@ -45,9 +63,22 @@ func AllProfiles() []string {
 	}
 }
 
-// baseArgs returns the common compose arguments.
+// baseArgs returns the common compose arguments for the detected
+// runtime. For Docker this is ["compose", "-f", ...]; for Podman 4.4+
+// it's the same shape; for the podman-compose wrapper the leading
+// "compose" is omitted because the wrapper IS the compose tool.
+//
+// Defaults to ["compose"] when c.Runtime is the zero value so tests
+// that instantiate Compose{} directly (without going through New())
+// still produce the Docker-shaped argv.
 func (c *Compose) baseArgs() []string {
-	return []string{"compose", "-f", c.ComposeFile, "--env-file", c.EnvFile}
+	prefix := c.Runtime.ComposeArgs
+	if prefix == nil && c.Runtime.Bin == "" {
+		prefix = []string{"compose"}
+	}
+	args := append([]string{}, prefix...)
+	args = append(args, "-f", c.ComposeFile, "--env-file", c.EnvFile)
+	return args
 }
 
 // ContainerName builds the docker container name for a Decepticon
@@ -78,7 +109,8 @@ func (c *Compose) readVersion() string {
 }
 
 // composeEnv returns the parent environment with DECEPTICON_VERSION pinned
-// from the .version file. docker compose treats the process environment as
+// from the .version file plus any runtime-derived env (DOCKER_HOST for
+// Podman, etc.). docker compose treats the process environment as
 // higher precedence than --env-file, so this overrides any stale value the
 // user may have written into .env and avoids the silent `:latest` drift
 // that occurs when the variable is unset.
@@ -87,13 +119,17 @@ func (c *Compose) composeEnv() []string {
 	if v := c.readVersion(); v != "" {
 		env = append(env, "DECEPTICON_VERSION="+imageTag(v))
 	}
+	// Inject DOCKER_HOST for Podman so nested Docker-API clients in
+	// containers (testcontainers, kubectl-with-docker-shim) find the
+	// Podman socket. No-op for Docker.
+	env = c.Runtime.Apply(env)
 	return env
 }
 
-// run executes a docker compose command and returns its output.
+// run executes a compose command via the detected runtime.
 func (c *Compose) run(args []string, interactive bool) error {
-	cmdArgs := append([]string{"compose", "-f", c.ComposeFile, "--env-file", c.EnvFile}, args...)
-	cmd := exec.Command("docker", cmdArgs...)
+	cmdArgs := append(c.baseArgs(), args...)
+	cmd := exec.Command(c.Runtime.Bin, cmdArgs...)
 	cmd.Env = c.composeEnv()
 	if interactive {
 		cmd.Stdin = os.Stdin
@@ -104,7 +140,7 @@ func (c *Compose) run(args []string, interactive bool) error {
 		cmd.Stderr = os.Stderr
 	}
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker compose %s: %w", strings.Join(args, " "), err)
+		return fmt.Errorf("%s compose %s: %w", c.Runtime.Name, strings.Join(args, " "), err)
 	}
 	return nil
 }
@@ -158,16 +194,17 @@ func (c *Compose) DownAndPurge() error {
 // argument overrides the .version file (used by the updater right after a
 // new release lands). Empty version → fall back to whatever .version says.
 func (c *Compose) Pull(version string) error {
-	cmd := exec.Command("docker", append(c.baseArgs(), "pull")...)
+	cmd := exec.Command(c.Runtime.Bin, append(c.baseArgs(), "pull")...)
 	if version != "" {
-		cmd.Env = append(os.Environ(), "DECEPTICON_VERSION="+imageTag(version))
+		env := append(os.Environ(), "DECEPTICON_VERSION="+imageTag(version))
+		cmd.Env = c.Runtime.Apply(env)
 	} else {
 		cmd.Env = c.composeEnv()
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker compose pull: %w", err)
+		return fmt.Errorf("%s compose pull: %w", c.Runtime.Name, err)
 	}
 	return nil
 }
@@ -215,13 +252,13 @@ func (c *Compose) RunInteractive(profiles []string, service string, env map[stri
 	cmdArgs = append(cmdArgs, service)
 	cmdArgs = append(cmdArgs, command...)
 
-	cmd := exec.Command("docker", cmdArgs...)
+	cmd := exec.Command(c.Runtime.Bin, cmdArgs...)
 	cmd.Env = c.composeEnv()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker compose run %s: %w", service, err)
+		return fmt.Errorf("%s compose run %s: %w", c.Runtime.Name, service, err)
 	}
 	return nil
 }
@@ -232,7 +269,7 @@ func (c *Compose) RunInteractive(profiles []string, service string, env map[stri
 // versions.
 func (c *Compose) CleanScratch() {
 	cmd := exec.Command(
-		"docker",
+		c.Runtime.Bin,
 		"exec",
 		ContainerName("sandbox"),
 		"rm",
@@ -240,6 +277,7 @@ func (c *Compose) CleanScratch() {
 		"/workspace/.scratch",
 		"/workspace/.sessions",
 	)
+	cmd.Env = c.composeEnv()
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	_ = cmd.Run()
@@ -249,18 +287,23 @@ func (c *Compose) CleanScratch() {
 func (c *Compose) RemoveOrphanedCLI() {
 	// Best-effort cleanup of orphaned CLI containers.
 	// Anchor the filter to the stack naming convention used by ContainerName
-	// so we don't accidentally match unrelated containers.
+	// so we don't accidentally match unrelated containers. Use the detected
+	// runtime binary (docker / podman / nerdctl) and its env.
 	stack := strings.TrimSpace(os.Getenv("DECEPTICON_STACK_NAME"))
 	prefix := "decepticon"
 	if stack != "" {
 		prefix = "decepticon-" + stack
 	}
-	out, err := exec.Command("docker", "ps", "-aq", "--filter", fmt.Sprintf("name=^%s-cli", prefix)).Output()
+	ps := exec.Command(c.Runtime.Bin, "ps", "-aq", "--filter", fmt.Sprintf("name=^%s-cli", prefix))
+	ps.Env = c.composeEnv()
+	out, err := ps.Output()
 	if err != nil || len(out) == 0 {
 		return
 	}
 	ids := strings.Fields(strings.TrimSpace(string(out)))
 	for _, id := range ids {
-		_ = exec.Command("docker", "rm", "-f", id).Run()
+		rm := exec.Command(c.Runtime.Bin, "rm", "-f", id)
+		rm.Env = c.composeEnv()
+		_ = rm.Run()
 	}
 }

--- a/clients/launcher/internal/runtime/runtime.go
+++ b/clients/launcher/internal/runtime/runtime.go
@@ -1,0 +1,247 @@
+// Package runtime detects which container runtime is available on the
+// host (Docker, Podman, or nerdctl) and exposes the binary path plus
+// the right "compose" sub-command so the rest of the launcher can call
+// `Runtime().Bin compose ...` without caring which one is installed.
+//
+// Selection order (first hit wins):
+//  1. $DECEPTICON_CONTAINER_RUNTIME explicit override ("docker", "podman", "nerdctl")
+//  2. `docker` on $PATH and `docker info` succeeds (real Docker, Lima/Colima/Rancher Desktop docker shim)
+//  3. `podman` on $PATH and `podman info` succeeds (rootless or rootful Podman 4+)
+//  4. `nerdctl` on $PATH and `nerdctl info` succeeds (containerd-native)
+//
+// On Podman, if a Docker compatibility socket is published, `DOCKER_HOST`
+// is auto-set so any nested tooling (kubectl-with-docker-shim,
+// playwright/testcontainers, etc.) finds the socket.
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Runtime is a snapshot of the detected container runtime.
+type Runtime struct {
+	// Name is the canonical short name: "docker", "podman", "nerdctl".
+	Name string
+	// Bin is the absolute path of the binary to invoke.
+	Bin string
+	// ComposeArgs is the prefix to prepend before compose sub-arguments.
+	// For Docker this is ["compose"] (Compose v2 plugin). For Podman it
+	// is also ["compose"] when Podman 4.4+ ships the built-in compose
+	// command, OR ["compose"] via the `podman-compose` Python wrapper
+	// (both expose the same `compose -f file up -d` shape).
+	ComposeArgs []string
+	// DockerHost is the socket the runtime exposes through the Docker API.
+	// For native Docker this is unset. For Podman it points at the
+	// rootless or rootful Podman socket so other Docker-API consumers
+	// keep working.
+	DockerHost string
+	// Rootless reports whether the runtime is running unprivileged.
+	// Affects volume-mount semantics + recommended sysctls.
+	Rootless bool
+	// Version is the runtime's reported version string ("28.0.1" /
+	// "5.2.0" / etc.) for diagnostics.
+	Version string
+}
+
+// Detect runs the selection rules and returns the chosen runtime. It
+// never panics; on failure it returns a zero-value Runtime and an error
+// so the caller can render an installation hint.
+func Detect() (Runtime, error) {
+	// 1. Explicit override
+	if forced := strings.ToLower(strings.TrimSpace(os.Getenv("DECEPTICON_CONTAINER_RUNTIME"))); forced != "" {
+		switch forced {
+		case "docker", "podman", "nerdctl":
+			r, err := probe(forced)
+			if err != nil {
+				return Runtime{}, fmt.Errorf("DECEPTICON_CONTAINER_RUNTIME=%s requested but unusable: %w", forced, err)
+			}
+			return r, nil
+		default:
+			return Runtime{}, fmt.Errorf("DECEPTICON_CONTAINER_RUNTIME=%q is not one of docker|podman|nerdctl", forced)
+		}
+	}
+
+	// 2-4. Autodetect in order of preference
+	for _, name := range []string{"docker", "podman", "nerdctl"} {
+		if r, err := probe(name); err == nil {
+			return r, nil
+		}
+	}
+
+	return Runtime{}, fmt.Errorf("no container runtime found on PATH (looked for docker, podman, nerdctl)")
+}
+
+// probe attempts to use a specific runtime; returns Runtime if it
+// responds to `<bin> info`, or an error.
+func probe(name string) (Runtime, error) {
+	bin, err := exec.LookPath(name)
+	if err != nil {
+		return Runtime{}, fmt.Errorf("%s not on PATH", name)
+	}
+	// `<bin> info` succeeds only when the daemon is reachable. Don't
+	// blindly accept the binary's presence — Docker Desktop might be
+	// installed but stopped.
+	if err := exec.Command(bin, "info").Run(); err != nil {
+		return Runtime{}, fmt.Errorf("%s installed but daemon not reachable: %w", name, err)
+	}
+
+	r := Runtime{Name: name, Bin: bin, ComposeArgs: []string{"compose"}}
+	r.Version = versionString(bin)
+	r.Rootless = rootless(bin, name)
+
+	switch name {
+	case "podman":
+		// Try the well-known rootless + rootful socket paths and stick
+		// the first existing one into DOCKER_HOST so anything else that
+		// speaks the Docker API auto-finds Podman's compatibility socket.
+		if sock := podmanSocket(); sock != "" {
+			r.DockerHost = "unix://" + sock
+		}
+		// `podman compose` is built-in from Podman 4.4 onward; older
+		// installs need the separate `podman-compose` Python wrapper.
+		// Fall back to it only if `podman compose --help` rejects.
+		if !hasBuiltinPodmanCompose(bin) {
+			if pc, err := exec.LookPath("podman-compose"); err == nil {
+				r.Bin = pc
+				r.ComposeArgs = nil // podman-compose IS the compose binary
+			}
+		}
+	case "nerdctl":
+		// nerdctl's compose sub-command is built-in since 0.16; older
+		// builds had a separate `nerdctl-compose`.
+	}
+
+	return r, nil
+}
+
+// podmanSocket returns the path of an existing Podman API socket, or
+// "" if none can be located. Checks rootless ($XDG_RUNTIME_DIR) first,
+// then the rootful default.
+func podmanSocket() string {
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		p := filepath.Join(xdg, "podman", "podman.sock")
+		if fileExists(p) {
+			return p
+		}
+	}
+	// Rootless fallback for $XDG_RUNTIME_DIR unset on Linux distros
+	// that don't export it for interactive shells.
+	if uid := os.Getuid(); uid >= 0 {
+		p := filepath.Join("/run", "user", strconv.Itoa(uid), "podman", "podman.sock")
+		if fileExists(p) {
+			return p
+		}
+	}
+	// Rootful default
+	if fileExists("/run/podman/podman.sock") {
+		return "/run/podman/podman.sock"
+	}
+	// macOS Podman Desktop uses a different path; user can override via
+	// DECEPTICON_DOCKER_HOST if needed.
+	return ""
+}
+
+// rootless returns true when the runtime is running without root
+// privileges. Docker Desktop on macOS/Windows is "rootless" from the
+// host's perspective; the linux Docker daemon defaults to rootful.
+func rootless(bin, name string) bool {
+	switch name {
+	case "podman":
+		// `podman info --format {{.Host.Security.Rootless}}` returns
+		// "true" or "false". Older Podman doesn't have that key — assume
+		// rootless when the binary path is in $HOME (homebrew, nix).
+		out, err := exec.Command(bin, "info", "--format", "{{.Host.Security.Rootless}}").Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)) == "true"
+		}
+		return strings.HasPrefix(bin, os.Getenv("HOME"))
+	case "docker":
+		// Linux Docker is rootful unless explicitly configured (dockerd-
+		// rootless-setuptool.sh). macOS/Windows Docker Desktop is rootless
+		// from the host's perspective.
+		if runtime.GOOS == "linux" {
+			// `docker info --format {{.SecurityOptions}}` lists "rootless"
+			// when the daemon is rootless.
+			out, err := exec.Command(bin, "info", "--format", "{{.SecurityOptions}}").Output()
+			if err == nil && strings.Contains(string(out), "rootless") {
+				return true
+			}
+			return false
+		}
+		return true
+	case "nerdctl":
+		// Same heuristic as podman.
+		out, err := exec.Command(bin, "info", "--format", "{{.SecurityOptions}}").Output()
+		return err == nil && strings.Contains(string(out), "rootless")
+	}
+	return false
+}
+
+// hasBuiltinPodmanCompose returns true when `podman compose --help`
+// exits 0 (i.e. Podman 4.4+ ships compose support inline).
+func hasBuiltinPodmanCompose(bin string) bool {
+	err := exec.Command(bin, "compose", "--help").Run()
+	return err == nil
+}
+
+// versionString returns the runtime's reported version, "unknown" on
+// failure.
+func versionString(bin string) string {
+	out, err := exec.Command(bin, "version", "--format", "{{.Server.Version}}").Output()
+	if err != nil || len(out) == 0 {
+		// Some clients don't expose --format
+		out, err = exec.Command(bin, "--version").Output()
+		if err != nil {
+			return "unknown"
+		}
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// fileExists is a small wrapper for sock-path existence checks.
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// Apply mutates the provided env slice to include any runtime-derived
+// env vars (DOCKER_HOST for Podman, etc.). Pure: the input slice is not
+// modified — a new slice is returned.
+func (r Runtime) Apply(env []string) []string {
+	if r.DockerHost == "" {
+		return env
+	}
+	out := make([]string, 0, len(env)+1)
+	// Only add DOCKER_HOST if the caller hasn't already set it — let
+	// the user's explicit choice win.
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "DOCKER_HOST=") {
+			return env
+		}
+		out = append(out, kv)
+	}
+	out = append(out, "DOCKER_HOST="+r.DockerHost)
+	return out
+}
+
+// String renders a one-line diagnostic for the onboard System Check
+// panel and the `decepticon version` output.
+func (r Runtime) String() string {
+	bits := []string{r.Name}
+	if r.Version != "" {
+		bits = append(bits, r.Version)
+	}
+	if r.Rootless {
+		bits = append(bits, "rootless")
+	}
+	if r.DockerHost != "" {
+		bits = append(bits, "socket="+r.DockerHost)
+	}
+	return strings.Join(bits, " · ")
+}

--- a/clients/launcher/internal/runtime/runtime_test.go
+++ b/clients/launcher/internal/runtime/runtime_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRuntime_String_OnlyName(t *testing.T) {
+	r := Runtime{Name: "docker"}
+	if got := r.String(); got != "docker" {
+		t.Errorf("String() = %q, want %q", got, "docker")
+	}
+}
+
+func TestRuntime_String_FullFields(t *testing.T) {
+	r := Runtime{
+		Name:       "podman",
+		Version:    "5.2.0",
+		Rootless:   true,
+		DockerHost: "unix:///run/user/1000/podman/podman.sock",
+	}
+	got := r.String()
+	for _, want := range []string{"podman", "5.2.0", "rootless", "unix:///run/user/1000/podman/podman.sock"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestRuntime_Apply_AddsDockerHostWhenUnset(t *testing.T) {
+	r := Runtime{Name: "podman", DockerHost: "unix:///run/user/1000/podman/podman.sock"}
+	env := []string{"PATH=/usr/bin", "HOME=/home/op"}
+	got := r.Apply(env)
+	found := false
+	for _, kv := range got {
+		if kv == "DOCKER_HOST=unix:///run/user/1000/podman/podman.sock" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Apply() did not append DOCKER_HOST; got %v", got)
+	}
+}
+
+func TestRuntime_Apply_RespectsExistingDockerHost(t *testing.T) {
+	r := Runtime{Name: "podman", DockerHost: "unix:///run/user/1000/podman/podman.sock"}
+	env := []string{"DOCKER_HOST=tcp://1.2.3.4:2375", "PATH=/usr/bin"}
+	got := r.Apply(env)
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "DOCKER_HOST=") && kv != "DOCKER_HOST=tcp://1.2.3.4:2375" {
+			t.Errorf("Apply() overwrote user DOCKER_HOST; got %v", got)
+		}
+	}
+	// User's value must survive
+	if len(got) != 2 {
+		t.Errorf("Apply() altered slice length unexpectedly: got %v", got)
+	}
+}
+
+func TestRuntime_Apply_NoOpWhenNoDockerHost(t *testing.T) {
+	r := Runtime{Name: "docker"}
+	env := []string{"PATH=/usr/bin"}
+	got := r.Apply(env)
+	if len(got) != len(env) {
+		t.Errorf("Apply() altered env when DockerHost empty: got %v", got)
+	}
+}
+
+func TestDetect_RespectsInvalidOverride(t *testing.T) {
+	t.Setenv("DECEPTICON_CONTAINER_RUNTIME", "kubernetes")
+	_, err := Detect()
+	if err == nil {
+		t.Fatal("Detect() should reject unknown runtime override")
+	}
+	if !strings.Contains(err.Error(), "kubernetes") {
+		t.Errorf("error should name the bad override; got %v", err)
+	}
+}
+
+func TestPodmanSocket_ReturnsEmptyWhenNothingExists(t *testing.T) {
+	// Force every search path to a non-existent directory by clearing
+	// XDG_RUNTIME_DIR; getuid() will still be set but the rootless +
+	// rootful paths are very unlikely to exist on a CI runner that
+	// doesn't have podman installed.
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/does-not-exist-decepticon-test")
+	// Best-effort: this also succeeds on a runner with Podman
+	// installed, so just check it returns a string (path) or empty.
+	got := podmanSocket()
+	// On runners without Podman it should be empty; on dev workstations
+	// with Podman installed the test simply confirms we don't panic.
+	_ = got
+}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -27,7 +27,7 @@ Complete installation, authentication, and configuration reference.
 | Requirement | Minimum | Recommended |
 |-------------|---------|-------------|
 | OS | Linux (x86_64, arm64), macOS (arm64, x86_64), WSL2 on Windows | Ubuntu 22.04+ / Kali 2024+ / macOS 14+ / WSL2 with Ubuntu or Kali |
-| Docker | Docker Engine 24+ with Compose v2 | Docker Desktop or Colima |
+| Container runtime | Docker Engine 24+ with Compose v2 **OR** Podman 4.4+ with `podman compose` **OR** nerdctl with compose plugin | Docker Desktop / Colima / Podman Desktop |
 | RAM | 8 GB | 16 GB |
 | Disk | 10 GB free | 20 GB free |
 | Network | Outbound HTTPS | Low-latency connection |
@@ -189,6 +189,35 @@ curl -fsSL https://decepticon.red/install | bash
 ```
 
 This downloads the `decepticon` CLI binary for your platform and places it in your PATH.
+
+### Using Podman instead of Docker
+
+Decepticon detects Podman 4.4+ automatically. The launcher prefers Docker when both are available; set `DECEPTICON_CONTAINER_RUNTIME=podman` to force Podman:
+
+```bash
+# Linux (rootless Podman, recommended)
+systemctl --user enable --now podman.socket          # enable the API socket
+export DECEPTICON_CONTAINER_RUNTIME=podman           # force Podman selection
+decepticon start                                      # launcher detects + uses podman compose
+```
+
+What the launcher handles for you:
+- Selects `podman` if `docker` is absent (or if you set the override).
+- Auto-discovers the Podman API socket (`$XDG_RUNTIME_DIR/podman/podman.sock` or `/run/user/$UID/podman/podman.sock` for rootless; `/run/podman/podman.sock` for rootful) and exports `DOCKER_HOST` so any nested Docker-API tooling (testcontainers, etc.) keeps working.
+- Uses `podman compose` (Podman 4.4+ built-in); falls back to the `podman-compose` Python wrapper on older Podman.
+
+Rootless Podman caveats:
+- The `c2-sliver` profile binds privileged ports (443, 53). On rootless Podman you need either `sudo setcap CAP_NET_BIND_SERVICE=+eip $(which podman)` or add `net.ipv4.ip_unprivileged_port_start = 53` to `/etc/sysctl.conf`. Or just run rootful.
+- Bind mounts under your home directory work transparently. Mounting `/var/run/...` requires `--security-opt label=disable` on SELinux distros (Fedora, RHEL).
+
+### Using nerdctl
+
+```bash
+export DECEPTICON_CONTAINER_RUNTIME=nerdctl
+decepticon start
+```
+
+Requires nerdctl ≥ 0.16 (built-in compose) and a running containerd (`containerd` or `Rancher Desktop` with the containerd engine).
 
 ### Manual Install (from source)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,26 +45,47 @@ preflight() {
         exit 1
     fi
 
-    # Docker
-    if ! command -v docker >/dev/null 2>&1; then
-        error "Error: Docker is required but not installed."
-        echo -e "${DIM}Install Docker: ${NC}https://docs.docker.com/get-docker/"
+    # Container runtime — Docker (preferred) OR Podman 4.4+ (compose v2
+    # compatible). Honor explicit DECEPTICON_CONTAINER_RUNTIME override
+    # if the user is on a non-default setup (e.g. nerdctl, Rancher Desktop).
+    local rt="${DECEPTICON_CONTAINER_RUNTIME:-}"
+    if [[ -z "$rt" ]]; then
+        if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+            rt="docker"
+        elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+            rt="podman"
+        else
+            error "Error: no container runtime found."
+            echo -e "${DIM}Install one of:${NC}"
+            echo -e "${DIM}  Docker:  ${NC}https://docs.docker.com/get-docker/"
+            echo -e "${DIM}  Podman:  ${NC}https://podman.io/docs/installation"
+            echo -e "${DIM}  …or set DECEPTICON_CONTAINER_RUNTIME=nerdctl${NC}"
+            exit 1
+        fi
+    elif ! command -v "$rt" >/dev/null 2>&1 || ! "$rt" info >/dev/null 2>&1; then
+        error "Error: DECEPTICON_CONTAINER_RUNTIME=$rt requested but unusable."
         exit 1
     fi
+    info "Container runtime: $rt"
+    DECEPTICON_RUNTIME="$rt"
 
-    # Docker daemon
-    if ! docker info >/dev/null 2>&1; then
-        error "Error: Docker daemon is not running."
-        echo -e "${DIM}Start Docker and re-run the installer.${NC}"
-        exit 1
-    fi
-
-    # Docker Compose v2
-    if ! docker compose version >/dev/null 2>&1; then
-        error "Error: Docker Compose v2 is required."
-        echo -e "${DIM}Docker Compose is included with Docker Desktop.${NC}"
-        echo -e "${DIM}For Linux: ${NC}https://docs.docker.com/compose/install/linux/"
-        exit 1
+    # Compose v2 — required for the multi-file `docker compose up --wait`
+    # pattern. Docker Desktop ships it; Podman 4.4+ ships `podman compose`
+    # built-in (fallback: the podman-compose Python wrapper).
+    if [[ "$rt" == "docker" ]]; then
+        if ! docker compose version >/dev/null 2>&1; then
+            error "Error: Docker Compose v2 is required."
+            echo -e "${DIM}Docker Compose is included with Docker Desktop.${NC}"
+            echo -e "${DIM}For Linux: ${NC}https://docs.docker.com/compose/install/linux/"
+            exit 1
+        fi
+    elif [[ "$rt" == "podman" ]]; then
+        if ! podman compose --help >/dev/null 2>&1 \
+            && ! command -v podman-compose >/dev/null 2>&1; then
+            error "Error: 'podman compose' (Podman 4.4+) or 'podman-compose' is required."
+            echo -e "${DIM}Install: ${NC}https://github.com/containers/podman-compose"
+            exit 1
+        fi
     fi
 
     # sha256 tool — required for download integrity verification. Linux


### PR DESCRIPTION
Re-applies #292 on current main. Authorship preserved via cherry-pick. Original PR: #292

## Content
1. **Container runtime detection** — `clients/launcher/internal/runtime/` (new package). `Detect()` selects docker → podman → nerdctl (first reachable wins), honoring a `DECEPTICON_CONTAINER_RUNTIME` override. For Podman: picks `podman compose` (4.4+) or the `podman-compose` wrapper, discovers the rootless/rootful API socket, injects `DOCKER_HOST` into the compose subprocess env, detects rootless mode.
2. **Compose refactor** — `exec.Command("docker", …)` → `exec.Command(c.Runtime.Bin, …)`; `baseArgs()` built from `c.Runtime.ComposeArgs`. Backward-compatible: `Compose{}` instantiated directly (legacy tests) falls back to docker-shaped argv.
3. **Installer** — `scripts/install.sh` preflight accepts Docker OR Podman OR explicit override.
4. **PR-time arm64 smoke** — new `docker-build-arm64` CI job builds cli + langgraph under QEMU for `linux/arm64` (validate-only, `load: false`). sandbox/web excluded — 20+ min under QEMU would dominate PR CI; they're validated post-push.
5. **Docs** — setup-guide.md gains Podman / nerdctl sections with rootless caveats.

## Conflict resolved
`compose.go` `RemoveOrphanedCLI()` conflicted with #285's stack-anchored container filter. Merged both: kept #285's `name=^<prefix>-cli` anchoring (stack-aware, avoids matching unrelated containers) AND #292's runtime abstraction (`c.Runtime.Bin` + `composeEnv()`).

## Review notes
- **Docker users**: zero behavioral change — detection picks docker first, emits the same `docker compose -f … up --no-build --wait` argv.
- `--no-build` discipline preserved (present on `up`, intentionally absent on `run` per the existing comment — compose `run` rejects the flag).
- `go vet ./...`, `go build ./...`, `go test ./internal/compose ./internal/runtime` all pass. New runtime_test.go: 7 cases (Apply DOCKER_HOST injection, override rejection, socket discovery).
- No Python runtime code touched.

Co-authored-by: VoidChecksum <halvorsentech@gmail.com>