### PR TITLE
chore(compose): make image namespace env-overridable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,6 +233,18 @@ COMPOSE_PROFILES=c2-sliver
 # (even when blank) silences the compose "variable is not set" WARN.
 DECEPTICON_STACK_NAME=
 
+# --- Image namespace override ---
+# Override the GHCR prefix for decepticon-* images. Defaults to the
+# upstream-published namespace. Forks should set this to their own GHCR
+# (or local registry) prefix so `docker compose pull` resolves to their
+# images instead of upstream's.
+#   default: ghcr.io/purpleailab
+#   fork example: ghcr.io/pol2up/decepticon-mac
+# IMPORTANT: do NOT include a trailing slash — one is added automatically.
+# Bad:  DECEPTICON_IMAGE_NAMESPACE=ghcr.io/myorg/
+# Good: DECEPTICON_IMAGE_NAMESPACE=ghcr.io/myorg
+# DECEPTICON_IMAGE_NAMESPACE=ghcr.io/purpleailab
+
 # --- Language ---
 # Pin agent output language to an ISO 639-1 code. All agent prose output
 # (menus, questions, summaries, errors) renders in this language.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # LiteLLM Proxy — LLM API Gateway
   # Handles model routing, authentication, usage tracking, billing
   litellm:
-    image: ghcr.io/purpleailab/decepticon-litellm:${DECEPTICON_VERSION:-latest}
+    image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-litellm:${DECEPTICON_VERSION:-latest}
     build:
       context: .
       dockerfile: containers/litellm.Dockerfile
@@ -136,7 +136,7 @@ services:
   # via ``/var/run/docker.sock`` was removed in the HTTP-only migration —
   # see decepticon/backends/factory.py for the rationale.
   sandbox:
-    image: ghcr.io/purpleailab/decepticon-sandbox:${DECEPTICON_VERSION:-latest}
+    image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-sandbox:${DECEPTICON_VERSION:-latest}
     # Multi-arch image — linux/amd64 + linux/arm64. Apple Silicon and
     # Linux arm64 hosts pull the native manifest; no Rosetta needed.
     # On an unusual arch the manifest list won't match — force a
@@ -239,7 +239,7 @@ services:
   # Exposes all agents (decepticon, soundwave, recon, exploit, postexploit)
   # as a streaming API on port 2024. Ink CLI connects here.
   langgraph:
-    image: ghcr.io/purpleailab/decepticon-langgraph:${DECEPTICON_VERSION:-latest}
+    image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-langgraph:${DECEPTICON_VERSION:-latest}
     build:
       context: .
       dockerfile: containers/langgraph.Dockerfile
@@ -310,7 +310,7 @@ services:
   # Web Dashboard — Next.js UI
   # Migrations run automatically at startup via web-entrypoint.sh (prisma migrate deploy).
   web:
-    image: ghcr.io/purpleailab/decepticon-web:${DECEPTICON_VERSION:-latest}
+    image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-web:${DECEPTICON_VERSION:-latest}
     build:
       context: .
       dockerfile: containers/web.Dockerfile
@@ -353,7 +353,7 @@ services:
   # Ink CLI — Interactive terminal UI
   # Runs via: docker compose run --rm cli
   cli:
-    image: ghcr.io/purpleailab/decepticon-cli:${DECEPTICON_VERSION:-latest}
+    image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-cli:${DECEPTICON_VERSION:-latest}
     build:
       context: .
       dockerfile: containers/cli.Dockerfile
@@ -381,7 +381,7 @@ services:
   # Swap: change COMPOSE_PROFILES to c2-havoc, etc.
   # Agent connects via: sliver-client (pre-installed in sandbox)
   c2-sliver:
-    image: ghcr.io/purpleailab/decepticon-c2-sliver:${DECEPTICON_VERSION:-latest}
+    image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-c2-sliver:${DECEPTICON_VERSION:-latest}
     # Multi-arch image — see decepticon-sandbox above for the same notes.
     build:
       context: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ testpaths = [
     "packages/decepticon-core/tests",
     "packages/decepticon/tests",
     "packages/decepticon-sdk/tests",
+    "tests",  # repo-root tests: stack-level concerns like docker-compose rendering
 ]
 markers = [
     "asyncio: mark test as async (pytest-asyncio)",

--- a/tests/test_compose_namespace.py
+++ b/tests/test_compose_namespace.py
@@ -1,0 +1,96 @@
+"""Verify docker-compose.yml respects DECEPTICON_IMAGE_NAMESPACE override.
+
+Renders the compose file via `docker compose config` with the env var set,
+then asserts that every Decepticon image reference uses the override prefix.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+DOTENV = REPO_ROOT / ".env"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_dotenv():
+    """`docker compose config` fails if env_file targets are missing.
+
+    Services in docker-compose.yml declare `env_file: .env`, which the
+    operator normally generates via the launcher onboard flow. In CI /
+    fresh checkouts that file isn't present, so create an empty stand-in
+    for the duration of the test and remove it afterward if we created it.
+    """
+    created = False
+    if not DOTENV.exists():
+        DOTENV.touch()
+        created = True
+    try:
+        yield
+    finally:
+        if created:
+            DOTENV.unlink(missing_ok=True)
+
+
+def _render(env_overrides: dict[str, str]) -> dict:
+    """Run `docker compose config` and parse the result."""
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI not available")
+    env = {**os.environ, **env_overrides}
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE), "config"],
+        env=env,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"`docker compose config` failed (exit {result.returncode}):\n"
+            f"--- stderr ---\n{result.stderr}\n--- stdout ---\n{result.stdout}"
+        )
+    return yaml.safe_load(result.stdout)
+
+
+def _decepticon_image_refs(rendered: dict) -> list[str]:
+    """Return every `image:` value for a namespaced Decepticon image.
+
+    Images without a `/` (e.g. local-build `decepticon-sandbox-reversing`)
+    are excluded by design — they have no registry prefix to override.
+    """
+    refs: list[str] = []
+    for svc in (rendered.get("services") or {}).values():
+        img = svc.get("image", "")
+        if "/" not in img:
+            continue  # local-build image; no registry prefix to namespace
+        if "decepticon-" in img:
+            refs.append(img)
+    return refs
+
+
+def test_default_namespace_is_purpleailab():
+    rendered = _render({})
+    refs = _decepticon_image_refs(rendered)
+    assert refs, "expected at least one decepticon image reference"
+    for ref in refs:
+        assert ref.startswith("ghcr.io/purpleailab/decepticon-"), (
+            f"default namespace should be ghcr.io/purpleailab/, got: {ref}"
+        )
+
+
+def test_namespace_override_via_env():
+    rendered = _render({"DECEPTICON_IMAGE_NAMESPACE": "example.invalid/test-ns"})
+    refs = _decepticon_image_refs(rendered)
+    assert refs, "expected at least one decepticon image reference"
+    for ref in refs:
+        assert ref.startswith("example.invalid/test-ns/decepticon-"), (
+            f"override should rewrite namespace, got: {ref}"
+        )


### PR DESCRIPTION
## Motivation

Hard-coded `ghcr.io/purpleailab/` on every `decepticon-*` image line forces forks to patch `docker-compose.yml` to point at their own registry or locally-built images. That patch then has to be maintained against every upstream change.

## Change

Replace each `image: ghcr.io/purpleailab/decepticon-*` line with `image: ${DECEPTICON_IMAGE_NAMESPACE:-ghcr.io/purpleailab}/decepticon-*`. Default behavior unchanged.

## Test

`tests/test_compose_namespace.py` renders the compose file via `docker compose config` with the env var set / unset and asserts the image refs reflect it.