### PR TITLE
fix(middleware): materialize engagement workspace + mask internal paths in errors

### DIFF
--- a/packages/decepticon/decepticon/middleware/filesystem.py
+++ b/packages/decepticon/decepticon/middleware/filesystem.py
@@ -65,6 +65,27 @@ class EngagementFilesystemBackend(BackendProtocol):
     def __init__(self, backend: BackendProtocol, workspace_path: str | None) -> None:
         self._backend = backend
         self._root = _normalize_engagement_workspace(workspace_path)
+        # Engagement subdir under WORKSPACE is otherwise materialized lazily by
+        # the first ``write`` — but the very first agent step is typically a
+        # filesystem inspection (``ls`` / ``glob``), which the backend surfaces
+        # as ``path_not_found`` against the not-yet-created subdir. Drop a
+        # marker file at the root on construction so the workspace is always
+        # observable. Backends auto-create parent dirs on write, so this is
+        # the cheapest way to enforce the "workspace is reachable" invariant
+        # without expanding the backend protocol.
+        self._root_ensured = False
+
+    def _ensure_root(self) -> None:
+        if self._root_ensured or self._root is None:
+            return
+        self._root_ensured = True
+        try:
+            self._backend.write(f"{self._root}/.engagement", "")
+        except Exception:
+            # Best-effort: a second engagement reusing the same backend will
+            # find the marker already there and the write will refuse. That's
+            # fine — the dir is materialized regardless.
+            pass
 
     def _real(self, path: str | None) -> str:
         if self._root is None:
@@ -110,14 +131,24 @@ class EngagementFilesystemBackend(BackendProtocol):
         path = self._virtual(info.get("path", ""))
         return {**info, "path": path} if path else None
 
+    def _mask(self, error: str | None, real_path: str) -> str | None:
+        """Backend errors interpolate the resolved real path (e.g.
+        ``/workspace/<engagement-slug>/...``); rewrite it back to the virtual
+        path the agent originally asked for so engagement-internal naming
+        never leaks into tool output."""
+        if not error or self._root is None:
+            return error
+        return error.replace(real_path, self._virtual(real_path) or real_path)
+
     def ls(self, path: str) -> LsResult:
+        self._ensure_root()
         try:
             real_path = self._real(path)
         except ValueError as e:
             return LsResult(error=str(e))
         result = self._backend.ls(real_path)
         if result.error:
-            return result
+            return LsResult(error=self._mask(result.error, real_path))
         return LsResult(
             entries=[mapped for item in result.entries or [] if (mapped := self._info(item))]
         )
@@ -127,16 +158,25 @@ class EngagementFilesystemBackend(BackendProtocol):
         return result.entries or []
 
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        self._ensure_root()
         try:
-            return self._backend.read(self._real(file_path), offset=offset, limit=limit)
+            real_path = self._real(file_path)
         except ValueError as e:
             return ReadResult(error=str(e))
+        result = self._backend.read(real_path, offset=offset, limit=limit)
+        return (
+            replace(result, error=self._mask(result.error, real_path)) if result.error else result
+        )
 
     def write(self, file_path: str, content: str) -> WriteResult:
+        self._ensure_root()
         try:
-            result = self._backend.write(self._real(file_path), content)
+            real_path = self._real(file_path)
         except ValueError as e:
             return WriteResult(error=str(e))
+        result = self._backend.write(real_path, content)
+        if result.error:
+            return replace(result, error=self._mask(result.error, real_path))
         path = self._virtual(result.path or "") if result.path else None
         return replace(result, path=path) if path else result
 
@@ -147,21 +187,26 @@ class EngagementFilesystemBackend(BackendProtocol):
         new_string: str,
         replace_all: bool = False,
     ) -> EditResult:
+        self._ensure_root()
         try:
-            result = self._backend.edit(self._real(file_path), old_string, new_string, replace_all)
+            real_path = self._real(file_path)
         except ValueError as e:
             return EditResult(error=str(e))
+        result = self._backend.edit(real_path, old_string, new_string, replace_all)
+        if result.error:
+            return replace(result, error=self._mask(result.error, real_path))
         path = self._virtual(result.path or "") if result.path else None
         return replace(result, path=path) if path else result
 
     def grep(self, pattern: str, path: str | None = None, glob: str | None = None) -> GrepResult:
+        self._ensure_root()
         try:
             real_path = self._real(path)
         except ValueError as e:
             return GrepResult(error=str(e))
         result = self._backend.grep(pattern, path=real_path, glob=glob)
         if result.error:
