### PR TITLE
fix(tools/ad): wire unconstrained/constrained delegation detection

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -114,9 +114,75 @@ def _upsert_bh_object(graph: KnowledgeGraph, obj: dict[str, Any], type_name: str
         haslaps=props.get("haslaps"),
         hasspn=props.get("hasspn"),
         dontreqpreauth=props.get("dontreqpreauth"),
+        trustedfordelegation=props.get("trustedfordelegation"),
+        unconstraineddelegation=props.get("unconstraineddelegation"),
     )
     graph.upsert_node(node)
     return node
+
+
+def _ingest_delegation_edges(
+    graph: KnowledgeGraph,
+    src: Node,
+    obj: dict[str, Any],
+    stats: ImportStats,
+    bh_index: dict[str, Node],
+) -> None:
+    for entry in obj.get("AllowedToDelegate") or []:
+        sid = entry.get("ObjectIdentifier") if isinstance(entry, dict) else str(entry)
+        if not sid:
+            continue
+        dst = bh_index.get(sid)
+        if dst is None:
+            dst = Node.make(
+                NodeKind.HOST,
+                sid,
+                key=f"bh::Computer::{sid}",
+                bh_id=sid,
+                bh_type="Computer",
+            )
+            graph.upsert_node(dst)
+            bh_index[sid] = dst
+        spn = entry.get("Value", "") if isinstance(entry, dict) else ""
+        graph.upsert_edge(
+            Edge.make(
+                src.id,
+                dst.id,
+                EdgeKind.ENABLES,
+                weight=0.4,
+                key=f"bh-deleg::AllowedToDelegate::{sid}",
+                bh_right="AllowedToDelegate",
+                spn=spn,
+            )
+        )
+        stats.edges += 1
+
+    for entry in obj.get("AllowedToActOnBehalfOfOtherIdentity") or []:
+        sid = entry.get("ObjectIdentifier") if isinstance(entry, dict) else str(entry)
+        if not sid:
+            continue
+        actor = bh_index.get(sid)
+        if actor is None:
+            actor = Node.make(
+                NodeKind.HOST,
+                sid,
+                key=f"bh::Computer::{sid}",
+                bh_id=sid,
+                bh_type="Computer",
+            )
+            graph.upsert_node(actor)
+            bh_index[sid] = actor
+        graph.upsert_edge(
+            Edge.make(
+                actor.id,
+                src.id,
+                EdgeKind.ENABLES,
+                weight=0.4,
+                key=f"bh-deleg::AllowedToAct::{sid}",
+                bh_right="AllowedToAct",
+            )
+        )
+        stats.edges += 1
 
 
 def _build_bh_index(graph: KnowledgeGraph) -> dict[str, Node]:
