### PR TITLE
[codex] wire skill slug resolver into load_skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -11,10 +11,18 @@ Skills use **progressive disclosure** across three loading stages:
 | Stage | What loads | Token cost | When |
 |-------|-----------|-----------|------|
 | 1 | YAML frontmatter (`name` + `description` only) | ~50–100 | Agent boot — injected into system prompt for all relevant skills |
-| 2 | Full `SKILL.md` body | ~500–2,000 | Agent calls `read_file()` after deciding the skill is relevant |
+| 2 | Full `SKILL.md` body | ~500–2,000 | Agent calls `load_skill()` after deciding the skill is relevant |
 | 3 | `references/` documents | variable | Agent reads supplementary references when the skill body instructs it to |
 
-The agent sees only frontmatter initially. When a task matches a skill's description, the agent reads the full file. This keeps context windows lean while making deep knowledge available when needed.
+The agent sees only frontmatter initially. When a task matches a skill's description, the agent loads the full file. This keeps context windows lean while making deep knowledge available when needed.
+
+`load_skill()` is the only supported reader for skill markdown. It accepts:
+
+- exact virtual paths such as `/skills/standard/recon/passive-recon/SKILL.md`
+- relative paths such as `standard/recon/passive-recon/SKILL.md`
+- unique slugs such as `passive-recon`
+
+Ambiguous slugs return a list of exact paths instead of guessing.
 
 **System prompt injection** (generated automatically by `SkillsMiddleware`):
 
@@ -23,7 +31,7 @@ Available Skills:
 - **passive-recon**: Use when gathering intelligence WITHOUT touching the target: WHOIS,
   DNS, subdomain enumeration, crt.sh, ASN mapping. Triggers on: 'passive recon', 'WHOIS',
   'subdomain', 'amass'.
