### PR TITLE
fix(security): quarantine scanner tool output (scan_shard / rank_candidates)

### DIFF
--- a/packages/decepticon/decepticon/middleware/untrusted_output.py
+++ b/packages/decepticon/decepticon/middleware/untrusted_output.py
@@ -69,6 +69,13 @@ UNTRUSTED_TOOL_NAMES: frozenset[str] = frozenset(
         "kg_neighbors",
         "kg_stats",
         "kg_backend_health",
+        # Scanner prefilter tools surface raw bytes from the (attacker-
+        # controlled) target tree: scan_shard returns code snippets walked
+        # out of /workspace/target, and rank_candidates re-emits those hits.
+        # Quarantine their output so an injection payload planted in a scanned
+        # file reaches the model wrapped + risk-scored, not as trusted text.
+        "scan_shard",
+        "rank_candidates",
     }
 )
 

--- a/packages/decepticon/tests/unit/middleware/test_untrusted_output.py
+++ b/packages/decepticon/tests/unit/middleware/test_untrusted_output.py
@@ -124,6 +124,21 @@ class TestEnvelopeWrapping:
         assert "Hello, world!" in result.content
         assert "</UNTRUSTED_TOOL_OUTPUT>" in result.content
 
+    def test_scanner_tools_output_is_quarantined(self) -> None:
+        # Regression: scan_shard / rank_candidates surface raw bytes walked out
+        # of the (attacker-controlled) target tree, so their output must be
+        # enveloped — an injection payload planted in a scanned file must reach
+        # the model wrapped, not as trusted text.
+        mw = UntrustedOutputMiddleware()
+        for tool_name in ("scan_shard", "rank_candidates"):
+            request = _make_request(tool_name)
+            handler = MagicMock(return_value=_tool_message("candidate hit from target file"))
+            result = mw.wrap_tool_call(request, handler)
+            assert isinstance(result, ToolMessage)
+            assert "<UNTRUSTED_TOOL_OUTPUT" in result.content, tool_name
+            assert f'origin="{tool_name}"' in result.content, tool_name
+            assert "candidate hit from target file" in result.content, tool_name
+
     def test_embedded_marker_cannot_break_out_of_envelope(self) -> None:
         # Regression: attacker-controlled tool output containing the closing
         # envelope marker must not forge/close the quarantine and smuggle text


### PR DESCRIPTION
## The gap

`UntrustedOutputMiddleware` quarantines the output of every tool in `UNTRUSTED_TOOL_NAMES` (bash, read_file, kg_*) — wrapping it in an `<UNTRUSTED_TOOL_OUTPUT origin=… risk=…>` envelope and logging high-risk hits to the quarantine ledger, so attacker-controlled bytes reach the model marked as data.

But the allowlist omitted the **scanner prefilter tools**:
- `scan_shard` (`tools/research/scanner_tools.py`) walks `root` (typically `/workspace/target`) and returns raw code snippets ("heuristic vulnerability candidates").
- `rank_candidates` re-emits those hits.

A red-team scanner pointed at a malicious target repo surfaces any source file as a snippet — so an attacker who plants `</UNTRUSTED_TOOL_OUTPUT> … ignore previous instructions …` (or any jailbreak) in a scanned file had that text reach the scanner agent's model **unwrapped and un-risk-scored**.

## Fix

Add `scan_shard` + `rank_candidates` to `UNTRUSTED_TOOL_NAMES`. Pure allowlist addition — their output now gets the same envelope + risk scoring + ledger treatment as bash/file/KG output.

## Verification

- New `TestEnvelopeWrapping.test_scanner_tools_output_is_quarantined` asserts both tools' output is enveloped with the correct `origin`.
- `ruff` + `ruff format --check` clean, `basedpyright` 0 errors, `pytest test_untrusted_output.py` → 42 passed.

> Follow-up worth considering (out of scope): the allowlist is inherently fragile — any new byte-returning tool must be remembered here. Inverting to a deny-list of known-trusted tool names (mirroring the shield's `_is_trusted_internal_tool`) would fail safe. Left as a maintainer design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