@@ -263,6 +329,7 @@ def merge_bloodhound_json(
         bh_index[node.props.get("bh_id", "")] = node
         _ingest_aces(graph, node, obj, stats, bh_index)
         _ingest_memberships(graph, node, obj, stats, bh_index)
+        _ingest_delegation_edges(graph, node, obj, stats, bh_index)
         if hasattr(stats, counter_attr):
             setattr(stats, counter_attr, getattr(stats, counter_attr) + 1)
     return stats

--- a/packages/decepticon/decepticon/tools/ad/delegation.py
+++ b/packages/decepticon/decepticon/tools/ad/delegation.py
@@ -37,11 +37,9 @@ _SENSITIVE_SPNS = {"ldap", "cifs", "http", "host", "mssql", "krbtgt"}
 
 
 def _is_dc(node_props: dict[str, Any]) -> bool:
-    """Heuristic: a node is a domain controller if its label contains 'DC' or admincount is set."""
     label = str(node_props.get("label", "")).upper()
-    bh_type = node_props.get("bh_type", "")
-    # DCs are typically in the Domain Controllers OU or have specific markers
-    return bh_type == "Computer" and (
+    bh_type = str(node_props.get("bh_type", "")).lower()
+    return bh_type == "computer" and (
         node_props.get("is_dc", False) or "DOMAIN CONTROLLER" in label
     )
 
@@ -64,7 +62,7 @@ def analyze_delegation(graph: KnowledgeGraph) -> list[DelegationFinding]:
     # Pass 1: unconstrained delegation via node properties
     for node in graph.nodes.values():
         bh_type = node.props.get("bh_type", "")
-        if bh_type != "Computer":
+        if str(bh_type).lower() != "computer":
             continue
         trusted = node.props.get("trustedfordelegation", False)
         unconstr = node.props.get("unconstraineddelegation", False)

--- a/packages/decepticon/tests/unit/ad/test_delegation_props.py
+++ b/packages/decepticon/tests/unit/ad/test_delegation_props.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from decepticon.tools.ad.bloodhound import merge_bloodhound_json
+from decepticon.tools.ad.delegation import analyze_delegation
+from decepticon_core.types.kg import KnowledgeGraph
+
+
+def _bh_computer(sid: str, name: str, **extra_props: object) -> dict:
+    return {
+        "ObjectIdentifier": sid,
+        "Properties": {"name": name, "domain": "CORP.LOCAL", **extra_props},
+        "Aces": [],
+        "MemberOf": [],
+        "AllowedToDelegate": [],
+        "AllowedToActOnBehalfOfOtherIdentity": [],
+    }
+
+
+def test_trustedfordelegation_prop_produces_unconstrained_finding() -> None:
+    bh = {
+        "meta": {"type": "computers"},
+        "data": [
+            _bh_computer(
+                "S-1-5-21-1-1-1-2001",
+                "WEB01.CORP.LOCAL",
+                trustedfordelegation=True,
+            )
+        ],
+    }
+    g = KnowledgeGraph()
+    merge_bloodhound_json(bh, g)
+
+    node = next(
+        (n for n in g.nodes.values() if "WEB01" in n.label),
+        None,
+    )
+    assert node is not None, "computer node not created"
+    assert node.props.get("trustedfordelegation") is True, (
+        "trustedfordelegation was not stored on the node — Pass 1 would always skip"
+    )
+
+    findings = analyze_delegation(g)
+    assert any(f.delegation_type == "unconstrained" and "WEB01" in f.target for f in findings), (
+        "unconstrained delegation finding not emitted despite trustedfordelegation=True"
+    )
+
+
+def test_allowed_to_delegate_array_produces_constrained_finding() -> None:
+    src_sid = "S-1-5-21-1-1-1-3001"
+    dst_sid = "S-1-5-21-1-1-1-3002"
+    bh_src = {
+        "ObjectIdentifier": src_sid,
+        "Properties": {"name": "SVC01.CORP.LOCAL", "domain": "CORP.LOCAL"},
+        "Aces": [],
+        "MemberOf": [],
+        "AllowedToDelegate": [{"ObjectIdentifier": dst_sid, "Value": "cifs/DC01.CORP.LOCAL"}],
+        "AllowedToActOnBehalfOfOtherIdentity": [],
+    }
+    bh_dst = _bh_computer(dst_sid, "DC01.CORP.LOCAL")
+    bh = {
+        "meta": {"type": "computers"},
+        "data": [bh_src, bh_dst],
+    }
+    g = KnowledgeGraph()
+    stats = merge_bloodhound_json(bh, g)
+
+    assert stats.edges >= 1, "no delegation edge created"
+    deleg_edges = [e for e in g.edges.values() if e.props.get("bh_right") == "AllowedToDelegate"]
+    assert len(deleg_edges) == 1, f"expected 1 AllowedToDelegate edge, got {len(deleg_edges)}"
+
+    findings = analyze_delegation(g)
+    assert any(f.delegation_type == "constrained" for f in findings), (
+        "constrained delegation finding not emitted despite AllowedToDelegate edge"
+    )
+
+
+def test_allowed_to_act_array_produces_rbcd_finding() -> None:
+    actor_sid = "S-1-5-21-1-1-1-4001"
+    target_sid = "S-1-5-21-1-1-1-4002"
+    bh_target = {
+        "ObjectIdentifier": target_sid,
+        "Properties": {"name": "FILESRV.CORP.LOCAL", "domain": "CORP.LOCAL"},
+        "Aces": [],
+        "MemberOf": [],
+        "AllowedToDelegate": [],
+        "AllowedToActOnBehalfOfOtherIdentity": [{"ObjectIdentifier": actor_sid}],
+    }
+    bh_actor = _bh_computer(actor_sid, "ACTOR.CORP.LOCAL")
+    bh = {
+        "meta": {"type": "computers"},
+        "data": [bh_target, bh_actor],
+    }
+    g = KnowledgeGraph()
+    stats = merge_bloodhound_json(bh, g)
+
+    assert stats.edges >= 1
+    rbcd_edges = [e for e in g.edges.values() if e.props.get("bh_right") == "AllowedToAct"]
+    assert len(rbcd_edges) == 1, f"expected 1 AllowedToAct edge, got {len(rbcd_edges)}"
+
+    findings = analyze_delegation(g)
+    assert any(f.delegation_type == "rbcd" for f in findings), (
+        "RBCD finding not emitted despite AllowedToActOnBehalfOfOtherIdentity edge"
+    )


### PR DESCRIPTION
## Defect

`delegation_audit` returned zero findings for every BloodHound-imported graph due to three compounding wiring failures:

1. **Pass 1 (unconstrained delegation)** — `analyze_delegation` reads `node.props["trustedfordelegation"]` and `node.props["unconstraineddelegation"]`, but `_upsert_bh_object` never copied those keys from BloodHound `Properties` into the node. Every Computer node had them absent so every node was skipped.

2. **Pass 2 (constrained / RBCD)** — The code consumed edges with `bh_right` in `{AllowedToDelegate, AllowedToAct}`, but `_ingest_aces` only walks the `Aces` array. BloodHound emits `AllowedToDelegate` and `AllowedToActOnBehalfOfOtherIdentity` as separate top-level arrays on each object — these were never ingested and the edges were never created.

3. **bh_type case mismatch** — `meta.get("type")` returns lowercase (e.g. `"computers"`), so `type_singular = object_type.rstrip("s")` stores `bh_type="computer"`, but `analyze_delegation` guarded with `bh_type != "Computer"` (capital C), silently skipping all Computer nodes even after fix 1.

## Fix

- `_upsert_bh_object`: pass `trustedfordelegation` and `unconstraineddelegation` from BloodHound `Properties` into `Node.make`.
- New `_ingest_delegation_edges`: walks `AllowedToDelegate` and `AllowedToActOnBehalfOfOtherIdentity` arrays on each BH object and emits `ENABLES` edges with `bh_right=AllowedToDelegate` / `bh_right=AllowedToAct`, matching the existing `_BH_EDGE_MAP` entries and Pass 2 consumption.
- `analyze_delegation` and `_is_dc`: normalise `bh_type` comparison to lowercase so it works regardless of the import path's capitalisation.

## Regression tests

`packages/decepticon/tests/unit/ad/test_delegation_props.py` — three tests, each verifying one of the fixed paths:
- `test_trustedfordelegation_prop_produces_unconstrained_finding`: prop stored + finding emitted for a Computer with `trustedfordelegation=True`.
- `test_allowed_to_delegate_array_produces_constrained_finding`: `AllowedToDelegate` array ingested as an edge + constrained finding emitted.
- `test_allowed_to_act_array_produces_rbcd_finding`: `AllowedToActOnBehalfOfOtherIdentity` array ingested as an edge + RBCD finding emitted.

All three fail on `main`, pass with this PR. Existing `test_ad.py` suite (17 tests) unaffected.

No interaction with any known in-flight coverage PR.