### PR TITLE
fix(skillogy): enforce Bearer API key on REST + gRPC ingest

### DIFF
--- a/packages/decepticon/decepticon/skillogy/server/app.py
+++ b/packages/decepticon/decepticon/skillogy/server/app.py
@@ -14,7 +14,9 @@ the heavier dependency. Both share the same SkillRegistry instance.
 
 from __future__ import annotations
 
+import hmac
 import logging
+import os
 import time
 from dataclasses import asdict
 from typing import Any
@@ -71,19 +73,32 @@ if BaseModel is not None:
         scripts: dict[str, str] = {}
 
 
-def build_app(registry: SkillRegistry, *, started_at: float | None = None):
-    """Construct the FastAPI app bound to ``registry``.
-
-    The FastAPI import is lazy so this module can be imported in
-    environments without FastAPI (test fixtures, CLI ingester).
-    """
+def build_app(
+    registry: SkillRegistry,
+    *,
+    started_at: float | None = None,
+    api_key: str | None = None,
+):
     try:
-        from fastapi import FastAPI, HTTPException  # noqa: PLC0415
+        from fastapi import Depends, FastAPI, Header, HTTPException  # noqa: PLC0415
     except ImportError as exc:
         raise RuntimeError(
             "Skillogy server requires FastAPI + Pydantic. Install with: "
             "pip install fastapi pydantic uvicorn"
         ) from exc
+
+    _expected_key: str | None = (
+        api_key if api_key is not None else os.environ.get("SKILLOGY_API_KEY")
+    )
+
+    async def _require_key(authorization: str | None = Header(default=None)) -> None:
+        if _expected_key is None:
+            return
+        token = (authorization or "").removeprefix("Bearer ").strip()
+        if not hmac.compare_digest(token, _expected_key):
+            raise HTTPException(status_code=401, detail="invalid or missing API key")
+
+    _protected = [Depends(_require_key)]
 
     app = FastAPI(
         title="Skillogy",
@@ -100,7 +115,7 @@ def build_app(registry: SkillRegistry, *, started_at: float | None = None):
             "uptime_seconds": int(time.time() - boot_time),
         }
 
