### PR TITLE
fix(oss): de-duplicate ctrl+o hint + silence DECEPTICON_STACK_NAME compose warning

### DIFF
--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -29,7 +29,6 @@ import { CoordinatorPanel } from "../components/agents/CoordinatorPanel.js";
 import { ScreenProvider } from "../components/shell/ScreenContext.js";
 import { ExpandOutputProvider } from "../components/shell/ExpandOutputContext.js";
 import { SubAgentProvider } from "../components/shell/SubAgentContext.js";
-import { CtrlOToExpand } from "../components/shell/CtrlOToExpand.js";
 import { parseSlashCommand, findCommand } from "../commands/registry.js";
 import { groupConsecutiveTools } from "../utils/groupEvents.js";
 import { formatDuration } from "../utils/format.js";
@@ -275,10 +274,12 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
 
           {agent.error && <ErrorMessage content={agent.error} />}
 
-          {/* Transcript mode hint */}
-          {agent.runState === "idle" && agent.events.length > 0 && (
-            <CtrlOToExpand />
-          )}
+          {/* No global "(ctrl+o to expand)" hint here: the Prompt footer
+              already shows "ctrl+o: expand" persistently while idle, and
+              truncated/collapsed items (BashResult, ToolGroupSummary, …)
+              render their own hint inline. A blanket hint below the Static
+              region duplicated whichever hint the last item already showed,
+              producing two identical "(ctrl+o to expand)" lines. */}
 
           {showSessionPicker ? (
             <SessionPicker

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -82,11 +82,11 @@ func (c *Compose) baseArgs() []string {
 }
 
 // ContainerName builds the docker container name for a Decepticon
-// service, mirroring the ``${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}``
+// service, mirroring the “${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}“
 // template used by docker-compose.yml (#216). Unset/empty → today's
-// ``decepticon-<svc>`` name verbatim; ``stack2`` → ``decepticon-stack2-<svc>``.
+// “decepticon-<svc>“ name verbatim; “stack2“ → “decepticon-stack2-<svc>“.
 // Keeps the Go launcher and YAML naming convention in lockstep so
-// ``docker exec``/``logs``/``stop`` resolve the right container in
+// “docker exec“/“logs“/“stop“ resolve the right container in
 // dual-stack runs.
 func ContainerName(svc string) string {
 	stack := strings.TrimSpace(os.Getenv("DECEPTICON_STACK_NAME"))
@@ -118,6 +118,19 @@ func (c *Compose) composeEnv() []string {
 	env := os.Environ()
 	if v := c.readVersion(); v != "" {
 		env = append(env, "DECEPTICON_VERSION="+imageTag(v))
+	}
+	// Ensure DECEPTICON_STACK_NAME is always *set* (empty when the
+	// operator didn't choose a stack) so docker compose's interpolation
+	// of ${DECEPTICON_STACK_NAME:+...} in container_name never emits a
+	// `The "DECEPTICON_STACK_NAME" variable is not set` warning. Compose
+	// versions before ~2.24 warn on the nested reference even though the
+	// `:+` form leaves it unused — an empty-but-set value is
+	// interpolation-equivalent to unset for `:+`. The .env.example
+	// declaration (#238) only covers fresh installs from that release on;
+	// this also silences the warning for users whose pre-#238 .env
+	// predates the declaration, without forcing a re-onboard.
+	if _, ok := os.LookupEnv("DECEPTICON_STACK_NAME"); !ok {
+		env = append(env, "DECEPTICON_STACK_NAME=")
 	}
 	// Inject DOCKER_HOST for Podman so nested Docker-API clients in
 	// containers (testcontainers, kubectl-with-docker-shim) find the
@@ -195,12 +208,14 @@ func (c *Compose) DownAndPurge() error {
 // new release lands). Empty version → fall back to whatever .version says.
 func (c *Compose) Pull(version string) error {
 	cmd := exec.Command(c.Runtime.Bin, append(c.baseArgs(), "pull")...)
+	// Base off composeEnv so the stack-name + runtime injections apply
+	// here too; an explicit version arg overrides the .version-derived
+	// DECEPTICON_VERSION (later entries win in the child process env).
+	env := c.composeEnv()
 	if version != "" {
-		env := append(os.Environ(), "DECEPTICON_VERSION="+imageTag(version))
-		cmd.Env = c.Runtime.Apply(env)
-	} else {
-		cmd.Env = c.composeEnv()
+		env = append(env, "DECEPTICON_VERSION="+imageTag(version))
 	}
+	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Two OSS CLI/launcher UX bugs reported together.

## 1. Duplicate `(ctrl+o to expand)` hint — `clients/cli/src/screens/REPL.tsx`

**Symptom:** the hint appeared twice, back to back:
```
 (ctrl+o to expand)
 (ctrl+o to expand)
```

**Cause:** the prompt view rendered a blanket `<CtrlOToExpand />` below the `<Static>` region whenever idle with events. But `ctrl+o` is a single global expand control, and the last Static item already renders its own hint — `ToolGroupSummary` shows it *unconditionally*, `BashResult`/`DiffResult`/`ToolCallMessage`/`UserMessage`/`ErrorMessage` show it when truncated. The blanket hint duplicated whatever the last item already showed. The `Prompt` footer also shows `ctrl+o: expand` persistently while idle — a third copy.

**Fix:** remove the blanket hint (and its now-unused import). Per-item inline hints (which point at the actual truncation) and the persistent Prompt-footer affordance are retained.

## 2. `DECEPTICON_STACK_NAME` compose warning — `clients/launcher/internal/compose/compose.go`

**Symptom:** at launcher start, one warning per service (9×):
```
WARN[0000] The "DECEPTICON_STACK_NAME" variable is not set. Defaulting to a blank string.
```

**Cause:** `docker-compose.yml` interpolates `${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}` in 9 `container_name` fields. When the variable is genuinely unset, docker compose warns once per nested reference — **reproduced on Compose v2.39.1**, so this is not an old-version quirk. The launcher calls compose with `--env-file ~/.decepticon/.env`, which disables the default `./.env` autoload; a stale pre-#238 `.env` has no `DECEPTICON_STACK_NAME` line, so it stays unset. #238 only added the line to `.env.example` (fresh installs); existing users' generated `.env` is never re-synced, and `decepticon update` does not touch `.env`.

**Fix:** inject `DECEPTICON_STACK_NAME=` into the compose process environment in `composeEnv()` when it is unset, so compose always sees it as *set* (empty == unset for the `:+` form, so container names are unchanged). Covers every launcher compose path (`up`/`down`/`pull`/`run`/…), every Compose version, and stale `.env` files — no re-onboard required. `Pull(version)` now also routes through `composeEnv()` so the injection applies there.

This is the correct fix for OSS users, who only ever invoke compose through the launcher.

## Not changed
GitHub star → start flow was investigated and left as-is per maintainer decision: declining the star does not block `start`; the `.starred` ack suppresses re-prompts. No "start anyway?" gate exists, and none was requested.

## Verification
- `DECEPTICON_STACK_NAME` warning: **9 → 0** with the injection (Compose v2.39.1), container names verified unchanged (`decepticon-litellm`; `decepticon-stack2-litellm` when a stack is set).
- Go launcher: `go vet ./...` ✅, `go test ./...` ✅, `gofmt -l` clean ✅, `go build ./...` ✅
- CLI: `npm run typecheck` ✅, `npm test` ✅ (21 passed)