### PR TITLE
feat(streaming): include tool_call_id in subagent_tool_call/result events

### DIFF
--- a/packages/decepticon/decepticon/core/subagent_streaming.py
+++ b/packages/decepticon/decepticon/core/subagent_streaming.py
@@ -241,6 +241,14 @@ class StreamingRunnable(RunnableBinding):
                                     "agent": self._name,
                                     "tool": tc["name"],
                                     "args": tc_args,
+                                    # LangChain ToolCall id — exposed to
+                                    # consumers (CLI / Web) so they can pair
+                                    # this event with the matching
+                                    # subagent_tool_result emission instead of
+                                    # falling back to positional FIFO by
+                                    # tool name. None when the model omitted
+                                    # the id (rare; logged as a warning above).
+                                    "id": tc_id,
                                 }
                             )
 
@@ -265,6 +273,11 @@ class StreamingRunnable(RunnableBinding):
                             "args": tc_args,
                             "content": content,
                             "status": status,
+                            # Same id as the matching subagent_tool_call —
+                            # lets consumers pair the result back to its
+                            # originating call exactly, no per-tool-name
+                            # FIFO heuristic required.
+                            "id": msg.tool_call_id,
                         }
                     )
 


### PR DESCRIPTION
## Summary

Forwards the LangChain ToolCall id on the ``subagent_tool_call`` and
``subagent_tool_result`` custom events. The id is already tracked
internally in ``StreamingRunnable._process_messages`` (via the
``active_tool_calls`` map so a later ``ToolMessage`` resolves back to
the originating ToolCall name) — this PR just adds it to the writer
payload.

## Why

Consumers (CLI renderers, the SaaS web run console) currently have to
pair ``subagent_tool_call`` with its matching ``subagent_tool_result``
by positional FIFO over tool name. That works for the current
sequential emission path, but it's a heuristic that mis-pairs as soon
as the same tool name is invoked in parallel or out of order.

The supervisor side already gets exact pairing — its events ride the
``values`` stream's ``AIMessage.tool_calls`` / ``ToolMessage.tool_call_id``
which carry the id natively. This PR makes sub-agents match.

## Diff

Two writer payload additions, ``"id": tc_id`` on subagent_tool_call and
``"id": msg.tool_call_id`` on subagent_tool_result. No internal state
changes; ``active_tool_calls`` already had the values.

## Consumer impact

- **CLI renderers** ignore the field unless they opt in — no
  regression.
- **SaaS web** (PurpleAILAB/decepticon-saas) already accepts an
  optional ``toolCallId`` field on its TimelineEntry and falls back to
  positional matching when absent. Once this PR ships in a release
  pin, the fallback becomes inert and sub-agent tool pairing flips to
  exact ids.

## Test plan
- [x] ``git diff`` shows two additive payload fields, nothing else.
- [ ] Existing subagent_streaming unit tests still pass.
- [ ] CI green.