### PR TITLE
fix(tools/cloud): honor IAM NotAction semantics in policy analyzer

### DIFF
--- a/packages/decepticon/decepticon/tools/cloud/aws.py
+++ b/packages/decepticon/decepticon/tools/cloud/aws.py
@@ -134,7 +134,47 @@ def analyze_iam_policy(policy: str | dict[str, Any]) -> list[IAMFinding]:
         effect = (stmt.get("Effect") or "Allow").lower()
         if effect != "allow":
             continue
-        for action in _as_list(stmt.get("Action") or stmt.get("NotAction") or "*"):
+
+        not_action_list = stmt.get("NotAction")
+        if not_action_list is not None:
+            excluded = [str(a).lower() for a in _as_list(not_action_list)]
+            resources = _as_list(stmt.get("Resource") or "*")
+            has_star_resource = any(str(r) == "*" for r in resources)
+            resource_summary = ", ".join(str(r) for r in resources)
+            excluded_summary = ", ".join(excluded) if excluded else "(none)"
+            idx += 1
+            if has_star_resource:
+                findings.append(
+                    IAMFinding(
+                        id=f"iam-{idx:04d}",
+                        severity="critical",
+                        title="Allow with NotAction on Resource=* grants near-admin",
+                        detail=(
+                            f"NotAction excludes only: {excluded_summary}. "
+                            "All other actions are allowed on every resource — "
+                            "effective admin grant."
+                        ),
+                        action=f"NotAction: {excluded_summary}",
+                        resource="*",
+                    )
+                )
+            else:
+                findings.append(
+                    IAMFinding(
+                        id=f"iam-{idx:04d}",
+                        severity="high",
+                        title="Allow with NotAction — inverted action set",
+                        detail=(
+                            f"NotAction excludes: {excluded_summary} on {resource_summary}. "
+                            "All other actions on those resources are implicitly allowed."
+                        ),
+                        action=f"NotAction: {excluded_summary}",
+                        resource=resource_summary,
+                    )
+                )
+            continue
+
+        for action in _as_list(stmt.get("Action") or "*"):
             act = str(action).lower()
             for resource in _as_list(stmt.get("Resource") or "*"):
                 res = str(resource)
@@ -151,7 +191,6 @@ def analyze_iam_policy(policy: str | dict[str, Any]) -> list[IAMFinding]:
                         )
                     )
                     continue
-                # Wildcarded action families
                 if act.endswith(":*") and res == "*":
                     idx += 1
                     findings.append(
@@ -164,7 +203,6 @@ def analyze_iam_policy(policy: str | dict[str, Any]) -> list[IAMFinding]:
                             resource=res,
                         )
                     )
-                # Known privesc primitives
                 matched = _PRIVESC_PRIMITIVES.get(act.strip("*"))
                 if matched:
                     sev, title, detail = matched

--- a/packages/decepticon/tests/unit/cloud/test_aws_notaction.py
+++ b/packages/decepticon/tests/unit/cloud/test_aws_notaction.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from decepticon.tools.cloud.aws import analyze_iam_policy
+
+
+class TestNotActionSemantics:
+    def test_notaction_star_resource_is_critical(self) -> None:
+        policy = {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "NotAction": "s3:GetObject",
+                    "Resource": "*",
+                }
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "critical"
+        assert "NotAction" in f.title
+        assert "s3:getobject" in f.detail
+
+    def test_notaction_scoped_resource_is_high(self) -> None:
+        policy = {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "NotAction": "iam:CreateAccessKey",
+                    "Resource": "arn:aws:iam::123456789012:user/bob",
+                }
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "high"
+        assert "NotAction" in f.title
+        assert "iam:createaccesskey" in f.detail
+
+    def test_notaction_does_not_match_primitives_as_if_action(self) -> None:
+        policy = {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "NotAction": "iam:CreateAccessKey",
+                    "Resource": "*",
+                }
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert not any("CreateAccessKey privilege escalation" in f.title for f in findings)
+
+    def test_notaction_list_star_resource_is_critical(self) -> None:
+        policy = {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "NotAction": ["s3:GetObject", "s3:PutObject"],
+                    "Resource": "*",
+                }
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert any(f.severity == "critical" for f in findings)
+        assert any("NotAction" in f.title for f in findings)
+
+    def test_action_path_still_works_after_fix(self) -> None:
+        policy = {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:CreateAccessKey",
+                    "Resource": "*",
+                }
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert any("CreateAccessKey" in f.title for f in findings)
+
+    def test_deny_notaction_is_ignored(self) -> None:
+        policy = {
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "NotAction": "s3:GetObject",
+                    "Resource": "*",
+                }
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert len(findings) == 0


### PR DESCRIPTION
## Defect

`analyze_iam_policy` in `packages/decepticon/decepticon/tools/cloud/aws.py` (line 137) aliased `NotAction` to `Action` via `stmt.get("Action") or stmt.get("NotAction")`. AWS `NotAction` has inverted semantics: `{"Effect":"Allow","NotAction":"s3:GetObject","Resource":"*"}` grants **every** action except `s3:GetObject` — effective admin access. The old code iterated only the excluded action, ran it through the primitive matcher, reported nothing, and returned zero findings — a false negative on a common privesc pattern. Conversely, a `NotAction: "iam:CreateAccessKey"` statement would trigger a false-positive CreateAccessKey finding even though that action is the one being withheld.

## Impact

The `iam_policy_audit` tool silently produces wrong results for any policy using `NotAction`. A `NotAction`+`Resource=*` grant (a known IAM privilege-escalation pattern used in real attacker policies) goes entirely unreported.

## Fix

`NotAction` statements are now handled in a dedicated branch before the `Action` loop:
- `Allow` + `NotAction` + `Resource=*` → **critical** finding (near-admin grant)
- `Allow` + `NotAction` + scoped resource → **high** finding (inverted action set on those resources)
- The per-primitive privesc matcher only runs against genuine `Action` lists

## Regression test

`packages/decepticon/tests/unit/cloud/test_aws_notaction.py` — 6 cases covering:
- `NotAction` + `Resource=*` → critical
- `NotAction` + scoped resource → high
- No false-positive primitive match from `NotAction` values
- List-valued `NotAction`
- Regular `Action` path still produces correct findings
- `Deny`+`NotAction` ignored

All 29 tests (6 new + 23 existing cloud tests) green.

No interaction with in-flight PRs (no open PR touches `aws.py` or the cloud test suite).