### PR TITLE
fix(auth): stop leaking OAuth tokens in the Codex refresh error message

### DIFF
--- a/config/codex_chatgpt_handler.py
+++ b/config/codex_chatgpt_handler.py
@@ -145,8 +145,16 @@ def _refresh_tokens(auth: dict[str, Any]) -> dict[str, Any]:
     access_token = data.get("access_token")
     id_token = data.get("id_token")
     if not access_token or not id_token:
+        # Do NOT interpolate the raw refresh response: on a partial-but-
+        # successful refresh it contains the freshly-minted access / refresh /
+        # id tokens, which would then leak into logs and the caller-visible
+        # AuthenticationError. Report only the (non-sensitive) field names.
+        present = sorted(data.keys()) if isinstance(data, dict) else type(data).__name__
         raise litellm.AuthenticationError(
-            message=f"Codex ChatGPT refresh response missing fields: {data}",
+            message=(
+                "Codex ChatGPT refresh response missing required fields "
+                f"(need access_token + id_token); present fields: {present}"
+            ),
             model="auth",
             llm_provider="auth",
         )


### PR DESCRIPTION
## The bug (credential leak)

In `config/codex_chatgpt_handler.py`, `_refresh_tokens` raised:

```python
raise litellm.AuthenticationError(
    message=f"Codex ChatGPT refresh response missing fields: {data}", ...)
```

`data` is the **raw token-endpoint response**. The guard fires when `access_token` *or* `id_token` is missing — so on a partial-but-successful refresh `data` still contains the freshly-minted **access token** and the **rotated refresh token**. Those secrets get interpolated into an `AuthenticationError` that is logged and surfaced to the caller — a credential leak into logs/transcripts.

## Fix

Interpolate only the (non-sensitive) **field names** that were present, never their values:

```python
present = sorted(data.keys()) if isinstance(data, dict) else type(data).__name__
raise litellm.AuthenticationError(
    message=f"Codex ChatGPT refresh response missing required fields (need access_token + id_token); present fields: {present}", ...)
```

This keeps the error debuggable (you can see which fields came back) without exposing token values.

## Verification
- `ruff check` / `ruff format --check` clean.
- No unit test: the handler imports `litellm`, which is a **container-only** runtime dependency (not in the dev/test env — importing it raises `ModuleNotFoundError` under `uv sync --dev`), so config handlers have no standard-suite tests. The change is a one-line redaction verified by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
