### PR TITLE
fix(tools/ad): match BloodHound GPO node type case-insensitively

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -49,6 +49,15 @@ class ImportStats:
 # BloodHound edge types mapped to our EdgeKind with semantically correct
 # relationship types. Lower weight = easier-to-abuse relationship.
 
+_BH_TYPE_SINGULAR: dict[str, str] = {
+    "users": "User",
+    "computers": "Computer",
+    "groups": "Group",
+    "domains": "Domain",
+    "gpos": "GPO",
+    "ous": "OU",
+}
+
 _BH_EDGE_MAP: dict[str, tuple[EdgeKind, float]] = {
     # Group membership
     "MemberOf": (EdgeKind.MEMBER_OF, 0.8),
@@ -241,7 +250,7 @@ def merge_bloodhound_json(
     meta_raw = data.get("meta")
     meta = meta_raw if isinstance(meta_raw, dict) else {}
     object_type = type_hint or meta.get("type") or "Users"
-    type_singular = object_type.rstrip("s")
+    type_singular = _BH_TYPE_SINGULAR.get(object_type.lower(), object_type.rstrip("s"))
 
     items_raw = data.get("data") if "data" in data else data.get("items")
     if items_raw is None:

--- a/packages/decepticon/decepticon/tools/ad/gpo.py
+++ b/packages/decepticon/decepticon/tools/ad/gpo.py
@@ -54,7 +54,7 @@ def analyze_gpo_abuse(graph: KnowledgeGraph) -> list[GPOFinding]:
     # Identify GPO nodes
     gpo_nodes: dict[str, str] = {}  # node_id -> label
     for node in graph.nodes.values():
-        if node.props.get("bh_type") == "GPO":
+        if str(node.props.get("bh_type", "")).upper() == "GPO":
             gpo_nodes[node.id] = node.label
 
     if not gpo_nodes:

--- a/packages/decepticon/tests/unit/ad/test_gpo_bh_type_case.py
+++ b/packages/decepticon/tests/unit/ad/test_gpo_bh_type_case.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from decepticon.tools.ad.bloodhound import merge_bloodhound_json
+from decepticon.tools.ad.gpo import analyze_gpo_abuse
+from decepticon_core.types.kg import KnowledgeGraph
+
+_GPO_BH_PAYLOAD = {
+    "meta": {"type": "gpos"},
+    "data": [
+        {
+            "ObjectIdentifier": "GPO-1",
+            "Properties": {"name": "DefaultDomainPolicy@corp.local"},
+            "Aces": [{"RightName": "GenericAll", "PrincipalSID": "S-1-5-21-1-1-1-1106"}],
+        }
+    ],
+}
+
+_ATTACKER_PAYLOAD = {
+    "meta": {"type": "users"},
+    "data": [
+        {
+            "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+            "Properties": {"name": "lowpriv@corp.local"},
+            "Aces": [],
+        }
+    ],
+}
+
+
+def _graph_with_gpo_and_attacker() -> KnowledgeGraph:
+    g = KnowledgeGraph()
+    merge_bloodhound_json(_GPO_BH_PAYLOAD, g)
+    merge_bloodhound_json(_ATTACKER_PAYLOAD, g)
+    return g
+
+
+def test_gpo_imported_with_canonical_bh_type() -> None:
+    g = _graph_with_gpo_and_attacker()
+    gpo_nodes = [n for n in g.nodes.values() if n.props.get("bh_type", "").upper() == "GPO"]
+    assert len(gpo_nodes) == 1, "expected exactly one GPO node after ingest"
+    assert gpo_nodes[0].props["bh_type"] == "GPO"
+
+
+def test_analyze_gpo_abuse_finds_acl_abuse_via_bloodhound_ingest() -> None:
+    g = _graph_with_gpo_and_attacker()
+    findings = analyze_gpo_abuse(g)
+    assert len(findings) >= 1, "analyze_gpo_abuse must find GenericAll on GPO node"
+    assert findings[0].acl_abuse == "GenericAll"
+    assert findings[0].gpo_name == "DefaultDomainPolicy@corp.local"
+
+
+def test_gpo_type_comparison_case_insensitive_in_analyze() -> None:
+    from decepticon_core.types.kg import Node, NodeKind
+
+    g = KnowledgeGraph()
+    gpo_node = Node.make(NodeKind.GROUP, "TestGPO", bh_type="Gpo")
+    attacker = Node.make(NodeKind.USER, "attacker", bh_type="User")
+    from decepticon_core.types.kg import Edge, EdgeKind
+
+    ace_edge = Edge.make(attacker.id, gpo_node.id, EdgeKind.ENABLES, bh_right="GenericAll")
+    g.upsert_node(gpo_node)
+    g.upsert_node(attacker)
+    g.upsert_edge(ace_edge)
+
+    findings = analyze_gpo_abuse(g)
+    assert len(findings) >= 1, "case-insensitive comparison must match bh_type='Gpo'"


### PR DESCRIPTION
## Defect

`bloodhound.py` derives `type_singular` from the BloodHound `meta.type` field with a blanket `object_type.rstrip("s")`. For `"gpos"` this produces `"Gpo"`, not the canonical `"GPO"`. `_upsert_bh_object` stores `bh_type="Gpo"` on every GPO node.

`gpo.py` line 57 then compares `node.props.get("bh_type") == "GPO"` (exact uppercase), which never matches. Result: `gpo_nodes` is always empty, `analyze_gpo_abuse` returns zero findings for any BloodHound-imported graph, and GPO attack-path detection is completely dead. `_node_kind_for_bh` also missed `"Gpo"` and fell through to `NodeKind.HOST`, mislabeling every GPO node as a host.

## Fix

- Added `_BH_TYPE_SINGULAR` explicit lookup table in `bloodhound.py` mapping `"gpos" -> "GPO"` and `"ous" -> "OU"` (with case-insensitive key lookup). Unknown types fall back to the original `rstrip("s")`.
- `gpo.py`: added `.upper() == "GPO"` case-insensitive comparison as defense-in-depth for any future ingester that may produce a different case variant.

## Impact

GPO ACL abuse detection (`analyze_gpo_abuse` / `gpo_audit` tool) now fires correctly on BloodHound-imported data. GPO nodes are also correctly labeled as `NodeKind.GROUP` rather than `NodeKind.HOST`.

## Regression Test

`packages/decepticon/tests/unit/ad/test_gpo_bh_type_case.py` (new file, no existing test files modified):

- `test_gpo_imported_with_canonical_bh_type` — verifies `merge_bloodhound_json` with `meta.type="gpos"` stores `bh_type="GPO"` (fails without the bloodhound.py fix)
- `test_analyze_gpo_abuse_finds_acl_abuse_via_bloodhound_ingest` — end-to-end: ingest GPO + attacker, assert `GenericAll` finding is returned (fails without both fixes)
- `test_gpo_type_comparison_case_insensitive_in_analyze` — directly injects a node with `bh_type="Gpo"` and asserts `analyze_gpo_abuse` still matches (fails without gpo.py fix)

All 18 tests pass (15 existing + 3 new). No interaction with any in-flight coverage PR as this adds a new test file only.