### PR TITLE
ci: ratchet coverage floor 35% -> 60%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: uv run pytest -n auto -q -m "not slow"
       - name: Pytest with coverage (main — enforces threshold)
         if: github.event_name == 'push'
-        run: uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=35
+        run: uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=60
       - name: Upload coverage artifact
         if: github.event_name == 'push' && always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Raise the main-push coverage gate from `--cov-fail-under=35` to `--cov-fail-under=60`.

## Why

The job comment already says *"Ratchet up over time."* The framework package (`packages/decepticon/decepticon`, the coverage `source`) currently measures **~70.6%** locally, and the main-push lane runs the **full** suite (incl. `slow` tests) so its coverage is ≥ that. The `35` floor no longer reflects reality and wouldn't catch a real regression. `60` is a conservative first ratchet — it locks in the recent coverage additions while leaving ~10pt margin below the current level so normal run-to-run variance won't flake.

Only the **main-push** lane enforces coverage; PRs keep the fast no-coverage lane, so PR feedback latency is unchanged.

> Suggestion: once the in-flight coverage PRs merge, raise this again toward ~75. Left conservative here on purpose.

## Verification
- One-line change to the `--cov-fail-under` value; `git diff` touches only `.github/workflows/ci.yml`.
- The `actionlint` CI job validates the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
