### PR TITLE
fix(backends): key HTTPSandbox job mirror by workspace + session

### DIFF
--- a/packages/decepticon/decepticon/backends/http_sandbox.py
+++ b/packages/decepticon/decepticon/backends/http_sandbox.py
@@ -48,7 +48,9 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import logging
+import re
 import time
 
 import httpx
@@ -62,6 +64,38 @@ from deepagents.backends.sandbox import BaseSandbox
 from decepticon.sandbox_kernel import BackgroundJob, BackgroundJobTracker
 
 log = logging.getLogger(__name__)
+
+_WORKSPACE_DEFAULT = "/workspace"
+
+
+def _normalize_workspace(workspace_path: str | None) -> str:
+    path = (workspace_path or _WORKSPACE_DEFAULT).strip()
+    if path == _WORKSPACE_DEFAULT:
+        return path
+    if not path.startswith("/workspace/"):
+        return _WORKSPACE_DEFAULT
+    path = path.rstrip("/")
+    components = path[len("/workspace/") :].split("/")
+    if any(not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", c) for c in components):
+        return _WORKSPACE_DEFAULT
+    return path
+
+
+def _workspace_slug(workspace_path: str) -> str:
+    path = _normalize_workspace(workspace_path)
+    if path == _WORKSPACE_DEFAULT:
+        return "root"
+    digest = hashlib.sha1(path.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
+    slug = path.rsplit("/", 1)[-1] or "workspace"
+    safe_slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", slug).strip("-") or "workspace"
+    return f"{safe_slug}-{digest}"
+
+
+def _mirror_key(session: str, workspace_path: str | None) -> str:
+    path = _normalize_workspace(workspace_path)
+    if path == _WORKSPACE_DEFAULT:
+        return session
+    return f"{_workspace_slug(path)}:{session}"
 
 
 class SandboxError(RuntimeError):
@@ -326,11 +360,13 @@ class HTTPSandbox(BaseSandbox):
         # the local mirror so SandboxNotificationMiddleware's
         # iteration can find it; `poll_completion` will replace the
         # stub's status / exit_code on the next refresh tick.
-        ws = workspace_path or "/workspace"
+        ws = _normalize_workspace(workspace_path)
+        mirror_key = _mirror_key(session, ws)
         self._jobs.register(
             session=session,
             command=command,
             initial_markers=0,
+            key=mirror_key,
             workspace_path=ws,
         )
 
@@ -362,34 +398,22 @@ class HTTPSandbox(BaseSandbox):
             completed_at=j.get("completed_at"),
             consumed=j.get("consumed", False),
         )
-        # Keep the local mirror coherent: refresh status from the
-        # daemon's view so ``BackgroundJobTracker.pending_completions``
-        # surfaces this job to SandboxNotificationMiddleware on its next
-        # tick. Dedupe of already-emitted completions is handled by
-        # ``mark_consumed`` (the middleware calls it post-emit) — not by
-        # removing from the mirror, which would make the done state
-        # invisible to ``pending_completions`` entirely.
-        local = self._jobs.get(session=job.session)
+        mirror_key = _mirror_key(job.session, job.workspace_path)
+        local = self._jobs.get(session=job.session, key=mirror_key)
         if local is None:
-            # Stub entry was never registered (e.g. start_background was
-            # called from a different agent process, or the local mirror
-            # was cleared). Re-register so subsequent polls find it.
             self._jobs.register(
                 session=job.session,
                 command=job.command,
                 initial_markers=job.initial_markers,
+                key=mirror_key,
                 workspace_path=job.workspace_path,
             )
-            local = self._jobs.get(session=job.session)
+            local = self._jobs.get(session=job.session, key=mirror_key)
         if local is not None and job.status != "running":
-            # The daemon reports exit_code as ``int | None``; if the job
-            # raced past completion before its exit code was captured,
-            # fall back to ``-1`` so the local mirror still flips to
-            # ``done`` and the notification path can fire.
             self._jobs.mark_complete(
                 session=job.session,
                 exit_code=job.exit_code if job.exit_code is not None else -1,
-                key=local.key,
+                key=mirror_key,
             )
         return job
 

--- a/packages/decepticon/tests/unit/backends/test_http_sandbox_job_key.py
+++ b/packages/decepticon/tests/unit/backends/test_http_sandbox_job_key.py
@@ -1,0 +1,120 @@
+import time as _t
+from unittest.mock import MagicMock, patch
+
+from decepticon.backends.http_sandbox import HTTPSandbox, _mirror_key
+
+
+def _make_sandbox():
+    sb = HTTPSandbox.__new__(HTTPSandbox)
+    from decepticon.sandbox_kernel import BackgroundJobTracker
+
+    sb._base_url = "http://localhost:9999"
+    sb._token = None
+    sb._timeout = 30.0
+    sb._client = None
+    sb._jobs = BackgroundJobTracker()
+    return sb
+
+
+def test_mirror_key_default_workspace_equals_session():
+    assert _mirror_key("main", None) == "main"
+    assert _mirror_key("main", "/workspace") == "main"
+
+
+def test_mirror_key_non_default_workspace_is_composite():
+    key = _mirror_key("main", "/workspace/eng-abc")
+    assert key != "main"
+    assert "main" in key
+    assert ":" in key
+
+
+def test_mirror_key_same_session_different_workspace_produces_different_keys():
+    key_a = _mirror_key("main", "/workspace/eng-alpha")
+    key_b = _mirror_key("main", "/workspace/eng-beta")
+    assert key_a != key_b
+
+
+def test_start_background_two_workspaces_same_session_no_collision():
+    sb = _make_sandbox()
+
+    with patch.object(sb, "_request"):
+        sb.start_background("nmap a", session="main", workspace_path="/workspace/eng-alpha")
+        sb.start_background("nmap b", session="main", workspace_path="/workspace/eng-beta")
+
+    all_jobs = sb._jobs.all_jobs()
+    assert len(all_jobs) == 2
+    commands = {j.command for j in all_jobs}
+    assert commands == {"nmap a", "nmap b"}
+
+
+def test_start_background_second_workspace_does_not_overwrite_first():
+    sb = _make_sandbox()
+
+    with patch.object(sb, "_request"):
+        sb.start_background("nmap a", session="main", workspace_path="/workspace/eng-alpha")
+        sb.start_background("nmap b", session="main", workspace_path="/workspace/eng-beta")
+
+    key_a = _mirror_key("main", "/workspace/eng-alpha")
+    key_b = _mirror_key("main", "/workspace/eng-beta")
+    job_a = sb._jobs.get(session="main", key=key_a)
+    job_b = sb._jobs.get(session="main", key=key_b)
+    assert job_a is not None and job_a.command == "nmap a"
+    assert job_b is not None and job_b.command == "nmap b"
+
+
+def _build_job_response(session, workspace, status="running", exit_code=None):
+    return {
+        "job": {
+            "session": session,
+            "key": _mirror_key(session, workspace),
+            "command": "nmap x",
+            "initial_markers": 1,
+            "started_at": _t.monotonic(),
+            "workspace_path": workspace or "/workspace",
+            "status": status,
+            "exit_code": exit_code,
+            "completed_at": None,
+            "consumed": False,
+        }
+    }
+
+
+def test_poll_completion_updates_correct_workspace_job():
+    sb = _make_sandbox()
+
+    with patch.object(sb, "_request"):
+        sb.start_background("nmap a", session="main", workspace_path="/workspace/eng-alpha")
+        sb.start_background("nmap b", session="main", workspace_path="/workspace/eng-beta")
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = _build_job_response(
+        "main", "/workspace/eng-alpha", status="done", exit_code=0
+    )
+
+    with patch.object(sb, "_request", return_value=mock_resp):
+        sb.poll_completion(session="main", workspace_path="/workspace/eng-alpha")
+
+    key_a = _mirror_key("main", "/workspace/eng-alpha")
+    key_b = _mirror_key("main", "/workspace/eng-beta")
+    job_a = sb._jobs.get(session="main", key=key_a)
+    job_b = sb._jobs.get(session="main", key=key_b)
+    assert job_a is not None and job_a.status == "done"
+    assert job_b is not None and job_b.status == "running"
+
+
+def test_poll_completion_default_workspace_uses_session_key():
+    sb = _make_sandbox()
+
+    with patch.object(sb, "_request"):
+        sb.start_background("nmap c", session="main", workspace_path=None)
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = _build_job_response(
+        "main", "/workspace", status="done", exit_code=0
+    )
+
+    with patch.object(sb, "_request", return_value=mock_resp):
+        sb.poll_completion(session="main", workspace_path=None)
+
+    job = sb._jobs.get(session="main", key="main")
+    assert job is not None and job.status == "done"


### PR DESCRIPTION
## Defect

`HTTPSandbox.start_background` registered the local mirror job under the bare session name (e.g. `"main"`), ignoring `workspace_path`. The daemon side keys by `_manager_key(session, workspace)` — a composite `{slug}:{session}` for non-default workspaces. A single process-global `HTTPSandbox` serves multiple engagements; when two engagements share a session name but use different workspaces, the second `start_background` silently overwrote the first entry in `_jobs`. `poll_completion` then only ever found one job per session name, losing completion notifications for whichever engagement happened to register first.

## Impact

Background-command completion notifications (`SandboxNotificationMiddleware.pending_completions`) are silently dropped for all but the last engagement that registered a session under a shared session name. `bash_status` returns stale data for the affected engagement.

## Fix

Added `_mirror_key(session, workspace_path)` in `http_sandbox.py` — mirrors the daemon's `_manager_key` logic (workspace slug + session for non-default workspaces, bare session for `/workspace`). Applied in `start_background` (pass `key=mirror_key` to `register`) and `poll_completion` (look up, re-register, and mark-complete by the same composite key derived from `job.workspace_path`).

## Regression test

`packages/decepticon/tests/unit/backends/test_http_sandbox_job_key.py` (new file):
- `test_start_background_two_workspaces_same_session_no_collision` — verifies two jobs exist after registering same session in two different workspaces (fails without fix)
- `test_start_background_second_workspace_does_not_overwrite_first` — verifies each job is independently retrievable by workspace-aware key
- `test_poll_completion_updates_correct_workspace_job` — only the targeted workspace job flips to `done`; sibling job stays `running`
- `test_poll_completion_default_workspace_uses_session_key` — backward-compat: default workspace still uses bare session key

No interaction with any in-flight coverage PR (new file only, existing test files untouched).