### PR TITLE
fix(tools/reversing): correct Ghidra recon script entry-point handling

### DIFF
--- a/packages/decepticon/decepticon/tools/reversing/scripts.py
+++ b/packages/decepticon/decepticon/tools/reversing/scripts.py
@@ -32,7 +32,6 @@ print("[+] Functions: {{}}".format(fm.getFunctionCount()))
 for f in fm.getFunctions(True):
     name = f.getName()
     if not f.isThunk() and f.isExternal() is False:
-        addrs = [str(a) for a in f.getEntryPoint()]
         print("fn {{}} @ {{}}".format(name, f.getEntryPoint()))
 
 # Dump external imports (likely interesting APIs)

--- a/packages/decepticon/tests/unit/reversing/test_ghidra_script_entrypoint.py
+++ b/packages/decepticon/tests/unit/reversing/test_ghidra_script_entrypoint.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from decepticon.tools.reversing.scripts import ghidra_recon_script
+
+
+class TestGhidraReconScriptEntrypoint:
+    def test_no_iterable_getentrypoint(self) -> None:
+        src = ghidra_recon_script("/workspace/target")
+        assert "for a in f.getEntryPoint()" not in src
+
+    def test_addrs_variable_absent(self) -> None:
+        src = ghidra_recon_script("/workspace/target")
+        assert "addrs" not in src
+
+    def test_entrypoint_printed_once(self) -> None:
+        src = ghidra_recon_script("/workspace/target")
+        assert src.count("getEntryPoint()") == 1
+
+    def test_binary_path_substituted(self) -> None:
+        src = ghidra_recon_script("/tmp/malware.exe")
+        assert "/tmp/malware.exe" in src


### PR DESCRIPTION
## Defect

`_GHIDRA_RECON` (in `scripts.py` line 35) contained:

```python
addrs = [str(a) for a in f.getEntryPoint()]
```

`Function.getEntryPoint()` returns a single `ghidra.program.model.address.Address` object, which is not iterable. In Jython this raises `TypeError: 'GenericAddress' object is not iterable` the first time a real (non-thunk, non-external) function is visited, aborting the entire generated recon script before it can print any function list or imports.

The `addrs` variable was also never referenced anywhere else, making the line purely dead-then-crash code.

## Impact

The `bin_ghidra_script` `@tool` emits this script body for the agent to write to disk and execute via `analyzeHeadless`. Any RE workflow invoking the standard Ghidra recon script produces a runtime crash with no function output.

## Fix

Deleted the broken unused line. `getEntryPoint()` is already printed correctly on the immediately following `print(...)` line — no functional change needed, just removal.

## Regression Test

`packages/decepticon/tests/unit/reversing/test_ghidra_script_entrypoint.py` — 4 new assertions:
- `test_no_iterable_getentrypoint`: asserts the broken `for a in f.getEntryPoint()` pattern is absent (FAIL without fix, PASS with fix)
- `test_addrs_variable_absent`: asserts `addrs` is not in the generated script (FAIL without fix, PASS with fix)
- `test_entrypoint_printed_once`: asserts `getEntryPoint()` appears exactly once — the correct print call (FAIL without fix due to duplicate, PASS with fix)
- `test_binary_path_substituted`: sanity-checks binary path substitution works