-  -> Read `/skills/standard/recon/passive-recon/SKILL.md` for full instructions
+  -> `load_skill("passive-recon")` or `load_skill("/skills/standard/recon/passive-recon/SKILL.md")`
 ```
 
 ---

--- a/packages/decepticon/decepticon/middleware/skills.py
+++ b/packages/decepticon/decepticon/middleware/skills.py
@@ -102,10 +102,12 @@ Match the current objective against **triggers** — load the most specific matc
 - Multiple matches → load the most specific skill first
 
 ### Access Rules
-- `load_skill("/skills/<category>/<skill-name>/SKILL.md")` — **REQUIRED** for
-  every /skills/* file. Returns the FULL body (no line limit) plus a base
-  directory header and an index of references/* and sibling sub-skills in the
-  same directory.
+- `load_skill("<slug-or-path>")` — **REQUIRED** for every /skills/* file.
+  Accepts an exact `/skills/.../*.md` path, a relative `standard/.../SKILL.md`
+  path, or a unique slug such as `sql-injection`. Returns the FULL body (no
+  line limit) plus a base directory header and an index of references/* and
+  sibling sub-skills in the same directory. If a slug is ambiguous, use one of
+  the exact paths returned in the error.
 - `read_file("/skills/...")` and `bash(command="cat /skills/...")` — DO NOT
   use these for skill files. `/skills/` is served in-process by a local
   FilesystemBackend (not the sandbox); only `load_skill` resolves it.

--- a/packages/decepticon/decepticon/tools/skills.py
+++ b/packages/decepticon/decepticon/tools/skills.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from functools import lru_cache
+from importlib.resources import as_file, files
 from typing import Any
 
 from langchain_core.tools import tool
+
+from decepticon.tools.skills_registry import (
+    AmbiguousSkill,
+    SkillRecord,
+    build_registry_from_package,
+    resolve_skill,
+)
 
 # ── load_skill tool ──────────────────────────────────────────────────────────
 # A Decepticon-specific replacement for `load_skill("/skills/...")` that
@@ -12,6 +22,21 @@ from langchain_core.tools import tool
 # base-directory header and an index of references/* in the same directory.
 
 _SKILL_PATH_PREFIX = "/skills/"
+
+
+@lru_cache(maxsize=1)
+def _default_skill_registry() -> tuple[SkillRecord, ...]:
+    """Return the packaged OSS skill registry.
+
+    ``importlib.resources.as_file`` keeps this compatible with both editable
+    installs and wheel layouts where package data may not be a plain directory.
+    """
+    try:
+        root = files("decepticon").joinpath("skills")
+        with as_file(root) as skills_root:
+            return tuple(build_registry_from_package(skills_root))
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return ()
 
 
 def _strip_frontmatter(text: str) -> tuple[str, dict[str, str]]:
@@ -119,6 +144,56 @@ def _validate_skill_path(skill_path: Any, sources: list[str]) -> str | None:
     return None
 
 
+def _short_path_candidates(query: str) -> list[str]:
+    """Expand relative skill paths into canonical ``/skills/...`` candidates."""
+    q = query.strip().lstrip("/")
+    if not q or q.startswith("skills/") or "/" not in q:
+        return []
+    prefixed = f"{_SKILL_PATH_PREFIX}{q}"
+    candidates = [prefixed]
+    if not prefixed.endswith(".md"):
+        candidates.append(prefixed.rstrip("/") + "/SKILL.md")
+    return candidates
+
+
+def _format_ambiguous_skill(result: AmbiguousSkill) -> str:
+    lines = [
+        f"[load_skill error] Ambiguous skill query {result.query!r}. Use one of these exact paths:"
+    ]
+    lines.extend(f"- {candidate.id}" for candidate in result.candidates)
+    return "\n".join(lines)
+
+
+def _resolve_skill_path(
+    skill_path: Any,
+    sources: list[str],
+    registry: Iterable[SkillRecord],
+) -> tuple[str | None, str | None]:
+    """Resolve exact paths, relative paths, or slugs to a safe skill path."""
+    if not isinstance(skill_path, str) or not skill_path.strip():
+        return None, "[load_skill error] skill_path must be a non-empty string."
+    query = skill_path.strip()
+
+    if query.startswith(_SKILL_PATH_PREFIX):
+        path_error = _validate_skill_path(query, sources)
+        return (None, path_error) if path_error is not None else (query, None)
+
+    if "\\" in query or ".." in query.split("/"):
+        return None, f"[load_skill error] Unsafe skill query rejected: {query!r}"
+
+    for candidate in _short_path_candidates(query):
+        path_error = _validate_skill_path(candidate, sources)
+        if path_error is None:
+            return candidate, None
+
+    resolved = resolve_skill(query, registry, allowed_sources=sources)
+    if isinstance(resolved, SkillRecord):
+        return resolved.id, None
+    if isinstance(resolved, AmbiguousSkill):
+        return None, _format_ambiguous_skill(resolved)
+    return None, f"[load_skill error] Skill not found for query: {query!r}"
+
+
 def _format_skill_body(skill_path: str, raw: str) -> tuple[list[str], str, str]:
     """Build the header + body sections for a loaded skill file.
 
@@ -142,7 +217,12 @@ def _format_skill_body(skill_path: str, raw: str) -> tuple[list[str], str, str]:
     return sections, base_dir, path_parts[-1]
 
 
-def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-untyped-def]
+def build_load_skill_tool(
+    backend: Any,
+    sources: list[str],
+    *,
+    registry: Iterable[SkillRecord] | None = None,
+):  # type: ignore[no-untyped-def]
     """Construct the ``load_skill`` LangChain tool.
 
     Returns a closure-bound ``@tool``-decorated function that reads a skill
@@ -156,19 +236,23 @@ def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-
     langgraph container. No manual unwrapping needed.
     """
 
+    skill_registry = tuple(registry) if registry is not None else _default_skill_registry()
+
     @tool
     def load_skill(skill_path: str, include_siblings: bool = False) -> str:
         """Load a Decepticon skill file (full body, no line-limit truncation).
 
-        Use this for ANY ``/skills/*.md`` file instead of ``read_file``. It
-        returns the entire skill body (frontmatter stripped) prepended with a
-        base directory header, followed by an index of any ``references/`` files
-        in the same directory so you know what additional templates / cheat
-        sheets exist for this skill.
+        Use this for skill markdown instead of ``read_file``. ``skill_path`` may
+        be an exact ``/skills/.../*.md`` path, a relative path under ``/skills/``,
+        or a unique skill slug such as ``sql-injection``. The tool returns the
+        entire skill body (frontmatter stripped) prepended with a base directory
+        header, followed by an index of any ``references/`` files in the same
+        directory so you know what additional templates / cheat sheets exist.
 
         Args:
-            skill_path: Absolute path under ``/skills/``, e.g.
-                ``/skills/standard/exploit/web/crypto/SKILL.md``.
+            skill_path: Skill path or slug, e.g.
+                ``/skills/standard/exploit/web/crypto/SKILL.md``,
+                ``standard/exploit/web/crypto/SKILL.md``, or ``crypto``.
             include_siblings: If True, also list sibling ``.md`` files in the
                 same directory (useful when the skill is a category index).
                 Default False to avoid duplicating the catalog already in the
@@ -178,15 +262,15 @@ def build_load_skill_tool(backend: Any, sources: list[str]):  # type: ignore[no-
             The skill body with a header + references index. Errors are
             returned as ``[load_skill error] ...`` strings (never raised).
         """
-        path_error = _validate_skill_path(skill_path, sources)
-        if path_error is not None:
-            return path_error
+        resolved_path, path_error = _resolve_skill_path(skill_path, sources, skill_registry)
+        if resolved_path is None:
+            return path_error or "[load_skill error] Skill could not be resolved."
 
-        raw, err = _read_via_backend(backend, skill_path)
+        raw, err = _read_via_backend(backend, resolved_path)
         if raw is None:
-            return f"[load_skill error] Skill not found: {skill_path} ({err})"
+            return f"[load_skill error] Skill not found: {resolved_path} ({err})"
 
-        sections, base_dir, basename = _format_skill_body(skill_path, raw)
+        sections, base_dir, basename = _format_skill_body(resolved_path, raw)
 
         refs_dir = base_dir.rstrip("/") + "/references"
         refs = _list_dir_via_backend(backend, refs_dir)

--- a/packages/decepticon/decepticon/tools/skills_registry.py
+++ b/packages/decepticon/decepticon/tools/skills_registry.py
@@ -10,11 +10,9 @@ sources) and lets callers resolve a skill by:
 2. trailing slug (``sql-injection`` → ``/skills/standard/analyst/sql-injection/SKILL.md``),
 3. fuzzy match with disambiguation (no silent guessing on ambiguity).
 
-A future PR will plug this resolver into the existing ``load_skill``
-tool so a running agent can name a skill by slug and persist the
-loaded id into LangGraph state for the next turn's prompt. Shipping
-the resolver as a standalone library here lets the integration land
-as a small, focused follow-up against well-tested ground truth.
+The ``load_skill`` tool uses this resolver so a running agent can name
+a skill by exact path, relative path, or unique slug without opening a
+general-purpose filesystem read surface.
 
 Path safety contract:
 

--- a/packages/decepticon/tests/unit/tools/test_skills.py
+++ b/packages/decepticon/tests/unit/tools/test_skills.py
@@ -1,0 +1,145 @@
+"""Tests for the Decepticon ``load_skill`` tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from decepticon.tools.skills import build_load_skill_tool
+from decepticon.tools.skills_registry import SkillRecord
+
+
+@dataclass
+class _BackendResult:
+    error: str | None = None
+    file_data: dict[str, Any] | None = None
+
+
+class _Backend:
+    def __init__(self, files: dict[str, str], dirs: dict[str, list[str]] | None = None) -> None:
+        self.files = files
+        self.dirs = dirs or {}
+        self.reads: list[str] = []
+
+    def read(self, path: str) -> _BackendResult:
+        self.reads.append(path)
+        if path not in self.files:
+            return _BackendResult(error="not found")
+        return _BackendResult(file_data={"content": self.files[path]})
+
+    def ls(self, path: str) -> _BackendResult:
+        return _BackendResult(file_data={"entries": self.dirs.get(path, [])})
+
+
+def _record(path: str, slug: str) -> SkillRecord:
+    return SkillRecord(id=path, slug=slug, name=slug, description="", source="/skills/")
+
+
+def _skill_body(name: str = "sql-injection") -> str:
+    return f"---\nname: {name}\ndescription: test skill\n---\n# Body\nDo the safe thing.\n"
+
+
+def _invoke(tool_obj, skill_path: str, include_siblings: bool = False) -> str:
+    return tool_obj.invoke({"skill_path": skill_path, "include_siblings": include_siblings})
+
+
+def test_load_skill_accepts_exact_path() -> None:
+    path = "/skills/standard/analyst/sql-injection/SKILL.md"
+    backend = _Backend({path: _skill_body()})
+    tool = build_load_skill_tool(backend, ["/skills/standard/analyst/"], registry=[])
+
+    out = _invoke(tool, path)
+
+    assert "Base directory for this skill: /skills/standard/analyst/sql-injection" in out
+    assert "# Body" in out
+    assert backend.reads == [path]
+
+
+def test_load_skill_resolves_unique_slug() -> None:
+    path = "/skills/standard/analyst/sql-injection/SKILL.md"
+    backend = _Backend({path: _skill_body()})
+    tool = build_load_skill_tool(
+        backend,
+        ["/skills/standard/analyst/"],
+        registry=[_record(path, "sql-injection")],
+    )
+
+    out = _invoke(tool, "sql injection")
+
+    assert "Skill: sql-injection" in out
+    assert backend.reads == [path]
+
+
+def test_load_skill_resolves_relative_path() -> None:
+    path = "/skills/standard/exploit/web/sqli/SKILL.md"
+    backend = _Backend({path: _skill_body("sqli")})
+    tool = build_load_skill_tool(backend, ["/skills/standard/exploit/"], registry=[])
+
+    out = _invoke(tool, "standard/exploit/web/sqli")
+
+    assert "Skill: sqli" in out
+    assert backend.reads == [path]
+
+
+def test_load_skill_reports_ambiguous_slug_without_reading() -> None:
+    first = "/skills/standard/analyst/reporting/SKILL.md"
+    second = "/skills/standard/decepticon/reporting/SKILL.md"
+    backend = _Backend({first: _skill_body("reporting"), second: _skill_body("reporting")})
+    tool = build_load_skill_tool(
+        backend,
+        ["/skills/standard/"],
+        registry=[_record(first, "reporting"), _record(second, "reporting")],
+    )
+
+    out = _invoke(tool, "reporting")
+
+    assert "[load_skill error] Ambiguous skill query" in out
+    assert first in out
+    assert second in out
+    assert backend.reads == []
+
+
+def test_load_skill_rejects_slug_outside_allowed_sources() -> None:
+    path = "/skills/standard/contracts/reentrancy/SKILL.md"
+    backend = _Backend({path: _skill_body("reentrancy")})
+    tool = build_load_skill_tool(
+        backend,
+        ["/skills/standard/analyst/"],
+        registry=[_record(path, "reentrancy")],
+    )
+
+    out = _invoke(tool, "reentrancy")
+
+    assert "[load_skill error] Skill not found for query" in out
+    assert backend.reads == []
+
+
+def test_load_skill_rejects_unsafe_short_path() -> None:
+    backend = _Backend({})
+    tool = build_load_skill_tool(backend, ["/skills/standard/"], registry=[])
+
+    out = _invoke(tool, "../standard/analyst/sql-injection/SKILL.md")
+
+    assert "Unsafe skill query rejected" in out
+    assert backend.reads == []
+
+
+def test_load_skill_lists_references_and_siblings_for_resolved_slug() -> None:
+    path = "/skills/standard/analyst/sql-injection/SKILL.md"
+    backend = _Backend(
+        {path: _skill_body()},
+        dirs={
+            "/skills/standard/analyst/sql-injection/references": ["cheatsheet.md"],
+            "/skills/standard/analyst/sql-injection": ["SKILL.md", "variant.md"],
+        },
+    )
+    tool = build_load_skill_tool(
+        backend,
+        ["/skills/standard/analyst/"],
+        registry=[_record(path, "sql-injection")],
+    )
+
+    out = _invoke(tool, "sql-injection", include_siblings=True)
+
+    assert "/skills/standard/analyst/sql-injection/references/cheatsheet.md" in out
+    assert "/skills/standard/analyst/sql-injection/variant.md" in out


### PR DESCRIPTION
## Summary

- Let `load_skill` resolve exact skill paths, relative `/skills` paths, and unique skill slugs through the packaged skills registry.
- Return explicit ambiguity errors with exact paths instead of guessing when a slug matches multiple skills.
- Update skill-loading docs and middleware prompt guidance, and add unit coverage for exact path, relative path, slug, ambiguity, source filtering, unsafe path rejection, and reference/sibling listing behavior.

## Root Cause

The skill registry already supported slug and fuzzy resolution, but the runtime `load_skill` tool still required exact `/skills/.../*.md` virtual paths. Agents could discover a skill by slug in the catalog and then fail or fall back to unsupported filesystem reads when loading the full playbook.

## Validation

- `python -m uv run pytest packages/decepticon/tests/unit/tools/test_skills.py packages/decepticon/tests/unit/tools/test_skills_registry.py -q`
- `python -m uv run ruff check .`
- `python -m uv run ruff format --check .`
- `python -m uv run basedpyright --outputjson` (0 errors)
- `python -m uv run pytest -n auto -q -m "not slow"`
- `_default_skill_registry()` smoke check loads 215 packaged skills
