### PR TITLE
fix(soundwave): strip ' (Recommended)' suffix from picker answers to break interview loop (#328)

### DIFF
--- a/packages/decepticon/decepticon/tools/interaction/ask_user.py
+++ b/packages/decepticon/decepticon/tools/interaction/ask_user.py
@@ -25,6 +25,32 @@ from langgraph.types import interrupt
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 HEADER_MAX_CHARS = 60
+RECOMMENDED_SUFFIX = " (Recommended)"
+
+
+def _strip_recommended_suffix(value: Any) -> Any:
+    """Strip the ``" (Recommended)"`` UI marker from operator answers.
+
+    Option labels surface the marker so the operator sees which choice the
+    agent recommends in the picker; the marker is purely a display hint and
+    must never reach the agent's tool-result content. Without stripping, the
+    model treats the marker as part of the answer (e.g. ``"Internal Network
+    Audit (Recommended)"`` becomes the engagement name), decides the
+    parenthetical meta-text is not a valid value, and re-asks the same
+    question — the Soundwave interview loop bug from issue #328.
+
+    Operates on single-select strings and multi-select string lists; any
+    other shape is returned unchanged.
+    """
+
+    def _strip(v: Any) -> Any:
+        if isinstance(v, str) and v.endswith(RECOMMENDED_SUFFIX):
+            return v[: -len(RECOMMENDED_SUFFIX)]
+        return v
+
+    if isinstance(value, list):
+        return [_strip(v) for v in value]
+    return _strip(value)
 
 
 def _coerce_options_list(value: Any) -> list[Any]:
@@ -157,4 +183,4 @@ def ask_user_question(
     if writer is not None:
         writer(payload)
 
-    return interrupt(payload)
+    return _strip_recommended_suffix(interrupt(payload))

--- a/packages/decepticon/tests/unit/tools/test_ask_user_question.py
+++ b/packages/decepticon/tests/unit/tools/test_ask_user_question.py
@@ -180,7 +180,10 @@ def test_coerces_options_json_string_from_local_models():
             return_value="External Web (Recommended)",
         ),
     ):
-        assert _invoke(options=options) == "External Web (Recommended)"
+        # The emitted event preserves the operator-facing label (with the
+        # marker) so the picker can render the recommendation hint, but the
+        # tool return value has the marker stripped — see issue #328.
+        assert _invoke(options=options) == "External Web"
 
     assert captured[0]["options"] == [
         {"label": "External Web (Recommended)", "description": "Public website"}
@@ -254,6 +257,75 @@ def test_rejects_option_without_label_or_description():
         ]
         with pytest.raises(ValidationError):
             _invoke(options=bad)
+
+
+def test_strips_recommended_suffix_from_single_select_return():
+    """Regression for issue #328 — the picker's ' (Recommended)' UI marker
+    must never reach the agent's tool result. Without stripping, the model
+    treats the parenthetical meta-text as part of the answer, rejects it,
+    and locks the Soundwave interview in a loop."""
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda _evt: None,
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value="Internal Network Audit (Recommended)",
+        ),
+    ):
+        assert _invoke() == "Internal Network Audit"
+
+
+def test_strips_recommended_suffix_from_multi_select_return():
+    """Multi-select returns a list of labels; every entry must be stripped."""
+    chosen = ["Recon (Recommended)", "Exploitation", "Post-exploit (Recommended)"]
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda _evt: None,
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value=chosen,
+        ),
+    ):
+        assert _invoke(multi_select=True) == ["Recon", "Exploitation", "Post-exploit"]
+
+
+def test_preserves_free_text_without_recommended_suffix():
+    """Operator-typed answers via the Other fallback never carry the marker;
+    the stripper is a no-op for them."""
+    typed = "Acme Q1-2026 Adversary Sim"
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda _evt: None,
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value=typed,
+        ),
+    ):
+        assert _invoke(allow_other=True) == typed
+
+
+def test_does_not_strip_recommended_when_not_a_trailing_suffix():
+    """Only the trailing marker is a UI hint. A label that genuinely embeds
+    ' (Recommended)' mid-string is not a picker artifact and must survive
+    intact — the strip is suffix-only, not substring-wide."""
+    embedded = "Mode (Recommended) for review"
+    with (
+        patch(
+            "decepticon.tools.interaction.ask_user.get_stream_writer",
+            return_value=lambda _evt: None,
+        ),
+        patch(
+            "decepticon.tools.interaction.ask_user.interrupt",
+            return_value=embedded,
+        ),
+    ):
+        assert _invoke() == embedded
 
 
 def test_rejects_option_with_extra_fields():


