### PR TITLE
[codex] add audit ledger verification CLI

### DIFF
--- a/packages/decepticon/decepticon/cli/__main__.py
+++ b/packages/decepticon/decepticon/cli/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 
+from decepticon.cli.audit import main as audit_main
 from decepticon.cli.auth import main as auth_main
 from decepticon.cli.scan import main as scan_main
 
@@ -14,6 +15,7 @@ def _print_help() -> int:
         "Subcommands:\n"
         "  scan    Run a one-shot security scan and emit SARIF\n"
         "  auth    Show provider/auth configuration (API keys + subscriptions)\n\n"
+        "  audit   Verify engagement audit ledgers\n\n"
         "Run a subcommand with --help for its flags.",
         file=sys.stderr,
     )
@@ -30,6 +32,8 @@ def main(argv: list[str] | None = None) -> int:
         return scan_main(rest)
     if sub == "auth":
         return auth_main(rest)
+    if sub == "audit":
+        return audit_main(rest)
     print(f"unknown subcommand: {sub}\n", file=sys.stderr)
     _print_help()
     return 2

--- a/packages/decepticon/decepticon/cli/audit.py
+++ b/packages/decepticon/decepticon/cli/audit.py
@@ -1,0 +1,99 @@
+"""``decepticon-cli audit`` - engagement audit ledger utilities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from decepticon.middleware._audit_sink import VerifyResult, verify_ledger
+
+EXIT_OK = 0
+EXIT_TAMPERED = 1
+EXIT_CONFIG = 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="decepticon-cli audit",
+        description="Verify Decepticon engagement audit ledgers.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+    verify = sub.add_parser(
+        "verify",
+        help="Verify a RoE audit JSONL hash chain and optional HMAC binder.",
+    )
+    verify.add_argument(
+        "ledger",
+        type=Path,
+        help="Path to the audit JSONL ledger, usually <workspace>/audit/roe-decisions.jsonl.",
+    )
+    verify.add_argument(
+        "--hmac-key",
+        default=None,
+        help=(
+            "Operator-held HMAC key. Defaults to $DECEPTICON_AUDIT_HMAC_KEY when set; "
+            "omit both to verify only the hash chain."
+        ),
+    )
+    verify.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return p
+
+
+def _hmac_key(arg_value: str | None) -> bytes | None:
+    value = arg_value if arg_value is not None else os.environ.get("DECEPTICON_AUDIT_HMAC_KEY")
+    return value.encode("utf-8") if value else None
+
+
+def _render_text(path: Path, result: VerifyResult, *, hmac_checked: bool) -> str:
+    status = "OK" if result.ok else "FAILED"
+    lines = [
+        f"Audit ledger verification: {status}",
+        f"  ledger: {path}",
+        f"  records_checked: {result.records_checked}",
+        f"  hmac_checked: {'yes' if hmac_checked else 'no'}",
+    ]
+    if result.first_bad_seq is not None:
+        lines.append(f"  first_bad_seq: {result.first_bad_seq}")
+    if result.reason:
+        lines.append(f"  reason: {result.reason}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_json(path: Path, result: VerifyResult, *, hmac_checked: bool) -> str:
+    payload = {
+        "ok": result.ok,
+        "ledger": str(path),
+        "records_checked": result.records_checked,
+        "first_bad_seq": result.first_bad_seq,
+        "reason": result.reason,
+        "hmac_checked": hmac_checked,
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command != "verify":
+        return EXIT_CONFIG
+
+    path = Path(args.ledger)
+    if not path.exists():
+        print(f"error: audit ledger not found: {path}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    key = _hmac_key(args.hmac_key)
+    result = verify_ledger(path, hmac_key=key)
+    output = (
+        _render_json(path, result, hmac_checked=key is not None)
+        if args.json
+        else _render_text(path, result, hmac_checked=key is not None)
+    )
+    print(output, end="")
+    return EXIT_OK if result.ok else EXIT_TAMPERED
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/decepticon/pyproject.toml
+++ b/packages/decepticon/pyproject.toml
@@ -82,6 +82,7 @@ telemetry = [
 all = ["decepticon[neo4j,telemetry]"]
 
 [project.scripts]
+decepticon-cli = "decepticon.cli.__main__:main"
 decepticon-kg-health = "decepticon.tools.research.health:main"
 
 # Plugin entry-point groups consumed by ``decepticon.plugin_loader``.

--- a/packages/decepticon/tests/unit/cli/test_audit.py
+++ b/packages/decepticon/tests/unit/cli/test_audit.py
@@ -1,0 +1,90 @@
+"""Tests for ``decepticon-cli audit``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from decepticon.cli.__main__ import main as cli_main
+from decepticon.cli.audit import EXIT_CONFIG, EXIT_OK, EXIT_TAMPERED
+from decepticon.cli.audit import main as audit_main
+from decepticon.middleware._audit_sink import RoEAuditSink
+
+
+def _ledger(path: Path, *, hmac_key: bytes | None = None) -> Path:
+    ledger = path / "roe-decisions.jsonl"
+    sink = RoEAuditSink(path=ledger, hmac_key=hmac_key)
+    sink.append({"event": "allow", "decision": "allow"})
+    sink.append({"event": "refuse", "decision": "refuse"})
+    return ledger
+
+
+def test_verify_clean_ledger_text(tmp_path: Path, capsys) -> None:
+    ledger = _ledger(tmp_path)
+    rc = audit_main(["verify", str(ledger)])
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    assert "Audit ledger verification: OK" in out
+    assert "records_checked: 2" in out
+
+
+def test_verify_clean_ledger_json(tmp_path: Path, capsys) -> None:
+    ledger = _ledger(tmp_path)
+    rc = audit_main(["verify", str(ledger), "--json"])
+    assert rc == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["records_checked"] == 2
+    assert payload["hmac_checked"] is False
+
+
+def test_verify_tampered_ledger_returns_nonzero(tmp_path: Path, capsys) -> None:
+    ledger = _ledger(tmp_path)
+    lines = ledger.read_text(encoding="utf-8").splitlines()
+    rec = json.loads(lines[0])
+    rec["decision"] = "tampered"
+    lines[0] = json.dumps(rec)
+    ledger.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    rc = audit_main(["verify", str(ledger)])
+
+    assert rc == EXIT_TAMPERED
+    out = capsys.readouterr().out
+    assert "Audit ledger verification: FAILED" in out
+    assert "hash mismatch" in out
+
+
+def test_verify_hmac_from_env(tmp_path: Path, monkeypatch, capsys) -> None:
+    ledger = _ledger(tmp_path, hmac_key=b"secret")
+    monkeypatch.setenv("DECEPTICON_AUDIT_HMAC_KEY", "secret")
+
+    rc = audit_main(["verify", str(ledger), "--json"])
+
+    assert rc == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["hmac_checked"] is True
+
+
+def test_verify_wrong_hmac_key_fails(tmp_path: Path, capsys) -> None:
+    ledger = _ledger(tmp_path, hmac_key=b"secret")
+
+    rc = audit_main(["verify", str(ledger), "--hmac-key", "wrong"])
+
+    assert rc == EXIT_TAMPERED
+    assert "hmac mismatch" in capsys.readouterr().out
+
+
+def test_verify_missing_ledger_is_config_error(tmp_path: Path, capsys) -> None:
+    rc = audit_main(["verify", str(tmp_path / "missing.jsonl")])
+
+    assert rc == EXIT_CONFIG
+    assert "audit ledger not found" in capsys.readouterr().err
+
+
+def test_top_level_dispatcher_routes_audit(tmp_path: Path, capsys) -> None:
+    ledger = _ledger(tmp_path)
+
+    rc = cli_main(["audit", "verify", str(ledger)])
+
+    assert rc == EXIT_OK
+    assert "Audit ledger verification: OK" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Adds the missing headless audit verifier promised by the RoE audit sink and exposes the Python CLI as an installed `decepticon-cli` console script.

## What changed

- Added `decepticon-cli audit verify <ledger>` for RoE audit JSONL ledgers.
- Verifies the existing SHA-256 chain and optional HMAC binder via `--hmac-key` or `DECEPTICON_AUDIT_HMAC_KEY`.
- Returns distinct exit codes for OK, tamper detected, and invocation/config errors.
- Wires the top-level Python CLI dispatcher and package entry point.
- Adds unit coverage for clean ledgers, JSON output, tampering, HMAC mismatch, missing files, and dispatcher routing.

## Validation

- `python -m uv run ruff check .`
- `python -m uv run ruff format --check .`
- `python -m uv run pytest -q -m "not slow"` -> 1713 passed, 26 skipped, 12 deselected
- `python -m uv run basedpyright --outputjson` -> 0 errors, 152 existing warnings
- `npm run build --workspace=@decepticon/streaming`
- `npm run typecheck --workspace=@decepticon/cli`
- `npm run build --workspace=@decepticon/cli`
- `npm run test --workspace=@decepticon/cli` -> 21 passed

## Notes

Local `decepticon-cli audit verify` currently triggers the package framework boot before reaching the subcommand; that was pre-existing import-time behavior and is left out of this narrow PR.