### PR TITLE
chore(ci): emit pass on path-irrelevant jobs so the ruleset doesn't block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,11 @@ jobs:
     # platform/system.go introduces the OS-specific code in this PR).
     name: CLI (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.cli == 'true'
+    # Job-level ``if`` removed on purpose. Each step gates on
+    # ``needs.changes.outputs.cli``; when the PR doesn't touch CLI code
+    # the job emits a one-line noop and reports success. The repo
+    # ruleset treats a literal ``skipping`` status as missing-required,
+    # so every required-status job must always report success/failure.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -251,13 +255,18 @@ jobs:
       run:
         shell: bash
     steps:
+      - if: needs.changes.outputs.cli != 'true'
+        run: 'echo "No CLI-relevant changes — emitting success."'
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.cli == 'true'
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.cli == 'true'
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci
+      - if: needs.changes.outputs.cli == 'true'
+        run: npm ci
       # ── rollup native-binary workaround for npm/cli#4828 ────────────
       # `npm ci` from a Linux-generated lock file silently skips the
       # platform-specific optional deps that rollup uses for its native
@@ -266,7 +275,7 @@ jobs:
       # Force-install the matching binary so the lock file stays
       # canonical but the test runner can resolve its native dep.
       - name: Repair rollup native binary on non-Linux runners
-        if: runner.os != 'Linux'
+        if: needs.changes.outputs.cli == 'true' && runner.os != 'Linux'
         shell: bash
         run: |
           case "${{ runner.os }}-${{ runner.arch }}" in
@@ -279,31 +288,45 @@ jobs:
       # resolve the workspace by walking that main, so the dist has to
       # exist before either downstream build runs.
       - name: Build shared streaming workspace
+        if: needs.changes.outputs.cli == 'true'
         run: npm run build --workspace=@decepticon/streaming
-      - run: cd clients/cli && npm run typecheck
+      - if: needs.changes.outputs.cli == 'true'
+        run: cd clients/cli && npm run typecheck
       - name: Run CLI tests
+        if: needs.changes.outputs.cli == 'true'
         run: cd clients/cli && npm test --if-present
 
   web:
     name: Web (lint + build)
     needs: changes
-    if: needs.changes.outputs.web == 'true'
+    # See the ``cli`` job for the rationale on job-level ``if`` removal +
+    # per-step ``if`` gating: the ruleset requires this status, so it must
+    # always succeed/fail rather than be skipped.
     runs-on: ubuntu-latest
     steps:
+      - if: needs.changes.outputs.web != 'true'
+        run: 'echo "No Web-relevant changes — emitting success."'
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.web == 'true'
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.web == 'true'
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci
+      - if: needs.changes.outputs.web == 'true'
+        run: npm ci
       - name: Build shared streaming workspace
+        if: needs.changes.outputs.web == 'true'
         run: npm run build --workspace=@decepticon/streaming
       - name: Generate Prisma client
+        if: needs.changes.outputs.web == 'true'
         run: cd clients/web && npx prisma generate
       - name: Lint
+        if: needs.changes.outputs.web == 'true'
         run: cd clients/web && npx eslint src/ --max-warnings 0
       - name: Build
+        if: needs.changes.outputs.web == 'true'
         run: cd clients/web && npm run build
         env:
           NEXT_PUBLIC_DECEPTICON_EDITION: oss
@@ -322,22 +345,29 @@ jobs:
     # not exist.
     name: Launcher (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.launcher == 'true'
+    # See the ``cli`` job for the rationale on job-level ``if`` removal +
+    # per-step ``if`` gating.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - if: needs.changes.outputs.launcher != 'true'
+        run: 'echo "No Launcher-relevant changes — emitting success."'
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.launcher == 'true'
       - uses: actions/setup-go@v5
+        if: needs.changes.outputs.launcher == 'true'
         with:
           go-version: "1.24"
           cache-dependency-path: clients/launcher/go.sum
       - name: go vet
+        if: needs.changes.outputs.launcher == 'true'
         working-directory: clients/launcher
         run: go vet ./...
       - name: go test
+        if: needs.changes.outputs.launcher == 'true'
         working-directory: clients/launcher
         run: go test ./...
 


### PR DESCRIPTION
## Summary
- Repo ruleset의 `required_status_checks`가 `skipping` job을 missing-required로 봐서, 한 영역(예: python-only)만 건드린 PR이 BLOCKED 됨 (외부 admin merge 필요).
- 또한 ruleset이 outdated context `CLI (typecheck + test)`를 require 중이지만 ci.yml job name은 matrix `CLI (${{ matrix.os }})` → 영원히 fulfilled 안 됨.

## Changes
**`.github/workflows/ci.yml`** (+37/-7)
- `cli` / `web` / `launcher` 3 job: job-level `if` 제거 + 각 step에 `if: needs.changes.outputs.<area> == 'true'` 추가.
- 첫 step에 `if: <area> != 'true'`로 noop echo — 영역 무관 PR은 일관 success status emit.
- `docker-build`/`docker-arm-smoke`는 ruleset required 아님 → 변경 없음.

**Ruleset `main` (id 14869722)** — REST API로 동시 갱신:
- ~~`CLI (typecheck + test)`~~ 제거
- `CLI (ubuntu-latest)` + `CLI (macos-latest)` 추가
- 나머지 그대로 (Python / Web / Security)

## Origin
PR #347이 python-only 변경인데 BLOCKED 상태로 admin merge 필요했음. ruleset이 cli/web 등 skipping을 missing으로 봤기 때문. 이번 PR은 self-test로 `chore` 변경 — cli.yml만 건드리니까 path filter에 의해 cli/web/launcher가 noop success로 떨어져야 함.

## Test plan
- [ ] 이번 PR이 CI 통과 + 새 ruleset이 PR 자체를 BLOCKED 안 함 ← self-test
- [ ] 다음 PR(python-only)이 admin merge 없이 일반 merge 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)