### PR TITLE
refactor(streaming): consumer-agnostic subagent error detection + tests

### DIFF
--- a/clients/cli/src/hooks/sub-agent-sessions.test.ts
+++ b/clients/cli/src/hooks/sub-agent-sessions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSubAgentSessions, type StreamEvent } from "@decepticon/streaming";
+
+let seq = 0;
+/** Build a minimal StreamEvent with sensible id/timestamp defaults. */
+function ev(over: Partial<StreamEvent> & { type: string }): StreamEvent {
+  seq += 1;
+  return { id: `e${seq}`, timestamp: seq, ...over };
+}
+
+describe("deriveSubAgentSessions", () => {
+  it("groups a start/end pair into one completed session", () => {
+    const sessions = deriveSubAgentSessions([
+      ev({ type: "subagent_start", subagent: "recon", content: "scan target" }),
+      ev({ type: "subagent_end", subagent: "recon", status: "success" }),
+    ]);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ agent: "recon", description: "scan target", status: "completed" });
+    expect(sessions[0].endEventId).toBeDefined();
+    expect(sessions[0].endTime).toBeDefined();
+  });
+
+  it("marks errored when subagent_end carries status='error' (CLI-normalized shape)", () => {
+    const sessions = deriveSubAgentSessions([
+      ev({ type: "subagent_start", subagent: "exploit" }),
+      ev({ type: "subagent_end", subagent: "exploit", status: "error" }),
+    ]);
+    expect(sessions[0].status).toBe("error");
+  });
+
+  it("marks errored when subagent_end carries error=true (raw backend shape)", () => {
+    const sessions = deriveSubAgentSessions([
+      ev({ type: "subagent_start", subagent: "exploit" }),
+      ev({ type: "subagent_end", subagent: "exploit", error: true }),
+    ]);
+    expect(sessions[0].status).toBe("error");
+  });
+
+  it("leaves a session running until its subagent_end arrives", () => {
+    const sessions = deriveSubAgentSessions([
+      ev({ type: "subagent_start", subagent: "recon" }),
+      ev({ type: "tool_result", subagent: "recon" }),
+    ]);
+    expect(sessions[0].status).toBe("running");
+    expect(sessions[0].endEventId).toBeUndefined();
+    expect(sessions[0].endTime).toBeUndefined();
+  });
+
+  it("counts only tool_result and bash_result events between start and end", () => {
+    const sessions = deriveSubAgentSessions([
+      ev({ type: "subagent_start", subagent: "recon" }),
+      ev({ type: "tool_result", subagent: "recon" }),
+      ev({ type: "bash_result", subagent: "recon" }),
+      ev({ type: "ai_message", subagent: "recon" }), // not a tool result → not counted
+      ev({ type: "subagent_end", subagent: "recon" }),
+    ]);
+    expect(sessions[0].toolCount).toBe(2);
+    expect(sessions[0].eventIds).toHaveLength(5);
+  });
+
+  it("ignores a subagent_end with no matching open session", () => {
+    const sessions = deriveSubAgentSessions([ev({ type: "subagent_end", subagent: "ghost" })]);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("derives independent sessions for interleaved subagents", () => {
+    const sessions = deriveSubAgentSessions([
+      ev({ type: "subagent_start", subagent: "recon" }),
+      ev({ type: "subagent_start", subagent: "exploit" }),
+      ev({ type: "subagent_end", subagent: "exploit", error: true }),
+      ev({ type: "subagent_end", subagent: "recon", status: "success" }),
+    ]);
+    expect(sessions).toHaveLength(2);
+    const byAgent = Object.fromEntries(sessions.map((s) => [s.agent, s.status]));
+    expect(byAgent).toEqual({ recon: "completed", exploit: "error" });
+  });
+
+  it("falls back to a default description when content is absent", () => {
+    const sessions = deriveSubAgentSessions([ev({ type: "subagent_start", subagent: "recon" })]);
+    expect(sessions[0].description).toBe("Starting recon");
+  });
+});

--- a/clients/shared/streaming/src/sessions.ts
+++ b/clients/shared/streaming/src/sessions.ts
@@ -64,9 +64,11 @@ export function deriveSubAgentSessions(events: readonly StreamEvent[]): SubAgent
       if (session) {
         session.endEventId = event.id;
         session.endTime = event.timestamp;
-        session.status = event.type === "subagent_end" && (event as { status?: string }).status === "error"
-          ? "error"
-          : "completed";
+        // Detect failure from either the CLI-normalized `status` field or the
+        // raw backend `error` boolean (SubagentCustomEvent). The enclosing
+        // branch already guarantees this is a `subagent_end` event.
+        session.status =
+          event.status === "error" || event.error === true ? "error" : "completed";
         session.eventIds.push(event.id);
         openSessions.delete(event.subagent);
       }

--- a/clients/shared/streaming/src/types.ts
+++ b/clients/shared/streaming/src/types.ts
@@ -59,4 +59,14 @@ export interface StreamEvent {
   content?: string;
   subagent?: string;
   timestamp: number;
+  /**
+   * Terminal status for `subagent_end` events. The CLI normalizes the
+   * backend's `error` boolean into `"error" | "success"` before events reach
+   * the shared utilities; consumers that forward the raw backend event leave
+   * this unset and set `error` instead (see {@link SubagentCustomEvent}).
+   * `deriveSubAgentSessions` honors either signal.
+   */
+  status?: string;
+  /** Raw backend error flag on `subagent_end` (the SubagentCustomEvent contract). */
+  error?: boolean;
 }


### PR DESCRIPTION
## Context

`deriveSubAgentSessions` in `@decepticon/streaming` is the shared helper that groups the LangGraph event stream into sub-agent sessions. It decided a finished session's terminal status by reading an **undeclared** `status` field off the event through a cast:

```ts
session.status = event.type === "subagent_end" && (event as { status?: string }).status === "error"
  ? "error" : "completed";
```

## Why this is fragile (not currently user-visible)

- The **CLI** is today's only consumer, and it normalizes the backend's `error` boolean into `status: "error" | "success"` (`useAgent.ts`) *before* events reach this function — so the CLI works correctly.
- But the documented event contract (`SubagentCustomEvent`) carries `error: boolean`, and the **Web** client reads `event.error` directly. Any consumer that forwards the raw backend event to `deriveSubAgentSessions` would have errored sessions silently shown as **"completed"**, with no type error to catch it (the field was accessed via a cast, not the type).

## Change

- Model both signals on the shared `StreamEvent` type (`status?: string`, `error?: boolean`), removing the unsafe cast.
- Detect failure from **either** `status === "error"` **or** `error === true`.
- Add the **first** unit tests for this shared utility (it had zero coverage): error via both event shapes, running vs completed, `toolCount` accumulation, orphan `subagent_end`, interleaved subagents, default description.

**No behavior change for the CLI** — its events already carry the normalized `status`.

## Verification
- `tsc --noEmit` (cli) clean; `vitest run` → 29 passed (8 new).
- `eslint src/ --max-warnings 0` (web) clean.
- Touches `clients/shared/streaming/**`, so both the `cli` and `web` CI jobs run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
