### PR TITLE
fix(streaming): preserve StreamingRunnable across deepagents .with_config()

### DIFF
--- a/packages/decepticon/decepticon/core/subagent_streaming.py
+++ b/packages/decepticon/decepticon/core/subagent_streaming.py
@@ -16,10 +16,15 @@ Architecture:
   → emits events via both channels
   → returns same result as invoke() for SubAgentMiddleware compatibility
 
-IMPORTANT: LangGraph runs the agent graph asynchronously (all middleware uses
-awrap_* methods). SubAgentMiddleware's atask() calls subagent.ainvoke(), so
-the ainvoke() method MUST be implemented here — otherwise __getattr__ delegates
-to the underlying runnable's ainvoke(), bypassing all streaming logic.
+Why a RunnableBinding subclass:
+  deepagents.middleware.subagents._get_subagents() normalises every spec by
+  calling `compiled["runnable"].with_config({"metadata":..., "run_name":...})`
+  and stores the *returned* object as the subagent. If StreamingRunnable were
+  a plain class with __getattr__ forwarding, with_config would fall through
+  to the inner compiled graph and return a RunnableBinding wrapping the bare
+  graph — silently dropping this wrapper before dispatch. RunnableBinding's
+  built-in with_config() reconstructs `self.__class__(...)`, so subclassing
+  preserves the wrapper across deepagents' registration step.
 """
 
 from __future__ import annotations
@@ -32,6 +37,7 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 from langchain_core.messages.tool import ToolCall
+from langchain_core.runnables import Runnable, RunnableBinding
 
 log = logging.getLogger("decepticon.subagent_streaming")
 
@@ -64,7 +70,7 @@ def _get_writer() -> Callable | None:
         return None
 
 
-class StreamingRunnable:
+class StreamingRunnable(RunnableBinding):
     """Wraps a compiled LangGraph agent to stream events during invoke()/ainvoke().
 
     Drop-in replacement for the runnable field in CompiledSubAgent.
@@ -75,15 +81,55 @@ class StreamingRunnable:
 
     If neither channel is available, falls back to plain invoke()/ainvoke().
 
-    IMPORTANT: Both invoke() AND ainvoke() must be implemented because LangGraph
-    runs agent graphs asynchronously — SubAgentMiddleware's atask() calls
-    subagent.ainvoke(). Without ainvoke() here, __getattr__ would delegate to
-    the underlying runnable's ainvoke(), bypassing all streaming event emission.
+    Subclasses ``RunnableBinding`` so deepagents' SubAgentMiddleware._get_subagents()
+    call to ``compiled["runnable"].with_config(...)`` reconstructs a StreamingRunnable
+    (via ``self.__class__``) rather than collapsing back to the bare inner graph.
+    Without this, the wrapper's invoke/ainvoke would be silently bypassed at
+    dispatch time and zero ``subagent_*`` custom events would reach the LangGraph
+    Platform HTTP stream.
     """
 
-    def __init__(self, runnable: Any, name: str):
-        self._runnable = runnable
-        self._name = name
+    # Legacy positional constructor: ``StreamingRunnable(runnable, name)``.
+    # Also supports the keyword-only construction RunnableBinding.with_config()
+    # uses internally (``bound=...``, ``config=...``, ``kwargs=...``, etc.).
+    def __init__(
+        self,
+        runnable: Runnable | None = None,
+        name: str | None = None,
+        **data: Any,
+    ) -> None:
+        if runnable is not None and "bound" not in data:
+            data["bound"] = runnable
+        if name is not None and "name" not in data:
+            data["name"] = name
+        super().__init__(**data)
+
+    # ── Back-compat aliases for OSS callers / tests ────────────────────
+    # Internal code (and unit tests) refer to ``self._runnable`` / ``self._name``;
+    # surface them as read-only views on the RunnableBinding fields.
+
+    @property
+    def _runnable(self) -> Runnable:
+        return self.bound
+
+    @property
+    def _name(self) -> str:
+        """Agent name for event emission.
+
+        Construction sets ``self.name`` directly. After deepagents calls
+        with_config({"run_name": ...}), ``self.name`` is still preserved by
+        RunnableBinding.with_config (it copies via ``self.__class__(...)``);
+        fall back to ``config["run_name"]`` then ``metadata["lc_agent_name"]``
+        for robustness if a future caller drops ``name``.
+        """
+        if self.name:
+            return self.name
+        cfg = self.config or {}
+        run_name = cfg.get("run_name")
+        if run_name:
+            return run_name
+        md = cfg.get("metadata") or {}
+        return md.get("lc_agent_name") or "subagent"
 
     def _get_channels(self) -> tuple[Any, bool, Callable | None]:
         """Get renderer and writer channels. Returns (renderer, has_renderer, writer)."""
@@ -385,7 +431,3 @@ class StreamingRunnable:
             }
 
         return last_state
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate all other attribute access to the underlying runnable."""
-        return getattr(self._runnable, name)

