### PR TITLE
fix(sandbox): reap zombie children on SIGCHLD and clean up tmux sessions

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/base.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/base.py
@@ -356,5 +356,48 @@ class SandboxBase(BaseSandbox):
             self.reset_session_log_offset(session, effective_workspace)
             self._jobs.remove(session, key=manager_key)
 
+    def kill_all_sessions(self) -> int:
+        """Kill every tmux session this sandbox has handed out a manager for.
+
+        Returns the number of sessions kill-session was invoked on. Used by
+        the sandbox daemon's shutdown hook to make sure tmux servers don't
+        outlive the daemon process and leave behind zombie ``bash``/``tmux``
+        children when their parent disappears.
+
+        Best-effort: every kill is wrapped in try/except so one stuck
+        session doesn't block the rest from being torn down.
+        """
+        with self._managers_lock:
+            managers = list(self._managers.values())
+            keys = list(self._managers.keys())
+            self._managers.clear()
+        killed = 0
+        for mgr in managers:
+            try:
+                # Each TmuxSessionManager runs its own ``tmux -L <name>``
+                # socket (see TmuxSessionManager._tmux), so kill-server
+                # terminates exactly the tmux process backing this session
+                # — including reaping the bash child the new-session
+                # command spawned. This is more thorough than kill-session
+                # for the shutdown path: even if the session was already
+                # detached, the tmux server itself exits.
+                mgr._tmux(["kill-server"], timeout=5)
+                killed += 1
+            except (RuntimeError, subprocess.TimeoutExpired, OSError) as e:
+                log.debug(
+                    "kill-server failed for session '%s' during shutdown: %s",
+                    _safe_log(mgr.session),
+                    _safe_log(e),
+                )
+        # Reset all per-session tracking state alongside the manager
+        # cache so a subsequent restart starts from a clean slate.
+        with TmuxSessionManager._init_lock:
+            for mgr in managers:
+                TmuxSessionManager._initialized.discard(mgr.session)
+        for key in keys:
+            with self._log_offsets_lock:
+                self._log_offsets.pop(key, None)
+        return killed
+
 
 # ─── Pre-flight check ────────────────────────────────────────────────────

--- a/packages/decepticon/decepticon/sandbox_server/app.py
+++ b/packages/decepticon/decepticon/sandbox_server/app.py
@@ -39,8 +39,11 @@ the right thing to ship as the default.
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import logging
 import os
+import signal
 from contextlib import asynccontextmanager
 from typing import Annotated, AsyncIterator
 
@@ -48,6 +51,9 @@ from fastapi import Depends, FastAPI, Header, HTTPException, status
 from pydantic import BaseModel, Field
 
 from decepticon.sandbox_kernel.daemon import DaemonSandbox
+from decepticon.sandbox_server.reaper import install_sigchld_reaper, reap_zombies
+
+log = logging.getLogger("decepticon.sandbox_server")
 
 # ── Wire models. Mirror the in-process types one-to-one so the daemon
 # stays a thin transport layer over the canonical DockerSandbox API. ──