### PR DESCRIPTION
## Summary

Fixes #328 — the Soundwave interview locks into a loop because the picker's `" (Recommended)"` UI marker leaks into the agent's tool result.

## Root cause

`ask_user_question` options carry a recommendation hint on the label per the prompt spec:

```python
{"label": "Internal Network Audit (Recommended)", "description": "..."}
```

When the operator picks that option, the CLI's `QuestionPicker` submits the **raw label** (suffix included) via `Command({ resume: value })`. `interrupt(payload)` in [`ask_user.py`](packages/decepticon/decepticon/tools/interaction/ask_user.py) returns that string verbatim. The model then receives e.g. `"Internal Network Audit (Recommended)"` as the answer, treats the parenthetical meta-text as part of the value, decides it isn't a valid engagement name, and re-asks the same question — exactly the loop the user reported, with `Skill (roe-template / conops-template / threat-profile / structured-questions)` cycling between each re-ask.

The user's workaround in the bug report — typing `internal` via the **Other** fallback — works precisely because free-text answers don't carry the marker.

## Fix

One backend change: strip the trailing `" (Recommended)"` suffix from `interrupt()`'s return value inside `ask_user_question` before handing it to the agent. The emitted custom event still carries the raw label so the CLI/web pickers render the recommendation hint unchanged — this is a one-sided strip, only the agent-visible side is cleaned.

The fix handles both single-select strings and multi-select string lists, and is a no-op for free-text answers (which never carry the marker).

**Why backend instead of the picker:** centralises the fix for every current and future client (CLI, web terminal, headless callers, plugins). The picker still shows `(Recommended)` to the operator in the chat history, which is the intended UX.

## Files changed

- `packages/decepticon/decepticon/tools/interaction/ask_user.py` — added `_strip_recommended_suffix(...)` and wired it into the tool's return path.
- `packages/decepticon/tests/unit/tools/test_ask_user_question.py` — 4 new regression tests + 1 updated existing test that previously asserted verbatim preservation.

## Test plan

```
$ .venv/Scripts/python.exe -m pytest packages/decepticon/tests/unit/tools/test_ask_user_question.py -v
============================== 17 passed in 6.57s ==============================
```

New coverage:

| Test | Asserts |
|---|---|
| `test_strips_recommended_suffix_from_single_select_return` | `"Internal Network Audit (Recommended)"` → `"Internal Network Audit"` |
| `test_strips_recommended_suffix_from_multi_select_return` | Every entry in a multi-select list is stripped |
| `test_preserves_free_text_without_recommended_suffix` | Free-text answers via Other survive unchanged (no-op path) |
| `test_does_not_strip_recommended_when_not_a_trailing_suffix` | Only the trailing marker is treated as a UI hint — embedded `(Recommended)` mid-string survives |
| `test_coerces_options_json_string_from_local_models` (updated) | Emitted event keeps the label-with-marker; return value strips it |

## Out of scope

- No change to picker rendering (`QuestionPicker.tsx`) — operators still see `1. Internal Network Audit (Recommended)` as before.
- No change to the prompt or `structured-questions` skill — the `(Recommended)` convention is preserved; it just no longer leaks past the tool boundary.
- No changes to other models' picker logic — the web client doesn't use the structured picker so wasn't affected.
