### PR TITLE
fix(roe): close two target-extraction scope bypasses (URL userinfo + TLD/extension collision)

### DIFF
--- a/packages/decepticon/decepticon/middleware/_command_targets.py
+++ b/packages/decepticon/decepticon/middleware/_command_targets.py
@@ -33,7 +33,10 @@ from collections.abc import Callable
 
 _IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 _CIDR_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}\b")
-_URL_RE = re.compile(r"\b(?:https?|ftp|file|smb|nfs|ssh|rdp|ldaps?)://([^\s/:]+)", re.IGNORECASE)
+_URL_RE = re.compile(
+    r"\b(?:https?|ftp|file|smb|nfs|ssh|rdp|ldaps?)://(?:[^\s/@]+@)?([^\s/:@]+)",
+    re.IGNORECASE,
+)
 _HOSTNAME_AFTER_VERB_RE = re.compile(
     r"\b(?:curl|wget|httpx|nmap|masscan|rustscan|ssh|scp|sftp|rsync|"
     r"smbclient|smbmap|crackmapexec|nxc|netexec|nikto|sqlmap|hydra|ffuf|"
@@ -47,10 +50,15 @@ _HOSTNAME_AFTER_VERB_RE = re.compile(
 )
 
 
-# Final labels that mark a token as a local file argument, never a network
-# target. No public DNS TLD collides with any of these, so excluding them is
-# safe and prevents RoE ENFORCE mode from refusing legitimate commands whose
-# option values (``-i key.pem``, ``-oA scan.txt``) look hostname-shaped.
+# Final labels that mark a token as a local-file argument, never a network
+# target, so RoE ENFORCE mode does not refuse legitimate commands whose option
+# values (``-i key.pem``, ``-oA scan.txt``) look hostname-shaped.
+#
+# SECURITY: an entry here is only safe if it is NOT also a delegated DNS TLD.
+# Real TLDs (``.sh`` ``.md`` ``.py`` ``.pl`` ``.pub`` ``.zip`` …) were removed:
+# leaving them in silently dropped genuine hosts such as ``evil.zip`` from RoE
+# scope enforcement. Per this module's design, over-extracting a spurious
+# target (which the operator can override) is safer than dropping a real one.
 _NON_TARGET_EXTENSIONS: frozenset[str] = frozenset(
     {
         "pem",
@@ -61,7 +69,6 @@ _NON_TARGET_EXTENSIONS: frozenset[str] = frozenset(
         "der",
         "p12",
         "pfx",
-        "pub",
         "txt",
         "log",
         "json",
@@ -76,12 +83,8 @@ _NON_TARGET_EXTENSIONS: frozenset[str] = frozenset(
         "xml",
         "html",
         "htm",
-        "md",
         "rst",
-        "sh",
-        "py",
         "rb",
-        "pl",
         "ps1",
         "bat",
         "pcap",
@@ -95,7 +98,6 @@ _NON_TARGET_EXTENSIONS: frozenset[str] = frozenset(
         "sqlite",
         "sqlite3",
         "gz",
-        "zip",
         "tar",
         "tgz",
         "7z",

--- a/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
+++ b/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
@@ -25,7 +25,9 @@ def test_userinfo_host_still_strips_port():
 
 
 def test_plain_url_host_unchanged():
-    assert any(target == "example.com" for target in extract_targets("curl https://example.com/path?q=1"))
+    assert any(
+        target == "example.com" for target in extract_targets("curl https://example.com/path?q=1")
+    )
 
 
 @pytest.mark.parametrize(

--- a/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
+++ b/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from decepticon.middleware._command_targets import _is_valid_target, extract_targets
+
+
+@pytest.mark.parametrize(
+    "command,expected_host",
+    [
+        ("curl https://user:pass@evil.example/", "evil.example"),
+        ("curl ftp://anonymous@out.example", "out.example"),
+        ("wget http://attacker%40svc@hidden.example/x", "hidden.example"),
+        ("smbclient smb://user@10.20.30.40/share", "10.20.30.40"),
+    ],
+)
+def test_userinfo_does_not_hide_the_real_host(command, expected_host):
+    assert expected_host in extract_targets(command)
+
+
+def test_userinfo_host_still_strips_port():
+    targets = extract_targets("curl https://user:pass@example.com:8443/admin")
+    assert "example.com" in targets
+    assert "example.com:8443" not in targets
+
+
+def test_plain_url_host_unchanged():
+    assert "example.com" in extract_targets("curl https://example.com/path?q=1")
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["evil.zip", "target.sh", "pay.md", "exploit.py", "domain.pl", "docs.pub"],
+)
+def test_tld_colliding_hosts_are_extracted(host):
+    assert _is_valid_target(host) is True
+    assert host in extract_targets(f"curl https://{host}/")
+
+
+@pytest.mark.parametrize(
+    "fname",
+    ["key.pem", "scan.txt", "creds.json", "out.log", "dump.pcap", "data.csv", "archive.tar"],
+)
+def test_local_file_arguments_are_still_excluded(fname):
+    assert _is_valid_target(fname) is False
+    assert fname not in extract_targets(f"nmap -oA {fname} 10.0.0.1")
+
+
+def test_oa_output_file_excluded_but_ip_kept():
+    targets = extract_targets("nmap -oA report.txt 10.0.0.1")
+    assert targets == {"10.0.0.1"}

--- a/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
+++ b/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
@@ -15,17 +15,17 @@ from decepticon.middleware._command_targets import _is_valid_target, extract_tar
     ],
 )
 def test_userinfo_does_not_hide_the_real_host(command, expected_host):
-    assert expected_host in extract_targets(command)
+    assert any(target == expected_host for target in extract_targets(command))
 
 
 def test_userinfo_host_still_strips_port():
     targets = extract_targets("curl https://user:pass@example.com:8443/admin")
-    assert "example.com" in targets
-    assert "example.com:8443" not in targets
+    assert any(target == "example.com" for target in targets)
+    assert all(target != "example.com:8443" for target in targets)
 
 
 def test_plain_url_host_unchanged():
-    assert "example.com" in extract_targets("curl https://example.com/path?q=1")
+    assert any(target == "example.com" for target in extract_targets("curl https://example.com/path?q=1"))
 
 
 @pytest.mark.parametrize(
@@ -34,7 +34,7 @@ def test_plain_url_host_unchanged():
 )
 def test_tld_colliding_hosts_are_extracted(host):
     assert _is_valid_target(host) is True
-    assert host in extract_targets(f"curl https://{host}/")
+    assert any(target == host for target in extract_targets(f"curl https://{host}/"))
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_tld_colliding_hosts_are_extracted(host):
 )
 def test_local_file_arguments_are_still_excluded(fname):
     assert _is_valid_target(fname) is False
-    assert fname not in extract_targets(f"nmap -oA {fname} 10.0.0.1")
+    assert all(target != fname for target in extract_targets(f"nmap -oA {fname} 10.0.0.1"))
 
 
 def test_oa_output_file_excluded_but_ip_kept():


### PR DESCRIPTION
## Summary
The RoE evaluator refuses out-of-scope hosts only for targets returned by `extract_targets()` (`middleware/roe.py:205`). Two extraction gaps let a host evade scope enforcement entirely.

### 1. URL userinfo bypass (security)
`_URL_RE` captured `[^\s/:]+` immediately after `://`, so `curl https://user:pass@evil.example/` captured `user` (dropped as invalid) and the **real host `evil.example` was never evaluated** by RoE. The regex now skips an optional `userinfo@` segment and captures the host, excluding `@`.

### 2. TLD / file-extension collision (security)
`_NON_TARGET_EXTENSIONS` dropped any token whose last label matched a file extension — but `.sh .md .py .pl .pub .zip` are **delegated DNS TLDs**, so `curl https://evil.zip` was silently dropped from scope enforcement. Those real-TLD entries are removed (file-only extensions retained); the stale comment claiming no TLD collides is corrected with a security rationale to prevent regression.

Both fixes err toward over-extraction, matching this module's documented *"false positives are safer than false negatives"* design — a spurious target is operator-overridable; a dropped real one is a silent scope breach.

## Tests
New `tests/unit/middleware/test_command_targets_scope_bypass.py`: userinfo stripping (with port handling), TLD-colliding hosts now extracted, and confirmation that genuine local-file arguments (`key.pem`, `scan.txt`, …) stay excluded. Full existing RoE suite passes (64 tests green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)