### PR TITLE
fix(tools/web): make http_request async (deadlocked under LangGraph's event loop)

### DIFF
--- a/packages/decepticon/decepticon/tools/web/tools.py
+++ b/packages/decepticon/decepticon/tools/web/tools.py
@@ -167,7 +167,7 @@ def _get_session() -> HTTPSession:
 
 
 @tool
-def http_request(
+async def http_request(
     method: str,
     url: str,
     headers_json: str = "{}",
@@ -186,14 +186,16 @@ def http_request(
     Returns:
         JSON with status, headers, body (truncated), elapsed_ms, request_id
     """
-    import asyncio
-
     try:
         headers = json.loads(headers_json) if headers_json else {}
     except json.JSONDecodeError:
         return _json({"error": "Invalid headers JSON"})
 
-    async def _do():
+    # Async tool: await the session directly. The previous implementation
+    # drove the coroutine via ``asyncio.get_event_loop().run_until_complete``,
+    # which raises ``RuntimeError: ... cannot be called from a running event
+    # loop`` under LangGraph's async runtime. Mirrors the async bash tools.
+    try:
         session = _get_session()
         resp = await session.request(
             method=method.upper(),
@@ -202,10 +204,6 @@ def http_request(
             body=body.encode() if body else None,
             tag=tag,
         )
-        return resp
-
-    try:
-        resp = asyncio.get_event_loop().run_until_complete(_do())
         return _json(
             {
                 "status": resp.status,

--- a/packages/decepticon/tests/unit/tools/web/test_http_request.py
+++ b/packages/decepticon/tests/unit/tools/web/test_http_request.py
@@ -1,0 +1,64 @@
+"""Regression: ``http_request`` must work inside a running event loop.
+
+The tool previously drove its async HTTP session via
+``asyncio.get_event_loop().run_until_complete(...)``, which raises
+``RuntimeError: ... cannot be called from a running event loop`` under
+LangGraph's async runtime. It is now an async ``@tool``; these tests
+invoke it from *within* a running loop (pytest-asyncio auto mode) with a
+stubbed session to prove it no longer crashes and forwards args correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import decepticon.tools.web.tools as web_tools
+from decepticon.tools.web.tools import http_request
+
+
+class _FakeResp:
+    status = 200
+    headers = {"Content-Type": "text/plain"}
+    elapsed_ms = 12.3
+    request_id = "req-1"
+
+    def text(self, max_chars: int = 4000) -> str:
+        return "hello"
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def request(self, *, method, url, headers, body, tag):
+        self.calls.append(
+            {"method": method, "url": url, "headers": headers, "body": body, "tag": tag}
+        )
+        return _FakeResp()
+
+
+async def test_http_request_runs_inside_running_loop(monkeypatch):
+    fake = _FakeSession()
+    monkeypatch.setattr(web_tools, "_get_session", lambda: fake)
+
+    # ainvoke drives the tool coroutine on the *current* running loop — the
+    # exact condition that broke the old run_until_complete implementation.
+    raw = await http_request.ainvoke(
+        {"method": "get", "url": "http://target.example/x", "headers_json": '{"X-A": "1"}'}
+    )
+
+    out = json.loads(raw)
+    assert out["status"] == 200
+    assert out["body"] == "hello"
+    assert out["request_id"] == "req-1"
+    # method upper-cased, headers parsed, forwarded to the session.
+    assert fake.calls[0]["method"] == "GET"
+    assert fake.calls[0]["url"] == "http://target.example/x"
+    assert fake.calls[0]["headers"] == {"X-A": "1"}
+
+
+async def test_http_request_invalid_headers_json(monkeypatch):
+    monkeypatch.setattr(web_tools, "_get_session", lambda: _FakeSession())
+    raw = await http_request.ainvoke({"method": "GET", "url": "http://x", "headers_json": "{bad"})
+    assert json.loads(raw)["error"] == "Invalid headers JSON"

--- a/packages/decepticon/tests/unit/tools/web/test_http_request.py
+++ b/packages/decepticon/tests/unit/tools/web/test_http_request.py
@@ -14,7 +14,6 @@ import json
 from typing import Any
 
 import decepticon.tools.web.tools as web_tools
-from decepticon.tools.web.tools import http_request
 
 
 class _FakeResp:
@@ -44,7 +43,7 @@ async def test_http_request_runs_inside_running_loop(monkeypatch):
 
     # ainvoke drives the tool coroutine on the *current* running loop — the
     # exact condition that broke the old run_until_complete implementation.
-    raw = await http_request.ainvoke(
+    raw = await web_tools.http_request.ainvoke(
         {"method": "get", "url": "http://target.example/x", "headers_json": '{"X-A": "1"}'}
     )
 
@@ -59,6 +58,8 @@ async def test_http_request_runs_inside_running_loop(monkeypatch):
 
 
 async def test_http_request_invalid_headers_json(monkeypatch):
-    monkeypatch.setattr(web_tools, "_get_session", lambda: _FakeSession())
-    raw = await http_request.ainvoke({"method": "GET", "url": "http://x", "headers_json": "{bad"})
+    monkeypatch.setattr(web_tools, "_get_session", _FakeSession)
+    raw = await web_tools.http_request.ainvoke(
+        {"method": "GET", "url": "http://x", "headers_json": "{bad"}
+    )
     assert json.loads(raw)["error"] == "Invalid headers JSON"


### PR DESCRIPTION
## What

`http_request` (in `decepticon/tools/web/tools.py`) was a **sync** `@tool` that ran its async `HTTPSession` like this:

```python
resp = asyncio.get_event_loop().run_until_complete(_do())
```

## Why it's a bug

Under LangGraph's async runtime the loop is already running, so `run_until_complete` raises `RuntimeError: ... cannot be called from a running event loop`. Every other network-touching tool (`bash`, `bash_output`, …) is already an `async def @tool`. The defect is **latent** only because no standard agent currently imports `WEB_TOOLS` — but it would fire the instant a web agent is wired.

## Fix

Convert `http_request` to `async def` and `await session.request(...)` directly, dropping the `_do` closure, the `run_until_complete` call, and the local `asyncio` import. Output is byte-for-byte identical.

## Verification

- First tests for the web tool layer (`tests/unit/tools/web/`): invokes the tool **inside a running event loop** (the exact condition that used to crash) with a stubbed session, asserts the response JSON + arg forwarding, and covers the invalid-headers path.
- `ruff` clean, `basedpyright` 0 errors, `pytest tests/unit/tools/web/` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
