### PR TITLE
feat(skills): adversary-emulation APT profiles + macOS post-exploitation playbook

### DIFF
--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: adversary-emulation
+description: "Threat-informed adversary emulation — pick a real APT, load its profile, and reproduce its TTPs within RoE scope to test detection & response. Index of available actor profiles + the emulation methodology."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "adversary emulation, emulate APT, threat actor, threat-informed, mimic adversary, APT29 APT28 APT33 APT34 APT41 Lazarus FIN7 Sandworm Volt Typhoon Scattered Spider, purple team, ATT&CK evaluation, TTP replay"
+  tags: adversary-emulation, threat-intel, mitre-attack, apt, purple-team, ttp, threat-informed
+  mitre_attack: T1566, T1078, T1059, T1071, T1021, T1486
+---
+
+# Adversary Emulation — index & methodology
+
+**Adversary emulation** reproduces a *specific, named* threat actor's tactics,
+techniques and procedures (TTPs) — drawn from real, attributed intelligence —
+to test whether the target's people, process, and tooling detect and respond
+the way they should. It is distinct from generic penetration testing
+(opportunistic) and from *simulation* (abstract/random): emulation is
+**threat-informed** — every action traces to something a real group has been
+documented doing, mapped to [MITRE ATT&CK](https://attack.mitre.org/).
+
+> **Authorized use only.** Emulate an actor's TTPs **only** within the engagement's
+> Rules of Engagement and approved scope. Destructive techniques (Impact tactic:
+> ransomware, wipers, ICS manipulation) are emulated as *non-destructive proofs*
+> (e.g., a benign canary file, a dry-run) unless the RoE explicitly authorizes
+> otherwise. The goal is to measure detection, not to cause damage.
+
+## When to use this
+
+- The operator (or `roe.json` threat profile) names a specific actor to emulate,
+  or names a sector/region whose dominant threat is a known group.
+- A purple-team / ATT&CK-evaluation engagement: run an actor's TTP chain while the
+  blue cell measures detection (see `kill-chain-analysis` and the `blue_cell`).
+- You want a *realistic, defensible* attack plan instead of an ad-hoc one.
+
+## Methodology (5 steps)
+
+1. **Select the actor.** Map the engagement's industry/region/crown-jewels to a
+   relevant group (see the catalog below). When unsure, ask the operator via
+   `ask_user_question`. Record the choice in the OPPLAN.
+2. **Load the profile.** `load_skill <slug>` (e.g. `load_skill apt29-cozy-bear`).
+   Each profile carries attribution, targeting, dated campaigns, the actor's TTPs
+   mapped to ATT&CK technique IDs, signature tooling, **emulation guidance** (how
+   to reproduce each TTP with Decepticon's own tools), and detection notes.
+3. **Scope to RoE.** Intersect the actor's TTPs with the approved scope. Drop or
+   down-scope anything out of bounds (e.g., replace a real wiper with a canary).
+   Forbidden-destination / out-of-scope checks still apply at tool-call time.
+4. **Emulate in kill-chain order.** Walk Initial Access → Execution → Persistence
+   → Priv-Esc → Defense Evasion → Credential Access → Discovery → Lateral Movement
+   → Collection → C2 → Exfiltration → (proof-of) Impact, using only the techniques
+   this actor is known for. Cite the ATT&CK ID in each finding.
+5. **Measure & report.** Record which actions the blue cell detected/blocked vs.
+   missed (`kill-chain-analysis`, MTTD), and produce a threat-informed report that
+   ties each result to the emulated actor + ATT&CK technique. Feeds the final report.
+
+This complements `soundwave/threat-profile` (which picks the actor at planning time)
+and `kill-chain-analysis` (which scores detection across the chain).
+
+## Actor catalog
+
+| Profile (`load_skill <slug>`) | Aliases | Attribution | Motivation | Notable for |
+| --- | --- | --- | --- | --- |
+| `apt29-cozy-bear` | Midnight Blizzard, NOBELIUM, The Dukes | Russia (SVR) | Espionage | Stealthy cloud/identity intrusions; SolarWinds supply chain |
+| `apt28-fancy-bear` | Forest Blizzard, Sofacy, STRONTIUM | Russia (GRU) | Espionage / influence | Credential phishing, election & defense targeting |
+| `apt33-elfin` | Peach Sandstorm, HOLMIUM | Iran | Espionage (destructive links) | Aerospace & energy, Gulf-region targeting |
+| `apt34-oilrig` | Helix Kitten, Hazel Sandstorm | Iran | Espionage | DNS-tunneling C2, Middle-East supply-chain access |
+| `apt41-double-dragon` | Wicked Panda, BARIUM | China | Espionage **and** financial | Software supply-chain compromise; dual-use ops |
+| `lazarus-group` | Hidden Cobra, Diamond Sleet | North Korea | Financial + destructive | Bank/crypto heists, WannaCry, supply chain |
+| `fin7-carbanak` | Carbon Spider, Sangria Tempest | Financially motivated | Financial | POS/retail intrusions, Carbanak, ransomware affiliate |
+| `sandworm-team` | Voodoo Bear, Seashell Blizzard | Russia (GRU) | Destructive / disruptive | NotPetya, Ukraine power-grid attacks, ICS |
+| `volt-typhoon` | Vanguard Panda, Insidious Taurus | China | Pre-positioning | Living-off-the-land in US critical infrastructure |
+| `scattered-spider` | UNC3944, Octo Tempest, Muddled Libra | Financially motivated | Financial / extortion | Help-desk social engineering, SIM-swap, MFA fatigue |
+
+> Profiles are grounded in MITRE ATT&CK group pages + public advisories; each lists
+> its sources. ATT&CK technique IDs are the source of truth — verify against
+> <https://attack.mitre.org/groups/> if intel looks stale.

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt28-fancy-bear/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt28-fancy-bear/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: apt28-fancy-bear
+description: "Adversary-emulation profile for APT28 (G0007 / Fancy Bear / Forest Blizzard / Sofacy / STRONTIUM), Russia's GRU Unit 26165 cyber-espionage actor."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "APT28, Fancy Bear, Forest Blizzard, Sofacy, Sednit, STRONTIUM, Pawn Storm, GRU 26165, G0007, Russian GRU espionage emulation, NTLM relay / CVE-2023-23397 Outlook, GooseEgg print spooler, password spraying, credential harvesting, NATO/Ukraine logistics targeting, election interference TTPs"
+  tags: apt28, fancy-bear, forest-blizzard, sofacy, strontium, gru, russia, espionage, nation-state, g0007, adversary-emulation, mitre-attack
+  mitre_attack: T1583.001, T1583.003, T1583.006, T1586.002, T1595.002, T1589.001, T1591, T1598.003, T1566.001, T1204.001, T1204.002, T1669, T1190, T1189, T1203, T1210, T1221, T1133, T1199, T1059.001, T1059.003, T1059.004, T1059.005, T1059.006, T1047, T1204, T1569.002, T1547.001, T1037.001, T1137.002, T1546.015, T1542.003, T1547.004, T1547.005, T1547.006, T1547.013, T1543.001, T1543.002, T1543.003, T1505.003, T1574.001, T1548.002, T1068, T1134.001, T1134.005, T1027, T1027.002, T1027.011, T1027.013, T1036, T1036.005, T1070.004, T1070.006, T1112, T1218.005, T1218.010, T1218.011, T1553.004, T1564.001, T1564.003, T1564.004, T1497, T1202, T1003.001, T1003.002, T1003.003, T1003.004, T1003.006, T1110.001, T1110.003, T1555.003, T1555.004, T1056.001, T1557.001, T1557.004, T1040, T1528, T1552.001, T1098.002, T1558.001, T1558.002, T1606, T1087.001, T1087.002, T1083, T1046, T1135, T1518.001, T1018, T1082, T1016, T1016.002, T1482, T1201, T1021.001, T1021.002, T1021.004, T1550.002, T1119, T1005, T1039, T1025, T1113, T1114.002, T1213.002, T1560.001, T1074.001, T1074.002, T1071.001, T1071.003, T1090.001, T1090.003, T1102.002, T1105, T1573.001, T1573.002, T1568.002, T1008, T1095, T1572, T1041, T1048.002, T1567, T1052.001, T1020, T1030, T1561.001, T1498, T1602
+---
+
+# APT28 (Fancy Bear, Forest Blizzard, Sofacy, STRONTIUM) — Adversary Emulation Profile
+
+APT28 (MITRE ATT&CK **G0007**) is a long-running cyber-espionage group attributed to Russia's General Staff Main Intelligence Directorate (GRU) 85th Main Special Service Center (GTsSS), **military unit 26165**, operating since at least 2004. Across two decades it has hit governments, militaries, diplomatic bodies, defense and aerospace, anti-doping and chemical-weapons watchdogs, media, and — since 2022 — Western logistics and IT firms supporting Ukraine. APT28 is best characterized by disciplined credential operations (spearphishing, large-scale password spraying, NTLM-coercion), pragmatic use of N-day exploits (Outlook, Exchange, WinRAR, Windows Print Spooler), a broad cross-platform malware stable (Windows/Linux/macOS/Android, plus the LoJax UEFI rootkit), and a willingness to pivot from pure espionage into influence, hack-and-leak, and occasional destructive/DDoS operations. This profile maps its tradecraft to ATT&CK so Decepticon can emulate it inside an authorized engagement and the blue cell can anticipate detection.
+
+## Attribution & motivation
+
+- **Sponsor / nation:** Russian Federation — GRU 85th GTsSS, Military Unit 26165. The 2018 U.S. DOJ indictments named specific GRU officers of Units 26165 and 74455; the UK, EU, and France have formally attributed multiple campaigns to this unit.
+- **Motivation:** Primarily **strategic intelligence collection (espionage)** aligned with Russian state interests — military, diplomatic, and political intelligence. Secondary motivations include **influence / information operations** (hack-and-leak against the 2016 U.S. election, WADA athlete data dumps) and occasional **destructive / disruptive** action (TV5Monde disruption, WADA DDoS).
+- **Attribution confidence:** **High.** Backed by U.S. DOJ criminal indictments and coordinated government attributions (UK NCSC, EU, France ANSSI/MFA) plus consistent named vendor reporting (Microsoft, Mandiant, Palo Alto Unit 42, ESET).
+
+## Targeting
+
+- **Sectors:** Government and diplomatic bodies; defense, military, and aerospace; **logistics, transport, and IT/technology firms supporting aid to Ukraine** (since 2022); think tanks, NGOs, and political organizations/campaigns; media; anti-doping (WADA, USADA) and chemical-weapons bodies (OPCW, Spiez); critical infrastructure and energy.
+- **Regions:** NATO and allied states — heavy focus on Ukraine, Western/Eastern Europe (notably Germany, France, Poland, the Baltics), North America, and international organizations.
+- **Victim profile:** High-value strategic targets — individuals and orgs whose mailboxes, credentials, and documents yield military, political, or diplomatic intelligence. Frequently targets webmail (Outlook/OWA, Roundcube, Yahoo/Google) and edge/network devices as footholds.
+
+## Notable campaigns
+
+- **2015-04 — TV5Monde disruption.** French broadcaster's 11 channels and online presence knocked offline behind a false "CyberCaliphate" hacktivist persona; French investigators and infrastructure overlap tied it to APT28. (securityaffairs / Wikipedia background)
+- **2015 — German Bundestag intrusion.** Compromise of the German federal parliament network; the UK later sanctioned GRU Unit 26165 officers for it. (gov.uk)
+- **2016 — U.S. election interference (DNC / DCCC / Clinton campaign).** Spearphishing and credential theft, lateral movement DCCC→DNC, and hack-and-leak. Detailed in the July 2018 DOJ/Mueller indictment of 12 GRU officers. (justice.gov / FBI)
+- **2014-2018 — WADA / USADA / OPCW / Spiez.** Remote and close-access ("Wi-Fi") operations against anti-doping and chemical-weapons bodies, including a 2016 DDoS and leak of athlete medical data; charged in the October 2018 DOJ indictment of seven GRU officers. (justice.gov / NPR)
+- **2018 — LoJax UEFI rootkit.** ESET documented the first in-the-wild UEFI rootkit, used by APT28 for firmware-level persistence surviving OS reinstall. (MITRE software S0397 / ESET)
+- **2022-2025 — Western logistics & tech targeting (aid to Ukraine).** Joint CISA advisory **AA25-141A**: password spraying, spearphishing, Outlook NTLM coercion (CVE-2023-23397), Roundcube CVEs (CVE-2020-12641, CVE-2020-35730, CVE-2021-44026), and WinRAR (CVE-2023-38831) against logistics/IT firms and IP-camera networks. (CISA AA25-141A)
+- **2023 — Outlook NTLM (CVE-2023-23397) exploitation.** Zero-click NTLM-hash theft via crafted Outlook calendar reminders; documented by Microsoft and Unit 42 ("Fighting Ursa"). (microsoft.com / unit42)
+- **2024-04 — GooseEgg / Print Spooler (CVE-2022-38028).** Microsoft disclosed APT28's custom GooseEgg launcher abusing Windows Print Spooler for SYSTEM-level privilege escalation; CISA added the CVE to the KEV catalog. (microsoft.com)
+- **2023-04 — Cisco router operations.** Joint CISA/NCSC advisory **AA23-108** on APT28 exploiting SNMP weaknesses (CVE-2017-6742) to deploy "Jaguar Tooth" and conduct reconnaissance on Cisco IOS routers. (CISA AA23-108)
+- **2025-04/07 — France formal attribution.** France's MFA/ANSSI publicly attributed a decade of intrusions against French entities (incl. TV5Monde lineage and government/defense targets) to APT28. (diplomatie.gouv.fr)
+
+## TTPs by ATT&CK tactic
+
+### Initial Access
+- **T1566.001** — Spearphishing attachments: weaponized Office docs and RAR archives (incl. WinRAR CVE-2023-38831).
+- **T1598.003** — Spearphishing links for credential harvesting (fake login pages on Blogspot, lookalike webmail).
+- **T1204.001 / T1204.002** — User execution of malicious links and macro-laden files.
+- **T1190** — Exploit public-facing apps: Exchange (CVE-2020-0688, CVE-2020-17144), Roundcube CVEs, SQLi.
+- **T1189** — Drive-by compromise via custom exploit kits / XSS.
+- **T1133** — External remote services: VPN/Tor fronting for brute-force and access.
+- **T1199** — Trusted relationship: pivoted from DCCC to DNC network.
+- **T1669** — Wi-Fi networks: "close-access" exploitation of open/nearby Wi-Fi (incl. "nearest-neighbor" pivots).
+- **T1078 (implied)** — Valid accounts obtained via spraying/phishing reused for access.
+
+### Execution
+- **T1059.001 / .003 / .004 / .005 / .006** — PowerShell, Windows cmd/batch, Unix shell (Drovorub), VBScript (Koadic), Python (reGeorg, LAMEHUG).
+- **T1047** — WMI via Koadic and the LAMEHUG implant.
+- **T1203** — Exploitation for client execution (CVE-2017-0262 in Office).
+- **T1569.002** — Service execution via Net/Koadic.
+- **T1221** — Template injection: Word docs pulling remote weaponized templates.
+
+### Persistence
+- **T1547.001** — Registry Run keys / Startup folder.
+- **T1037.001** — Logon script via `UserInitMprLogonScript`.
+- **T1137.002** — Office Test persistence.
+- **T1546.015** — COM hijacking (MMDeviceEnumerator).
+- **T1542.003** — Bootkit (Downdelph) and **LoJax UEFI rootkit** (firmware persistence).
+- **T1547.004 / .005 / .006 / .013** — Winlogon Helper DLL (Cannon), SSP, Linux kernel modules (Drovorub), XDG autostart (Fysbis).
+- **T1543.001 / .002 / .003** — macOS Launch Agent (Komplex), Linux systemd (Fysbis), Windows service (JHUHUGIT).
+- **T1505.003** — Web shell (reGeorg on OWA).
+- **T1574.001** — DLL hijacking (Downdelph).
+
+### Privilege Escalation
+- **T1068** — Exploitation for privesc: CVE-2014-4076, CVE-2015-1701, CVE-2015-2387, CVE-2017-0263, and **CVE-2022-38028 (Print Spooler, via GooseEgg)**.
+- **T1548.002** — UAC bypass (Koadic, Downdelph).
+- **T1134.001 / .005** — Token impersonation (CVE-2015-1701 → SYSTEM) and SID-History injection (Mimikatz).
+
+### Defense Evasion
+- **T1027 / .002 / .011 / .013** — Obfuscation: base64/XOR/RC4, software packing (Zebrocy), fileless storage (CHOPSTICK), encrypted/encoded files.
+- **T1036 / .005** — Masquerading: renamed WinRAR, file-extension and location spoofing.
+- **T1070.004 / .006** — File deletion (CCleaner) and timestomping.
+- **T1112** — Registry modification (LoJax).
+- **T1218.005 / .010 / .011** — Mshta/Regsvr32 (Koadic), Rundll32 (CHOPSTICK).
+- **T1553.004** — Install root certificate via certutil.
+- **T1564.001 / .003 / .004** — Hidden files, hidden PowerShell windows (`-WindowStyle Hidden`), NTFS attribute hiding (LoJax).
+- **T1497** — Sandbox/VM evasion (CHOPSTICK).
+- **T1202** — Indirect command execution via Forfiles.
+
+### Credential Access
+- **T1110.001 / .003** — Password guessing and **large-scale password spraying** (reconstituted spray infra, Tor/VPN-fronted).
+- **T1557.001** — NBT-NS/LLMNR poisoning (Responder).
+- **T1187 / CVE-2023-23397** — **Forced NTLM authentication / coercion** via crafted Outlook reminders to capture Net-NTLM hashes.
+- **T1003.001 / .002 / .003 / .004 / .006** — LSASS dump, SAM via `reg save`, NTDS via ntdsutil/VSS, LSA secrets, DCSync (Mimikatz).
+- **T1555.003 / .004** — Browser credential theft (XAgentOSX, Zebrocy, OLDBAIT), Windows Credential Manager.
+- **T1056.001** — Keylogging.
+- **T1528** — Steal application access tokens via OAuth apps masquerading as Google/Yahoo.
+- **T1098.002** — Add mailbox delegate / ApplicationImpersonation permissions via PowerShell (Exchange).
+- **T1558.001 / .002** — Golden/Silver Kerberos tickets (Mimikatz).
+- **T1606** — Forge web credentials (phishing pages).
+- **T1552.001** — Credentials in files (XTunnel).
+
+### Discovery
+- **T1087.001 / .002** — Local/domain account enumeration (Net, LAMEHUG).
+- **T1083** — File/directory discovery (Forfiles for PDF/Office docs).
+- **T1046 / T1135 / T1018** — Network service, share, and remote-system discovery (Koadic, Net, Zebrocy).
+- **T1016 / .002** — Network config and **Wi-Fi interface discovery** (for close-access ops).
+- **T1518.001** — Security software discovery (CHOPSTICK, netsh).
+- **T1482** — Domain trust discovery (LAMEHUG).
+- **T1201** — Password policy discovery (Net).
+- **T1082** — System information discovery (many families).
+
+### Lateral Movement
+- **T1021.001 / .002 / .004** — RDP, SMB/admin shares, SSH (via reGeorg tunnel).
+- **T1550.002** — Pass-the-hash.
+- **T1210** — Exploitation of remote services (SMB RCE).
+
+### Collection
+- **T1114.002** — Remote email collection from Exchange/OWA mailboxes.
+- **T1213.002** — Data from SharePoint repositories.
+- **T1005 / T1039 / T1025** — Local system, network-share, and removable-media collection.
+- **T1119** — Automated collection (publicly available tools on DCCC/DNC; USBStealer; LAMEHUG).
+- **T1113** — Screen capture (Cannon, XAgentOSX, Zebrocy).
+- **T1056.001** — Keylogging for collection.
+- **T1602** — Data from network devices (Cisco router config via SNMP).
+- **T1560.001** — Archive via WinRAR (password-protected) / PowerShell `Compress-Archive`.
+- **T1074.001 / .002** — Local staging (e.g., `C:\ProgramData`, `pi.log`) and remote staging on OWA server.
+
+### Command & Control
+- **T1071.001 / .003** — Web (HTTP/S) and mail protocols (IMAP/POP3/SMTP via Google Mail) for C2.
+- **T1102.002** — Bidirectional C2 over Google Drive web service.
+- **T1568.002** — DGA (CHOPSTICK).
+- **T1008** — Fallback channels (CHOPSTICK, JHUHUGIT, XTunnel).
+- **T1090.001 / .003** — Internal proxy (`netsh portproxy`) and multi-hop proxy (Tor/VPN).
+- **T1572 / T1095** — Protocol tunneling (reGeorg) and non-application-layer protocols (Drovorub).
+- **T1573.001 / .002** — Symmetric and asymmetric encrypted channels.
+- **T1105** — Ingress tool transfer.
+
+### Exfiltration
+- **T1041** — Exfil over C2 channel.
+- **T1048.002** — Exfil over alternate protocol: HTTPS via compromised OWA server.
+- **T1567** — Exfil over web service (Google Drive).
+- **T1030** — Data transfer size limits (split archives into <1MB chunks).
+- **T1052.001 / T1020** — Automated USB exfiltration (USBStealer) for air-gap bridging.
+
+### Impact
+- **T1561.001** — Disk content wipe via `cipher.exe`.
+- **T1498** — Network DoS (2016 DDoS against WADA).
+
+## Signature tooling & malware
+
+| Name | ATT&CK ID | Type | Public/Custom |
+|---|---|---|---|
+| CHOPSTICK / X-Agent | S0023 | Modular Windows implant (DGA, fileless) | Custom |
+| JHUHUGIT / Seduploader | S0044 | First-stage Windows implant | Custom |
+| ADVSTORESHELL | S0045 | Backdoor with custom archiving | Custom |
+| XTunnel | S0117 | Network proxy/tunnel | Custom |
+| CORESHELL / Sofacy | S0137 | Windows downloader/backdoor | Custom |
+| Downdelph | S0134 | Delphi backdoor + bootkit | Custom |
+| LoJax | S0397 | **UEFI rootkit** (firmware persistence) | Custom |
+| Drovorub | S0502 | Linux malware suite + kernel rootkit | Custom |
+| Fysbis | S0410 | Linux backdoor | Custom |
+| Komplex / XAgentOSX | S0162 / S0161 | macOS trojan / implant | Custom |
+| X-Agent for Android | S0314 | Android surveillance | Custom |
+| Zebrocy | S0251 | Multi-stage downloader/collector | Custom |
+| Cannon | S0351 | Backdoor with email-based exfil | Custom |
+| OLDBAIT | S0138 | Credential stealer | Custom |
+| USBStealer | S0136 | USB/air-gap exfil | Custom |
+| GooseEgg | (no ATT&CK software ID assigned) | Print Spooler privesc launcher (CVE-2022-38028) | Custom |
+| LAMEHUG | S9035 | LLM-assisted post-compromise implant | Custom |
+| reGeorg | S1187 | Web shell / SOCKS tunnel | Public (Living-off-tooling) |
+| Koadic | S0250 | Post-exploitation framework | Public |
+| Mimikatz | S0002 | Credential dumping | Public |
+| Responder | S0174 | LLMNR/NBT-NS poisoning | Public |
+| Tor | S0183 | Anonymity / proxy | Public |
+| Net / netsh / certutil / Wevtutil / Forfiles | S0039 / S0108 / S0160 / S0645 / S0193 | LOLBins | Built-in |
+
+> Note: "GooseEgg" is a Microsoft-attributed custom tool; it is **not** the same as ATT&CK software S1145 (Pikabot), so no false software ID is assigned here.
+
+## Emulation guidance (Decepticon)
+
+> **Authorized-use caveat:** Execute the following ONLY within the documented rules of engagement, target scope, and time window of an authorized engagement. Never run destructive (T1561/T1498) or firmware (LoJax-style) actions outside an explicitly sanctioned, isolated lab.
+
+Map APT28's signature plays to Decepticon's own capabilities:
+
+- **Initial access — credential ops (T1110.003, T1598.003, T1566.001).** Use the phishing/credential-harvest skill to stand up lookalike webmail login pages; drive **slow, low-and-slow password spraying** (~few attempts/account/hour) against in-scope OWA/M365 endpoints, fronted through rotating egress to mimic Tor/VPN spray infra. Stage macro/RAR lures with the payload-builder; if WinRAR is in scope, emulate CVE-2023-38831 archive lures.
+- **NTLM coercion (T1187 / CVE-2023-23397, T1557.001).** With the AD/lateral-movement skill, run **Responder** for LLMNR/NBT-NS poisoning and emulate Outlook-reminder NTLM coercion to capture Net-NTLM hashes, then relay or crack offline. This is APT28's defining 2023-2025 play — prioritize it.
+- **Privilege escalation (T1068, T1548.002).** Use the privesc/defense-evasion skill to emulate **GooseEgg-style Print Spooler abuse (CVE-2022-38028)** for SYSTEM in a patched-vs-unpatched lab, and UAC bypass chains analogous to Koadic/Downdelph.
+- **Credential access (T1003.*, T1558.*, T1550.002).** Drive the AD skill / **Mimikatz** for LSASS dump, DCSync, golden/silver tickets, and pass-the-hash — mirroring APT28's domain-takeover pattern.
+- **C2 (T1071.001, T1102.002, T1090, T1572).** Use **Sliver** (c2 skill) over HTTPS as the primary channel; add a **mail-protocol or Google-Drive web-service profile** to emulate Cannon/Drive C2, and chain `netsh portproxy` internal proxies + reGeorg-style web-shell tunneling for pivoting.
+- **Cloud / token theft (T1528, T1098.002, T1114.002, T1213.002).** With the cloud/M365 skill, emulate OAuth-app consent abuse, ApplicationImpersonation/delegate-permission grants, and bulk mailbox + SharePoint collection.
+- **Collection & exfil (T1560.001, T1030, T1048.002, T1567).** Use bash/PowerShell to archive with password-protected RAR/`Compress-Archive`, **split into <1MB chunks**, and exfil over HTTPS through a compromised OWA-equivalent or a web service to reproduce the signature exfil pattern.
+- **Edge devices (T1602, T1133).** Where routers/IP cameras are in scope, emulate SNMP/credential weaknesses (cf. AA23-108) to recon network-device config — APT28 favors edge footholds.
+
+## Detection & defense
+
+- **NTLM coercion / CVE-2023-23397:** Patch Outlook; block outbound SMB (TCP 445) and WebDAV at the perimeter; add high-value users to the **Protected Users** group; hunt for Exchange messages with `PidLidReminderFileParameter` UNC paths; alert on outbound NTLM to external hosts.
+- **Password spraying (T1110.003):** Enforce **phishing-resistant MFA**; alert on distributed low-rate auth failures across many accounts from rotating/Tor/VPN IPs; disable legacy/basic auth on M365/OWA; monitor impossible-travel and new-ASN sign-ins.
+- **Print Spooler / GooseEgg (CVE-2022-38028):** Apply Oct-2022+ patches; disable the Spooler where not needed; monitor for `spoolsv.exe` spawning cmd/PowerShell and writes to Spooler driver/JS-constraints paths.
+- **Credential dumping (T1003.*):** Enable LSA protection (RunAsPPL) and Credential Guard; alert on LSASS handle access, `ntdsutil`/`vssadmin` shadow-copy creation, and `reg save` of SAM/SYSTEM/SECURITY; monitor DCSync replication from non-DC accounts.
+- **OAuth/delegation abuse (T1528, T1098.002):** Audit enterprise app consent and mailbox `Add-MailboxPermission`/ApplicationImpersonation role grants; restrict user consent; review delegate/forwarding rules.
+- **Web shells & tunneling (T1505.003, T1572, T1090.001):** Monitor OWA/IIS directories for new aspx/script files (reGeorg); alert on `netsh interface portproxy add`; baseline web-server child processes.
+- **Persistence (T1547, T1137.002, T1542.003):** Monitor Run keys, `UserInitMprLogonScript`, Office Test registry keys; deploy Secure Boot + firmware integrity (against LoJax-class UEFI implants).
+- **Edge/network devices (T1602):** Replace default SNMP community strings, restrict SNMP to management VLANs, patch Cisco IOS (cf. CVE-2017-6742), and monitor for unexpected config reads (Jaguar Tooth pattern).
+- **Exfiltration (T1030, T1048.002, T1567):** DLP/egress monitoring for chunked password-protected archives and uploads to Google Drive / unusual HTTPS endpoints, especially staged from mail servers.
+
+## Sources
+
+- https://attack.mitre.org/groups/G0007/
+- https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-141a
+- https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-108
+- https://www.microsoft.com/en-us/security/blog/2024/04/22/analyzing-forest-blizzards-custom-post-compromise-tool-for-exploiting-cve-2022-38028-to-obtain-credentials/
+- https://www.microsoft.com/en-us/security/blog/2023/03/24/guidance-for-investigating-attacks-using-cve-2023-23397/
+- https://unit42.paloaltonetworks.com/russian-apt-fighting-ursa-exploits-cve-2023-233397/
+- https://www.justice.gov/archives/opa/pr/us-charges-russian-gru-officers-international-hacking-and-related-influence-and
+- https://www.fbi.gov/news/stories/russian-gru-officers-charged-with-hacking-100418
+- https://www.gov.uk/government/news/uk-enforces-new-sanctions-against-russia-for-cyber-attack-on-german-parliament
+- https://www.diplomatie.gouv.fr/en/country-files/russia/news/2025/article/russia-attribution-of-cyber-attacks-on-france-to-the-russian-military
+- https://attack.mitre.org/software/S0397/

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt29-cozy-bear/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt29-cozy-bear/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: apt29-cozy-bear
+description: "Adversary-emulation profile for APT29 (Cozy Bear / Midnight Blizzard / NOBELIUM / The Dukes), Russia's SVR-attributed cyber-espionage group, mapping its ATT&CK TTPs to Decepticon emulation tooling."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "APT29, Cozy Bear, Midnight Blizzard, NOBELIUM, The Dukes, CozyDuke, UNC2452, Dark Halo, SVR, Russian state-sponsored espionage, SolarWinds emulation, golden SAML, OAuth abuse, password spray cloud access, supply chain compromise emulation, stealthy long-dwell APT emulation"
+  tags: apt29, cozy-bear, midnight-blizzard, nobelium, the-dukes, svr, russia, espionage, cloud-attack, golden-saml, oauth-abuse, supply-chain, password-spray, adversary-emulation, mitre-attack, G0016
+  mitre_attack: T1595.002, T1589.001, T1598.003, T1566.001, T1566.002, T1566.003, T1190, T1195.002, T1199, T1133, T1078, T1078.002, T1078.003, T1078.004, T1204.001, T1204.002, T1059.001, T1059.003, T1059.005, T1059.009, T1106, T1053.005, T1047, T1569.002, T1547.001, T1546.003, T1098.001, T1098.002, T1098.003, T1098.005, T1136.003, T1556.007, T1505.003, T1543.003, T1068, T1548.002, T1484.002, T1027.006, T1027.002, T1036.005, T1070.004, T1070.006, T1070.008, T1218.011, T1553.002, T1497, T1620, T1110.003, T1003.003, T1003.006, T1003.001, T1558.003, T1606.001, T1606.002, T1528, T1539, T1621, T1555.003, T1649, T1087.002, T1087.004, T1018, T1482, T1526, T1538, T1069.002, T1021.001, T1021.006, T1021.007, T1550.001, T1550.002, T1550.003, T1570, T1114.002, T1213, T1530, T1560.001, T1071.001, T1071.004, T1573.002, T1090.004, T1568, T1102.002, T1041, T1567.002, T1048
+---
+
+# APT29 (Cozy Bear, Midnight Blizzard, NOBELIUM, The Dukes) — Adversary Emulation Profile
+
+APT29 (MITRE ATT&CK **G0016**; also tracked as Cozy Bear, Midnight Blizzard, NOBELIUM, The Dukes, CozyDuke, UNC2452, Dark Halo, NobleBaron, YTTRIUM, Blue Kitsune, IRON RITUAL/IRON HEMLOCK) is a Russian state-sponsored cyber-espionage group attributed by multiple governments to Russia's Foreign Intelligence Service (SVR). Active since at least 2008, it is among the most operationally disciplined intrusion sets on record: it favors patient, stealthy, long-dwell access against high-value strategic targets, custom and living-off-the-land tooling, rigorous operational security (residential-proxy infrastructure, anti-forensic indicator removal, low-and-slow authentication attacks), and a sustained pivot toward cloud and identity-plane attacks (Microsoft 365 / Entra ID, OAuth, federation). It is best known for the 2015–2016 DNC intrusion, the 2020 SolarWinds Orion supply-chain compromise, and the 2024 Microsoft corporate-email breach. This profile teaches Decepticon to emulate APT29's signature TTPs so an authorized red team can exercise the blue cell against a realistic, identity-and-cloud-centric espionage adversary.
+
+## Attribution & motivation
+
+- **Suspected sponsor / nation:** Russian Federation — Foreign Intelligence Service (Sluzhba Vneshney Razvedki, **SVR**). Attribution is publicly asserted by the U.S. government (CISA/FBI/NSA), the UK NCSC, Canada's CSE, and corroborated by vendor reporting (Mandiant/Google, Microsoft, CrowdStrike).
+- **Motivation:** Strategic **espionage** — collection of foreign-policy, diplomatic, defense, government, and technology intelligence in support of Russian state interests. APT29 is not financially motivated and is not primarily a destructive actor; its goal is durable, covert access and exfiltration of intelligence, not disruption.
+- **Confidence:** **High** for SVR attribution — it is the consensus of multiple Five Eyes governments and independent commercial vendors, reinforced by consistent tradecraft across a decade-plus of operations.
+
+## Targeting
+
+- **Sectors:** National governments and foreign ministries, diplomatic missions/embassies, think tanks and policy research institutes, defense and military organizations, IT and managed/cloud service providers (used as a stepping stone to downstream victims), technology companies, healthcare/pharmaceutical and vaccine research (2020), and aviation/education/law enforcement (post-SolarWinds expansion).
+- **Regions:** Primarily NATO and Western-aligned states — United States, United Kingdom, Europe broadly, and other governments of intelligence interest to Russia.
+- **Victim profile:** Organizations holding information of strategic value to Russian foreign policy and security. APT29 frequently exploits **trusted relationships** (T1199) — compromising cloud solution providers, MSPs, and software vendors to reach the ultimate intelligence target downstream.
+
+## Notable campaigns
+
+- **2008–2018 — "The Dukes" espionage operations.** Long-running campaigns against Western governments and think tanks using the MiniDuke/CosmicDuke/CozyDuke/SeaDuke/HAMMERTOSS toolset. (MITRE ATT&CK G0016: https://attack.mitre.org/groups/G0016/)
+- **2015–2016 — U.S. Democratic National Committee (DNC) compromise.** Spearphishing-led intrusion attributed to APT29 alongside APT28. (MITRE ATT&CK G0016: https://attack.mitre.org/groups/G0016/)
+- **2020 — COVID-19 vaccine research targeting (WellMess / WellMail).** NCSC/CSE/CISA/NSA joint advisory (16 July 2020) detailed APT29 targeting vaccine-development organizations in the UK, US, and Canada, exploiting internet-facing CVEs (Citrix, Pulse Secure, FortiGate, Zimbra), spearphishing for credentials, and deploying the WellMess and WellMail implants. (NCSC: https://www.ncsc.gov.uk/news/advisory-apt29-targets-covid-19-vaccine-development)
+- **Aug 2019 – Jan 2021 — SolarWinds Orion supply-chain compromise (ATT&CK Campaign C0024; UNC2452/"SolarStorm"; SUNBURST).** APT29 trojanized SolarWinds Orion updates (versions 2019.4–2020.2.1), reaching ~18,000 organizations, then selectively deployed TEARDROP/RAINDROP loaders for Cobalt Strike and forged SAML tokens ("Golden SAML") to access Microsoft 365 and Azure AD. Publicly disclosed 13 December 2020. (MITRE C0024: https://attack.mitre.org/campaigns/C0024/ ; Mandiant/Google: https://cloud.google.com/blog/topics/threat-intelligence/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor)
+- **Since Sept 2023 — JetBrains TeamCity exploitation (CVE-2023-42793).** FBI/CISA/NSA/NCSC/Polish SKW joint advisory (AA23-347A) attributed large-scale exploitation of the TeamCity authentication-bypass flaw to the SVR, deploying the GraphicalProton backdoor for follow-on espionage and software supply-chain positioning. (CISA AA23-347A: https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-347a)
+- **Nov 2023 – Jan 2024 — Microsoft corporate email breach ("Midnight Blizzard").** Password-spray (from residential proxies) against a legacy non-production test tenant account lacking MFA; abuse of a legacy test **OAuth** application granted the Exchange Online `full_access_as_app` role to read corporate mailboxes (incl. senior leadership). Detected 12 Jan 2024. (Microsoft MSRC: https://www.microsoft.com/en-us/msrc/blog/2024/01/microsoft-actions-following-attack-by-nation-state-actor-midnight-blizzard ; Microsoft Security: https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/)
+- **Feb 2024 — CISA AA24-057A "SVR Cyber Actors Adapt Tactics for Initial Cloud Access."** Documented the group's shift to cloud/identity initial access: password spraying, brute force, exploitation of dormant/service accounts, token theft, MFA fatigue/bombing, and device-registration persistence. (CISA AA24-057A: https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-057a)
+
+## TTPs by ATT&CK tactic
+
+### Initial Access
+- **T1566.001 / .002 / .003** — Spearphishing via attachment, link, and trusted service; HTML-smuggling lures (e.g., EnvyScout) deliver droppers.
+- **T1190** — Exploit public-facing applications, including CVE-2023-42793 (JetBrains TeamCity) and 2020 edge appliance CVEs (Citrix, Pulse Secure, FortiGate, Zimbra).
+- **T1195.002** — Software supply-chain compromise (trojanized SolarWinds Orion builds → SUNBURST).
+- **T1199** — Trusted-relationship abuse: compromise of cloud solution providers, MSPs, and vendors to reach downstream victims.
+- **T1133** — External remote services / valid-account access to VPNs and remote portals.
+- **T1078 / .004** — Valid accounts, especially **cloud accounts** (compromised O365/Entra admins, dormant test tenants).
+
+### Execution
+- **T1059.001 / .003 / .005 / .009** — PowerShell, Windows command shell, VBScript, and **Cloud API** execution.
+- **T1204.001 / .002** — User execution of malicious links and files.
+- **T1106** — Native API; **T1047** — WMI; **T1569.002** — service execution.
+
+### Persistence
+- **T1547.001** — Registry Run keys / Startup folder; **T1546.003** — WMI event subscription.
+- **T1053.005** — Scheduled tasks.
+- **T1098.001 / .002 / .003 / .005** — Cloud account manipulation: add credentials to service principals/OAuth apps, grant additional email-delegate and cloud-role permissions, and register attacker devices.
+- **T1136.003** — Create new cloud accounts; **T1556.007** — modify hybrid-identity authentication.
+- **T1505.003** — Web shells; **T1543.003** — Windows service.
+
+### Privilege Escalation
+- **T1068** — Exploitation for privilege escalation; **T1548.002** — UAC bypass.
+- **T1484.002** — Domain/tenant trust modification (add federated IdP / trusted domain to mint tokens).
+
+### Defense Evasion
+- **T1027.006** — HTML smuggling; **T1027.002** — software packing.
+- **T1036.005** — Match legitimate name/location; **T1218.011** — rundll32 proxy execution.
+- **T1070.004 / .006 / .008** — File deletion (sdelete), timestomp, and **clear mailbox data**.
+- **T1553.002** — Code signing with valid/abused certificates; **T1497** — sandbox/VM evasion; **T1620** — reflective/in-memory loading (TEARDROP).
+- Operational hallmark: **residential-proxy / "TOR-like" rotating egress** to defeat IOC- and geo-based detection.
+
+### Credential Access
+- **T1110.003** — Password spraying (low-and-slow, distributed proxies).
+- **T1003.001 / .003 / .006** — LSASS dumping, NTDS.dit theft, and **DCSync**.
+- **T1558.003** — Kerberoasting.
+- **T1606.001 / .002** — Forge web cookies and **forge SAML tokens ("Golden SAML")** using a stolen ADFS token-signing certificate.
+- **T1528** — Steal application access tokens; **T1539** — steal web session cookies; **T1621** — MFA request generation (push bombing/fatigue).
+- **T1555.003** — Credentials from browsers; **T1649** — steal/forge authentication certificates.
+
+### Discovery
+- **T1087.002 / .004** — Domain and **cloud** account discovery; **T1018** — remote system discovery.
+- **T1482** — Domain-trust discovery; **T1069.002** — domain group discovery.
+- **T1526** — Cloud service discovery; **T1538** — cloud service dashboard enumeration.
+
+### Lateral Movement
+- **T1021.001 / .006 / .007** — RDP, WinRM, and **cloud services** (e.g., Exchange Online via OAuth app).
+- **T1550.001 / .002 / .003** — Use of alternate auth material: **application access tokens**, pass-the-hash, pass-the-ticket.
+- **T1570** — Lateral tool transfer.
+
+### Collection
+- **T1114.002** — Remote email collection (cloud mailboxes, the SolarWinds and Midnight Blizzard objective).
+- **T1213** — Data from information repositories; **T1530** — data from cloud storage.
+- **T1560.001** — Archive collected data via utility before exfil.
+
+### Command & Control
+- **T1071.001 / .004** — Web (HTTPS) and DNS C2; **T1102.002** — bidirectional web-service C2 (HAMMERTOSS used Twitter/GitHub/cloud storage as dead-drops).
+- **T1573.002** — Asymmetric encrypted channels; **T1568** — dynamic resolution; **T1090.004** — domain fronting.
+
+### Exfiltration
+- **T1041** — Exfiltration over C2 channel.
+- **T1567.002** — Exfiltration to cloud storage.
+- **T1048** — Exfiltration over alternative protocol.
+
+### Impact
+- APT29 is an **espionage** actor; it deliberately avoids destructive impact. The "impact" of an APT29 operation is confidentiality loss (mass mailbox and document theft) and durable strategic access, not data destruction or ransom.
+
+## Signature tooling & malware
+
+- **Custom backdoors / implants (custom):** SUNBURST (S0559), TEARDROP (S0560), RAINDROP, GoldMax/SUNSHUTTLE (S0588), GoldFinder (S0597), Sibot, BoomBox (S0635), EnvyScout (S0634), FoggyWeb (S0661), MagicWeb, GraphicalProton, WellMess, WellMail, the "Duke" family (MiniDuke, CosmicDuke S0050, CozyCar S0046, SeaDuke, HAMMERTOSS S0037, PolyglotDuke, RegDuke, FatDuke S0512, LiteDuke S0513, GeminiDuke S0049, CloudDuke S0054), POSHSPY, SUNSPOT (build-process implant).
+- **Identity / cloud tooling (custom + public):** AADInternals (S0677) for Entra ID / federation abuse and SAML-token operations; custom .NET utilities to extract ADFS token-signing certificates for Golden SAML.
+- **Commodity / dual-use (public):** Cobalt Strike (S0154) BEACON, Impacket (S0357), Mimikatz, BloodHound (S0521), AdFind (S0552), sdelete, ipconfig (S0100), and other living-off-the-land binaries.
+
+## Emulation guidance (Decepticon)
+
+> **Authorized use only.** Execute these TTPs strictly within the documented rules of engagement, target scope, and time window of a signed authorization. Do not touch out-of-scope tenants, accounts, or third parties.
+
+Emulate APT29's *style*, not just its techniques: be patient, quiet, and identity-centric. Prefer valid credentials and cloud/OAuth paths over noisy malware; rotate egress; clean up artifacts.
+
+- **Initial access (T1566.x, T1190, T1110.003):** Use the **bash** tool and phishing/payload tooling to stage HTML-smuggling lures mirroring EnvyScout, and exercise the **defense-evasion** skill to package droppers. For cloud-first emulation, run **low-and-slow password spraying** via the **cloud** skill against in-scope test/dormant identities — small attempt counts, spread over time, sourced from approved rotating/proxy egress to mimic residential infrastructure.
+- **Supply-chain & trusted-relationship (T1195.002, T1199):** Where the engagement authorizes a build-pipeline or vendor-trust scenario, use the **bash**/CI tooling to plant a benign marker in a build artifact to validate that build-integrity and downstream-trust controls fire — never ship a real backdoor to production.
+- **Execution & C2 (T1059.001, T1071.001, T1573.002, T1090.004):** Use the **c2/sliver** skill as the BEACON/TEARDROP analogue — HTTPS beacons with long jitter, asymmetric encryption, optional domain-fronting/redirector chains, and DNS fallback to reproduce APT29's encrypted, resilient C2.
+- **Credential access & identity abuse (T1003.006, T1558.003, T1606.002, T1528, T1550.001):** Use the **AD skills** to demonstrate DCSync, Kerberoasting, and NTDS extraction in scope; use the **cloud** skill (Entra ID / AADInternals-style workflows) to emulate **Golden SAML** token forging from a captured/lab signing certificate, OAuth application-token theft, and consent-grant abuse — the defining Midnight Blizzard play.
+- **Persistence (T1098.x, T1136.003, T1484.002):** Via the **cloud** skill, register a controlled service principal / OAuth app, add credentials to it, grant a scoped mailbox/Graph permission, and (where authorized) add a federated trust — then verify the blue cell detects the new app, consent grant, and federation change.
+- **Lateral movement & collection (T1021.007, T1550.x, T1114.002):** Use the **lateral-movement** skill for pass-the-ticket/token reuse on-prem, and the **cloud** skill to pivot into Exchange Online via the consented app and perform scoped mailbox collection that mirrors the real objective.
+- **Defense evasion & exfil (T1070.x, T1620, T1567.002):** Use the **defense-evasion** skill for in-memory loading, timestomping, and log/mailbox-artifact cleanup, and stage scoped exfiltration to an approved cloud-storage endpoint to test DLP and egress monitoring.
+
+## Detection & defense
+
+- **Identity is the control plane.** Enforce phishing-resistant **MFA** on *every* account including legacy/service/test tenants; eliminate dormant accounts; apply conditional access and block legacy auth. The Midnight Blizzard root cause was an MFA-less legacy tenant (mitigates T1110.003, T1078.004).
+- **Password spray / brute force (T1110.003):** Alert on many accounts × few attempts from rotating IPs; correlate residential-proxy / ASN-anomalous sign-ins rather than relying on per-IP IOCs.
+- **OAuth & consent abuse (T1528, T1098.001/.003, T1550.001):** Audit and alert on new/over-privileged OAuth app registrations and consent grants — especially `full_access_as_app`, `ApplicationImpersonation`, and Graph mail scopes; review credentials added to service principals; use Microsoft Defender for Cloud Apps / Entra ID Protection anomaly detection.
+- **Federation & Golden SAML (T1606.002, T1484.002, T1556.007):** Protect and monitor the ADFS/Entra token-signing certificate; alert on new federated domains/trusts and on tokens minted outside the IdP; review `Set-MSOLDomainAuthentication`-equivalent changes.
+- **On-prem credential theft (T1003.006, T1558.003):** Monitor for DCSync (non-DC replication requests), LSASS access, NTDS.dit copy, and Kerberoasting; restrict Domain Admin and replication rights.
+- **Supply chain (T1195.002, T1199):** Enforce build-pipeline integrity, code-signing verification, and least-privilege for vendor/CSP delegated access; monitor partner/delegated-admin activity.
+- **C2 & exfil (T1071.001, T1090.004, T1567.002, T1041):** Inspect TLS for domain-fronting and anomalous SNI/host mismatches; baseline DNS; apply DLP and egress controls on cloud-storage uploads and bulk mailbox export (`MailItemsAccessed`/EWS audit).
+- **Anti-forensics (T1070.004/.006/.008):** Centralize and protect logs (mailbox-audit, unified audit, Sysmon, EDR) with off-host retention so APT29's file deletion, timestomping, and mailbox-data clearing cannot blind the responder.
+
+## Sources
+
+- MITRE ATT&CK — APT29 (G0016): https://attack.mitre.org/groups/G0016/
+- MITRE ATT&CK — SolarWinds Compromise (Campaign C0024): https://attack.mitre.org/campaigns/C0024/
+- CISA AA24-057A — SVR Cyber Actors Adapt Tactics for Initial Cloud Access: https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-057a
+- CISA AA23-347A — Russian SVR Exploiting JetBrains TeamCity CVE-2023-42793 Globally: https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-347a
+- Microsoft MSRC — Microsoft Actions Following Attack by Nation State Actor Midnight Blizzard: https://www.microsoft.com/en-us/msrc/blog/2024/01/microsoft-actions-following-attack-by-nation-state-actor-midnight-blizzard
+- Microsoft Security Blog — Midnight Blizzard: Guidance for responders on nation-state attack: https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
+- NCSC — Advisory: APT29 targets COVID-19 vaccine development: https://www.ncsc.gov.uk/news/advisory-apt29-targets-covid-19-vaccine-development
+- Mandiant / Google Cloud — SUNBURST backdoor SolarWinds supply-chain compromise: https://cloud.google.com/blog/topics/threat-intelligence/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor
+- Mandiant / Google Cloud — UNC2452 Merged into APT29: https://cloud.google.com/blog/topics/threat-intelligence/unc2452-merged-into-apt29

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt33-elfin/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt33-elfin/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: apt33-elfin
+description: "Adversary-emulation profile for APT33 (Elfin, Peach Sandstorm, HOLMIUM), a suspected Iranian state-sponsored espionage group, mapped to MITRE ATT&CK G0064 with Decepticon emulation guidance."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "APT33, Elfin, Peach Sandstorm, HOLMIUM, Refined Kitten, Iran, Iranian APT, G0064, aviation, energy, petrochemical, defense industrial base, satellite, password spray, FalseFont, Tickler, StoneDrill, Shamoon, .hta spearphishing, Azure abuse, AzureHound, Roadtools, WinRAR CVE-2018-20250, emulate Iranian espionage actor"
+  tags: adversary-emulation, threat-intel, mitre-attack, apt33, iran, espionage, peach-sandstorm, password-spray, cloud, red-team
+  mitre_attack: T1071.001, T1560.001, T1547.001, T1110.003, T1059.001, T1059.005, T1555, T1555.003, T1132.001, T1573.001, T1546.003, T1048.003, T1203, T1068, T1105, T1040, T1571, T1027.013, T1588.002, T1003.001, T1003.004, T1003.005, T1566.001, T1566.002, T1053.005, T1552.001, T1552.006, T1204.001, T1204.002, T1078, T1078.004, T0852, T0853, T0865
+---
+
+# APT33 (Elfin, Peach Sandstorm, HOLMIUM) — Adversary Emulation Profile
+
+APT33 (MITRE ATT&CK **G0064**; aliases Elfin, Peach Sandstorm, HOLMIUM) is a suspected Iranian state-sponsored threat group that has conducted cyber-espionage operations since at least 2013. The group is best known for spearphishing-driven intrusions against the aviation, energy, and petrochemical sectors in the United States, Saudi Arabia, and South Korea, and for an enduring evolution from `.hta`-based phishing toward large-scale cloud-identity attacks. Its operations blend publicly available offensive tooling with custom backdoors, and the group has been linked — with varying confidence — to destructive wiper malware. This profile maps APT33's documented TTPs to ATT&CK and provides emulation guidance for Decepticon under authorized engagement scope.
+
+## Attribution & motivation
+
+- **Suspected sponsor / nation:** Iran. FireEye/Mandiant assessed APT33 works at the behest of the Iranian government and reported evidence linking the group to the Nasr Institute, an Iranian organization associated with cyber-warfare operations. Microsoft tracks the same actor as **Peach Sandstorm** and likewise attributes it to Iranian state interests.
+- **Primary motivation:** Strategic **espionage / intelligence collection** aligned with Iranian state interests (aerospace, defense, energy). Microsoft assessed the 2023 password-spray campaign was likely intended to facilitate intelligence collection supporting Iranian state objectives.
+- **Secondary / destructive dimension:** APT33 has been *linked* to the **StoneDrill** wiper, which shares similarities with the Shamoon family used against Saudi Aramco and RasGas (2012). Confidence on the destructive link is **lower than the espionage attribution** — Kaspersky and FireEye both noted it is unproven whether the Shamoon and StoneDrill operators are the same group or merely aligned in interests/region. Treat any destructive capability claim as plausible-but-unconfirmed.
+- **Attribution confidence:** Moderate-to-high for Iranian state-sponsored espionage (multiple independent vendors converge: FireEye/Mandiant, Symantec, Microsoft). Lower for the destructive/wiper attribution.
+
+## Targeting
+
+- **Sectors:** Aviation (both military and commercial), energy with ties to petrochemical production (Mandiant 2017); chemical, engineering, manufacturing, consulting, finance, telecoms, research, and government (Symantec 2019). More recently: **satellite, defense, the Defense Industrial Base (DIB), pharmaceutical, communications, oil & gas, and government** (Microsoft 2023–2024).
+- **Regions:** Historically concentrated on **Saudi Arabia** (Symantec attributed ~42% of observed Elfin attacks since 2016) and the **United States** (including Fortune 500 firms), plus **South Korea**. Recent Peach Sandstorm campaigns are global, including the U.S. and UAE.
+- **Victim profile:** Organizations of strategic interest to Iran — aerospace/defense contractors and supply-chain subcontractors, energy/petrochemical operators, and satellite/communications providers. Spearphishing has often targeted individuals in aviation-related roles using recruitment/job-themed lures.
+
+## Notable campaigns
+
+- **2016–mid 2017 — Aviation & petrochemical intrusions.** APT33 compromised a U.S. aviation organization and targeted a Saudi business conglomerate with aviation holdings and a South Korean oil-refining/petrochemical company; May 2017 lures impersonated job vacancies at a Saudi petrochemical firm. (FireEye/Mandiant, "APT33: Insights into Iranian Cyber Espionage," Sept 2017.)
+- **2017 — StoneDrill wiper discovery.** Kaspersky disclosed StoneDrill, a destructive wiper found in campaigns against Middle Eastern and European targets and linked to APT33-aligned activity, with conceptual similarities to Shamoon. (Kaspersky/Securelist, "From Shamoon to StoneDrill," 2017.)
+- **Feb 2019 — Elfin / WinRAR exploitation.** Symantec reported the Elfin (APT33) group attacked ~50 organizations across Saudi Arabia, the U.S., and other countries, and attempted to exploit **CVE-2018-20250** (WinRAR ACE) against a Saudi chemical-sector target. (Symantec, "Elfin: Relentless Espionage Group," Mar 2019.)
+- **Feb–Jul 2023 — Peach Sandstorm password-spray.** Microsoft observed large-scale password-spray authentication attempts against thousands of organizations in satellite, defense, and pharmaceutical sectors, followed by Entra ID reconnaissance with AzureHound/Roadtools on successful compromises. (Microsoft, "Peach Sandstorm password spray campaigns," Sept 14 2023.)
+- **Nov–Dec 2023 — FalseFont backdoor against the DIB.** Microsoft observed Peach Sandstorm delivering the custom **FalseFont** backdoor to Defense Industrial Base organizations, enabling remote access, file launch, and C2 exfiltration. (Microsoft / The Hacker News / BleepingComputer, Dec 2023.)
+- **Apr–Jul 2024 — Tickler malware & Azure abuse.** Microsoft reported Peach Sandstorm deploying the custom multi-stage **Tickler** backdoor against satellite, communications, oil & gas, and U.S./UAE government targets, using fraudulent Azure subscriptions (compromised education-sector accounts) for Azure App Service C2 nodes, plus LinkedIn social engineering and SMB lateral movement. (Microsoft, "Peach Sandstorm deploys new custom Tickler malware," Aug 28 2024.)
+
+## TTPs by ATT&CK tactic
+
+**Initial Access**
+- `T1566.001` — Spearphishing Attachment: archive attachments delivered in spearphishing emails.
+- `T1566.002` — Spearphishing Link: emails linking to malicious `.hta` HTML application files (recruitment/job lures).
+- `T1110.003` — Password Spraying: large-scale spray against cloud/Internet-facing auth to gain initial footholds (Peach Sandstorm 2023, low-and-slow with `go-http-client` UA).
+- `T1078` / `T1078.004` — Valid Accounts (incl. Cloud Accounts): use of compromised credentials, including Office 365 / Microsoft 365 accounts (historically with the Ruler tool).
+- `T1203` — Exploitation for Client Execution: WinRAR `CVE-2018-20250` and Outlook `CVE-2017-11774`.
+
+**Execution**
+- `T1059.001` — PowerShell: download payloads from C2 and run scripts.
+- `T1059.005` — Visual Basic: VBScript to initiate payload delivery.
+- `T1204.001` / `T1204.002` — User Execution (Malicious Link / Malicious File): luring users to click `.hta` links or open malicious attachments.
+
+**Persistence**
+- `T1547.001` — Registry Run Keys: used for DarkComet-style autostart persistence.
+- `T1546.003` — WMI Event Subscription: WMI subscriptions for persistence.
+- `T1053.005` — Scheduled Task: `.vbe` execution scheduled to run multiple times per day.
+
+**Privilege Escalation**
+- `T1068` — Exploitation for Privilege Escalation: `CVE-2017-0213`.
+- `T1078` — Valid Accounts also leveraged to operate at elevated/legitimate privilege.
+
+**Defense Evasion**
+- `T1132.001` — Standard Encoding: Base64-encoded C2 traffic.
+- `T1027.013` — Obfuscated/Encoded File: Base64-encoded payloads.
+- (2024 Tickler) DLL sideloading via legitimate Windows binaries to blend persistence with trusted processes.
+
+**Credential Access**
+- `T1003.001` — LSASS Memory: LaZagne, Mimikatz, and ProcDump.
+- `T1003.004` — LSA Secrets: LaZagne.
+- `T1003.005` — Cached Domain Credentials: LaZagne.
+- `T1555` / `T1555.003` — Credentials from Password Stores / Web Browsers: LaZagne.
+- `T1040` — Network Sniffing: SniffPass for credential capture.
+- `T1552.001` — Credentials In Files: LaZagne file-based credential discovery.
+- `T1552.006` — Group Policy Preferences: Gpppassword to recover GPP-stored credentials.
+
+**Discovery**
+- Active Directory and Microsoft Entra ID reconnaissance: AzureHound (via Microsoft Graph / Azure REST APIs) and Roadtools against cloud tenants after successful auth; AD snapshot extraction on-prem.
+
+**Lateral Movement**
+- SMB-based propagation across the network following initial compromise (Peach Sandstorm 2024); attempted deployment of AnyDesk remote management for access.
+
+**Collection**
+- `T1560.001` — Archive via Utility: WinRAR to compress data prior to exfiltration.
+- `T0852` (ICS) — Screen Capture: backdoor screenshot capability.
+
+**Command and Control**
+- `T1071.001` — Web Protocols: HTTP for C2.
+- `T1573.001` — Symmetric Cryptography: AES-encrypted C2 channel.
+- `T1571` — Non-Standard Port: HTTP over TCP ports 808 and 880.
+- `T1105` — Ingress Tool Transfer: download additional files/programs from C2.
+- (2024) Azure App Service apps (e.g., `*.azurewebsites.net`) as C2 nodes under fraudulent Azure subscriptions.
+
+**Exfiltration**
+- `T1048.003` — Exfiltration Over Alternative Protocol: FTP for file exfiltration separate from the C2 channel.
+
+**Impact**
+- StoneDrill (`S0380`) wiper capability — destructive disk-wiping linked to APT33-aligned activity (attribution lower-confidence; conceptually related to Shamoon).
+
+**Resource Development / ICS-adjacent**
+- `T1588.002` — Obtain Capabilities (Tool): acquisition of publicly available offensive tools.
+- `T0853` (ICS) — Scripting: PowerShell for C2 and file installation.
+- `T0865` (ICS) — Spearphishing Attachment: `.hta` files with embedded malicious code.
+
+## Signature tooling & malware
+
+Custom families: **TURNEDUP** (`S0198`/backdoor — RAT, `S0199`), **NanoCore** (`S0336`), **NETWIRE** (`S0198`), **POWERTON** (`S0371`, PowerShell backdoor), **PoshC2** (`S0378`), **AutoIt backdoor** (`S0129`), **DEADWOOD** (`S1134`, 2019), **StoneDrill** (`S0380`, wiper), plus newer custom backdoors **FalseFont** (2023, DIB) and **Tickler** (2024, multi-stage Azure-backed). 
+
+Publicly available / dual-use: **Mimikatz** (`S0002`), **LaZagne** (`S0349`), **PowerSploit** (`S0194`), **Empire** (`S0363`), **Pupy** (`S0192`), **Ruler** (`S0358`, Outlook/O365), **ftp** (`S0095`), **Net** (`S0039`), **ProcDump**, **SniffPass**, **Gpppassword**, **AzureHound**, **Roadtools**, and **AnyDesk** (abused RMM).
+
+## Emulation guidance (Decepticon)
+
+> Authorized-use only: execute these emulations strictly within the engagement's written scope, target list, and rules of engagement. Destructive/wiper TTPs must NEVER be executed against client systems — emulate Impact only via documented, reversible markers or out-of-scope-by-default.
+
+Map APT33's signature chain to Decepticon's own capabilities:
+
+- **Initial access — password spray (`T1110.003`) + cloud valid accounts (`T1078.004`):** This is the modern APT33 signature. Use Decepticon's cloud skills to run a low-and-slow spray against the engagement's M365/Entra ID tenant with a custom user-agent and lockout-aware throttling, mirroring the `go-http-client` low-volume pattern. Pair with the engagement's authorized credential list. Avoid lockouts to stay in scope.
+- **Initial access — spearphishing (`T1566.001/.002`, `T1204`):** If phishing is in scope, emulate `.hta`/archive-attachment lures with recruitment/job themes via the engagement's sanctioned phishing harness; otherwise simulate the post-delivery effect by assuming a foothold.
+- **Execution / staging (`T1059.001`, `T1105`):** Use Decepticon's bash/PowerShell tooling to fetch and run a stager from your redirector, mirroring PowerShell download-and-execute.
+- **C2 — emulate with Sliver:** Stand up a Sliver HTTP listener (matches `T1071.001`), enable symmetric-crypto transport (`T1573.001`), and bind to non-standard ports analogous to 808/880 (`T1571`). For high-fidelity cloud emulation, front C2 through an authorized Azure App Service / `*.azurewebsites.net` redirector to replicate the Tickler infrastructure pattern — only with cloud-team approval.
+- **Cloud/AD discovery (`AzureHound`/`Roadtools`/AD snapshot):** Use Decepticon's cloud and AD skills to enumerate Entra ID via Graph/Azure REST (AzureHound-style) and pull an AD snapshot/BloodHound collection on-prem — the exact recon APT33 runs post-auth.
+- **Credential access (`T1003.001/.004/.005`, `T1555`, `T1552.006`):** Via the defense-evasion / credential workflow, emulate LSASS dumping (Mimikatz/ProcDump-style), LaZagne-style store harvesting, and GPP password recovery — log every artifact for the blue cell.
+- **Lateral movement (`T1078`, SMB):** Use Decepticon's lateral-movement skill for SMB-based propagation with recovered valid accounts; optionally emulate AnyDesk RMM deployment if RMM abuse is in scope.
+- **Collection & exfil (`T1560.001`, `T1048.003`):** Archive staged data with a WinRAR-equivalent utility, then exfiltrate over a *separate* FTP channel distinct from C2 to reproduce APT33's split-channel pattern.
+- **Defense evasion (`T1132.001`, `T1027.013`, DLL sideloading):** Base64-encode tasking/payloads and emulate DLL sideloading against a benign legitimate binary to test the blue cell's sideload detection.
+- **Persistence (`T1547.001`, `T1546.003`, `T1053.005`):** Plant a Run-key, a WMI event subscription, and a recurring scheduled task (multiple daily triggers) as APT33 does — document each for clean teardown.
+
+## Detection & defense
+
+- **Password spray / cloud identity (`T1110.003`, `T1078.004`):** Enforce phishing-resistant MFA, conditional access, and risk-based sign-in policies; alert on high-volume failed auth from single/few source IPs, anomalous user-agents (e.g., `go-http-client`), and impossible-travel. Monitor for fraudulent Azure subscription creation and unexpected Azure App Service deployments.
+- **Spearphishing / `.hta` (`T1566`, `T1204`):** Block/inspect `.hta` and archive attachments at the gateway; disable `mshta.exe` where feasible; user-awareness on recruitment-themed lures.
+- **Exploits (`T1203`, `T1068`):** Patch WinRAR (CVE-2018-20250), Outlook (CVE-2017-11774), and Windows (CVE-2017-0213); restrict legacy archive utilities.
+- **Cloud/AD recon (AzureHound/Roadtools):** Monitor Microsoft Graph / Azure REST enumeration spikes from newly authenticated principals; alert on bulk directory reads and AD snapshot/`ntds`-style access.
+- **Credential access (`T1003.x`):** Enable LSASS protection (PPL/Credential Guard), alert on ProcDump/Mimikatz LSASS handle access, and remediate GPP passwords (KB2962486).
+- **Persistence (`T1547.001`, `T1546.003`, `T1053.005`):** Baseline Run keys, WMI event subscriptions, and scheduled tasks; alert on `.vbe`/`.hta`-spawned task creation.
+- **C2 / exfil (`T1071.001`, `T1571`, `T1573.001`, `T1048.003`):** Inspect HTTP on non-standard ports (808/880), flag long-lived beaconing to `*.azurewebsites.net` not tied to business use, and alert on outbound FTP to non-approved hosts.
+- **Lateral movement / RMM:** Detect anomalous SMB admin-share writes and unauthorized AnyDesk/RMM installation.
+- **Impact (wiper):** Maintain tested offline backups and EDR rules for mass file overwrite / MBR tampering given the StoneDrill/Shamoon-adjacent risk.
+
+## Sources
+
+- https://attack.mitre.org/groups/G0064/
+- https://www.mandiant.com/resources/blog/apt33-insights-into-iranian-cyber-espionage
+- https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/elfin-apt33-espionage
+- https://www.microsoft.com/en-us/security/blog/2023/09/14/peach-sandstorm-password-spray-campaigns-enable-intelligence-collection-at-high-value-targets/
+- https://www.microsoft.com/en-us/security/blog/2024/08/28/peach-sandstorm-deploys-new-custom-tickler-malware-in-long-running-intelligence-gathering-operations/
+- https://thehackernews.com/2023/12/microsoft-warns-of-new-falsefont.html
+- https://www.bleepingcomputer.com/news/security/microsoft-hackers-target-defense-firms-with-new-falsefont-malware/
+- https://securelist.com/from-shamoon-to-stonedrill/77725/
+- https://attack.mitre.org/software/S0380/

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt34-oilrig/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt34-oilrig/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: apt34-oilrig
+description: "Adversary-emulation profile for APT34 / OilRig (G0049), an Iranian state-sponsored espionage group, mapping its ATT&CK TTPs to Decepticon tooling for authorized red-team emulation."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "APT34, OilRig, Helix Kitten, Hazel Sandstorm, Earth Simnavaz, Crambus, Cobalt Gypsy, Evasive Serpens, Iranian APT, MOIS, Middle East espionage, DNS tunneling, BONDUPDATER, POWRUNER, SideTwist, STEALHOOK, Outlook Home Page persistence, Exchange exfiltration, password filter DLL, emulate Iranian threat actor"
+  tags: adversary-emulation, apt34, oilrig, iran, espionage, g0049, dns-tunneling, middle-east, mitre-attack, red-team
+  mitre_attack: T1566.001, T1566.002, T1566.003, T1204.001, T1204.002, T1133, T1078, T1078.002, T1190, T1195, T1059.001, T1059.003, T1059.005, T1047, T1203, T1218.001, T1053.005, T1543.003, T1505.003, T1137.004, T1556.002, T1133, T1068, T1543.003, T1112, T1140, T1070.004, T1027.005, T1027.013, T1036, T1036.005, T1553.002, T1588.003, T1497.001, T1686.003, T1003.001, T1003.004, T1003.005, T1555, T1555.003, T1555.004, T1552.001, T1110, T1056.001, T1115, T1087.001, T1087.002, T1082, T1016, T1049, T1033, T1007, T1057, T1518, T1069.001, T1069.002, T1201, T1120, T1012, T1046, T1021.001, T1021.004, T1572, T1219, T1005, T1119, T1074.001, T1113, T1217, T1025, T1071.001, T1071.004, T1132.001, T1008, T1573.002, T1105, T1048.003, T1585.003, T1583.001, T1584.004, T1586.002, T1587.001, T1588.002, T1608.001
+---
+
+# APT34 (OilRig, Helix Kitten, Hazel Sandstorm) — Adversary Emulation Profile
+
+APT34 — tracked as OilRig, Helix Kitten, Hazel Sandstorm, Earth Simnavaz, Crambus, Cobalt Gypsy / COBALT GYPSY, IRN2, Evasive Serpens, EUROPIUM, ITG13, and TA452 (MITRE ATT&CK **G0049**) — is a suspected Iranian state-sponsored cyber-espionage group operational since at least 2014. It conducts long-running, reconnaissance-heavy intrusions against Middle Eastern and international organizations, favoring spearphishing for initial access, heavy use of PowerShell/VBScript backdoors, custom DNS-tunneling C2, supply-chain and trust-relationship abuse, and patient credential harvesting. The group continually re-tools (BONDUPDATER → SideTwist → cloud/Exchange-based C2) and is notable for living-off-the-land tradecraft, password-filter-DLL credential capture, and exfiltrating data through victim-owned Microsoft Exchange servers to blend with legitimate mail flow.
+
+## Attribution & motivation
+- **Suspected sponsor:** Iran. FireEye/Mandiant assesses APT34 "works on behalf of the Iranian government based on infrastructure details that contain references to Iran, use of Iranian infrastructure, and targeting that aligns with nation-state interests." Multiple vendors (Trend Micro, Microsoft, CrowdStrike) link the cluster to Iranian intelligence services.
+- **Motivation:** Strategic **cyber espionage** — long-term reconnaissance and credential/data theft to advance Iranian geopolitical interests in the region. Primary intent is intelligence collection, not financial gain. (A separate but related Iranian destructive operation, ZeroCleare wiper (S1151), is associated with the same cluster, indicating latent destructive capability.)
+- **Confidence:** High that the activity is Iranian state-aligned espionage; the precise sponsoring agency varies by vendor naming. Attribution of any single intrusion should be treated as suspected unless backed by collected infrastructure/tooling overlap.
+
+## Targeting
+- **Sectors:** Financial/banking, government, energy/oil & gas, chemical, telecommunications, critical infrastructure, and aviation/transport.
+- **Regions:** Primarily the Middle East — Gulf Cooperation Council states (UAE, Saudi Arabia, Kuwait, Qatar, Bahrain), plus Israel; with international reach into the U.S. and other regions via supply-chain and trust-relationship pivots.
+- **Victim profile:** Government ministries and state-aligned enterprises in strategic sectors; the group frequently compromises one organization (e.g., HR/job portals, telecoms) and abuses that trust to reach higher-value government targets.
+
+## Notable campaigns
+- **2014–2016 — Emergence (Helminth):** Social-engineering attacks delivering the Helminth backdoor (S0170) via macro-enabled Excel spreadsheets against Middle Eastern banks; FireEye began tracking the cluster as APT34. (Source: MITRE G0049; LevelBlue/Trustwave APT34 profile.)
+- **December 2017 — CVE-2017-11882 government campaign:** Within a week of Microsoft's Nov-2017 patch, APT34 spearphished a Middle East government org with a malicious .rtf exploiting CVE-2017-11882 (Equation Editor) to deploy **POWRUNER** (S0184) and **BONDUPDATER** (S0360), the latter using a custom DGA for DNS-based C2. (Source: FireEye/Mandiant, 2017-12-07.)
+- **Mid-2018 onward — Outlook Home Page persistence (CVE-2017-11774):** APT34 (alongside APT33) abused the Outlook Home Page feature for code execution and persistence after obtaining valid credentials. (Source: FireEye/Mandiant; U.S. Cyber Command advisory; Dark Reading.)
+- **April 2019 — Tool/source leak:** A leak via the "Lab Dookhtegan" Telegram channel exposed OilRig webshells, DNS-tunneling tooling, and victim data, confirming TTPs and infrastructure. (Source: BankInfoSecurity.)
+- **October 2024 — Earth Simnavaz Gulf campaign:** Trend Micro reported APT34/Earth Simnavaz targeting UAE/Gulf government and critical-infrastructure orgs: initial access via a webshell on a vulnerable web server, privilege escalation with **CVE-2024-30088** (Windows Kernel), a registered **password filter DLL** to capture plaintext credentials, the **STEALHOOK** backdoor exfiltrating data as attachments through the victim's own **Microsoft Exchange** server, and **ngrok** for tunneling/lateral movement to the Domain Controller. (Source: Trend Micro; Industrial Cyber; Dark Reading.)
+
+## TTPs by ATT&CK tactic
+*(Every technique below is grounded in the MITRE ATT&CK G0049 entry unless otherwise noted.)*
+
+### Initial Access
+- **T1566.001 / T1566.002 / T1566.003** — Spearphishing via attachment (macro-enabled Excel/Word, .rtf), via link, and via service (LinkedIn personas/fake job sites).
+- **T1190** — Exploitation of public-facing web servers to drop webshells (Earth Simnavaz initial access; complements T1505.003).
+- **T1133** — External remote services: persistence/access via VPN, Citrix, and OWA.
+- **T1195** — Supply-chain / trust-relationship compromise: leveraging one breached org to reach government targets.
+- **T1078 / T1078.002** — Valid (incl. domain) accounts using harvested credentials.
+
+### Execution
+- **T1059.001 / .003 / .005** — PowerShell, Windows Command Shell (batch), and VBScript macros for code execution.
+- **T1047** — WMI for execution.
+- **T1203** — Exploitation for client execution (CVE-2017-11882, CVE-2024-30088).
+- **T1218.001** — Compiled HTML (.chm) payloads to load malware.
+- **T1204.001 / .002** — User execution of malicious links and macro-enabled documents.
+
+### Persistence
+- **T1053.005** — Scheduled tasks executing VBScript.
+- **T1543.003** — Windows services created on remote Domain Controllers.
+- **T1505.003** — Webshells (e.g., SEASHARPEE S0185, RGDoor S0258) for durable network access.
+- **T1137.004** — Outlook Home Page abuse (CVE-2017-11774) for persistence.
+- **T1556.002** — Password Filter DLL registered both for credential capture and as a persistence/delivery mechanism.
+- **T1133** — Re-entry via VPN/Citrix/OWA.
+
+### Privilege Escalation
+- **T1068** — Exploitation for privilege escalation via Windows Kernel CVE-2024-30088.
+- **T1543.003** — Service creation for elevated execution.
+
+### Defense Evasion
+- **T1140** — Decode base64 with certutil/PowerShell.
+- **T1070.004** — Delete payload files post-execution.
+- **T1027.005 / .013** — Modify samples to evade AV; base64-encrypted/encoded files.
+- **T1036 / T1036.005** — Masquerading (e.g., `.doc`-extension executables; Plink renamed `\ProgramData\Adobe.exe`).
+- **T1553.002 / T1588.003** — Code signing with stolen certificates (and acquiring those certs).
+- **T1497.001** — Sandbox evasion via mouse-presence/system checks.
+- **T1112** — Modify registry via reg.exe.
+- **T1686.003** — Disable/modify Windows firewall for remote access.
+
+### Credential Access
+- **T1003.001 / .004 / .005** — LSASS (Mimikatz S0002), LSA Secrets and cached domain creds (LaZagne S0349).
+- **T1555 / .003 / .004** — Password stores; browser creds (LaZagne, PICKPOCKET); Windows Credential Manager (VALUEVAULT).
+- **T1552.001** — Credentials in files via LaZagne.
+- **T1556.002** — Password Filter DLL to capture plaintext credentials at logon/change.
+- **T1110** — Brute force / password spraying.
+- **T1056.001** — Keylogging (KEYPUNCH, LONGWATCH).
+- **T1115** — Clipboard capture via infostealers.
+
+### Discovery
+- **T1087.001 / .002** — Local/domain account enumeration (`net user`, net commands).
+- **T1082 / T1016 / T1049 / T1033 / T1007** — System info (`systeminfo`, `hostname`), network config (`ipconfig /all`), connections (`netstat -an`), user (`whoami`), services (`sc query`).
+- **T1057 / T1518** — Process listing (`tasklist`); installed software (incl. Chrome).
+- **T1069.001 / .002** — Local and domain permission-group enumeration.
+- **T1201** — Password policy discovery (`net accounts`).
+- **T1120 / T1012** — Peripheral (mouse) discovery; registry queries (Terminal Server Client keys).
+- **T1046** — Network service discovery (SoftPerfect Network Scanner, GOLDIRONY).
+
+### Lateral Movement
+- **T1021.001** — RDP (often through tunneling).
+- **T1021.004** — SSH via PuTTY.
+- **T1572** — Protocol tunneling with Plink.
+- **T1219** — ngrok used as remote-access/tunneling RMM to reach the DC (Earth Simnavaz).
+- PsExec (S0029) for remote execution.
+
+### Collection
+- **T1005 / T1119 / T1074.001** — Local data collection, automated collection, local staging in `%TEMP%`.
+- **T1113** — Screen capture (CANDYKING).
+- **T1217 / T1025** — Browser data dumpers (MKG, CDumper, EDumper); USB capture via Wireshark `usbcapcmd`.
+- **T1056.001 / T1115** — Keylogging and clipboard data (also credential access).
+
+### Command and Control
+- **T1071.001** — HTTP web-protocol C2.
+- **T1071.004** — DNS-tunneling C2 (signature TTP; BONDUPDATER DGA, requestbin.net).
+- **T1132.001** — Base64 standard encoding of C2 data.
+- **T1008** — Fallback channels (ISMAgent falls back to DNS when HTTP unavailable).
+- **T1573.002** — Asymmetric encrypted channels (PowerExchange/tunneling utilities).
+- **T1105** — Ingress tool transfer.
+
+### Exfiltration
+- **T1048.003** — Exfiltration over alternative protocol via the victim's own Microsoft Exchange server (STEALHOOK emails data as attachments) and FTP.
+
+### Impact
+- No routine destructive impact in espionage operations, but the cluster is associated with the **ZeroCleare** (S1151) wiper, demonstrating latent destructive capability — relevant for blue-cell worst-case planning.
+
+### Resource Development (pre-intrusion)
+- **T1583.001 / T1584.004 / T1586.002** — Acquire domains (fake VPN/job sites), compromise infrastructure (hijacked Israeli HR/job portals as C2), compromise email accounts for phishing.
+- **T1585.003** — Establish M365 cloud accounts for C2.
+- **T1587.001 / T1588.002 / T1608.001** — Develop malware (Solar, Mango); obtain tools (Plink, Mimikatz); host malware on fake targeting sites.
+
+## Signature tooling & malware
+**Custom:** BONDUPDATER (S0360, DGA DNS downloader), POWRUNER (S0184, PowerShell backdoor), Helminth (S0170, VBScript/PowerShell + EXE), ISMInjector (S0189), QUADAGENT (S0269), OopsIE (S0264), SideTwist (S0610), RDAT (S0495, DNS/email-steganography C2), RGDoor (S0258, IIS backdoor), SEASHARPEE (S0185, webshell), PowerExchange (S1173, Exchange-based C2), Solar / Mango (S1166 / S1169), SampleCheck5000 (S1168), ODAgent (S1170), OilCheck (S1171), OilBooster (S1172), ZeroCleare (S1151, wiper). Named (non-MITRE-software) tooling from reporting: STEALHOOK, VALUEVAULT, PICKPOCKET, KEYPUNCH, LONGWATCH, CANDYKING, GOLDIRONY, MKG/CDumper/EDumper.
+**Public / dual-use:** Mimikatz (S0002), LaZagne (S0349), PsExec (S0029), ngrok (S0508), certutil (S0160), Net (S0039), Reg (S0075), Tasklist (S0057), Systeminfo (S0096), netstat (S0104), ipconfig (S0100), ftp (S0095), Plink/PuTTY, SoftPerfect Network Scanner, Wireshark (`usbcapcmd`).
+
+## Emulation guidance (Decepticon)
+**AUTHORIZED USE ONLY — execute these techniques exclusively within the documented scope, rules of engagement, and target list of a signed engagement; never against systems you are not explicitly authorized to test.**
+
+Map APT34's signature behaviors to Decepticon capabilities to reproduce the actor's tradecraft for blue-cell exercise:
+- **Initial access (T1566.x / T1204.x):** Use the phishing/social-engineering skill to craft macro-enabled Office or .rtf lures and LinkedIn-style personas (mirroring T1566.003). For web-facing entry (T1190/T1505.003), use the web-exploitation/bash tooling to drop an authorized webshell on an in-scope test server.
+- **Execution (T1059.001/.003/.005, T1047, T1218.001):** Drive PowerShell, cmd, VBScript, WMI, and .chm-loader payloads via the bash/command-execution and defense-evasion skills. Stage a custom-DGA "BONDUPDATER-style" beacon to emulate the actor's loader behavior.
+- **C2 (T1071.004 DNS tunneling, T1071.001 HTTP, T1008 fallback, T1573.002):** Configure your **C2/Sliver** profile for DNS-over-HTTP fallback to replicate APT34's hallmark DNS-tunneling and HTTP-with-DNS-failover beaconing. Use base64 encoding (T1132.001) on C2 traffic to match the actor.
+- **Persistence (T1053.005, T1543.003, T1505.003, T1137.004, T1556.002):** Via the persistence/AD skills, plant scheduled tasks, create services on a (lab) DC, deploy a webshell, and — where the engagement explicitly authorizes endpoint persistence — emulate Outlook Home Page abuse and a benign password-filter-DLL to demonstrate the credential-capture vector.
+- **Privilege escalation (T1068):** Use the local-privesc tooling to emulate kernel-exploit escalation in a patched-vs-unpatched lab; do not weaponize live CVEs outside scope.
+- **Credential access (T1003.x, T1555.x, T1556.002, T1110, T1056.001):** Run Mimikatz/LaZagne-equivalent modules from the credential-access skill for LSASS/LSA/browser/Credential-Manager dumping; emulate password-spray (T1110) and a keylogger to mirror APT34 harvesting.
+- **Discovery (T1087/T1082/T1016/T1049/T1069/T1201/T1046):** Execute the LOLBin recon sequence (`whoami`, `net user`/`net group`, `ipconfig /all`, `netstat -an`, `net accounts`, `sc query`) via bash and run an authorized network scan to mirror the actor's footprint.
+- **Lateral movement (T1021.001/.004, T1572, T1219):** Use the lateral-movement skill with RDP/SSH plus Plink/ngrok-style tunneling to traverse to a lab DC, replicating the Earth Simnavaz path.
+- **Collection & exfiltration (T1113/T1074.001/T1048.003):** Stage data in `%TEMP%`, capture screenshots, then emulate exfiltration through an in-scope Exchange/mail path (STEALHOOK pattern) or DNS tunnel to validate DLP/egress detections.
+- **Cloud (T1585.003):** Where the engagement includes M365/Azure, use the cloud skill to stand up an authorized cloud-mail C2 account mirroring the actor's M365 abuse.
+
+Sequence the emulation as the actor does: phish → execute loader → DNS/HTTP C2 → recon → credential harvest → escalate → lateral to DC → stage → exfil via mail/DNS — so the blue cell can validate detection at each hop.
+
+## Detection & defense
+- **Phishing/macros (T1566, T1204, T1218.001):** Block macros from the internet, disable Equation Editor, strip/ sandbox .rtf and .chm attachments; user-reporting + attachment detonation.
+- **DNS-tunneling C2 (T1071.004, T1008):** Monitor for high-volume/long/encoded TXT/A queries, DGA-like subdomains, and unusual resolver patterns; baseline DNS egress and alert on anomalous query length/entropy. This is the highest-signal detection for APT34.
+- **Outlook Home Page persistence (T1137.004):** Audit/disable the Outlook Home Page registry keys; ensure the CVE-2017-11774 patch is applied and not rolled back; alert on creation of `Software\Microsoft\Office\*\Outlook\WebView` URL values.
+- **Password Filter DLL (T1556.002):** Monitor `HKLM\SYSTEM\CurrentControlSet\Control\Lsa\Notification Packages` for new entries and unexpected DLLs loaded into LSASS.
+- **Credential dumping (T1003.x):** Enable LSASS protection (RunAsPPL/Credential Guard), alert on suspicious LSASS access and on LaZagne/Mimikatz behavior.
+- **Exchange exfiltration (T1048.003):** Alert on programmatic mail sends with attachments from server/service contexts, anomalous EWS/Exchange transport activity, and outbound mail to unfamiliar external addresses.
+- **Tunneling/RMM (T1572, T1219, T1021):** Detect ngrok/Plink/PuTTY binaries and renamed copies (e.g., `Adobe.exe` in `ProgramData` — T1036.005), monitor for unexpected RDP/SSH tunnels, and restrict outbound to known RMM domains.
+- **Webshells (T1505.003):** File-integrity monitoring on web roots, alert on web-server processes spawning cmd/PowerShell.
+- **Exploitation/patching (T1203, T1068):** Prioritize patching CVE-2017-11882, CVE-2017-0199, CVE-2017-11774, and CVE-2024-30088; restrict kernel-exploit prerequisites.
+- **Living-off-the-land recon (T1059.001, certutil decode T1140):** Enable PowerShell script-block/module logging and alert on `certutil -decode`, base64 blobs, and the clustered LOLBin recon sequence.
+- **Identity (T1078, T1110, T1133):** Enforce MFA on VPN/Citrix/OWA/M365, monitor for password spraying and impossible-travel logons.
+
+## Sources
+- MITRE ATT&CK — OilRig (G0049): https://attack.mitre.org/groups/G0049/
+- FireEye/Mandiant — "New Targeted Attack in the Middle East by APT34 … Using CVE-2017-11882 Exploit" (2017-12-07): https://cloud.google.com/blog/topics/threat-intelligence/targeted-attack-in-middle-east-by-apt34/
+- Mandiant/FireEye — "Breaking the Rules: A Tough Outlook for Home Page Attacks (CVE-2017-11774)": https://cloud.google.com/blog/topics/threat-intelligence/breaking-the-rules-tough-outlook-for-home-page-attacks/
+- Trend Micro — "Earth Simnavaz (aka APT34) Levies Advanced Cyberattacks Against Middle East" (2024-10): https://www.trendmicro.com/en_us/research/24/j/earth-simnavaz-cyberattacks.html
+- Industrial Cyber — Trend Micro Earth Simnavaz Exchange backdoor coverage: https://industrialcyber.co/ransomware/trend-micro-reveals-earth-simnavaz-apt-targets-gulf-organizations-using-microsoft-exchange-server-backdoor/
+- Dark Reading — "Iran's APT34 Abuses MS Exchange to Spy on Gulf Gov'ts": https://www.darkreading.com/cyberattacks-data-breaches/iran-apt34-ms-exchange-spy-gulf-govts
+- Dark Reading — "Attackers Continue to Exploit Outlook Home Page Flaw" (CVE-2017-11774): https://www.darkreading.com/vulnerabilities-threats/attackers-continue-to-exploit-outlook-home-page-flaw
+- BankInfoSecurity — "Leak Exposes OilRig APT Group's Tools": https://www.bankinfosecurity.com/leak-exposes-oilrig-apt-groups-tools-a-12397

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt41-double-dragon/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/apt41-double-dragon/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: apt41-double-dragon
+description: "Adversary-emulation profile for APT41 (Double Dragon / Wicked Panda / BARIUM / Brass Typhoon, ATT&CK G0096), a Chinese dual-mandate espionage-and-cybercrime actor."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "APT41, Double Dragon, Wicked Panda, BARIUM, Brass Typhoon, Winnti, G0096, Chinese state-sponsored, dual espionage and cybercrime, supply chain compromise, ShadowPad, PlugX, KEYPLUG, DUSTTRAP, Cobalt Strike, web shell, code-signing certificate theft, video game industry, emulate this actor"
+  tags: adversary-emulation, apt41, double-dragon, china, mss, espionage, cybercrime, supply-chain, web-shell, cobalt-strike, mitre-attack, g0096
+  mitre_attack: T1595.002, T1595.003, T1596.005, T1593.002, T1594, T1583.001, T1583.003, T1583.006, T1583.007, T1588.002, T1588.003, T1195.002, T1190, T1203, T1133, T1566.001, T1684.001, T1059.001, T1059.003, T1059.004, T1059.007, T1218.001, T1218.007, T1218.011, T1047, T1569.002, T1197, T1547.001, T1037, T1136.001, T1543.003, T1546.008, T1542.003, T1053.005, T1505.003, T1134, T1548.002, T1548.003, T1070.003, T1070.004, T1070.005, T1562.006, T1574.001, T1574.006, T1036.004, T1036.005, T1027, T1027.002, T1027.013, T1553.002, T1480.001, T1110, T1555, T1555.003, T1556.001, T1056.001, T1003.001, T1003.002, T1003.003, T1550.002, T1087.001, T1087.002, T1046, T1135, T1057, T1012, T1018, T1518, T1082, T1016, T1049, T1033, T1613, T1083, T1210, T1570, T1021.001, T1021.002, T1071.001, T1071.002, T1071.004, T1001.003, T1008, T1573.002, T1568.002, T1105, T1104, T1571, T1090, T1090.004, T1572, T1102.001, T1102, T1030, T1048.003, T1041, T1567.002, T1119, T1213.003, T1213.006, T1005, T1074.001, T1486
+---
+
+# APT41 (Double Dragon, Wicked Panda, BARIUM) — Adversary Emulation Profile
+
+APT41 (MITRE ATT&CK **G0096**; also tracked as Double Dragon, Wicked Panda, Winnti, BARIUM, and Microsoft's **Brass Typhoon**) is a prolific Chinese threat actor unique for running **state-sponsored cyber-espionage in parallel with financially motivated cybercrime** — often reusing the same non-public malware for both missions. First publicly profiled by FireEye/Mandiant in August 2019, the group has been active since at least 2012, beginning in the video-game economy (virtual-currency theft, ransomware, code-signing certificate theft) and expanding into wide-ranging espionage. APT41 is best known for **software supply-chain compromises** (poisoning legitimately signed installers), rapid weaponization of newly disclosed vulnerabilities, abuse of **stolen code-signing certificates**, and a deep, modular toolset spanning Windows and Linux. This profile maps APT41's documented TTPs to ATT&CK so Decepticon can emulate them under authorized scope and the blue cell can anticipate detection.
+
+## Attribution & motivation
+
+- **Suspected sponsor / nation:** People's Republic of China. Mandiant assesses APT41 operates under the **MSS (Ministry of State Security) contractor model** — nominally private companies executing intelligence taskings for provincial MSS bureaus — rather than the PLA model. The group is operationally linked to the Chengdu-based front company **Chengdu 404 Network Technology Co., Ltd.**
+- **Motivation:** **Dual-mandate.** Espionage (intellectual property, strategic intelligence, surveillance of dissidents/pro-democracy figures) interleaved with **financial gain** (game virtual-currency manipulation, ransomware, cryptomining). Mandiant observed espionage during Beijing business hours and financially motivated activity during off-hours, suggesting moonlighting on shared infrastructure.
+- **Confidence:** **High** for China nexus and dual motivation. The U.S. DOJ on **September 16, 2020** indicted five Chinese nationals (Zhang Haoran, Tan Dailin, Jiang Lizhi, Qian Chuan, Fu Qiang) and two Malaysian accomplices (Wong Ong Hua, Ling Yang Ching) in connection with attacks on 100+ victims globally, lending strong public attribution. Specific operation-to-operator mapping within individual intrusions carries lower confidence.
+
+## Targeting
+
+- **Sectors:** Video games & game publishers, software/IT and computer hardware, telecommunications (incl. call-record interception), healthcare & pharmaceuticals, high-tech/semiconductors, media & entertainment, shipping & logistics, automotive, financial services, education, think tanks, and government.
+- **Regions:** Global — North America, Europe (Italy, Spain, UK), East and Southeast Asia (Taiwan, Thailand, Hong Kong, Japan, South Korea), the Middle East (Turkey), and beyond. U.S. **state governments** were a notable target.
+- **Victim profile:** Both broad opportunistic compromise (any org running a freshly exploitable internet-facing app) and deliberate strategic targeting. Notably includes **Hong Kong pro-democracy activists and politicians** and individuals of intelligence interest, alongside large enterprises and supply-chain "watering hole" vendors used to reach downstream customers.
+
+## Notable campaigns
+
+- **2012–2019 — Video-game economy & supply-chain origins.** Members conducted financially motivated game-currency theft and ransomware, then injected malicious code into legitimately signed software. APT41 is associated with the **CCleaner (2017)** and **ASUS Live Update / "Operation ShadowHammer" (2018)** supply-chain compromises and the **ShadowPad** privately-sold backdoor. (FireEye/Mandiant 2019; Kaspersky Securelist; SentinelLabs)
+- **August 2019 — Public attribution.** FireEye publishes "**APT41: A Dual Espionage and Cyber Crime Operation**," formally naming the group and documenting its dual mandate. (Mandiant)
+- **Jan–Mar 2020 — Global exploitation wave.** Mandiant observed APT41 attempt to exploit Citrix NetScaler/ADC (CVE-2019-19781), Cisco routers, and Zoho ManageEngine Desktop Central (CVE-2020-10189) across 75+ customers — one of the broadest campaigns by a Chinese actor observed at the time. (Mandiant)
+- **September 16, 2020 — DOJ indictments.** U.S. charges seven defendants ("APT41 actors") for intrusions against 100+ organizations; FBI adds five to Cyber's Most Wanted. (DOJ / TechCrunch / BleepingComputer)
+- **May 2021 – Feb 2022 (Campaign C0017) — U.S. state government networks.** APT41 compromised at least six U.S. state governments by exploiting internet-facing web apps, including a **zero-day in the USAHerds livestock application (CVE-2021-44207)** and **Log4j (CVE-2021-44228)** within hours of disclosure; deployed custom loaders (DEADEYE), KEYPLUG, and DUSTPAN. (Mandiant, "APT41 Targeting U.S. State Government Networks")
+- **Jan 2023 – Jun 2024 (Campaign C0040, "APT41 DUST") / July 2024 report — DUSTTRAP campaign.** Sustained intrusions into shipping/logistics, media, technology, and automotive orgs in Italy, Spain, Taiwan, Thailand, Turkey, and the UK. Chain: **ANTSWORD/BLUEBEAM web shells → DUSTPAN/DUSTTRAP droppers → BEACON (Cobalt Strike)**; DUSTTRAP decrypts payloads in memory and was signed with **stolen code-signing certificates** (one tied to a South Korean gaming company). Oracle DB exfiltration via SQLULDR2/PINEGROVE to OneDrive. (Google Cloud / Mandiant + Google TAG, "APT41 Has Arisen From the DUST")
+
+## TTPs by ATT&CK tactic
+
+### Reconnaissance
+- **T1595.002 / T1595.003** — Active scanning: vulnerability scanning (Acunetix, JexBoss) and web-directory brute-forcing (wordlist scanning).
+- **T1596.005** — Passive scanning of victims via fofa.su.
+- **T1593.002 / T1594** — Target development via search engines and direct browsing of victim-owned websites.
+
+### Resource Development
+- **T1583.001 / .003 / .006 / .007** — Acquire domains, VPS, web services, and serverless infrastructure (Cloudflare Workers) for staging and C2.
+- **T1588.002** — Obtain offensive tooling: Mimikatz, pwdump, PowerSploit, credential editors.
+- **T1588.003 / T1553.002** — Obtain and abuse **code-signing certificates** (frequently stolen, e.g., DUST campaign) to sign malware.
+- **T1195.002** — Supply-chain compromise: inject malicious code into legitimately signed software (CCleaner, ASUS, ShadowPad).
+
+### Initial Access
+- **T1190** — Exploit public-facing apps. Rapid weaponization: CVE-2019-19781 (Citrix ADC), CVE-2020-10189 (Zoho ManageEngine), CVE-2021-26855 (Exchange ProxyLogon), CVE-2021-44207 (USAHerds 0-day), CVE-2021-44228 (Log4j).
+- **T1203** — Exploitation for client execution via malicious documents (CVE-2017-0199, CVE-2017-11882, etc.).
+- **T1133** — External remote services / third-party VPN access to reach billing/payment systems.
+- **T1566.001** — Spearphishing attachments, notably compiled-HTML (.chm) files.
+- **T1684.001** — Impersonation (e.g., posing as video-game-developer employees).
+
+### Execution
+- **T1059.001/.003/.004/.007** — PowerShell, Windows cmd (`cmd.exe /c` on remote hosts), Unix shell for surveys, and JScript web shells.
+- **T1218.001 / .007 / .011** — Proxy execution via compiled HTML (.chm), msiexec, and rundll32 loaders.
+- **T1047** — WMI for remote command execution (WMIEXEC) and persistence.
+- **T1569.002** — Service execution (svchost/Net) to deploy Cobalt Strike.
+- **T1197** — BITSAdmin to download/install payloads.
+
+### Persistence
+- **T1547.001** — Registry Run keys / startup-folder modifications for Cobalt Strike.
+- **T1037** — Linux boot/logon init scripts (hidden scripts in `/etc/rc.d/init.d`) for rootkit loading.
+- **T1136.001** — Create local accounts.
+- **T1543.003** — Create/modify Windows services (e.g., `StorSyncSvc`; "Windows Defend" service for DUSTPAN).
+- **T1546.008** — Accessibility-feature (sticky keys) backdoor.
+- **T1542.003** — MBR bootkits (ROCKBOOT).
+- **T1053.005** — Create new and hijack legitimate scheduled tasks.
+- **T1505.003** — Web shells: ANTSWORD, BLUEBEAM, China Chopper, ASPXSpy, JScript shells.
+
+### Privilege Escalation
+- **T1134** — Access-token manipulation via a ConfuserEx-obfuscated BADPOTATO exploit to reach `NT AUTHORITY\SYSTEM`.
+- **T1548.002 / .003** — Bypass UAC on Windows; abuse sudo on Linux.
+
+### Defense Evasion
+- **T1070.003/.004/.005** — Clear bash history, delete files/artifacts, clear Windows event logs.
+- **T1562.006** — Custom **ETW-bypass** injector to blind Windows logging (Disable/Modify tools/telemetry).
+- **T1574.001 / .006** — **DLL search-order hijacking & side-loading** (used for DUSTTRAP); `LD_PRELOAD` hijacking on Linux.
+- **T1036.004 / .005** — Masquerade services/tasks as benign tooling; disguise files as AV software; reuse names like USERS/SYSUSER/SYSLOG.
+- **T1027 / .002 / .013** — Obfuscation: VMProtect/Themida packing, splitting binaries across disk sections, in-memory-decrypted encrypted payloads.
+- **T1553.002** — Code-signing with stolen certificates (DUSTTRAP).
+- **T1480.001** — Environmental keying / guardrails: DPAPI encryption; RC5 key derived from volume serial number.
+
+### Credential Access
+- **T1110** — Brute-force local admin passwords.
+- **T1555 / .003** — Harvest credential stores and browser-saved creds (BrowserGhost).
+- **T1056.001** — GEARSHIFT keylogger.
+- **T1003.001/.002/.003** — Dump LSASS (Mimikatz, ProcDump, WCE, hashdump), SAM (`reg save`, shadow copies), and NTDS (`ntdsutil` → ntds.dit).
+- **T1550.002** — Pass-the-Hash using Mimikatz-captured hashes.
+- **T1556.001** — Modify domain-controller authentication process.
+
+### Discovery
+- **T1087.001/.002** — `net` enumeration of local and domain admins.
+- **T1046 / T1135** — Network service scanning (WIDETONE) and `net share` enumeration.
+- **T1057 / T1012 / T1082 / T1016 / T1049 / T1033** — Process, registry (RDP ports), `systeminfo`/`net config`, `ipconfig`/MAC, `netstat`/HIGHNOON RDP-session enumeration, `whoami`.
+- **T1018 / T1083 / T1518 / T1613** — Remote-system discovery (MiPing), file/dir discovery, software discovery, domain-trust discovery.
+
+### Lateral Movement
+- **T1210** — Exploitation of remote services.
+- **T1570** — Lateral tool transfer over remote shares.
+- **T1021.001 / .002** — RDP (NATBypass to expose RDP ports) and SMB/admin shares (implant transfer + WMI execution).
+
+### Collection
+- **T1005 / T1074.001** — Collect local data, machine info, PII; stage to local CSVs and staging dirs (SAM/SYSTEM hives).
+- **T1119** — Automated collection via SQLULDR2 and PINEGROVE.
+- **T1213.003 / .006** — Clone victim Git repositories; bulk-extract Oracle databases.
+
+### Command & Control
+- **T1071.001/.002/.004** — HTTP/HTTPS, FTP, and DNS C2.
+- **T1573.002** — Encrypted channels (HTTPS / asymmetric crypto).
+- **T1001.003** — Protocol/service impersonation (LOWKEY.PASSIVE blends into normal web traffic).
+- **T1568.002** — DGA rotating C2 monthly.
+- **T1008 / T1102 / T1102.001** — Fallback channels and web-service dead-drop resolvers (GitHub, Pastebin, Microsoft TechNet, Steam community pages).
+- **T1090 / .004** — Proxying (CLASSFON, Cloudflare CDN) and domain fronting.
+- **T1571 / T1572** — Non-standard ports and protocol tunneling.
+- **T1105 / T1104** — Ingress tool transfer (certutil) and multi-stage channels (BEACON downloading second-stage backdoors).
+
+### Exfiltration
+- **T1041** — Exfil over C2 channel (Cloudflare services).
+- **T1048.003** — Exfil over DNS by encoding data into subdomains.
+- **T1567.002** — Exfil to cloud storage (OneDrive).
+- **T1030** — Fixed-size chunking to evade size-based detection.
+
+### Impact
+- **T1486** — Data encrypted for impact: Encryptor RaaS ransomware; abuse of BitLocker and Jetico BestCrypt (primarily in financially motivated operations).
+
+## Signature tooling & malware
+
+- **Custom / closely-held:** ShadowPad (S0596), PlugX (S0013), Winnti for Linux (S0430), Derusbi (S0021), KEYPLUG (S1051), DEADEYE (S1052), DUSTPAN (S1158), DUSTTRAP (S1159), MESSAGETAP (S0443, telco SMS interception), MOPSLED (S1221), LightSpy (S1185, mobile), GEARSHIFT keylogger, LOWKEY, HIGHNOON, WIDETONE, ROCKBOOT (S0112, MBR bootkit), gh0st RAT (S0032), ZxShell (S0412), njRAT (S0385), BLACKCOFFEE (S0069).
+- **Web shells:** ANTSWORD, BLUEBEAM, China Chopper (S0020), ASPXSpy (S0073), custom JScript shells.
+- **Commodity / public / dual-use:** Cobalt Strike BEACON (S0154), Empire (S0363), Mimikatz (S0002), Impacket (S0357 — incl. wmiexec), PowerSploit (S0194), pwdump (S0006), Windows Credential Editor, ProcDump, BrowserGhost, sqlmap (S0225), SQLULDR2 & PINEGROVE (Oracle exfil), NATBypass, CLASSFON, certutil (S0160), BITSAdmin (S0190), and native LOLBins (Net, ipconfig, netstat, ping, dsquery, ftp).
+
+## Emulation guidance (Decepticon)
+
+> **Authorized use only:** Execute these techniques solely within the documented engagement scope, rules of engagement, and authorization window. Stay inside approved target ranges and obtain explicit sign-off before any destructive or impact-stage action.
+
+Map APT41's signature behaviors to Decepticon's own capabilities:
+
+- **Initial access (T1190, T1505.003):** Use Decepticon's recon/scanning and exploitation skills to identify and exploit an in-scope internet-facing app, then drop an in-scope **web shell** (emulate China Chopper / ANTSWORD behavior). Mirror APT41's defining trait: weaponize a recently disclosed CVE *fast* against the approved target.
+- **Execution & ingress (T1105, T1218.011, T1197):** From the web shell, emulate the DUSTPAN pattern — use `certutil`/BITSAdmin (bash/Windows command skills) to pull a stager, then load via `rundll32` / DLL side-loading.
+- **C2 (T1071.001, T1573.002, T1090, T1102.001):** Stand up **Sliver (c2/sliver skill)** as the BEACON analog over HTTPS. Emulate APT41 tradecraft with the **defense-evasion** kit: domain fronting / CDN proxying, web-service dead-drop resolvers, and DGA-style or non-standard-port profiles where the C2 framework supports it.
+- **Defense evasion (T1574.001, T1027.002, T1553.002, T1562.006):** Use the **defense-evasion skill** for DLL search-order hijacking / side-loading, packing/obfuscation of the implant, signing test payloads with an authorized cert (emulating stolen-cert behavior), and ETW/event-log tampering — log every change for the blue cell.
+- **Credential access (T1003.001/.003, T1550.002):** Use **AD skills** to dump LSASS, SAM, and `ntdsutil` ntds.dit, then perform Pass-the-Hash exactly as APT41 does with Mimikatz/Impacket-equivalent tooling.
+- **Lateral movement (T1021.001/.002, T1047, T1570):** Use the **lateral-movement skill** to pivot via SMB/admin shares + WMI (wmiexec analog) and RDP, transferring the implant over remote shares.
+- **Discovery (T1087, T1018, T1082, T1613):** Emulate APT41's `net`/`whoami`/`systeminfo`/`netstat` LOLBin survey via the bash/command skills and AD enumeration; add domain-trust discovery before pivoting.
+- **Collection & exfil (T1119, T1213.006, T1048.003, T1567.002):** If databases are in scope, emulate SQLULDR2-style bulk extraction to staged CSVs, then exfiltrate via **DNS-subdomain encoding** or to **cloud storage** using the **cloud skills** — chunked to fixed sizes (T1030).
+- **Impact (T1486):** Only if the ROE explicitly authorizes destructive emulation — otherwise simulate/flag the ransomware stage rather than executing it.
+
+Recommended emulation chain (DUST campaign analog): *web shell → certutil/DUSTPAN-style dropper → side-loaded loader → Sliver BEACON over HTTPS/CDN → credential dump + PtH → SMB/WMI lateral movement → DB collection → DNS/cloud exfil.*
+
+## Detection & defense
+
+- **Web shells (T1505.003):** Monitor web roots for new/modified server-executable files; baseline web-server child processes (w3wp/httpd spawning cmd/powershell). Hunt for ANTSWORD/BLUEBEAM/China Chopper signatures and anomalous POST patterns.
+- **Rapid CVE exploitation (T1190):** Aggressively patch internet-facing apps; prioritize the same families APT41 weaponizes (Citrix ADC, Exchange, ManageEngine, Log4j, niche LOB apps like USAHerds). Alert on exploitation attempts within hours of public PoC.
+- **DLL side-loading & signed malware (T1574.001, T1553.002):** Detect legitimate signed binaries loading unsigned/anomalous DLLs from non-standard paths; track certificate-revocation and unexpected signer identities (stolen-cert reuse).
+- **In-memory / fileless loaders (DUSTTRAP, T1027.013, T1055-style):** Deploy EDR with in-memory scanning; alert on encrypted payloads decrypted and executed in memory with minimal disk artifacts.
+- **Telemetry tampering (T1562.006, T1070.005):** Alert on ETW provider disable/patch and Windows event-log clears; forward logs off-host so local clears don't blind the SOC.
+- **Credential theft (T1003.x):** Detect LSASS access by non-system processes, `reg save` of SAM/SYSTEM, shadow-copy creation, and `ntdsutil`/NTDS access on DCs. Enable Credential Guard and LSASS protection.
+- **Lateral movement (T1021.002, T1047, T1550.002):** Monitor remote service creation, WMI process creation events (Event ID 4688 + WMI-Activity), admin-share writes, and PtH indicators (NTLM logons from unexpected hosts). Tier/segment admin credentials.
+- **C2 / exfil (T1071.004, T1048.003, T1090.004, T1567.002):** Inspect DNS for high-entropy/long subdomains and abnormal query volume; detect domain fronting and unexpected CDN/Cloudflare-Worker callbacks; monitor cloud-storage uploads (OneDrive) from servers and chunked transfer patterns.
+- **General:** Restrict outbound from servers, enforce app allow-listing to curb LOLBin abuse (certutil/bitsadmin/rundll32), and hunt dead-drop-resolver beaconing to GitHub/Pastebin/Steam.
+
+## Sources
+
+- MITRE ATT&CK — APT41 (G0096): https://attack.mitre.org/groups/G0096/
+- Mandiant/FireEye — "APT41: A Dual Espionage and Cyber Crime Operation": https://www.mandiant.com/resources/report-apt41-double-dragon-a-dual-espionage-and-cyber-crime-operation
+- Mandiant — "APT41 Targeting U.S. State Government Networks" (Campaign C0017): https://cloud.google.com/blog/topics/threat-intelligence/apt41-us-state-governments
+- Google Cloud / Mandiant + Google TAG — "APT41 Has Arisen From the DUST" (DUSTTRAP, 2024): https://cloud.google.com/blog/topics/threat-intelligence/apt41-arisen-from-dust
+- U.S. DOJ — "Seven International Cyber Defendants, Including 'APT41' Actors, Charged…" (Sept 16, 2020): https://www.justice.gov/archives/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer
+- TechCrunch — "Justice Department charges five Chinese members of APT41": https://techcrunch.com/2020/09/16/justice-department-charges-apt41-chinese-hackers/
+- Kaspersky Securelist — "Operation ShadowHammer" (ASUS supply chain): https://securelist.com/operation-shadowhammer/89992/
+- SentinelLabs — "ShadowPad: A Masterpiece of Privately Sold Malware in Chinese Espionage": https://www.sentinelone.com/labs/shadowpad-a-masterpiece-of-privately-sold-malware-in-chinese-espionage/

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/fin7-carbanak/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/fin7-carbanak/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: fin7-carbanak
+description: "Adversary-emulation profile for FIN7 (G0046; aka Carbanak, Carbon Spider, Sangria Tempest, GOLD NIAGARA, ELBRUS) \u2014 a financially motivated Russian-speaking crime group, mapping its TTPs to Decepticon tooling for authorized red-team emulation."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "FIN7, Carbanak, Carbon Spider, Sangria Tempest, GOLD NIAGARA, ELBRUS, ITG14, financially motivated, POS / payment-card theft, big game hunting, ransomware affiliate (Darkside, BlackMatter, Cl0p, Black Basta, REvil, ALPHV/BlackCat, LockBit), spearphishing with weaponized Office docs / LNK, malicious USB (BadUSB), POWERTRASH, Carbanak/Anunak backdoor, Lizar/Diceloader, JSS Loader, Cobalt Strike, AvNeutralizer/AuKill EDR killer, Checkmarks auto-exploit, ProxyShell, Kerberoasting, OpenSSH tunneling, ESXi ransomware \u2014 emulate this actor or build detections for it."
+  tags: adversary-emulation, threat-intel, fin7, carbanak, carbon-spider, sangria-tempest, financially-motivated, ransomware, big-game-hunting, mitre-attack, g0046, red-team
+  mitre_attack: T1583.001, T1583.006, T1587.001, T1588.002, T1608.001, T1608.004, T1608.005, T1591, T1591.004, T1566.001, T1566.002, T1190, T1195.002, T1091, T1078.003, T1204.001, T1204.002, T1059.001, T1059.003, T1059.005, T1059.007, T1059, T1559.002, T1106, T1218.005, T1218.011, T1047, T1053.005, T1569.002, T1674, T1620, T1547.001, T1543.003, T1546.011, T1036.004, T1133, T1210, T1558.003, T1003, T1027.010, T1027.016, T1140, T1553.002, T1562.001, T1564.001, T1564.003, T1036.005, T1571, T1497.002, T1087.002, T1069.002, T1057, T1082, T1033, T1124, T1021.001, T1021.004, T1021.005, T1572, T1071.004, T1008, T1102.002, T1219, T1105, T1005, T1113, T1125, T1567.002, T1486
+---
+
+# FIN7 (Carbanak, Carbon Spider, Sangria Tempest) — Adversary Emulation Profile
+
+FIN7 (MITRE ATT&CK **G0046**; also tracked as Carbanak, Carbon Spider, Sangria Tempest, GOLD NIAGARA, ELBRUS, and ITG14) is one of the most prolific and best-documented financially motivated cybercrime groups, active since at least 2013. Originally infamous for large-scale point-of-sale (POS) intrusions to steal payment-card data — operating behind the front company "Combi Security" — the group pivoted to "big game hunting" ransomware around 2020, running its own Darkside/BlackMatter Ransomware-as-a-Service and acting as an affiliate/tooling supplier for REvil, Cl0p, Black Basta, ALPHV/BlackCat, LockBit, and others. FIN7 is characterized by disciplined operational tradecraft: convincing social engineering (including spearphishing of IT staff and physically mailed BadUSB drives), heavily obfuscated custom loaders (POWERTRASH), signature backdoors (Carbanak/Anunak, Lizar/Diceloader), purchased/cracked commercial tooling (Cobalt Strike, Core Impact), and a productized EDR-killer (AvNeutralizer/AuKill) sold on criminal forums.
+
+## Attribution & motivation
+- **Sponsor / nation:** Not a state-sponsored actor. FIN7 is an organized **criminal enterprise** assessed by multiple vendors to be Russian-speaking / Russia-based, with confirmed Ukrainian national members (per the 2018 U.S. DOJ indictment).
+- **Motivation:** **Financial.** Early operations monetized stolen payment-card data sold on carding/darknet markets; later operations monetize via ransomware extortion (own RaaS brands and as a ransomware affiliate) and by selling intrusion tooling (e.g., the AvNeutralizer EDR killer) to other crews.
+- **Confidence:** **High** for the activity cluster and financial motivation (corroborated by DOJ indictments/convictions and consistent CrowdStrike, Mandiant, Microsoft, SentinelOne, and Secureworks reporting). Note that the "Carbanak" backdoor has been used by more than one actor, so backdoor-only attributions to FIN7 should be treated with lower confidence than TTP-clustered attributions.
+
+## Targeting
+- **Sectors:** Historically heavy on **retail, restaurant, hospitality, and gaming** (POS-era payment-card theft). Post-2020 ransomware era broadened to **software, consulting, financial services, medical equipment/pharmaceutical, cloud services, media, food & beverage, transportation, utilities, manufacturing, legal, and the public sector**, plus the **automotive** industry.
+- **Regions:** Predominantly the **United States** (the DOJ described theft of card data from 100+ U.S. companies across 47 states), with European victims also reported.
+- **Victim profile:** During POS operations, customer-facing businesses processing large card volumes. In the ransomware/BGH era, victim selection is revenue-driven (targets filtered by company revenue using ZoomInfo) and FIN7 specifically phishes **IT staff with elevated administrative privileges** to accelerate domain compromise.
+
+## Notable campaigns
+- **2017 — Restaurant/retail POS theft (Chipotle and others):** Large-scale spearphishing of hospitality/restaurant chains delivering Carbanak/HALFBAKED and POS scrapers (e.g., Pillowmint) to harvest payment-card data. *(CrowdStrike, Secureworks GOLD NIAGARA)*
+- **2018 — Saks Fifth Avenue / Lord & Taylor breach:** POS compromise of high-end retailers exposing roughly 5 million payment cards sold on darknet markets. *(Multiple vendor reporting)*
+- **Aug 1, 2018 — DOJ indictment & arrests:** Three Ukrainian nationals (Fedir Hladyr, Dmytro Fedorov, Andrii Kolpakov) charged; the indictment exposed the **Combi Security** front company used to recruit operators. *(CrowdStrike "Arrests Put New Focus on CARBON SPIDER")*
+- **2020 — Pivot to big game hunting:** FIN7 stands up its own RaaS (**Darkside**, later **BlackMatter**) and begins deploying ransomware as the end objective. *(CrowdStrike "CARBON SPIDER Embraces Big Game Hunting")*
+- **Apr 2021 — Member sentencing:** Fedir Hladyr sentenced to 10 years following a 2019 guilty plea. *(CrowdStrike / DOJ)*
+- **Oct 2021 — "Bastion Secure" fake-pentest-firm scheme:** FIN7 ran a sham security company to hire legitimate penetration testers/IT specialists who unknowingly performed ransomware-intrusion work. *(Vendor reporting)*
+- **2022 — "Checkmarks" automated exploitation platform:** FIN7 built an automated attack system mass-exploiting public-facing Microsoft Exchange via ProxyShell (CVE-2021-34473, CVE-2021-34523, CVE-2021-31207) with an Auto-SQLi (SQLMap) module; intrusions hit U.S. manufacturing, legal, and public-sector firms (medium-confidence attribution). *(SentinelOne "FIN7 Reboot")*
+- **2022 onward — AvNeutralizer / AuKill EDR-killer:** FIN7 developed an EDR-tampering tool (first operational use ~mid-2022; an updated version abuses the Windows `ProcLaunchMon.sys`/Process Explorer driver) and sold it on criminal forums; used by Black Basta and later multiple ransomware crews. *(SentinelOne, IBM)*
+- **Apr 2023 — Return with Cl0p ransomware (Sangria Tempest):** Microsoft observed FIN7 use **POWERTRASH** to load the **Lizar** post-exploitation tool, then **OpenSSH** and **Impacket** for lateral movement before deploying **Cl0p** ransomware. *(Microsoft / The Hacker News)*
+- **Late 2023 (reported Apr 2024) — Automaker IT-staff spearphishing:** FIN7 phished privileged IT employees at a large U.S.-based multinational automaker using a typosquatted Advanced IP Scanner site (`advanced-ip-sccanner[.]com` → `myipscanner[.]com`), a Dropbox-hosted `WsTaskLoad.exe`, POWERTRASH, the **Anunak/Carbanak** backdoor, and OpenSSH for persistence. *(BlackBerry / BleepingComputer)*
+
+## TTPs by ATT&CK tactic
+
+### Initial Access
+- **T1566.001 — Spearphishing Attachment:** Weaponized Microsoft Office documents and RTF files (often DDE-triggered) sent to targeted employees.
+- **T1566.002 — Spearphishing Link:** Phishing emails with malicious / typosquatted links (e.g., fake Advanced IP Scanner download site) redirecting to attacker-controlled hosting (Dropbox).
+- **T1091 — Replication Through Removable Media:** Physically mails **BadUSB** drives that emulate a keyboard to victims to trigger malware downloads.
+- **T1190 — Exploit Public-Facing Application:** Mass-exploited Microsoft Exchange (ProxyShell, incl. CVE-2021-31207) via the automated "Checkmarks" platform with an Auto-SQLi module.
+- **T1195.002 — Compromise Software Supply Chain:** Trojanized legitimate digital products / software supply chains to gain access.
+- **T1078.003 — Valid Accounts (Local Accounts):** Reused compromised credentials to obtain SYSTEM-level access on Exchange servers.
+
+### Execution
+- **T1204.001 / T1204.002 — User Execution (Malicious Link / Malicious File):** Lures victims into clicking links or double-clicking attachments (image lures that execute hidden LNK files; JSS Loader/Harpy delivery).
+- **T1059.001 — PowerShell:** **POWERTRASH** heavily obfuscated PowerShell reflectively loads PE payloads in memory (Carbanak, Lizar/Diceloader, Core Impact).
+- **T1059.003 / .005 / .007 — Windows Command Shell / VBScript / JavaScript:** cmd.exe, VBS, and JS scripting for on-host tasking; **T1059** SQL scripts for victim-machine tasks.
+- **T1559.002 — Dynamic Data Exchange:** Office documents abusing DDE for code execution.
+- **T1218.005 / .011 — Mshta / Rundll32:** mshta.exe runs VBScript; rundll32.exe executes malware DLLs.
+- **T1047 — Windows Management Instrumentation:** WMI used to install malware on targeted systems.
+- **T1674 — Input Injection:** Malicious USBs emulate keystrokes to launch PowerShell downloaders.
+- **T1620 — Reflective Code Loading:** Loads .NET assemblies via `Reflection.Assembly::Load` (and in-memory PE loading via POWERTRASH).
+
+### Persistence
+- **T1547.001 — Registry Run Keys / Startup Folder:** Run/RunOnce keys and Startup-folder items.
+- **T1543.003 — Windows Service:** Creates new Windows services tied to startup.
+- **T1053.005 — Scheduled Task:** Persistence tasks (e.g., masqueraded "AdobeFlashSync"); also uses OpenSSH for persistence.
+- **T1546.011 — Application Shimming:** Application shim databases for persistence.
+- **T1569.002 — Service Execution:** Starts the SSH service via `sc start sshd`.
+
+### Privilege Escalation
+- **T1210 — Exploitation of Remote Services:** Exploited ZeroLogon (CVE-2020-1472) against vulnerable domain controllers.
+- **T1078.003 / T1543.003 / T1053.005 / T1547.001:** Service- and task-based escalation/persistence as above.
+
+### Defense Evasion
+- **T1027.010 / .016 — Command Obfuscation / Junk Code Insertion:** Fragmented strings, env-var indirection, stdin, character-replacement, and random junk code.
+- **T1140 — Deobfuscate/Decode Files or Information:** `certutil` to decode PowerShell; XOR-deobfuscation routines.
+- **T1553.002 — Code Signing:** Carbanak payloads and phishing documents signed with purchased/abused certificates.
+- **T1562.001 — Impair Defenses (Disable or Modify Tools):** **AvNeutralizer/AuKill** tampers with/kills EDR and AV (kernel-mode abuse of `ProcLaunchMon.sys` / Process Explorer driver). *(SentinelOne; mapped to T1562.001)*
+- **T1564.001 / .003 — Hidden Files & Directories / Hidden Window:** `attrib +h` to hide an SSH folder; `.txt`-concealed PowerShell.
+- **T1036.004 / .005 — Masquerading:** Scheduled task named "AdobeFlashSync"; ransomware staged as `sleep.exe`; loader masquerades as `WsTaskLoad.exe`.
+- **T1571 — Non-Standard Port:** Port/protocol mismatches on 53/80/443/8080 and firewall openings on TCP 59999 and 9898.
+- **T1497.002 — Virtualization/Sandbox Evasion (User Activity Based Checks):** Payloads detonate only on user interaction (double-click of embedded image).
+
+### Credential Access
+- **T1558.003 — Kerberoasting:** PowerShell-driven Kerberoasting for credential access and lateral movement.
+- **T1003 — OS Credential Dumping:** Uses Mimikatz (S0002) to harvest credentials. *(ATT&CK software mapping; mapped to T1003)*
+
+### Discovery
+- **T1087.002 — Domain Account Discovery:** Enumerates domain admins via PowerShell and `csvde.exe`.
+- **T1069.002 — Permission Groups (Domain Groups):** `net group` to enumerate domain groups.
+- **T1057 — Process Discovery:** `tasklist /v` via WsTaskLoad.exe / PowerShell.
+- **T1082 — System Information Discovery:** `csvde.exe` and WsTaskLoad for host enumeration.
+- **T1033 — System Owner/User Discovery:** `cmd.exe /C quser` for active sessions.
+- **T1124 — System Time Discovery:** `net time` via PowerShell script.
+- **T1591 / T1591.004 — Gather Victim Org Information / Identify Roles:** ZoomInfo to filter targets by revenue and to identify IT staff with elevated admin rights (uses AdFind, S0552, internally).
+
+### Lateral Movement
+- **T1021.001 — RDP:** Remote Desktop for lateral movement.
+- **T1021.004 — SSH:** OpenSSH for lateral movement and reverse tunnels.
+- **T1021.005 — VNC:** TightVNC to control compromised hosts.
+- **Impacket / CrackMapExec (S0488):** Used for remote execution/spread in the ransomware era (CrackMapExec is an ATT&CK-listed FIN7 tool).
+
+### Collection
+- **T1005 — Data from Local System:** Collects files and sensitive data from compromised hosts.
+- **T1113 — Screen Capture / T1125 — Video Capture:** Screenshots and custom desktop video recording to surveil operators/environments (notably reconnaissance of POS/back-office staff).
+
+### Command and Control
+- **T1071.004 — Application Layer Protocol (DNS):** C2 over DNS A, OPT, and TXT records.
+- **T1008 — Fallback Channels:** Harpy backdoor falls back to DNS if HTTP C2 fails.
+- **T1102.002 — Web Service (Bidirectional):** Google Docs, Google Scripts, and Pastebin for C2.
+- **T1572 — Protocol Tunneling:** OpenSSH reverse tunnels for C2/egress.
+- **T1219 — Remote Access Tools:** Abuses Atera RMM to download/run malware.
+- **T1105 — Ingress Tool Transfer:** Pulls additional payloads via PowerShell shellcode stagers.
+
+### Exfiltration
+- **T1567.002 — Exfiltration to Cloud Storage:** Stolen data exfiltrated to MEGA file-sharing.
+
+### Impact
+- **T1486 — Data Encrypted for Impact:** Deploys ransomware as the end objective, including Darkside encrypting ESXi virtual-disk volumes; affiliate deployment of Cl0p, Black Basta, REvil, etc.
+
+## Signature tooling & malware
+- **Carbanak / Anunak (S0030)** — *custom* flagship backdoor; full-featured RAT for control, recon, and POS data theft.
+- **POWERTRASH (a.k.a. Powertrash)** — *custom* heavily obfuscated PowerShell loader that reflectively loads PE payloads in memory (a strong FIN7 fingerprint; ~50 samples tracked 2020–2022).
+- **Lizar / Diceloader / IceBot (S0681)** — *custom* modular post-exploitation backdoor / loader.
+- **JSS Loader (S0648)** — *custom* .NET/JS-based loader for follow-on payloads.
+- **GRIFFON (S0417)** — *custom* JavaScript-based modular implant/recon backdoor.
+- **HALFBAKED (S0151), POWERSOURCE/DNSMessenger (S0145), TEXTMATE (S0146), SQLRat (S0390)** — *custom* loaders/backdoors from the spearphishing/POS era.
+- **BOOSTWRITE (S0415) / RDFSNIFFER (S0416)** — *custom*; BOOSTWRITE is a DLL-hijack loader, RDFSNIFFER tampers with the Aloha Command Center RDP client (POS targeting).
+- **Pillowmint (S0517)** — *custom* POS RAM-scraper for payment-card data.
+- **AvNeutralizer / AuKill** — *custom* EDR/AV-killer (kernel driver abuse) marketed/sold on criminal forums.
+- **Cobalt Strike (S0154), PowerSploit (S0194), Mimikatz (S0002), AdFind (S0552), CrackMapExec (S0488), Core Impact, Impacket, OpenSSH, TightVNC, Atera RMM** — *public / commercial / cracked* offensive and dual-use tooling.
+- **Ransomware payloads:** Darkside / BlackMatter (*own RaaS*); affiliate use of Maze (S0449), REvil (S0496), Cl0p, Black Basta, ALPHV/BlackCat, LockBit; SystemBC (S9001) as a proxy/loader.
+
+## Emulation guidance (Decepticon)
+> **Authorized use only:** Execute these emulation steps **strictly inside the agreed engagement scope and rules of engagement**, with written authorization, against in-scope assets only — never against third parties or production data you are not cleared to touch. Use benign substitutes for destructive impact actions.
+
+Map FIN7's signature chain to Decepticon's own capabilities:
+
+- **Initial access (phishing IT staff) — T1566.001/.002, T1204, T1583.001:** Use Decepticon's phishing/social-engineering workflow to stand up a **typosquatted "IT tool" landing page** (mimic Advanced IP Scanner) and deliver a benign tracked payload via a cloud-share link (Dropbox-style). Prioritize recipients with admin rights, mirroring FIN7's IT-staff focus. Stage decoy infra via the cloud skills (look-alike domain + object-storage hosting, T1583.006/T1608.001).
+- **BadUSB drop — T1091/T1674:** If physical-access testing is in scope, emulate the mailed-USB vector with a HID/keystroke-injection device that triggers a benign PowerShell beacon download. Otherwise document the vector without execution.
+- **Loader & in-memory execution — T1059.001/T1620/T1027:** Use the **bash/PowerShell tooling** plus the **defense-evasion skill** to reproduce a POWERTRASH-style obfuscated reflective PE loader (string fragmentation, junk code, in-memory load) delivering your C2 stage — do not drop a payload to disk.
+- **C2 — T1071.004/T1102.002/T1572/T1219:** Drive C2 through the **c2/sliver** skill. Emulate FIN7's channel diversity: an HTTP(S) Sliver listener, a DNS listener (mirrors T1071.004), web-service C2 (mirror T1102.002), with **OpenSSH reverse-tunnel** egress (T1572) and an RMM-style channel as a fallback. Configure non-standard ports (T1571) to test egress controls.
+- **Discovery & cred access — T1087.002/T1069.002/T1558.003/T1003:** Use the **Active Directory skills** to enumerate domain admins/groups (`net group`, csvde-equivalent), then perform **Kerberoasting** and credential extraction (Mimikatz-equivalent via the AD/cred-access tooling) exactly as FIN7 chains recon → Kerberoast → lateral movement.
+- **Lateral movement — T1021.001/.004/.005/T1572:** Use the **lateral-movement skill** for RDP, SSH, VNC, and Impacket/CrackMapExec-style remote execution to traverse to high-value hosts (Exchange, hypervisors, file servers).
+- **Defense evasion / EDR tampering — T1562.001/T1553.002:** With the **defense-evasion skill**, emulate AvNeutralizer-style EDR-tamper *detection testing* (e.g., attempt to stop/blind the agreed test sensor in a controlled VM) and code-signing/masquerading of artifacts — never disable production security controls outside an isolated test host.
+- **Exchange/ProxyShell + Auto-SQLi — T1190/T1195.002:** If web-facing assets are in scope, emulate the "Checkmarks" pattern with the **cloud/web-exploitation tooling** (ProxyShell-class checks, SQLi probing) against the designated test target only.
+- **Impact (ransomware) — T1486:** **Do not encrypt real data.** Emulate the BGH end-state with a **benign canary "ransom" routine** (touch marker files / rename in an isolated directory) and stage a simulated exfil-then-encrypt to MEGA-like storage (T1567.002) to exercise blue-cell DLP and backup detection.
+
+## Detection & defense
+- **Phishing of privileged IT staff (T1566/T1204):** Detect typosquatted domains impersonating admin tools (Advanced IP Scanner, etc.); alert on cloud-share downloads of EXE/MSI by IT-admin accounts; block/inspect newly registered look-alike domains; enforce mark-of-the-web and macro/DDE disablement on Office.
+- **BadUSB / HID injection (T1091/T1674):** Enforce USB device-control policy; alert on a "keyboard" enumerating immediately followed by PowerShell network egress.
+- **POWERTRASH / in-memory loaders (T1059.001/T1620/T1027):** Enable PowerShell Script Block Logging, AMSI, and Module Logging; alert on reflective `Assembly::Load` / in-memory PE patterns, `certutil` decoding, and heavily obfuscated/fragmented script content.
+- **Persistence (T1547.001/T1543.003/T1053.005/T1569.002):** Monitor new Run keys, new services, scheduled tasks with masquerading names ("AdobeFlashSync"), and `sc start sshd` / unexpected `sshd` services on Windows.
+- **Lateral movement & cred access (T1021/T1558.003/T1003):** Alert on Kerberoast TGS-REQ bursts (RC4), LSASS access, Impacket/CrackMapExec patterns, and anomalous RDP/SSH/VNC between workstations and servers; deploy honey SPNs.
+- **C2 (T1071.004/T1102.002/T1572/T1219):** Inspect/limit outbound DNS (large TXT/OPT volume), monitor for SSH reverse tunnels from non-admin hosts, baseline use of Google Docs/Scripts/Pastebin and Atera/other RMM agents; block unsanctioned RMM.
+- **EDR tampering (T1562.001):** Enable tamper protection; monitor for vulnerable-driver loads (e.g., `ProcLaunchMon.sys`, Process Explorer driver) and BYOVD patterns; alert on security-service stop/kill events.
+- **Exploitation (T1190/T1210):** Patch Exchange ProxyShell (CVE-2021-34473/-34523/-31207) and ZeroLogon (CVE-2020-1472); monitor Exchange for webshell drops and Auto-SQLi/SQLMap signatures.
+- **Impact (T1486/T1567.002):** Protect/segment ESXi management; immutable, offline backups; DLP and egress monitoring for MEGA/cloud-storage bulk uploads; alert on mass-rename/encryption file events.
+
+## Sources
+- MITRE ATT&CK — FIN7 (G0046): https://attack.mitre.org/groups/G0046/
+- CrowdStrike — "Arrests Put New Focus on CARBON SPIDER Adversary Group": https://www.crowdstrike.com/en-us/blog/arrests-put-new-focus-on-carbon-spider-adversary-group/
+- CrowdStrike — "CARBON SPIDER Embraces Big Game Hunting, Part 2": https://www.crowdstrike.com/en-us/blog/carbon-spider-embraces-big-game-hunting-part-2/
+- SentinelOne — "FIN7 Reboot | Cybercrime Gang Enhances Ops with New EDR Bypasses and Automated Attacks": https://www.sentinelone.com/labs/fin7-reboot-cybercrime-gang-enhances-ops-with-new-edr-bypasses-and-automated-attacks/
+- The Hacker News — "Notorious Cyber Gang FIN7 Returns With Cl0p Ransomware": https://thehackernews.com/2023/05/notorious-cyber-gang-fin7-returns-cl0p.html
+- BleepingComputer — "FIN7 targets American automaker's IT staff in phishing attacks": https://www.bleepingcomputer.com/news/security/fin7-targets-american-automakers-it-staff-in-phishing-attacks/
+- IBM — "Hacker group FIN7 is selling EDR evasion tools to other cyber criminals": https://www.ibm.com/think/news/hacker-group-fin7-selling-edr-evasion-tools-other-cyber-criminals
+- Secureworks — "GOLD NIAGARA Threat Profile": https://www.secureworks.com/research/threat-profiles/gold-niagara

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/lazarus-group/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/lazarus-group/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: lazarus-group
+description: "Adversary-emulation profile for Lazarus Group (G0032, aka Hidden Cobra / Diamond Sleet / Labyrinth Chollima), a North Korean RGB-linked actor conducting espionage, destructive, and financially motivated operations."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "lazarus, lazarus group, hidden cobra, diamond sleet, labyrinth chollima, zinc, guardians of peace, nickel academy, north korea, dprk, rgb, applejeus, tradertraitor, operation dream job, 3cx, fastcash, wannacry, bangladesh bank swift, cryptocurrency theft, fake job offer, supply chain, G0032, emulate north korean apt"
+  tags: adversary-emulation, threat-intel, lazarus, north-korea, dprk, hidden-cobra, diamond-sleet, financial-crime, cryptocurrency, supply-chain, wiper, espionage, mitre-attack, G0032
+  mitre_attack: T1087.002, T1010, T1083, T1589.002, T1591.004, T1046, T1057, T1012, T1018, T1082, T1614.001, T1016, T1049, T1033, T1124, T1593.001, T1189, T1566.001, T1566.002, T1566.003, T1204.001, T1204.002, T1059.001, T1059.003, T1059.005, T1106, T1053.005, T1218.005, T1218.010, T1218.011, T1047, T1220, T1203, T1221, T1547.001, T1547.009, T1543.003, T1542.003, T1505.004, T1134.002, T1548.002, T1197, T1140, T1622, T1070.003, T1070.004, T1070.006, T1564.001, T1574.001, T1036.004, T1036.005, T1027.002, T1027.007, T1027.009, T1553.002, T1497.001, T1497.003, T1620, T1098, T1110.003, T1557.001, T1056.001, T1021.001, T1021.002, T1021.004, T1078, T1119, T1560.001, T1560.003, T1005, T1074.001, T1041, T1567.002, T1048.003, T1071.001, T1573.001, T1008, T1571, T1090.001, T1090.002, T1102.002, T1105, T1104, T1485, T1561.001, T1561.002, T1489, T1529, T1491.001, T1587.001, T1588.003
+---
+
+# Lazarus Group (Hidden Cobra, Diamond Sleet, Labyrinth Chollima) — Adversary Emulation Profile
+
+Lazarus Group (MITRE ATT&CK **G0032**) is a North Korean state-sponsored threat actor active since at least 2009 and attributed by the U.S. Government and the security industry to the DPRK's Reconnaissance General Bureau (RGB). It is one of the most versatile and prolific nation-state actors observed, running three overlapping mission types in parallel: strategic **espionage**, **destructive/disruptive** attacks (e.g., the 2014 Sony Pictures wiper and the 2017 WannaCry outbreak), and large-scale **financially motivated** theft to fund the sanctioned regime (SWIFT bank fraud, ATM "FASTCash" cash-outs, and cryptocurrency heists). MITRE and vendors track several clusters/aliases under or alongside the Lazarus umbrella — **HIDDEN COBRA, Guardians of Peace, ZINC, NICKEL ACADEMY, Diamond Sleet (Microsoft), and Labyrinth Chollima (CrowdStrike)** — with financial sub-clusters often labeled APT38 / BlueNoroff / Stardust Chollima. The group blends bespoke malware, trojanized legitimate software, supply-chain compromise, and elaborate social engineering (fake recruiter "job offers") to reach hardened targets.
+
+## Attribution & motivation
+- **Suspected sponsor / nation:** North Korea (DPRK), tied to the Reconnaissance General Bureau (RGB). The U.S. Government uses the umbrella name **HIDDEN COBRA** for DPRK malicious cyber activity.
+- **Motivation (mixed):**
+  - **Financial** — sanctions-driven revenue generation: SWIFT interbank fraud, FASTCash ATM cash-outs, and cryptocurrency theft from exchanges, DeFi, and blockchain firms.
+  - **Espionage** — collection against defense, aerospace, government, and crypto/fintech targets, frequently via fake-job-offer lures (Operation Dream Job).
+  - **Destructive / disruptive** — wiper and ransomware operations (Sony Pictures 2014; WannaCry 2017).
+- **Confidence of attribution:** **High.** Backed by a 2018 U.S. DOJ criminal complaint naming DPRK programmer Park Jin Hyok, multiple joint FBI/CISA/Treasury/USCYBERCOM advisories, and corroborating Mandiant/ESET/Kaspersky/Microsoft reporting. Individual sub-cluster boundaries (Lazarus vs. APT38/BlueNoroff) carry moderate analyst-to-analyst variance.
+
+## Targeting
+- **Sectors:** financial services and banks (SWIFT endpoints, ATM switch infrastructure), cryptocurrency exchanges / blockchain / DeFi / Web3 and crypto-related software, defense and aerospace, government, media/entertainment, energy, gaming, and IT/DevOps personnel at high-value firms.
+- **Regions:** global. Heavy activity against the United States, South Korea, Japan, and Europe, with bank-fraud operations reaching South/Southeast Asia, Africa, and Latin America.
+- **Victim profile:** organizations holding liquid value or strategic data, and **individual employees** — especially software developers, DevOps, system administrators, and crypto/financial staff who are approached with tailored recruiter or business-development lures on LinkedIn, Telegram, Discord, and email.
+
+## Notable campaigns
+- **2014-11 — Sony Pictures Entertainment (Guardians of Peace):** destructive wiper intrusion that destroyed data and leaked internal material; one of the events that established the group's destructive capability. (DOJ complaint; MITRE G0032)
+- **2016-02 — Bangladesh Bank SWIFT heist:** spearphishing-led network compromise of SWIFT-connected terminals; fraudulent SWIFT instructions attempted ~US$1B, with US$81M successfully transferred before the rest was blocked. (CISA AA20-239A; DOJ complaint)
+- **2017-05 — WannaCry 2.0:** self-propagating ransomware (leveraging the EternalBlue SMB exploit) that hit hundreds of thousands of systems globally, including the UK NHS. (DOJ complaint)
+- **2018-06 — DOJ complaint unsealed (Park Jin Hyok):** U.S. charges link Lazarus to Sony, Bangladesh Bank, and WannaCry, attributing the activity to a DPRK government front company. (DOJ press release)
+- **2018-10 — FASTCash ATM cash-out (TA18-275A):** malware on bank payment-switch application servers manipulates ISO 8583 messages to authorize fraudulent ATM withdrawals across many countries simultaneously. (CISA TA18-275A)
+- **2020-08 — FASTCash 2.0 / "BeagleBoyz" (AA20-239A):** expanded ATM cash-out tradecraft and bank targeting; advisory notes attempts to steal nearly US$2B since 2015. (CISA AA20-239A)
+- **2020-onward — Operation Dream Job:** fake job-offer social engineering against defense, aerospace, and crypto targets delivering custom implants (e.g., DRATzarus); flagship lure framework reused across later operations. (ESET; MITRE)
+- **2021-02 — AppleJeus (AA21-048A):** trojanized cryptocurrency trading applications backdoor victims to steal crypto from individuals and exchanges. (CISA AA21-048A)
+- **2022-04 — TraderTraitor (AA22-108A):** FBI/CISA/Treasury advisory on spearphishing of crypto/blockchain employees (admins, devs, DevOps) with trojanized crypto apps to steal keys and funds. (CISA AA22-108A)
+- **2023-03 — 3CX double supply-chain compromise:** trojanized 3CXDesktopApp installer pushed second-stage malware; Mandiant assessed initial access came from a *prior* supply-chain compromise of the X_TRADER application (VEILEDSIGNAL backdoor), making it the first observed cascading software supply-chain attack; ESET/Kaspersky linked artifacts to Operation Dream Job and AppleJeus. (Mandiant; ESET)
+
+## TTPs by ATT&CK tactic
+*(Technique IDs verified against MITRE ATT&CK G0032.)*
+
+**Initial Access**
+- **T1566.001 / .002 / .003 (Phishing — Attachment / Link / via Service):** spearphishing with malicious documents, links, and social-platform messages (LinkedIn, Telegram, Discord, WhatsApp), commonly themed as recruiter/job offers.
+- **T1189 (Drive-by Compromise):** watering-hole and strategic-web compromises to deliver implants.
+- **T1078 (Valid Accounts):** uses stolen/legitimate credentials for access and to blend in.
+- **T1204.001 / .002 (User Execution — Malicious Link / File):** relies on the lured employee opening a weaponized doc or running a trojanized app.
+
+**Execution**
+- **T1059.001 / .003 / .005 (PowerShell / Windows Command Shell / Visual Basic):** scripted loaders and post-exploitation.
+- **T1106 (Native API), T1203 (Exploitation for Client Execution), T1221 (Template Injection):** API-based execution, document-exploit delivery, and remote-template fetch.
+- **T1047 (WMI), T1053.005 (Scheduled Task), T1218.005/.010/.011 (Mshta / Regsvr32 / Rundll32), T1220 (XSL Script Processing):** proxied/native execution to run payloads and tasks.
+
+**Persistence**
+- **T1547.001 / .009 (Registry Run Keys/Startup Folder / Shortcut Modification):** autostart implants.
+- **T1543.003 (Windows Service):** installs services for persistent execution.
+- **T1542.003 (Bootkit):** pre-OS persistence in select destructive/espionage tooling.
+- **T1505.004 (Server Software Component — IIS Components):** web-server-resident persistence/backdoors.
+
+**Privilege Escalation**
+- **T1134.002 (Create Process with Token):** token manipulation to run as another user.
+- **T1548.002 (Bypass UAC):** elevation on Windows hosts.
+
+**Defense Evasion**
+- **T1574.001 (DLL Side-Loading):** plants malicious DLLs next to signed binaries (a Lazarus signature, used in 3CX-era tooling).
+- **T1553.002 (Code Signing) + T1587.001/T1588.003 (Develop/Obtain Code-Signing Certs):** signs malware with stolen or acquired certificates.
+- **T1027.002 / .007 / .009 (Software Packing / Dynamic API Resolution / Embedded Payloads), T1140 (Deobfuscate/Decode), T1620 (Reflective Code Loading):** packed, encoded, in-memory payloads.
+- **T1036.004 / .005 (Masquerade Task or Service / Match Legitimate Name or Location), T1564.001 (Hidden Files):** disguises artifacts as legitimate software.
+- **T1070.003 / .004 / .006 (Clear Command History / File Deletion / Timestomp), T1197 (BITS Jobs), T1622 (Debugger Evasion):** cleanup and stealth.
+- **T1497.001 / .003 (Sandbox System Checks / Time-Based Checks):** anti-analysis/anti-VM logic.
+
+**Credential Access**
+- **T1056.001 (Keylogging):** captures credentials and keystrokes.
+- **T1110.003 (Password Spraying):** credential guessing against exposed services.
+- **T1557.001 (LLMNR/NBT-NS Poisoning & SMB Relay):** uses Responder-style poisoning to capture/relay hashes.
+
+**Discovery**
+- **T1087.002 (Domain Account Discovery), T1082 (System Info), T1083 (File/Directory), T1057 (Process), T1012 (Query Registry), T1018 (Remote System), T1016/T1049 (Network Config/Connections), T1033 (System Owner/User), T1124 (System Time), T1614.001 (System Language), T1010 (App Window), T1046 (Network Service Scanning):** broad host/network enumeration to orient before lateral movement and to fingerprint (e.g., language checks to avoid certain locales).
+
+**Lateral Movement**
+- **T1021.001 / .002 / .004 (RDP / SMB-Admin Shares / SSH):** moves between hosts using remote services.
+- **T1098 (Account Manipulation):** modifies accounts to maintain access.
+
+**Collection**
+- **T1119 (Automated Collection), T1005 (Data from Local System), T1074.001 (Local Data Staging):** harvests and stages target data locally.
+- **T1560.001 / .003 (Archive via Utility / Custom Method):** compresses/encrypts data before exfil.
+- **T1056.001 (Keylogging):** also serves collection.
+
+**Command & Control**
+- **T1071.001 (Web Protocols), T1102.002 (Bidirectional Web Service), T1573.001 (Symmetric Encrypted Channel), T1008 (Fallback Channels), T1104 (Multi-Stage Channels), T1571 (Non-Standard Port), T1090.001/.002 (Internal/External Proxy), T1105 (Ingress Tool Transfer):** HTTP(S)-based, encrypted, multi-stage C2 with proxies and fallback infrastructure.
+
+**Exfiltration**
+- **T1041 (Exfiltration Over C2 Channel), T1567.002 (Exfil to Cloud Storage), T1048.003 (Exfil Over Unencrypted Non-C2 Protocol):** routes stolen data out via C2, cloud services, or alternate protocols.
+
+**Impact**
+- **T1485 (Data Destruction), T1561.001 / .002 (Disk Content / Structure Wipe), T1489 (Service Stop), T1529 (System Shutdown/Reboot), T1491.001 (Internal Defacement):** destructive operations (Sony-style wipers, WannaCry-class disruption).
+
+## Signature tooling & malware
+*(IDs from MITRE ATT&CK Software associated with G0032; "custom" = DPRK-developed, "public" = commodity/open tool.)*
+- **AppleJeus (S0584)** — *custom*: trojanized cryptocurrency-trading apps for crypto theft (CISA AA21-048A).
+- **DRATzarus (S0694)** — *custom*: RAT delivered via Operation Dream Job fake-job lures.
+- **BLINDINGCAN (S0520)** — *custom*: full-featured RAT (CISA-reported).
+- **Bankshot (S0239)** / **BADCALL (S0245)** / **AuditCred (S0347)** — *custom*: implants/backdoors.
+- **Dtrack (S0567)** — *custom*: spyware/backdoor used in financial and infrastructure intrusions.
+- **Dacls (S0497)** — *custom*: cross-platform (Windows/Linux/macOS) RAT.
+- **Cryptoistic (S0498)** — *custom*: macOS/Swift backdoor used in crypto operations.
+- **Torisma (S0678)** — *custom*: implant used in Operation Dream Job-style targeting.
+- **ECCENTRICBANDWAGON (S0593)** — *custom*: keylogger/screenshot collector.
+- **Responder (S0174)** — *public*: LLMNR/NBT-NS poisoning & SMB-relay credential capture.
+- **Additional widely reported families (not all in the G0032 software list):** WannaCry ransomware, FASTCash ATM-switch malware (ISO 8583 manipulation), and the 3CX-era VEILEDSIGNAL / Gopuram tooling — *custom*. Validate any of these against current primary reporting before citing in a deliverable.
+
+## Emulation guidance (Decepticon)
+> **Authorized use only.** Execute these emulations exclusively inside the signed rules-of-engagement and scope of the current engagement. Never touch out-of-scope assets, never deploy genuinely destructive payloads against production, and use benign, instrumented stand-ins for any wiper/ransomware behavior.
+
+Map Lazarus signature TTPs to Decepticon capabilities to reproduce the actor's behavior chain for the blue cell:
+- **Initial access — fake-job-offer social engineering (T1566.001/.002/.003, T1204):** stage a recruiter-themed lure (LinkedIn/Telegram/email) delivering a benign tracked document or "trial app." Use the **phishing/social-engineering** workflow; deliver a marked payload (beacon-only) rather than live malware. Capture which employees execute (DevOps/admin/dev personas mirror real targeting).
+- **Trojanized app / supply-chain feel (T1189, T1204.002):** with explicit approval, host a signed-looking "installer" on in-scope infrastructure that drops the C2 stager — emulate AppleJeus/3CX delivery without redistributing real malware.
+- **C2 — encrypted multi-stage HTTPS beacon (T1071.001, T1573.001, T1104, T1008, T1090):** deploy **Sliver** (c2/sliver skill) with HTTPS/mTLS profiles, jitter, fallback listeners, and a redirector/proxy to mirror Lazarus's encrypted, multi-stage, proxied C2.
+- **Execution & persistence (T1059.001/.003, T1053.005, T1547.001, T1543.003):** via the **bash/command-execution** and host tooling, register a Scheduled Task and a Run key / Windows service for autostart persistence on the implanted host.
+- **Defense evasion (T1574.001 DLL side-loading, T1553.002 code signing, T1027 packing, T1620 reflective loading):** use the **defense-evasion** skill to build a side-loading scenario next to a signed binary, sign payloads with a test cert, and load in-memory — exercising the EDR's side-load and unsigned-memory-module detections.
+- **Credential access (T1557.001, T1110.003, T1056.001):** run **Responder**-style LLMNR/NBT-NS poisoning + SMB relay, scoped password spraying, and a benign keylogger to test credential-capture detections.
+- **Discovery + lateral movement (T1087.002, T1018, T1046, T1021.001/.002/.004, T1078):** chain the **AD** and **lateral-movement** skills — enumerate domain accounts/hosts, then pivot via RDP/SMB/SSH using captured/seeded valid accounts.
+- **Collection & exfil (T1560, T1074.001, T1041, T1567.002):** stage and archive marked "sensitive" canary data locally, then exfiltrate over the Sliver C2 channel and to an in-scope **cloud** storage bucket to validate DLP/egress monitoring.
+- **Impact (emulated only) (T1485/T1561/T1489):** do **not** run real wipers. Use a controlled, reversible marker (touch a flagged file / stop a non-critical test service in a lab segment) so the blue cell can validate destructive-action and service-stop alerting without data loss.
+
+## Detection & defense
+- **Social-engineering / lure hygiene:** train high-value staff (devs, DevOps, admins, crypto/finance) on unsolicited recruiter "coding test" / "trading app" lures; restrict execution of files arriving via personal chat platforms; mark and sandbox inbound documents (counters T1566.*, T1204).
+- **Supply-chain & code signing:** monitor for unexpected child processes spawned by signed installers/updaters; alert on **DLL side-loading** (signed binary loading an unsigned/mislocated DLL) and on newly trusted code-signing certs (counters T1574.001, T1553.002).
+- **Execution telemetry:** flag PowerShell/WScript, `mshta`/`regsvr32`/`rundll32` proxy execution, WMI process creation, and new Scheduled Tasks/Services with masqueraded names (counters T1059, T1218, T1047, T1053.005, T1036.004).
+- **Credential defenses:** disable LLMNR/NBT-NS and require SMB signing to defeat Responder-style relay; alert on password spraying and unexpected keystroke/hook drivers (counters T1557.001, T1110.003, T1056.001).
+- **Lateral movement:** monitor RDP/SMB/SSH from non-admin hosts and anomalous valid-account use; segment SWIFT/payment-switch and ATM-controller networks and tightly monitor ISO 8583 message integrity for FASTCash-style fraud (counters T1021.*, T1078).
+- **C2 / exfil:** inspect TLS for anomalous JA3/beacon cadence on non-standard ports, alert on traffic to newly registered domains and unsanctioned cloud-storage egress; enforce DLP on archived/staged data (counters T1071.001, T1573.001, T1571, T1567.002, T1041).
+- **Anti-destruction:** maintain offline, tested backups and protect MBR/VBR; alert on mass file overwrite/deletion, `vssadmin`/shadow-copy tampering, and unexpected service-stop or shutdown commands (counters T1485, T1561, T1489, T1529).
+- **Persistence audits:** baseline and monitor Run keys, startup shortcuts, services, scheduled tasks, and IIS module installs; alert on bootkit-level disk changes (counters T1547, T1543.003, T1505.004, T1542.003).
+
+## Sources
+- MITRE ATT&CK — Lazarus Group (G0032): https://attack.mitre.org/groups/G0032/
+- CISA AA22-108A — TraderTraitor: North Korean State-Sponsored APT Targets Blockchain Companies: https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-108a
+- CISA AA21-048A — AppleJeus: Analysis of North Korea's Cryptocurrency Malware: https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-048a
+- CISA AA20-239A — FASTCash 2.0: North Korea's BeagleBoyz Robbing Banks: https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-239a
+- CISA TA18-275A — HIDDEN COBRA – FASTCash Campaign: https://us-cert.cisa.gov/ncas/alerts/TA18-275A
+- U.S. DOJ — North Korean Regime-Backed Programmer Charged (Park Jin Hyok complaint): https://www.justice.gov/archives/opa/pr/north-korean-regime-backed-programmer-charged-conspiracy-conduct-multiple-cyber-attacks-and
+- Mandiant (Google Cloud) — 3CX Software Supply Chain Compromise Initiated by a Prior Software Supply Chain Compromise: https://cloud.google.com/blog/topics/threat-intelligence/3cx-software-supply-chain-compromise
+- ESET WeLiveSecurity — Linux malware strengthens links between Lazarus and the 3CX supply-chain attack: https://www.welivesecurity.com/2023/04/20/linux-malware-strengthens-links-lazarus-3cx-supply-chain-attack/

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/sandworm-team/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/sandworm-team/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: sandworm-team
+description: "Adversary-emulation profile for Sandworm Team (Voodoo Bear / Seashell Blizzard / APT44 / ELECTRUM), Russia's GRU Unit 74455 destructive ICS/OT and influence actor (ATT&CK G0034)."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "sandworm, voodoo bear, seashell blizzard, apt44, electrum, telebots, iron viking, iridium, frozenbarents, gru unit 74455, G0034, industroyer, notpetya, olympic destroyer, blackenergy, killdisk, caddywiper, prestige, badpilot, ukraine power grid, ics ot destructive attack, microscada scilc, wiper malware emulation, russian gru destructive"
+  tags: adversary-emulation, threat-intel, mitre-attack, G0034, sandworm, apt44, seashell-blizzard, voodoo-bear, gru, russia, ics, ot, scada, destructive, wiper, ransomware, supply-chain, red-team
+  mitre_attack: T1595.002, T1592.002, T1589.002, T1589.003, T1590.001, T1591.002, T1593, T1594, T1583.001, T1583.004, T1584.004, T1584.005, T1585.001, T1585.002, T1586.001, T1587.001, T1588.002, T1588.006, T1608.001, T1190, T1133, T1195, T1195.002, T1199, T1078, T1078.002, T1566.001, T1566.002, T1598.003, T1204.001, T1204.002, T1059.001, T1059.003, T1059.005, T1047, T1106, T1203, T1219, T1072, T1543.002, T1543.003, T1136.002, T1053.005, T1505.001, T1505.003, T1554, T1098, T1484.001, T1027, T1027.002, T1027.010, T1036, T1036.004, T1036.005, T1036.008, T1036.010, T1112, T1140, T1070.004, T1218.011, T1685, T1685.001, T1003.001, T1003.003, T1056.001, T1110, T1539, T1555.003, T1040, T1087.002, T1087.003, T1018, T1082, T1083, T1049, T1033, T1021.002, T1570, T1071.001, T1095, T1571, T1090, T1102.002, T1132.001, T1572, T1055, T1105, T1005, T1213.006, T1041, T1485, T1486, T1490, T1489, T1561.002, T1491.002, T1499
+---
+
+# Sandworm Team (Voodoo Bear, Seashell Blizzard, ELECTRUM) — Adversary Emulation Profile
+
+Sandworm Team (MITRE ATT&CK **G0034**; also tracked as APT44, Voodoo Bear, Seashell Blizzard, ELECTRUM, Telebots, IRON VIKING, IRIDIUM, FROZENBARENTS, and historically BlackEnergy/Quedagh) is a destructive Russian state threat group attributed to the GRU's Main Center for Special Technologies (GTsST), military unit 74455, active since at least 2009. Unlike espionage-focused peers, Sandworm is the GRU's premier *sabotage and influence* unit: it pairs conventional intrusion tradecraft with bespoke ICS/OT attack capability, disk wipers, fake ransomware, hacktivist-persona leaks, and disruptive operations timed to geopolitical and kinetic events. It is the only actor publicly documented to have triggered electric-grid blackouts via cyberattack (Ukraine, 2015 and 2016) and later repeated an OT grid attack in 2022. This profile maps Sandworm's signature TTPs to ATT&CK so Decepticon can emulate them within an authorized engagement and so the blue cell can anticipate detection.
+
+## Attribution & motivation
+
+- **Sponsor / nation:** Russian Federation — GRU (Main Intelligence Directorate), Main Center for Special Technologies (GTsST), military unit **74455**. Attribution is **high confidence**, backed by the October 2020 US DOJ indictment of six named Unit 74455 officers, concurrent UK/EU/Five Eyes statements, and Mandiant's April 2024 graduation of the cluster to the named APT designation **APT44**.
+- **Motivation:** Primarily **destructive/disruptive sabotage** and **influence operations** in support of Russian military and political objectives, with **espionage** and pre-positioning for access as enabling activity. Financial theft is rare and generally a cover (e.g., NotPetya and Prestige used ransomware/wiper framing for destructive ends rather than profit).
+- **Strategic character:** Operations are frequently synchronized with kinetic events (e.g., the October 2022 OT attack coincided with Russian missile strikes on Ukraine) and elections, and use false hacktivist or criminal personas for plausible deniability.
+
+## Targeting
+
+- **Sectors:** Energy/electric utilities and ICS/OT operators (primary signature), oil and gas, government, defense and arms manufacturing, transportation and shipping, telecommunications, media, financial services, and civil society. The BadPilot subgroup (Microsoft, 2025) broadened opportunistic access into any Internet-facing enterprise software it can exploit.
+- **Regions:** Heaviest focus on **Ukraine** and Russia's "near abroad" (e.g., Georgia, Poland, Kazakhstan). Global spillover and deliberate targeting includes Western Europe, the **United States and United Kingdom** (expanded since early 2024 via BadPilot), and one-off high-impact events worldwide (e.g., the 2018 PyeongChang Winter Olympics, the OPCW, the 2017 French presidential campaign).
+- **Victim profile:** Critical-infrastructure and government operators of strategic value to Russia, organizations tied to events Moscow seeks to disrupt, and any edge-exposed organization useful as a foothold or for later sabotage/influence.
+
+## Notable campaigns
+
+- **2015-12 — Ukraine power grid (BlackEnergy/KillDisk):** First-of-its-kind cyber-induced blackout; operators used stolen credentials and HMI access to open breakers, then KillDisk to hamper recovery. (DOJ 2020 indictment; MITRE G0034)
+- **2016-12 — Ukraine power grid (Industroyer/CRASHOVERRIDE):** Purpose-built ICS malware (S0604) automated breaker manipulation in Kyiv. (Google Cloud / Mandiant)
+- **2017-06 — NotPetya (S0368):** Supply-chain compromise of the M.E.Doc Ukrainian tax-software updater delivered a self-propagating wiper masquerading as ransomware, causing global multi-billion-dollar damage. (DOJ 2020 indictment; MITRE G0034)
+- **2017 — French presidential campaign targeting & 2017-06 Bad Rabbit (S0606):** Spearphishing/influence operations and a separate ransomware-style outbreak. (DOJ 2020 indictment)
+- **2018-02 — Olympic Destroyer (S0365):** Disruptive wiper against the PyeongChang Winter Olympics IT systems, deliberately seeded with false-flag artifacts. (DOJ 2020 indictment; MITRE G0034)
+- **2018 — OPCW targeting:** Operations against the Organisation for the Prohibition of Chemical Weapons. (DOJ 2020 indictment)
+- **2019 — Georgia website defacement & disruption:** Defaced ~15,000 Georgian government/private websites and disrupted broadcasters after compromising a hosting provider. (MITRE G0034; DOJ)
+- **2022-02/03 — Ukraine wiper wave (CaddyWiper S0693, AcidRain S1125):** Destructive malware around the full-scale invasion; AcidRain bricked Viasat KA-SAT modems. (Mandiant APT44)
+- **2022-04 — Industroyer2:** Attempted blackout against a Ukrainian electricity provider using an Industroyer variant plus CaddyWiper. (Google Cloud / Mandiant)
+- **2022-10 — Living-off-the-land OT grid attack:** Used a malicious ISO (`a.iso`) → `lun.vbs` → `n.bat` → native MicroSCADA `scilc.exe` (SCIL-API) to issue unauthorized breaker commands (Oct 10), followed two days later by CaddyWiper deployed via GPO. (Google Cloud / Mandiant)
+- **2022-10/11 — Prestige ransomware (S1058):** Encrypted logistics/transport organizations in Ukraine and Poland. (Microsoft; MITRE G0034)
+- **2024-04 — APT44 designation (Mandiant):** Formal graduation reflecting sustained global sabotage, espionage, and influence activity.
+- **2021-2025 — BadPilot subgroup global access operation:** Multiyear opportunistic exploitation of Internet-facing software (Exchange, Outlook, ConnectWise ScreenConnect, Fortinet, Zimbra, OpenFire, JetBrains TeamCity) to establish persistent footholds, expanding to US/UK targets since early 2024. (Microsoft, 2025-02)
+
+## TTPs by ATT&CK tactic
+
+### Reconnaissance & Resource Development
+- **T1595.002 / T1592.002 / T1589.002 / T1589.003 / T1590.001 / T1591.002 / T1593 / T1594** — Vulnerability-scans target infrastructure; profiles software in use for supply-chain ops; harvests emails, employee names, domain properties, partner/business relationships; researches third-party and victim-owned sites (e.g., Ukraine's EDRPOU registry, Georgian parliament domain).
+- **T1583.001 / T1583.004 / T1584.004 / T1584.005** — Registers look-alike domains (login/password-reset pages), leases servers via resellers, compromises legitimate Linux EXIM servers, and operates large SOHO-device botnets.
+- **T1585.001 / T1585.002 / T1586.001** — Establishes social-media and email accounts (hacktivist personas) and compromises real social accounts for leak/influence ops.
+- **T1587.001 / T1588.002 / T1588.006 / T1608.001** — Develops custom malware (NotPetya, Olympic Destroyer) and acquires offensive tooling (Cobalt Strike, Empire, PoshC2, Impacket, Invoke-PSImage, RemoteExec); stages trojanized installers on forums.
+
+### Initial Access
+- **T1190** — Exploits public-facing applications (BadPilot: ScreenConnect CVE-2024-1709, Fortinet CVE-2023-48788, Exchange CVE-2021-34473, Outlook CVE-2023-23397, Zimbra CVE-2022-41352, OpenFire CVE-2023-32315, TeamCity CVE-2023-42793; ICS HMIs GE Cimplicity/Advantech WebAccess).
+- **T1566.001 / T1566.002 / T1598.003** — Spearphishing with malicious Office/ZIP attachments and credential-harvesting links.
+- **T1195 / T1195.002** — Supply-chain compromise (M.E.Doc updater for NotPetya; forum-staged installers).
+- **T1133 / T1078 / T1078.002 / T1199** — VPN/SSH external remote services, valid (often domain-admin) accounts, and trusted cross-organization network links.
+
+### Execution
+- **T1059.001 / T1059.003 / T1059.005** — PowerShell (in-memory credential tools), Windows Command Shell via MS-SQL `xp_cmdshell`, and VBScript/VBA (e.g., `lun.vbs`, `vba_macro.exe`).
+- **T1047 / T1106 / T1203 / T1204.001 / T1204.002** — Impacket WMIexec, native API calls, client-side exploits (CVE-2014-4114 OLE, CVE-2013-3906 TIFF), and macro/link user-execution lures.
+- **T1219 / T1072** — ICS client software and remote-admin tools to operate breakers; RemoteExec for agentless RCE.
+
+### Persistence
+- **T1543.002 / T1543.003 / T1136.002 / T1053.005 / T1505.001 / T1505.003 / T1554 / T1098** — systemd services (GOGETTER), Windows services (Industroyer), created privileged domain accounts, scheduled tasks (SHARPIVORY), MS-SQL stored procedures, web shells (P.A.S., Neo-REGEORG), a trojanized Notepad binary, and SQL linked-server account manipulation.
+
+### Privilege Escalation / Defense Evasion
+- **T1484.001** — Group Policy Object modification to deploy and execute malware (CaddyWiper, Prestige) across a domain from the DC.
+- **T1027 / T1027.002 / T1027.010 / T1140** — Base64/ROT13/AES/zlib obfuscation, UPX-packed Mimikatz, multi-stage decode chains.
+- **T1036 / T1036.004 / T1036.005 / T1036.008 / T1036.010** — Masquerades installers as Windows updates, services as legitimate (GOGETTER), binaries as `explorer.exe`, executables as `.txt`, and accounts as `admin`/`система`.
+- **T1112 / T1685 / T1685.001 / T1070.004 / T1218.011** — Lowers registry internet-security settings, disables tools and Windows event logging, deletes attack files, and proxies execution via `rundll32.exe`.
+
+### Credential Access
+- **T1003.001 / T1003.003 / T1056.001 / T1110 / T1539 / T1555.003 / T1040** — LSASS dumping (modified Mimikatz, `comsvcs.dll`, plainpwd), NTDS extraction via `ntdsutil.exe`, keylogging (`SetWindowsHookEx`), RPC brute force, browser session-cookie and saved-password theft (CredRaptor), and network sniffing (intercepter-NG, BlackEnergy sniffer). Also alters OWA sign-in pages to capture credentials in real time (BadPilot).
+
+### Discovery
+- **T1087.002 / T1087.003 / T1018 / T1082 / T1083 / T1049 / T1033** — LDAP/AD account enumeration, M.E.Doc account harvesting, remote-system discovery, OS/system info, file/directory enumeration, network-connection and RDP-session mapping, and user discovery.
+
+### Lateral Movement
+- **T1021.002 / T1570** — SMB/ADMIN$ copy and `net use`; lateral tool transfer (e.g., copying Prestige to the DC via GPO, ICS payload staging).
+
+### Command & Control
+- **T1071.001 / T1095 / T1571 / T1090 / T1102.002 / T1132.001 / T1572 / T1055 / T1105** — HTTP(S) C2 (BlackEnergy, BCS-server), non-application-layer/TLS-tunneled proxying, non-standard ports (SSH 6789), internal proxies, bidirectional web-service C2 (Telegram Bot API, M.E.Doc update requests), Base64-over-HTML encoding, Yamux/TLS tunneling (GOGETTER), process injection into `svchost.exe`, and ingress tool transfer.
+
+### Collection & Exfiltration
+- **T1005 / T1213.006 / T1041** — Local-system document theft, database exfiltration via Adminer, and exfil over the HTTP C2 channel.
+
+### Impact (signature)
+- **T1485** — Data destruction with CaddyWiper, SDelete, BlackEnergy KillDisk, and JUNKMAIL (file/disk overwrite).
+- **T1561.002** — Disk-structure wipe (KillDisk MBR corruption).
+- **T1486 / T1490 / T1489** — Prestige ransomware encryption, deletion of backup catalog and volume shadow copies, and service-stop (MSSQL) to ensure encryption.
+- **T1491.002 / T1499** — External website defacement (~15,000 Georgian sites) and endpoint denial-of-service.
+- **ICS impact** — Native-binary breaker manipulation (MicroSCADA `scilc.exe` / SCIL-API, ATT&CK ICS T1692.001/T0831), serial-to-ethernet firmware overwrite to block OT messages (T1693.001/T1691), causing loss of control/availability and ~6-hour regional blackouts.
+
+## Signature tooling & malware
+
+| Family | ATT&CK | Type | Role |
+|---|---|---|---|
+| BlackEnergy | S0089 | Custom | Modular backdoor/keylogger/sniffer; original grid-attack platform |
+| KillDisk | S0607 | Custom | Disk/MBR wiper used to hamper recovery |
+| Industroyer / Industroyer2 | S0604 | Custom | ICS/SCADA malware that automates breaker manipulation |
+| NotPetya | S0368 | Custom | Self-propagating wiper masquerading as ransomware (supply-chain) |
+| Olympic Destroyer | S0365 | Custom | Disruptive wiper with false-flag artifacts |
+| Bad Rabbit | S0606 | Custom | Ransomware-style outbreak |
+| CaddyWiper | S0693 | Custom | Wiper deployed via GPO (2022 Ukraine ops) |
+| AcidRain / AcidPour | S1125 / S1167 | Custom | Wipers (AcidRain bricked Viasat modems) |
+| Cyclops Blink | S0687 | Custom | Botnet/router implant (SOHO devices) |
+| Prestige | S1058 | Custom | Ransomware against Ukraine/Poland logistics |
+| P.A.S. Webshell | S0598 | Custom/shared | Web shell for persistence |
+| CHEMISTGAMES | S0555 | Custom | Mobile backdoor |
+| GOGETTER / TANKTRAP / SHARPIVORY / CredRaptor / plainpwd | — | Custom | Tunneler, PowerShell deployer, dropper, browser-cred stealer, LSASS dumper |
+| Mimikatz / Impacket / Cobalt Strike / Empire / PoshC2 / Invoke-PSImage / SDelete / RemoteExec / Adminer / Neo-REGEORG / intercepter-NG | S0002 / S0357 / S0154 / S0363 / S0378 / S0231 / S0195 / — | Public | Off-the-shelf cred theft, lateral movement, C2, sniffing, exfil, wiping |
+
+## Emulation guidance (Decepticon)
+
+**Authorized use only:** every action below is destructive-capable and must run strictly inside the documented engagement scope, on approved targets, with rules-of-engagement sign-off and (for any wipe/encrypt/OT step) explicit written authorization and reversible/lab-only execution. Never touch real ICS/OT or production data outside an isolated test range.
+
+- **Edge-exploit initial access (BadPilot style, T1190):** Use Decepticon's recon/scanning and exploit tooling against in-scope perimeter apps; emulate ScreenConnect/Fortinet/Exchange-class footholds. Chain to web-shell drop (T1505.003) via the **bash** tool and the **lateral-movement** skill.
+- **Phishing & supply-chain (T1566/T1195):** Drive the spearphishing/credential-harvest path with Decepticon's phishing/initial-access capability; emulate trojanized-installer staging only against engagement-provided artifacts.
+- **Valid-account + AD escalation (T1078.002/T1003/T1087/T1484.001):** Use the **AD skills** to enumerate via LDAP, dump LSASS/NTDS (emulating modified-Mimikatz/`ntdsutil`/`comsvcs.dll`), and reach Domain Admin — Sandworm's defining pivot is GPO-based mass deployment, so practice pushing a benign payload domain-wide via GPO.
+- **C2 (T1071.001/T1572/T1102.002):** Stand up **c2/sliver** with HTTPS and TLS-tunneled (Yamux-like) profiles; emulate Telegram/web-service bidirectional C2 with a benign beacon and internal-proxy pivoting.
+- **Defense evasion (T1027/T1036/T1685.001/T1070.004):** Use the **defense-evasion** skill to pack/obfuscate payloads, masquerade binaries and accounts (`explorer.exe`, `система`), disable event logging, and clean up artifacts — then verify the blue cell catches them.
+- **Lateral movement (T1021.002/T1570/T1047):** Use the **lateral-movement** skill for SMB/ADMIN$ copy, `net use`, Impacket WMIexec, and GPO/RemoteExec-style mass execution to mirror Sandworm's DC-to-fleet propagation.
+- **Cloud / hosting tradecraft (T1583/T1584):** Use **cloud skills** to provision reseller-leased infra and look-alike domains for the engagement's C2 and phishing surface.
+- **Impact emulation (T1485/T1486/T1490/T1561.002):** ONLY in an isolated lab range — emulate wiper behavior with SDelete-style overwrites, shadow-copy/backup deletion, and service-stop-then-encrypt sequencing to test EDR/recovery. Do not run destructive payloads against any host the customer needs.
+- **OT/ICS (ICS T1692.001/T0831, etc.):** Treat as tabletop/range-only. Emulate the living-off-the-land chain (ISO → VBS → batch → native SCADA utility) conceptually so the blue cell can build detections; never issue control commands against real equipment.
+
+## Detection & defense
+
+- **Edge/initial access:** Patch and monitor Internet-facing apps (Exchange/Outlook, ScreenConnect, Fortinet, Zimbra, OpenFire, TeamCity); alert on new web shells (T1505.003) and anomalous OWA sign-in-page modifications/DNS changes (BadPilot credential capture).
+- **AD & GPO abuse (T1484.001):** Audit GPO creation/linking and SYSVOL changes; alert on scheduled tasks or services deployed fleet-wide from a DC; monitor `ntdsutil.exe`, LSASS access, and `comsvcs.dll` MiniDump (T1003).
+- **LotL execution:** Detect `wscript.exe`/`cscript.exe` spawning batch files, mounted ISO autoruns, `xp_cmdshell` enablement, `rundll32.exe` proxy execution (T1218.011), and PowerShell that loads code in memory; baseline native SCADA utilities (e.g., `scilc.exe`) and alert on any unexpected invocation.
+- **Credential theft:** Deploy LSASS protection (Credential Guard/RunAsPPL), browser-credential and session-cookie monitoring, and network-sniffer detection.
+- **C2 / evasion:** Inspect TLS-tunneled and non-standard-port traffic, Telegram/cloud-service beaconing, and `svchost.exe` injection; alert on Windows event-log clearing/disabling (T1685.001) and mass file deletion.
+- **Destructive containment:** Maintain offline, immutable backups; alert on volume-shadow-copy and backup-catalog deletion (T1490), `vssadmin`/`wbadmin` misuse, mass service stops (T1489), and rapid multi-host file overwrite (T1485). Segment IT from OT; restrict and monitor HMI/ICS-client access and serial-to-ethernet device firmware integrity.
+
+## Sources
+
+- MITRE ATT&CK — Sandworm Team (G0034): https://attack.mitre.org/groups/G0034/
+- Google Cloud (Mandiant) — "Sandworm Disrupts Power in Ukraine Using a Novel Attack Against Operational Technology": https://cloud.google.com/blog/topics/threat-intelligence/sandworm-disrupts-power-ukraine-operational-technology/
+- Google Cloud (Mandiant) — "Unearthing APT44: Russia's Notorious Cyber Sabotage Unit Sandworm": https://cloud.google.com/blog/topics/threat-intelligence/apt44-unearthing-sandworm
+- Microsoft Security Blog — "The BadPilot campaign: Seashell Blizzard subgroup conducts multiyear global access operation": https://www.microsoft.com/en-us/security/blog/2025/02/12/the-badpilot-campaign-seashell-blizzard-subgroup-conducts-multiyear-global-access-operation/
+- Wikipedia (corroborating overview, DOJ indictment summary) — "Sandworm (hacker group)": https://en.wikipedia.org/wiki/Sandworm_(hacker_group)

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/scattered-spider/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/scattered-spider/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: scattered-spider
+description: "Adversary-emulation profile for Scattered Spider (UNC3944/Octo Tempest), a financially motivated social-engineering-led intrusion group, mapped to ATT&CK G1015 and Decepticon tooling."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "scattered spider, unc3944, octo tempest, muddled libra, star fraud, 0ktapus, storm-0875, scatter swine, help desk social engineering, sim swap, mfa fatigue, mfa bypass, vishing, smishing, okta phishing, entra id federation abuse, esxi ransomware, dragonforce, blackcat alphv, ransomhub, qilin, the com emulation, identity attack, rmm abuse"
+  tags: adversary-emulation, scattered-spider, unc3944, octo-tempest, g1015, social-engineering, identity-attacks, ransomware, cloud, mfa-bypass, sim-swapping, e-crime, mitre-attack
+  mitre_attack: T1589, T1589.001, T1598, T1598.001, T1598.003, T1598.004, T1583.001, T1585.001, T1588.001, T1588.002, T1102, T1451, T1566.004, T1660, T1190, T1133, T1078, T1078.004, T1621, T1199, T1204, T1059.001, T1059.004, T1047, T1219.002, T1098, T1098.001, T1098.003, T1098.005, T1136, T1543.002, T1547.005, T1556.006, T1556.009, T1484.002, T1068, T1548.002, T1553.002, T1564.008, T1070.008, T1562, T1685, T1027, T1134, T1003, T1003.003, T1003.006, T1555.005, T1539, T1552.001, T1552.004, T1684.001, T1087, T1087.002, T1087.003, T1087.004, T1069.002, T1069.003, T1018, T1046, T1082, T1016, T1083, T1580, T1538, T1213.002, T1213.003, T1213.005, T1021.001, T1021.004, T1021.007, T1572, T1090, T1578.002, T1530, T1114, T1114.003, T1074, T1041, T1567.002, T1486, T1490, T1657, T1006, T1217
+---
+
+# Scattered Spider (UNC3944, Octo Tempest, Muddled Libra, Star Fraud) — Adversary Emulation Profile
+
+Scattered Spider (MITRE ATT&CK **G1015**) is a financially motivated, predominantly native English-speaking cybercriminal collective active since at least 2022 and widely linked to the loosely affiliated "The Com" social network. The group is exceptional not for novel malware but for **aggressive, high-tempo social engineering of human identity processes**: it phones and SMS-phishes help desks and employees, impersonates IT staff, bypasses MFA (push bombing, SIM swapping, attacker-registered tokens), and rapidly pivots into cloud identity (Microsoft Entra ID, Okta, AWS, Azure) and virtualization (VMware ESXi/vCenter) before staging data theft and ransomware. It began with the 2022 "0ktapus" Okta-credential phishing wave, escalated to the high-profile 2023 MGM Resorts and Caesars Entertainment intrusions, and through 2024–2025 operated as an affiliate of multiple ransomware-as-a-service brands (BlackCat/ALPHV, RansomHub, Qilin, DragonForce), hitting retail, insurance, and aviation. This profile teaches Decepticon to emulate G1015's signature identity-centric TTPs inside an authorized engagement and helps the blue cell anticipate detection.
+
+## Attribution & motivation
+
+- **Sponsor / nation:** Non-state, criminal. Members are assessed to be primarily young, native English speakers based in the US and UK, affiliated with the broader "The Com" cybercrime community. **Not** a nation-state actor; multiple arrests and a 2025 US extradition have been reported (per Krebs on Security / Infosecurity Magazine).
+- **Motivation:** Primarily **financial** — credential theft, SIM-swap fraud / crypto theft, data extortion, and ransomware (`T1657` Financial Theft). There is no credible espionage, destructive-only, or influence mandate; destruction (encryption) is in service of extortion.
+- **Confidence:** High confidence the cluster tracked as Scattered Spider = UNC3944 (Mandiant/Google) = Octo Tempest / Storm-0875 (Microsoft) = Muddled Libra (Palo Alto Unit 42) = Roasted 0ktapus = Scatter Swine = Star Fraud. Note these vendor clusters overlap but are not byte-for-byte identical; treat as a fluid affiliate community rather than a fixed roster.
+
+## Targeting
+
+- **Sectors:** Initially telecom, BPO/outsourcing, and CRM/SaaS providers (for SIM-swap and downstream access); from 2023 expanded to hospitality & gaming (casinos), retail, technology/MSP, manufacturing, and **financial services / insurance**; in mid-2025, **aviation**.
+- **Regions:** Primarily English-speaking targets — United States, United Kingdom, Canada, Australia — with reporting of expansion toward Singapore and India.
+- **Victim profile:** Large enterprises with **large outsourced or tiered IT help desks**, heavy reliance on SSO/MFA (Okta, Microsoft Entra ID), significant cloud/SaaS footprint, and VMware-virtualized data centers. The human help desk and identity-recovery workflow is the deliberately chosen weak point.
+
+## Notable campaigns
+
+- **Aug 2022 — "0ktapus" / Roasted 0ktapus:** SMS smishing campaign harvesting Okta credentials and OTPs via ~169 lookalike domains; ~130 organizations compromised, including downstream intrusions at Twilio, Cloudflare (blocked), Mailchimp, DoorDash, and LastPass. (Group-IB, "Roasting 0ktapus.")
+- **Sep 2023 — MGM Resorts & Caesars Entertainment:** Help-desk vishing (an employee impersonation reportedly seeded from LinkedIn) granted access; MGM suffered major operational disruption, Caesars reportedly paid a ransom. BlackCat/ALPHV ransomware was associated. (Reuters/CyberScoop reporting; CISA AA23-320A.)
+- **Nov 16, 2023 — CISA/FBI Joint Advisory AA23-320A** first published, codifying the group's TTPs. (CISA.)
+- **2024 — RaaS affiliate shift:** Following ALPHV's collapse, the group operated with RansomHub and Qilin affiliates.
+- **Apr–May 2025 — UK retail wave:** Marks & Spencer (initial access reportedly Feb 2025), Co-op, and Harrods; M&S disruption estimated in the hundreds of millions of GBP, with **DragonForce** ransomware deployed against ESXi. UK arrests of four suspects followed. (The Hacker News; Mandiant/Google.)
+- **Jun 2025 — US insurance sector:** Reported intrusions including Philadelphia Insurance Companies and Erie Insurance. (Push Security; Claranet.)
+- **Late Jun–Jul 2025 — Aviation:** FBI warned of expansion to airlines; incidents reported at Hawaiian Airlines, WestJet, and Qantas (third-party contact-center platform). (CSO Online.)
+- **Jul 29, 2025 — AA23-320A updated** by FBI/CISA + international partners (RCMP, ASD's ACSC, AFP, CCCS, NCSC-UK) with TTPs current to June 2025 and confirmation of DragonForce deployment. (IC3/CISA.)
+
+## TTPs by ATT&CK tactic
+
+### Resource Development
+- `T1583.001` Acquire Infrastructure: Domains — registers lookalike/SSO-spoofing domains (e.g. `victim-helpdesk[.]com`, `victim-sso[.]com`).
+- `T1585.001` Establish Accounts: Social Media — builds fake personas; uses LinkedIn for target profiling.
+- `T1588.001` / `T1588.002` Obtain Capabilities (Malware/Tools) — acquires info-stealers, RATs, ransomware, and offensive tools (RustScan, LinPEAS, aws_consoler, rsocx, Level RMM).
+- `T1102` Web Service — stages/downloads tooling from file.io, GitHub, paste.ee.
+
+### Initial Access
+- `T1598.004` / `T1566.004` Spearphishing Voice (vishing) — calls help desks/employees impersonating IT to trigger password and MFA resets; signature technique.
+- `T1660` / `T1598.003` Phishing (mobile / spearphishing link) — SMS smishing to credential-harvesting portals mimicking SSO.
+- `T1598.001` Spearphishing Service — Telegram/Teams messages impersonating IT personnel.
+- `T1451` SIM-Card Swap — social-engineers carriers to port victim numbers and intercept SMS OTPs.
+- `T1190` Exploit Public-Facing Application — opportunistic (e.g., CVE-2021-35464 in ForgeRock OpenAM).
+- `T1133` External Remote Services — abuses VPNs, Citrix, and remote-access tooling for entry.
+- `T1078` / `T1078.004` Valid Accounts (incl. Cloud) — logs in with socially-engineered credentials; compromised Entra ID/Azure accounts.
+- `T1199` Trusted Relationship — pivots through MSPs, BPOs, and third-party contact-center platforms.
+- `T1621` MFA Request Generation — push-bombing / MFA-fatigue until a victim approves.
+
+### Execution
+- `T1204` User Execution — directs impersonated victims to install RMM agents.
+- `T1219.002` Remote Desktop Software — deploys TeamViewer, AnyDesk, LogMeIn, ConnectWise, ngrok-based access.
+- `T1059.001` PowerShell — e.g., `Get-ADUser` and recon scripting.
+- `T1059.004` Unix Shell — installs Teleport and tooling on Linux/ESXi.
+- `T1047` Windows Management Instrumentation — via Impacket for remote execution/lateral movement.
+
+### Persistence
+- `T1098.005` Device Registration — registers attacker MFA devices/endpoints for durable access through VPN.
+- `T1136` Create Account — creates new identities in the victim tenant/domain.
+- `T1098` / `T1098.001` / `T1098.003` Account Manipulation — adds accounts to privileged groups (e.g., ESX Admins), adds cloud credentials, assigns admin roles.
+- `T1556.006` Modify Authentication Process: MFA — registers own MFA tokens post-compromise.
+- `T1484.002` Domain Trust Modification — adds a rogue federated IdP to the SSO tenant for backdoor authentication.
+- `T1543.002` / `T1547.005` Systemd Service / SSP — Teleport persistence on Linux; Mimikatz SSP.
+
+### Privilege Escalation
+- `T1556.009` Conditional Access Policies — adds trusted locations / weakens CA to bypass MFA for controlled accounts.
+- `T1068` Exploitation for Privilege Escalation — has deployed a malicious kernel driver (BYOVD via CVE-2015-2291).
+- `T1548.002` Bypass UAC — via tooling (BlackCat, WarzoneRAT).
+
+### Defense Evasion
+- `T1685` Disable or Modify Tools / `T1562` Impair Defenses — uninstalls/disables EDR and security agents.
+- `T1564.008` Email Hiding Rules / `T1070.008` Clear Mailbox Data — auto-deletes vendor security alert emails; deletes traces of its own account activity.
+- `T1553.002` Code Signing — abuses self-signed and stolen certificates (e.g., NVIDIA, Global Software LLC).
+- `T1027` Obfuscated Files / `T1134` Access Token Manipulation — malware-delivered obfuscation and token abuse.
+
+### Credential Access
+- `T1003` / `T1003.003` / `T1003.006` OS Credential Dumping (Mimikatz, LaZagne), NTDS extraction via shadow copies, and DCSync.
+- `T1555.005` Password Managers — hunts HashiCorp Vault and PAM solutions.
+- `T1539` Steal Web Session Cookie / `T1217` Browser Information — harvests cookies and browser data (Raccoon Stealer).
+- `T1552.001` / `T1552.004` Credentials in Files / Private Keys — searches credential docs; exfiltrates code-signing certs.
+- `T1684.001` Impersonation — impersonates IT help desk to reset passwords/MFA.
+- `T1589` / `T1589.001` Gather Victim Identity Info / Credentials — leverages prior-breach data to pass identity-verification challenges.
+
+### Discovery
+- `T1087.002/.003/.004` Account Discovery (Domain/Email/Cloud) — enumerates AD, Entra ID groups and members.
+- `T1069.002` / `T1069.003` Permission Groups Discovery — ADExplorer/ADRecon.ps1 for domain groups; Azure AD group membership.
+- `T1018` Remote System Discovery — maps vCenter/ESXi infrastructure.
+- `T1046` Network Service Discovery — RustScan port scanning.
+- `T1082` / `T1016` / `T1083` System/Network/File Discovery — OS fingerprinting, `ping`/`nltest`, hunting MFA docs, network diagrams, and credentials.
+- `T1580` / `T1538` Cloud Infrastructure Discovery — enumerates AWS S3 and Systems Manager Inventory.
+- `T1213.002/.003/.005` Data from Information Repositories — SharePoint (VPN/MFA enrollment info), internal GitHub repos, Slack/Teams.
+
+### Lateral Movement
+- `T1021.001` RDP, `T1021.004` SSH (incl. vCenter), `T1021.007` Cloud Services (EC2/Azure).
+- `T1572` Protocol Tunneling — Teleport.sh, Chisel, ngrok, Pinggy, MobaXterm SSH tunnels.
+- `T1090` Proxy — proxy networks and rsocx reverse proxy to blend in.
+
+### Collection
+- `T1530` Data from Cloud Storage — OneDrive and cloud resources.
+- `T1114` / `T1114.003` Email Collection / Forwarding Rule — searches Exchange for incident-response emails and forwards/redirects security alerts.
+- `T1074` Data Staged — consolidates stolen data into a central store.
+
+### Command & Control
+- RMM tools (`T1219.002`) and tunnelers (`T1572`) double as resilient C2. ngrok (S0508) and Tor (S0183) appear in operations.
+- `T1578.002` Modify Cloud Compute Infrastructure — spins up attacker EC2/Azure VMs as staging/C2.
+
+### Exfiltration
+- `T1041` Exfiltration Over C2 Channel — via Teleport.
+- `T1567.002` Exfiltration to Cloud Storage — MEGA, AWS S3; abuse of cloud DB platforms (e.g., Snowflake tenants). Rclone (S1040) used for cloud transfer.
+
+### Impact
+- `T1486` Data Encrypted for Impact — BlackCat/ALPHV and later DragonForce ransomware, notably against VMware ESXi.
+- `T1490` Inhibit System Recovery — stops Volume Shadow Copy service.
+- `T1006` Direct Volume Access — shadow-copies DC disks to grab NTDS.dit.
+- `T1657` Financial Theft — double-extortion: data theft + encryption with leak-site threats.
+
+## Signature tooling & malware
+
+- **Ransomware (RaaS affiliate, not owned):** BlackCat/ALPHV (S1068), DragonForce, RansomHub, Qilin — deployed especially against ESXi.
+- **Credential tooling (public):** Mimikatz (S0002), LaZagne (S0349), Impacket (S0357), Raccoon Stealer (S1148).
+- **Remote access / RMM (legitimate, abused):** TeamViewer, AnyDesk, LogMeIn, ConnectWise ScreenConnect (S0591), Level RMM, Splashtop, Pulseway.
+- **Tunneling / C2:** ngrok (S0508), Chisel, Teleport.sh, Pinggy, rsocx, MobaXterm, Tor (S0183).
+- **Recon / cloud:** RustScan, ADExplorer, ADRecon.ps1, SharpHound, LinPEAS, aws_consoler.
+- **Exfil:** Rclone (S1040), MEGA client.
+- **RATs / drivers:** WarzoneRAT (S0670); BYOVD kernel driver (CVE-2015-2291).
+- Hallmark: minimal custom malware — the group weaponizes **legitimate admin/RMM software and identity systems**, making it hard to catch with signature-based detection.
+
+## Emulation guidance (Decepticon)
+
+**Authorized use only:** Execute the below exclusively within the documented rules of engagement and approved scope for this engagement; never SIM-swap real subscribers, social-engineer real third-party carriers/help desks outside scope, or deploy real ransomware against production data.
+
+- **Initial access via identity, not exploits.** Lead with `defense-evasion`/social-engineering playbooks emulating help-desk vishing and SSO smishing (`T1598.004`, `T1660`). Use the phishing/portal-cloning capability to stand up an in-scope lookalike SSO page (`T1583.001`) and harvest test credentials/OTPs. Emulate MFA fatigue (`T1621`) and attacker-MFA-device registration (`T1098.005`, `T1556.006`) against authorized test identities rather than performing a real SIM swap (`T1451` — emulate the OTP-interception outcome with a provisioned test number).
+- **Cloud/identity pivot.** Use the **cloud skills** (Azure/Entra + AWS) to emulate G1015's identity tradecraft: enumerate Entra ID/AWS accounts and groups (`T1087.004`, `T1069.003`, `T1580`, `T1538`), add cloud credentials/roles (`T1098.001`, `T1098.003`), weaken Conditional Access / add trusted locations (`T1556.009`), and add a rogue federation trust (`T1484.002`) — all against the engagement's lab/test tenant.
+- **AD operations.** Drive the **AD skills**: ADExplorer/SharpHound-style enumeration (`T1069.002`, `T1087.002`), DCSync and NTDS via shadow copy (`T1003.006`, `T1003.003`, `T1006`), Mimikatz/LaZagne dumping (`T1003`). Use **bash/PowerShell** for `Get-ADUser`, `nltest`, and `ping` recon (`T1059.001`, `T1016`).
+- **Lateral movement & C2.** Use the **lateral-movement** skill for RDP/SSH/WMI (`T1021.001`, `T1021.004`, `T1047`) and the **c2/Sliver** capability plus **protocol tunneling** (ngrok/Chisel-style, `T1572`, `T1090`) to mirror RMM-and-tunnel C2 (`T1219.002`). Deploy an approved RMM agent to a test host to replicate the signature `T1204`→`T1219.002` chain.
+- **Virtualization target.** Where the lab includes VMware, emulate vCenter/ESXi enumeration and SSH access (`T1018`, `T1021.004`) and group manipulation (`T1098`) — stop short of encryption; instead validate that backup/immutability controls would have blocked `T1486`/`T1490`.
+- **Collection & exfil simulation.** Stage benign canary data (`T1074`) and exfiltrate to an in-scope cloud bucket via Rclone-style transfer (`T1567.002`) to test DLP/egress controls; emulate inbox-rule evasion (`T1564.008`, `T1114.003`) on a test mailbox.
+- **Impact (simulated):** For ransomware emulation, use a benign/inert payload or a detonation-safe simulator against test ESXi/hosts to exercise EDR-disable (`T1685`), shadow-copy deletion (`T1490`), and encryption (`T1486`) detections — never real ransomware on production.
+
+## Detection & defense
+
+- **Identity verification at the help desk:** require strong, out-of-band, on-camera or in-person verification before any password/MFA reset; never rely on DOB/last-4-SSN; temporarily disable self-service MFA resets during active threats. Directly counters `T1598.004`/`T1684.001`.
+- **Phishing-resistant MFA:** remove SMS/voice/email factors; deploy FIDO2/number-matching; restrict MFA registration to trusted IPs/compliant devices; alert on the same MFA method registered across multiple users (counters `T1621`, `T1451`, `T1556.006`, `T1098.005`).
+- **Entra ID / SSO monitoring:** alert on changes to Conditional Access Policies, Trusted Named Locations, and federation/domain config; verify all federated domains (counters `T1556.009`, `T1484.002`).
+- **Detect lookalike domains & smishing portals:** continuous brand/typosquat domain monitoring; user training to reject MFA push-bombing and report IT-impersonation SMS/Teams messages (counters `T1583.001`, `T1660`, `T1598.001`).
+- **RMM control:** allow-list approved remote-access software; alert on TeamViewer/AnyDesk/ScreenConnect/ngrok install or execution and outbound to tunneling services (counters `T1219.002`, `T1572`).
+- **Teams/collaboration detection:** alert on external-tenant chats with display names containing "help"/"helpdesk" (Mandiant-provided KQL/SecOps rules).
+- **Recon tooling:** alert on ADRecon, ADExplorer, SharpHound, RustScan execution; lock down docs containing VPN/MFA-enrollment/network-diagram info (counters discovery cluster).
+- **Identity store segregation & Tier-0:** decouple AD from cloud/virtualization/backup identity; local, vault-excluded, MFA-enforced root accounts for ESXi/vCenter; enable ESXi lockdown mode; immutable, network-isolated backups (counters `T1486`, `T1490`, `T1003.x`).
+- **Egress restriction & session monitoring:** restrict outbound from DCs/TSI servers; block Tor exit nodes and VPS ranges; alert on impossible-travel, proxy/VPN logins, and token replay (counters C2/exfil cluster).
+
+## Sources
+
+- MITRE ATT&CK — Scattered Spider (G1015): https://attack.mitre.org/groups/G1015/
+- Mandiant / Google Cloud — "Defending Against UNC3944: Cybercrime Hardening Guidance from the Frontlines": https://cloud.google.com/blog/topics/threat-intelligence/unc3944-proactive-hardening-recommendations
+- CISA/FBI Joint Advisory AA23-320A — Scattered Spider: https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-320a
+- CISA alert — "CISA and Partners Release Updated Advisory on Scattered Spider Group" (July 29, 2025): https://www.cisa.gov/news-events/alerts/2025/07/29/cisa-and-partners-release-updated-advisory-scattered-spider-group
+- IC3 PDF of AA23-320A (July 29, 2025): https://www.ic3.gov/CSA/2025/250729.pdf
+- Group-IB — "Roasting 0ktapus: The phishing campaign going after Okta identity credentials": https://www.group-ib.com/blog/0ktapus/
+- The Hacker News — "Scattered Spider Behind Cyberattacks on M&S and Co-op": https://thehackernews.com/2025/06/scattered-spider-behind-cyberattacks-on.html
+- CSO Online — "Scattered Spider shifts focus to airlines": https://www.csoonline.com/article/4014787/scattered-spider-shifts-focus-to-airlines-as-strikes-hit-hawaiian-westjet-and-now-qantas.html
+- Krebs on Security — "Alleged 'Scattered Spider' Member Extradited to U.S.": https://krebsonsecurity.com/2025/04/alleged-scattered-spider-member-extradited-to-u-s/

--- a/packages/decepticon/decepticon/skills/shared/adversary-emulation/volt-typhoon/SKILL.md
+++ b/packages/decepticon/decepticon/skills/shared/adversary-emulation/volt-typhoon/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: volt-typhoon
+description: "Adversary-emulation profile for Volt Typhoon (G1017), a PRC state-sponsored actor pre-positioning in US critical infrastructure via living-off-the-land TTPs."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: adversary-emulation
+  when_to_use: "volt typhoon, bronze silhouette, vanguard panda, insidious taurus, voltzite, dev-0391, unc3236, G1017, PRC critical infrastructure, living off the land, LOTL, LOLBins, SOHO router botnet, KV botnet, OT pre-positioning, China state-sponsored stealth espionage emulation"
+  tags: adversary-emulation, china, prc, nation-state, critical-infrastructure, living-off-the-land, lotl, edge-devices, espionage, ot, stealth, G1017
+  mitre_attack: T1590, T1590.004, T1590.006, T1591, T1591.004, T1589, T1589.002, T1592, T1593, T1594, T1596.005, T1583.003, T1584.003, T1584.004, T1584.005, T1584.008, T1587.001, T1587.004, T1588.002, T1588.006, T1190, T1133, T1078, T1078.002, T1059.001, T1059.003, T1059.004, T1047, T1218, T1505.003, T1003.001, T1003.003, T1555, T1555.003, T1552, T1552.004, T1556, T1068, T1070.001, T1070.004, T1070.007, T1027.002, T1036.004, T1036.005, T1036.008, T1112, T1497.001, T1140, T1090, T1090.001, T1090.003, T1071.001, T1573.001, T1573.002, T1095, T1571, T1105, T1570, T1021.001, T1087.001, T1087.002, T1069.001, T1069.002, T1016, T1049, T1018, T1057, T1046, T1518.001, T1654, T1005, T1560.001, T1074.001, T1056.001, T1113
+---
+
+# Volt Typhoon (BRONZE SILHOUETTE, Vanguard Panda, Insidious Taurus) — Adversary Emulation Profile
+
+Volt Typhoon is a People's Republic of China (PRC) state-sponsored cyber actor active since at least mid-2021, tracked by MITRE ATT&CK as **G1017** and known by the aliases BRONZE SILHOUETTE (Secureworks), Vanguard Panda (CrowdStrike), Voltzite (Dragos), Insidious Taurus (Palo Alto Unit 42), DEV-0391 (Microsoft's pre-naming designation), and UNC3236 (Mandiant). Unlike financially motivated crews, Volt Typhoon's hallmark is patient, ultra-stealthy **pre-positioning** inside US critical infrastructure — communications, energy, water, and transportation — using almost exclusively **living-off-the-land (LOTL)** techniques and legitimate stolen credentials, with little or no custom malware on victim hosts. CISA, the NSA, and the FBI assess the group is establishing persistent access not for immediate espionage value but to enable lateral movement to operational technology (OT) for potential disruptive or destructive attacks during a future geopolitical crisis or conflict. Its operational signature is hands-on-keyboard activity, native OS binaries, web shells on edge appliances, and traffic proxied through compromised small-office/home-office (SOHO) routers to blend into normal network noise.
+
+## Attribution & motivation
+
+- **Sponsor / nation:** People's Republic of China (PRC), state-sponsored. CISA/NSA/FBI and Microsoft attribute the activity to a PRC nexus; Microsoft assessed the actor as PRC state-sponsored with high confidence.
+- **Motivation:** Strategic pre-positioning / preparation of the environment rather than classic data-theft espionage. Microsoft assessed *with moderate confidence* that the campaign pursues capabilities that could **disrupt critical communications infrastructure between the US and the Asia region during a future crisis**. CISA's AA24-038A frames the intent as enabling **destructive or disruptive cyberattacks against OT** in the event of conflict. This is closer to destructive/wartime-enabling than financial or influence motivation.
+- **Confidence:** Attribution to a PRC state-sponsored actor is high (joint government + multiple vendor concurrence). The disruptive-intent assessment is moderate confidence per the original reporting.
+
+## Targeting
+
+- **Sectors:** US critical infrastructure — communications, energy/utility (electric, water/wastewater), transportation systems, maritime, manufacturing, construction, government, information technology, and education.
+- **Regions:** Continental United States and **US territories, notably Guam** (a strategic Indo-Pacific military hub). Activity also observed against partners in the Five Eyes. The August 2024 Versa Director campaign hit US-based ISPs, MSPs, and IT-sector organizations and at least one non-US victim.
+- **Victim profile:** Organizations whose disruption would have outsized strategic/military impact, plus the ISPs/MSPs/edge-device fleets that provide stealthy infrastructure and downstream reach. The group also targets the personal email of key network and IT staff to aid intrusion.
+
+## Notable campaigns
+
+- **Mid-2021 onward — Initial critical-infrastructure intrusions.** Volt Typhoon begins long-dwell operations against US critical infrastructure, including in Guam. (Microsoft, 2023-05-24)
+- **2023-05-24 — Public exposure ("Volt Typhoon").** Microsoft and a Five Eyes joint advisory detail LOTL tradecraft, initial access via internet-facing Fortinet FortiGuard devices, and C2 proxying through compromised SOHO routers (ASUS, Cisco, D-Link, NETGEAR, Zyxel). (Microsoft Security Blog)
+- **2023-12 — KV Botnet disclosure.** Lumen's Black Lotus Labs publicly discloses the **KV Botnet**, a covert network of compromised end-of-life Cisco and NETGEAR SOHO routers used to anonymize and proxy Volt Typhoon operations. (Lumen / Black Lotus Labs)
+- **2024-01-31 — DOJ/FBI court-authorized takedown.** The US announces a December 2023 court-authorized operation that remotely removed KV Botnet malware from hundreds of US-based SOHO routers and severed their C2. (US DOJ)
+- **2024-02-07 — CISA AA24-038A.** CISA, NSA, FBI and international partners publish "PRC State-Sponsored Actors Compromise and Maintain Persistent Access to U.S. Critical Infrastructure," reporting persistence of up to ~five years in some victim networks and explicit OT pre-positioning concerns, alongside supplemental LOTL hunting guidance. (CISA)
+- **2024-08-27 — Versa Director zero-day (CVE-2024-39717).** Black Lotus Labs attributes (moderate confidence) exploitation of a Versa Director SD-WAN management zero-day, beginning around 2024-06-12, deploying the bespoke in-memory **VersaMem** Java web shell to harvest plaintext credentials at ISPs/MSPs/IT firms. (Lumen / Black Lotus Labs)
+
+## TTPs by ATT&CK tactic
+
+### Reconnaissance
+- **T1590 / T1590.004 / T1590.006** — Extensive pre-compromise gathering of victim network info, network topology, and network security appliances.
+- **T1591 / T1591.004** — Org reconnaissance; identifies key network/IT staff roles.
+- **T1589 / T1589.002** — Gathers identity info including personal email addresses of network/IT personnel.
+- **T1592** — Host reconnaissance prior to compromise.
+- **T1593 / T1594** — Searches open websites/domains and victim-owned sites.
+- **T1596.005** — Uses scan databases (Shodan, Censys, FOFA) to find exposed infrastructure.
+
+### Resource Development
+- **T1583.003 / T1584.003 / T1584.004 / T1584.005 / T1584.008** — Acquires VPS and compromises VPS, servers (e.g., PRTG), botnets (KV Botnet), and network edge devices in victim geographies for C2.
+- **T1587.001 / T1587.004** — Develops the VersaMem web shell variant and zero-day exploits.
+- **T1588.002 / T1588.006** — Obtains legitimate/forensic tooling and publicly available exploit code.
+
+### Initial Access
+- **T1190** — Exploits public-facing applications: Fortinet FortiGuard, Ivanti, Citrix, Cisco, NETGEAR, and Versa Director (CVE-2024-39717).
+- **T1133** — Uses external remote services / VPNs to connect and run post-exploitation actions.
+- **T1078 / T1078.002** — Relies primarily on valid (often domain) accounts for access and persistence.
+
+### Execution
+- **T1059.001 / T1059.003 / T1059.004** — PowerShell, Windows cmd, and Unix/Bash shells for discovery and hands-on-keyboard ops (KV Botnet uses Bash).
+- **T1047** — WMI/WMIC for execution, discovery, and creating temp directories.
+- **T1218** — Native LOLBins to expand access.
+
+### Persistence
+- **T1505.003** — Web shells (e.g., `AuditReport.jspx`, `iisstart.aspx`, Awen, and VersaMem on Versa Director).
+- **T1078 / T1078.002** — Stolen valid/domain credentials are the primary persistence mechanism (no implant needed).
+
+### Privilege Escalation
+- **T1068** — Exploits OS and network-service vulnerabilities for escalation.
+- **T1078.002** — Reuses harvested domain admin credentials to operate at elevated privilege.
+
+### Defense Evasion
+- **T1070.001 / T1070.004 / T1070.007** — Selectively clears Windows event logs, deletes working directories (`rd /S`), and scrubs IP addresses from server logs.
+- **T1027.002** — UPX-packs tools (BrightmetricAgent.exe, ScanLine).
+- **T1036.004 / T1036.005 / T1036.008** — Masquerades process/service names (KV Botnet renames to `[kworker/0:1]`), uses legitimate-looking filenames (`cisco_up.exe`, `Win.exe`), and appends `.gif` to exfil archives of ntds.dit.
+- **T1112** — `netsh` PortProxy registry modification.
+- **T1497.001** — System checks to detect virtualized/sandbox environments.
+- **T1140** — Base64 decode and deobfuscation (incl. via certutil).
+
+### Credential Access
+- **T1003.001** — Attempts LSASS memory access for hashed credentials.
+- **T1003.003** — Uses `ntdsutil` to create domain controller install media containing the NTDS database; dumps ntds.dit.
+- **T1555 / T1555.003** — Targets password stores (OpenSSH, RealVNC, PuTTY) and browser-stored credentials of network admins.
+- **T1552 / T1552.004** — Harvests credentials from network appliances and private keys (Chrome Local State AES key).
+- **T1556** — Hooks Versa's authentication routine via VersaMem to capture plaintext credentials.
+
+### Discovery
+- **T1087.001 / T1087.002** — `net user`, `quser`, `net group /dom` for local and domain account discovery.
+- **T1069.001 / T1069.002** — `net localgroup administrators`, `net group` for local/domain groups.
+- **T1016** — `ipconfig`, `netsh interface firewall`, `netsh interface portproxy`.
+- **T1049** — `netstat -ano`.
+- **T1018 / T1046** — Remote system discovery (Ping) and network service discovery via commercial + LOTL tools.
+- **T1057** — Process enumeration (KV Botnet flags security processes).
+- **T1518.001** — Security-software discovery.
+- **T1654** — Log enumeration via `wevtutil.exe` and PowerShell `Get-EventLog`.
+
+### Lateral Movement
+- **T1021.001** — RDP to domain controllers with compromised credentials.
+- **T1570** — Copies web shells between servers.
+
+### Collection
+- **T1005** — Steals files from sensitive servers, Active Directory, and event logs.
+- **T1560.001** — Archives ntds.dit into multi-volume password-protected 7-Zip archives.
+- **T1074.001** — Stages ntds.dit, SYSTEM, and SECURITY hives in `C:\Windows\Temp\`.
+- **T1056.001** — Keylogging (`rult3uil.log` on domain controllers).
+- **T1113** — Screen capture via gdi32.dll/gdiplus.dll.
+
+### Command and Control
+- **T1090 / T1090.001 / T1090.003** — Proxying through compromised SOHO devices; internal `netsh port proxy`; multi-hop proxy chains. Customized FRP, Earthworm, and Impacket.
+- **T1071.001 / T1573.001 / T1573.002** — HTTPS web-protocol C2 (Versa) on 443; AES-encrypted Awen web shell; asymmetric/symmetric encrypted channels.
+- **T1095 / T1571** — Non-application-layer / custom protocols; KV Botnet random high port (>30000).
+- **T1105** — Ingress tool transfer (e.g., downloads outdated comsvcs.dll).
+
+### Exfiltration
+- Exfiltration occurs over the encrypted proxied C2 channel (**T1090 / T1071.001 / T1573.002**), moving the password-protected, often `.gif`-renamed archives (**T1560.001 / T1036.008**) staged on the host. The group avoids large-volume exfil to stay quiet, consistent with its access-maintenance objective.
+
+### Impact
+- No destructive impact has been publicly confirmed in victim networks; the documented activity is **pre-positioning** for potential future disruptive/destructive attacks against OT per CISA AA24-038A. Emulation should model the access path and dwell, not actual destruction.
+
+## Signature tooling & malware
+
+- **VersaMem (S1154)** — Custom in-memory Java web shell; injects into the Apache Tomcat process via the Java Instrumentation API + Javassist to hook authentication and steal plaintext credentials. Custom.
+- **KV Botnet** — Custom Linux malware running on compromised EOL Cisco/NETGEAR SOHO routers; renames to `[kworker/0:1]`, uses random high ports, bind-mounts to `/proc/`, and proxies/anonymizes operator traffic. Custom.
+- **FRP / Fast Reverse Proxy (S1144), Earthworm, Impacket (S0357)** — Customized open-source proxy/tunneling and lateral-movement frameworks.
+- **Mimikatz (S0002)** — Credential dumping (LSASS).
+- **Living-off-the-land binaries:** `cmd` (S0106), `certutil` (S0160), `netsh` (S0108), `Net` (S0039), `netstat` (S0104), `Nltest` (S0359), `Ping` (S0097), `PsExec` (S0029), `Reg` (S0075), `Systeminfo` (S0096), `Tasklist` (S0057), `Wevtutil` (S0645), `ipconfig` (S0100), plus `ntdsutil`, `wmic`, `vssadmin`, `wevtutil`. Web shells observed: Awen, `AuditReport.jspx`, `iisstart.aspx`. Recon/post-ex: ScanLine, BrightmetricAgent (UPX-packed).
+
+## Emulation guidance (Decepticon)
+
+> **Authorized use only.** Execute these TTPs solely within the documented scope and rules of engagement of an explicitly authorized red-team engagement. Do not target out-of-scope systems, real critical-infrastructure OT, or third-party edge devices, and never stage destructive actions — Volt Typhoon's value to emulate is its *stealth and dwell*, not impact.
+
+Map Volt Typhoon's signature to Decepticon capabilities:
+
+- **Initial access (T1190 / T1133):** Use Decepticon's exploitation/recon tooling to identify and exploit in-scope internet-facing appliances (VPN/SD-WAN/edge). Mirror the edge-device-first pattern. Capture device-stored AD service-account credentials and pivot inward with **valid accounts (T1078)** instead of dropping implants.
+- **LOTL execution (T1059.x / T1047 / T1218):** Drive everything through the **bash** skill and native Windows binaries — `wmic`, `powershell`, `cmd`, `netsh`. Forbid yourself from uploading EXEs where a LOLBin works. This is the defining behavior to reproduce.
+- **AD / credential access (T1003.003 / T1003.001 / T1555):** Use the **AD skills** to emulate `ntdsutil`/`ntds.dit` capture and LSASS access; stage hives in `C:\Windows\Temp\`, 7-Zip into password-protected multi-volume archives, and rename with a `.gif` extension to mirror **T1560.001 / T1074.001 / T1036.008**.
+- **Persistence via web shells (T1505.003):** Use the **defense-evasion** / payload skills to plant a minimal web shell on an in-scope server, mimicking VersaMem's auth-hook credential capture rather than a noisy beacon.
+- **C2 & proxying (T1090 / T1071.001 / T1573.x):** Configure **Sliver (c2)** for HTTPS on 443 through an in-scope multi-hop proxy chain to emulate the SOHO-router relay pattern; route via the **lateral-movement** skill with `netsh portproxy` for internal pivots (**T1090.001 / T1112**).
+- **Lateral movement (T1021.001 / T1570):** Use harvested domain creds for RDP to a DC and copy the web shell between hosts via the lateral-movement skill.
+- **Defense evasion (T1070.x / T1497.001):** Selectively clear engagement-relevant event logs (with blue-cell coordination/snapshots), run sandbox checks, and masquerade tool/process names to test the SOC's LOTL-detection maturity.
+- **Cloud skills:** If the in-scope environment is hybrid, emulate harvesting cloud/identity creds and pivoting to cloud-hosted management planes consistent with the actor's identity-centric tradecraft.
+- **Discovery (T1087/T1069/T1016/T1049/T1018):** Run the exact native commands (`net user`, `net group /dom`, `net localgroup administrators`, `ipconfig`, `netstat -ano`, `ping`) so blue can validate baseline detections.
+
+Pace operations slowly and quietly to exercise long-dwell detection rather than tripping volume-based alerts.
+
+## Detection & defense
+
+- **Hunt LOTL command lines:** Alert on anomalous `wmic`, `ntdsutil`/`ntdsutil.exe create`, `vssadmin create shadow`, `netsh interface portproxy add`, `reg save HKLM\SYSTEM|SECURITY`, `wevtutil cl`, and `net group /domain` issued by non-admin or service contexts (T1059, T1003.003, T1112, T1070.001). Follow CISA AA24-038A's supplemental LOTL guidance.
+- **NTDS/credential theft (T1003.003 / T1560.001):** Monitor for ntds.dit copies outside DCs, 7-Zip multi-volume archives, and files with mismatched extensions (e.g., `.gif` that are actually archives) in `C:\Windows\Temp\`.
+- **PortProxy / proxying (T1090.001 / T1112):** Detect `HKLM\...\PortProxy\v4tov4` registry writes and unexpected `netsh portproxy` listeners; baseline egress to identify SOHO/edge relays and multi-hop proxy chains.
+- **Edge & SOHO device hygiene (T1190 / T1584.005):** Patch/replace EOL routers (Cisco, NETGEAR), restrict management-interface exposure, and patch Fortinet/Ivanti/Citrix/Versa (notably CVE-2024-39717 — upgrade Versa Director ≥ 22.1.4). Restrict outbound from edge devices.
+- **Web shells (T1505.003):** Monitor web-server directories for new `.jspx`/`.aspx` files and unusual Tomcat/IIS child processes; for Versa, hunt in-memory Java agents hooking authentication and inspect `/var/versa` upload paths.
+- **Credential & identity controls (T1078 / T1556):** Enforce phishing-resistant MFA, segment and tier admin accounts, rotate appliance/service-account credentials, and disable credential storage in browsers/PuTTY for admin workstations. Alert on RDP to DCs from atypical hosts (T1021.001).
+- **Log integrity (T1070):** Forward logs off-host in real time so selective clearing on the endpoint does not erase evidence; alert on Security log clears (Event ID 1102) and Sysmon process-creation gaps.
+- **OT segmentation:** Strictly segment IT from OT, monitor IT-to-OT pivot paths, and treat any IT foothold near OT as a pre-positioning indicator consistent with this actor's intent.
+
+## Sources
+
+- MITRE ATT&CK — Volt Typhoon (G1017): https://attack.mitre.org/groups/G1017/
+- Microsoft Security Blog — "Volt Typhoon targets US critical infrastructure with living-off-the-land techniques" (2023-05-24): https://www.microsoft.com/en-us/security/blog/2023/05/24/volt-typhoon-targets-us-critical-infrastructure-with-living-off-the-land-techniques/
+- CISA AA24-038A — "PRC State-Sponsored Actors Compromise and Maintain Persistent Access to U.S. Critical Infrastructure" (2024-02-07): https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-038a
+- Lumen Black Lotus Labs — Versa Director zero-day (CVE-2024-39717) / VersaMem (2024-08-27): https://blog.lumen.com/uncovering-the-versa-director-zero-day-exploitation/
+- US DOJ / FBI — KV Botnet court-authorized takedown reporting (2024-01-31): https://www.securityweek.com/us-gov-disrupts-soho-router-botnet-used-by-chinese-apt-volt-typhoon/

--- a/packages/decepticon/decepticon/skills/standard/post-exploit/macos/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/post-exploit/macos/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: macos-post-exploitation
+description: "macOS endpoint post-exploitation — launchd persistence, TCC bypass, Keychain credential access, dylib hijacking, Gatekeeper/quarantine evasion, and discovery on Apple hosts."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: post-exploitation
+  when_to_use: "macOS, mac, osx, apple, launchd, LaunchAgent, LaunchDaemon, TCC, keychain, dylib hijack, Gatekeeper, quarantine, xattr, codesign, dscl, jamf, mdm"
+  tags: macos, osx, persistence, tcc, keychain, dylib, gatekeeper, launchd, privesc, credential-access
+  mitre_attack: T1543.001, T1543.004, T1547.011, T1574.004, T1547.015, T1555.001, T1059.002, T1553.001, T1222.002, T1087.001, T1518, T1647
+---
+
+# macOS post-exploitation
+
+Post-compromise operations on Apple/macOS endpoints. Apple's controls
+(TCC, Gatekeeper/quarantine, SIP, code signing, AMFI) shape every step, so the
+playbook is organized around defeating or living within them. Prefer
+on-host built-ins (`launchctl`, `security`, `sqlite3`, `dscl`, `system_profiler`,
+`codesign`, `xattr`) over dropped tooling for OPSEC.
+
+> Authorized engagements only. Stay within RoE scope; emulate destructive
+> actions as benign proofs unless explicitly authorized.
+
+## Discovery (T1087.001 / T1518 / T1647)
+- `system_profiler SPSoftwareDataType SPHardwareDataType` — OS build, model, SIP.
+- `csrutil status` — System Integrity Protection on/off.
+- `dscl . -list /Users | grep -v '^_'` — local accounts; `id`, `groups`.
+- `sw_vers`, `profiles status -type enrollment` — MDM/Jamf managed? (T1647 plist prefs).
+- Installed security tooling: `ls /Library/Objective-See`, `pgrep -l 'CrowdStrike|SentinelOne|falcon|Jamf|santad'`.
+
+## Privilege escalation
+- **TCC bypass / abuse (T1548 family).** TCC gates access to Documents, Desktop,
+  Downloads, camera/mic, Full Disk Access. Check `sqlite3
+  ~/Library/Application\ Support/com.apple.TCC/TCC.db 'select * from access'`
+  (user) and `/Library/Application Support/com.apple.TCC/TCC.db` (system, needs root).
+  Abuse an already-FDA-granted app (e.g. a terminal/Electron app) to read
+  protected data instead of triggering a prompt.
+- **Sudo / admin group.** `sudo -n true` (cached creds), membership in `admin`.
+- **Setuid hunting:** `find / -perm -4000 -type f 2>/dev/null`.
+
+## Persistence
+- **LaunchAgents / LaunchDaemons (T1543.001 / T1543.004).** Drop a plist in
+  `~/Library/LaunchAgents` (user, no root) or `/Library/LaunchDaemons` (root,
+  runs as root at boot); `launchctl bootstrap gui/$(id -u) <plist>`. The classic,
+  noisy-but-reliable mechanism.
+- **Login items (T1547.015)** via `osascript -e 'tell application "System Events"
+  to make login item ...'` or a Service Management (`SMAppService`) helper.
+- **Dylib hijacking / proxying (T1574.004).** Find apps with a writable/missing
+  `@rpath` or weak-linked dylib (`otool -l <app>`); plant a malicious dylib that
+  re-exports the original. Survives as the host app's identity.
+- **Re-opened apps / cron / emond / at** — lower-signal fallbacks.
+
+## Defense evasion
+- **Gatekeeper / quarantine (T1553.001).** Downloaded files carry the
+  `com.apple.quarantine` xattr; `xattr -d com.apple.quarantine <file>` (or
+  `xattr -c`) strips it so the binary runs without the Gatekeeper prompt.
+- **Code signing (T1553).** `codesign --force --deep --sign - <bundle>` ad-hoc
+  signs a tampered bundle; check `codesign -dv --verbose=4` and `spctl -a -vv`.
+- **File-permission/attribute manipulation (T1222.002):** `chflags`, `chmod`.
+- **AppleScript / osascript execution (T1059.002)** for living-off-the-land.
+
+## Credential access (T1555.001)
+- **Keychain.** `security find-generic-password -ga <svc>` /
+  `security find-internet-password`; `security dump-keychain -d
+  ~/Library/Keychains/login.keychain-db` (prompts unless unlocked). Offline:
+  exfil the `*.keychain-db` + the login password and crack with `chainbreaker`.
+- **Browser & app secrets** under `~/Library/Application Support/...` (often
+  TCC-protected — see TCC abuse above).
+- **Sudo/SSH keys** in `~/.ssh`, `~/.aws`, `~/.kube`.
+
+## Collection, C2 & exfil
+- Stage under `/tmp` or `~/Library/Caches`; archive with `tar`/`ditto`.
+- C2: prefer signed, allow-listed channels; see `post-exploit/c2` and
+  `post-exploit/c2-sliver` (Sliver has a macOS implant). Beacon over HTTPS to
+  blend with managed-device telemetry.
+
+## Detection & defense (blue-cell notes)
+- Monitor new plists in `*/LaunchAgents` and `*/LaunchDaemons` and `launchctl`
+  bootstraps; alert on `xattr -d com.apple.quarantine`, ad-hoc `codesign`,
+  `security dump-keychain`, and TCC.db reads by non-Apple binaries.
+- Endpoint Security framework (ES) + tools like santad/Objective-See catch most
+  of the above; LOTL via `osascript`/`launchctl` is the gap to watch.
+
+## See also
+`post-exploit/credential-access`, `post-exploit/lateral-movement`,
+`post-exploit/privilege-escalation`, `shared/defense-evasion`, `reverser/ios-static`.


### PR DESCRIPTION
## What

A **threat-informed adversary-emulation** skill pack + a macOS asset-coverage playbook — addressing the request for more skills/playbooks, better asset coverage, and real APT profiles.

### `shared/adversary-emulation/` (loaded by every role)
- **`SKILL.md`** — index + a 5-step emulation **methodology** (select actor → load profile → scope to RoE → emulate in kill-chain order → measure & report), explicit authorized-use guardrails (destructive `Impact` techniques emulated as benign proofs), and an actor catalog. Ties into `soundwave/threat-profile` and `kill-chain-analysis`.
- **10 actor profiles**, each grounded in the authoritative **MITRE ATT&CK group page** (G-number verified) + public advisories (CISA/NCSC/Mandiant/Microsoft/Symantec/Kaspersky):

  | Profile | ATT&CK | Attribution / motivation |
  |---|---|---|
  | `apt29-cozy-bear` | G0016 | Russia SVR — espionage (SolarWinds, Midnight Blizzard) |
  | `apt28-fancy-bear` | G0007 | Russia GRU — espionage/influence |
  | `apt33-elfin` | G0064 | Iran — aerospace/energy espionage |
  | `apt34-oilrig` | G0049 | Iran — DNS-tunneling espionage |
  | `apt41-double-dragon` | G0096 | China — espionage **+** financial |
  | `lazarus-group` | G0032 | DPRK — financial + destructive |
  | `fin7-carbanak` | G0046 | financial — POS/retail, ransomware affiliate |
  | `sandworm-team` | G0034 | Russia GRU — destructive/ICS (NotPetya) |
  | `volt-typhoon` | G1017 | China — LOTL pre-positioning in critical infra |
  | `scattered-spider` | G1015 | financial — help-desk social engineering |

  Each profile: attribution & motivation (**why**), targeting (**who/where**), dated campaign timeline (**when/what**), **TTPs by ATT&CK tactic (how)** with real technique IDs, signature tooling/malware, **Decepticon emulation guidance** (maps each TTP to Decepticon's own tools/skills for authorized emulation), blue-cell **detection & defense** notes, and a **Sources** list. Uncertain intel is hedged (e.g., APT33↔StoneDrill flagged unproven), not asserted.

### `standard/post-exploit/macos/SKILL.md`
macOS endpoint post-exploitation (launchd persistence, TCC/Keychain, dylib hijacking, Gatekeeper/quarantine evasion, discovery), ATT&CK-mapped — the KB had Android + iOS-reversing but no macOS endpoint playbook.

## Verification
- All 12 new SKILL.md parse through **both** real frontmatter parsers (the flat in-process loader in `tools/skills.py` and the skillogy YAML registry) and are discovered by `iter_skill_records` → **227 skills** total.
- G-numbers independently verified against the live MITRE ATT&CK groups index; one profile (APT33) spot-checked end-to-end (real technique IDs incl. ICS `T085x`, real CVEs/campaigns, sourced).
- `ruff check` clean; `pytest` skills + skillogy unit suites → 77 passed. (Skills are markdown loaded on demand — no runtime/type surface.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