-            return result
+            return GrepResult(error=self._mask(result.error, real_path))
         return GrepResult(
             matches=[
                 {**match, "path": mapped}
@@ -180,6 +225,7 @@ class EngagementFilesystemBackend(BackendProtocol):
         return result.error if result.error else result.matches or []
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        self._ensure_root()
         try:
             real_pattern = self._glob(pattern)
             real_path = self._real(path)
@@ -187,7 +233,7 @@ class EngagementFilesystemBackend(BackendProtocol):
             return GlobResult(error=str(e))
         result = self._backend.glob(real_pattern, path=real_path)
         if result.error:
-            return result
+            return GlobResult(error=self._mask(result.error, real_path))
         return GlobResult(
             matches=[mapped for item in result.matches or [] if (mapped := self._info(item))]
         )

--- a/packages/decepticon/tests/unit/middleware/test_filesystem.py
+++ b/packages/decepticon/tests/unit/middleware/test_filesystem.py
@@ -202,3 +202,64 @@ def test_invalid_path_outside_workspace_fails_closed() -> None:
 
     assert scoped.ls("/workspace").error is not None
     assert backend.calls == []
+
+
+def test_engagement_root_is_materialized_on_first_tool_call() -> None:
+    """The engagement subdir under ``/workspace`` must exist by the time the
+    first agent tool call lands. Backends create dirs lazily on the first
+    ``write``, so without this materialization step the first ``ls`` (the
+    planner's "what is here?" probe) trips ``path_not_found`` against the
+    not-yet-created subdir. Verify a single marker write is issued on
+    construction, and that it happens before any other backend call.
+    """
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace/eng-1")
+    # No backend traffic until first tool call.
+    assert backend.calls == []
+    scoped.ls("/workspace")
+    # Marker write precedes the ls.
+    op_names = [name for (name, _) in backend.calls]
+    assert op_names == ["write", "ls_info"]
+    first_op, first_args = backend.calls[0]
+    assert first_op == "write"
+    assert first_args[0] == "/workspace/eng-1/.engagement"  # type: ignore[index]
+
+
+def test_engagement_root_materialized_only_once_across_tool_calls() -> None:
+    """The marker write is idempotent at the middleware level — running
+    five tool calls in a row must yield exactly one materialization write."""
+    backend = RecordingBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace/eng-1")
+    scoped.ls("/workspace")
+    scoped.ls("/workspace/plan")
+    scoped.read("/workspace/plan/roe.json")
+    scoped.glob("**/*.json")
+    scoped.grep("target", path="/workspace")
+    write_calls = [op for (op, _) in backend.calls if op == "write"]
+    assert len(write_calls) == 1
+
+
+class _ErrorBackend(RecordingBackend):
+    """Surface a path_not_found error that interpolates the resolved real
+    path. Mirrors what the HTTPSandbox backend does on a missing dir."""
+
+    def ls(self, path: str) -> LsResult:
+        self.calls.append(("ls_info", path))
+        return LsResult(error=f"Path '{path}': path_not_found")
+
+
+def test_backend_error_does_not_leak_engagement_internal_path() -> None:
+    """Backend error strings interpolate the resolved real path (e.g.
+    ``/workspace/<engagement-slug>``); the middleware must rewrite that back
+    to the virtual path the agent originally asked for, so error output
+    never exposes harness-internal naming."""
+    backend = _ErrorBackend()
+    scoped = EngagementFilesystemBackend(backend, "/workspace/eng-1")
+
+    result = scoped.ls("/workspace")
+
+    assert result.error is not None
+    # Agent asked for "/workspace" — error must echo "/workspace", not
+    # "/workspace/eng-1".
+    assert "/workspace/eng-1" not in result.error
+    assert "/workspace" in result.error


### PR DESCRIPTION
## Summary
- `EngagementFilesystemBackend.__init__`이 `_root` 경로만 계산했고, 실제 디렉터리는 **첫 `write` 호출에서 lazy 생성**됨. agent run은 보통 ls/glob으로 시작하므로 첫 tool 결과가 `path_not_found` → 가시적 에러.
- backend 에러 메시지가 resolved real path(`/workspace/<engagement-slug>`)를 그대로 interpolate해서 agent에게 노출 (agent는 `/workspace`만 물었음).

근본 원인은 **"engagement workspace는 사용 시점에 존재해야 한다"는 invariant 미강제** + **에러 경로 mapping 누락**.

## Changes
**`packages/decepticon/decepticon/middleware/filesystem.py`** (+56/-6)
1. `_ensure_root()` — 첫 tool 호출 시 `.engagement` marker write로 idempotent 디렉터리 materialization. backend.write가 makedirs를 호출하므로 backend protocol 확장 없음.
2. `_mask(error, real_path)` — 에러 통과 시 `_virtual()` 매핑으로 real→virtual swap. `ls`/`read`/`write`/`edit`/`grep`/`glob` 모두 일관 적용.

**`packages/decepticon/tests/unit/middleware/test_filesystem.py`** (+61)
- `test_engagement_root_is_materialized_on_first_tool_call`
- `test_engagement_root_materialized_only_once_across_tool_calls`
- `test_backend_error_does_not_leak_engagement_internal_path`

## Observed
LangSmith trace `019e6df3-6717-7810-abc5-2ffcd4f0f7a6` (decepticon-saas APT29 benchmark rerun, 2026-05-28):
```
t=09:38:55  ls('/workspace')  →  Error: Path '/workspace/apt29-run-1': path_not_found
t=09:38:59  ls('/')           →  Error: Path '/workspace/apt29-run-1': path_not_found
t=09:39:10  ls('/workspace')  →  ['/workspace/plan']  ✓  (self-healed after first write)
```

## Test plan
- [x] Unit tests: `pytest packages/decepticon/tests/unit/middleware/test_filesystem.py` → **14 passed**
- [ ] CI green
- [ ] manual: 다음 benchmark run에서 첫 ls가 success로 시작하는지 LangSmith에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)