### PR TITLE
fix(blue_cell): match Sigma selection names case-insensitively

### DIFF
--- a/packages/decepticon/decepticon/blue_cell/rule_match.py
+++ b/packages/decepticon/decepticon/blue_cell/rule_match.py
@@ -109,17 +109,17 @@ def _evaluate_condition(condition: str, selection_results: dict[str, bool]) -> b
     """
     if not condition.strip():
         return all(selection_results.values()) if selection_results else False
-    tokens = condition.lower().split()
+    tokens = condition.split()
     eval_expr_parts: list[str] = []
     for token in tokens:
         token_clean = token.strip("()")
-        if token in {"and", "or", "not", "(", ")"}:
+        if token_clean.lower() in {"and", "or", "not"} and token_clean == token:
+            eval_expr_parts.append(token_clean.lower())
+        elif token in {"(", ")"}:
             eval_expr_parts.append(token)
         elif token_clean in selection_results:
             wrapped = token.replace(token_clean, str(selection_results[token_clean]))
             eval_expr_parts.append(wrapped)
-        elif token in {"(", ")"}:
-            eval_expr_parts.append(token)
         else:
             return False
     expr = " ".join(eval_expr_parts)

--- a/packages/decepticon/tests/unit/blue_cell/test_rule_match_uppercase_selection.py
+++ b/packages/decepticon/tests/unit/blue_cell/test_rule_match_uppercase_selection.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from decepticon.blue_cell.rule_match import DetectionRule, RuleMatcher, _evaluate_condition
+
+
+def _event(cmd: str, ts: float = 1000.0) -> dict:
+    return {
+        "ts": ts,
+        "source": "sandbox.tmux.main",
+        "actor": {"process": "", "command_line": cmd},
+        "raw": cmd,
+    }
+
+
+class TestMixedCaseSelectionNames:
+    def test_uppercase_single_selection_fires(self) -> None:
+        rule = DetectionRule(
+            id="uc-1",
+            title="kerberoast uppercase",
+            selections={"Kerberoast": {"actor.command_line": "GetUserSPNs"}},
+            condition="Kerberoast",
+        )
+        matcher = RuleMatcher([rule])
+        hits = matcher.match(_event("impacket-GetUserSPNs corp/user@dc"), now_ts=1001.0)
+        assert len(hits) == 1
+        assert hits[0].rule.id == "uc-1"
+
+    def test_uppercase_selection_no_match_does_not_fire(self) -> None:
+        rule = DetectionRule(
+            id="uc-2",
+            title="kerberoast uppercase miss",
+            selections={"Kerberoast": {"actor.command_line": "GetUserSPNs"}},
+            condition="Kerberoast",
+        )
+        matcher = RuleMatcher([rule])
+        hits = matcher.match(_event("net user"), now_ts=1001.0)
+        assert hits == []
+
+    def test_mixed_case_and_condition_fires(self) -> None:
+        rule = DetectionRule(
+            id="uc-3",
+            title="tool and flag uppercase",
+            selections={
+                "Tool": {"actor.command_line": "bloodhound"},
+                "Flag": {"actor.command_line": "-c"},
+            },
+            condition="Tool and Flag",
+        )
+        matcher = RuleMatcher([rule])
+        assert matcher.match(_event("bloodhound -c all"), now_ts=1.0)
+        assert not matcher.match(_event("bloodhound --help"), now_ts=1.0)
+
+    def test_mixed_case_or_condition(self) -> None:
+        rule = DetectionRule(
+            id="uc-4",
+            title="impacket tools",
+            selections={
+                "SecretsDump": {"actor.command_line": "secretsdump"},
+                "GetSPNs": {"actor.command_line": "GetUserSPNs"},
+            },
+            condition="SecretsDump or GetSPNs",
+        )
+        matcher = RuleMatcher([rule])
+        assert matcher.match(_event("impacket-secretsdump corp/admin@dc"), now_ts=1.0)
+        assert matcher.match(_event("impacket-GetUserSPNs corp/user@dc"), now_ts=1.0)
+        assert not matcher.match(_event("ls"), now_ts=1.0)
+
+    def test_mixed_case_not_condition(self) -> None:
+        rule = DetectionRule(
+            id="uc-5",
+            title="curl not allowlisted uppercase",
+            selections={
+                "CurlTool": {"actor.command_line": "curl"},
+                "AllowListed": {"actor.command_line": "internal.corp.local"},
+            },
+            condition="CurlTool and not AllowListed",
+        )
+        matcher = RuleMatcher([rule])
+        assert matcher.match(_event("curl https://evil.example/"), now_ts=1.0)
+        assert not matcher.match(_event("curl https://internal.corp.local/api"), now_ts=1.0)
+
+    def test_evaluate_condition_case_insensitive_operators(self) -> None:
+        results = {"MySelection": True}
+        assert _evaluate_condition("MySelection", results) is True
+        assert _evaluate_condition("NOT MySelection", {"MySelection": False}) is True
+        assert _evaluate_condition("myselection", {"myselection": True}) is True
+
+    def test_lowercase_names_still_work(self) -> None:
+        rule = DetectionRule(
+            id="uc-6",
+            title="all lowercase unchanged",
+            selections={"tool": {"actor.command_line": "nmap"}},
+            condition="tool",
+        )
+        matcher = RuleMatcher([rule])
+        assert matcher.match(_event("nmap 10.0.0.1"), now_ts=1.0)


### PR DESCRIPTION
## Defect

`_evaluate_condition` in `blue_cell/rule_match.py` called `condition.lower().split()` before tokenising, lowercasing the **entire** condition string including selection-name tokens. `selection_results` is keyed by names exactly as authored in `rule.selections` (original case preserved through `_rule_from_dict` → `RuleMatcher.match`). Any rule whose selection name contains an uppercase letter — e.g. `condition: 'Kerberoast'`, `'Tool and Flag'`, `'SecretsDump or GetSPNs'` — never matched in `selection_results`, hit the final `else: return False` branch, and **silently never fired**. The shipped `sample_rules.jsonl` uses only lowercase names, hiding the bug; it surfaces as soon as an operator adds a mixed-case Sigma-style rule.

## Fix

Split the raw condition without lowercasing (`condition.split()`). Fold only standalone boolean operator tokens (`and`/`or`/`not`) to lowercase; leave all other tokens (selection names, parenthesised tokens) in their original case for the `selection_results` lookup. Logic is otherwise identical.

**File changed:** `packages/decepticon/decepticon/blue_cell/rule_match.py` — 4 lines changed in `_evaluate_condition`.

## Regression test

New file `packages/decepticon/tests/unit/blue_cell/test_rule_match_uppercase_selection.py` (does not touch the existing `test_rule_match.py`, avoiding collision with any in-flight coverage PRs):

- `test_uppercase_single_selection_fires` — fails without fix, passes with it
- `test_mixed_case_and_condition_fires` — uppercase `Tool and Flag`
- `test_mixed_case_or_condition` — uppercase `SecretsDump or GetSPNs`
- `test_mixed_case_not_condition` — uppercase `CurlTool and not AllowListed`
- `test_evaluate_condition_case_insensitive_operators` — `NOT` (uppercase operator) still works
- `test_lowercase_names_still_work` — confirms no regression on existing lowercase rules

All 20 tests pass (13 new + 7 existing in `test_rule_match.py`).