### PR TITLE
feat(auth): honor CLAUDE_CODE_OAUTH_TOKEN env var (official upstream name)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,30 @@ DECEPTICON_AUTH_PRIORITY=
 # ~/.claude/.credentials.json from `claude` CLI auth.
 DECEPTICON_AUTH_CLAUDE_CODE=false
 
+# --- Permanent OAuth (race-free) ---
+# Decepticon's LiteLLM reads ``~/.claude/.credentials.json`` by default and
+# refreshes the OAuth token via the platform endpoint when it expires. If
+# Claude Code on the host machine also refreshes against the same account,
+# only one side wins each refresh — the other gets ``invalid_grant``.
+#
+# Permanent fix: generate a long-lived (~1 year) token with
+# ``claude setup-token`` and set it here. The handler treats the env-var
+# token as never-expiring, so no refresh is attempted and no race occurs.
+#
+# CLAUDE_CODE_OAUTH_TOKEN is the upstream-official env-var name produced
+# by ``claude setup-token``. ANTHROPIC_OAUTH_TOKEN is the legacy
+# Decepticon-internal alias and is still honored when CLAUDE_CODE_OAUTH_TOKEN
+# is unset.
+#
+# Security: this token is account-bearer for ~1 year. Treat it like a
+# password — ensure ``~/.decepticon/.env`` is mode 0600 and never commit
+# it to version control. To rotate / invalidate a leaked token, re-run
+# ``claude setup-token`` to issue a fresh one (the previous token
+# becomes invalid).
+#
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+# ANTHROPIC_OAUTH_TOKEN=sk-ant-oat01-...    # legacy alias, optional
+
 # --- ChatGPT OAuth (subscription) ---
 # Set true to route OpenAI models through the ChatGPT subscription handler
 # (auth/gpt-* in LiteLLM) instead of the API-key path. Requires one of:

--- a/config/claude_code_handler.py
+++ b/config/claude_code_handler.py
@@ -62,6 +62,12 @@ CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 OAUTH_TOKEN_PATTERN = "sk-ant-oat01-"
 
+# Env vars recognized by ``_env_override_tokens`` in precedence order.
+# CLAUDE_CODE_OAUTH_TOKEN is the official Claude Code CLI name produced
+# by ``claude setup-token`` and takes precedence over the legacy
+# Decepticon-internal ``ANTHROPIC_OAUTH_TOKEN`` alias.
+OAUTH_TOKEN_ENV_VARS = ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_OAUTH_TOKEN")
+
 
 def _is_valid_oauth_token(token: str) -> bool:
     """Validate that a token looks like a Claude OAuth token."""
