### PR TITLE
fix(sandbox): reject path traversal in workspace-path normalization

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/base.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/base.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import posixpath
 import re
 import subprocess
 import threading
@@ -86,6 +87,16 @@ class SandboxBase(BaseSandbox):
         if not path.startswith("/workspace/"):
             return "/workspace"
         path = path.rstrip("/")
+        # Reject path traversal: a "." or ".." component passes the per-segment
+        # character class below, so without this guard "/workspace/../../etc"
+        # would be returned verbatim and escape the per-engagement subtree.
+        # Mirror the EngagementFilesystem guard (middleware/filesystem.py): fail
+        # closed to /workspace unless the path is already fully normalized.
+        # posixpath (not os.path) because these are virtual POSIX paths —
+        # os.path.normpath rewrites "/" to "\\" on Windows and would reject
+        # every valid path.
+        if posixpath.normpath(path) != path:
+            return "/workspace"
         components = path[len("/workspace/") :].split("/")
         if any(not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", component) for component in components):
             return "/workspace"

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_workspace_path.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_workspace_path.py
@@ -1,0 +1,55 @@
+"""Regression: ``SandboxBase._normalize_workspace_path`` must reject traversal.
+
+A "." or ".." path component passes the per-segment character class, so without
+the ``posixpath.normpath`` guard ``/workspace/../../etc`` was returned verbatim
+and escaped the per-engagement workspace subtree (the sibling
+EngagementFilesystem layer already guarded this; the sandbox_kernel + bash
+callers did not). The sanitizer must fail closed to ``/workspace``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon.sandbox_kernel.base import SandboxBase
+
+_norm = SandboxBase._normalize_workspace_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/workspace",
+        "/workspace/eng1",
+        "/workspace/a/b",
+        "/workspace/ok_dir-1.2",
+        "/workspace/UPPER_and-1.2.3",
+        "/workspace/trailing/",  # rstrip -> still valid
+    ],
+)
+def test_legit_paths_preserved(path: str) -> None:
+    assert _norm(path) == path.rstrip("/")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/workspace/../../etc",
+        "/workspace/../etc",
+        "/workspace/a/../../etc",
+        "/workspace/..",
+        "/workspace/./x",
+        "/workspace/a/./b",
+        "/workspace//x",  # empty component
+        "/etc/passwd",
+        "/workspaceevil",  # not under the /workspace/ prefix
+        "../../etc",
+    ],
+)
+def test_traversal_and_escapes_fail_closed(path: str) -> None:
+    assert _norm(path) == "/workspace"
+
+
+def test_none_and_blank_default_to_workspace() -> None:
+    assert _norm(None) == "/workspace"
+    assert _norm("   ") == "/workspace"


### PR DESCRIPTION
## The bug

`SandboxBase._normalize_workspace_path` (the sandbox layer's sole workspace sanitizer) validated each path component against `[A-Za-z0-9_.-]{1,128}` — which **accepts `.` and `..`**. Reproduced on `main`:

```
_normalize_workspace_path("/workspace/../../etc")  -> "/workspace/../../etc"   (unchanged!)
_normalize_workspace_path("/workspace/a/../../etc") -> "/workspace/a/../../etc"
```

That traversable path then flows into the real tmux/file operations (e.g. `tmux.py` pipe-pane log paths, file IO) that are supposed to be confined to `/workspace/<engagement>` — letting the agent escape its per-engagement subtree. The sibling `EngagementFilesystem` layer already guards exactly this (`middleware/filesystem.py` uses `posixpath.normpath` + a regression test that documents the gap), but the `sandbox_kernel` and bash callers call `_normalize_workspace_path` **directly**, without that guard.

## Fix

Add the same fail-closed guard: if `posixpath.normpath(path) != path`, return the safe `/workspace` default. This catches `..`, `.`, and `//` while preserving legitimate (including dotted) directory names like `ok_dir-1.2`. Uses `posixpath` (not `os.path`) so Windows dev hosts don't see `/`→`\` rewrites that would reject every valid path.

## Verification

- New `tests/unit/sandbox_kernel/test_workspace_path.py`: legit paths preserved; `../../etc`, `..`, `./x`, `//x`, `/etc/passwd`, non-prefixed, and bare-`..` inputs all fail closed to `/workspace`.
- `ruff` + `ruff format --check` clean, `basedpyright` 0 errors, `pytest tests/unit/sandbox_kernel/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
