### PR TITLE
feat(launcher): macOS Keychain detection in onboard for Claude OAuth method

### DIFF
--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -977,6 +977,14 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	fmt.Println(ui.Dim.Render("  └──────────────────────────────────┘"))
 	fmt.Println()
 
+	// macOS-specific: when the user picked the Claude Code OAuth method,
+	// surface guidance about the Keychain ↔ credentials-file split that
+	// otherwise causes silent 401s or periodic refresh-token races. The
+	// probe is a no-op on non-darwin builds (see onboard_keychain_other.go).
+	if contains(methods, methodAnthropicOAuth) {
+		printClaudeOAuthGuidance()
+	}
+
 	// One-time GitHub star ask — the natural post-onboarding moment.
 	// Suppressed on subsequent runs by the ack file at
 	// $DECEPTICON_HOME/.starred, so a re-run of `decepticon onboard
@@ -989,6 +997,55 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 
 func contains(haystack []string, needle string) bool {
 	return slices.Contains(haystack, needle)
+}
+
+// printClaudeOAuthGuidance prints macOS-specific guidance about the
+// Keychain ↔ credentials-file split that affects users who picked the
+// Claude Code OAuth method during onboard.
+//
+// On macOS the Claude Code CLI stores OAuth credentials in the system
+// Keychain (service "Claude Code-credentials"), but Decepticon's
+// LiteLLM custom handler reads from ~/.claude/.credentials.json. Three
+// outcomes from the probe each get tailored guidance:
+//
+//   - Item not found: nothing to say (either non-macOS or no Claude Code
+//     CLI session). probeClaudeCredentials always returns this on
+//     non-darwin builds, so this function emits zero output there.
+//   - Item present, file absent: WARN — the silent-401 case. Recommend
+//     the long-lived-token path (CLAUDE_CODE_OAUTH_TOKEN via
+//     `claude setup-token`, which fix/oauth-token-env-var honors) or a
+//     one-time `security ... -w >` export as a fallback.
+//   - Item present AND file present: INFO — the refresh-race case.
+//     Both sides will race the refresh token and periodically hit
+//     invalid_grant 401s; recommend CLAUDE_CODE_OAUTH_TOKEN to eliminate
+//     the race.
+func printClaudeOAuthGuidance() {
+	switch probeClaudeCredentials() {
+	case keychainItemPresentFileAbsent:
+		ui.Warning("macOS Keychain has Claude Code credentials, but ~/.claude/.credentials.json is absent.")
+		ui.DimText("  The OAuth handler reads the file, not Keychain, so authentication will fail with 401.")
+		fmt.Println()
+		ui.DimText("  Recommended (permanent fix, no refresh race):")
+		ui.DimText("    claude setup-token")
+		ui.DimText("    # then set CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-... in")
+		ui.DimText("    # ~/.decepticon/.env after onboard finishes.")
+		fmt.Println()
+		ui.DimText("  Alternative (works but requires periodic re-export):")
+		ui.DimText(`    security find-generic-password -s "Claude Code-credentials" -w \`)
+		ui.DimText("      > ~/.claude/.credentials.json && chmod 600 ~/.claude/.credentials.json")
+		fmt.Println()
+	case keychainItemPresentFilePresent:
+		ui.Info("Both ~/.claude/.credentials.json and macOS Keychain have Claude Code credentials.")
+		ui.DimText("  If the host Claude Code CLI is in use, both sides will race refresh-tokens")
+		ui.DimText("  against the same account, causing periodic invalid_grant 401s.")
+		fmt.Println()
+		ui.DimText("  To eliminate the race, set CLAUDE_CODE_OAUTH_TOKEN in ~/.decepticon/.env")
+		ui.DimText("  to a long-lived token from:")
+		ui.DimText("    claude setup-token")
+		fmt.Println()
+	default:
+		// keychainItemNotFound — emit nothing.
+	}
 }
 
 func nonEmpty(s string) error {

--- a/clients/launcher/cmd/onboard_keychain_darwin.go
+++ b/clients/launcher/cmd/onboard_keychain_darwin.go
@@ -1,0 +1,79 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// keychainProbeState represents the outcome of probing for the Claude
+// Code Keychain item plus the on-disk credentials file.
+//
+// Background: on macOS, Claude Code stores its OAuth credentials in the
+// system Keychain under the generic-password service name
+// "Claude Code-credentials". Decepticon's LiteLLM custom handler reads
+// the credentials from `~/.claude/.credentials.json` instead, so users
+// who picked the OAuth method during onboard but only have Keychain
+// state silently fall through to file-based auth and hit 401s.
+type keychainProbeState int
+
+const (
+	// keychainItemNotFound means the macOS Keychain has no
+	// "Claude Code-credentials" item (user is not logged into the
+	// Claude Code CLI on this Mac, or never has been).
+	keychainItemNotFound keychainProbeState = iota
+
+	// keychainItemPresentFileAbsent is the silent-401 case: Keychain
+	// has the item but Decepticon's reader (the file) has nothing.
+	keychainItemPresentFileAbsent
+
+	// keychainItemPresentFilePresent is the refresh-race case: both
+	// sides have credentials and both will try to refresh the same
+	// account, eventually yielding invalid_grant 401s.
+	keychainItemPresentFilePresent
+)
+
+// probeClaudeCredentials checks for the macOS Keychain item used by
+// Claude Code AND for the on-disk credentials file Decepticon's
+// LiteLLM handler reads.
+//
+// The probe uses `security find-generic-password -s 'Claude Code-credentials'`
+// WITHOUT the `-w` flag, so it inspects metadata only and never reads
+// the secret. This is deliberate — `-w` triggers the macOS GUI Keychain
+// access prompt which is hostile during a CLI onboarding flow, whereas
+// the metadata-only form is silent.
+//
+// On unexpected errors (security binary missing, permission denied on
+// HOME, etc.) we conservatively return keychainItemNotFound: spurious
+// warnings during onboard are more harmful than a missed hint, and
+// Decepticon still functions without this guidance.
+func probeClaudeCredentials() keychainProbeState {
+	out, err := exec.Command(
+		"security", "find-generic-password", "-s", "Claude Code-credentials",
+	).CombinedOutput()
+	// security exits non-zero with "could not be found" when the item
+	// is absent. Any non-zero exit (binary missing, malformed args)
+	// collapses to not-found for the reasons documented above.
+	if err != nil {
+		_ = out
+		return keychainItemNotFound
+	}
+	if len(out) == 0 {
+		return keychainItemNotFound
+	}
+
+	home, herr := os.UserHomeDir()
+	if herr != nil {
+		// Can't resolve HOME → can't check the file. Treat as
+		// present-and-present so the user gets the race warning rather
+		// than nothing — the silent-401 path is the worse failure mode.
+		return keychainItemPresentFilePresent
+	}
+	credsPath := filepath.Join(home, ".claude", ".credentials.json")
+	if _, ferr := os.Stat(credsPath); os.IsNotExist(ferr) {
+		return keychainItemPresentFileAbsent
+	}
+	return keychainItemPresentFilePresent
+}

--- a/clients/launcher/cmd/onboard_keychain_darwin_test.go
+++ b/clients/launcher/cmd/onboard_keychain_darwin_test.go
@@ -1,0 +1,101 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// stubSecurityBinary creates a tiny shim "security" binary in a temp
+// dir and prepends that dir to PATH for the duration of the test. The
+// shim mimics `security find-generic-password -s "Claude Code-credentials"`
+// based on the SECURITY_TEST_BEHAVIOR env var:
+//
+//	"exists" → exit 0 with one line of fake metadata on stdout
+//	"absent" → exit 44 ("item not found") with the canonical stderr msg
+//
+// 44 is the exit code real `security` uses for missing items
+// (errSecItemNotFound, -25300, mapped through to 44 by the CLI). We
+// don't actually assert on the exit code in production code, but
+// matching it keeps the shim faithful.
+func stubSecurityBinary(t *testing.T, behavior string) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin only")
+	}
+	t.Helper()
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "security")
+	src := `#!/bin/sh
+case "$SECURITY_TEST_BEHAVIOR" in
+  exists) echo 'attributes: <SecKeychainAttribute>'; exit 0 ;;
+  absent) echo 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.' >&2; exit 44 ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(shim, []byte(src), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir+":"+origPath)
+	t.Setenv("SECURITY_TEST_BEHAVIOR", behavior)
+	// Sanity-check the shim resolves first on PATH.
+	resolved, err := exec.LookPath("security")
+	if err != nil {
+		t.Fatalf("shim not on PATH: %v", err)
+	}
+	if resolved != shim {
+		t.Fatalf("shim not earliest on PATH: resolved %q want %q", resolved, shim)
+	}
+}
+
+func TestProbeClaudeCredentials_NotFound(t *testing.T) {
+	stubSecurityBinary(t, "absent")
+	// Force a fake HOME so we don't pick up the developer's real
+	// ~/.claude/.credentials.json by accident — the not-found branch
+	// returns early before checking the file, but be defensive.
+	t.Setenv("HOME", t.TempDir())
+	got := probeClaudeCredentials()
+	if got != keychainItemNotFound {
+		t.Fatalf("expected keychainItemNotFound (%d), got %d",
+			keychainItemNotFound, got)
+	}
+}
+
+func TestProbeClaudeCredentials_ItemPresentFileAbsent(t *testing.T) {
+	stubSecurityBinary(t, "exists")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Parent dir present but no .credentials.json — this is the
+	// silent-401 case.
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got := probeClaudeCredentials()
+	if got != keychainItemPresentFileAbsent {
+		t.Fatalf("expected keychainItemPresentFileAbsent (%d), got %d",
+			keychainItemPresentFileAbsent, got)
+	}
+}
+
+func TestProbeClaudeCredentials_ItemPresentFilePresent(t *testing.T) {
+	stubSecurityBinary(t, "exists")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	credsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(credsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	credsFile := filepath.Join(credsDir, ".credentials.json")
+	if err := os.WriteFile(credsFile, []byte(`{"claudeAiOauth":{}}`), 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+	got := probeClaudeCredentials()
+	if got != keychainItemPresentFilePresent {
+		t.Fatalf("expected keychainItemPresentFilePresent (%d), got %d",
+			keychainItemPresentFilePresent, got)
+	}
+}

--- a/clients/launcher/cmd/onboard_keychain_other.go
+++ b/clients/launcher/cmd/onboard_keychain_other.go
@@ -1,0 +1,20 @@
+//go:build !darwin
+
+package cmd
+
+// Non-darwin builds get the no-op stub: there's no macOS Keychain to
+// probe, so the probe always reports "not found" and the warning path
+// in onboard.go is skipped entirely. Linux and Windows users see zero
+// change.
+
+type keychainProbeState int
+
+const (
+	keychainItemNotFound keychainProbeState = iota
+	keychainItemPresentFileAbsent
+	keychainItemPresentFilePresent
+)
+
+func probeClaudeCredentials() keychainProbeState {
+	return keychainItemNotFound
+}


### PR DESCRIPTION
## Motivation

On macOS, the Claude Code CLI stores OAuth credentials in the Keychain (not in `~/.claude/.credentials.json`). Decepticon's LiteLLM custom handler only reads the file, so users who pick the Claude Code OAuth method during `decepticon onboard` silently fall through to the file-based path and hit 401s with no diagnostic guidance.

## Change

When the user selects `methodAnthropicOAuth` and is on macOS, probe for the Keychain item via `security find-generic-password -s 'Claude Code-credentials'` (without `-w`, so no GUI prompt fires) AND check for the credentials file. Print actionable guidance based on three outcomes:

- **Item not found:** silent (user isn't logged into Claude Code on this Mac).
- **Item present, file absent:** WARN — silent-401 case. Recommend `claude setup-token` + `CLAUDE_CODE_OAUTH_TOKEN` (permanent, no race) or one-time `security ... -w >` export as fallback.
- **Item present AND file present:** INFO — refresh-token race case. Both sides race the same account causing periodic invalid_grant 401s; recommend `CLAUDE_CODE_OAUTH_TOKEN` as the race-free path.

Platform isolation via Go build tags: real probe on `darwin`, no-op stub elsewhere — non-Mac users see zero change.

## Test

Three Go tests stub the `security` binary on PATH via tempdir and assert each branch. Skipped automatically on non-darwin via the test file's `//go:build darwin` tag.

```
=== RUN   TestProbeClaudeCredentials_NotFound
--- PASS: TestProbeClaudeCredentials_NotFound (0.24s)
=== RUN   TestProbeClaudeCredentials_ItemPresentFileAbsent
--- PASS: TestProbeClaudeCredentials_ItemPresentFileAbsent (0.08s)
=== RUN   TestProbeClaudeCredentials_ItemPresentFilePresent
--- PASS: TestProbeClaudeCredentials_ItemPresentFilePresent (0.08s)
PASS
```

## Related

- This PR's guidance points users at the `CLAUDE_CODE_OAUTH_TOKEN` workflow that PR #332 makes Decepticon honor.