### PR TITLE
fix(skillogy): fail loud on the unwired gRPC transport (no silent dead port)

### DIFF
--- a/packages/decepticon/decepticon/skillogy/server/app.py
+++ b/packages/decepticon/decepticon/skillogy/server/app.py
@@ -1,15 +1,17 @@
-"""FastAPI REST app + gRPC service for Skillogy.
+"""FastAPI REST app for Skillogy — the supported transport.
 
-REST endpoints (mirror gRPC methods 1:1):
+REST endpoints (named after the proto's RPC methods):
 - ``POST /v1/skills:list``        -> ListSkills
 - ``POST /v1/skills:load``        -> LoadSkill
 - ``POST /v1/skills:ingest``      -> IngestSkill
 - ``GET  /v1/health``             -> Health
 - ``GET  /openapi.json``          -> generated OpenAPI 3.1 schema
 
-The gRPC service is exposed when grpcio is installed; the REST app
-runs standalone without grpcio so the CLI / test paths don't require
-the heavier dependency. Both share the same SkillRegistry instance.
+A gRPC transport is sketched in ``skillogy.proto`` but is not yet wired
+(no protoc-generated bindings), so ``build_grpc_server`` raises and the
+service falls back to REST — see that function's docstring. The REST app
+runs standalone without grpcio so the CLI / test paths don't require the
+heavier dependency.
 """
 
 from __future__ import annotations
@@ -22,7 +24,6 @@ from typing import Any
 from decepticon.skillogy.proto import (
     SkillEnvelope,
     SkillListRequest,
-    SkillMeta,
 )
 from decepticon.skillogy.server.registry import SkillRegistry
 
@@ -137,63 +138,23 @@ def build_app(registry: SkillRegistry, *, started_at: float | None = None):
 
 
 def build_grpc_server(registry: SkillRegistry, *, port: int = 50051):
-    """Construct a grpcio Server bound to ``registry``. Lazy-imports grpcio.
+    """The gRPC transport is not wired yet — this always raises ``RuntimeError``.
 
-    Returns a ``grpc.Server`` instance the caller starts / waits / stops.
-    Falls back to ``RuntimeError`` if grpcio is unavailable.
+    Skillogy ships a hand-rolled ``skillogy.proto`` but no ``protoc``-generated
+    bindings, so there is no servicer registrar (``add_*Servicer_to_server``)
+    and no message (de)serializers. A ``grpc.Server`` constructed here would
+    bind ``port`` yet answer every RPC with ``UNIMPLEMENTED`` — a silent dead
+    port that *looks* healthy. Until codegen is wired into the build, **REST is
+    the only supported transport** (``build_app`` + ``RestSkillogyClient``);
+    ``decepticon.skillogy.__main__._start_grpc`` already catches this
+    ``RuntimeError`` and serves REST only.
+
+    ``registry`` and ``port`` are accepted so this stays signature-compatible
+    with its single call site and the future protoc-backed implementation.
     """
-    try:
-        import grpc  # noqa: PLC0415
-    except ImportError as exc:
-        raise RuntimeError(
-            "Skillogy gRPC requires grpcio. Install with: pip install grpcio grpcio-tools"
-        ) from exc
-
-    class _RawSkillogyServicer:
-        def ListSkills(self, request, _context):
-            return _RawResponse(
-                registry.list(
-                    SkillListRequest(
-                        subdomain_filter=list(getattr(request, "subdomain_filter", []) or []),
-                        tag_filter=list(getattr(request, "tag_filter", []) or []),
-                        mitre_filter=list(getattr(request, "mitre_filter", []) or []),
-                        include_safety_critical=getattr(request, "include_safety_critical", True),
-                        include_gated=getattr(request, "include_gated", True),
-                        page_size=getattr(request, "page_size", 100),
-                        page_token=getattr(request, "page_token", "") or "",
-                    )
-                )
-            )
-
-        def LoadSkill(self, request, _context):
-            return registry.load(getattr(request, "path", "")) or SkillEnvelope(meta=SkillMeta())
-
-        def IngestSkill(self, request, _context):
-            return registry.ingest(
-                getattr(request, "path", ""),
-                getattr(request, "body", ""),
-                references=dict(getattr(request, "references", {}) or {}),
-                scripts=dict(getattr(request, "scripts", {}) or {}),
-            )
-
-        def Health(self, _request, _context):
-            return _HealthResp(status="ok", skill_count=len(registry))
-
-    server = grpc.server(
-        thread_pool=__import__("concurrent.futures").futures.ThreadPoolExecutor(max_workers=10)
+    raise RuntimeError(
+        "Skillogy gRPC transport is not wired: skillogy.proto has no "
+        "protoc-generated bindings, so the server would register no servicer "
+        "and could not (de)serialize messages. Use the REST transport — "
+        "build_app(registry) served by uvicorn, with RestSkillogyClient."
     )
-    server.add_insecure_port(f"0.0.0.0:{port}")
-    return server, _RawSkillogyServicer()
-
-
-class _RawResponse:
-    def __init__(self, list_resp):
-        self.skills = list_resp.skills
-        self.next_page_token = list_resp.next_page_token
-        self.total_count = list_resp.total_count
-
-
-class _HealthResp:
-    def __init__(self, status, skill_count):
-        self.status = status
-        self.skill_count = skill_count

--- a/packages/decepticon/tests/unit/skillogy/test_grpc_server.py
+++ b/packages/decepticon/tests/unit/skillogy/test_grpc_server.py
@@ -1,0 +1,31 @@
+"""``build_grpc_server`` must fail loud until the gRPC transport is wired.
+
+The hand-rolled ``skillogy.proto`` has no protoc-generated bindings, so a
+``grpc.Server`` built from it would bind a port but answer every RPC with
+``UNIMPLEMENTED`` — a silent dead port. ``build_grpc_server`` therefore raises
+``RuntimeError``, and ``__main__._start_grpc`` degrades gracefully to REST.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon.skillogy.server import SkillRegistry, build_grpc_server
+
+
+def test_build_grpc_server_raises_until_wired() -> None:
+    with pytest.raises(RuntimeError) as exc:
+        build_grpc_server(SkillRegistry(), port=50051)
+    msg = str(exc.value)
+    assert "gRPC" in msg
+    # The message must point operators at the supported transport.
+    assert "REST" in msg
+
+
+def test_start_grpc_degrades_to_rest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The boot path swallows the RuntimeError and returns None (no thread),
+    so the REST server still comes up."""
+    from decepticon.skillogy import __main__ as skillogy_main
+
+    thread = skillogy_main._start_grpc(SkillRegistry(), 50051)
+    assert thread is None


### PR DESCRIPTION
## The bug

`build_grpc_server` built a `grpc.Server`, bound `0.0.0.0:<port>`, and returned a servicer — but **never registered it** (`add_*Servicer_to_server` is never called; there are no `protoc`-generated bindings for `skillogy.proto`). The hand-rolled `_RawSkillogyServicer` also returned plain Python objects with **no message serializers**. So whenever `grpcio` was installed, `__main__._start_grpc` opened a port that accepts TCP connections but answers **every** RPC (`ListSkills`/`LoadSkill`/`IngestSkill`/`Health`) with `UNIMPLEMENTED` — a silent dead port that looks healthy to a liveness probe.

REST is the only wired transport: the client is `RestSkillogyClient`, and the skillogy middleware (consumed elsewhere) connects over REST to `:9100`.

## Fix

`build_grpc_server` now raises `RuntimeError` with a message that names the cause and points at the REST transport. `__main__._start_grpc` **already** catches `RuntimeError` and logs `gRPC disabled: …`, so the service degrades cleanly to REST-only with no dead port. Removed the dead servicer + `_RawResponse`/`_HealthResp` scaffolding (their RPC→registry mapping is identical to the REST handlers) and the now-unused `SkillMeta` import; updated the module docstring. The function signature is unchanged so the future protoc-backed implementation drops in.

## Verification
- New tests: `build_grpc_server` raises (message mentions gRPC **and** REST); `_start_grpc` returns `None` (graceful degrade).
- `ruff` + `ruff format --check` clean, `basedpyright` 0 errors, `pytest tests/unit/skillogy/` → 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
