### PR TITLE
feat(runtime): optional docker-compose.platform.yml overlay for LangGraph Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Configure via `decepticon onboard`. → **[Full model reference & fallback examp
 | Neo4j knowledge graph | [Knowledge Graph](docs/knowledge-graph.md) |
 | End-to-end engagement workflow | [Engagement Workflow](docs/engagement-workflow.md) |
 | Offensive Vaccine loop | [Offensive Vaccine](docs/offensive-vaccine.md) |
+| Optional LangGraph Platform runtime (durable threads, queue) | [Platform Mode](docs/runtime/platform-mode.md) |
 | Contributing to Decepticon | [Contributing](docs/contributing.md) |
 
 ---

--- a/containers/langgraph-platform-entrypoint.sh
+++ b/containers/langgraph-platform-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# LangGraph Platform boot wrapper for the optional platform-mode image
+# (see containers/langgraph.platform.Dockerfile). Synthesises
+# LANGSERVE_GRAPHS from the OSS graph_registry, then execs the base
+# image's entrypoint.
+#
+# LANGSERVE_GRAPHS is composed at boot so plugin-contributed agents
+# (decepticon.agents entry-point group) appear automatically once their
+# packages are pip-installed - no Dockerfile rebuild required.
+#
+# An explicit LANGSERVE_GRAPHS already in the environment (e.g. a Cloud
+# Run revision narrowing the exposed graph set) wins; this wrapper only
+# fills the gap when the env is empty.
+
+set -e
+
+# OSS graph_registry emits file-form graph paths like
+# `./packages/decepticon/decepticon/agents/standard/decepticon.py:graph`
+# that resolve relative to CWD. The packages are installed editable, so
+# the source tree on disk is the resolution root - chdir there before
+# booting.
+cd /deps/decepticon
+
+if [ -z "${LANGSERVE_GRAPHS-}" ]; then
+  LANGSERVE_GRAPHS="$(python -m decepticon.graph_registry)"
+  export LANGSERVE_GRAPHS
+fi
+
+exec /storage/entrypoint.sh "$@"

--- a/containers/langgraph.platform.Dockerfile
+++ b/containers/langgraph.platform.Dockerfile
@@ -1,0 +1,91 @@
+# Optional production runtime: LangGraph Platform (Self-Hosted Lite or
+# Self-Hosted Enterprise) layered with the Decepticon framework.
+#
+# This image is NOT used by the default `docker-compose.yml`. It is the
+# build target for the optional `docker-compose.platform.yml` overlay
+# (see `docs/runtime/platform-mode.md` for when and why to opt in).
+#
+# Layered on `langchain/langgraph-api` so the LangGraph Platform server
+# (PostgresSaver checkpointer, Redis queue, multi-worker scheduler)
+# handles durability and the OSS Decepticon package contributes the
+# graphs / agents / skills.
+#
+# License gate at runtime:
+#   - `LANGSMITH_API_KEY`            → Self-Hosted Lite (1M nodes/yr,
+#                                       phones home to LangSmith Beacon)
+#   - `LANGGRAPH_CLOUD_LICENSE_KEY`  → Self-Hosted Enterprise (paid,
+#                                       optional air-gap)
+# Neither set → container exits at boot with
+# `ValueError: License verification failed` from the base image.
+#
+# The default OSS `containers/langgraph.Dockerfile` remains the canonical
+# image. It runs `langgraph dev` (free, in-memory, no phone-home) and
+# stays the supported path for individual contributors, CTF / benchmark
+# runs, air-gapped labs, and anyone who hasn't opted in to a LangGraph
+# commercial tier.
+
+ARG LANGGRAPH_API_VERSION=3.13
+FROM langchain/langgraph-api:${LANGGRAPH_API_VERSION}
+
+WORKDIR /deps/decepticon
+
+# uv for fast, reproducible installs against the base image's
+# constraints file (locks transitive versions to what the langgraph-api
+# server was tested with — prevents a pip upgrade from sliding
+# langgraph-core out from under the server).
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /usr/local/bin/uv
+
+# Workspace files. Same shape as the OSS dev image so the source-relative
+# graph paths in `langgraph.json` resolve identically.
+COPY pyproject.toml langgraph.json README.md uv.lock ./
+COPY packages/ packages/
+
+# Stamp the package version from the git tag at build time. Local builds
+# use the 0.0.0 sentinel from pyproject; release CI overrides via
+# --build-arg VERSION=<tag>.
+ARG VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DECEPTICON=${VERSION} \
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DECEPTICON_CORE=${VERSION} \
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DECEPTICON_SDK=${VERSION}
+
+# Install Decepticon (core + framework + sdk) against the base image's
+# constraints file. -e installs the three workspace packages editable so
+# the on-disk source remains the source of truth — matches the dev-mode
+# image's behaviour and keeps `--reload` workflows usable.
+RUN PYTHONDONTWRITEBYTECODE=1 uv pip install \
+        --system --no-cache-dir \
+        -c /api/constraints.txt \
+        -e ./packages/decepticon-core \
+        -e ./packages/decepticon-sdk \
+        -e ./packages/decepticon
+
+# Postgres + Redis checkpointer adapters. The base image ships the
+# runtime hooks but expects these packages installed for the production
+# checkpointer to bind. Redis adapter is needed for the queue / pubsub
+# layer, not for checkpoints.
+RUN PYTHONDONTWRITEBYTECODE=1 uv pip install \
+        --system --no-cache-dir \
+        -c /api/constraints.txt \
+        langgraph-checkpoint-postgres
+
+# Process-level plugin bundle baseline. OSS resolves enabled bundles
+# from a 4-tier hierarchy (env > .decepticon.toml > pyproject.toml >
+# hardcoded ["standard"]); we set the env explicitly so activation
+# isn't dependent on whatever CWD the container starts from.
+ENV DECEPTICON_PLUGINS=standard
+
+# Mirror the OSS langgraph.json multitask strategy on the platform
+# runtime. Override at runtime if a deployment needs different
+# semantics.
+ENV LANGGRAPH_HTTP='{"multitask_strategy": "interrupt"}'
+
+# LANGSERVE_GRAPHS is composed at boot (see entrypoint below) rather
+# than baked into the image so plugin-contributed agents
+# (`decepticon.agents` entry-point group) appear automatically once
+# their packages are pip-installed — no Dockerfile rebuild required.
+
+# Boot wrapper. Synthesises LANGSERVE_GRAPHS from the OSS graph_registry
+# then execs the base image's entrypoint.
+COPY containers/langgraph-platform-entrypoint.sh /usr/local/bin/langgraph-platform-entrypoint.sh
+RUN chmod +x /usr/local/bin/langgraph-platform-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/langgraph-platform-entrypoint.sh"]

--- a/containers/postgres-init/02-create-langgraph-cp.sql
+++ b/containers/postgres-init/02-create-langgraph-cp.sql
@@ -1,0 +1,15 @@
+-- LangGraph Platform checkpoint database.
+--
+-- Created only when the optional docker-compose.platform.yml overlay is
+-- active (it mounts this script into /docker-entrypoint-initdb.d/). Runs
+-- after 01-create-decepticon-web.sql on first volume init only - existing
+-- deployments must create the database manually if they switch in:
+--     docker compose exec postgres \
+--         psql -U decepticon -c 'CREATE DATABASE langgraph_cp;'
+--
+-- The LangGraph Platform server (langchain/langgraph-api) creates its
+-- own schema (checkpoints, checkpoint_blobs, checkpoint_writes, ...) on
+-- first boot, so we only need the empty database here.
+
+SELECT 'CREATE DATABASE langgraph_cp'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'langgraph_cp')\gexec

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -1,0 +1,93 @@
+# Optional overlay: swap the default `langgraph dev` runtime for the
+# commercial LangGraph Platform server (Self-Hosted Lite or Enterprise).
+#
+# Usage:
+#     docker compose -f docker-compose.yml -f docker-compose.platform.yml up
+#
+# What this gives you:
+#   - PostgresSaver checkpointer (threads survive container restart;
+#     `docker compose restart langgraph` no longer wipes chat history).
+#   - Redis-backed queue (multi-worker scheduling, prerequisite for
+#     scaling langgraph horizontally).
+#   - The same `LANGSERVE_GRAPHS` set as dev mode; agents and plugin
+#     contributions are unchanged.
+#
+# What this costs you:
+#   - A LangSmith account + API key (free tier OK for Self-Hosted Lite).
+#     Set `LANGSMITH_API_KEY` in `.env` BEFORE bringing this up - the
+#     base image refuses to boot without it.
+#   - Phone-home traffic to `beacon.langchain.com` on every startup.
+#   - 1,000,000 node executions / year on the Lite tier (Decepticon
+#     engagements consume thousands per run - monitor your budget at
+#     `https://smith.langchain.com/o/<org>/settings/usage`).
+#   - Air-gap / unlimited execution requires Self-Hosted Enterprise
+#     (paid, set `LANGGRAPH_CLOUD_LICENSE_KEY` instead).
+#
+# Full trade-off discussion: docs/runtime/platform-mode.md
+#
+# The default `docker-compose.yml` remains the canonical OSS path
+# (langgraph dev, free, in-memory, no phone-home). This file is a pure
+# overlay: it only redefines the `langgraph` service plus the new
+# `langgraph-redis` it depends on, and reuses the `postgres` service
+# already in the base stack for the checkpoint database.
+
+services:
+
+  langgraph:
+    image: ghcr.io/purpleailab/decepticon-langgraph-platform:${DECEPTICON_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: containers/langgraph.platform.Dockerfile
+      args:
+        VERSION: ${VERSION:-0.0.0}
+        LANGGRAPH_API_VERSION: ${LANGGRAPH_API_VERSION:-3.13}
+    environment:
+      # License gate. EXACTLY ONE of these must be set in .env, else the
+      # base image exits at boot with `License verification failed`.
+      #   LANGSMITH_API_KEY            -> Self-Hosted Lite (1M nodes/yr)
+      #   LANGGRAPH_CLOUD_LICENSE_KEY  -> Self-Hosted Enterprise
+      - LANGSMITH_API_KEY=${LANGSMITH_API_KEY:-}
+      - LANGGRAPH_CLOUD_LICENSE_KEY=${LANGGRAPH_CLOUD_LICENSE_KEY:-}
+      # PostgresSaver target. Reuses the base stack's `postgres` service
+      # (running on `decepticon-net`); the `langgraph_cp` database is
+      # auto-created by `containers/postgres-init/02-create-langgraph-cp.sql`.
+      - POSTGRES_URI=postgres://decepticon:${POSTGRES_PASSWORD:-decepticon}@postgres:5432/langgraph_cp?sslmode=disable
+      # Queue / pubsub backend. New redis service below; not shared with
+      # any other component so a `docker compose down` of the overlay
+      # doesn't impact the rest of the stack.
+      - REDIS_URI=redis://langgraph-redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      langgraph-redis:
+        condition: service_healthy
+      litellm:
+        condition: service_healthy
+
+  # Postgres in the base stack already runs at decepticon-net:5432. The
+  # overlay adds an init script (mounted alongside the existing initdb
+  # scripts) that creates the `langgraph_cp` database on first volume
+  # mount. Existing deployments with a populated postgres_data volume
+  # must create the database manually:
+  #     docker compose exec postgres \
+  #         psql -U decepticon -c 'CREATE DATABASE langgraph_cp;'
+  postgres:
+    volumes:
+      - ./containers/postgres-init/02-create-langgraph-cp.sql:/docker-entrypoint-initdb.d/02-create-langgraph-cp.sql:ro
+
+  # Dedicated redis for the LangGraph Platform queue. Not shared with
+  # any LiteLLM / Decepticon component, so footprint stays bounded and
+  # the overlay is self-contained.
+  langgraph-redis:
+    image: redis:7.4-alpine
+    container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-langgraph-redis
+    networks:
+      - decepticon-net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]

