### PR TITLE
fix(llm): route configured subscriptions by default

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -92,21 +92,30 @@ async def call_with_timeout(coro: Awaitable[Any], timeout: float) -> Any:
         raise LLMTimeoutError(f"LLM request timed out after {timeout:g} seconds") from exc
 
 
-# Default ordering when DECEPTICON_AUTH_PRIORITY is not set. OAuth methods
-# precede the matching API method so a subscription primary falls back to
-# the paid API only when the subscription quota hits — not the other way.
-# OLLAMA_LOCAL sits at the end: cloud providers are usually preferred
-# (faster, smarter) when both are available; Ollama still gets picked up
-# as a last-resort fallback when its env vars are wired but no priority
-# list was authored.
+# Default ordering when DECEPTICON_AUTH_PRIORITY is not set. Every OAuth
+# (subscription) method precedes its closest paid-API peer so a subscription
+# is spent first and only falls back to the metered API when its quota hits —
+# never the other way. Copilot (broad multi-model subscription) sits just
+# after the OpenAI slot; Perplexity (search-augmented, niche for general
+# agent work) sits low. Local/cloud-local methods sit at the end: hosted
+# providers are usually preferred when both are available; locals are the
+# last-resort fallback.
+#
+# NOTE: all six subscription methods are listed here so a credential wired
+# without an explicit DECEPTICON_AUTH_PRIORITY is actually routed. Before,
+# google/copilot/grok/perplexity OAuth were absent — a configured
+# subscription was silently never used (surfaced by `decepticon-cli auth`).
 _DEFAULT_AUTH_PRIORITY: tuple[AuthMethod, ...] = (
     AuthMethod.ANTHROPIC_OAUTH,
     AuthMethod.ANTHROPIC_API,
     AuthMethod.OPENAI_OAUTH,
     AuthMethod.OPENAI_API,
+    AuthMethod.COPILOT_OAUTH,
+    AuthMethod.GOOGLE_OAUTH,
     AuthMethod.GOOGLE_API,
     AuthMethod.MINIMAX_API,
     AuthMethod.DEEPSEEK_API,
+    AuthMethod.GROK_OAUTH,
     AuthMethod.XAI_API,
     AuthMethod.MISTRAL_API,
     AuthMethod.OPENROUTER_API,
@@ -122,6 +131,7 @@ _DEFAULT_AUTH_PRIORITY: tuple[AuthMethod, ...] = (
     AuthMethod.BEDROCK_API,
     AuthMethod.VERTEX_API,
     AuthMethod.AZURE_API,
+    AuthMethod.PERPLEXITY_OAUTH,
     AuthMethod.LMSTUDIO_LOCAL,
     AuthMethod.LLAMACPP_LOCAL,
     AuthMethod.CUSTOM_OPENAI_API,

--- a/packages/decepticon/tests/unit/cli/test_auth.py
+++ b/packages/decepticon/tests/unit/cli/test_auth.py
@@ -72,10 +72,10 @@ def test_placeholder_key_is_not_configured(clean_env):
     assert not inv.any_active
 
 
-def test_subscription_configured_but_idle(clean_env, tmp_path):
-    # google_oauth is NOT in the default priority chain, so a fully-wired
-    # Gemini Advanced subscription is configured yet never routed — exactly
-    # the silent footgun this command exists to surface.
+def test_subscription_auto_routes_by_default(clean_env, tmp_path):
+    # A fully-wired Gemini Advanced subscription is now in the DEFAULT priority
+    # chain, so it is routed without the user authoring DECEPTICON_AUTH_PRIORITY
+    # (the footgun the earlier release left for google/copilot/grok/perplexity).
     cred = tmp_path / "gemini.json"
     cred.write_text(json.dumps({"access_token": "x"}))
     clean_env.setenv("DECEPTICON_AUTH_GEMINI", "true")
@@ -84,9 +84,24 @@ def test_subscription_configured_but_idle(clean_env, tmp_path):
     gem = next(s for s in inv.statuses if s.method == AuthMethod.GOOGLE_OAUTH)
     assert gem.configured
     assert gem.kind == "subscription"
-    assert not gem.in_priority
-    assert not gem.active
-    assert AuthMethod.GOOGLE_OAUTH in {s.method for s in inv.configured_but_idle}
+    assert gem.in_priority
+    assert gem.active
+    assert AuthMethod.GOOGLE_OAUTH in inv.resolved_chain
+    assert AuthMethod.GOOGLE_OAUTH not in {s.method for s in inv.configured_but_idle}
+
+
+def test_configured_but_idle_when_priority_omits(clean_env):
+    # configured_but_idle still flags a credential the user excluded via an
+    # explicit priority list — wired but deliberately not routed.
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-" + "x" * 40)
+    clean_env.setenv("OPENAI_API_KEY", "sk-" + "y" * 48)
+    clean_env.setenv("DECEPTICON_AUTH_PRIORITY", "openai_api")
+    inv = factory.auth_inventory()
+    anthropic = next(s for s in inv.statuses if s.method == AuthMethod.ANTHROPIC_API)
+    assert anthropic.configured
+    assert not anthropic.in_priority
+    assert not anthropic.active
+    assert AuthMethod.ANTHROPIC_API in {s.method for s in inv.configured_but_idle}
 
 
 def test_explicit_priority_routes_subscription(clean_env, tmp_path):


### PR DESCRIPTION
## What
Adds the four missing subscription methods (`google_oauth`, `copilot_oauth`, `grok_oauth`, `perplexity_oauth`) to `_DEFAULT_AUTH_PRIORITY`, each positioned before its closest paid-API peer.

## Why
`decepticon-cli auth` (merged in #350) surfaced a real footgun: only `anthropic_oauth` and `openai_oauth` were in the default priority chain. A user who wired a **Gemini Advanced / Copilot Pro / SuperGrok / Perplexity Pro** subscription but did *not* author an explicit `DECEPTICON_AUTH_PRIORITY` had their credential **silently never used** — the runtime fell through to API methods (or 401s). The status command flagged these as "configured but idle"; this fixes the root cause so they auto-route.

## Safety
Behavior-preserving for existing setups: only *configured* methods enter the chain, and the relative order of all pre-existing methods is unchanged — so e.g. `test_oauth_plus_api_priority_default` (`anthropic_oauth > anthropic_api > openai_api`) still holds. Onboarded users (who get an explicit priority from the Go wizard) are unaffected; this only changes the no-explicit-priority fallback.

## Tests
- `test_subscription_auto_routes_by_default` — a wired Gemini sub is now active by default.
- `test_configured_but_idle_when_priority_omits` — `configured_but_idle` still flags a credential excluded by an explicit priority list.
- Full factory + auth suites green (81 passed locally).

First of the post-#350 follow-ups from the Strix/oh-my-pi audit (wave 1b: provider-routing polish).