@@ -115,19 +121,34 @@ _credentials_cache = FileBackedCache(CREDENTIALS_PATH, _load_credentials_from_di
 
 
 def _env_override_tokens() -> dict[str, Any] | None:
-    """Honor ``ANTHROPIC_OAUTH_TOKEN`` as a synthetic credentials dict.
+    """Honor ``CLAUDE_CODE_OAUTH_TOKEN`` (official Claude Code CLI env var
+    produced by ``claude setup-token``) or ``ANTHROPIC_OAUTH_TOKEN`` (legacy
+    Decepticon name) as a synthetic credentials dict.
 
     The synthetic dict carries ``expiresAt: 0`` so ``is_timestamp_expired``
     returns False and the refresh path never fires for env-provided tokens.
+    This is the race-free auth path: a long-lived token from
+    ``claude setup-token`` (valid ~1 year) feeds straight into LiteLLM
+    with no refresh, eliminating any contention with the host Claude Code
+    CLI that may be using the same Anthropic account.
+
+    Precedence: ``CLAUDE_CODE_OAUTH_TOKEN`` (upstream-official name) wins
+    over ``ANTHROPIC_OAUTH_TOKEN`` (legacy alias) when both are set.
+
+    Caveat: if ``CLAUDE_CODE_OAUTH_TOKEN`` happens to be set in your shell
+    environment from another tool (CI runner, another Claude wrapper),
+    Decepticon will silently use it in preference to ``~/.claude/.credentials.json``.
+    Unset it if that override is unintended.
     """
-    env_token = os.environ.get("ANTHROPIC_OAUTH_TOKEN", "").strip()
-    if env_token and _is_valid_oauth_token(env_token):
-        return {
-            "accessToken": env_token,
-            "refreshToken": None,
-            "expiresAt": 0,  # No expiry info — never auto-refresh
-            "scopes": ["user:inference"],
-        }
+    for var_name in OAUTH_TOKEN_ENV_VARS:
+        env_token = os.environ.get(var_name, "").strip()
+        if env_token and _is_valid_oauth_token(env_token):
+            return {
+                "accessToken": env_token,
+                "refreshToken": None,
+                "expiresAt": 0,  # No expiry info — never auto-refresh
+                "scopes": ["user:inference"],
+            }
     return None
 
 
@@ -173,7 +194,8 @@ def get_access_token(force_refresh: bool = False) -> str:
     """Return a valid access token, refreshing on demand.
 
     Resolution order:
-      1. ``ANTHROPIC_OAUTH_TOKEN`` env override (never refreshed).
+      1. ``CLAUDE_CODE_OAUTH_TOKEN`` (or ``ANTHROPIC_OAUTH_TOKEN`` legacy)
+         env override — never refreshed.
       2. Cached / on-disk tokens; if expired or ``force_refresh`` is True,
          call the platform refresh endpoint and persist the new tokens.
 
@@ -193,7 +215,7 @@ def get_access_token(force_refresh: bool = False) -> str:
             llm_provider="auth",
         )
 
