### PR TITLE
chore: remove two confirmed dead-code defects

### DIFF
--- a/packages/decepticon/decepticon/blue_cell/rule_match.py
+++ b/packages/decepticon/decepticon/blue_cell/rule_match.py
@@ -118,8 +118,6 @@ def _evaluate_condition(condition: str, selection_results: dict[str, bool]) -> b
         elif token_clean in selection_results:
             wrapped = token.replace(token_clean, str(selection_results[token_clean]))
             eval_expr_parts.append(wrapped)
-        elif token in {"(", ")"}:
-            eval_expr_parts.append(token)
         else:
             return False
     expr = " ".join(eval_expr_parts)

--- a/packages/decepticon/decepticon/tools/reversing/tools.py
+++ b/packages/decepticon/decepticon/tools/reversing/tools.py
@@ -113,7 +113,6 @@ def bin_ghidra_script(binary: str, script_name: str = "decepticon_recon.py") -> 
 def bin_r2_script(binary: str) -> str:
     """Emit a radare2 recon script body the agent can feed via ``r2 -i``."""
     return _json({"source": r2_recon_script(binary)})
-    return _json({"source": r2_recon_script(binary)})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two unreachable-code defects found during a code audit. **No behavior change.**

### 1. `tools/reversing/tools.py` — duplicate `return`
`bin_r2_script` had the same `return _json({"source": r2_recon_script(binary)})` line twice; the second was dead. Removed.

### 2. `blue_cell/rule_match.py` — unreachable `elif`
In `_evaluate_condition`, the branch `elif token in {"(", ")"}` can never execute: the preceding `if token in {"and","or","not","(",")"}` already matches `"("` and `")"`. Parenthesis handling is preserved by that first branch (the tokens still reach the whitelisted `eval`).

## Verification
- `ruff check` / `ruff format --check` clean
- `basedpyright` 0 errors
- `pytest packages/decepticon/tests/unit/blue_cell packages/decepticon/tests/unit/reversing` → 41 passed
- Full fast-lane `pytest -m "not slow"` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
