### PR TITLE
docs(changelog): v1.1.3 release notes

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -20,6 +20,12 @@ extend-ignore-re = [
     # flags the "mis" token as a typo of miss/mist. The whole compound
     # is correct (mis-fire, mis-split, mis-configure, mis-allocation).
     "mis-[a-z]+",
+    # "ICS-OT" / "ICS/OT" (Industrial Control Systems / Operational
+    # Technology) — typos splits on the separator and flags the bare "OT"
+    # token. Ignore only this exact compound so we don't globally
+    # allow-list "OT" (the rest of the tree keeps full coverage; the
+    # ics-ot skill bodies are handled by the files exclude below).
+    "ICS[-/]OT",
 ]
 
 [default.extend-words]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,139 @@
 All notable changes to the Decepticon project. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning
 follows [Semantic Versioning](https://semver.org/) from `1.0.0`
-onward (the `0.x` cycle is pre-stable per
-[spec §13.4](docs/superpowers/specs/2026-05-23-core-framework-sdk-split-design.md)).
+onward (the `0.x` cycle is pre-stable per the core/framework/sdk split
+design spec, §13.4).
+
+## [1.1.3] — 2026-05-27
+
+Consolidation release on top of `v1.1.2` (the core/framework/sdk split).
+Lands a backlog of contributor PRs across skills, cross-OS support,
+reverse engineering, CLI/launcher, web dashboard, vulnresearch, runtime
+stability, and CI — each re-reviewed and re-merged on current `main` with
+conflicts resolved and dead code dropped. The OSS default runtime,
+public API, and three-package layout are unchanged; every change is
+additive or a fix.
+
+### Added
+
+- **Native Windows support** — `scripts/install.ps1` PowerShell installer
+  (StrictMode, SHA-256 verification, Docker pre-flight); the Go launcher
+  gains an OS/arch/distro + Docker-readiness System Check at `onboard`;
+  release artifacts now include `windows_amd64` + `windows_arm64`. README +
+  setup guide document the native path alongside WSL2. (#281)
+- **Podman + nerdctl container runtimes** — the launcher auto-detects
+  docker → podman → nerdctl (first reachable wins) with a
+  `DECEPTICON_CONTAINER_RUNTIME` override; Podman socket discovery injects
+  `DOCKER_HOST` so nested Docker-API consumers keep working. Docker users
+  see zero behavioral change. (#292)
+- **Ghidra 12.1 reverse-engineering backend** — `decepticon/tools/reversing/ghidra.py`
+  (headless `analyzeHeadless` + optional MCP-bridge sidecar): `ghidra_analyze`,
+  `ghidra_decompile`, `ghidra_xrefs`, `ghidra_status`. Gated behind
+  `INSTALL_REVERSING=false` so the default sandbox image stays lean; the
+  `ghidra-mcp` sidecar opts in via the `reversing` compose profile. (#288)
+- **76 new skill playbooks** across two batches, all under the canonical
+  `<skill-name>/SKILL.md` layout with `metadata.when_to_use` routing:
+  - AD (ADCS ESC1/coercer/ntlm-relay/dcsync/kerberoasting/LAPS/netexec…),
+    Cloud (IMDS/k8s/S3/Terraform + container escapes), Smart Contracts
+    (access-control/flash-loan/oracle/signature-replay/proxy + bridge/
+    governance/MEV), Web Exploit (jwt/oauth/saml/nosqli/…), LLM Red Team
+    (AATMF T01–T15, under `plugins/`), Mobile, Reverser, Supply Chain. (#281, #291)
+  - Modern API (gRPC/SOAP/WebSocket/SSE), ICS-OT (Modbus/BACnet/S7Comm/DNP3,
+    with SAFETY-CRITICAL write-scope confirmation), C2 (Havoc/Mythic). (#291)
+- **AD attack tooling** — new `delegation.py` (unconstrained/constrained/RBCD),
+  `gpo.py` (GPO ACL abuse), `shadow_creds.py` (msDS-KeyCredentialLink);
+  BloodHound-CE ingest format; `dcsync` multi-domain; kerberos AES128
+  pre-auth pattern. (#290)
+- **Web `@tool` surface** — `http_request` / `http_history` exposed to the
+  agent; graphql IDOR heuristic; OAuth state-length + PKCE-downgrade checks. (#290)
+- **Release scaffolding** — `RELEASE.md` documenting the 0.0.0-sentinel +
+  tag-time version stamping flow; the Soundwave engagement bundle and its
+  docs aligned to the full 8-document output. (#287)
+
+### Fixed
+
+- **Soundwave interview loop** — the picker's `" (Recommended)"` UI marker
+  leaked into the agent's tool-result, so the model treated it as part of
+  the engagement name, rejected it, and re-asked the same question forever.
+  `ask_user_question` now strips the trailing marker on the agent-visible
+  return (single + multi-select), leaving the picker UI unchanged. (#339, issue #328)
+- **Codex/ChatGPT OAuth handler** dropped function names mid-stream
+  (synthesized `function_call` had `name=""`, looping the model with
+  "is not a valid tool") — added `response.output_item.added/.done`
+  handlers. Fixes the empty-tool-name error reported in #321. (#295)
+- **Streaming**: `StreamingRunnable` now subclasses `RunnableBinding` so it
+  survives deepagents' `_get_subagents()` `.with_config()` call — the
+  LangGraph Platform HTTP `stream_mode=["custom"]` path now delivers
+  `subagent_*` events (was 0). (#324)
+- **Sandbox zombie processes** — reparented `tmux`/`bash` grandchildren
+  accumulated as `<defunct>` zombies until the PID table filled and
+  `fork()` failed (`EAGAIN`). Now reaped by an init process (tini, run as
+  PID 1 via `init: true` on the sandbox compose service) plus
+  `kill_all_sessions()` on daemon shutdown. An earlier in-process SIGCHLD
+  reaper was replaced after it was found to race with the daemon's own
+  `subprocess.run` calls and clobber command exit codes to 0. (#336, #340)
+- **`langgraph dev` BlockingError** — a sync `httpx` call inside the
+  third-party `deepagents` subagent dispatch aborted runs ~85s in. The
+  langgraph service now defaults to `--allow-blocking` (downgrades to a
+  warning), with `LANGGRAPH_STRICT_ASYNC=1` to restore fatal behavior for
+  debugging. Complements #295's structural fix for Decepticon's own sync
+  calls. (#333)
+- **LiteLLM truncated tool_use** — Claude models had no `max_tokens`, so
+  LiteLLM fell back to its 4096 default and cut off 30–50KB report writes.
+  Set per-model caps (Opus 4.7 = 128k, Sonnet/Haiku = 64k) across all three
+  model groups. (#295)
+- **poc.py inverted ZFP logic** — valid findings that demonstrated impact
+  were being rejected; sandbox-runner errors now sentinel-prefixed. (#290)
+- **CVE lookups**: capped 3 unbounded `httpx.AsyncClient` timeouts (NVD 30s /
+  OSV 15s) that caused intermittent false-negatives. (#294)
+- **`bash_kill` BlockingError** under `langgraph dev` — `session_log_path()`
+  wrapped in `asyncio.to_thread`. **GraphRecursionError** — 7 sub-agents
+  bumped 250 → 1000. (#295)
+- **Web dashboard (≈16)** — terminal clears on tab switch (resize-to-0 PTY
+  corruption), heartbeat pong-timer leak, health API real probe, N+1
+  findings fetch, duplicate-name 409, infinite redirect loop, unmount
+  guards, O(n²) event accumulation, findings parser CVSS/CWE/MITRE. (#307)
+- **CLI Ink TUI** — empty-filter `selectedIndex=-1`, autocomplete dedupe,
+  O(1) event push, tilde expansion, synchronous update check, subagent id
+  no longer hardcoded. (#285, #307)
+- **Silent exception swallows** surfaced to `log.debug` across
+  research `_state`/`chain`/`cve` and the prompt compat shim. (#289, #294)
+- **Docker startup race** — `sandbox` now waits on `neo4j` via
+  `service_healthy` (was `service_started`). **sandbox.pids_limit** 1024 →
+  4096 for parallel Go/Rust toolchains. (#307, #295)
+- **Local test suite on macOS/Windows** — `posixpath` for virtual workspace
+  paths, `pytest -n auto` class-state isolation, `USERPROFILE` alongside
+  `HOME` in launcher tests. (#286, #284)
+
+### Changed
+
+- **Skill layout unified** to nested `<skill-name>/SKILL.md` (canonical
+  Agent Skills spec) — migrated 23 legacy flat `exploit/web/*.md` +
+  `recon/web-recon/*.md` files; 25+ `load_skill()` routing references
+  updated. (#291 review follow-up)
+- **`prompts/__init__.py`** (533 lines) split into a re-export shim +
+  `builder.py` + `registry.py`; `llm/factory.py` and `sandbox_kernel`
+  oversized helpers extracted. Public API unchanged. (#289)
+- **Retired the dead docker-exec transport** — `_docker_tmux` → `_tmux`,
+  `exec_prefix` defaults to `[]`; `HTTPSandbox` → in-container
+  `DaemonSandbox` is the only path. (#289 review follow-up)
+- **`DECEPTICON_LLM__TIMEOUT`** default 120s → 600s for long Opus
+  generations. (#295)
+
+### Dev infrastructure
+
+- **Pre-commit hook gate** — file hygiene + shellcheck + hadolint + typos
+  (with a `.typos.toml` allowlist for offensive-security jargon), run on
+  every PR via a `pre-commit` CI job. (#293)
+- **Tree-wide LF renormalization** — 45 files committed with CRLF brought
+  into line with the `.gitattributes` `eol=lf` policy. (#293)
+- **CI matrix** — Python lane is ubuntu-only by design (the backend runs in
+  the Linux langgraph container); the Go launcher runs ubuntu+macOS+windows;
+  PR-time `linux/arm64` Docker smoke build for cli+langgraph. Coverage gate
+  raised 30% → 35%. (#284, #292, #318, #310)
+- **Repo hygiene** — `skills/_corpus/` ignored, stale `clients/ee/` ignore
+  rules removed, internal design specs untracked, `xbow-validation-benchmarks`
+  submodule bumped to the buster apt-archive fix. (#282)
 
 ## [1.1.2-localfixes.1] — 2026-05-25 (fork — mohamedq9900/Decepticon)
 
@@ -100,11 +231,11 @@ sustained multi-hour Cosmos / Web3 / Web2 bug-bounty audits with
 parallel sub-agent fan-out, large recon outputs, and 30-50 KB
 report writes on `auth/claude-opus-4-7` and `auth/gpt-5.5`.
 
-## [Unreleased] — targets v1.1.2
+## [1.1.2] — 2026-05-23
 
-This release introduces the three-package split (additive — every
-legacy import path keeps working via compat shims). Targets
-``v1.1.2`` against the OSS series currently at ``v1.1.1``. Removal of
+This release introduced the three-package split (additive — every
+legacy import path keeps working via compat shims), shipped as
+``v1.1.2`` on the OSS series. Removal of
 the compat shims, ``PluginBundle`` aggregate shape, and the legacy
 ``decepticon.agents.middleware_slots.MiddlewareSlot`` re-export is
 deferred to ``2.0.0`` (see "Deprecated" table below).
@@ -114,8 +245,8 @@ deferred to ``2.0.0`` (see "Deprecated" table below).
 OSS shifts from a monolithic `decepticon` wheel to three coordinated
 wheels. The split exposes a stable contract layer that commercial
 products, downstream frameworks, and the community can extend without
-touching framework internals. Full design rationale in
-[`docs/superpowers/specs/2026-05-23-core-framework-sdk-split-design.md`](docs/superpowers/specs/2026-05-23-core-framework-sdk-split-design.md).
+touching framework internals. Full design rationale in the
+core/framework/sdk split design spec.
 
 - **`decepticon-core`** (new) — pure types, protocols, plugin contracts,
   registry primitives. Zero `langchain` / `langgraph` / `deepagents` /
@@ -147,9 +278,8 @@ touching framework internals. Full design rationale in
 - `make_agent_backend(extra_routes=...)` with longest-prefix-wins
   routing (closes gap #1, gap #3). Tenant-specific paths like
   `/skills/tenant/<id>/` deterministically override the generic
-  `/skills/` default — load-bearing per [spec §16.4
-  #5](docs/superpowers/specs/2026-05-23-core-framework-sdk-split-design.md)
-  for the future B2B Enterprise tier.
+  `/skills/` default — load-bearing per the split design spec
+  §16.4 #5 for the future B2B Enterprise tier.
 - `RoleRegistry.register(name, *, slots, skill_sources,
   llm_role_fallback)` for custom agent roles (closes gap #5).
   Idempotent on identical parameters (multi-process worker startup
@@ -163,9 +293,9 @@ touching framework internals. Full design rationale in
   prefix + collision detection (closes gap #12). Malformed paths
   fail registration loudly.
 - `SafetyDeclaration` for plugin-extended safety-critical
-  tool/middleware names (closes gap #10). Additive-only per [spec
-  §16.4 #4](docs/superpowers/specs/2026-05-23-core-framework-sdk-split-design.md) —
-  plugins cannot remove safety on OSS-declared names.
+  tool/middleware names (closes gap #10). Additive-only per the split
+  design spec §16.4 #4 — plugins cannot remove safety on OSS-declared
+  names.
 - `PromptContribution` + `decepticon.prompts` entry-point group for
   prompt-only plugins (closes gap #8). No longer requires wrapping in
   `PluginBundle`.


### PR DESCRIPTION
Release notes for **v1.1.3** (consolidation release on top of v1.1.2). Merge this, then tag `v1.1.3`.

## What's in this PR

- **New `[1.1.3] — 2026-05-27` section** documenting everything merged since v1.1.2 (skills, cross-OS support, Ghidra reversing, AD tooling, CLI/launcher, web dashboard, runtime-stability fixes, CI). Scope matches the agreed decision: from the latest PR batch, **only the bug fixes #339 / #336 / #333** are included — the feature PRs (#330–#338) were closed, not merged.
- **Sandbox-zombie entry reflects the shipped fix**: tini via `init: true` (#340) + `kill_all_sessions()` (#336), and notes that the in-process SIGCHLD reaper was replaced because it raced with the daemon's `subprocess.run` and clobbered command exit codes.
- **Relabel** stale `[Unreleased] — targets v1.1.2` → `[1.1.2] — 2026-05-23` (that content shipped as v1.1.2) and fix its tense.
- **De-link four `docs/superpowers/specs/...` references** — that internal design dir is no longer tracked in OSS, so those links were broken.
- **`.typos.toml`**: scoped `ICS[-/]OT` ignore so the changelog's "ICS-OT" passes the typos hook without globally allow-listing the bare `OT` token.

## Checks

- `typos CHANGELOG.md .typos.toml` → clean
- all other CHANGELOG local-path links verified to resolve
- no `docs/superpowers` references remain