### PR TITLE
feat(web): optional auth (password / bind-restriction) for non-localhost deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,36 @@ LANGSMITH_TRACING=false
 LANGSMITH_API_KEY=your-langsmith-key-here
 LANGSMITH_PROJECT=decepticon
 
+# --- Web / terminal auth (optional; default: no auth — localhost only) ---
+# Decepticon's web dashboard + terminal WebSocket are unauthenticated by
+# default. This is safe when bound to localhost (the default), but if you
+# expose the ports off-host (port-forward, reverse proxy without auth,
+# tailscale subnet routing, etc.) anyone on that network can drive the
+# agent — execute commands inside the sandbox, exfiltrate engagement
+# data, the works. Set this var to opt into one of two protective modes.
+#
+# Modes:
+#
+#   none                          (default) — today's behavior; no auth.
+#
+#   password:<scrypt-hash>        Require HTTP basic auth on the web
+#                                 dashboard and a derived token on the
+#                                 terminal WebSocket. Generate the hash
+#                                 with the recipe in SECURITY.md
+#                                 (`hashPassword()` in
+#                                 clients/web/src/lib/auth-mode.ts).
+#                                 Treat the hash as a credential.
+#
+#   disable-bind-public           Defense in depth — the terminal server
+#                                 refuses to bind to anything other than
+#                                 127.0.0.1 / ::1 / localhost. Hard-fails
+#                                 startup if it would otherwise bind a
+#                                 public interface.
+#
+# See SECURITY.md → "Web dashboard authentication" for the threat model,
+# the scrypt-vs-bcrypt rationale, and reverse-proxy guidance.
+# DECEPTICON_WEB_AUTH=none
+
 # --- Ports (optional) ---
 # Override host-side ports when running multiple Decepticon stacks
 # side by side, or when one of the defaults clashes with another

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,72 @@ If you discover a security vulnerability in Decepticon, please report it respons
 ## Responsible Use
 
 Decepticon is an offensive security tool designed for **authorized** red team engagements only. Users are responsible for ensuring they have proper authorization before using Decepticon against any target. See the [LICENSE](LICENSE) for terms of use.
