### PR TITLE
feat(launcher): ldflag-configurable product name and home dir

### DIFF
--- a/clients/launcher/cmd/root.go
+++ b/clients/launcher/cmd/root.go
@@ -10,8 +10,18 @@ import (
 
 var version = "dev"
 
+// ProductName is the binary's user-facing name. Override at build time via
+// Go ldflags:
+//
+//	go build -ldflags="-X 'github.com/PurpleAILAB/Decepticon/clients/launcher/cmd.ProductName=decepticon-mac'"
+//
+// Pair with -X 'github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config.DefaultHome=.decepticon-mac'
+// to also override the data-dir basename. Defaults preserve the historical
+// "decepticon" name so unstamped builds behave identically to upstream.
+var ProductName = "decepticon"
+
 var rootCmd = &cobra.Command{
-	Use:   "decepticon",
+	Use:   ProductName,
 	Short: "Decepticon — Autonomous Hacking Agent for Red Team",
 	Long:  ui.RenderBanner() + "\n" + ui.Dim.Render("Autonomous Hacking Agent for Red Team"),
 	CompletionOptions: cobra.CompletionOptions{
@@ -30,5 +40,8 @@ func Execute() {
 
 func init() {
 	rootCmd.Version = version
-	rootCmd.SetVersionTemplate(fmt.Sprintf("Decepticon %s\n", version))
+	// Route the version banner through ProductName so ldflag-rebuilt
+	// binaries (e.g. "decepticon-mac") report their actual name in
+	// `--version` instead of a hard-coded "Decepticon".
+	rootCmd.SetVersionTemplate(fmt.Sprintf("%s %s\n", ProductName, version))
 }

--- a/clients/launcher/cmd/root_test.go
+++ b/clients/launcher/cmd/root_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestProductNameDefaultsToDecepticon(t *testing.T) {
+	if ProductName != "decepticon" {
+		t.Fatalf("expected ProductName default %q, got %q", "decepticon", ProductName)
+	}
+}
+
+func TestRootCommandUseFollowsProductName(t *testing.T) {
+	if !strings.HasPrefix(rootCmd.Use, ProductName) {
+		t.Fatalf("rootCmd.Use=%q should start with ProductName=%q", rootCmd.Use, ProductName)
+	}
+}
+
+// TestLdflagInjection_End2End builds the launcher with custom ldflags
+// and asserts the resulting binary reports the injected ProductName.
+func TestLdflagInjection_End2End(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping go-build test in -short mode")
+	}
+	// Find launcher module root (cmd is one level down from launcher/).
+	_, thisFile, _, _ := runtime.Caller(0)
+	launcherRoot := filepath.Dir(filepath.Dir(thisFile))
+	out := filepath.Join(t.TempDir(), "decepticon-mac-test")
+	cmd := exec.Command(
+		"go", "build",
+		"-ldflags",
+		"-X github.com/PurpleAILAB/Decepticon/clients/launcher/cmd.ProductName=decepticon-mac "+
+			"-X github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config.DefaultHome=.decepticon-mac",
+		"-o", out, ".",
+	)
+	cmd.Dir = launcherRoot
+	if buildOut, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ldflag build failed: %v\n%s", err, buildOut)
+	}
+	versionCmd := exec.Command(out, "--version")
+	versionOut, err := versionCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--version failed: %v\n%s", err, versionOut)
+	}
+	if !strings.Contains(string(versionOut), "decepticon-mac") {
+		t.Fatalf("expected --version to contain %q, got: %s",
+			"decepticon-mac", versionOut)
+	}
+	// Verify the DefaultHome ldflag actually baked into the binary's build
+	// metadata. `go version -m` prints the -ldflags string verbatim, which
+	// is sufficient evidence without needing a runtime "print home" subcommand.
+	infoCmd := exec.Command("go", "version", "-m", out)
+	infoOut, err := infoCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("`go version -m` failed: %v\n%s", err, infoOut)
+	}
+	if !strings.Contains(string(infoOut), "internal/config.DefaultHome=.decepticon-mac") {
+		t.Fatalf("expected ldflags to include DefaultHome override; got:\n%s", infoOut)
+	}
+}

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -13,8 +13,18 @@ import (
 //go:embed env.example
 var EnvTemplate string
 
+// DefaultHome is the default home-dir basename used by `DecepticonHome()`
+// when DECEPTICON_HOME is unset. Defined as a var (not const) so it can
+// be overridden at build time via Go ldflags, paired with cmd.ProductName:
+//
+//	go build -ldflags="-X 'github.com/PurpleAILAB/Decepticon/clients/launcher/cmd.ProductName=decepticon-mac' \
+//	                   -X 'github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config.DefaultHome=.decepticon-mac'"
+//
+// Default behavior preserves "~/.decepticon" so unstamped builds are
+// byte-identical to upstream.
+var DefaultHome = ".decepticon"
+
 const (
-	DefaultHome       = ".decepticon"
 	EnvFileName       = ".env"
 	EnvExampleName    = ".env.example"
 	PlaceholderSuffix = "-key-here"

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -415,3 +415,8 @@ func TestGet(t *testing.T) {
 		t.Error("expected default")
 	}
 }
+func TestDefaultHomeDefaultsToDotDecepticon(t *testing.T) {
+	if DefaultHome != ".decepticon" {
+		t.Fatalf("expected DefaultHome default %q, got %q", ".decepticon", DefaultHome)
+	}
+}


### PR DESCRIPTION
## Motivation

Running multiple Decepticon stacks on one machine (e.g. a dev fork next to a stock install, or two engagement personas) requires renaming the binary and the data dir. Today both are hard-coded.

## Change

Two new ldflag-injectable variables:
- `clients/launcher/cmd.ProductName` (default `decepticon`)
- `clients/launcher/internal/config.DefaultHome` (default `.decepticon`)

The cobra root command's `Use` field and the `--version` banner route through `ProductName`. `DecepticonHome()` resolves through `DefaultHome` when `DECEPTICON_HOME` is unset. Default build behavior is byte-identical to upstream.

## Test

- Unit tests assert both defaults preserved.
- End-to-end test builds with both ldflags, asserts `--version` reports the injected product name, AND asserts `go version -m` confirms the `DefaultHome` override is baked into the resulting binary.

## Example

```bash
go build -ldflags="\
  -X 'github.com/PurpleAILAB/Decepticon/clients/launcher/cmd.ProductName=decepticon-mac' \
  -X 'github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config.DefaultHome=.decepticon-mac'" \
  -o decepticon-mac ./clients/launcher
```

## Use case

Side-by-side dev/prod stacks on the same machine, or forks (e.g. `decepticon-mac`) that need to coexist with the stock install.
