### PR TITLE
fix: four runtime-stability patches + sandbox pids_limit + LLM timeout (re-merge of #295)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -267,3 +267,11 @@ DECEPTICON_STACK_NAME=
 # The Ghidra MCP bridge runs as a sidecar — enable with: COMPOSE_PROFILES=reversing
 
 DECEPTICON_LANGUAGE=en
+
+# --- LLM client timeout ---
+# Seconds to wait for a single LLM completion before raising
+# APITimeoutError. Default 120s is too short for long Opus generations
+# with max_tokens=128000 — generations routinely exceed 120s mid-stream
+# while LiteLLM proxy keeps returning 200 OK upstream. 600s (10min)
+# covers worst-case extended-thinking + large tool_use payloads.
+DECEPTICON_LLM__TIMEOUT=600

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,100 @@ follows [Semantic Versioning](https://semver.org/) from `1.0.0`
 onward (the `0.x` cycle is pre-stable per
 [spec §13.4](docs/superpowers/specs/2026-05-23-core-framework-sdk-split-design.md)).
 
+## [1.1.2-localfixes.1] — 2026-05-25 (fork — mohamedq9900/Decepticon)
+
+Runtime-stability fork of upstream `v1.1.2` carrying four targeted fixes
+that surfaced under sustained engagement load (multi-hour audits, large
+report writes, parallel sub-agent fan-out). All changes are minimal and
+preserve upstream contracts.
+
+### Fixed
+
+- **`bash_kill` BlockingError under `langgraph dev`** —
+  `_sandbox.session_log_path()` was called synchronously inside the
+  ASGI event loop, tripping `blockbuster`'s detector with
+  `BlockingError: socket.socket.send`. Wrapped in `asyncio.to_thread`
+  to match the pattern already used for the surrounding `kill_session`
+  call. The CLI previously surfaced this as "An internal error
+  occurred" on every successful session kill.
+  ([`packages/decepticon/decepticon/tools/bash/bash.py`](packages/decepticon/decepticon/tools/bash/bash.py))
+
+- **`GraphRecursionError: Recursion limit of 250 reached`** —
+  bumped `_RECURSION_LIMIT` from `250` to `1000` on seven sub-agents
+  that genuinely need deeper graphs for large engagements (recon
+  sweeps with many candidates, parallel CVE probes, multi-target
+  static analysis): `analyst`, `cloud_hunter`, `contract_auditor`,
+  `ad_operator`, `reverser`, `exploiter`, `vulnresearch`. Other
+  agents (`recon`, `exploit`, `postexploit`, `soundwave`,
+  orchestrator) were already sized at ≥400 and remain unchanged.
+  Cap of 1000 was chosen to cover observed worst-case depth without
+  unbounded headroom.
+  ([`packages/decepticon/decepticon/agents/standard/*.py`,
+  `packages/decepticon/decepticon/agents/plugins/*.py`](packages/decepticon/decepticon/agents/))
+
+- **`auth/gpt-*` Codex OAuth handler dropped tool names mid-stream** —
+  the streaming handler only processed
+  `response.function_call_arguments.delta` events, which carry the
+  arguments fragment but NOT the function `name`. Synthesized
+  function_calls ended up with `name=""`; on the next turn the model
+  saw a history full of mis-named tool_calls and looped re-calling
+  the same tool (e.g. `load_skill`) because tool_results couldn't be
+  linked back to the original call. Added handlers for
+  `response.output_item.added` (primary path, captures `name` +
+  `call_id` when the function_call item starts) and
+  `response.output_item.done` (defensive backfill for upstream
+  variants that emit only `done`).
+  ([`config/codex_chatgpt_handler.py`](config/codex_chatgpt_handler.py))
+
+- **LiteLLM truncated `tool_use` JSON mid-`content` field** —
+  `litellm_params` for every Claude model omitted `max_tokens`, so
+  LiteLLM defaulted Anthropic requests to its 4096-token OpenAI
+  fallback. Long `write_file` calls (a typical 30-50 KB markdown
+  report ≈ 10-15 K output tokens) were cut off mid-stream and the
+  `content` field arrived missing from the parsed tool_use, yielding
+  `content: Field required` validation errors. Set `max_tokens`
+  explicitly per model to match Claude Code's canonical caps:
+  Opus 4.7/4.6 → 128000, Sonnet 4.6 → 64000, Haiku 4.5 → 64000.
+  Applied to all three groups (`anthropic/`, `auth/`,
+  `openrouter/anthropic/`).
+  ([`config/litellm.yaml`](config/litellm.yaml))
+
+### Changed
+
+- **`sandbox.pids_limit`: `1024` → `4096`** — analyst sub-agents that
+  drive Go/Rust toolchains in parallel (`gosec` + `cargo` + `semgrep`
+  × fan-out) blow through the 1024-pid cgroup cap, then
+  `subprocess.run()` in the sandbox FastAPI daemon fails with
+  `BlockingIOError: [Errno 11] Resource temporarily unavailable`,
+  which the daemon surfaces as HTTP 500 and the CLI prints as "An
+  internal error occurred". 4096 has held under multi-hour Cosmos
+  and Web3 audits.
+  ([`docker-compose.yml`](docker-compose.yml))
+
+- **Default `DECEPTICON_LLM__TIMEOUT`: `120` → `600` (10 min)** —
+  with `max_tokens` bumped to 128K (fix above), long Opus generations
+  with extended thinking + large tool_use payloads routinely exceed
+  120s mid-stream. The langgraph httpx client aborted the connection
+  while LiteLLM proxy kept streaming successfully (200 OK in proxy
+  logs), surfacing in the CLI as `APITimeoutError: Request timed
+  out`. Documented in `.env.example`; defaults pass through via the
+  `DECEPTICON_LLM__*` Pydantic settings.
+  ([`.env.example`](.env.example))
+
+### Compatibility
+
+- Patches apply on top of upstream `v1.1.2` commit `e1afba6`.
+- No API or import surface changed; downstream code that imports
+  any of the modified modules works unchanged.
+- Reverting any single fix is a one-line revert against this branch.
+
+### Tested against
+
+Fedora 43, Docker 27.x, SELinux permissive. Engagement workload:
+sustained multi-hour Cosmos / Web3 / Web2 bug-bounty audits with
+parallel sub-agent fan-out, large recon outputs, and 30-50 KB
+report writes on `auth/claude-opus-4-7` and `auth/gpt-5.5`.
+
 ## [Unreleased] — targets v1.1.2
 
 This release introduces the three-package split (additive — every

--- a/config/codex_chatgpt_handler.py
+++ b/config/codex_chatgpt_handler.py
@@ -343,13 +343,29 @@ def _completed_payload(resp: httpx.Response) -> dict[str, Any]:
             delta = event.get("delta")
             if isinstance(delta, str):
                 text_parts.append(delta)
+        elif event_type == "response.output_item.added":
+            # FIX: capture the function_call name + call_id from the
+            # ``output_item.added`` event. The ``function_call_arguments.delta``
+            # events that follow only carry ``item_id`` + arguments, NOT the
+            # name. Without this, synthesized function_calls have name="" and
+            # the model loops because tool_results can't be linked to the
+            # original tool_call.
+            item = event.get("item") or {}
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                item_id = item.get("id") or item.get("call_id") or "tool_call"
+                function_calls[item_id] = {
+                    "type": "function_call",
+                    "call_id": item.get("call_id") or item_id,
+                    "name": item.get("name") or "",
+                    "arguments": item.get("arguments") or "",
+                }
         elif event_type == "response.function_call_arguments.delta":
-            call_id = event.get("item_id") or event.get("call_id") or "tool_call"
+            item_id = event.get("item_id") or event.get("call_id") or "tool_call"
             entry = function_calls.setdefault(
-                call_id,
+                item_id,
                 {
                     "type": "function_call",
-                    "call_id": call_id,
+                    "call_id": item_id,
                     "name": event.get("name") or "",
                     "arguments": "",
                 },
@@ -357,6 +373,25 @@ def _completed_payload(resp: httpx.Response) -> dict[str, Any]:
             delta = event.get("delta")
             if isinstance(delta, str):
                 entry["arguments"] += delta
+        elif event_type == "response.output_item.done":
+            # Backfill name/call_id if the ``output_item.added`` event was
+            # missed (defensive — some upstream variants only emit ``done``).
+            item = event.get("item") or {}
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                item_id = item.get("id") or item.get("call_id") or "tool_call"
+                entry = function_calls.setdefault(
+                    item_id,
+                    {
+                        "type": "function_call",
+                        "call_id": item.get("call_id") or item_id,
+                        "name": item.get("name") or "",
+                        "arguments": item.get("arguments") or "",
+                    },
+                )
+                if not entry.get("name") and item.get("name"):
+                    entry["name"] = item["name"]
+                if not entry.get("call_id") and item.get("call_id"):
+                    entry["call_id"] = item["call_id"]
         elif event_type == "response.completed" and isinstance(event.get("response"), dict):
             completed = event["response"]
         elif event_type in {"response.failed", "error"}:

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -42,6 +42,7 @@ model_list:
       model: anthropic/claude-opus-4-7
       api_key: os.environ/ANTHROPIC_API_KEY
       additional_drop_params: ["temperature"]
+      max_tokens: 128000
     model_info:
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
@@ -50,6 +51,7 @@ model_list:
     litellm_params:
       model: anthropic/claude-sonnet-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
+      max_tokens: 64000
     model_info:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
@@ -58,6 +60,7 @@ model_list:
     litellm_params:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
+      max_tokens: 64000
     model_info:
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000005
@@ -182,6 +185,7 @@ model_list:
     litellm_params:
       model: auth/claude-opus-4-7
       additional_drop_params: ["temperature"]
+      max_tokens: 128000
     model_info:
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
@@ -189,6 +193,7 @@ model_list:
   - model_name: auth/claude-sonnet-4-6
     litellm_params:
       model: auth/claude-sonnet-4-6
+      max_tokens: 64000
     model_info:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
@@ -196,6 +201,7 @@ model_list:
   - model_name: auth/claude-haiku-4-5
     litellm_params:
       model: auth/claude-haiku-4-5
+      max_tokens: 64000
     model_info:
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000005
@@ -298,6 +304,7 @@ model_list:
       model: openrouter/anthropic/claude-opus-4-7
       api_key: os.environ/OPENROUTER_API_KEY
       additional_drop_params: ["temperature"]
+      max_tokens: 128000
     model_info:
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
@@ -306,6 +313,7 @@ model_list:
     litellm_params:
       model: openrouter/anthropic/claude-sonnet-4-6
       api_key: os.environ/OPENROUTER_API_KEY
+      max_tokens: 64000
     model_info:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
@@ -314,6 +322,7 @@ model_list:
     litellm_params:
       model: openrouter/anthropic/claude-haiku-4-5
       api_key: os.environ/OPENROUTER_API_KEY
+      max_tokens: 64000
     model_info:
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000005

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
       # ``containers/langgraph.Dockerfile``) and are read in-process by
       # ``FilesystemBackend`` via ``CompositeBackend``. The sandbox only
       # owns ``/workspace/`` from here on.
-    pids_limit: 1024
+    pids_limit: 4096
     depends_on:
       neo4j:
         condition: service_started

--- a/packages/decepticon/decepticon/agents/plugins/exploiter.py
+++ b/packages/decepticon/decepticon/agents/plugins/exploiter.py
@@ -112,7 +112,7 @@ _SKILL_SOURCES: list[str] = [
 
 
 _ROLE = "exploiter"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 
 def create_exploiter_agent(

--- a/packages/decepticon/decepticon/agents/plugins/vulnresearch.py
+++ b/packages/decepticon/decepticon/agents/plugins/vulnresearch.py
@@ -70,7 +70,7 @@ from decepticon_core.plugin_loader import (
 )
 
 _ROLE = "vulnresearch"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 # Name-keyed baseline tools (tiny surface — read the graph only).
 _STANDARD_TOOLS: dict[str, Any] = {

--- a/packages/decepticon/decepticon/agents/standard/ad_operator.py
+++ b/packages/decepticon/decepticon/agents/standard/ad_operator.py
@@ -84,7 +84,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 
 _ROLE = "ad_operator"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 
 def create_ad_operator_agent(

--- a/packages/decepticon/decepticon/agents/standard/analyst.py
+++ b/packages/decepticon/decepticon/agents/standard/analyst.py
@@ -72,7 +72,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 
 _ROLE = "analyst"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 
 def create_analyst_agent(

--- a/packages/decepticon/decepticon/agents/standard/cloud_hunter.py
+++ b/packages/decepticon/decepticon/agents/standard/cloud_hunter.py
@@ -75,7 +75,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 
 _ROLE = "cloud_hunter"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 
 def create_cloud_hunter_agent(

--- a/packages/decepticon/decepticon/agents/standard/contract_auditor.py
+++ b/packages/decepticon/decepticon/agents/standard/contract_auditor.py
@@ -82,7 +82,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 
 _ROLE = "contract_auditor"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 
 def create_contract_auditor_agent(

--- a/packages/decepticon/decepticon/agents/standard/reverser.py
+++ b/packages/decepticon/decepticon/agents/standard/reverser.py
@@ -84,7 +84,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 
 _ROLE = "reverser"
-_RECURSION_LIMIT = 250
+_RECURSION_LIMIT = 1000
 
 
 def create_reverser_agent(

--- a/packages/decepticon/decepticon/tools/bash/bash.py
+++ b/packages/decepticon/decepticon/tools/bash/bash.py
@@ -482,7 +482,11 @@ async def bash_kill(session: str, config: RunnableConfig | None = None) -> str:
     )
 
     _reset_passive_read(workspace_path, session)
-    log_path = _sandbox.session_log_path(session, workspace_path)
+    log_path = await asyncio.to_thread(
+        _sandbox.session_log_path,
+        session,
+        workspace_path,
+    )
     return f"[KILLED] session '{session}' terminated. Log preserved at {log_path}."
 
 


### PR DESCRIPTION
Re-applies #295 on current main. Authorship preserved via cherry-pick. Original PR: #295 (@mohamedq9900)

## Fixed
- **bash_kill BlockingError under langgraph dev**: wrap `_sandbox.session_log_path()` in `asyncio.to_thread` to match the surrounding async kill_session pattern. CLI no longer surfaces "An internal error occurred" on every successful session kill.
- **GraphRecursionError 250-limit bump**: 7 sub-agents (analyst, cloud_hunter, contract_auditor, ad_operator, reverser, exploiter, vulnresearch) raised from `_RECURSION_LIMIT = 250` to `1000`. Aligns with the already-higher caps on exploit/recon (also 1000) and decepticon (400). Large recon sweeps and parallel CVE probes routinely hit the 250 cap mid-run.
- **Codex OAuth handler dropped function names mid-stream**: the streaming path only consumed `response.function_call_arguments.delta` events (which carry args but not the name); synthesized function_calls ended up with `name=""` and the model looped re-calling the same tool because tool_results couldn't be linked back. Added `response.output_item.added` (primary) + `response.output_item.done` (defensive backfill) handlers.
- **LiteLLM truncated tool_use mid-content**: `litellm_params` for every Claude model omitted `max_tokens`, so LiteLLM defaulted to its 4096-token OpenAI fallback. Long `write_file` calls (30–50KB markdown reports) were cut off mid-stream, raising "content: Field required". Set per-model caps across all three groups (`anthropic/`, `auth/`, `openrouter/anthropic/`): Opus 4.7 = 128k, Sonnet 4.6 = 64k, Haiku 4.5 = 64k.

## Changed
- **sandbox.pids_limit 1024 → 4096**: analyst sub-agents fanning out Go/Rust toolchains in parallel (gosec + cargo + semgrep) blew through 1024 pids; subsequent `subprocess.run()` returned BlockingIOError, surfaced as HTTP 500 from the sandbox FastAPI daemon.
- **DECEPTICON_LLM__TIMEOUT default 120s → 600s** (`.env.example`): long Opus generations with max_tokens=128000 + extended thinking + large tool_use payloads routinely exceed 120s while LiteLLM proxy keeps streaming 200 OK; raised the per-completion ceiling to match.

## Conflict resolved
`docker-compose.yml` had a whole-file CRLF↔LF diff against current main (renormalized in #322). Resolved by keeping main's LF version + applying the one substantive change (line 178 `pids_limit: 1024 → 4096`) on top.

## Verification
ruff clean; basedpyright 0 errors (the 2 litellm-import warnings on codex_chatgpt_handler are pre-existing and module-runtime-only); `docker compose config` valid; recursion limits applied across 9 agents (PR's 7 + the 2 already at 1000 pre-existing).

Co-authored-by: mohamedq9900 <gfvm227373@gmail.com>