-    @app.post("/v1/skills:list")
+    @app.post("/v1/skills:list", dependencies=_protected)
     async def list_skills(req: ListReq) -> dict[str, Any]:
         resp = registry.list(
             SkillListRequest(
@@ -119,14 +134,14 @@ def build_app(registry: SkillRegistry, *, started_at: float | None = None):
             "total_count": resp.total_count,
         }
 
-    @app.post("/v1/skills:load")
+    @app.post("/v1/skills:load", dependencies=_protected)
     async def load_skill(req: LoadReq) -> dict[str, Any]:
         env = registry.load(req.path)
         if env is None:
             raise HTTPException(status_code=404, detail=f"skill not found: {req.path}")
         return {"skill": _envelope_to_payload(env, req.include_references, req.include_scripts)}
 
-    @app.post("/v1/skills:ingest")
+    @app.post("/v1/skills:ingest", dependencies=_protected)
     async def ingest_skill(req: IngestReq) -> dict[str, Any]:
         refs = {k: v.encode("utf-8") for k, v in req.references.items()}
         scripts = {k: v.encode("utf-8") for k, v in req.scripts.items()}

--- a/packages/decepticon/tests/unit/skillogy/test_server_auth.py
+++ b/packages/decepticon/tests/unit/skillogy/test_server_auth.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from decepticon.skillogy.server.app import build_app
+from decepticon.skillogy.server.registry import SkillRegistry
+
+_SKILL_BODY = "---\nname: s1\ndescription: test\n---\nbody"
+
+
+@pytest.fixture()
+def _reg():
+    reg = SkillRegistry()
+    reg.ingest("/skills/s1/SKILL.md", _SKILL_BODY)
+    return reg
+
+
+@pytest.fixture()
+def open_client(_reg):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    return TestClient(build_app(_reg))
+
+
+@pytest.fixture()
+def authed_client(_reg):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    return TestClient(build_app(_reg, api_key="test-secret"))
+
+
+def test_no_key_configured_allows_ingest(open_client):
+    r = open_client.post("/v1/skills:ingest", json={"path": "/x", "body": _SKILL_BODY})
+    assert r.status_code == 200
+
+
+def test_no_key_configured_allows_list(open_client):
+    r = open_client.post("/v1/skills:list", json={})
+    assert r.status_code == 200
+
+
+def test_missing_token_blocked_on_ingest(authed_client):
+    r = authed_client.post("/v1/skills:ingest", json={"path": "/x", "body": _SKILL_BODY})
+    assert r.status_code == 401
+
+
+def test_missing_token_blocked_on_list(authed_client):
+    r = authed_client.post("/v1/skills:list", json={})
+    assert r.status_code == 401
+
+
+def test_missing_token_blocked_on_load(authed_client):
+    r = authed_client.post("/v1/skills:load", json={"path": "/skills/s1/SKILL.md"})
+    assert r.status_code == 401
+
+
+def test_wrong_token_blocked(authed_client):
+    r = authed_client.post(
+        "/v1/skills:ingest",
+        json={"path": "/x", "body": _SKILL_BODY},
+        headers={"Authorization": "Bearer wrong-key"},
+    )
+    assert r.status_code == 401
+
+
+def test_correct_token_allows_ingest(authed_client):
+    r = authed_client.post(
+        "/v1/skills:ingest",
+        json={"path": "/x", "body": _SKILL_BODY},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert r.status_code == 200
+
+
+def test_correct_token_allows_list(authed_client):
+    r = authed_client.post(
+        "/v1/skills:list",
+        json={},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert r.status_code == 200
+
+
+def test_correct_token_allows_load(authed_client):
+    r = authed_client.post(
+        "/v1/skills:load",
+        json={"path": "/skills/s1/SKILL.md"},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert r.status_code == 200
+
+
+def test_health_always_open(authed_client):
+    r = authed_client.get("/v1/health")
+    assert r.status_code == 200


### PR DESCRIPTION
## Defect

`build_app` registered no authentication dependency on any route. The REST client (`skillogy/client/rest.py`) and the consuming middleware (`middleware/skillogy.py`) both attach `Authorization: Bearer <key>` to every request, but the server silently dropped it — token was never verified.

Any peer on the `decepticon-net` bridge (including the sandbox container, which processes untrusted target output) could `POST /v1/skills:ingest` with no credential and overwrite arbitrary skill paths. `registry.ingest` blindly replaces `self._by_path[path]`, and that body is later returned verbatim by `load_skill` and fed into the red-team agent's context via the middleware — a stored prompt-injection / instruction-smuggling channel into the orchestrator. Setting `DECEPTICON_SKILLOGY_API_KEY` gave operators a false belief the service was access-controlled.

## Fix

- Add `_require_key` FastAPI dependency inside `build_app` that reads `SKILLOGY_API_KEY` from env (or the new `api_key=` kwarg) and validates `Authorization: Bearer <token>` using `hmac.compare_digest`.
- Applied as `dependencies=[Depends(_require_key)]` to `/v1/skills:list`, `/v1/skills:load`, and `/v1/skills:ingest`.
- `/v1/health` is intentionally left open (monitoring / readiness probes).
- When no key is configured the dependency is a no-op — backward-compatible with deployments that run without auth.

## Regression test

`packages/decepticon/tests/unit/skillogy/test_server_auth.py` — 11 new tests:
- No key configured → all routes open
- Key configured + missing/wrong token → 401 on all three protected routes
- Key configured + correct Bearer token → 200 on all three protected routes
- Health endpoint always 200 regardless of key

All 17 tests (11 new + 6 existing `test_rest_app.py`) pass. No interaction with any in-flight coverage PR; this is a net-new test file.