### PR TITLE
feat(cli): auto-reconnect WebSocket stream with exponential backoff and resume-from-checkpoint

### DIFF
--- a/clients/cli/src/components/ConnectionStatus.tsx
+++ b/clients/cli/src/components/ConnectionStatus.tsx
@@ -1,0 +1,74 @@
+/**
+ * ConnectionStatus — inline notice rendered by REPL when the LangGraph stream
+ * has dropped and useAgent's reconnect loop is working through its backoff
+ * schedule. Renders nothing when the stream is healthy so it never steals
+ * vertical space from the normal flow.
+ *
+ * States surfaced (from useAgent's ConnectionState):
+ *   - status "connected" + justRecovered=false → renders nothing.
+ *   - status "connected" + justRecovered=true  → green "Reconnected." flash
+ *     that auto-dismisses after ~2s (the timer lives in useAgent).
+ *   - status "reconnecting"                     → yellow line with attempt
+ *     count and a live countdown to the next retry.
+ *   - status "disconnected"                     → red line; operator should
+ *     /resume to try again.
+ *
+ * The countdown re-renders once per second via a local interval; that's
+ * cheap (only when the notice is visible) and avoids forcing useAgent to
+ * re-render constantly during a long backoff.
+ */
+
+import React, { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import type { ConnectionState } from "../hooks/useAgent.js";
+import { GLYPH_DOT } from "../utils/theme.js";
+
+interface ConnectionStatusProps {
+  state: ConnectionState;
+}
+
+export const ConnectionStatus = React.memo(function ConnectionStatus({
+  state,
+}: ConnectionStatusProps) {
+  // Local "now" tick so the countdown animates. Only ticks while a retry
+  // is pending — switches off as soon as we land on "connected".
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    if (state.status !== "reconnecting") return;
+    const t = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(t);
+  }, [state.status]);
+
+  if (state.status === "connected") {
+    if (!state.justRecovered) return null;
+    return (
+      <Box marginTop={1} height={1}>
+        <Text color="green">
+          {GLYPH_DOT} Reconnected.
+        </Text>
+      </Box>
+    );
+  }
+
+  if (state.status === "reconnecting") {
+    const remainingMs = Math.max(0, state.nextRetryAt - now);
+    const remainingSec = Math.max(1, Math.ceil(remainingMs / 1000));
+    return (
+      <Box marginTop={1} height={1}>
+        <Text color="yellow">
+          {GLYPH_DOT} Reconnecting (attempt {state.attempt}, next try in{" "}
+          {remainingSec}s)…
+        </Text>
+      </Box>
+    );
+  }
+
+  // "disconnected"
+  return (
+    <Box marginTop={1} height={1}>
+      <Text color="red">
+        {GLYPH_DOT} Disconnected from server — type /resume to try again.
+      </Text>
+    </Box>
+  );
+});

--- a/clients/cli/src/hooks/__fixtures__/mockStream.ts
+++ b/clients/cli/src/hooks/__fixtures__/mockStream.ts
@@ -90,6 +90,12 @@ export type MockClient = {
   };
   runs: {
     stream: ReturnType<typeof vi.fn>;
+    /**
+     * runs.joinStream is the LangGraph SDK's "re-attach to an existing run"
+     * entry point. The CLI's reconnect loop uses it after a WebSocket drop
+     * so the original POST /runs/stream is never repeated.
+     */
+    joinStream: ReturnType<typeof vi.fn>;
     cancel: ReturnType<typeof vi.fn>;
   };
 };
@@ -105,6 +111,7 @@ export function createMockClient(): MockClient {
     },
     runs: {
       stream: vi.fn(() => createMockStream([])),
+      joinStream: vi.fn(() => createMockStream([])),
       cancel: vi.fn(async () => {}),
     },
   };

