### PR TITLE
fix(engagement): honor resolved workspace root in engagement injection

### DIFF
--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -152,13 +152,21 @@ def _resolve_workspace_path(state: Any) -> str:
 
 
 def _build_engagement_injection(slug: str, workspace: str) -> str:
+    # ``workspace`` is the live engagement root resolved from state/config by
+    # ``_resolve_workspace_path``. It is ``/workspace`` for the default
+    # single-tenant launcher, but multi-tenant / SaaS launchers mount each
+    # engagement under a distinct root — so the injection must reflect the
+    # resolved path, not a hardcoded ``/workspace`` (which would point the
+    # agent at the wrong directory). Trailing slashes are trimmed so the
+    # ``{root}/plan/`` guidance never doubles up.
+    root = workspace.rstrip("/") or workspace
     return (
         "\n\n[Engagement context — set by the launcher]\n"
         f"Workspace slug: {slug}\n"
-        "Workspace root: /workspace\n"
-        "Treat /workspace as the only engagement directory for this run. "
+        f"Workspace root: {root}\n"
+        f"Treat {root} as the only engagement directory for this run. "
         "Read and write planning documents directly under "
-        "/workspace/plan/. Do NOT re-prompt the operator for a slug or an "
+        f"{root}/plan/. Do NOT re-prompt the operator for a slug or an "
         "engagement directory name; the launcher already chose them. The "
         "human-friendly engagement title belongs in roe.json:engagement_name "
         "and may differ from this slug."

--- a/packages/decepticon/tests/unit/middleware/test_engagement.py
+++ b/packages/decepticon/tests/unit/middleware/test_engagement.py
@@ -168,6 +168,25 @@ def test_engagement_only_injection(middleware: EngagementContextMiddleware) -> N
     assert "BENCHMARK MODE" not in text  # benchmark section absent
 
 
+def test_engagement_injection_honors_custom_workspace(
+    middleware: EngagementContextMiddleware,
+) -> None:
+    """Multi-tenant / SaaS launchers mount engagements under a non-default
+    root; the injection must name the resolved workspace, not a hardcoded
+    ``/workspace`` (regression: the path was previously hardcoded)."""
+    req = _FakeRequest(
+        state={"engagement_name": "blue-falcon", "workspace_path": "/srv/engagements/bf"},
+    )
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "Workspace root: /srv/engagements/bf" in text
+    assert "Treat /srv/engagements/bf as the only engagement directory" in text
+    assert "/srv/engagements/bf/plan/" in text
+    # The stale default must not leak into a custom-root engagement.
+    assert "/workspace" not in text
+
+
 def test_benchmark_mode_env_off_does_not_inject_challenge_context(
     middleware: EngagementContextMiddleware,
 ) -> None:


### PR DESCRIPTION
## What

`EngagementContextMiddleware._build_engagement_injection(slug, workspace)` accepted a `workspace` argument but **hardcoded `/workspace`** in three spots:

- `Workspace root: /workspace`
- `Treat /workspace as the only engagement directory for this run.`
- `Read and write planning documents directly under /workspace/plan/.`

## Why it's a bug

The caller (`_inject`) passes the **resolved** workspace from `_resolve_workspace_path`, which reads `config.configurable.workspace_path` (set per-run by the launcher) and only falls back to `/workspace`. Multi-tenant / SaaS launchers mount each engagement under a distinct root, so for any non-default workspace the agent was told the wrong engagement directory — it would read/write planning docs at `/workspace/plan/` even when the real root was elsewhere.

## Fix

Template all three occurrences with the passed root (trailing slash trimmed so `{root}/plan/` never doubles up). **Default single-tenant behavior is unchanged** — `workspace_path` still defaults to `/workspace`.

## Verification

- New regression test `test_engagement_injection_honors_custom_workspace` asserts a custom `workspace_path` round-trips into the injection and that the stale `/workspace` default does not leak.
- Local gate green: `ruff check` + `ruff format --check` clean, `basedpyright` 0 errors, `pytest packages/decepticon/tests/unit/middleware/test_engagement.py` → 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
