### PR TITLE
test(middleware/budget): cover env parsing, cache TTL, scope keys, wrappers & warn-event — 73%→88%

### DIFF
--- a/packages/decepticon/tests/unit/middleware/test_budget_internals.py
+++ b/packages/decepticon/tests/unit/middleware/test_budget_internals.py
@@ -1,0 +1,210 @@
+"""Infra-free coverage for ``decepticon.middleware.budget`` internals.
+
+``test_budget.py`` covers cache set/get/eviction and the ``_enforce``
+threshold paths. This adds the remaining pure, DB-free logic that a
+silent regression would slip through:
+
+* ``_env_float`` — empty / whitespace / invalid / valid env parsing
+  (a wrong fallback silently disables or mis-sizes the spend cap);
+* ``_SpendCache`` **TTL expiry** — a stale entry that never expires would
+  let spend drift unbounded between polls;
+* ``_scope_keys`` — request-state + runtime extraction and the
+  env / hard-coded-default fallback chain (wrong scope key = wrong cap);
+* ``wrap_model_call`` / ``awrap_model_call`` — both delegate to the
+  handler under cap and short-circuit (raise) *before* the handler runs
+  once the cap is hit.
+
+The spend source is injected, so there is no LiteLLM / Postgres dependency.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon.middleware import budget as budget_mod
+from decepticon.middleware.budget import (
+    BudgetEnforcementMiddleware,
+    BudgetExceeded,
+    _emit_warning_event,
+    _env_float,
+    _SpendCache,
+)
+
+# ---------------------------------------------------------------- _env_float
+
+_ENV = "DECEPTICON_BUDGET__TEST_CAP"
+
+
+def test_env_float_unset_returns_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(_ENV, raising=False)
+    assert _env_float(_ENV, 4.0) == 4.0
+
+
+def test_env_float_blank_and_whitespace_return_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(_ENV, "   ")
+    assert _env_float(_ENV, 2.5) == 2.5
+
+
+def test_env_float_invalid_returns_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(_ENV, "not-a-number")
+    assert _env_float(_ENV, 9.0) == 9.0
+
+
+def test_env_float_valid_parses(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(_ENV, "12.5")
+    assert _env_float(_ENV, 0.0) == 12.5
+
+
+# ---------------------------------------------------------------- _SpendCache TTL
+
+
+def test_spend_cache_entry_expires_after_ttl(monkeypatch: pytest.MonkeyPatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(budget_mod.time, "monotonic", lambda: clock["t"])
+    cache = _SpendCache(ttl_seconds=5.0)
+    cache.set("k", 3.0)
+
+    clock["t"] = 1004.0  # still within ttl
+    assert cache.get("k") == 3.0
+
+    clock["t"] = 1006.0  # past ttl
+    assert cache.get("k") is None
+    assert "k" not in cache._entries  # expired entry is dropped, not just hidden
+
+
+# ---------------------------------------------------------------- _scope_keys
+
+
+class _Runtime:
+    def __init__(self, agent_name: str) -> None:
+        self.agent_name = agent_name
+
+
+class _Req:
+    def __init__(self, state: object = None, runtime: object = None) -> None:
+        self.state = state
+        self.runtime = runtime
+
+
+def _mw() -> BudgetEnforcementMiddleware:
+    return BudgetEnforcementMiddleware(
+        engagement_cap_usd=10.0,
+        per_agent_cap_usd=5.0,
+        spend_provider=lambda _k: 0.0,
+    )
+
+
+def test_scope_keys_reads_state_and_runtime():
+    mw = _mw()
+    req = _Req(state={"engagement_name": "eng-7"}, runtime=_Runtime("recon"))
+    assert mw._scope_keys(req) == ("eng-7", "recon")
+
+
+def test_scope_keys_falls_back_to_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DECEPTICON_ENGAGEMENT_ID", "env-eng")
+    eng, agent = _mw()._scope_keys(_Req(state={}, runtime=None))
+    assert eng == "env-eng"
+    assert agent == "default-agent"
+
+
+def test_scope_keys_ultimate_defaults(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DECEPTICON_ENGAGEMENT_ID", raising=False)
+    eng, agent = _mw()._scope_keys(_Req(state=None, runtime=None))
+    assert eng == "default-engagement"
+    assert agent == "default-agent"
+
+
+# ---------------------------------------------------------------- wrap_model_call
+
+
+def test_wrap_model_call_invokes_handler_under_cap(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DECEPTICON_BUDGET__PER_AGENT_USD", raising=False)
+    mw = BudgetEnforcementMiddleware(engagement_cap_usd=100.0, spend_provider=lambda _k: 1.0)
+    called: dict[str, bool] = {}
+
+    def handler(_req: object) -> str:
+        called["ran"] = True
+        return "RESULT"
+
+    assert mw.wrap_model_call(_Req(state={}, runtime=None), handler) == "RESULT"
+    assert called == {"ran": True}
+
+
+def test_wrap_model_call_short_circuits_when_over_cap():
+    mw = BudgetEnforcementMiddleware(engagement_cap_usd=10.0, spend_provider=lambda _k: 999.0)
+
+    def handler(_req: object) -> str:
+        raise AssertionError("handler must not run once the budget is exceeded")
+
+    with pytest.raises(BudgetExceeded) as exc:
+        mw.wrap_model_call(_Req(state={}, runtime=None), handler)
+    assert exc.value.scope == "engagement"
+
+
+async def test_awrap_model_call_invokes_handler_under_cap(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DECEPTICON_BUDGET__PER_AGENT_USD", raising=False)
+    mw = BudgetEnforcementMiddleware(engagement_cap_usd=100.0, spend_provider=lambda _k: 1.0)
+
+    async def handler(_req: object) -> str:
+        return "ASYNC_RESULT"
+
+    assert await mw.awrap_model_call(_Req(state={}, runtime=None), handler) == "ASYNC_RESULT"
+
+
+async def test_awrap_model_call_short_circuits_when_over_cap():
+    mw = BudgetEnforcementMiddleware(engagement_cap_usd=10.0, spend_provider=lambda _k: 999.0)
+
+    async def handler(_req: object) -> str:
+        raise AssertionError("handler must not run once the budget is exceeded")
+
+    with pytest.raises(BudgetExceeded):
+        await mw.awrap_model_call(_Req(state={}, runtime=None), handler)
+
+
+# ---------------------------------------------------------------- disabled passthrough
+def test_disabled_middleware_is_passthrough(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DECEPTICON_BUDGET__ENGAGEMENT_USD", raising=False)
+    monkeypatch.delenv("DECEPTICON_BUDGET__PER_AGENT_USD", raising=False)
+    mw = BudgetEnforcementMiddleware()  # no caps -> disabled no-op
+
+    def handler(_req: object) -> str:
+        return "OK"
+
+    assert mw.wrap_model_call(_Req(state={}, runtime=None), handler) == "OK"
+
+
+# ---------------------------------------------------------------- _emit_warning_event
+def test_emit_warning_event_writes_dashboard_contract(monkeypatch: pytest.MonkeyPatch):
+    import langgraph.config as lgconfig
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        lgconfig,
+        "get_stream_writer",
+        lambda: lambda payload: captured.update(payload),
+    )
+    _emit_warning_event("engagement", 7.0, 10.0, 0.7)
+    assert captured == {
+        "type": "budget_warning",
+        "scope": "engagement",
+        "spent_usd": 7.0,
+        "cap_usd": 10.0,
+        "used_pct": 70.0,
+    }
+
+
+def test_emit_warning_event_noop_when_no_writer(monkeypatch: pytest.MonkeyPatch):
+    import langgraph.config as lgconfig
+
+    monkeypatch.setattr(lgconfig, "get_stream_writer", lambda: None)
+    _emit_warning_event("agent", 1.0, 2.0, 0.5)  # must not raise
+
+
+def test_emit_warning_event_swallows_writer_errors(monkeypatch: pytest.MonkeyPatch):
+    import langgraph.config as lgconfig
+
+    def _boom(_payload: object) -> None:
+        raise RuntimeError("stream closed")
+
+    monkeypatch.setattr(lgconfig, "get_stream_writer", lambda: _boom)
+    _emit_warning_event("agent", 1.0, 2.0, 0.5)  # logged, not raised


### PR DESCRIPTION
## What

`test_budget.py` covers the cache set/get/eviction and `_enforce` threshold paths, but the rest of `middleware/budget.py`'s **DB-free** logic sat uncovered at **73%**. This adds 16 tests lifting it to **88%** (only the LiteLLM/Postgres spend provider — which needs a live DB — remains uncovered).

## Why it matters

`BudgetEnforcementMiddleware` is the financial guardrail that hard-stops a runaway engagement before it accrues hundreds of dollars. The uncovered paths were the ones where a regression fails *silently*:

- **`_env_float`** — empty / whitespace / invalid / valid env parsing. A wrong fallback silently **disables or mis-sizes** the USD cap.
- **`_SpendCache` TTL expiry** — proves an entry past its ttl is *dropped* (not merely hidden), so spend can't drift unbounded between polls.
- **`_scope_keys`** — request-state + runtime extraction and the env / hard-coded default fallback chain (a wrong scope key applies the **wrong cap**).
- **`wrap_model_call` / `awrap_model_call`** — both delegate to the handler under cap and **short-circuit (raise `BudgetExceeded`) before the handler runs** once the cap is hit; a disabled middleware (no caps) is a pure passthrough.
- **`_emit_warning_event`** — asserts the `budget_warning` **dashboard-event contract** (field names + rounding the UI depends on), the no-writer no-op, and error swallowing.

The spend source is dependency-injected, so there is no network / DB / LLM dependency.

## Verification (local, mirrors CI)
- `pytest test_budget.py test_budget_internals.py` → **25 passed** (9 existing + 16 new)
- `--cov=decepticon.middleware.budget` → **88%**
- `ruff check` ✅ · `ruff format --check` ✅ · `basedpyright` 0 errors ✅

New test file only; no runtime code touched.