--- a/packages/decepticon/tests/unit/core/test_subagent_streaming.py
+++ b/packages/decepticon/tests/unit/core/test_subagent_streaming.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import Runnable
 
 from decepticon.core.subagent_streaming import (
     StreamingRunnable,
@@ -23,8 +24,13 @@ from decepticon.core.subagent_streaming import (
 )
 
 
-class CountingRunnable:
-    """Minimal fake LangGraph runnable for side-effect counting."""
+class CountingRunnable(Runnable):
+    """Minimal fake LangGraph runnable for side-effect counting.
+
+    Subclasses Runnable so StreamingRunnable (a RunnableBinding subclass) accepts
+    it as ``bound``. The wrapper now mirrors how a real compiled subagent looks
+    to deepagents — bare ducktypes are no longer enough.
+    """
 
     def __init__(self, stream_items: list[Any], invoke_payload: Any | None = None):
         self._stream_items = stream_items


### PR DESCRIPTION
## Summary

Subclass `RunnableBinding` so `StreamingRunnable` survives `deepagents.middleware.subagents._get_subagents()`'s `compiled["runnable"].with_config({...})` call. Without this, the wrapper is silently dropped before dispatch and **zero `subagent_*` custom events** reach the LangGraph Platform HTTP stream.

## The bug

`StreamingRunnable` was a plain class with `__getattr__` forwarding to the wrapped graph. deepagents normalises each spec at registration time with:

```python
runnable = compiled["runnable"].with_config({"metadata": {"lc_agent_name": ...}, "run_name": ...})
```

`with_config` is not defined on the wrapper, so `__getattr__` forwards the call to the inner compiled graph. The returned `RunnableBinding` has `bound = inner_raw_graph`, not the streaming wrapper — every subsequent `await subagent.ainvoke(...)` goes straight to the unwrapped binding.

The CLI/UIRenderer channel still worked because that path is set via a contextvar before `.with_config(...)` ever runs (and reads from the same contextvar inside the subagent's nodes/tools). The LangGraph Platform HTTP `stream_mode=["custom"]` path was always broken; no `subagent_*` event ever reached it.

## The fix

Subclass `RunnableBinding`. Its `with_config()` reconstructs via `self.__class__(...)`, so the subclass identity is preserved across deepagents' registration step.

- `bound` / `name` / `config` now live on the Pydantic fields `RunnableBinding` already exposes.
- `_runnable` and `_name` become read-only properties for back-compat with existing callers and the regression tests.
- `__getattr__` is removed — `RunnableBinding` covers the attributes deepagents and downstream middleware actually touch.
- The constructor accepts both the legacy positional `StreamingRunnable(runnable, name)` shape used at registration sites and the keyword-only `bound=..., config=..., kwargs=...` shape `RunnableBinding.with_config()` uses internally.

## Verification

Against `langgraph` 1.2.1 / `langchain-core` 1.4.0 / `deepagents` 0.6.3 on a LangGraph Platform self-hosted run:

| | Before patch | After patch |
|---|---|---|
| `custom` SSE frames for one `task("recon", …)` delegation | **0** | **5** (`subagent_start`, `subagent_tool_call` for `bash`, `subagent_tool_result`, `subagent_message`, `subagent_end`) |
| `StreamingRunnable.ainvoke()` invoked | no | yes |
| CLI UIRenderer channel | works | works (unchanged) |

The seven regression tests in `tests/unit/core/test_subagent_streaming.py` pass. The `CountingRunnable` shim was a duck-typed class; `RunnableBinding.bound` now validates `isinstance(Runnable)`, so the fake is updated to subclass `Runnable`. This actually brings the test closer to production — deepagents only ever hands real compiled graphs through this path.

## Test plan

- [x] `pytest packages/decepticon/tests/unit/core/test_subagent_streaming.py` — all 7 pass
- [x] End-to-end: send a fresh kickoff to a Decepticon supervisor on a LangGraph Platform self-hosted instance and capture `runs/stream?stream_mode=["custom"],stream_subgraphs=true`. Five `subagent_*` custom frames now appear inside the parent stream (root `event: custom`).
- [x] CLI/UIRenderer path unchanged (renderer contextvar still receives `on_subagent_*` callbacks during invoke).

## References

- `langchain-core` `runnables/base.py` — `RunnableBinding.with_config` reconstructs via `self.__class__(...)`.
- `deepagents` `middleware/subagents.py` `_get_subagents` line 97 — the `.with_config(...)` call this patch is reactive to.