### PR TITLE
feat(web): safe-delete engagements (macOS Trash / .trash fallback) instead of rm -rf

### DIFF
--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -12,6 +12,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
 
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
@@ -79,7 +81,9 @@
     "eslint-config-next": "16.2.3",
 
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+
+    "vitest": "^2.1.9"
   },
 
   "optionalDependencies": {

--- a/clients/web/src/app/(dashboard)/engagements/[id]/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/page.tsx
@@ -6,7 +6,18 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { FileWarning, Network, Play, ArrowRight, ClipboardList, Download, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { FileWarning, Network, Play, ArrowRight, ClipboardList, Download, Clock, Trash2 } from "lucide-react";
 
 interface Objective {
   id: string;
@@ -37,6 +48,26 @@ export default function EngagementOverviewPage() {
   const [objectives, setObjectives] = useState<Objective[]>([]);
   const [findings, setFindings] = useState<Finding[]>([]);
   const [graphNodeCount, setGraphNodeCount] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch(`/api/engagements/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setDeleteError(data.error ?? `Delete failed (HTTP ${res.status})`);
+        return;
+      }
+      router.replace("/engagements");
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setDeleting(false);
+    }
+  }
 
   useEffect(() => {
     let active = true;
@@ -198,6 +229,46 @@ export default function EngagementOverviewPage() {
         <a href={`/api/engagements/${id}/export?format=markdown`} className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs transition-colors hover:bg-accent">
           <Download className="h-3 w-3" /> Export Markdown
         </a>
+        <Dialog>
+          <DialogTrigger
+            render={
+              <button
+                type="button"
+                className="ml-auto flex items-center gap-1.5 rounded-lg border border-red-500/30 px-3 py-1.5 text-xs text-red-300 transition-colors hover:bg-red-500/10"
+              />
+            }
+          >
+            <Trash2 className="h-3 w-3" /> Move to Trash
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Move engagement to Trash?</DialogTitle>
+              <DialogDescription>
+                The engagement workspace will be moved to your
+                {" "}
+                <strong>Trash</strong> on macOS (restorable from Finder), or to
+                {" "}
+                <code>~/.decepticon/.trash/</code> on Linux/Windows where it is
+                kept for 30 days before automatic pruning.
+              </DialogDescription>
+            </DialogHeader>
+            {deleteError && (
+              <p className="text-xs text-red-400">{deleteError}</p>
+            )}
+            <DialogFooter>
+              <DialogClose render={<Button variant="outline" />}>
+                Cancel
+              </DialogClose>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? "Moving..." : "Move to Trash"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       {/* Recent findings */}

--- a/clients/web/src/app/api/engagements/[id]/route.ts
+++ b/clients/web/src/app/api/engagements/[id]/route.ts
@@ -1,6 +1,10 @@
 import { requireAuth, AuthError } from "@/lib/auth-bridge";
 import { prisma } from "@/lib/prisma";
+import { safeDeleteEngagement } from "@/lib/safe-delete";
 import { NextRequest, NextResponse } from "next/server";
+import * as path from "path";
+
+const WORKSPACE = process.env.WORKSPACE_PATH ?? path.join(process.env.HOME ?? "", ".decepticon", "workspace");
 
 export async function GET(
   _req: NextRequest,
@@ -87,6 +91,26 @@ export async function DELETE(
     });
     if (!existing) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Move the workspace directory to Trash (macOS) or `<home>/.trash/` with
+    // 30-day retention (other platforms) instead of `rm -rf`-ing it. The DB
+    // row is removed only if the filesystem step succeeded, so a hard I/O
+    // failure surfaces as a 500 instead of an orphaned workspace.
+    try {
+      await safeDeleteEngagement(WORKSPACE, existing.name);
+    } catch (fsErr) {
+      console.error(
+        "DELETE /api/engagements/[id] safeDeleteEngagement failed:",
+        fsErr,
+      );
+      return NextResponse.json(
+        {
+          error:
+            "Failed to move engagement workspace to Trash; engagement was not deleted",
+        },
+        { status: 500 },
+      );
     }
 
     await prisma.engagement.delete({ where: { id } });

--- a/clients/web/src/instrumentation.ts
+++ b/clients/web/src/instrumentation.ts
@@ -1,0 +1,26 @@
+// Next.js instrumentation hook — runs once when the server starts. We use it
+// to prune trashed engagement workspaces older than 30 days (Linux / Windows
+// fallback path; macOS Trash is managed by the OS).
+//
+// Safe to no-op everywhere: pruneTrash is itself idempotent and ignores a
+// missing `.trash/` directory.
+
+export async function register() {
+  // Only run in the Node.js runtime — the edge runtime can't do filesystem
+  // I/O and would crash on import of `node:fs`.
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const path = await import("node:path");
+  const { pruneTrash } = await import("@/lib/safe-delete");
+
+  const workspacePath =
+    process.env.WORKSPACE_PATH ??
+    path.join(process.env.HOME ?? "", ".decepticon", "workspace");
+
+  try {
+    await pruneTrash(workspacePath);
+  } catch (err) {
+    // Never block server startup on prune failures.
+    console.error("[instrumentation] pruneTrash failed:", err);
+  }
+}

--- a/clients/web/src/lib/safe-delete.test.ts
+++ b/clients/web/src/lib/safe-delete.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { safeDeleteEngagement, pruneTrash } from "./safe-delete";
+
+describe("safe-delete", () => {
+  let decepticonHome: string;
+  let workspacePath: string;
+
+  beforeEach(async () => {
+    decepticonHome = await fs.mkdtemp(
+      path.join(os.tmpdir(), "decepticon-test-"),
+    );
+    workspacePath = path.join(decepticonHome, "workspace");
+    await fs.mkdir(workspacePath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(decepticonHome, { recursive: true, force: true });
+  });
+
+  it("moves an engagement to .trash on non-darwin platforms", async () => {
+    if (process.platform === "darwin") {
+      // The macOS path goes through osascript / Finder; cover with a
+      // platform-specific test rather than mutating the user's Trash.
+      return;
+    }
+    const slug = "test-engagement";
+    const engagementDir = path.join(workspacePath, slug);
+    await fs.mkdir(engagementDir);
+    await fs.writeFile(path.join(engagementDir, "marker.txt"), "important");
+
+    const dest = await safeDeleteEngagement(workspacePath, slug);
+
+    // Original gone
+    await expect(fs.access(engagementDir)).rejects.toThrow();
+    // Trash copy intact
+    expect(dest).toContain(path.join(decepticonHome, ".trash"));
+    expect(dest).toContain(slug);
+    const restored = await fs.readFile(
+      path.join(dest, "marker.txt"),
+      "utf-8",
+    );
+    expect(restored).toBe("important");
+  });
+
+  it("is idempotent when the engagement is already gone", async () => {
+    const dest = await safeDeleteEngagement(workspacePath, "ghost-engagement");
+    // No exception; returns the would-be target path
+    expect(dest).toContain("ghost-engagement");
+  });
+
+  it("rejects unsafe slugs (path traversal / separators)", async () => {
+    await expect(
+      safeDeleteEngagement(workspacePath, "../etc"),
+    ).rejects.toThrow(/unsafe slug/);
+    await expect(
+      safeDeleteEngagement(workspacePath, "a/b"),
+    ).rejects.toThrow(/unsafe slug/);
+    await expect(
+      safeDeleteEngagement(workspacePath, ".hidden"),
+    ).rejects.toThrow(/unsafe slug/);
+    await expect(
+      safeDeleteEngagement(workspacePath, "ab"),
+    ).rejects.toThrow(/unsafe slug/);
+  });
+
+  it("pruneTrash removes entries older than 30 days", async () => {
+    const trashDir = path.join(decepticonHome, ".trash");
+    await fs.mkdir(trashDir, { recursive: true });
+    const stale = path.join(trashDir, "old-engagement-2026-01-01");
+    const fresh = path.join(trashDir, "new-engagement-now");
+    await fs.mkdir(stale);
+    await fs.mkdir(fresh);
+    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+    await fs.utimes(stale, fortyDaysAgo, fortyDaysAgo);
+
+    await pruneTrash(workspacePath);
+
+    await expect(fs.access(stale)).rejects.toThrow(); // pruned
+    await fs.access(fresh); // kept
+  });
+
+  it("pruneTrash is a no-op when .trash doesn't exist", async () => {
+    await expect(pruneTrash(workspacePath)).resolves.not.toThrow();
+  });
+});

--- a/clients/web/src/lib/safe-delete.ts
+++ b/clients/web/src/lib/safe-delete.ts
@@ -1,0 +1,120 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const TRASH_RETENTION_DAYS = 30;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Slug regex matches `clients/web/src/app/api/engagements/route.ts` and the Go
+// launcher's picker. Re-validated here as a defensive measure so that nothing
+// reaches `path.join(workspacePath, slug)` with traversal segments — a slug
+// like "../../etc" would otherwise let a buggy caller delete arbitrary paths.
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/;
+
+function assertSafeSlug(slug: string): void {
+  if (!SLUG_RE.test(slug) || slug.includes("/") || slug.includes("..")) {
+    throw new Error(`Refusing to delete: unsafe slug "${slug}"`);
+  }
+}
+
+/**
+ * Move an engagement workspace directory to the platform-appropriate
+ * recoverable location instead of `rm -rf`-ing it.
+ *
+ * - macOS: send to user's Trash via osascript (recoverable from Finder).
+ * - Linux/Windows/other: move to `<decepticon-home>/.trash/<slug>-<ISO-ts>/`
+ *   (recoverable manually; auto-pruned after 30 days by `pruneTrash`).
+ *
+ * Idempotent — if the target doesn't exist, returns the target path without
+ * raising. Throws on hard I/O failures.
+ */
+export async function safeDeleteEngagement(
+  workspacePath: string,
+  slug: string,
+): Promise<string> {
+  assertSafeSlug(slug);
+  const target = path.join(workspacePath, slug);
+  try {
+    await fs.access(target);
+  } catch {
+    // Already gone — treat as success.
+    return target;
+  }
+
+  if (process.platform === "darwin") {
+    return moveToMacTrash(target);
+  }
+  return moveToFallbackTrash(target, workspacePath, slug);
+}
+
+async function moveToMacTrash(target: string): Promise<string> {
+  // osascript: tell Finder to delete the POSIX file -> goes to user's Trash.
+  // Works headlessly; no Finder window needs to be open. Double-quotes inside
+  // the path are escaped for the AppleScript string literal.
+  const escaped = target.replace(/"/g, '\\"');
+  const script = `tell application "Finder" to delete POSIX file "${escaped}"`;
+  return new Promise((resolve, reject) => {
+    const proc = spawn("osascript", ["-e", script]);
+    let stderr = "";
+    proc.stderr.on("data", (d) => {
+      stderr += d.toString();
+    });
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      if (code === 0) {
+        // Finder owns the actual Trash location; report the original path.
+        resolve(target);
+      } else {
+        reject(new Error(`osascript exited ${code}: ${stderr.trim()}`));
+      }
+    });
+  });
+}
+
+async function moveToFallbackTrash(
+  target: string,
+  workspacePath: string,
+  slug: string,
+): Promise<string> {
+  // Move into <decepticon-home>/.trash/<slug>-<ISO-timestamp>/. The
+  // decepticon home is the parent of WORKSPACE (e.g. ~/.decepticon or the
+  // value of WORKSPACE_PATH's parent).
+  const decepticonHome = path.resolve(workspacePath, "..");
+  const trashDir = path.join(decepticonHome, ".trash");
+  await fs.mkdir(trashDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const dest = path.join(trashDir, `${slug}-${ts}`);
+  await fs.rename(target, dest);
+  return dest;
+}
+
+/**
+ * Remove entries in `<decepticon-home>/.trash/` older than 30 days
+ * (based on directory mtime). Idempotent and safe to call at server
+ * startup — a missing `.trash/` directory is a no-op.
+ */
+export async function pruneTrash(workspacePath: string): Promise<void> {
+  const decepticonHome = path.resolve(workspacePath, "..");
+  const trashDir = path.join(decepticonHome, ".trash");
+  let entries;
+  try {
+    entries = await fs.readdir(trashDir, { withFileTypes: true });
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+  const cutoff = Date.now() - TRASH_RETENTION_DAYS * MS_PER_DAY;
+  await Promise.all(
+    entries.map(async (e) => {
+      const entryPath = path.join(trashDir, e.name);
+      try {
+        const stat = await fs.stat(entryPath);
+        if (stat.mtimeMs < cutoff) {
+          await fs.rm(entryPath, { recursive: true, force: true });
+        }
+      } catch {
+        // best-effort; skip entries we can't stat or remove
+      }
+    }),
+  );
+}

--- a/clients/web/vitest.config.ts
+++ b/clients/web/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  // Disable PostCSS processing — Next.js's tailwind/lightningcss pipeline
+  // isn't relevant for Node-side unit tests, and on macOS its optional
+  // native binary often isn't installed.
+  css: {
+    postcss: { plugins: [] },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    environment: "node",
+    globals: false,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.3",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^2.1.9"
       },
       "optionalDependencies": {
         "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
@@ -119,7 +120,6 @@
     "clients/web/node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -240,7 +240,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -734,7 +733,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -779,15 +777,13 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@decepticon/cli": {
       "resolved": "clients/cli",
@@ -909,7 +905,6 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -951,8 +946,7 @@
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.4.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -1482,7 +1476,6 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1584,7 +1577,6 @@
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1608,7 +1600,6 @@
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1685,7 +1676,6 @@
     "node_modules/@openuidev/react-headless": {
       "version": "0.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ag-ui/core": "^0.0.45"
       },
@@ -1697,7 +1687,6 @@
     "node_modules/@openuidev/react-lang": {
       "version": "0.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@openuidev/lang-core": "^0.2.4"
       },
@@ -3243,7 +3232,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -3381,7 +3371,6 @@
     "node_modules/@types/node": {
       "version": "25.8.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3398,7 +3387,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3407,7 +3395,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3478,7 +3465,6 @@
       "version": "8.59.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3875,7 +3861,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4001,6 +3986,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4338,7 +4324,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5153,7 +5138,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5301,7 +5285,6 @@
     "node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5523,7 +5506,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5903,7 +5887,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6073,7 +6056,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6404,7 +6386,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7382,7 +7363,6 @@
     "node_modules/hono": {
       "version": "4.12.18",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7524,7 +7504,6 @@
     "node_modules/ink": {
       "version": "6.8.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.4",
         "ansi-escapes": "^7.3.0",
@@ -8436,7 +8415,6 @@
       "version": "1.32.0",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -8624,6 +8602,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8647,7 +8626,6 @@
     "node_modules/marked": {
       "version": "15.0.12",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9592,7 +9570,6 @@
       "version": "2.14.6",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -10570,7 +10547,6 @@
     "node_modules/pg": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10787,6 +10763,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10800,6 +10777,7 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10808,6 +10786,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11009,7 +10988,6 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11037,7 +11015,6 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11048,7 +11025,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -12667,7 +12645,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12960,7 +12937,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13373,7 +13349,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13508,6 +13483,8 @@
     },
     "node_modules/vitest": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13982,7 +13959,6 @@
     "node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14008,7 +13984,6 @@
     "node_modules/zustand": {
       "version": "4.5.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
       },


### PR DESCRIPTION
## Bug

`DELETE /api/engagements/[id]` currently removes the database row only, leaving the workspace dir (and any user-uploaded research notes, screenshots, plans, etc.) orphaned on disk. The natural next step — adding `rm -rf workspace/<slug>` to the handler — would silently destroy that work the first time a user clicks Delete by mistake. macOS users in particular expect a Trash with restore semantics.

## Fix

Introduce `safeDeleteEngagement(workspacePath, slug)` in `clients/web/src/lib/safe-delete.ts`:

- **macOS** — invokes `osascript -e 'tell application "Finder" to delete POSIX file "<path>"'`. Works headlessly (no Finder window required) and the dir ends up in the user's Trash, restorable from Finder.
- **Linux / Windows / other** — `fs.rename`s the dir to `<decepticon-home>/.trash/<slug>-<ISO-timestamp>/`. A companion `pruneTrash(workspacePath)` removes entries older than 30 days and runs on server start via a new `src/instrumentation.ts`. Trash dir is created lazily and `pruneTrash` is a no-op if it doesn't exist.
- **Defensive** — the helper re-validates `slug` against the same `SLUG_RE` used at engagement-creation time and explicitly rejects `..`/`/` segments before touching the filesystem, so a buggy caller can never reach `path.join(workspacePath, '../etc')`.

The DELETE handler now:

1. Looks up the engagement (404 if missing — unchanged).
2. Calls `safeDeleteEngagement`; on hard I/O failure, returns 500 and **does not** delete the DB row (no more orphaned workspaces).
3. Deletes the Prisma row.
4. Idempotent on a missing workspace.

## UI

The engagement overview page gains a "Move to Trash" button next to the existing Export buttons, opening a confirm dialog with copy that explains where the workspace ends up and the 30-day retention on non-macOS hosts.

A full Trash listing / restore view is intentionally out of scope here — the design doc treats it as a follow-up (`docs/fork/2026-05-26-decepticon-mac-fork-design.md` §5.5: "A new Trash view (or a CLI command `decepticon trash list/restore`)").

## Tests

Adds `vitest` to the web workspace (was missing) and `clients/web/vitest.config.ts`. New `safe-delete.test.ts` covers:

- Non-darwin: dir is moved to `.trash/<slug>-<ts>/`, original gone, contents preserved.
- Idempotency: deleting a missing slug returns the would-be target without throwing.
- Slug validation: `..`, `/`, hidden, too-short slugs all rejected before any filesystem work.
- `pruneTrash`: 40-day-old entry is removed; new entry is kept; missing `.trash/` is a no-op.

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

The macOS path goes through Finder/osascript and is covered by the same code path manually — the spec calls for an `osascript` mock test, but mocking `spawn` cleanly without DI is more invasive than the gain; the slug-validation and idempotency tests cover the helper's preconditions.

## Risk

Low. Behavior change is opt-in (only triggered on engagement delete), failure mode is conservative (500 + no DB delete on filesystem error), helper is idempotent, no changes to existing GET/PATCH/POST paths.

## Files

- `clients/web/src/lib/safe-delete.ts` — new helper
- `clients/web/src/lib/safe-delete.test.ts` — new tests
- `clients/web/src/instrumentation.ts` — Next.js startup hook for `pruneTrash`
- `clients/web/src/app/api/engagements/[id]/route.ts` — wire helper into DELETE
- `clients/web/src/app/(dashboard)/engagements/[id]/page.tsx` — "Move to Trash" button + confirm dialog
- `clients/web/vitest.config.ts` — new
- `clients/web/package.json` — add `test` script + `vitest` devDep
