### PR TITLE
fix(core/types): re-export RoE enforcement submodule + lock its public surface

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/__init__.py
+++ b/packages/decepticon-core/decepticon_core/types/__init__.py
@@ -1,6 +1,6 @@
 """Pure-pydantic types for the Decepticon contract layer.
 
-Three submodules:
+Four submodules:
 
   * ``engagement`` — red-team planning documents (RoE, ConOps, OPPLAN,
     Finding, Objective, OpsecLevel, C2Tier, MITREPhase, ...). Was
@@ -10,6 +10,12 @@ Three submodules:
     ProxyConfig). Was ``decepticon/llm/models.py``.
   * ``kg`` — knowledge-graph node / edge types and helpers. Was
     ``decepticon/tools/research/graph.py``.
+  * ``roe`` — machine-readable Rules-of-Engagement *enforcement* schema
+    (``EnforcementMode``, ``ScopeRule``, ``MachineEnforcement``,
+    ``Decision``, ``evaluate_target``, ``evaluate_command``). The
+    evaluation layer that decides allow/deny for a target or command;
+    consumed by the framework's RoE-enforcement middleware. Distinct from
+    ``engagement.RoE`` (the planning document).
 
 These modules import only ``pydantic`` + stdlib + ``typing_extensions`` —
 no ``langchain`` / ``langgraph`` / ``deepagents`` / ``httpx`` /
@@ -18,6 +24,6 @@ no ``langchain`` / ``langgraph`` / ``deepagents`` / ``httpx`` /
 
 from __future__ import annotations
 
-from decepticon_core.types import engagement, kg, llm
+from decepticon_core.types import engagement, kg, llm, roe
 
-__all__ = ["engagement", "llm", "kg"]
+__all__ = ["engagement", "llm", "kg", "roe"]

--- a/packages/decepticon-core/tests/test_public_api_stability.py
+++ b/packages/decepticon-core/tests/test_public_api_stability.py
@@ -54,6 +54,13 @@ CORE_PUBLIC_API: tuple[tuple[str, str], ...] = (
     ("decepticon_core.types.kg", "EdgeKind"),
     ("decepticon_core.types.kg", "Severity"),
     ("decepticon_core.types.kg", "KnowledgeGraph"),
+    # decepticon_core.types.roe — machine-readable RoE enforcement schema
+    ("decepticon_core.types.roe", "EnforcementMode"),
+    ("decepticon_core.types.roe", "ScopeRule"),
+    ("decepticon_core.types.roe", "MachineEnforcement"),
+    ("decepticon_core.types.roe", "Decision"),
+    ("decepticon_core.types.roe", "evaluate_target"),
+    ("decepticon_core.types.roe", "evaluate_command"),
     # decepticon_core.protocols
     ("decepticon_core.protocols", "BackendProtocol"),
     ("decepticon_core.protocols", "MiddlewareProtocol"),
@@ -129,7 +136,7 @@ def test_manifest_count_unchanged() -> None:
     a major-version bump is an audit signal.
     """
     # Update this number deliberately when adding/removing public names.
-    expected = 69
+    expected = 75
     actual = len(CORE_PUBLIC_API)
     assert actual == expected, (
         f"CORE_PUBLIC_API has {actual} entries, expected {expected}. "


### PR DESCRIPTION
## What

`decepticon_core.types` (the langchain-free contract layer) re-exported `engagement`, `llm`, and `kg` — but **not `roe`**, despite `types/roe.py` being a fourth submodule that is consumed across the package boundary (`decepticon.middleware.roe` imports `from decepticon_core.types.roe import ...`). The package docstring even said *"Three submodules"*.

## Change

- **Re-export `roe`** alongside its siblings (`import` + `__all__`).
- **Fix the docstring** to describe all four submodules and disambiguate this *enforcement* schema (`EnforcementMode`, `ScopeRule`, `MachineEnforcement`, `Decision`, `evaluate_target`, `evaluate_command`) from `engagement.RoE` (the planning document).
- **Lock roe's six public symbols** in `test_public_api_stability.py` and bump the manifest count `69 → 75`, following the manifest's own documented update process.

Pure additive change — no existing import path changes.

> Note: the CHANGELOG is curated at release time (no `Unreleased` section in this repo), so I've left it to the release flow rather than inventing a section.

## Verification
- `ruff check` / `ruff format --check` clean
- `basedpyright` 0 errors
- `pytest packages/decepticon-core/tests` → 88 passed (incl. the public-API stability manifest and the langchain-free runtime guarantee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