@@ -207,10 +213,46 @@ def auth(
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     global _required_token
     _required_token = os.environ.get("SAAS_SANDBOX_TOKEN") or None
+
+    # Install a SIGCHLD reaper BEFORE the backend warms up (which is
+    # the first thing that spawns subprocesses). Without this, every
+    # tmux server / bash grandchild that gets reparented to the daemon
+    # process becomes a zombie that lingers for the daemon's lifetime.
+    # See ``reaper.py`` for the full rationale.
+    install_sigchld_reaper()
+    # Also wire the reaper onto the asyncio event loop. The plain
+    # ``signal.signal`` handler is interrupt-driven and may race with
+    # CPython's GIL acquisition on some kernels; the loop-level
+    # handler is a belt-and-braces drain that runs in the event loop
+    # thread between iterations.
+    if hasattr(signal, "SIGCHLD"):
+        try:
+            asyncio.get_running_loop().add_signal_handler(
+                signal.SIGCHLD,
+                reap_zombies,
+            )
+        except (NotImplementedError, RuntimeError, ValueError) as e:
+            # NotImplementedError on Windows (no SIGCHLD).
+            # RuntimeError if no loop is running.
+            # ValueError when not on the main thread (anyio test workers).
+            # All are non-fatal — the signal.signal handler above still works.
+            log.debug("loop-level SIGCHLD handler not installed: %s", e)
+
     # Warm the backend so the first agent request doesn't pay the
     # init cost on its critical path.
     _get_backend()
     yield
+    # Shutdown: kill every tmux session we ever handed out so the tmux
+    # servers don't outlive the daemon and leave bash zombies behind.
+    # Then drain any final zombies so the process exits clean.
+    try:
+        backend = _get_backend()
+        killed = backend.kill_all_sessions()
+        if killed:
+            log.info("shutdown: killed %d tmux session(s)", killed)
+    except Exception:
+        log.exception("shutdown: kill_all_sessions raised")
+    reap_zombies()
 
 
 app = FastAPI(

--- a/packages/decepticon/decepticon/sandbox_server/reaper.py
+++ b/packages/decepticon/decepticon/sandbox_server/reaper.py
@@ -1,0 +1,96 @@
+"""SIGCHLD reaper for the sandbox daemon.
+
+The daemon spawns many short-lived child processes — every ``tmux``
+subcommand, every ``sh -c`` for ``execute()``, every ``mkdir`` for
+``pipe-pane`` setup. Most of these are run through
+``subprocess.run(...)`` which waits on its child, but the tmux server
+itself, the bash shells launched by ``tmux new-session``, and any
+shell-spawned grandchildren are **not** waited on by the daemon — the
+parent of those grandchildren (the tmux server) reaps them, but when
+the tmux server itself exits its children get reparented to PID 1
+(the daemon) and the daemon never calls ``waitpid`` on them.
+
+Without a SIGCHLD handler those reparented children become zombies
+that linger until the daemon process exits. A long-running engagement
+session was observed accumulating four ``<defunct>`` ``tmux``/``bash``
+processes; under sustained use the kernel's per-process PID table
+fills up and ``fork()`` starts failing with EAGAIN.
+
+The fix is the standard Unix pattern: install one SIGCHLD handler at
+startup that loops ``os.waitpid(-1, os.WNOHANG)`` until no more exited
+children remain. The handler is reentrant-safe — ``os.waitpid`` is an
+async-signal-safe syscall wrapper and we do no allocation in the
+signal frame beyond what the CPython signal machinery already does.
+
+Placement: installed from the FastAPI ``lifespan`` startup hook so it
+covers the entire daemon process lifetime, BEFORE any ``DaemonSandbox``
+subprocess is spawned. Tests can import :func:`reap_zombies` and
+:func:`install_sigchld_reaper` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+from types import FrameType
+
+log = logging.getLogger("decepticon.sandbox_server.reaper")
+
+
+def reap_zombies(signum: int | None = None, frame: FrameType | None = None) -> int:
+    """Drain any exited child processes the kernel is holding for us.
+
+    Loops ``os.waitpid(-1, os.WNOHANG)`` until no more zombies remain.
+    Safe to call both as a ``signal.signal`` handler (the ``signum`` /
+    ``frame`` args match that contract) and as a plain function from
+    tests.
+
+    Returns the number of children reaped — useful for assertions in
+    tests and for the debug log line below.
+    """
+    reaped = 0
+    while True:
+        try:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            # No children at all — fully drained.
+            break
+        if pid == 0:
+            # Children exist but none have exited yet.
+            break
+        reaped += 1
+    if reaped:
+        log.debug("reaped %d zombie child process(es)", reaped)
+    return reaped
+
+
+def install_sigchld_reaper() -> None:
+    """Install :func:`reap_zombies` as the SIGCHLD handler.
+
+    Should be called from the main thread (``signal.signal`` restriction)
+    BEFORE any subprocess is spawned. Idempotent — re-installing the
+    handler is safe.
+
+    On platforms without SIGCHLD (Windows) this is a no-op; the daemon
+    only runs inside the Linux sandbox container in production, but
+    keeping the call cross-platform-safe means test runners on macOS /
+    Linux dev boxes don't blow up importing the module.
+
+    A ``ValueError`` from ``signal.signal`` ("signal only works in main
+    thread of the main interpreter") is downgraded to a warning. In
+    production the lifespan startup runs on the main thread so the
+    install succeeds; the only path that hits this branch is unit
+    tests that spin the FastAPI app inside an anyio worker thread.
+    """
+    if not hasattr(signal, "SIGCHLD"):
+        log.debug("SIGCHLD not available on this platform; reaper not installed")
+        return
+    try:
+        signal.signal(signal.SIGCHLD, reap_zombies)
+    except ValueError as e:
+        # "signal only works in main thread of the main interpreter" —
+        # benign in tests; production lifespan runs on the main thread.
+        log.warning("could not install SIGCHLD handler (not main thread): %s", e)
+        return
+    log.info("SIGCHLD zombie reaper installed")

--- a/packages/decepticon/tests/unit/backends/test_session_log.py
+++ b/packages/decepticon/tests/unit/backends/test_session_log.py
@@ -326,6 +326,69 @@ def test_kill_session_swallows_errors():
     assert sandbox._jobs.get("flaky") is None
 
 
+def test_kill_all_sessions_kills_every_manager_and_clears_caches():
+    sandbox = DaemonSandbox(container_name="test")
+    # Populate three independent sessions across two workspaces so we
+    # exercise both the root-workspace and engagement-scoped manager keys.
+    mgrs = [
+        sandbox._get_manager("alpha"),
+        sandbox._get_manager("beta"),
+        sandbox._get_manager("gamma", workspace_path="/workspace/eng-1"),
+    ]
+    TmuxSessionManager._initialized.update(m.session for m in mgrs)
+    sandbox._log_offsets["alpha"] = 1
+    sandbox._log_offsets["beta"] = 2
+
+    # Patch every manager's _tmux to record kill-server calls.
+    with (
+        patch.object(mgrs[0], "_tmux") as t0,
+        patch.object(mgrs[1], "_tmux") as t1,
+        patch.object(mgrs[2], "_tmux") as t2,
+    ):
+        killed = sandbox.kill_all_sessions()
+
+    assert killed == 3, "every active session should have kill-server invoked"
+    for t in (t0, t1, t2):
+        sent = [c.args[0] for c in t.call_args_list]
+        assert ["kill-server"] in sent, f"kill-server not invoked for one of the sessions: {sent}"
+
+    # Manager cache fully drained.
+    assert sandbox._managers == {}
+    # _initialized set drained of every session we created.
+    for mgr in mgrs:
+        assert mgr.session not in TmuxSessionManager._initialized
+    # Log offsets for the cleared manager keys are gone.
+    assert "alpha" not in sandbox._log_offsets
+    assert "beta" not in sandbox._log_offsets
+
+
+def test_kill_all_sessions_continues_past_individual_failures():
+    """One stuck session must not block the rest from being torn down."""
+    sandbox = DaemonSandbox(container_name="test")
+    m1 = sandbox._get_manager("good-1")
+    m2 = sandbox._get_manager("bad")
+    m3 = sandbox._get_manager("good-2")
+
+    with (
+        patch.object(m1, "_tmux") as t1,
+        patch.object(m2, "_tmux", side_effect=RuntimeError("tmux server gone")) as t2,
+        patch.object(m3, "_tmux") as t3,
+    ):
+        killed = sandbox.kill_all_sessions()
+
+    # Only the two healthy sessions count as successfully killed.
+    assert killed == 2
+    # All three were attempted.
+    assert t1.called and t2.called and t3.called
+    # Manager cache cleared regardless of per-session failures.
+    assert sandbox._managers == {}
+
+
+def test_kill_all_sessions_is_noop_when_no_managers():
+    sandbox = DaemonSandbox(container_name="test")
+    assert sandbox.kill_all_sessions() == 0
+
+
 def test_read_screen_handles_capture_timeout_gracefully():
     """read_screen() must NOT crash on subprocess.TimeoutExpired from capture-pane."""
     mgr = TmuxSessionManager("hung", "decepticon-sandbox")

--- a/packages/decepticon/tests/unit/sandbox_server/test_app.py
+++ b/packages/decepticon/tests/unit/sandbox_server/test_app.py
@@ -413,3 +413,52 @@ def test_token_set_correct_bearer_is_200() -> None:
         )
     assert resp.status_code == 200
     assert resp.json()["output"] == "hello\n"
+
+
+# ── Zombie reaper / shutdown cleanup ─────────────────────────────────────
+
+
+def test_lifespan_installs_sigchld_reaper() -> None:
+    """The startup hook must install the SIGCHLD reaper BEFORE the backend warms.
+
+    Asserts ``install_sigchld_reaper`` was called inside ``lifespan``; the
+    reaper module itself owns the actual signal-handler-installation
+    contract (covered by ``test_reaper.py``).
+    """
+    backend = _make_backend()
+    with patch.object(app_module, "install_sigchld_reaper") as install_mock:
+        with _client(backend) as _client_ctx:
+            # Lifespan startup runs on TestClient context-enter.
+            pass
+    install_mock.assert_called_once()
+
+
+def test_lifespan_shutdown_kills_all_tmux_sessions() -> None:
+    """The shutdown hook must drain every tmux session via kill_all_sessions
+    so tmux servers do not outlive the daemon and leak zombies."""
+    backend = _make_backend()
+    backend.kill_all_sessions.return_value = 3
+    with _client(backend) as _client_ctx:
+        pass  # context exit triggers lifespan shutdown
+    backend.kill_all_sessions.assert_called_once()
+
+
+def test_lifespan_shutdown_drains_zombies() -> None:
+    """The shutdown hook must call ``reap_zombies`` after killing sessions
+    so the process exits with no defunct children."""
+    backend = _make_backend()
+    with patch.object(app_module, "reap_zombies") as reap_mock:
+        with _client(backend) as _client_ctx:
+            pass
+    # Called at least once on shutdown — may also be wired into the
+    # asyncio loop as a signal handler, so we don't pin call_count.
+    assert reap_mock.called
+
+
+def test_lifespan_shutdown_swallows_kill_all_sessions_errors() -> None:
+    """A failure tearing down tmux must not crash the daemon shutdown."""
+    backend = _make_backend()
+    backend.kill_all_sessions.side_effect = RuntimeError("tmux server dead")
+    # If the lifespan re-raises, _client's __exit__ would propagate.
+    with _client(backend) as _client_ctx:
+        pass

--- a/packages/decepticon/tests/unit/sandbox_server/test_reaper.py
+++ b/packages/decepticon/tests/unit/sandbox_server/test_reaper.py
@@ -1,0 +1,210 @@
+"""Tests for the sandbox daemon's SIGCHLD zombie reaper.
+
+Without the reaper, every subprocess that gets reparented to the daemon
+(tmux servers exiting, bash grandchildren outliving their tmux parent)
+becomes a ``<defunct>`` process the daemon never waits on. This module
+verifies the reaper's two contracts:
+
+  1. ``reap_zombies()`` returns the count of children reaped and leaves
+     no zombies behind when called explicitly.
+  2. ``install_sigchld_reaper()`` wires the reaper as the SIGCHLD
+     handler so subprocess exits are drained automatically.
+
+The tests fork real child processes via ``subprocess.Popen(["true"])``
+because mocking ``os.waitpid`` would only verify the function shape,
+not the actual zombie-draining behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from decepticon.sandbox_server.reaper import (
+    install_sigchld_reaper,
+    reap_zombies,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SIGCHLD / waitpid semantics are POSIX-only; the daemon ships in a Linux container",
+)
+
+
+@pytest.fixture
+def _restore_sigchld() -> Iterator[None]:
+    """Snapshot and restore the SIGCHLD handler around each test.
+
+    The reaper installation is process-global state; without this fixture
+    a failing test would leak its handler into every subsequent test.
+    """
+    prev = signal.getsignal(signal.SIGCHLD)
+    yield
+    signal.signal(signal.SIGCHLD, prev)
+
+
+def _count_zombie_children() -> int:
+    """Return how many of this process's children are zombies right now.
+
+    Reads ``/proc/<pid>/status`` on Linux; falls back to ``ps`` elsewhere
+    (macOS dev boxes). Counting via ``waitpid`` would itself drain the
+    zombies, defeating the assertion.
+    """
+    pid = os.getpid()
+    # Try Linux /proc first — the production container is Linux.
+    try:
+        with open(f"/proc/{pid}/task/{pid}/children", encoding="ascii") as f:
+            child_pids = [int(p) for p in f.read().split() if p.strip()]
+    except FileNotFoundError:
+        # macOS / BSD — use ps to enumerate children.
+        result = subprocess.run(
+            ["ps", "-o", "pid=,state=", "--ppid", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            # Different ps flavour (BSD): use -A and filter.
+            result = subprocess.run(
+                ["ps", "-A", "-o", "pid=,ppid=,state="],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            zombies = 0
+            for line in result.stdout.splitlines():
+                parts = line.split()
+                if len(parts) >= 3 and parts[1] == str(pid) and parts[2].startswith("Z"):
+                    zombies += 1
+            return zombies
+        zombies = 0
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].startswith("Z"):
+                zombies += 1
+        return zombies
+
+    # Linux path: probe each child's state.
+    zombies = 0
+    for child_pid in child_pids:
+        try:
+            with open(f"/proc/{child_pid}/status", encoding="ascii") as f:
+                for line in f:
+                    if line.startswith("State:"):
+                        if "Z" in line.split()[1]:
+                            zombies += 1
+                        break
+        except FileNotFoundError:
+            # Child exited & was reaped between listing and probing.
+            continue
+    return zombies
+
+
+def test_reap_zombies_returns_zero_when_no_children() -> None:
+    """With no children alive, reap_zombies must return 0 and not raise."""
+    # Drain anything carried over from previous tests first.
+    reap_zombies()
+    assert reap_zombies() == 0
+
+
+def test_reap_zombies_drains_short_lived_children(_restore_sigchld: None) -> None:
+    """Spawn 10 quick-exit children with NO signal handler installed, then
+    verify reap_zombies() finds and drains them."""
+    # Make sure no handler is active — we want zombies to accumulate so
+    # we can observe the drain.
+    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+
+    procs = [subprocess.Popen(["true"]) for _ in range(10)]
+    # Give the kernel time to fire SIGCHLD + flip child state to Z.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if all(p.poll() is not None for p in procs):
+            break
+        time.sleep(0.05)
+
+    # ``poll()`` on subprocess.Popen calls waitpid internally and would
+    # reap the children itself. To force real zombies, we'd need to
+    # bypass Popen's wait — but the daemon's actual hazard is exactly
+    # the children that Popen does NOT track (reparented grandchildren).
+    # Here we instead assert the reaper drains *whatever* zombies the
+    # OS surfaces, including any from the burst above that Popen hasn't
+    # explicitly waited on.
+    reaped_or_polled = reap_zombies()
+    # Either Popen reaped them via __del__ probes or the reaper did;
+    # the invariant is the same: zero zombies remaining.
+    assert _count_zombie_children() == 0, (
+        f"zombie children remained after reap: reaped={reaped_or_polled}"
+    )
+
+
+def test_install_sigchld_reaper_drains_unwaited_grandchildren(
+    _restore_sigchld: None,
+) -> None:
+    """Real scenario: spawn a parent that forks a child then exits.
+
+    The grandchild gets reparented to this test process (its grandparent
+    via PID inheritance) and, without a reaper, becomes a permanent
+    zombie. With the reaper installed, the SIGCHLD on the grandchild's
+    exit should drain it within a few hundred ms.
+
+    Uses ``sh -c`` to fork a backgrounded ``true``: the parent shell
+    exits immediately (Popen reaps it), but the backgrounded ``true``
+    grandchild outlives the parent and is reparented to us.
+    """
+    install_sigchld_reaper()
+
+    # Parent shell forks a backgrounded short-lived child then exits.
+    # 'sleep 0.1' is short enough that the test stays fast but long
+    # enough that the parent shell is guaranteed to exit before the
+    # grandchild does, forcing the reparent.
+    for _ in range(10):
+        p = subprocess.Popen(["sh", "-c", "sleep 0.1 & exit 0"])
+        p.wait()  # reaps the immediate child shell
+
+    # Give grandchildren time to exit and SIGCHLD to fire.
+    time.sleep(0.6)
+
+    # The reaper, wired as the SIGCHLD handler, should have drained
+    # every reparented grandchild as they exited.
+    assert _count_zombie_children() == 0, (
+        "reparented grandchildren left behind as zombies — reaper not firing"
+    )
+
+
+def test_install_sigchld_reaper_is_idempotent(_restore_sigchld: None) -> None:
+    """Calling install_sigchld_reaper twice must not raise or break the handler."""
+    install_sigchld_reaper()
+    install_sigchld_reaper()
+    handler = signal.getsignal(signal.SIGCHLD)
+    # The reaper should still be the handler after a second install.
+    assert handler is reap_zombies
+
+
+def test_install_sigchld_reaper_skips_on_no_sigchld() -> None:
+    """On platforms without SIGCHLD (Windows), install is a no-op, not a crash.
+
+    Implementation note: Python's ``signal`` module is a process-global
+    singleton, so we can't safely ``monkeypatch.delattr`` SIGCHLD without
+    breaking every other test in the process. Instead we directly test
+    the ``hasattr`` branch by stubbing the reaper module's ``signal``
+    reference with a shim that lacks SIGCHLD.
+    """
+    import types as _types
+
+    import decepticon.sandbox_server.reaper as reaper_mod
+
+    real_signal = reaper_mod.signal
+    fake_signal = _types.SimpleNamespace(signal=lambda *a, **k: None)
+    # ``fake_signal`` deliberately has no SIGCHLD attribute.
+    reaper_mod.signal = fake_signal  # type: ignore[assignment]
+    try:
+        # Should return without raising — the hasattr guard handles it.
+        install_sigchld_reaper()
+    finally:
+        reaper_mod.signal = real_signal  # type: ignore[assignment]


### PR DESCRIPTION
## Problem

`decepticon-sandbox` accumulates `<defunct>` `tmux` + `bash` processes during long-running engagements (observed: 4 zombies in one session). The HTTP daemon spawns many short-lived subprocesses (tmux subcommands, `sh -c` for `execute()`), and while most are reaped by their immediate `subprocess.run(...)` caller, the tmux server itself, the bash shells inside `tmux new-session`, and any shell-spawned grandchildren are not waited on by the daemon. When the tmux server exits, its children get reparented to the daemon (PID 1 of the sandbox container) and the daemon never calls `waitpid` on them, so they linger as zombies for the daemon's lifetime. Under sustained use the per-process PID table eventually fills and `fork()` starts failing with `EAGAIN`.

## Fix

### Part 1 — SIGCHLD reaper

New `decepticon.sandbox_server.reaper` module installs a signal handler that loops `os.waitpid(-1, os.WNOHANG)` until no more zombies remain. Wired from the FastAPI `lifespan` startup hook **before** the backend warms up (which is the first thing that spawns subprocesses). The reaper is also registered on the asyncio event loop via `loop.add_signal_handler()` as a belt-and-braces drain that runs in the event-loop thread.

The reaper is reentrant-safe — `os.waitpid` with `WNOHANG` in a loop is the standard async-signal-safe Unix idiom and we do no allocation in the signal frame beyond what CPython's signal machinery already does.

### Part 2 — tmux session cleanup on shutdown

New `SandboxBase.kill_all_sessions()` iterates every `TmuxSessionManager` the sandbox has handed out and runs `tmux kill-server` on each; the lifespan shutdown hook invokes it so no tmux server outlives the daemon. `kill-server` (rather than `kill-session`) is the right hammer for shutdown: it guarantees the tmux process **and** every bash child it spawned exit, leaving nothing for the kernel to reparent.

Both code paths are best-effort with errors logged not raised — one stuck session must not block the rest from being torn down.

## Tests

- **`tests/unit/sandbox_server/test_reaper.py`** (5 tests): reaper in isolation, including a real `fork() + parent exits + grandchild exits` scenario to verify the SIGCHLD handler drains reparented grandchildren.
- **`tests/unit/backends/test_session_log.py`** (3 new tests): `kill_all_sessions` contract — every manager killed, failure-isolation, no-op when empty.
- **`tests/unit/sandbox_server/test_app.py`** (4 new tests): lifespan wiring — startup installs the reaper, shutdown calls `kill_all_sessions` + `reap_zombies`, shutdown swallows tear-down errors.

```
$ uv run pytest packages/decepticon/tests/unit/sandbox_server/ packages/decepticon/tests/unit/backends/ packages/decepticon/tests/unit/sandbox_kernel/
116 passed
```

## Risk

Low — sandbox-internal process management. The reaper only mutates global signal state (recoverable on shutdown) and the kill-server-on-shutdown path only fires during daemon teardown when the sandbox is going away anyway. No production caller behaviour changes.