### PR TITLE
fix(compose): default `langgraph dev` to --allow-blocking (with LANGGRAPH_STRICT_ASYNC opt-out)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,6 +210,14 @@ LANGSMITH_PROJECT=decepticon
 # NEO4J_HTTP_PORT=7474
 # NEO4J_BOLT_PORT=7687
 
+# --- LangGraph dev-mode strictness ---
+# By default langgraph dev runs with --allow-blocking so a sync I/O
+# call in a third-party dep (e.g. deepagents' subagents.py atask path)
+# downgrades blockbuster's BlockingError to a non-fatal warning.
+# Set this to 1 to remove --allow-blocking and reinstate the fatal-
+# on-sync behavior (useful when debugging async issues in your own code).
+# LANGGRAPH_STRICT_ASYNC=1
+
 # --- C2 Framework ---
 # Default C2 server profile. Change to swap C2 frameworks.
 # Options: c2-sliver (default), c2-havoc (future)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,25 @@ services:
   # as a streaming API on port 2024. Ink CLI connects here.
   langgraph:
     image: ghcr.io/purpleailab/decepticon-langgraph:${DECEPTICON_VERSION:-latest}
+    # Append --allow-blocking by default so blockbuster doesn't fatally
+    # abort runs on sync I/O in third-party deps (e.g. deepagents'
+    # subagents.py uses a sync httpx send in its atask path). Decepticon's
+    # own sync calls have been structurally fixed (see #325), but the
+    # third-party calls remain. Set LANGGRAPH_STRICT_ASYNC=1 in .env to
+    # opt out and reinstate the fatal-on-sync behavior (useful for
+    # debugging async issues in your own code).
+    # Note: $$ escapes compose interpolation so the literal $LANGGRAPH_STRICT_ASYNC
+    # reaches the shell — the env var is set on the container via env_file:.env,
+    # and the if/else decision happens at container start, not at compose render.
+    command:
+      - sh
+      - -c
+      - >
+        if [ -z "$${LANGGRAPH_STRICT_ASYNC:-}" ]; then
+          exec langgraph dev --host 0.0.0.0 --port 2024 --no-browser --n-jobs-per-worker 10 --allow-blocking;
+        else
+          exec langgraph dev --host 0.0.0.0 --port 2024 --no-browser --n-jobs-per-worker 10;
+        fi
     build:
       context: .
       dockerfile: containers/langgraph.Dockerfile

--- a/tests/test_compose_langgraph_command.py
+++ b/tests/test_compose_langgraph_command.py
@@ -1,0 +1,92 @@
+"""Verify docker-compose.yml's langgraph command honors LANGGRAPH_STRICT_ASYNC.
+
+Renders the compose file via ``docker compose config`` with and without
+the env var and asserts the resulting langgraph command line includes
+or omits ``--allow-blocking`` as expected.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_dotenv():
+    """``docker compose config`` needs a .env to satisfy env_file refs."""
+    env_file = REPO_ROOT / ".env"
+    created = False
+    if not env_file.exists():
+        env_file.write_text("")
+        created = True
+    yield
+    if created:
+        env_file.unlink(missing_ok=True)
+
+
+def _langgraph_command(env_overrides: dict[str, str]) -> str:
+    """Render compose and return the langgraph service's command as a single string."""
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI not available")
+    env = {**os.environ, **env_overrides}
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE), "config"],
+        env=env,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"docker compose config failed (exit {result.returncode}):\n"
+            f"--- stderr ---\n{result.stderr}\n"
+            f"--- stdout ---\n{result.stdout}"
+        )
+    rendered = yaml.safe_load(result.stdout)
+    cmd = (rendered.get("services") or {}).get("langgraph", {}).get("command")
+    if cmd is None:
+        pytest.fail("langgraph service has no `command` after compose render")
+    return cmd if isinstance(cmd, str) else " ".join(cmd)
+
+
+def test_default_command_includes_allow_blocking():
+    """Without LANGGRAPH_STRICT_ASYNC set, --allow-blocking should be in the command."""
+    cmd = _langgraph_command({})
+    assert "--allow-blocking" in cmd, (
+        f"expected --allow-blocking in default langgraph command; got:\n{cmd}"
+    )
+
+
+def test_strict_async_removes_allow_blocking():
+    """With LANGGRAPH_STRICT_ASYNC=1, --allow-blocking must NOT be in the STRICT branch."""
+    cmd = _langgraph_command({"LANGGRAPH_STRICT_ASYNC": "1"})
+    # The command string itself is a shell snippet; we need to verify
+    # the *executed* path doesn't have --allow-blocking. The else-branch
+    # of the if statement (which is what runs when STRICT is set) has
+    # the bare `langgraph dev ...` invocation without --allow-blocking.
+    # The string still CONTAINS "--allow-blocking" as a literal in the
+    # if-branch — that's OK; what matters is the branch logic. Assert
+    # both branches are present and the structure is intact.
+    assert "LANGGRAPH_STRICT_ASYNC" in cmd, (
+        f"expected LANGGRAPH_STRICT_ASYNC check in command; got:\n{cmd}"
+    )
+    # The if/else structure means BOTH branches are in the rendered command
+    # string (it's a shell snippet). The branch SELECTION happens at runtime
+    # inside sh -c. To verify the opt-out actually works, this test ensures
+    # the conditional structure is present and STRICT branch lacks the flag.
+    # A more rigorous test would run the actual shell snippet; this is the
+    # closest we can verify at compose-render time.
+    # Split on the else clause and check the else-branch text:
+    else_branch = cmd.split("else")[1] if "else" in cmd else ""
+    assert "--allow-blocking" not in else_branch, (
+        f"--allow-blocking should not appear in the STRICT (else) branch; got else: {else_branch!r}"
+    )


### PR DESCRIPTION
## Motivation

`langgraph dev` enables `blockbuster`, which turns any sync I/O inside the async event loop into a fatal `BlockingError`. PR #325 (commit `eaec7f3`) structurally fixed Decepticon's own sync calls — wrapping `bash_kill`'s `session_log_path` in `asyncio.to_thread`. But at least one sync call remains in a **third-party dep**: `deepagents/middleware/subagents.py:602`'s `atask` path uses a sync `httpx` `send_event` deep in its subagent dispatch. Decepticon imports deepagents and can't easily fix the dep's internals.

Result observed in the wild: BlockingError aborts the run after ~85s, surfacing as 'An internal error occurred' in the CLI mid-engagement.

## Change

Wrap the langgraph service's command in an `sh -c` that conditionally appends `--allow-blocking`:
- Default (env unset): `--allow-blocking` is appended → these third-party sync calls become non-fatal warnings.
- `LANGGRAPH_STRICT_ASYNC=1`: flag is omitted → fatal behavior restored (for debugging async issues in your own code).

`exec` is used inside the shell so signals propagate cleanly to the langgraph process; `docker stop` still shuts down without a 10s SIGKILL escalation. `$$` escapes compose's own interpolation so the env-var check runs in the container shell against the container-side env, not against the host env at compose-render time.

## Test

`tests/test_compose_langgraph_command.py` renders the compose file via `docker compose config` with and without the env var and asserts the flag is in the right branch.

## Related

- PR #325 / commit `eaec7f3` — the structural fix for Decepticon's own sync calls. This PR is the dep-compat counterpart.