--- a/docs/runtime/platform-mode.md
+++ b/docs/runtime/platform-mode.md
@@ -1,0 +1,134 @@
+# Optional: LangGraph Platform mode
+
+Decepticon ships with two runtime images for the orchestrator:
+
+| Image | Backed by | Default? | Use when |
+|---|---|---|---|
+| `containers/langgraph.Dockerfile` | `langgraph dev` (in-memory CLI) | **Yes** | Individual contributors, CTF / benchmark runs, air-gapped labs, anyone who has not opted in to a LangGraph commercial tier |
+| `containers/langgraph.platform.Dockerfile` | `langchain/langgraph-api` | No | Production-style deployments that want durable thread state, multi-worker scheduling, and the platform server's queue / pubsub |
+
+The default `docker-compose.yml` uses the first. **This document explains
+when and how to opt in to the second.** Both surfaces register the same
+`LANGSERVE_GRAPHS` set, run the same agents, and accept the same plugin
+contributions — the difference is the host runtime.
+
+## Why you might want this
+
+`langgraph dev` is great for development. The trade-offs become visible
+in production:
+
+- **Thread state is in-memory.** `docker compose restart langgraph`
+  wipes every active engagement's chat history. The agent recovers
+  because it re-reads `/workspace/` on resume (Ralph-loop pattern), but
+  the conversation feels reset.
+- **One worker.** The dev server is single-process; horizontal scaling
+  is not possible.
+- **No queue.** Long-running graph executions block the request that
+  triggered them. SSE clients survive disconnect, but a fresh client
+  cannot resume mid-run.
+
+The LangGraph Platform server addresses all three:
+
+- **PostgresSaver checkpointer.** Threads survive container restart,
+  postgres restart, host reboot. Verified by LangChain: a thread
+  created via `POST /threads`, then `docker compose restart langgraph`,
+  then `GET /threads/<id>` returns the same thread with status
+  preserved.
+- **Multi-worker.** Replace `langgraph` with N replicas behind a
+  shared Postgres / Redis pair.
+- **Redis-backed queue.** Disconnects, retries, fan-out all become
+  durable instead of best-effort.
+
+The cost is the LangGraph Platform license model — see "License gate"
+below.
+
+## License gate
+
+`langchain/langgraph-api` performs a **load-bearing license check at
+boot**:
+
+| Env set | Tier | Limit | Phone-home | Cost |
+|---|---|---|---|---|
+| `LANGSMITH_API_KEY` | Self-Hosted Lite | **1,000,000 node executions / year** | `beacon.langchain.com` on startup | Free with LangSmith account |
+| `LANGGRAPH_CLOUD_LICENSE_KEY` | Self-Hosted Enterprise | Unlimited; air-gap configurable | Configurable | [Contact LangChain sales](https://www.langchain.com/pricing) |
+| Neither | — | — | — | Container exits at boot with `ValueError: License verification failed` |
+
+**Decepticon engagements consume thousands of node executions each**
+(deep chain: recon → exploit → postexploit → analyst). On the Lite tier,
+100 engagements can exceed the entire annual budget. Monitor usage at
+`https://smith.langchain.com/o/<your-org>/settings/usage` and plan the
+upgrade to Enterprise if you intend to run continuously.
+
+## How to opt in
+
+1. **Get a LangSmith API key.** Sign up at
+   [smith.langchain.com](https://smith.langchain.com), navigate to
+   Settings → API keys, create one. (Or buy an Enterprise license and
+   get `LANGGRAPH_CLOUD_LICENSE_KEY` from your account team.)
+
+2. **Set the env var.** Add to `.env`:
+
+   ```bash
+   LANGSMITH_API_KEY=lsv2_pt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxx
+   ```
+
+3. **Bring up the overlay.** From the repo root:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.platform.yml up --build
+   ```
+
+   First boot creates the `langgraph_cp` Postgres database from
+   `containers/postgres-init/02-create-langgraph-cp.sql`. **If you have
+   an existing `postgres_data` volume**, that init script does not run
+   (Postgres only runs initdb scripts on empty volumes); create the
+   database manually:
+
+   ```bash
+   docker compose exec postgres \
+       psql -U decepticon -c 'CREATE DATABASE langgraph_cp;'
+   ```
+
+4. **Verify.** Threads should now survive a restart:
+
+   ```bash
+   # Start an engagement, then:
+   docker compose -f docker-compose.yml -f docker-compose.platform.yml restart langgraph
+   # Reopen the engagement in the web dashboard - chat history is intact.
+   ```
+
+## How to opt back out
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.platform.yml down
+docker compose up    # default langgraph dev runtime
+```
+
+The default runtime ignores the `langgraph_cp` database and the
+`langgraph-redis` service. They sit idle until the next overlay run.
+Delete them with `docker volume rm postgres_data` (destructive: wipes
+all Postgres data) or with `docker compose exec postgres psql -U
+decepticon -c 'DROP DATABASE langgraph_cp;'` (surgical) if you want to
+reclaim the space.
+
+## What this overlay does NOT do
+
+- **Run agents in production.** The platform runtime improves durability
+  and scheduling. It does not change the agent code, the safety gate,
+  or the engagement model. Production deployment also wants a hardened
+  reverse proxy, TLS termination, observability, etc. — out of scope
+  here.
+- **Replace the OSS image as the default.** `langgraph dev` remains
+  the canonical OSS path. We are not opinionated about which runtime
+  you choose; we just make both available.
+- **Enable multi-tenant gating.** A single Decepticon stack is still
+  single-tenant by design. Multi-tenant SaaS isolation is a layer on
+  top — see PurpleAILAB's hosted Decepticon Cloud for the productised
+  version.
+
+## Reference
+
+- [LangGraph Platform deployment options](https://github.com/langchain-ai/langgraph/blob/main/docs/docs/how-tos/deploy-self-hosted.md)
+- [LangSmith pricing](https://www.langchain.com/pricing)
+- `containers/langgraph.platform.Dockerfile` — the platform-mode image build.
+- `docker-compose.platform.yml` — the overlay itself.


### PR DESCRIPTION
## What this is

An **opt-in** production-runtime overlay for `docker compose`. The default OSS stack continues to use `langgraph dev` (in-memory, free, no phone-home). This PR adds a parallel `docker-compose.platform.yml` that swaps the orchestrator runtime for `langchain/langgraph-api` — what the published commercial-tier deployment guides refer to as **LangGraph Self-Hosted Lite / Enterprise**.

## Why

langgraph dev is the right OSS default — free, simple, no commercial dependency. But three properties of the dev runtime become friction in production-style deployments:

1. **Thread state is in-memory.** docker compose restart langgraph wipes every active engagement's chat history. The agent recovers (re-reads `/workspace/`, Ralph-loop pattern) but operators perceive a reset.
2. **Single worker.** No horizontal scaling.
3. **No queue.** Long-running graph executions block the request that triggered them.

The platform runtime addresses all three with PostgresSaver checkpointer + Redis queue + multi-worker scheduling. Many operators running OSS Decepticon for serious internal red-team work want exactly that durability without the multi-tenancy of a hosted product.

The OSS-side tracker for "we should make this easy to opt in to" has existed for a while — this PR delivers it without changing the OSS default.

## How

| File | Purpose |
|---|---|
| `containers/langgraph.platform.Dockerfile` | Layers OSS source (three workspace packages, editable install) on the published `langchain/langgraph-api` image. Pinned against `/api/constraints.txt` to lock transitive versions to whatever the base image was tested with. |
| `containers/langgraph-platform-entrypoint.sh` | Composes `LANGSERVE_GRAPHS` from `decepticon.graph_registry` at boot. Plugin-contributed agents appear automatically; an explicit `LANGSERVE_GRAPHS` in the env wins (deployments narrowing the exposed graph set still work). |
| `containers/postgres-init/02-create-langgraph-cp.sql` | Idempotent `CREATE DATABASE langgraph_cp` for the checkpointer. Only runs on fresh `postgres_data` volumes (Postgres convention); existing deployments create the DB manually — documented. |
| `docker-compose.platform.yml` | Pure overlay: redefines `langgraph`, adds a dedicated `langgraph-redis`, mounts the init script onto the existing `postgres` service. `docker compose down` of the overlay leaves the base stack working with the default runtime. |
| `docs/runtime/platform-mode.md` | Trade-off document, opt-in / opt-out steps, license-gate matrix, post-mortem verification command. |
| `README.md` | Single-row addition in the Documentation table pointing at the new doc. |

## License gate (this is the headline trade-off, called out clearly in the doc)

| Env set | Tier | Limit | Phone-home | Cost |
|---|---|---|---|---|
| `LANGSMITH_API_KEY` | Self-Hosted Lite | 1,000,000 node executions / year | `beacon.langchain.com` on startup | Free with LangSmith account |
| `LANGGRAPH_CLOUD_LICENSE_KEY` | Self-Hosted Enterprise | Unlimited; air-gap configurable | Configurable | [LangChain sales](https://www.langchain.com/pricing) |
| Neither | — | — | — | `ValueError: License verification failed` at boot — empirically verified |

The OSS default (`langgraph dev`) is untouched and remains the supported path for individual contributors, CTF / benchmark runs, air-gapped labs, and anyone who hasn't opted in to a LangGraph commercial tier.

## Usage

```bash
# Default OSS path (unchanged)
docker compose up

# Opt in to platform mode
echo 'LANGSMITH_API_KEY=lsv2_pt_...' >> .env
docker compose -f docker-compose.yml -f docker-compose.platform.yml up --build
```

## Out of scope

- Making this the default. Not the intent.
- Multi-tenant gating. A single Decepticon stack is single-tenant by design; multi-tenant isolation is a layer on top.
- Production observability, TLS termination, reverse proxy hardening. Separate concerns.

## Verification

```bash
# Default still works
docker compose config > /dev/null && echo "✓ base compose valid"

# Overlay merges cleanly
docker compose -f docker-compose.yml -f docker-compose.platform.yml config > /dev/null && echo "✓ overlay valid"
```

Closes the "Optional OSS PR; track separately" item.