### PR TITLE
fix(tools/bash): stop bypassing output-offload for '['-prefixed output

### DIFF
--- a/packages/decepticon/decepticon/tools/bash/bash.py
+++ b/packages/decepticon/decepticon/tools/bash/bash.py
@@ -68,6 +68,16 @@ _current_workspace_path: contextvars.ContextVar[str] = contextvars.ContextVar(
 INLINE_LIMIT = 15_000  # ≤15K chars: return inline; >15K: offload to <engagement>/.scratch/
 # >5M: size watchdog in sandbox_kernel/tmux.py kills the command (SIZE_WATCHDOG_CHARS)
 
+_STATUS_PREFIXES = (
+    "[BACKGROUND]",
+    "[RUNNING",
+    "[DONE",
+    "[IDLE]",
+    "[KILLED]",
+    "[EMPTY]",
+    "[STALE]",
+)
+
 # ─── Scratch-file TTL prune (bounds <engagement>/.scratch/ growth) ────────
 # Files persist long enough for the agent's grep/read multi-pass workflow,
 # then expire so the dir does not grow unboundedly across long engagements.
@@ -420,7 +430,7 @@ async def bash(
     # Tier 1 (≤15K): return inline — fits comfortably in context
     # Tier 2 (>15K): offload to file, return preview + file reference
     # Tier 3 (>5M): handled by size watchdog in sandbox_kernel/tmux.py (command killed)
-    if len(result) > INLINE_LIMIT and not result.startswith("["):
+    if len(result) > INLINE_LIMIT and not result.startswith(_STATUS_PREFIXES):
         return await _offload_large_output(result, command, session, workspace_path)
 
     return result

--- a/packages/decepticon/tests/unit/tools/bash/test_offload_bracket_prefix.py
+++ b/packages/decepticon/tests/unit/tools/bash/test_offload_bracket_prefix.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from decepticon.sandbox_kernel import BackgroundJobTracker
+from decepticon.tools.bash.bash import (
+    _STATUS_PREFIXES,
+    INLINE_LIMIT,
+    bash,
+    set_sandbox,
+)
+
+
+def _fake_sandbox():
+    sandbox = MagicMock()
+    sandbox._jobs = BackgroundJobTracker()
+    sandbox.execute = MagicMock()
+    sandbox.upload_files = MagicMock()
+    return sandbox
+
+
+OVER_LIMIT = INLINE_LIMIT + 1
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "[INF] ",
+        "[WRN] ",
+        "[ERR] ",
+        "[2024-01-01",
+        "[nuclei-template] ",
+        "[",
+    ],
+)
+def test_bracket_prefixed_real_output_is_offloaded(prefix):
+    sandbox = _fake_sandbox()
+    large_output = prefix + "x" * OVER_LIMIT
+    sandbox.execute_tmux_async = AsyncMock(return_value=large_output)
+    set_sandbox(sandbox)
+
+    result = asyncio.run(
+        bash.ainvoke(
+            {"command": "nuclei -u http://target"},
+            config={"configurable": {"workspace_path": "/workspace"}},
+        )
+    )
+
+    assert "not written" in result or "truncated" in result
+
+
+@pytest.mark.parametrize("status_prefix", _STATUS_PREFIXES)
+def test_status_prefixed_synthetic_output_is_not_offloaded(status_prefix):
+    sandbox = _fake_sandbox()
+    large_synthetic = status_prefix + "x" * OVER_LIMIT
+    sandbox.execute_tmux_async = AsyncMock(return_value=large_synthetic)
+    set_sandbox(sandbox)
+
+    result = asyncio.run(
+        bash.ainvoke(
+            {"command": ""},
+            config={"configurable": {"workspace_path": "/workspace"}},
+        )
+    )
+
+    assert result == large_synthetic
+
+
+def test_non_bracket_large_output_is_offloaded():
+    sandbox = _fake_sandbox()
+    large_output = "plain " + "x" * OVER_LIMIT
+    sandbox.execute_tmux_async = AsyncMock(return_value=large_output)
+    set_sandbox(sandbox)
+
+    result = asyncio.run(
+        bash.ainvoke(
+            {"command": "cat big.txt"},
+            config={"configurable": {"workspace_path": "/workspace"}},
+        )
+    )
+
+    assert "not written" in result or "truncated" in result


### PR DESCRIPTION
## Defect

`bash()` Tier-2 output management (offload to `<engagement>/.scratch/`) is
bypassed for any output whose first character is `[`. The guard was
`not result.startswith("[")`, intended to keep synthetic status banners
inline, but it also matches real tool output:

- nuclei lines: `[INF] ...`, `[WRN] ...`, `[template-id] [protocol] ...`
- JSON arrays: `[{"id": ...}]`
- Timestamp-prefixed lines: `[2024-01-01 ...]`

Any such output larger than 15 000 chars (INLINE_LIMIT) — a routine nuclei
or ffuf run — skips `_offload_large_output` entirely and returns the full
blob (up to ~5 MB) inline to the model, exhausting the context budget.

## Fix

Replace the overly-broad `startswith("[")` check with `startswith(_STATUS_PREFIXES)`,
a tuple covering only the synthetic status banners the bash tool itself emits:
`[BACKGROUND]`, `[RUNNING`, `[DONE`, `[IDLE]`, `[KILLED]`, `[EMPTY]`, `[STALE]`.

`str.startswith` accepts a tuple natively, so no extra logic is needed.

## Regression test

`packages/decepticon/tests/unit/tools/bash/test_offload_bracket_prefix.py`

- Parametrized test confirms `[INF]`-, `[WRN]`-, JSON-array-, and other
  `[`-prefixed real output >INLINE_LIMIT is now offloaded (truncation
  message present in result).
- Parametrized test over every `_STATUS_PREFIXES` entry confirms synthetic
  banners still bypass offload and are returned verbatim.
- Third case confirms non-`[`-prefixed large output continues to be offloaded.

All 23 tests in the bash tool unit suite pass.

No interaction with any in-flight coverage PR — this file is new.