### PR TITLE
fix(roe): normalize FQDN trailing dot so it can't bypass scope deny checks

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/roe.py
+++ b/packages/decepticon-core/decepticon_core/types/roe.py
@@ -175,15 +175,23 @@ def _glob_match(pattern: str, candidate: str) -> bool:
 
 def _matches_rule(rule: ScopeRule, target: str) -> bool:
     kind = rule.resolved_kind()
+    # A trailing dot is DNS-equivalent ("host." resolves identically to
+    # "host"), so strip it on BOTH the rule pattern and the target before
+    # matching. Without this, the FQDN form (``metadata.google.internal.`` or
+    # the IMDS IP ``169.254.169.254.``) slips past the forbidden-destination
+    # and out-of-scope deny checks — a verified scope bypass that enabled
+    # cloud-credential exfil in enforce mode. The IP case also failed
+    # ``ip_address()`` parsing (ValueError -> no match) before the strip.
+    norm_target = target.rstrip(".")
     if kind == "cidr":
         try:
             network = ipaddress.ip_network(rule.pattern, strict=False)
-            return ipaddress.ip_address(target) in network
+            return ipaddress.ip_address(norm_target) in network
         except ValueError:
             return False
     if kind == "domain-glob":
-        return _glob_match(rule.pattern, target)
-    return rule.pattern.lower() == target.lower()
+        return _glob_match(rule.pattern.rstrip("."), norm_target)
+    return rule.pattern.rstrip(".").lower() == norm_target.lower()
 
 
 def evaluate_target(

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -388,3 +388,47 @@ class TestSlotRegistration:
         factory = DEFAULT_SLOT_FACTORIES[MiddlewareSlot.ROE_ENFORCEMENT]
         mw = factory(role="recon")
         assert isinstance(mw, RoEEnforcementMiddleware)
+
+
+class TestFqdnTrailingDotNormalization:
+    """Regression: a trailing dot is DNS-equivalent, so the FQDN form of a host
+    must not bypass any scope check. Previously ``metadata.google.internal.``
+    and the IMDS IP ``169.254.169.254.`` slipped past the forbidden-destination
+    and out-of-scope deny rules (the IP form also failed ``ip_address()``
+    parsing and fell through to default-allow)."""
+
+    def test_trailing_dot_does_not_bypass_forbidden_destination(self) -> None:
+        rules = MachineEnforcement.from_dict({"mode": "enforce"})
+        for host in (
+            "metadata.google.internal",
+            "metadata.google.internal.",
+            "169.254.169.254",
+            "169.254.169.254.",
+        ):
+            decision = evaluate_target(host, rules)
+            assert decision.allow is False, host
+            assert decision.reason_code == "FORBIDDEN_DESTINATION", host
+
+    def test_trailing_dot_does_not_bypass_out_of_scope(self) -> None:
+        rules = MachineEnforcement.from_dict(
+            {"mode": "enforce", "in_scope": ["*.acme.com"], "out_of_scope": ["billing.acme.com"]}
+        )
+        for host in ("billing.acme.com", "billing.acme.com."):
+            decision = evaluate_target(host, rules)
+            assert decision.allow is False, host
+            assert decision.reason_code == "OUT_OF_SCOPE", host
+
+    def test_trailing_dot_still_matches_in_scope_glob(self) -> None:
+        rules = MachineEnforcement.from_dict({"mode": "enforce", "in_scope": ["*.acme.com"]})
+        for host in ("app.acme.com", "app.acme.com."):
+            decision = evaluate_target(host, rules)
+            assert decision.allow is True, host
+            assert decision.reason_code == "IN_SCOPE", host
+
+    def test_trailing_dot_on_exact_in_scope_host(self) -> None:
+        rules = MachineEnforcement.from_dict(
+            {"mode": "enforce", "in_scope": ["single-host.example"]}
+        )
+        assert evaluate_target("single-host.example.", rules).allow is True
+        # An unrelated FQDN-form host is still refused (not in scope).
+        assert evaluate_target("other.example.", rules).allow is False


### PR DESCRIPTION
## The bug (verified scope bypass — high severity)

A trailing dot is DNS-equivalent: `curl`, requests, and resolvers treat `metadata.google.internal.` identically to `metadata.google.internal`. But `_matches_rule` (in `decepticon_core/types/roe.py`) compared host patterns with only `.lower()` — no trailing-dot normalization. Reproduced on `main`:

```
evaluate_target("metadata.google.internal",  enforce) -> allow=False FORBIDDEN_DESTINATION
evaluate_target("metadata.google.internal.", enforce) -> allow=True  OK   ← bypass
evaluate_target("169.254.169.254",  enforce)          -> allow=False FORBIDDEN_DESTINATION
evaluate_target("169.254.169.254.", enforce)          -> allow=True  OK   ← bypass
```

In ENFORCE mode this lets the agent reach the cloud metadata service and exfiltrate service-account credentials **despite the built-in IMDS deny list**, and defeats any operator `out_of_scope` host rule — with the audit ledger recording the call as `allow`. The IMDS-IP form also failed `ip_address()` parsing and fell through to default-allow.

## Fix

Strip a trailing dot (keeping the existing case-fold) on **both** the rule pattern and the target inside `_matches_rule`, across host, domain-glob, and CIDR matching. Since `forbidden_destinations`, `out_of_scope`, and `in_scope` all route through `_matches_rule`, all three are normalized consistently. Legitimate in-scope FQDN-form hosts still match; the raw target is preserved in the decision detail for the audit trail.

## Verification

- New `TestFqdnTrailingDotNormalization` covers forbidden-destination, out-of-scope, and in-scope paths for both the host and IMDS-IP forms; confirms the bypass is closed and legitimate allow/deny is preserved.
- `ruff` + `ruff format --check` clean, `basedpyright` 0 errors, `pytest test_roe.py + decepticon-core/tests` → 130 passed.

> Follow-up worth considering (out of scope here): IDNA/punycode normalization to also catch homograph/unicode host forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