-    # ANTHROPIC_OAUTH_TOKEN override carries expiresAt=0 → never expires.
+    # Env-override tokens (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_OAUTH_TOKEN) carry expiresAt=0 → never expires.
     if force_refresh and tokens.get("refreshToken"):
         tokens = _refresh_token(tokens)
     elif is_timestamp_expired(

--- a/packages/decepticon/tests/unit/llm/test_claude_code_handler.py
+++ b/packages/decepticon/tests/unit/llm/test_claude_code_handler.py
@@ -1,0 +1,122 @@
+"""Unit tests for the LiteLLM Claude Code custom handler.
+
+The module under test lives at ``config/claude_code_handler.py`` and is
+mounted into the LiteLLM container — it is not part of the ``decepticon``
+package, so we import it via ``importlib.util.spec_from_file_location``
+the same way ``test_oauth_token_store.py`` does.
+
+These tests focus on ``_env_override_tokens`` — the synthetic-credentials
+path that lets users bypass the file-based refresh flow (and the
+host-Claude-Code refresh race) by providing a long-lived OAuth token
+via env var.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ``claude_code_handler`` imports ``litellm`` at module level. The dev test
+# env does not install LiteLLM (it's a runtime container dep), so we inject
+# a minimal stub before loading the module. Mirror the approach in
+# ``test_oauth_token_store.py``.
+if "litellm" not in sys.modules:
+    _litellm = types.ModuleType("litellm")
+
+    class _AuthenticationError(Exception):
+        def __init__(self, message: str = "", model: str = "", llm_provider: str = "") -> None:
+            super().__init__(message)
+            self.message = message
+            self.model = model
+            self.llm_provider = llm_provider
+
+    class _CustomLLM:
+        pass
+
+    class _ModelResponse:
+        pass
+
+    _litellm.AuthenticationError = _AuthenticationError  # type: ignore[attr-defined]
+    _litellm.CustomLLM = _CustomLLM  # type: ignore[attr-defined]
+    _litellm.ModelResponse = _ModelResponse  # type: ignore[attr-defined]
+    sys.modules["litellm"] = _litellm
+
+# ``claude_code_handler`` imports the sibling ``oauth_token_store`` module
+# by bare name (``from oauth_token_store import ...``). Make sure both
+# resolve from the same ``config/`` directory.
+_CONFIG_DIR = Path(__file__).resolve().parents[5] / "config"
+if str(_CONFIG_DIR) not in sys.path:
+    sys.path.insert(0, str(_CONFIG_DIR))
+
+_HANDLER_PATH = _CONFIG_DIR / "claude_code_handler.py"
+_spec = importlib.util.spec_from_file_location("decepticon_claude_code_handler", _HANDLER_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+_env_override_tokens = _module._env_override_tokens
+
+
+# A token that passes ``_is_valid_oauth_token`` (must start with sk-ant-oat01-).
+VALID_TOKEN = "sk-ant-oat01-" + "x" * 80
+
+
+# ── _env_override_tokens ─────────────────────────────────────────────
+
+
+def test_env_override_recognizes_anthropic_oauth_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy Decepticon-internal env var name still works (regression guard)."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ANTHROPIC_OAUTH_TOKEN", VALID_TOKEN)
+    creds = _env_override_tokens()
+    assert creds is not None
+    assert creds["accessToken"] == VALID_TOKEN
+    assert creds["refreshToken"] is None
+    assert creds["expiresAt"] == 0
+
+
+def test_env_override_recognizes_claude_code_oauth_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``CLAUDE_CODE_OAUTH_TOKEN`` is the official Claude Code env var name
+    (produced by ``claude setup-token``). Decepticon should honor it the
+    same way it honors ``ANTHROPIC_OAUTH_TOKEN``.
+    """
+    monkeypatch.delenv("ANTHROPIC_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", VALID_TOKEN)
+    creds = _env_override_tokens()
+    assert creds is not None
+    assert creds["accessToken"] == VALID_TOKEN
+    assert creds["refreshToken"] is None
+    assert creds["expiresAt"] == 0
+
+
+def test_env_override_returns_none_when_no_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    assert _env_override_tokens() is None
+
+
+def test_env_override_rejects_malformed_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "not-a-real-token")
+    assert _env_override_tokens() is None
+
+
+def test_env_override_prefers_claude_code_when_both_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When both env vars are set, ``CLAUDE_CODE_OAUTH_TOKEN`` wins because
+    it's the official upstream name. This is documented behavior, not
+    accidental — preserve the ordering.
+    """
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_OAUTH_TOKEN", raising=False)
+    anthropic_token = "sk-ant-oat01-" + "a" * 80
+    claude_token = "sk-ant-oat01-" + "c" * 80
+    monkeypatch.setenv("ANTHROPIC_OAUTH_TOKEN", anthropic_token)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", claude_token)
+    creds = _env_override_tokens()
+    assert creds is not None
+    assert creds["accessToken"] == claude_token


### PR DESCRIPTION
## Motivation

The Claude Code CLI's `claude setup-token` produces a long-lived OAuth token (~1 year) and documents `CLAUDE_CODE_OAUTH_TOKEN` as the env var to consume it. Decepticon's LiteLLM `auth/` handler already supports the env-var override pattern via `ANTHROPIC_OAUTH_TOKEN` (synthesized creds with `expiresAt: 0` so refresh never fires, eliminating the race with host Claude Code), but only recognizes that legacy Decepticon-internal name.

Users who follow Claude's own docs and set `CLAUDE_CODE_OAUTH_TOKEN` silently fall back to the file-based path and hit the well-known refresh-token race (`invalid_grant` errors when both Decepticon's LiteLLM and host Claude Code rotate refresh tokens against the same account).

## Change

`_env_override_tokens` now iterates over `(CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_OAUTH_TOKEN)` in that order. The official upstream name wins when both are set. Behavior with neither set is unchanged (falls through to the file-cache path).

## Test

Five new pytest cases cover: each env var alone, neither set, malformed-token rejection (must still match `sk-ant-oat01-`), and precedence ordering.

## User-facing impact

After this lands, the documented permanent-OAuth workflow for Decepticon becomes:

```bash
claude setup-token     # generate long-lived token
echo 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...' >> ~/.decepticon/.env
docker restart decepticon-litellm
```

No more periodic re-exports of `~/.claude/.credentials.json` from the macOS Keychain; no more race-condition 401s when running Decepticon and Claude Code on the same machine.