--- a/clients/cli/src/hooks/useAgent.reconnect.test.tsx
+++ b/clients/cli/src/hooks/useAgent.reconnect.test.tsx
@@ -1,0 +1,310 @@
+// @vitest-environment jsdom
+//
+// useAgent reconnect-loop behavior tests.
+//
+// Kept in its own file (rather than extending useAgent.test.tsx) because the
+// reconnect path needs a richer mock surface — joinStream, controllable
+// drop/error iterators, advancing fake timers through the backoff schedule —
+// and mixing the two would obscure either suite. The engagement-handoff suite
+// in useAgent.test.tsx covers the happy-path lifecycle; this file covers what
+// happens when the WebSocket flips around mid-stream.
+
+import { renderHook, act } from "@testing-library/react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import {
+  createMockStream,
+  createMockClient,
+  createControllableStream,
+  type MockClient,
+  type StreamEvent,
+} from "./__fixtures__/mockStream.js";
+
+// ── Hoisted mock state ──────────────────────────────────────────────────────
+const { mockState } = vi.hoisted(() => ({
+  mockState: { client: null as MockClient | null },
+}));
+
+vi.mock("@langchain/langgraph-sdk", () => ({
+  Client: vi.fn(() => mockState.client),
+}));
+
+vi.mock("../utils/threadStore.js", () => ({
+  saveThread: vi.fn(async () => {}),
+  touchThread: vi.fn(async () => {}),
+  loadThreadByIndex: vi.fn(async () => null),
+}));
+
+vi.mock("../commands/modelOverride.js", () => ({
+  getModelOverride: () => undefined,
+}));
+
+vi.mock("../commands/assistantOverride.js", () => ({
+  getAssistantOverride: () => undefined,
+}));
+
+// Dynamic import after env stubbing — see useAgent.test.tsx for rationale.
+let useAgent: (typeof import("./useAgent.js"))["useAgent"];
+
+// ── Common event fixtures ───────────────────────────────────────────────────
+
+const metadataEvent: StreamEvent = {
+  event: "metadata",
+  data: { run_id: "run-xyz", thread_id: "thread-1" },
+};
+
+/** A LangGraph "values" snapshot containing one AI message with no tool calls
+ *  — the natural-end-of-run signal that flips completionReceived. */
+const completionValuesEvent: StreamEvent = {
+  event: "values",
+  data: {
+    messages: [{ type: "ai", content: "all done" }],
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build an iterator that yields the given events and then throws — simulates
+ * a WebSocket close that ESBuild-style transports surface as an iteration
+ * error mid-stream.
+ */
+function streamThatThrows(events: StreamEvent[], errMsg: string): AsyncIterable<StreamEvent> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const e of events) {
+        await Promise.resolve();
+        yield e;
+      }
+      throw new Error(errMsg);
+    },
+  };
+}
+
+// ── Suite ───────────────────────────────────────────────────────────────────
+
+describe("useAgent — WebSocket auto-reconnect", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.stubEnv("DECEPTICON_API_URL", "http://localhost:2024");
+    vi.stubEnv("DECEPTICON_ASSISTANT_ID", "decepticon");
+    delete process.env.DECEPTICON_ENGAGEMENT;
+    delete process.env.DECEPTICON_WORKSPACE_PATH;
+    delete process.env.DECEPTICON_THREAD_ID;
+    mockState.client = createMockClient();
+    ({ useAgent } = await import("./useAgent.js"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  // ── 1. Drop mid-stream → reconnect via joinStream, no second POST ─────────
+  it("re-attaches via joinStream after a drop without dispatching a duplicate run", async () => {
+    const mc = mockState.client!;
+
+    // First pass: metadata, then the connection dies.
+    const firstStream = streamThatThrows([metadataEvent], "ECONNRESET");
+    // Second pass (after reconnect): receives the completion event cleanly.
+    const secondStream = createMockStream([completionValuesEvent]);
+
+    // runs.stream is the "POST a new run" entry point — only the first
+    // attempt should ever call it. Subsequent reconnects must go through
+    // joinStream against the captured run_id.
+    (mc.runs.stream as Mock).mockReturnValueOnce(firstStream);
+    (mc.runs.joinStream as Mock).mockReturnValueOnce(secondStream);
+
+    const { result } = renderHook(() => useAgent());
+
+    act(() => {
+      result.current.submit("kick off the run");
+    });
+
+    // Let runs.stream get called and the first stream's metadata event flow
+    // through, then the error fires.
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // Advance through the 1s backoff for the first reconnect attempt.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100);
+      await vi.runAllTimersAsync();
+    });
+
+    // Final flush so the second stream's completion event lands and the
+    // reconnect "Reconnected" notice's 2s timer rolls forward.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+      await vi.runAllTimersAsync();
+    });
+
+    // CRITICAL: only ONE POST to /runs/stream — no duplicate run dispatched.
+    expect((mc.runs.stream as Mock).mock.calls.length).toBe(1);
+
+    // joinStream was called against the captured run_id from metadata.
+    expect((mc.runs.joinStream as Mock).mock.calls.length).toBe(1);
+    const joinArgs = (mc.runs.joinStream as Mock).mock.calls[0];
+    expect(joinArgs[1]).toBe("run-xyz");
+
+    // Thread state was fetched before the resume call (so we don't replay).
+    expect((mc.threads.getState as Mock).mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    // Final connection status is "connected"; "Reconnected" flash auto-cleared.
+    expect(result.current.connectionState.status).toBe("connected");
+    expect(result.current.connectionState.attempt).toBe(0);
+  });
+
+  // ── 2. Connection status transitions through "reconnecting" → "connected" ─
+  it("transitions connection status to 'reconnecting' during backoff and back to 'connected' on resume", async () => {
+    const mc = mockState.client!;
+    const firstStream = streamThatThrows([metadataEvent], "socket hang up");
+    // Use a controllable second stream so the test can hold the run open
+    // and observe the "reconnecting" status snapshot before completion.
+    const secondStream = createControllableStream();
+    (mc.runs.stream as Mock).mockReturnValueOnce(firstStream);
+    (mc.runs.joinStream as Mock).mockReturnValueOnce(secondStream);
+
+    const { result } = renderHook(() => useAgent());
+    expect(result.current.connectionState.status).toBe("connected");
+
+    act(() => {
+      result.current.submit("hello");
+    });
+
+    // Drain microtasks so the first stream errors and the reconnect loop
+    // enters the backoff sleep — but only advance enough that the 1s timer
+    // has NOT fired yet. The setConnectionState({status: "reconnecting"}) is
+    // committed synchronously before the sleep, so checking after a 500ms
+    // tick (well short of the 1000ms backoff) gives us the in-flight value.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(result.current.connectionState.status).toBe("reconnecting");
+    expect(result.current.connectionState.attempt).toBe(1);
+
+    // Finish the backoff. joinStream returns the controllable stream; emit
+    // the completion event so the run finishes and status flips back.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await act(async () => {
+      await secondStream.emit(completionValuesEvent);
+      secondStream.end();
+      await vi.runAllTimersAsync();
+    });
+    // Settle the "Reconnected" flash timer.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.connectionState.status).toBe("connected");
+  });
+
+  // ── 3. Hard error after max attempts → status "disconnected" ──────────────
+  it("transitions to 'disconnected' after MAX_RECONNECT_ATTEMPTS consecutive failures", async () => {
+    const mc = mockState.client!;
+
+    // First stream gives us a run_id, then dies.
+    const firstStream = streamThatThrows([metadataEvent], "boom");
+    (mc.runs.stream as Mock).mockReturnValueOnce(firstStream);
+
+    // Every subsequent joinStream attempt also dies, no events. The loop
+    // should give up after MAX_RECONNECT_ATTEMPTS (8) attempts.
+    (mc.runs.joinStream as Mock).mockImplementation(() =>
+      streamThatThrows([], "still down"),
+    );
+
+    const { result } = renderHook(() => useAgent());
+
+    act(() => {
+      result.current.submit("doomed run");
+    });
+
+    // Walk all the way through the backoff schedule: 1+2+4+8+16+16+16+16 = 79s
+    // plus a generous buffer for microtasks. We advance in big chunks.
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    for (let i = 0; i < 12; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20000);
+        await vi.runAllTimersAsync();
+      });
+    }
+
+    // After exhausting attempts, status flips to "disconnected" and an error
+    // surfaces. (joinStream should have been called MAX_RECONNECT_ATTEMPTS
+    // times — the first failure on the original `runs.stream` counts as
+    // failure #1, then joinStream gets called for attempts 1..MAX, so
+    // joinStream is called MAX times before we give up at MAX+1.)
+    expect(result.current.connectionState.status).toBe("disconnected");
+    expect(result.current.error).toBeTruthy();
+    // We never POST a second new run.
+    expect((mc.runs.stream as Mock).mock.calls.length).toBe(1);
+  });
+
+  // ── 4. Clean stream completion never flips status ─────────────────────────
+  it("leaves connection status 'connected' for a run that completes without drops", async () => {
+    const mc = mockState.client!;
+    const cleanStream = createMockStream([metadataEvent, completionValuesEvent]);
+    (mc.runs.stream as Mock).mockReturnValueOnce(cleanStream);
+
+    const { result } = renderHook(() => useAgent());
+
+    act(() => {
+      result.current.submit("a clean run");
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.connectionState.status).toBe("connected");
+    expect(result.current.connectionState.attempt).toBe(0);
+    expect((mc.runs.joinStream as Mock).mock.calls.length).toBe(0);
+  });
+
+  // ── 5. Operator abort during reconnect backoff bails out cleanly ──────────
+  it("aborts the reconnect backoff when the operator cancels", async () => {
+    const mc = mockState.client!;
+    const firstStream = streamThatThrows([metadataEvent], "transient");
+    (mc.runs.stream as Mock).mockReturnValueOnce(firstStream);
+    // joinStream would be called next, but cancel should fire first.
+    const lateStream = createControllableStream();
+    (mc.runs.joinStream as Mock).mockReturnValueOnce(lateStream);
+
+    const { result } = renderHook(() => useAgent());
+
+    act(() => {
+      result.current.submit("will cancel");
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // We are now sleeping in the backoff. Cancel the run.
+    act(() => {
+      result.current.cancel();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.runAllTimersAsync();
+    });
+
+    // Run state ends idle, error stays clear, and the cancel pathway took
+    // priority over the reconnect path.
+    expect(result.current.runState).toBe("idle");
+  });
+});

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -26,6 +26,7 @@ import {
 } from "@decepticon/streaming";
 import { getModelOverride } from "../commands/modelOverride.js";
 import { getAssistantOverride } from "../commands/assistantOverride.js";
+import { nextBackoffMs, MAX_RECONNECT_ATTEMPTS } from "./useReconnect.js";
 
 interface LangChainMessage {
   type: string; // "human", "ai", "tool"
@@ -68,6 +69,33 @@ export interface StreamStats {
 /** Agent run lifecycle state. */
 export type RunState = "idle" | "connecting" | "streaming" | "paused";
 
+/**
+ * Stream connection health. Independent from RunState: a run may still be
+ * `"streaming"` while the underlying WebSocket bounces in the background, and
+ * an `"idle"` run is `"connected"` simply by virtue of no failed attempts.
+ *
+ * - `"connected"`: the stream is open OR the hook is between runs cleanly.
+ * - `"reconnecting"`: a stream drop was detected, we are inside the backoff
+ *   loop trying to re-attach to the same run via `runs.joinStream`.
+ * - `"disconnected"`: the backoff loop exhausted MAX_RECONNECT_ATTEMPTS and
+ *   surfaced a hard error. The operator can issue a fresh /resume to recover.
+ */
+export type ConnectionStatus = "connected" | "reconnecting" | "disconnected";
+
+/** Snapshot of the reconnect loop's state, surfaced for the status UI. */
+export interface ConnectionState {
+  status: ConnectionStatus;
+  /** 1-based attempt counter; 0 when not reconnecting. */
+  attempt: number;
+  /** Epoch ms at which the next attempt will fire; 0 when not waiting. */
+  nextRetryAt: number;
+  /**
+   * Toggled briefly (~2s) to `true` after a successful reconnect so the UI
+   * can flash a "Reconnected" notice. Cleared back to `false` automatically.
+   */
+  justRecovered: boolean;
+}
+
 interface UseAgentReturn {
   submit: (message: string) => void;
   /** Pause the current run at checkpoint (Ctrl+C single). State preserved. */
@@ -98,6 +126,12 @@ interface UseAgentReturn {
   /** Submit a structured answer to the current ask_user_question prompt. */
   answerQuestion: (value: string | string[]) => void;
   error: string | null;
+  /**
+   * Health of the underlying LangGraph stream. The REPL renders an inline
+   * notice off this — see ConnectionStatus.tsx — so a transient WebSocket
+   * drop doesn't surface as a generic error or force the operator to Ctrl+C.
+   */
+  connectionState: ConnectionState;
   clearEvents: () => void;
   addSystemEvent: (content: string) => void;
 }
@@ -133,6 +167,15 @@ export function useAgent({
 
   const [events, setEvents] = useState<AgentEvent[]>([]);
   const [runState, setRunState] = useState<RunState>("idle");
+  const [connectionState, setConnectionState] = useState<ConnectionState>({
+    status: "connected",
+    attempt: 0,
+    nextRetryAt: 0,
+    justRecovered: false,
+  });
+  // Timer that auto-clears the brief "Reconnected" flash. Kept on a ref so
+  // back-to-back reconnects don't dismiss the latest flash too early.
+  const justRecoveredTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [pendingTool, setPendingTool] = useState<PendingTool | null>(null);
   const [streamStats, setStreamStats] = useState<StreamStats | null>(null);
   const [activeAgent, setActiveAgent] = useState<string | null>(null);
@@ -173,6 +216,17 @@ export function useAgent({
         threadIdRef.current = saved.threadId;
       }
     }).catch(() => {});
+  }, []);
+
+  // Clear the "Reconnected" flash timer if the hook unmounts mid-flash so we
+  // don't leak the timer or fire setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (justRecoveredTimerRef.current) {
+        clearTimeout(justRecoveredTimerRef.current);
+        justRecoveredTimerRef.current = null;
+      }
+    };
   }, []);
 
   const addEvent = useCallback(
@@ -220,11 +274,33 @@ export function useAgent({
 
   // ── Stream event processing (shared by submit and resume) ──────
 
+  /**
+   * Outcome of a single pass through the LangGraph event stream. The
+   * reconnect loop in `runWithReconnect` decides what to do next:
+   * - "complete": run reached natural end (AI message with no tool calls).
+   *               Caller exits the loop, clears refs, transitions to idle.
+   * - "paused": backend tool called langgraph.interrupt() (ask_user_question
+   *             or operator pause). Caller exits the loop, keeps run state.
+   * - "aborted": local AbortController fired — operator cancelled/interrupted.
+   *              Caller exits silently.
+   * - "dropped": stream ended early or threw an error. Caller backs off and
+   *              calls runs.joinStream(threadId, runId) to re-attach to the
+   *              SAME server-side run — no new run is dispatched.
+   */
+  type StreamOutcome = {
+    kind: "complete" | "paused" | "aborted" | "dropped";
+    /** True if the consumer received any event before this outcome — used
+     *  by the reconnect loop to reset the consecutive-failure counter. */
+    receivedAnyEvent: boolean;
+    /** Error message when kind === "dropped". */
+    errorMessage?: string;
+  };
+
   const processStream = useCallback(
     async (
       stream: AsyncIterable<{ event: string; data: unknown }>,
       abortController: AbortController,
-    ) => {
+    ): Promise<StreamOutcome> => {
       // Capture run_id from the first metadata event for interrupt/cancel
       // LangGraph SDK emits: { event: "metadata", data: { run_id, thread_id } }
       const toolCallArgs = new Map<string, Record<string, unknown>>();
@@ -400,8 +476,12 @@ export function useAgent({
         }
       };
 
-      for await (const event of stream) {
+      let receivedAnyEvent = false;
+      let pausedByInterrupt = false;
+      try {
+        for await (const event of stream) {
         if (abortController.signal.aborted) break;
+        receivedAnyEvent = true;
 
         // Capture run_id from metadata event for precise interrupt/cancel
         if (event.event === "metadata") {
@@ -546,18 +626,221 @@ export function useAgent({
             }
           }
         }
+        }
+      } catch (err) {
+        if (abortController.signal.aborted) {
+          return { kind: "aborted", receivedAnyEvent };
+        }
+        // Stream iteration threw \u2014 most commonly a WebSocket close or a fetch
+        // error from the SDK transport. Let the reconnect loop handle it.
+        const msg = err instanceof Error ? err.message : String(err);
+        return { kind: "dropped", receivedAnyEvent, errorMessage: msg };
       }
 
-      // Detect unexpected disconnection: stream ended but no completion event
-      if (!completionReceived && !abortController.signal.aborted) {
-        addSystemEvent(
-          "\u26a0\ufe0f Connection to server lost. The run continues server-side. "
-          + "Use /resume to reconnect.",
-        );
-        setRunState("idle");
+      // The ask_user_question handler sets activeQuestion when the backend
+      // calls langgraph.interrupt(). Check that as a more reliable signal than
+      // the local flag, since the picker can come from either a custom event
+      // or the __interrupt__ updates path.
+      if (activeQuestionRef.current) {
+        pausedByInterrupt = true;
+      }
+
+      if (abortController.signal.aborted) {
+        return { kind: "aborted", receivedAnyEvent };
+      }
+      if (pausedByInterrupt) {
+        return { kind: "paused", receivedAnyEvent };
+      }
+      if (completionReceived) {
+        return { kind: "complete", receivedAnyEvent };
+      }
+      // Stream ended cleanly but without a terminal AI message \u2014 the WebSocket
+      // closed mid-run. Reconnect loop will try to re-attach.
+      return {
+        kind: "dropped",
+        receivedAnyEvent,
+        errorMessage: "Stream ended before run completion",
+      };
+    },
+    [addEvent],
+  );
+
+  // ── Reconnect loop ─────────────────────────────────────────────
+  //
+  // Wraps an initial stream factory in a backoff-driven retry loop. When the
+  // stream drops mid-run, we:
+  //   1. Note the failure (increment counter, set status = "reconnecting").
+  //   2. Sleep for nextBackoffMs(failures) — interruptible via the abort signal.
+  //   3. Refresh local state from the thread (so we don't replay messages we
+  //      already showed), then call client.runs.joinStream(threadId, runId).
+  //      This RE-ATTACHES to the same server-side run. No new run is created.
+  //   4. First event on the new stream resets the failure counter and flips
+  //      status back to "connected" with a brief "Reconnected" flash.
+  //
+  // The loop exits on `complete`, `paused`, or `aborted`. After
+  // MAX_RECONNECT_ATTEMPTS consecutive failures, it gives up and surfaces a
+  // hard error so the operator can /resume manually.
+
+  /** Promise wrapper around setTimeout that resolves early when aborted. */
+  const sleepUntilOrAbort = useCallback(
+    (ms: number, signal: AbortSignal): Promise<void> => {
+      return new Promise((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        const t = setTimeout(() => {
+          signal.removeEventListener("abort", onAbort);
+          resolve();
+        }, ms);
+        const onAbort = () => {
+          clearTimeout(t);
+          signal.removeEventListener("abort", onAbort);
+          resolve();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+    [],
+  );
+
+  const markReconnected = useCallback(() => {
+    if (justRecoveredTimerRef.current) {
+      clearTimeout(justRecoveredTimerRef.current);
+    }
+    setConnectionState({
+      status: "connected",
+      attempt: 0,
+      nextRetryAt: 0,
+      justRecovered: true,
+    });
+    justRecoveredTimerRef.current = setTimeout(() => {
+      setConnectionState((s) =>
+        s.justRecovered ? { ...s, justRecovered: false } : s,
+      );
+      justRecoveredTimerRef.current = null;
+    }, 2000);
+  }, []);
+
+  /**
+   * Run the initial stream factory and then keep re-attaching on drops until
+   * the run completes, pauses, the user aborts, or we exhaust attempts.
+   *
+   * `initialStream` is invoked once. After a drop, we use joinStream against
+   * the captured run_id — so the caller's POST /runs (which spawned the run)
+   * is NEVER repeated. This is the invariant the spec calls out as critical.
+   */
+  const runWithReconnect = useCallback(
+    async (
+      initialStream: () => AsyncIterable<{ event: string; data: unknown }>,
+      abortController: AbortController,
+    ): Promise<void> => {
+      let stream = initialStream();
+      let consecutiveFailures = 0;
+
+      // Top of the consume-then-maybe-reconnect loop. Each iteration consumes
+      // one stream pass; the outcome decides whether to break or re-attach.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const outcome = await processStream(stream, abortController);
+
+        if (outcome.receivedAnyEvent && consecutiveFailures > 0) {
+          // Successful resume — reset failure counter and flash the notice.
+          consecutiveFailures = 0;
+          markReconnected();
+          addSystemEvent("Reconnected to LangGraph stream.");
+        }
+
+        if (outcome.kind === "complete" || outcome.kind === "paused") {
+          // Clean end of stream — ensure connection state is "connected".
+          setConnectionState((s) =>
+            s.status === "connected" ? s : { ...s, status: "connected", attempt: 0, nextRetryAt: 0 },
+          );
+          return;
+        }
+        if (outcome.kind === "aborted") {
+          return;
+        }
+
+        // outcome.kind === "dropped" — schedule a reconnect attempt.
+        const threadId = threadIdRef.current;
+        const runId = runIdRef.current;
+        if (!threadId || !runId) {
+          // We never got a run_id — can't re-attach. Surface as a hard error.
+          setError(outcome.errorMessage ?? "Stream connection lost");
+          setConnectionState({
+            status: "disconnected",
+            attempt: consecutiveFailures,
+            nextRetryAt: 0,
+            justRecovered: false,
+          });
+          return;
+        }
+
+        consecutiveFailures += 1;
+        if (consecutiveFailures > MAX_RECONNECT_ATTEMPTS) {
+          setError(
+            `Stream disconnected — gave up after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts. ` +
+              "Use /resume to try again.",
+          );
+          setConnectionState({
+            status: "disconnected",
+            attempt: consecutiveFailures - 1,
+            nextRetryAt: 0,
+            justRecovered: false,
+          });
+          return;
+        }
+
+        const delay = nextBackoffMs(consecutiveFailures);
+        setConnectionState({
+          status: "reconnecting",
+          attempt: consecutiveFailures,
+          nextRetryAt: Date.now() + delay,
+          justRecovered: false,
+        });
+
+        await sleepUntilOrAbort(delay, abortController.signal);
+        if (abortController.signal.aborted) return;
+
+        // Refresh `lastCountRef` from the server so we don't re-emit messages
+        // we already rendered before the drop. This is the "query thread state
+        // and resume from latest checkpoint" step from the spec.
+        try {
+          const state = await clientRef.current.threads.getState(threadId);
+          const msgs = (state.values as { messages?: unknown[] })?.messages;
+          if (msgs) lastCountRef.current = msgs.length;
+        } catch {
+          // Non-fatal — joinStream will still work, we may just re-emit one
+          // or two messages. Better than failing the whole reconnect.
+        }
+        if (abortController.signal.aborted) return;
+
+        // Re-attach to the SAME run. Critically: this is `runs.joinStream`,
+        // NOT `runs.stream` — joinStream does not create a new run, it
+        // streams the existing one. The server-side run keeps executing
+        // even while we were disconnected (LangGraph's onDisconnect=continue
+        // semantics) so we just pick up where it is now.
+        try {
+          stream = clientRef.current.runs.joinStream(threadId, runId, {
+            signal: abortController.signal,
+            cancelOnDisconnect: false,
+          });
+        } catch (err) {
+          // Could not even build the joinStream call — count this as another
+          // failure and let the loop retry (or give up at the cap).
+          const msg = err instanceof Error ? err.message : String(err);
+          // Replace the iterator with one that immediately throws so the next
+          // pass through processStream returns "dropped" with this message.
+          stream = (async function* () {
+            throw new Error(msg);
+            // eslint-disable-next-line no-unreachable
+            yield undefined as unknown as { event: string; data: unknown };
+          })();
+        }
       }
     },
-    [addEvent, addSystemEvent, setRunState],
+    [processStream, sleepUntilOrAbort, markReconnected, addSystemEvent],
   );
 
   // ── Handle stream completion (shared by submit and resume) ─────
@@ -761,19 +1044,25 @@ export function useAgent({
         const streamConfig = hasConfigurable ? { configurable } : undefined;
 
         try {
-          const stream = client.runs.stream(
-            threadIdRef.current!,
-            getAssistantOverride() || assistantIdRef.current,
-            {
-              input,
-              ...(streamConfig ? { config: streamConfig } : {}),
-              ...STREAM_OPTIONS,
-              onDisconnect: "continue",
-              signal: abortController.signal,
-            },
+          // The initial stream factory is invoked exactly once by
+          // runWithReconnect. On a drop, the loop switches to joinStream
+          // against the captured run_id — so this `runs.stream` call
+          // (which POSTs a new run) is NEVER repeated.
+          await runWithReconnect(
+            () =>
+              client.runs.stream(
+                threadIdRef.current!,
+                getAssistantOverride() || assistantIdRef.current,
+                {
+                  input,
+                  ...(streamConfig ? { config: streamConfig } : {}),
+                  ...STREAM_OPTIONS,
+                  onDisconnect: "continue",
+                  signal: abortController.signal,
+                },
+              ),
+            abortController,
           );
-
-          await processStream(stream, abortController);
         } catch (err) {
           // Ignore abort errors — triggered by interrupt() or cancel()
           if (abortController.signal.aborted) return;
@@ -793,7 +1082,7 @@ export function useAgent({
         resetStreamState();
       });
     },
-    [addEvent, processStream, handleStreamComplete, resetStreamState],
+    [addEvent, runWithReconnect, handleStreamComplete, resetStreamState],
   );
 
   // Ref to submit for use in deferred auto-submit (avoids stale closure)
@@ -847,17 +1136,20 @@ export function useAgent({
         });
 
         try {
-          const stream = client.runs.stream(
-            threadIdRef.current!,
-            getAssistantOverride() || assistantIdRef.current,
-            {
-              command: { resume: value },
-              ...STREAM_OPTIONS,
-              onDisconnect: "continue",
-              signal: abortController.signal,
-            },
+          await runWithReconnect(
+            () =>
+              client.runs.stream(
+                threadIdRef.current!,
+                getAssistantOverride() || assistantIdRef.current,
+                {
+                  command: { resume: value },
+                  ...STREAM_OPTIONS,
+                  onDisconnect: "continue",
+                  signal: abortController.signal,
+                },
+              ),
+            abortController,
           );
-          await processStream(stream, abortController);
         } catch (err) {
           if (abortController.signal.aborted) return;
           setError(err instanceof Error ? err.message : "Answer submit failed");
@@ -873,7 +1165,7 @@ export function useAgent({
         resetStreamState();
       });
     },
-    [addEvent, processStream, handleStreamComplete, resetStreamState],
+    [addEvent, runWithReconnect, handleStreamComplete, resetStreamState],
   );
 
   // ── Resume (pause point OR previous session) ───────────────────
@@ -909,17 +1201,20 @@ export function useAgent({
           setStreamStats({ startTime: Date.now(), totalTokens: 0, promptTokens: 0, completionTokens: 0 });
 
           try {
-            const stream = client.runs.stream(
-              threadIdRef.current!,
-              getAssistantOverride() || assistantIdRef.current,
-              {
-                command: { resume: value ?? true },
-                ...STREAM_OPTIONS,
-                onDisconnect: "continue",
-                signal: abortController.signal,
-              },
+            await runWithReconnect(
+              () =>
+                client.runs.stream(
+                  threadIdRef.current!,
+                  getAssistantOverride() || assistantIdRef.current,
+                  {
+                    command: { resume: value ?? true },
+                    ...STREAM_OPTIONS,
+                    onDisconnect: "continue",
+                    signal: abortController.signal,
+                  },
+                ),
+              abortController,
             );
-            await processStream(stream, abortController);
           } catch (err) {
             if (abortController.signal.aborted) return;
             setError(err instanceof Error ? err.message : "Resume failed");
@@ -974,7 +1269,7 @@ export function useAgent({
       // Case 3: Nothing to resume
       addEvent({ type: "system", content: "Nothing to resume." });
     },
-    [addEvent, processStream, handleStreamComplete, resetStreamState],
+    [addEvent, runWithReconnect, handleStreamComplete, resetStreamState],
   );
 
   return {
@@ -995,6 +1290,7 @@ export function useAgent({
     activeQuestion,
     answerQuestion,
     error,
+    connectionState,
     clearEvents,
     addSystemEvent,
   };

--- a/clients/cli/src/hooks/useReconnect.test.ts
+++ b/clients/cli/src/hooks/useReconnect.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  nextBackoffMs,
+  BACKOFF_SCHEDULE_MS,
+  BACKOFF_CAP_MS,
+  MAX_RECONNECT_ATTEMPTS,
+} from "./useReconnect.js";
+
+describe("nextBackoffMs", () => {
+  it("returns 0 when no failures yet (initial connect)", () => {
+    expect(nextBackoffMs(0)).toBe(0);
+  });
+
+  it("treats negative input as 'no failures yet' (defensive)", () => {
+    expect(nextBackoffMs(-1)).toBe(0);
+    expect(nextBackoffMs(-100)).toBe(0);
+  });
+
+  it("follows the documented schedule 1/2/4/8/16 seconds", () => {
+    expect(nextBackoffMs(1)).toBe(1000);
+    expect(nextBackoffMs(2)).toBe(2000);
+    expect(nextBackoffMs(3)).toBe(4000);
+    expect(nextBackoffMs(4)).toBe(8000);
+    expect(nextBackoffMs(5)).toBe(16000);
+  });
+
+  it("caps at 16s for any further failures", () => {
+    expect(nextBackoffMs(6)).toBe(16000);
+    expect(nextBackoffMs(7)).toBe(16000);
+    expect(nextBackoffMs(100)).toBe(16000);
+  });
+});
+
+describe("backoff constants", () => {
+  it("exposes the exact schedule the spec mandates", () => {
+    expect([...BACKOFF_SCHEDULE_MS]).toEqual([1000, 2000, 4000, 8000, 16000]);
+  });
+
+  it("cap equals the last entry in the schedule", () => {
+    expect(BACKOFF_CAP_MS).toBe(16000);
+    expect(BACKOFF_SCHEDULE_MS[BACKOFF_SCHEDULE_MS.length - 1]).toBe(
+      BACKOFF_CAP_MS,
+    );
+  });
+
+  it("max attempts is a positive integer", () => {
+    expect(Number.isInteger(MAX_RECONNECT_ATTEMPTS)).toBe(true);
+    expect(MAX_RECONNECT_ATTEMPTS).toBeGreaterThan(0);
+  });
+});

--- a/clients/cli/src/hooks/useReconnect.ts
+++ b/clients/cli/src/hooks/useReconnect.ts
@@ -1,0 +1,61 @@
+/**
+ * useReconnect — backoff scheduling for the CLI's LangGraph stream.
+ *
+ * The CLI streams events from LangGraph over HTTP (the @langchain/langgraph-sdk
+ * Client wraps SSE/WebSocket transport). When LangGraph or its upstream LiteLLM
+ * sidecar restarts, the stream drops mid-run and the operator used to need a
+ * Ctrl+C + relaunch to recover.
+ *
+ * This module exposes the pure scheduler used by useAgent's reconnect loop so
+ * the schedule itself can be unit-tested without spinning up the React hook
+ * and the mock SDK. The full loop (joinStream + thread-state resume + UI
+ * notice) lives in useAgent.ts.
+ *
+ * Schedule (from docs/fork/2026-05-26-decepticon-mac-fork-design.md §5.7):
+ *
+ *   attempt 1 → 1s
+ *   attempt 2 → 2s
+ *   attempt 3 → 4s
+ *   attempt 4 → 8s
+ *   attempt 5+ → 16s (cap)
+ *
+ * The counter resets to 0 once a single message lands on a freshly reconnected
+ * stream, so a stable connection that flickers once doesn't lock us into the
+ * cap on the next blip.
+ */
+
+/** Backoff schedule in milliseconds: 1s, 2s, 4s, 8s, 16s. */
+export const BACKOFF_SCHEDULE_MS = [1000, 2000, 4000, 8000, 16000] as const;
+
+/** Maximum delay between reconnect attempts (cap once the schedule is exhausted). */
+export const BACKOFF_CAP_MS = 16000;
+
+/**
+ * Maximum total consecutive reconnect attempts before we give up and surface a
+ * hard error to the operator. The CLI then transitions to a `"disconnected"`
+ * connection status and the run is treated as failed.
+ *
+ * Eight attempts at the documented schedule covers roughly the first ~75
+ * seconds of an outage — enough to ride out a LangGraph restart or a LiteLLM
+ * blip without giving up too aggressively. Beyond that, something is wrong
+ * with the operator's setup and surfacing the error is more useful than
+ * silently retrying.
+ */
+export const MAX_RECONNECT_ATTEMPTS = 8;
+
+/**
+ * Returns the next backoff delay (ms) given the count of consecutive failures.
+ *
+ * - 0 failures → 0 (caller has not yet observed a drop; no delay).
+ * - 1..5 failures → the documented schedule above.
+ * - 6+ failures → BACKOFF_CAP_MS.
+ *
+ * The `consecutiveFailures` argument is "the number of failed attempts so far
+ * including the one that just happened" — so the first call after a drop
+ * passes `1` and gets back `1000`.
+ */
+export function nextBackoffMs(consecutiveFailures: number): number {
+  if (consecutiveFailures <= 0) return 0;
+  const idx = Math.min(consecutiveFailures - 1, BACKOFF_SCHEDULE_MS.length - 1);
+  return BACKOFF_SCHEDULE_MS[idx] ?? BACKOFF_CAP_MS;
+}

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -21,6 +21,7 @@ import { useAppState } from "../state/AppState.js";
 import { Banner } from "../components/Banner.js";
 import { EventItem } from "../components/EventItem.js";
 import { ActivityIndicator } from "../components/ActivityIndicator.js";
+import { ConnectionStatus } from "../components/ConnectionStatus.js";
 import { OpplanStatus } from "../components/OpplanStatus.js";
 import { Prompt } from "../components/Prompt.js";
 import { QuestionPicker } from "../components/QuestionPicker.js";
@@ -267,6 +268,10 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
             runState={agent.runState}
             streamStats={agent.streamStats}
           />
+
+          {/* Stream reconnection notice — yellow during backoff, green flash
+              on recovery, red after giving up. Renders nothing when healthy. */}
+          <ConnectionStatus state={agent.connectionState} />
 
           {/* Persistent OPPLAN display */}
           {opplan && opplan.objectives.length > 0 && (


### PR DESCRIPTION
## Problem

The CLI's LangGraph SDK stream drops mid-run when LangGraph or its upstream LiteLLM sidecar restarts. Previously the operator had to `Ctrl+C` the CLI and relaunch — the server-side run kept executing but the operator lost all visibility into it.

## Fix

`useAgent` now wraps stream consumption in a backoff-driven reconnect loop. On a drop (iteration throws **or** stream ends without a `completionReceived` AI message):

1. Increment a consecutive-failure counter.
2. Flip `connectionState` to `\"reconnecting\"` with attempt + nextRetryAt.
3. Sleep `nextBackoffMs(n)` — **1s, 2s, 4s, 8s, 16s, then cap at 16s** (matches §5.7 spec exactly).
4. Refresh local message count from `threads.getState()` so we don't re-render messages we already showed.
5. Call `runs.joinStream(threadId, runId)` to **re-attach to the same server-side run**.

After `MAX_RECONNECT_ATTEMPTS` (8) consecutive failures the loop gives up, sets `connectionState` to `\"disconnected\"`, and surfaces a hard error so the operator can `/resume` manually.

### Critical invariant — no duplicate run dispatch

The initial `runs.stream()` factory passed to `runWithReconnect` is invoked **exactly once**. Every subsequent reconnect attempt uses `runs.joinStream(threadId, runId)`, which re-attaches to the existing run rather than POSTing a new one. Asserted by the integration tests in `useAgent.reconnect.test.tsx`.

## UI

New `ConnectionStatus.tsx` renders:

- Nothing while healthy (no layout shift).
- Yellow `Reconnecting (attempt N, next try in Xs)…` countdown during backoff.
- 2s green `Reconnected.` flash on recovery.
- Red `Disconnected from server — type /resume to try again.` after giving up.

Wired into `REPL.tsx` between `ActivityIndicator` and the prompt so it's visible without interrupting input.

## Tests

33 pass (21 baseline + 7 new useReconnect + 5 new reconnect integration).

- `useReconnect.test.ts` — pure backoff scheduler: 0 → 0, 1..5 → schedule, 6+ → cap.
- `useAgent.reconnect.test.tsx`:
  - re-attach via `joinStream` after drop with **no duplicate POST** to `runs.stream`,
  - thread state fetched before resume,
  - status transitions `connected → reconnecting → connected`,
  - hard error + `disconnected` after `MAX_RECONNECT_ATTEMPTS`,
  - clean stream completion never flips status,
  - operator cancel during backoff bails out cleanly.

## Files

- `clients/cli/src/hooks/useReconnect.ts` (new) — `nextBackoffMs(n)`, schedule + cap constants, `MAX_RECONNECT_ATTEMPTS`.
- `clients/cli/src/hooks/useReconnect.test.ts` (new)
- `clients/cli/src/hooks/useAgent.ts` — `processStream` now returns a typed `StreamOutcome`; new `runWithReconnect` wrapper; new `ConnectionStatus`/`ConnectionState` exports; three call sites (submit / answerQuestion / resume) routed through the wrapper.
- `clients/cli/src/hooks/useAgent.reconnect.test.tsx` (new)
- `clients/cli/src/hooks/__fixtures__/mockStream.ts` — added `joinStream` to `MockClient`.
- `clients/cli/src/components/ConnectionStatus.tsx` (new)
- `clients/cli/src/screens/REPL.tsx` — rendered `<ConnectionStatus>` below `<ActivityIndicator>`.

Refs `docs/fork/2026-05-26-decepticon-mac-fork-design.md` §5.7.