### PR TITLE
feat(tools): add opt-in MCP client to consume external MCP tool servers

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,57 @@
+# MCP tool servers (opt-in)
+
+Decepticon can attach to external **Model Context Protocol** (MCP)
+servers — e.g. a Kali MCP daemon or HexStrike — and expose their
+tools to the agents alongside the built-in ones.
+
+The integration is **opt-in** and **additive**: nothing is loaded
+unless you both (a) install the optional adapter package and (b)
+point Decepticon at one or more MCP servers via an env var.
+
+## 1. Install the adapter
+
+```bash
+pip install langchain-mcp-adapters
+```
+
+The dependency is intentionally **not** in `decepticon`'s base
+install — operators who don't use MCP don't pay for it. If the
+package is missing when MCP is configured, Decepticon logs a single
+warning and continues with built-in tools only.
+
+## 2. Declare your servers
+
+Set `DECEPTICON_MCP__SERVERS` to a JSON object mapping a server name
+to a per-server config:
+
+```bash
+export DECEPTICON_MCP__SERVERS='{
+  "kali": {"url": "http://localhost:8000/mcp", "transport": "streamable_http"},
+  "hex":  {"command": "uvx", "args": ["hexstrike"], "transport": "stdio"}
+}'
+```
+
+Per-server fields:
+
+| Field       | Required for             | Notes                                   |
+|-------------|--------------------------|-----------------------------------------|
+| `transport` | always (default inferred) | `streamable_http`, `sse`, or `stdio`   |
+| `url`       | HTTP transports          | server endpoint                         |
+| `command`   | `stdio`                  | executable to launch                    |
+| `args`      | `stdio` (optional)       | list of CLI args                        |
+| `headers`   | HTTP (optional)          | extra headers, e.g. `Authorization`     |
+
+Malformed JSON, unknown transports, or unreachable servers are
+**logged and skipped** — they never crash the agent process.
+
+## 3. Programmatic use
+
+```python
+from decepticon.tools.mcp import load_mcp_tools, mcp_servers_configured
+
+if mcp_servers_configured():
+    tools = await load_mcp_tools()
+```
+
+Auto-wiring these tools into the live agent graphs is a planned
+follow-up; for now the loader is the seam.

--- a/packages/decepticon/decepticon/tools/mcp/__init__.py
+++ b/packages/decepticon/decepticon/tools/mcp/__init__.py
@@ -1,0 +1,26 @@
+"""MCP (Model Context Protocol) tool-server client integration.
+
+Opt-in bridge so Decepticon agents can use tools exposed by external
+MCP servers (e.g. Kali MCP server, HexStrike). Activation is purely
+env-driven (``DECEPTICON_MCP__SERVERS``) and requires the optional
+``langchain-mcp-adapters`` package to be installed separately —
+nothing in this subpackage is imported at framework start-up.
+
+See ``docs/mcp.md`` for operator-facing configuration notes.
+"""
+
+from __future__ import annotations
+
+from decepticon.tools.mcp.client import (
+    MCPServerConfig,
+    load_mcp_tools,
+    mcp_servers_configured,
+    parse_mcp_servers_env,
+)
+
+__all__ = [
+    "MCPServerConfig",
+    "load_mcp_tools",
+    "mcp_servers_configured",
+    "parse_mcp_servers_env",
+]