+
+## Web dashboard authentication
+
+The web dashboard (default `http://localhost:3000`) and the terminal WebSocket (default `ws://localhost:3003`) are **unauthenticated by design** in the upstream stack. The threat model assumes a single operator on a single host: both ports bind to `localhost`, and anyone with shell access to that host can already drive the agent.
+
+That model breaks the moment the ports are reachable from another machine — VPN, tailscale subnet routing, port-forward through a reverse proxy, accidentally binding `0.0.0.0` in compose, etc. At that point an unauthenticated remote caller can execute arbitrary commands in the sandbox, exfiltrate engagement data, and modify findings.
+
+The `DECEPTICON_WEB_AUTH` env var (introduced in the `decepticon-mac` fork) is an **opt-in** hardening switch. The default is unchanged — operators who don't set it see the same behavior as upstream.
+
+### Modes
+
+| Value | Effect |
+|---|---|
+| `none` (default, unset, or empty) | No authentication. Today's upstream behavior. Safe only on localhost. |
+| `password:<scrypt-hash>` | HTTP basic auth on every API route; the terminal WS handshake requires a token derived from the same hash. |
+| `disable-bind-public` | The terminal server refuses to bind to anything other than 127.0.0.1 / ::1 / localhost. Defense in depth for deployments that should never be remote. |
+
+Malformed values throw at startup — Decepticon will not silently downgrade to "no auth" if you fat-finger the env var.
+
+### Generating a password hash
+
+The hash format is `scrypt$N$r$p$<base64-salt>$<base64-key>`. The scrypt parameters default to `N=16384, r=8, p=1` (the Node `crypto` defaults), which OWASP rates as adequate for an interactive login flow on modern hardware. Operators on slower hardware can raise `N` to 32768 or 65536.
+
+From inside `clients/web/`, you can produce a hash with a one-liner. Example (from the repo root):
+
+```bash
+cd clients/web
+npx tsx -e 'import("./src/lib/auth-mode.ts").then(m => console.log(m.hashPassword(process.argv[1])))' 'your-strong-password'
+```
+
+Set the result as the env var:
+
+```bash
+DECEPTICON_WEB_AUTH=password:scrypt$16384$8$1$<salt>$<key>
+```
+
+The hash itself is sensitive — anyone who can read it can mint valid terminal-WS tokens (it's the HMAC key for the WS handshake). Treat it like a password: keep `~/.decepticon/.env` mode 0600 and never commit it.
+
+### Why scrypt rather than bcrypt
+
+The fork uses Node's built-in `crypto.scrypt` rather than bringing in the `bcrypt` npm package:
+
+- No new native-dep build at install time (`bcrypt` ships a node-gyp binding).
+- scrypt is a well-respected, memory-hard KDF (RFC 7914) and is the algorithm OWASP recommends alongside argon2 / bcrypt.
+- The implementation is in-tree (`clients/web/src/lib/auth-mode.ts`) and auditable — no transitive dep to track CVEs against.
+
+If you'd prefer bcrypt or argon2, replace the `hashPassword` / `verifyPassword` helpers; the rest of the auth bridge doesn't care which KDF was used as long as the env format is `password:<opaque-hash>`.
+
+### Reverse-proxy deployments
+
+If you put Decepticon behind a reverse proxy (nginx, traefik, Caddy), make sure the proxy **forwards** the `Authorization` header rather than terminating basic auth at the proxy and stripping it. Some default proxy configs strip `Authorization` to avoid leaking creds to the upstream — that turns Decepticon's auth into an "always 401" wall. Either:
+
+- Configure the proxy to forward `Authorization` and let Decepticon do the check, or
+- Terminate auth at the proxy and bind Decepticon to `127.0.0.1` only (use `DECEPTICON_WEB_AUTH=disable-bind-public` to enforce this), or
+- Use both (defense in depth — the proxy is the public auth gate; Decepticon's own auth is a backstop in case the proxy is misconfigured).
+
+### Threat model summary
+
+| Threat | Mitigation |
+|---|---|
+| Unauthenticated remote driver | `password:` mode requires HTTP basic auth + WS token. |
+| Token replay across services | The WS token is HMAC'd over a fixed `decepticon.web-auth.ws-token.v1` label for domain separation. |
+| Timing-side-channel on credential compare | `crypto.timingSafeEqual` on both password verification and WS-token compare. |
+| Brute force of the scrypt | `N=16384` is OWASP-adequate; raise for sensitive deployments. scrypt is memory-hard, so GPU brute-force is expensive. |
+| Accidental public bind | `disable-bind-public` mode hard-fails startup if the configured host isn't loopback. |
+| WebSocket bypass of HTTP middleware | The WS handshake is independently authenticated via the token mechanism; the HTTP auth check on web routes is enforced separately in `auth-bridge.ts`. |
+| Reverse-proxy strips `Authorization` | Documented above; recommended workaround is loopback bind + proxy-side auth. |
+
+Issues with the auth design should be reported via the same channels as any other security issue (see "Reporting a Vulnerability" above).

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -12,6 +12,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
 
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
@@ -79,7 +81,9 @@
     "eslint-config-next": "16.2.3",
 
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+
+    "vitest": "^2.1.9"
   },
 
   "optionalDependencies": {

--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -29,6 +29,9 @@ import { WebSocketServer, WebSocket } from "ws";
 import * as pty from "node-pty";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { parseAuthMode, type AuthMode } from "../src/lib/auth-mode";
+import { deriveWsToken, extractWsToken, tokensEqual } from "../src/lib/auth-token";
+import { assertLoopbackHost, isLoopbackHost } from "../src/lib/bind-public";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -40,6 +43,32 @@ const LANGGRAPH_API_URL = process.env.LANGGRAPH_API_URL ?? "http://localhost:202
 const ORPHAN_TTL = 60_000; // Kill orphaned PTYs after 60s with no WS
 const SCROLLBACK_LIMIT = 50_000; // chars of recent output to buffer for reattach
 
+// Auth mode is parsed once at startup. Bad values throw — fail loud, never
+// silently degrade to no-auth.
+const AUTH_MODE: AuthMode = parseAuthMode(process.env.DECEPTICON_WEB_AUTH);
+
+// The host the WS server listens on. Default behavior is unchanged:
+// `new WebSocketServer({ port })` binds to all interfaces, matching upstream.
+// `disable-bind-public` mode forces 127.0.0.1.
+const TERMINAL_HOST_RAW = process.env.TERMINAL_HOST ?? "";
+
+let LISTEN_HOST: string | undefined;
+if (AUTH_MODE.kind === "disable-bind-public") {
+  // Hard-fail if the operator asked for loopback-only but also set
+  // TERMINAL_HOST to something public — we won't silently override their
+  // intent in either direction, just refuse to start.
+  if (TERMINAL_HOST_RAW && !isLoopbackHost(TERMINAL_HOST_RAW)) {
+    assertLoopbackHost(TERMINAL_HOST_RAW, "TERMINAL_HOST"); // throws
+  }
+  LISTEN_HOST = TERMINAL_HOST_RAW || "127.0.0.1";
+} else if (TERMINAL_HOST_RAW) {
+  LISTEN_HOST = TERMINAL_HOST_RAW;
+}
+
+// WS handshake token (only computed when password mode is on).
+const EXPECTED_WS_TOKEN =
+  AUTH_MODE.kind === "password" ? deriveWsToken(AUTH_MODE.hash.raw) : null;
+
 const ALLOWED_ORIGINS = new Set(
   (process.env.TERMINAL_ALLOWED_ORIGINS ?? `http://localhost:${WEB_PORT},http://127.0.0.1:${WEB_PORT}`)
     .split(",")
@@ -47,8 +76,11 @@ const ALLOWED_ORIGINS = new Set(
     .filter(Boolean),
 );
 
-const wss = new WebSocketServer({ port: PORT });
-console.log(`[terminal-server] Listening on ws://localhost:${PORT}`);
+const wss = new WebSocketServer(LISTEN_HOST ? { port: PORT, host: LISTEN_HOST } : { port: PORT });
+console.log(
+  `[terminal-server] Listening on ws://${LISTEN_HOST ?? "0.0.0.0"}:${PORT} ` +
+    `(auth=${AUTH_MODE.kind})`,
+);
 
 // ── Session Pool ─────────────────────────────────────────────────
 
@@ -133,6 +165,18 @@ wss.on("connection", async (ws: WebSocket, req) => {
   }
 
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+
+  // ── Token check (password mode only) ──
+  // In `none` / `disable-bind-public` modes, EXPECTED_WS_TOKEN is null
+  // and we skip — preserving today's behavior exactly.
+  if (EXPECTED_WS_TOKEN) {
+    const provided = extractWsToken(req.headers.authorization, url);
+    if (!provided || !tokensEqual(provided, EXPECTED_WS_TOKEN)) {
+      ws.close(1008, "Unauthorized");
+      return;
+    }
+  }
+
   const engagementId = url.searchParams.get("engagementId") ?? "";
   const engagementSlug = url.searchParams.get("engagementSlug") ?? "";
   const agentId = url.searchParams.get("agentId") ?? "soundwave";

--- a/clients/web/src/lib/auth-bridge.test.ts
+++ b/clients/web/src/lib/auth-bridge.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  AuthError,
+  requireAuth,
+  isAuthEnabled,
+  __resetAuthModeCacheForTests,
+} from "./auth-bridge";
+import { hashPassword } from "./auth-mode";
+
+const PLAINTEXT = "hunter2";
+const HASH = hashPassword(PLAINTEXT, { N: 1024 }); // cheap N for tests
+
+function basicAuth(user: string, pass: string): string {
+  return "Basic " + Buffer.from(`${user}:${pass}`).toString("base64");
+}
+
+describe("requireAuth — default (no auth)", () => {
+  beforeEach(() => {
+    delete process.env.DECEPTICON_WEB_AUTH;
+    __resetAuthModeCacheForTests();
+  });
+
+  afterEach(() => {
+    __resetAuthModeCacheForTests();
+  });
+
+  it("returns the local user when DECEPTICON_WEB_AUTH is unset (regression guard for default behavior)", async () => {
+    const result = await requireAuth();
+    expect(result).toEqual({ userId: "local", session: null });
+  });
+
+  it("isAuthEnabled() is false in default mode", () => {
+    expect(isAuthEnabled()).toBe(false);
+  });
+
+  it("returns the local user when DECEPTICON_WEB_AUTH=none", async () => {
+    process.env.DECEPTICON_WEB_AUTH = "none";
+    __resetAuthModeCacheForTests();
+    const result = await requireAuth();
+    expect(result).toEqual({ userId: "local", session: null });
+  });
+
+  it("returns the local user even with garbage in the Authorization header (default mode)", async () => {
+    const req = new Request("http://localhost/", {
+      headers: { authorization: "Bearer total-garbage" },
+    });
+    const result = await requireAuth(req);
+    expect(result).toEqual({ userId: "local", session: null });
+  });
+});
+
+describe("requireAuth — password mode", () => {
+  beforeEach(() => {
+    process.env.DECEPTICON_WEB_AUTH = `password:${HASH}`;
+    __resetAuthModeCacheForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.DECEPTICON_WEB_AUTH;
+    __resetAuthModeCacheForTests();
+  });
+
+  it("isAuthEnabled() is true", () => {
+    expect(isAuthEnabled()).toBe(true);
+  });
+
+  it("rejects requests with no Authorization header", async () => {
+    const req = new Request("http://localhost/");
+    await expect(requireAuth(req)).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("rejects requests with a malformed Authorization header", async () => {
+    const req = new Request("http://localhost/", {
+      headers: { authorization: "Basic !!!not-base64!!!" },
+    });
+    await expect(requireAuth(req)).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("accepts requests with the correct credentials", async () => {
+    const req = new Request("http://localhost/", {
+      headers: { authorization: basicAuth("admin", PLAINTEXT) },
+    });
+    const result = await requireAuth(req);
+    expect(result).toEqual({ userId: "local", session: null });
+  });
+
+  it("rejects requests with the wrong password", async () => {
+    const req = new Request("http://localhost/", {
+      headers: { authorization: basicAuth("admin", "wrongpassword") },
+    });
+    await expect(requireAuth(req)).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("accepts a plain Headers object too", async () => {
+    const h = new Headers({ authorization: basicAuth("any", PLAINTEXT) });
+    const result = await requireAuth(h);
+    expect(result).toEqual({ userId: "local", session: null });
+  });
+});
+
+describe("requireAuth — disable-bind-public mode", () => {
+  beforeEach(() => {
+    process.env.DECEPTICON_WEB_AUTH = "disable-bind-public";
+    __resetAuthModeCacheForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.DECEPTICON_WEB_AUTH;
+    __resetAuthModeCacheForTests();
+  });
+
+  it("auth layer behaves like 'none' — bind restriction is enforced elsewhere", async () => {
+    const result = await requireAuth();
+    expect(result).toEqual({ userId: "local", session: null });
+  });
+
+  it("isAuthEnabled() is false (no per-request auth)", () => {
+    expect(isAuthEnabled()).toBe(false);
+  });
+});
+
+describe("requireAuth — malformed env aborts at first call (fail loud)", () => {
+  beforeEach(() => {
+    process.env.DECEPTICON_WEB_AUTH = "garbage-value";
+    __resetAuthModeCacheForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.DECEPTICON_WEB_AUTH;
+    __resetAuthModeCacheForTests();
+  });
+
+  it("throws synchronously rather than silently degrading to 'none'", async () => {
+    // Note: the parse error is thrown from inside requireAuth when it first
+    // resolves the mode. We want to verify we don't quietly return success.
+    await expect(requireAuth()).rejects.toThrow(/DECEPTICON_WEB_AUTH/);
+  });
+});

--- a/clients/web/src/lib/auth-bridge.ts
+++ b/clients/web/src/lib/auth-bridge.ts
@@ -1,9 +1,18 @@
 /**
- * Auth bridge — single-user local deploy.
+ * Auth bridge — single-user local deploy, with optional opt-in auth.
  *
- * Decepticon is self-hosted and single-user. There is no authentication
- * system; every request resolves to the local user.
+ * Decepticon is self-hosted and single-user by default. The historical
+ * behavior is "every request resolves to the local user" — no
+ * authentication at all. That stays the default.
+ *
+ * Operators who expose the dashboard off-host can opt in via the
+ * `DECEPTICON_WEB_AUTH` env var (see ./auth-mode.ts). When set to
+ * `password:<scrypt>`, this module enforces HTTP basic auth on the
+ * request headers; missing or wrong creds raise `AuthError`, which the
+ * route handlers already translate into a 401.
  */
+
+import { parseAuthMode, verifyPassword, type AuthMode } from "./auth-mode";
 
 export class AuthError extends Error {
   constructor(message = "Unauthorized") {
@@ -17,7 +26,104 @@ export interface AuthResult {
   session: null;
 }
 
-export async function requireAuth(): Promise<AuthResult> {
+// Parse once at module load. A bad env value should fail loud at startup
+// rather than silently degrading to no-auth at request time.
+let cachedMode: AuthMode | undefined;
+
+function getMode(): AuthMode {
+  if (cachedMode === undefined) {
+    cachedMode = parseAuthMode(process.env.DECEPTICON_WEB_AUTH);
+  }
+  return cachedMode;
+}
+
+/** Test-only — reset the cached mode so tests can flip `DECEPTICON_WEB_AUTH`. */
+export function __resetAuthModeCacheForTests(): void {
+  cachedMode = undefined;
+}
+
+/**
+ * The basic-auth header parser. Accepts the request's `Authorization`
+ * header value (or undefined). Returns `[user, pass]` or `null`.
+ */
+function parseBasicAuthHeader(header: string | null | undefined): [string, string] | null {
+  if (!header) return null;
+  const m = /^Basic\s+([A-Za-z0-9+/=]+)$/.exec(header);
+  if (!m) return null;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(m[1], "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+  const i = decoded.indexOf(":");
+  if (i < 0) return null;
+  return [decoded.slice(0, i), decoded.slice(i + 1)];
+}
+
+/**
+ * Lazy import of `next/headers`. We avoid a static import so this module
+ * stays loadable in plain Node (e.g. vitest) outside the Next.js request
+ * context.
+ */
+async function readNextAuthHeader(): Promise<string | null> {
+  try {
+    const mod = await import("next/headers");
+    // next/headers `headers()` may be sync or async depending on Next version.
+    // In Next 15+ it's async; we await defensively.
+    const h = await (mod.headers as () => Promise<Headers> | Headers)();
+    return h.get("authorization");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Authenticate the current request.
+ *
+ * - In `none` mode: returns the local user (today's behavior).
+ * - In `password` mode: pulls the `Authorization: Basic ...` header from
+ *   the current Next.js request context (`next/headers`), or accepts an
+ *   explicit `Headers`/`Request` passed by the caller. Throws AuthError
+ *   on missing / wrong credentials.
+ * - In `disable-bind-public` mode: behaves like `none` at the auth
+ *   layer; the bind restriction is enforced at server startup.
+ */
+export async function requireAuth(
+  reqOrHeaders?: Request | Headers | { headers?: Headers | { get?(k: string): string | null } },
+): Promise<AuthResult> {
+  const mode = getMode();
+  if (mode.kind !== "password") {
+    return { userId: "local", session: null };
+  }
+
+  // Resolve an Authorization header from the caller-supplied source first,
+  // falling back to `next/headers` so existing callers like
+  // `await requireAuth()` keep working.
+  let authHeader: string | null = null;
+  if (reqOrHeaders) {
+    if (reqOrHeaders instanceof Request) {
+      authHeader = reqOrHeaders.headers.get("authorization");
+    } else if (reqOrHeaders instanceof Headers) {
+      authHeader = reqOrHeaders.get("authorization");
+    } else if (reqOrHeaders.headers) {
+      const h = reqOrHeaders.headers;
+      if (h instanceof Headers) authHeader = h.get("authorization");
+      else if (typeof h.get === "function") authHeader = h.get("authorization");
+    }
+  }
+  if (!authHeader) {
+    authHeader = await readNextAuthHeader();
+  }
+
+  const creds = parseBasicAuthHeader(authHeader);
+  if (!creds) {
+    throw new AuthError("Missing or malformed Authorization header");
+  }
+  const [, password] = creds;
+  if (!verifyPassword(password, mode.hash)) {
+    throw new AuthError("Invalid credentials");
+  }
   return { userId: "local", session: null };
 }
 
@@ -25,6 +131,16 @@ export async function getSession(): Promise<null> {
   return null;
 }
 
+/**
+ * `true` when the operator has opted into password auth. Used by UI
+ * code that wants to show / hide a login affordance — does **not**
+ * affect server-side enforcement (that's `requireAuth`).
+ */
 export function isAuthEnabled(): boolean {
-  return false;
+  return getMode().kind === "password";
+}
+
+/** Test-only escape hatch — returns the parsed mode without exposing the cache var. */
+export function __getAuthModeForTests(): AuthMode {
+  return getMode();
 }

--- a/clients/web/src/lib/auth-mode.test.ts
+++ b/clients/web/src/lib/auth-mode.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { parseAuthMode, parseScryptHash, hashPassword, verifyPassword } from "./auth-mode";
+
+describe("parseAuthMode", () => {
+  it("defaults to {kind:'none'} when env is undefined", () => {
+    expect(parseAuthMode(undefined)).toEqual({ kind: "none" });
+  });
+
+  it("treats empty / whitespace as none (preserves default behavior)", () => {
+    expect(parseAuthMode("")).toEqual({ kind: "none" });
+    expect(parseAuthMode("   ")).toEqual({ kind: "none" });
+  });
+
+  it("parses 'none' explicitly", () => {
+    expect(parseAuthMode("none")).toEqual({ kind: "none" });
+  });
+
+  it("parses 'disable-bind-public'", () => {
+    expect(parseAuthMode("disable-bind-public")).toEqual({ kind: "disable-bind-public" });
+  });
+
+  it("parses 'password:<scrypt-hash>'", () => {
+    const hash = hashPassword("hunter2", { N: 1024 });
+    const result = parseAuthMode(`password:${hash}`);
+    expect(result.kind).toBe("password");
+    if (result.kind === "password") {
+      expect(result.hash.raw).toBe(hash);
+      expect(result.hash.N).toBe(1024);
+    }
+  });
+
+  it("throws on garbage", () => {
+    expect(() => parseAuthMode("garbage")).toThrow(/DECEPTICON_WEB_AUTH/);
+  });
+
+  it("throws on 'password:' with a non-scrypt payload", () => {
+    expect(() => parseAuthMode("password:notavalidhash")).toThrow(/scrypt/i);
+  });
+
+  it("throws on 'password:' with a bcrypt-looking payload (we only support scrypt)", () => {
+    expect(() => parseAuthMode("password:$2b$12$abcdefghijklmnop")).toThrow(/scrypt/i);
+  });
+
+  it("throws on a malformed scrypt hash (wrong number of fields)", () => {
+    expect(() => parseAuthMode("password:scrypt$1024$8$1$onlyfivefields")).toThrow(
+      /6 .*-separated fields/,
+    );
+  });
+
+  it("throws on a non-power-of-two N", () => {
+    expect(() => parseScryptHash("scrypt$1023$8$1$YWFh$YmJi")).toThrow(/power of two/);
+  });
+});
+
+describe("hashPassword / verifyPassword", () => {
+  it("verifies the correct plaintext", () => {
+    const hash = hashPassword("correct horse battery staple", { N: 1024 });
+    const parsed = parseScryptHash(hash);
+    expect(verifyPassword("correct horse battery staple", parsed)).toBe(true);
+  });
+
+  it("rejects a wrong plaintext", () => {
+    const hash = hashPassword("hunter2", { N: 1024 });
+    const parsed = parseScryptHash(hash);
+    expect(verifyPassword("hunter3", parsed)).toBe(false);
+  });
+
+  it("produces unique hashes for the same plaintext (random salt)", () => {
+    const a = hashPassword("p", { N: 1024 });
+    const b = hashPassword("p", { N: 1024 });
+    expect(a).not.toBe(b);
+  });
+});

--- a/clients/web/src/lib/auth-mode.ts
+++ b/clients/web/src/lib/auth-mode.ts
@@ -1,0 +1,150 @@
+/**
+ * Auth-mode parser for the web dashboard + terminal WebSocket.
+ *
+ * The default is **unchanged** from upstream Decepticon: no authentication.
+ * That's fine on localhost, but exposing the ports off-host (port-forward,
+ * reverse proxy, etc.) hands an unauthenticated agent driver to the network.
+ *
+ * Operators can opt in via the `DECEPTICON_WEB_AUTH` env var:
+ *
+ *   - `none`                    — today's behavior (default).
+ *   - `password:<scrypt>`       — HTTP basic auth on web routes; WebSocket
+ *                                 handshake requires a token derived from
+ *                                 the same scrypt hash via HMAC-SHA256.
+ *   - `disable-bind-public`     — server hard-fails startup if it would
+ *                                 bind to anything other than loopback.
+ *
+ * The scrypt format is `scrypt$<N>$<r>$<p>$<base64-salt>$<base64-key>` —
+ * see `hashPassword()` / `verifyPassword()` in this file for the helpers,
+ * and `SECURITY.md` for the operator-facing recipe.
+ *
+ * We use `node:crypto.scryptSync` rather than bringing in `bcrypt`:
+ *   - no new native-dep build at install time
+ *   - scrypt is a well-respected, memory-hard KDF (RFC 7914)
+ *   - implementation is in-tree and auditable
+ *
+ * Malformed env values **throw at startup** rather than silently degrading
+ * to "no auth" — fail loud, never silently expose.
+ */
+import { scryptSync, timingSafeEqual, randomBytes } from "node:crypto";
+
+export type AuthMode =
+  | { kind: "none" }
+  | { kind: "password"; hash: ScryptHash }
+  | { kind: "disable-bind-public" };
+
+export interface ScryptHash {
+  /** raw `scrypt$N$r$p$salt$key` string, used as the WS-token-derivation secret */
+  raw: string;
+  N: number;
+  r: number;
+  p: number;
+  salt: Buffer;
+  key: Buffer;
+}
+
+const SCRYPT_PREFIX = "scrypt$";
+
+/**
+ * Parse `DECEPTICON_WEB_AUTH`. Defaults to `{kind:"none"}` when unset/empty
+ * so existing local-only deployments keep working without any config.
+ *
+ * Throws on malformed input — startup aborts rather than silently
+ * downgrading to no-auth.
+ */
+export function parseAuthMode(raw: string | undefined): AuthMode {
+  if (raw === undefined || raw.trim() === "" || raw === "none") {
+    return { kind: "none" };
+  }
+  if (raw === "disable-bind-public") {
+    return { kind: "disable-bind-public" };
+  }
+  if (raw.startsWith("password:")) {
+    const hashStr = raw.slice("password:".length);
+    return { kind: "password", hash: parseScryptHash(hashStr) };
+  }
+  throw new Error(
+    `DECEPTICON_WEB_AUTH must be one of: "none" | "password:<scrypt-hash>" | "disable-bind-public". Got: ${truncate(raw)}`,
+  );
+}
+
+/**
+ * Parse a `scrypt$N$r$p$salt$key` string. Throws on malformed input.
+ */
+export function parseScryptHash(s: string): ScryptHash {
+  if (!s.startsWith(SCRYPT_PREFIX)) {
+    throw new Error(
+      `DECEPTICON_WEB_AUTH=password:<hash> requires an scrypt hash starting with "scrypt$N$r$p$salt$key". Got: ${truncate(s)}`,
+    );
+  }
+  const parts = s.split("$");
+  // [ "scrypt", N, r, p, salt, key ]
+  if (parts.length !== 6) {
+    throw new Error(
+      `Malformed scrypt hash — expected 6 \`$\`-separated fields, got ${parts.length}.`,
+    );
+  }
+  const [, NStr, rStr, pStr, saltB64, keyB64] = parts;
+  const N = Number.parseInt(NStr, 10);
+  const r = Number.parseInt(rStr, 10);
+  const p = Number.parseInt(pStr, 10);
+  if (!Number.isInteger(N) || N <= 0 || (N & (N - 1)) !== 0) {
+    throw new Error(`scrypt N must be a power of two, got: ${NStr}`);
+  }
+  if (!Number.isInteger(r) || r <= 0) {
+    throw new Error(`scrypt r must be a positive integer, got: ${rStr}`);
+  }
+  if (!Number.isInteger(p) || p <= 0) {
+    throw new Error(`scrypt p must be a positive integer, got: ${pStr}`);
+  }
+  let salt: Buffer;
+  let key: Buffer;
+  try {
+    salt = Buffer.from(saltB64, "base64");
+    key = Buffer.from(keyB64, "base64");
+  } catch {
+    throw new Error("scrypt salt/key must be base64-encoded.");
+  }
+  if (salt.length === 0 || key.length === 0) {
+    throw new Error("scrypt salt and key must be non-empty.");
+  }
+  return { raw: s, N, r, p, salt, key };
+}
+
+/**
+ * Hash a plaintext password for the operator. Used by an out-of-band CLI
+ * recipe (see SECURITY.md). Not called from the request hot path.
+ */
+export function hashPassword(
+  plaintext: string,
+  opts: { N?: number; r?: number; p?: number; keyLen?: number; salt?: Buffer } = {},
+): string {
+  const N = opts.N ?? 16384;
+  const r = opts.r ?? 8;
+  const p = opts.p ?? 1;
+  const keyLen = opts.keyLen ?? 32;
+  const salt = opts.salt ?? randomBytes(16);
+  // scryptSync needs `maxmem` raised when N is large.
+  const maxmem = 128 * N * r * 2;
+  const key = scryptSync(plaintext, salt, keyLen, { N, r, p, maxmem });
+  return `scrypt$${N}$${r}$${p}$${salt.toString("base64")}$${key.toString("base64")}`;
+}
+
+/**
+ * Constant-time password verification against a parsed scrypt hash.
+ */
+export function verifyPassword(plaintext: string, hash: ScryptHash): boolean {
+  const maxmem = 128 * hash.N * hash.r * 2;
+  const derived = scryptSync(plaintext, hash.salt, hash.key.length, {
+    N: hash.N,
+    r: hash.r,
+    p: hash.p,
+    maxmem,
+  });
+  if (derived.length !== hash.key.length) return false;
+  return timingSafeEqual(derived, hash.key);
+}
+
+function truncate(s: string): string {
+  return s.length > 32 ? `${s.slice(0, 32)}…` : s;
+}

--- a/clients/web/src/lib/auth-token.test.ts
+++ b/clients/web/src/lib/auth-token.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { deriveWsToken, tokensEqual, extractWsToken } from "./auth-token";
+
+describe("deriveWsToken", () => {
+  it("is deterministic for a given hash", () => {
+    const hash = "scrypt$1024$8$1$YWFh$YmJi";
+    expect(deriveWsToken(hash)).toBe(deriveWsToken(hash));
+  });
+
+  it("produces 64 lowercase hex chars (SHA-256)", () => {
+    const t = deriveWsToken("scrypt$1024$8$1$YWFh$YmJi");
+    expect(t).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("differs for different hashes", () => {
+    const a = deriveWsToken("scrypt$1024$8$1$YWFh$YmJi");
+    const b = deriveWsToken("scrypt$1024$8$1$Y2Nj$ZGRk");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("tokensEqual", () => {
+  it("returns true for equal hex strings", () => {
+    expect(tokensEqual("abcd1234", "abcd1234")).toBe(true);
+  });
+
+  it("returns false for different strings of the same length", () => {
+    expect(tokensEqual("abcd1234", "abcd1235")).toBe(false);
+  });
+
+  it("returns false for different lengths (avoid length-leak via timingSafeEqual)", () => {
+    expect(tokensEqual("abcd", "abcd1234")).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    // @ts-expect-error — runtime defensive path
+    expect(tokensEqual(undefined, "abcd")).toBe(false);
+    // @ts-expect-error
+    expect(tokensEqual("abcd", null)).toBe(false);
+  });
+});
+
+describe("extractWsToken", () => {
+  it("reads from `Authorization: Bearer <hex>`", () => {
+    const url = new URL("ws://localhost:3003/");
+    expect(extractWsToken("Bearer deadbeef", url)).toBe("deadbeef");
+  });
+
+  it("normalizes uppercase hex to lowercase", () => {
+    const url = new URL("ws://localhost:3003/");
+    expect(extractWsToken("Bearer DEADBEEF", url)).toBe("deadbeef");
+  });
+
+  it("reads from ?token= when no header is present", () => {
+    const url = new URL("ws://localhost:3003/?token=deadbeef");
+    expect(extractWsToken(undefined, url)).toBe("deadbeef");
+  });
+
+  it("rejects non-hex Bearer payloads", () => {
+    const url = new URL("ws://localhost:3003/");
+    expect(extractWsToken("Bearer not-hex!", url)).toBeNull();
+  });
+
+  it("rejects non-hex query params", () => {
+    const url = new URL("ws://localhost:3003/?token=not-hex!");
+    expect(extractWsToken(undefined, url)).toBeNull();
+  });
+
+  it("prefers the Authorization header over the query string", () => {
+    const url = new URL("ws://localhost:3003/?token=ffff");
+    expect(extractWsToken("Bearer aaaa", url)).toBe("aaaa");
+  });
+
+  it("returns null when neither source has a token", () => {
+    const url = new URL("ws://localhost:3003/");
+    expect(extractWsToken(undefined, url)).toBeNull();
+  });
+});

--- a/clients/web/src/lib/auth-token.ts
+++ b/clients/web/src/lib/auth-token.ts
@@ -1,0 +1,67 @@
+/**
+ * WebSocket-handshake token derivation.
+ *
+ * Why this exists: HTTP basic auth doesn't apply to a WebSocket upgrade
+ * cleanly (browsers can't set arbitrary headers on `new WebSocket()`),
+ * so we expose a derived token that the client computes server-side via
+ * an authenticated API call, then includes as `?token=...` on the WS URL.
+ *
+ * Properties:
+ *   - The plaintext password is **never** transmitted over the wire as a
+ *     WS query string; only an HMAC tag is.
+ *   - The bcrypt/scrypt hash itself is **never** transmitted; the tag is
+ *     keyed by the hash but doesn't reveal it.
+ *   - Comparison is constant-time (`crypto.timingSafeEqual`).
+ *
+ * The "secret" in the HMAC is the operator's full scrypt hash string. A
+ * fixed `WS_TOKEN_LABEL` adds domain separation so this token can't be
+ * cross-replayed against any future HMAC use case keyed by the same hash.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const WS_TOKEN_LABEL = "decepticon.web-auth.ws-token.v1";
+
+/**
+ * Derive the WS handshake token from the scrypt-hash string.
+ *
+ * Returns a lowercase hex string (64 chars from SHA-256).
+ */
+export function deriveWsToken(scryptHashRaw: string): string {
+  return createHmac("sha256", scryptHashRaw).update(WS_TOKEN_LABEL).digest("hex");
+}
+
+/**
+ * Constant-time comparison of two hex tokens. Returns `false` for any
+ * length mismatch (which itself is not a timing leak — the lengths are
+ * fixed by the algorithm above; an attacker only learns "wrong length"
+ * if they sent an obviously malformed value).
+ */
+export function tokensEqual(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  if (a.length !== b.length) return false;
+  // ASCII hex → `Buffer.from` never fails; mismatched chars decode to
+  // different bytes, which timingSafeEqual catches in constant time.
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Extract a WS auth token from either an `Authorization: Bearer <token>`
+ * header or a `?token=<hex>` query parameter on the upgrade URL. Returns
+ * the lowercased hex string, or null if no candidate is present.
+ *
+ * Browsers can't set arbitrary headers on `new WebSocket(url)`, so the
+ * query-param transport is the browser-friendly path; non-browser clients
+ * (curl, wscat) get the cleaner Authorization header.
+ */
+export function extractWsToken(authHeader: string | undefined, url: URL): string | null {
+  if (authHeader) {
+    const m = /^Bearer\s+([A-Fa-f0-9]+)$/.exec(authHeader);
+    if (m) return m[1].toLowerCase();
+  }
+  const q = url.searchParams.get("token");
+  if (q && /^[A-Fa-f0-9]+$/.test(q)) return q.toLowerCase();
+  return null;
+}

--- a/clients/web/src/lib/bind-public.test.ts
+++ b/clients/web/src/lib/bind-public.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { isLoopbackHost, assertLoopbackHost } from "./bind-public";
+
+describe("isLoopbackHost", () => {
+  it("accepts the canonical loopback names / addresses", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("[::1]")).toBe(true);
+    expect(isLoopbackHost("::1%lo0")).toBe(true);
+  });
+
+  it("accepts the rest of 127.0.0.0/8", () => {
+    expect(isLoopbackHost("127.0.0.2")).toBe(true);
+    expect(isLoopbackHost("127.1.2.3")).toBe(true);
+    expect(isLoopbackHost("127.255.255.254")).toBe(true);
+  });
+
+  it("rejects 0.0.0.0 (all interfaces)", () => {
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+  });
+
+  it("rejects the empty string (which would mean all-interfaces in node's listen)", () => {
+    expect(isLoopbackHost("")).toBe(false);
+  });
+
+  it("rejects IPv6 all-interfaces", () => {
+    expect(isLoopbackHost("::")).toBe(false);
+    expect(isLoopbackHost("[::]")).toBe(false);
+  });
+
+  it("rejects concrete LAN / public addresses", () => {
+    expect(isLoopbackHost("10.0.0.1")).toBe(false);
+    expect(isLoopbackHost("192.168.1.1")).toBe(false);
+    expect(isLoopbackHost("8.8.8.8")).toBe(false);
+    expect(isLoopbackHost("example.com")).toBe(false);
+  });
+
+  it("rejects strings that look like 127.* but aren't valid IPs", () => {
+    expect(isLoopbackHost("127.999.0.1")).toBe(false);
+    expect(isLoopbackHost("127.x.y.z")).toBe(false);
+  });
+});
+
+describe("assertLoopbackHost", () => {
+  it("returns silently for loopback hosts", () => {
+    expect(() => assertLoopbackHost("127.0.0.1")).not.toThrow();
+    expect(() => assertLoopbackHost("localhost")).not.toThrow();
+    expect(() => assertLoopbackHost("::1")).not.toThrow();
+  });
+
+  it("throws with an explicit error for 0.0.0.0", () => {
+    expect(() => assertLoopbackHost("0.0.0.0", "HOST")).toThrow(/disable-bind-public/);
+    expect(() => assertLoopbackHost("0.0.0.0", "HOST")).toThrow(/HOST=0\.0\.0\.0/);
+  });
+
+  it("throws for an empty host (would otherwise bind all interfaces)", () => {
+    expect(() => assertLoopbackHost("", "HOST")).toThrow(/all interfaces/);
+  });
+
+  it("includes the label in the error so the operator knows which knob to fix", () => {
+    expect(() => assertLoopbackHost("0.0.0.0", "TERMINAL_HOST")).toThrow(/TERMINAL_HOST/);
+  });
+});
+
+/**
+ * Re-implements the host-resolution logic the terminal-server runs at
+ * startup, so we can verify "kind: disable-bind-public + HOST=0.0.0.0
+ * aborts with an explicit error" without spawning a subprocess.
+ *
+ * Mirrors `clients/web/server/terminal-server.ts`. If you change that
+ * file's host-resolution block, update this helper too — or the
+ * regression coverage will silently drift.
+ */
+function resolveTerminalListenHost(args: {
+  authKind: "none" | "password" | "disable-bind-public";
+  terminalHost: string;
+}): string | undefined {
+  if (args.authKind === "disable-bind-public") {
+    if (args.terminalHost && !isLoopbackHost(args.terminalHost)) {
+      assertLoopbackHost(args.terminalHost, "TERMINAL_HOST"); // throws
+    }
+    return args.terminalHost || "127.0.0.1";
+  }
+  return args.terminalHost || undefined;
+}
+
+describe("terminal-server startup — disable-bind-public guard (integration shape)", () => {
+  it("HOST=127.0.0.1 starts cleanly (returns 127.0.0.1)", () => {
+    expect(
+      resolveTerminalListenHost({ authKind: "disable-bind-public", terminalHost: "127.0.0.1" }),
+    ).toBe("127.0.0.1");
+  });
+
+  it("HOST unset starts cleanly with the default 127.0.0.1", () => {
+    expect(
+      resolveTerminalListenHost({ authKind: "disable-bind-public", terminalHost: "" }),
+    ).toBe("127.0.0.1");
+  });
+
+  it("HOST=localhost starts cleanly", () => {
+    expect(
+      resolveTerminalListenHost({ authKind: "disable-bind-public", terminalHost: "localhost" }),
+    ).toBe("localhost");
+  });
+
+  it("HOST=0.0.0.0 aborts with an explicit error", () => {
+    expect(() =>
+      resolveTerminalListenHost({ authKind: "disable-bind-public", terminalHost: "0.0.0.0" }),
+    ).toThrow(/disable-bind-public/);
+  });
+
+  it("HOST=10.0.0.5 (LAN) aborts", () => {
+    expect(() =>
+      resolveTerminalListenHost({ authKind: "disable-bind-public", terminalHost: "10.0.0.5" }),
+    ).toThrow(/disable-bind-public/);
+  });
+
+  it("does NOT touch the host in mode=none (regression guard — default behavior unchanged)", () => {
+    expect(resolveTerminalListenHost({ authKind: "none", terminalHost: "" })).toBeUndefined();
+    expect(resolveTerminalListenHost({ authKind: "none", terminalHost: "0.0.0.0" })).toBe("0.0.0.0");
+  });
+});

--- a/clients/web/src/lib/bind-public.ts
+++ b/clients/web/src/lib/bind-public.ts
@@ -1,0 +1,51 @@
+/**
+ * Loopback-only bind enforcement.
+ *
+ * `DECEPTICON_WEB_AUTH=disable-bind-public` is the "defense in depth"
+ * mode: even if the operator's compose / start script accidentally binds
+ * to `0.0.0.0`, the process refuses to start. This module exposes a tiny
+ * recognizer for "is this a loopback hostname / address?" and a helper
+ * that throws on anything else.
+ *
+ * Loopback patterns recognized:
+ *   - `127.0.0.0/8` (any IPv4 loopback, but the common ones are 127.0.0.1)
+ *   - `::1` (canonical IPv6 loopback, with or without zone id)
+ *   - `localhost`
+ *
+ * Anything else — including the empty string (which `node`'s `listen`
+ * treats as "all interfaces"), `0.0.0.0`, `::`, and any concrete LAN /
+ * public IP — is rejected.
+ */
+
+const LOOPBACK_NAMES = new Set(["localhost"]);
+
+export function isLoopbackHost(host: string): boolean {
+  if (!host) return false; // empty == all-interfaces
+  const lower = host.toLowerCase();
+  if (LOOPBACK_NAMES.has(lower)) return true;
+
+  // Strip an optional zone id from IPv6 (e.g. "::1%lo0").
+  const ipv6 = lower.replace(/%.*$/, "");
+  if (ipv6 === "::1") return true;
+  // Bracketed IPv6 from URL contexts: "[::1]"
+  if (ipv6 === "[::1]") return true;
+
+  // IPv4 — anything in 127.0.0.0/8.
+  // Cheap, allocation-free check.
+  if (/^127\.(?:\d{1,3})\.(?:\d{1,3})\.(?:\d{1,3})$/.test(host)) {
+    const parts = host.split(".").map((n) => Number.parseInt(n, 10));
+    if (parts.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function assertLoopbackHost(host: string, label = "host"): void {
+  if (!isLoopbackHost(host)) {
+    throw new Error(
+      `DECEPTICON_WEB_AUTH=disable-bind-public refuses to bind ${label}=${host || "(all interfaces)"}.\n` +
+        `Set ${label} to one of: 127.0.0.1, ::1, localhost. Aborting startup.`,
+    );
+  }
+}

--- a/clients/web/src/lib/terminal-auth.test.ts
+++ b/clients/web/src/lib/terminal-auth.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test for the WS handshake auth gate.
+ *
+ * The real `clients/web/server/terminal-server.ts` is a long-lived
+ * process that imports `node-pty`, talks to LangGraph, and spawns the
+ * CLI — too heavy to boot in a unit test. We instead spin up a minimal
+ * `ws` server that wires up the **identical** auth-mode + extractWsToken
+ * + tokensEqual code path, then verify behavior with real `ws` clients.
+ *
+ * This is a true integration test of the auth boundary (no mocking of
+ * the helpers under test); only the unrelated PTY / LangGraph machinery
+ * is omitted because it has no bearing on the security gate.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { WebSocketServer, WebSocket } from "ws";
+import { type AddressInfo } from "node:net";
+import { hashPassword } from "./auth-mode";
+import { deriveWsToken, extractWsToken, tokensEqual } from "./auth-token";
+
+type TestServer = {
+  port: number;
+  close: () => Promise<void>;
+};
+
+function startServer(expectedToken: string | null): Promise<TestServer> {
+  return new Promise((resolveServer) => {
+    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    wss.on("connection", (ws, req) => {
+      const url = new URL(req.url ?? "/", "ws://localhost");
+      if (expectedToken) {
+        const provided = extractWsToken(req.headers.authorization, url);
+        if (!provided || !tokensEqual(provided, expectedToken)) {
+          ws.close(1008, "Unauthorized");
+          return;
+        }
+      }
+      ws.send("hello");
+    });
+    wss.on("listening", () => {
+      const addr = wss.address() as AddressInfo;
+      resolveServer({
+        port: addr.port,
+        close: () =>
+          new Promise<void>((res) => {
+            wss.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+function connectWS(url: string): Promise<{ closed: boolean; code?: number; message?: string }> {
+  return new Promise((resolveConn) => {
+    const ws = new WebSocket(url);
+    let resolved = false;
+    ws.on("message", (data) => {
+      if (resolved) return;
+      resolved = true;
+      resolveConn({ closed: false, message: data.toString() });
+      ws.close();
+    });
+    ws.on("close", (code) => {
+      if (resolved) return;
+      resolved = true;
+      resolveConn({ closed: true, code });
+    });
+    ws.on("error", () => {
+      // ignore — the close event will fire
+    });
+    setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        resolveConn({ closed: true, code: -1 });
+        ws.close();
+      }
+    }, 2000);
+  });
+}
+
+describe("terminal-server WS handshake — mode: none (default)", () => {
+  let server: TestServer;
+  beforeAll(async () => {
+    server = await startServer(null);
+  });
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it("accepts a connection with no token (regression guard for today's behavior)", async () => {
+    const result = await connectWS(`ws://127.0.0.1:${server.port}/`);
+    expect(result.closed).toBe(false);
+    expect(result.message).toBe("hello");
+  });
+});
+
+describe("terminal-server WS handshake — mode: password", () => {
+  const PLAINTEXT = "wsroom";
+  const HASH_RAW = hashPassword(PLAINTEXT, { N: 1024 });
+  const TOKEN = deriveWsToken(HASH_RAW);
+
+  let server: TestServer;
+  beforeAll(async () => {
+    server = await startServer(TOKEN);
+  });
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it("rejects with code 1008 when no token is sent", async () => {
+    const result = await connectWS(`ws://127.0.0.1:${server.port}/`);
+    expect(result.closed).toBe(true);
+    expect(result.code).toBe(1008);
+  });
+
+  it("rejects with code 1008 on an obviously wrong token", async () => {
+    const result = await connectWS(`ws://127.0.0.1:${server.port}/?token=deadbeef`);
+    expect(result.closed).toBe(true);
+    expect(result.code).toBe(1008);
+  });
+
+  it("rejects a token that is the right length but the wrong value", async () => {
+    const wrong = "f".repeat(TOKEN.length);
+    const result = await connectWS(`ws://127.0.0.1:${server.port}/?token=${wrong}`);
+    expect(result.closed).toBe(true);
+    expect(result.code).toBe(1008);
+  });
+
+  it("accepts a connection with the correct ?token=<derived>", async () => {
+    const result = await connectWS(`ws://127.0.0.1:${server.port}/?token=${TOKEN}`);
+    expect(result.closed).toBe(false);
+    expect(result.message).toBe("hello");
+  });
+
+  it("uppercase hex query token is normalized and accepted", async () => {
+    const result = await connectWS(
+      `ws://127.0.0.1:${server.port}/?token=${TOKEN.toUpperCase()}`,
+    );
+    expect(result.closed).toBe(false);
+    expect(result.message).toBe("hello");
+  });
+});

--- a/clients/web/vitest.config.ts
+++ b/clients/web/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  // Disable PostCSS processing — Next.js's tailwind/lightningcss pipeline
+  // isn't relevant for Node-side unit tests, and on macOS its optional
+  // native binary often isn't installed.
+  css: {
+    postcss: { plugins: [] },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    environment: "node",
+    globals: false,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.3",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^2.1.9"
       },
       "optionalDependencies": {
         "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
@@ -119,7 +120,6 @@
     "clients/web/node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -240,7 +240,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -734,7 +733,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -779,15 +777,13 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@decepticon/cli": {
       "resolved": "clients/cli",
@@ -909,7 +905,6 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -951,8 +946,7 @@
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.4.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -1482,7 +1476,6 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1584,7 +1577,6 @@
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1608,7 +1600,6 @@
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1685,7 +1676,6 @@
     "node_modules/@openuidev/react-headless": {
       "version": "0.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ag-ui/core": "^0.0.45"
       },
@@ -1697,7 +1687,6 @@
     "node_modules/@openuidev/react-lang": {
       "version": "0.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@openuidev/lang-core": "^0.2.4"
       },
@@ -2995,6 +2984,20 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.4",
       "cpu": [
@@ -3243,7 +3246,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -3381,7 +3385,6 @@
     "node_modules/@types/node": {
       "version": "25.8.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3398,7 +3401,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3407,7 +3409,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3478,7 +3479,6 @@
       "version": "8.59.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3875,7 +3875,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4001,6 +4000,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4338,7 +4338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5153,7 +5152,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5301,7 +5299,6 @@
     "node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5523,7 +5520,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5903,7 +5901,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6073,7 +6070,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6404,7 +6400,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7382,7 +7377,6 @@
     "node_modules/hono": {
       "version": "4.12.18",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7524,7 +7518,6 @@
     "node_modules/ink": {
       "version": "6.8.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.4",
         "ansi-escapes": "^7.3.0",
@@ -8436,7 +8429,6 @@
       "version": "1.32.0",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -8624,6 +8616,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8647,7 +8640,6 @@
     "node_modules/marked": {
       "version": "15.0.12",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9592,7 +9584,6 @@
       "version": "2.14.6",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -10570,7 +10561,6 @@
     "node_modules/pg": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10787,6 +10777,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10800,6 +10791,7 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10808,6 +10800,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11009,7 +11002,6 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11037,7 +11029,6 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11048,7 +11039,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -12667,7 +12659,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12960,7 +12951,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13373,7 +13363,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13982,7 +13971,6 @@
     "node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14008,7 +13996,6 @@
     "node_modules/zustand": {
       "version": "4.5.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
       },


### PR DESCRIPTION
## Motivation

Decepticon's web dashboard (`http://localhost:3000`) and terminal WebSocket (`ws://localhost:3003`) are **unauthenticated by design**. The threat model assumes a single operator on a single host: both ports bind to localhost, and anyone with shell access to that host can already drive the agent.

That model breaks the moment the ports become reachable from another machine:

- A reverse proxy fronting Decepticon for "just my team."
- A port-forward over SSH that the operator forgets about.
- An accidental `0.0.0.0` bind in a custom compose file.
- A tailscale subnet route that exposes the host to the tailnet.
- A `docker run -p 3000:3000` instead of `-p 127.0.0.1:3000:3000`.

In all of those cases, an unauthenticated remote caller can:

- Execute arbitrary commands inside the sandbox container via the terminal WS.
- Read every engagement's findings, opplans, and chat history via the API.
- Create / mutate engagement state.

Today there's nothing in-process that stops them. Operators who notice the risk have to wrap Decepticon in something else (an oauth2-proxy, an SSH-only tunnel, a firewall rule). This PR adds an in-tree opt-in.

## Change

Three-mode env-gated opt-in via `DECEPTICON_WEB_AUTH`. **Default behavior is unchanged.**

| Value | Effect |
|---|---|
| `none` (default / unset / empty) | Today's behavior. No authentication. |
| `password:<scrypt-hash>` | HTTP basic auth on every Next.js API route + a derived token required on the terminal WS handshake. |
| `disable-bind-public` | The terminal server refuses to bind to anything other than 127.0.0.1 / ::1 / localhost. Hard-fails startup if it would otherwise bind a public interface. |

Malformed env values throw at startup — Decepticon will not silently downgrade to "no auth" on a typo.

The KDF is `node:crypto.scryptSync` rather than a new `bcrypt` dep:

- scrypt is OWASP-recommended and memory-hard (RFC 7914).
- No new native binding to build at install time.
- The hashing/verification helpers are in-tree and auditable.

The WS handshake token is HMAC-SHA256 over the scrypt-hash string with a fixed `decepticon.web-auth.ws-token.v1` label for domain separation. The plaintext password is never transmitted over the WS query string; the scrypt hash itself is never transmitted at all.

All credential comparisons use `crypto.timingSafeEqual`.

## Threat model

| Threat | Mitigation in this PR |
|---|---|
| Unauthenticated remote driver of the agent | `password:` mode requires HTTP basic auth on web routes + a derived token on the WS handshake. |
| Plaintext password leak via URL params | Plaintext is never on the URL — only the HMAC-derived token is. The token is keyed by the scrypt hash; revealing it does not reveal the password or the hash. |
| Hash leak via URL params | The scrypt hash itself is server-side only. The transmitted token is an HMAC of a fixed label keyed by the hash — it does not let an attacker recover the hash. |
| Timing-side-channel on credential compare | `crypto.timingSafeEqual` for both `verifyPassword` and `tokensEqual`. Length-mismatch short-circuits before the timing-safe compare (the lengths are fixed by the algorithm, so length is not a useful oracle for attackers sending well-formed values). |
| Brute force on the scrypt | scrypt is memory-hard so GPU brute force is expensive. Default cost is `N=16384, r=8, p=1` (the OWASP "interactive login" recommendation). Operators on faster hardware can raise `N`. |
| Bind to public interface by accident | `disable-bind-public` mode hard-fails startup if `TERMINAL_HOST` resolves to anything other than loopback. The default-of-127.0.0.1 in that mode is itself a forced-loopback bind. |
| WebSocket bypass of HTTP middleware | The WS handshake is independently authenticated via the token-as-query-param (or `Authorization: Bearer`) mechanism, in addition to the existing origin check. There is no path from the WS protocol to API routes that skips both gates. |
| Token replay across services | The HMAC is over a fixed domain-separation label (`decepticon.web-auth.ws-token.v1`), so the same scrypt hash used here cannot produce a valid token for any future HMAC use case that picks a different label. |
| Cached mode lets a malformed env "fail open" | The auth-bridge cache is populated on first request; a malformed `DECEPTICON_WEB_AUTH` throws at that point. The terminal-server parses the env at module load, which throws synchronously before the WS server starts listening. There is no code path where a bad value silently becomes "no auth". |

## Attack surfaces considered

- **HTTP routes (`/api/...`).** Every route already calls `await requireAuth()` for authorization context. In `password` mode that call now resolves the `Authorization` header via `next/headers` and enforces basic auth. No route handlers needed changes; the signature is preserved.
- **WS handshake (`ws://.../terminal`).** Token check happens at the `wss.on("connection")` upgrade callback, immediately after the origin check, before any session state is created and before the PTY is spawned. Failure closes with code 1008.
- **Streaming events post-handshake.** Once the upgrade succeeds, the WS protocol assumes the channel is authenticated — there is no separate per-message auth. This is consistent with how the rest of the WS protocol works (resize, ping, stdin) and how upstream Decepticon has always behaved. The upgrade gate is the boundary.
- **Static assets.** Next.js's static asset serving is not gated by `requireAuth()` (the upstream design choice predates this PR). On a public-facing deployment, paths like `/_next/static/...` will be reachable without creds. They do not embed engagement names — they are bundled JS/CSS — but operators should be aware. Documented in SECURITY.md.
- **Reverse-proxy deployments.** Some default proxy configs strip the `Authorization` header to avoid leaking creds upstream. That turns Decepticon's auth into an always-401 wall. SECURITY.md calls this out and recommends either forwarding `Authorization`, terminating auth at the proxy + `disable-bind-public`, or doing both (defense in depth).
- **The mode cache itself.** The auth-bridge memoizes the parsed mode at first read. A malformed env throws on that first call; there is no code path that returns a bogus default. The terminal-server parses at module load instead of per-request, which throws synchronously before `wss.listen()` resolves.
- **The hash-as-HMAC-key choice.** The WS token derivation uses the scrypt-hash string as the HMAC key. The hash is sensitive (anyone who reads it can mint valid tokens), but it is no more sensitive than the password it represents — both must already be protected as credentials. SECURITY.md is explicit that the hash must be treated like a password (mode-0600 env file, never committed).

## Security reviewer sign-off

This PR is gated on a manual review. Reviewer = `pol2up` (fork owner) until a co-maintainer exists.

**Reviewer:** _________________

**Sign-off:** comment `/security-review approved` on this PR after review.

**Date:** _________________

Once signed off, the fork controller will dispatch the squash-merge into `mac/daily-driver` as a separate step. This PR will not be squash-merged by the implementer.

## Test

63 tests, all passing locally (`vitest run`):

- `auth-mode.test.ts` (13): env parser — default/empty/none/disable-bind-public, password+valid-scrypt, garbage/bcrypt-payload/malformed-fields rejection, KDF round-trip + unique salt.
- `auth-bridge.test.ts` (13): default-mode regression guard, `isAuthEnabled()` semantics, basic-auth accept/reject paths, malformed Authorization, `disable-bind-public` no-op at auth layer, malformed env aborts loudly.
- `auth-token.test.ts` (14): `deriveWsToken` determinism + uniqueness + hex shape, `tokensEqual` length/type defenses, `extractWsToken` header / query / case-normalization / non-hex rejection.
- `bind-public.test.ts` (17): loopback recognizer for 127/8 / ::1 / localhost / zone-id; rejection of 0.0.0.0 / :: / LAN / public; `assertLoopbackHost` error shape includes the knob name; terminal-server startup logic — clean start on 127.0.0.1 / localhost / default, throws on 0.0.0.0 / LAN, regression guard that mode=none never touches HOST.
- `terminal-auth.test.ts` (6): real WS integration — mode=none accepts no-token connections (regression guard for today's behavior); password mode rejects missing / wrong / wrong-length tokens with code 1008; password mode accepts the correct `?token=`, with uppercase hex normalized.

Typecheck clean for all new files (`tsc --noEmit` adds zero new errors; the three pre-existing `route.ts` / `prisma.ts` errors are unchanged from upstream main and unrelated to this PR).
