### PR TITLE
fix(sandbox_server): constant-time daemon bearer-token comparison

### DIFF
--- a/packages/decepticon/decepticon/sandbox_server/app.py
+++ b/packages/decepticon/decepticon/sandbox_server/app.py
@@ -40,6 +40,7 @@ the right thing to ship as the default.
 from __future__ import annotations
 
 import base64
+import hmac
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -191,7 +192,7 @@ def _verify_token(authorization: str | None) -> None:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="missing bearer token",
         )
-    if authorization[len("Bearer ") :] != _required_token:
+    if not hmac.compare_digest(authorization[len("Bearer ") :], _required_token):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="invalid token",

--- a/packages/decepticon/tests/unit/sandbox_server/test_app_consttime_auth.py
+++ b/packages/decepticon/tests/unit/sandbox_server/test_app_consttime_auth.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+import types
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+app_module = importlib.import_module("decepticon.sandbox_server.app")
+app = app_module.app
+
+TOKEN = "correct-token-value"
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals() -> Iterator[None]:
+    for name in ("_backend", "_required_token"):
+        setattr(app_module, name, None)
+    yield
+    for name in ("_backend", "_required_token"):
+        setattr(app_module, name, None)
+
+
+def _make_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.execute.return_value = types.SimpleNamespace(
+        output="ok\n", exit_code=0, truncated=False
+    )
+    backend.kill_all_sessions.return_value = 0
+    return backend
+
+
+@contextlib.contextmanager
+def _client(backend: MagicMock, *, token: str | None) -> Iterator[TestClient]:
+    env: dict[str, str] = {} if token is None else {"SAAS_SANDBOX_TOKEN": token}
+    saved = os.environ.get("SAAS_SANDBOX_TOKEN")
+    with patch.object(app_module, "_get_backend", return_value=backend):
+        os.environ.pop("SAAS_SANDBOX_TOKEN", None)
+        os.environ.update(env)
+        try:
+            with TestClient(app) as client:
+                yield client
+        finally:
+            os.environ.pop("SAAS_SANDBOX_TOKEN", None)
+            if saved is not None:
+                os.environ["SAAS_SANDBOX_TOKEN"] = saved
+
+
+def test_verify_token_uses_compare_digest() -> None:
+    import hmac as _hmac
+
+    verify = app_module._verify_token
+    setattr(app_module, "_required_token", TOKEN)
+    calls: list[tuple[str, str]] = []
+    original = _hmac.compare_digest
+
+    def spy(a: str, b: str) -> bool:
+        calls.append((a, b))
+        return original(a, b)
+
+    with patch.object(_hmac, "compare_digest", side_effect=spy):
+        try:
+            verify(f"Bearer {TOKEN}")
+        except Exception:
+            pass
+
+    assert len(calls) == 1, "hmac.compare_digest must be called for token comparison"
+    assert calls[0] == (TOKEN, TOKEN)
+
+
+def test_correct_token_grants_access() -> None:
+    backend = _make_backend()
+    with _client(backend, token=TOKEN) as client:
+        resp = client.post(
+            "/execute",
+            json={"command": "echo hi"},
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+    assert resp.status_code == 200
+
+
+def test_wrong_token_is_rejected_401() -> None:
+    backend = _make_backend()
+    with _client(backend, token=TOKEN) as client:
+        resp = client.post(
+            "/execute",
+            json={"command": "echo hi"},
+            headers={"Authorization": "Bearer wrong-value"},
+        )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "invalid token"

--- a/packages/decepticon/tests/unit/sandbox_server/test_app_consttime_auth.py
+++ b/packages/decepticon/tests/unit/sandbox_server/test_app_consttime_auth.py
@@ -63,10 +63,8 @@ def test_verify_token_uses_compare_digest() -> None:
         return original(a, b)
 
     with patch.object(_hmac, "compare_digest", side_effect=spy):
-        try:
+        with contextlib.suppress(Exception):
             verify(f"Bearer {TOKEN}")
-        except Exception:
-            pass
 
     assert len(calls) == 1, "hmac.compare_digest must be called for token comparison"
     assert calls[0] == (TOKEN, TOKEN)


### PR DESCRIPTION
## Defect

`_verify_token` in `sandbox_server/app.py` compared the extracted bearer token against `_required_token` using Python's `!=` operator, which short-circuits on the first differing byte. This leaks timing information about the length of the correct prefix, enabling a remote timing oracle against `SAAS_SANDBOX_TOKEN` — the shared secret that gates every privileged sandbox endpoint (`/execute`, `/execute_tmux`, `/upload_files`, `/download_files`, `/start_background`, etc.).

The daemon supports arbitrary `base_url` hosts via `HTTPSandbox`, so it can be exposed on a service-mesh or Kubernetes address, making the timing surface reachable.

Every other secret comparison in the codebase already uses `hmac.compare_digest` (`middleware/_audit_sink.py:213`, `tools/web/jwt.py:266/276`); this site was the sole inconsistency.

## Fix

- Added `import hmac` to `sandbox_server/app.py`.
- Replaced `authorization[len("Bearer "):] != _required_token` with `not hmac.compare_digest(authorization[len("Bearer "):], _required_token)`.

## Regression test

New file `tests/unit/sandbox_server/test_app_consttime_auth.py` (does not edit the existing `test_app.py` to avoid collision with in-flight PRs):

- `test_verify_token_uses_compare_digest` — spies on `hmac.compare_digest` and asserts it is invoked with the token pair; this test **fails on the original code** (spy is never called) and **passes after the fix**.
- `test_correct_token_grants_access` — HTTP 200 with the right token.
- `test_wrong_token_is_rejected_401` — HTTP 401 with an incorrect token.

All 27 tests in the `sandbox_server` suite pass.