--- a/packages/decepticon/decepticon/tools/mcp/client.py
+++ b/packages/decepticon/decepticon/tools/mcp/client.py
@@ -1,0 +1,240 @@
+"""MCP tool-server client — opt-in, lazy, never fatal.
+
+This module is the single bridge between Decepticon and external
+Model Context Protocol (MCP) servers (e.g. a Kali MCP daemon,
+HexStrike). It is deliberately additive and self-contained:
+
+- Nothing here is imported at framework start-up.
+- The heavy dependency (``langchain-mcp-adapters``) is imported
+  *inside* :func:`load_mcp_tools`, wrapped in ``try/except
+  ImportError`` so missing it merely disables MCP — agents keep
+  working.
+- A single misconfigured server logs+skips; it never kills the
+  whole tool-load.
+
+Configuration
+-------------
+Operators set ``DECEPTICON_MCP__SERVERS`` to a JSON object mapping
+server-name -> per-server config::
+
+    DECEPTICON_MCP__SERVERS='{
+        "kali":    {"url": "http://localhost:8000/mcp",
+                    "transport": "streamable_http"},
+        "hex":     {"command": "uvx", "args": ["hexstrike"],
+                    "transport": "stdio"}
+    }'
+
+The env-var naming matches the existing ``DECEPTICON_<SECTION>__<KEY>``
+convention used by ``DECEPTICON_BUDGET__*``, ``DECEPTICON_RUNTIME__*``,
+``DECEPTICON_LLM__*``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from decepticon_core.utils.logging import get_logger
+
+log = get_logger("tools.mcp")
+
+#: Env var that carries the JSON server map. Empty / unset => MCP off.
+ENV_SERVERS = "DECEPTICON_MCP__SERVERS"
+
+#: Transports recognised by ``langchain-mcp-adapters``' MultiServerMCPClient.
+Transport = Literal["streamable_http", "sse", "stdio"]
+
+_VALID_TRANSPORTS: frozenset[str] = frozenset({"streamable_http", "sse", "stdio"})
+
+
+@dataclass(frozen=True)
+class MCPServerConfig:
+    """Parsed configuration for a single MCP server.
+
+    Mirrors the per-server kwargs accepted by
+    ``langchain_mcp_adapters.client.MultiServerMCPClient``. Only fields
+    relevant to the chosen ``transport`` are populated; the others
+    stay at their dataclass defaults.
+
+    Attributes:
+        name: server identifier (the JSON map key).
+        transport: ``streamable_http`` / ``sse`` (HTTP-style) or
+            ``stdio`` (subprocess-style).
+        url: target URL for HTTP transports.
+        command: executable for stdio transport.
+        args: argv tail for stdio transport.
+        headers: optional HTTP headers (auth tokens, etc.).
+    """
+
+    name: str
+    transport: Transport
+    url: str | None = None
+    command: str | None = None
+    args: tuple[str, ...] = ()
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+    def to_client_kwargs(self) -> dict[str, Any]:
+        """Render this config as the dict ``MultiServerMCPClient`` expects."""
+        payload: dict[str, Any] = {"transport": self.transport}
+        if self.transport == "stdio":
+            if self.command is not None:
+                payload["command"] = self.command
+            if self.args:
+                payload["args"] = list(self.args)
+        else:
+            if self.url is not None:
+                payload["url"] = self.url
+            if self.headers:
+                payload["headers"] = dict(self.headers)
+        return payload
+
+
+def _default_transport(entry: Mapping[str, Any]) -> Transport:
+    """Pick a sensible transport when the user omitted one.
+
+    Rules: ``command`` present => ``stdio``; otherwise ``streamable_http``
+    (the modern HTTP transport — operators on legacy SSE servers must
+    set ``transport`` explicitly).
+    """
+    if "command" in entry:
+        return "stdio"
+    return "streamable_http"
+
+
+def _parse_one(name: str, entry: Any) -> MCPServerConfig | None:
+    """Parse a single server entry. Returns ``None`` on invalid input."""
+    if not isinstance(entry, Mapping):
+        log.warning(
+            "ignoring MCP server %r: entry must be a JSON object, got %s",
+            name,
+            type(entry).__name__,
+        )
+        return None
+
+    transport_raw = entry.get("transport") or _default_transport(entry)
+    if transport_raw not in _VALID_TRANSPORTS:
+        log.warning(
+            "ignoring MCP server %r: unknown transport %r (expected one of %s)",
+            name,
+            transport_raw,
+            sorted(_VALID_TRANSPORTS),
+        )
+        return None
+    transport: Transport = transport_raw  # type: narrow
+
+    args_raw = entry.get("args") or ()
+    if not isinstance(args_raw, (list, tuple)):
+        log.warning("ignoring MCP server %r: 'args' must be a list", name)
+        return None
+
+    headers_raw = entry.get("headers") or {}
+    if not isinstance(headers_raw, Mapping):
+        log.warning("ignoring MCP server %r: 'headers' must be an object", name)
+        return None
+
+    return MCPServerConfig(
+        name=name,
+        transport=transport,
+        url=entry.get("url"),
+        command=entry.get("command"),
+        args=tuple(str(a) for a in args_raw),
+        headers={str(k): str(v) for k, v in headers_raw.items()},
+    )
+
+
+def parse_mcp_servers_env(raw: str | None) -> tuple[MCPServerConfig, ...]:
+    """Parse the JSON value of ``DECEPTICON_MCP__SERVERS``.
+
+    Empty / whitespace / unset input returns ``()``. Malformed JSON
+    logs a warning and also returns ``()`` (never raises — a busted
+    env var must not crash the agent process).
+    """
+    if not raw or not raw.strip():
+        return ()
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log.warning(
+            "ignoring %s: malformed JSON (%s); set it to a JSON object "
+            "mapping server-name -> config",
+            ENV_SERVERS,
+            exc,
+        )
+        return ()
+    if not isinstance(loaded, Mapping):
+        log.warning(
+            "ignoring %s: top-level value must be a JSON object, got %s",
+            ENV_SERVERS,
+            type(loaded).__name__,
+        )
+        return ()
+
+    parsed: list[MCPServerConfig] = []
+    for name, entry in loaded.items():
+        cfg = _parse_one(str(name), entry)
+        if cfg is not None:
+            parsed.append(cfg)
+    return tuple(parsed)
+
+
+def _read_env_servers() -> tuple[MCPServerConfig, ...]:
+    return parse_mcp_servers_env(os.environ.get(ENV_SERVERS))
+
+
+def mcp_servers_configured() -> bool:
+    """``True`` iff at least one MCP server is configured via env."""
+    return bool(_read_env_servers())
+
+
+async def load_mcp_tools(
+    config: tuple[MCPServerConfig, ...] | None = None,
+) -> list[Any]:
+    """Connect to every configured MCP server and return their tools.
+
+    If ``config`` is omitted, the env var is parsed. Empty config =>
+    ``[]`` with no work done. The optional ``langchain-mcp-adapters``
+    dependency is imported lazily here; absence is downgraded to a
+    one-line warning + empty list so agents stay usable.
+
+    A failure connecting to *one* server is logged and skipped — other
+    servers still contribute their tools.
+    """
+    servers = config if config is not None else _read_env_servers()
+    if not servers:
+        return []
+
+    try:
+        from langchain_mcp_adapters.client import MultiServerMCPClient
+    except ImportError:
+        log.warning(
+            "%s is set but the optional 'langchain-mcp-adapters' package "
+            "is not installed; install it (e.g. `pip install "
+            "langchain-mcp-adapters`) to enable MCP tools",
+            ENV_SERVERS,
+        )
+        return []
+
+    # MultiServerMCPClient accepts the whole connection dict up-front,
+    # but per-server connection failures inside get_tools() would tank
+    # the entire load. We therefore probe servers one-by-one so a
+    # single bad endpoint doesn't kill the rest.
+    collected: list[Any] = []
+    for srv in servers:
+        connections = {srv.name: srv.to_client_kwargs()}
+        try:
+            client = MultiServerMCPClient(connections)
+            tools = await client.get_tools()
+        except Exception as exc:  # noqa: BLE001 — third-party I/O
+            log.warning(
+                "MCP server %r unreachable, skipping (%s: %s)",
+                srv.name,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+        log.info("loaded %d tool(s) from MCP server %r", len(tools), srv.name)
+        collected.extend(tools)
+    return collected

--- a/packages/decepticon/tests/unit/tools/test_mcp_client.py
+++ b/packages/decepticon/tests/unit/tools/test_mcp_client.py
@@ -1,0 +1,260 @@
+"""Tests for ``decepticon.tools.mcp.client``.
+
+These tests must never reach the real network and must never require
+``langchain-mcp-adapters`` to be installed — both are simulated via
+monkeypatching ``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from decepticon.tools.mcp.client import (
+    ENV_SERVERS,
+    MCPServerConfig,
+    load_mcp_tools,
+    mcp_servers_configured,
+    parse_mcp_servers_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _propagate_mcp_logger():
+    """Let ``caplog`` see records — the ``decepticon`` root sets
+    ``propagate=False`` (see ``decepticon_core.utils.logging``).
+    """
+    # The "decepticon" root logger has ``propagate=False`` — records
+    # never reach pytest's root-level caplog handler unless we flip it.
+    root = logging.getLogger("decepticon")
+    prev = root.propagate
+    root.propagate = True
+    try:
+        yield
+    finally:
+        root.propagate = prev
+
+
+# ---------------------------------------------------------------- parse
+
+
+def test_parse_empty_returns_empty_tuple():
+    assert parse_mcp_servers_env(None) == ()
+    assert parse_mcp_servers_env("") == ()
+    assert parse_mcp_servers_env("   ") == ()
+
+
+def test_parse_two_servers_roundtrip():
+    raw = json.dumps(
+        {
+            "kali": {"url": "http://localhost:8000/mcp", "transport": "streamable_http"},
+            "hex": {"command": "uvx", "args": ["hexstrike"], "transport": "stdio"},
+        }
+    )
+    parsed = parse_mcp_servers_env(raw)
+    assert len(parsed) == 2
+    by_name = {s.name: s for s in parsed}
+    assert by_name["kali"].transport == "streamable_http"
+    assert by_name["kali"].url == "http://localhost:8000/mcp"
+    assert by_name["hex"].transport == "stdio"
+    assert by_name["hex"].command == "uvx"
+    assert by_name["hex"].args == ("hexstrike",)
+
+
+def test_parse_default_transport_http_when_url_only():
+    raw = json.dumps({"a": {"url": "http://x/mcp"}})
+    (cfg,) = parse_mcp_servers_env(raw)
+    assert cfg.transport == "streamable_http"
+
+
+def test_parse_default_transport_stdio_when_command_present():
+    raw = json.dumps({"a": {"command": "uvx", "args": ["foo"]}})
+    (cfg,) = parse_mcp_servers_env(raw)
+    assert cfg.transport == "stdio"
+
+
+def test_parse_malformed_json_returns_empty_and_warns(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = parse_mcp_servers_env("{not valid json")
+    assert result == ()
+    assert any("malformed JSON" in rec.message for rec in caplog.records)
+
+
+def test_parse_non_object_top_level_returns_empty(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = parse_mcp_servers_env(json.dumps(["not", "an", "object"]))
+    assert result == ()
+    assert any("must be a JSON object" in rec.message for rec in caplog.records)
+
+
+def test_parse_unknown_transport_is_skipped(caplog: pytest.LogCaptureFixture):
+    raw = json.dumps(
+        {
+            "good": {"url": "http://x/mcp", "transport": "streamable_http"},
+            "bad": {"url": "http://y/mcp", "transport": "carrier-pigeon"},
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        parsed = parse_mcp_servers_env(raw)
+    names = {s.name for s in parsed}
+    assert names == {"good"}
+    assert any("unknown transport" in rec.message for rec in caplog.records)
+
+
+def test_parse_bad_entry_shape_is_skipped(caplog: pytest.LogCaptureFixture):
+    raw = json.dumps({"weird": "not-an-object"})
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        parsed = parse_mcp_servers_env(raw)
+    assert parsed == ()
+    assert any("must be a JSON object" in rec.message for rec in caplog.records)
+
+
+def test_to_client_kwargs_http_includes_url_and_headers():
+    cfg = MCPServerConfig(
+        name="kali",
+        transport="streamable_http",
+        url="http://x/mcp",
+        headers={"Authorization": "Bearer t"},
+    )
+    kwargs = cfg.to_client_kwargs()
+    assert kwargs == {
+        "transport": "streamable_http",
+        "url": "http://x/mcp",
+        "headers": {"Authorization": "Bearer t"},
+    }
+
+
+def test_to_client_kwargs_stdio_includes_command_args():
+    cfg = MCPServerConfig(
+        name="hex", transport="stdio", command="uvx", args=("hexstrike", "--flag")
+    )
+    kwargs = cfg.to_client_kwargs()
+    assert kwargs == {
+        "transport": "stdio",
+        "command": "uvx",
+        "args": ["hexstrike", "--flag"],
+    }
+
+
+# ---------------------------------------------------------------- env probe
+
+
+def test_mcp_servers_configured_false_when_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(ENV_SERVERS, raising=False)
+    assert mcp_servers_configured() is False
+
+
+def test_mcp_servers_configured_true_when_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        ENV_SERVERS,
+        json.dumps({"k": {"url": "http://x/mcp", "transport": "streamable_http"}}),
+    )
+    assert mcp_servers_configured() is True
+
+
+# ---------------------------------------------------------------- load_mcp_tools
+
+
+async def test_load_mcp_tools_no_servers_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(ENV_SERVERS, raising=False)
+    assert await load_mcp_tools() == []
+
+
+async def test_load_mcp_tools_malformed_env_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    monkeypatch.setenv(ENV_SERVERS, "{bogus")
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = await load_mcp_tools()
+    assert result == []
+
+
+async def test_load_mcp_tools_missing_package_is_graceful(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """If langchain_mcp_adapters can't be imported, return [] with a warning."""
+    # Block both the package and the submodule. ``import x.y`` consults
+    # ``sys.modules`` first and raises ImportError when the value is None.
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters", None)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters.client", None)
+    servers = (MCPServerConfig(name="kali", transport="streamable_http", url="http://x/mcp"),)
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = await load_mcp_tools(servers)
+    assert result == []
+    assert any("langchain-mcp-adapters" in rec.message for rec in caplog.records)
+
+
+async def test_load_mcp_tools_uses_mock_client_when_package_present(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Inject a fake ``langchain_mcp_adapters.client.MultiServerMCPClient``."""
+    sentinel_tools = [object(), object()]
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self, connections: dict[str, Any]):
+            captured["connections"] = connections
+
+        async def get_tools(self) -> list[Any]:
+            return sentinel_tools
+
+    fake_pkg = types.ModuleType("langchain_mcp_adapters")
+    fake_client_mod = types.ModuleType("langchain_mcp_adapters.client")
+    fake_client_mod.MultiServerMCPClient = FakeClient  # type: ignore[attr-defined]
+    fake_pkg.client = fake_client_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters", fake_pkg)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters.client", fake_client_mod)
+
+    servers = (
+        MCPServerConfig(
+            name="kali",
+            transport="streamable_http",
+            url="http://localhost:8000/mcp",
+            headers={"X-Auth": "secret"},
+        ),
+    )
+    result = await load_mcp_tools(servers)
+    assert result == sentinel_tools
+    assert captured["connections"] == {
+        "kali": {
+            "transport": "streamable_http",
+            "url": "http://localhost:8000/mcp",
+            "headers": {"X-Auth": "secret"},
+        }
+    }
+
+
+async def test_load_mcp_tools_one_bad_server_does_not_kill_others(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    good_tool = object()
+
+    class FakeClient:
+        def __init__(self, connections: dict[str, Any]):
+            self._connections = connections
+
+        async def get_tools(self) -> list[Any]:
+            if "bad" in self._connections:
+                raise ConnectionError("nope")
+            return [good_tool]
+
+    fake_pkg = types.ModuleType("langchain_mcp_adapters")
+    fake_client_mod = types.ModuleType("langchain_mcp_adapters.client")
+    fake_client_mod.MultiServerMCPClient = FakeClient  # type: ignore[attr-defined]
+    fake_pkg.client = fake_client_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters", fake_pkg)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters.client", fake_client_mod)
+
+    servers = (
+        MCPServerConfig(name="bad", transport="streamable_http", url="http://x/mcp"),
+        MCPServerConfig(name="ok", transport="streamable_http", url="http://y/mcp"),
+    )
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = await load_mcp_tools(servers)
+    assert result == [good_tool]
+    assert any("unreachable" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## What

Adds an **opt-in MCP (Model Context Protocol) client** so operators can connect external MCP tool servers — e.g. the [Kali MCP server](https://www.kali.org/tools/mcp-kali-server/), [HexStrike](https://github.com/0x4m4/hexstrike-ai) — and expose their tools to Decepticon agents.

This was the one capability verified to be **genuinely absent** today (Decepticon has no MCP client or server). It directly matches the MCP-based tooling ecosystem several peer projects are built on.

## Design (additive, self-contained, never fatal)

- **Config**: `DECEPTICON_MCP__SERVERS` — a JSON object mapping `server-name -> {url|command, transport, ...}`. Matches the existing `DECEPTICON_<SECTION>__<KEY>` convention (`DECEPTICON_BUDGET__*`, `DECEPTICON_LLM__*`).
- **Lazy + graceful**: `langchain-mcp-adapters` is imported *inside* `load_mcp_tools()`, wrapped in `try/except ImportError`. Missing package → one-line warning + empty list; agents keep working. Nothing is imported at framework start-up.
- **Per-server isolation**: one misconfigured/unreachable server logs+skips; the rest still load.
- **Robust parsing**: empty/unset env, malformed JSON, and bad per-server entries all degrade to a warning + skip — a busted env var never crashes the agent process.

## Public API (`decepticon.tools.mcp`)

- `load_mcp_tools(config=None) -> list` (async)
- `mcp_servers_configured() -> bool`
- `parse_mcp_servers_env(raw) -> tuple[MCPServerConfig, ...]`
- `MCPServerConfig`

## Scope / why no dependency change

This PR ships the **foundation only** and intentionally makes **no `pyproject.toml`/`uv.lock` changes** (so `uv sync --locked` stays valid and CI stays green). The optional package is documented as a manual install in `docs/mcp.md`. Follow-ups: (1) add the locked `decepticon[mcp]` optional extra; (2) opt-in wiring of MCP tools into live agent graphs.

## Tests / verification (run locally)

- `ruff check` — All checks passed
- `ruff format --check` — clean
- `basedpyright` — **0 errors** (1 warning: the intentional lazy import of the optional package; the CI gate enforces errors only)
- `pytest` — **17 passed** (fully mocked: empty/malformed env, transport defaults, unknown transport, missing-package ImportError path, mock client constructor kwargs, one-bad-server-doesn't-kill-others). No network.

## Files

- `packages/decepticon/decepticon/tools/mcp/{__init__,client}.py`
- `packages/decepticon/tests/unit/tools/test_mcp_client.py`
- `docs/mcp.md`
