### PR TITLE
fix(runtime): correct Windows cross-process EventLog file lock

### DIFF
--- a/packages/decepticon/decepticon/runtime/event_log.py
+++ b/packages/decepticon/decepticon/runtime/event_log.py
@@ -112,6 +112,7 @@ def _acquire_lock(fd: int) -> None:
     if sys.platform == "win32":
         import msvcrt
 
+        os.lseek(fd, 0, os.SEEK_SET)
         while True:
             try:
                 msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
@@ -128,10 +129,11 @@ def _release_lock(fd: int) -> None:
     if sys.platform == "win32":
         import msvcrt
 
+        os.lseek(fd, 0, os.SEEK_SET)
         try:
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
         except OSError:
-            pass
+            log.warning("event-log lock release failed", exc_info=True)
     else:
         import fcntl
 

--- a/packages/decepticon/tests/unit/runtime/test_event_log_winlock.py
+++ b/packages/decepticon/tests/unit/runtime/test_event_log_winlock.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from decepticon.runtime.event_log import EventLog, EventType, _acquire_lock, _release_lock
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only locking path")
+def test_release_lock_seeks_to_byte_zero_before_unlock(tmp_path: Path) -> None:
+    target = tmp_path / "lock_test.bin"
+    target.write_bytes(b"existing content here")
+
+    mock_msvcrt = MagicMock()
+    mock_msvcrt.LK_LOCK = 2
+    mock_msvcrt.LK_UNLCK = 0
+
+    with patch.dict("sys.modules", {"msvcrt": mock_msvcrt}):
+        with open(target, "ab") as fh:
+            fd = fh.fileno()
+            _acquire_lock(fd)
+            fh.write(b"new line\n")
+            fh.flush()
+            position_after_write = os.lseek(fd, 0, os.SEEK_CUR)
+            assert position_after_write > 0
+            _release_lock(fd)
+            position_after_release = os.lseek(fd, 0, os.SEEK_CUR)
+
+    assert position_after_release == 0
+
+    lock_calls = [c for c in mock_msvcrt.mock_calls if "locking" in str(c)]
+    assert len(lock_calls) == 2
+    assert lock_calls[0] == call.locking(fd, mock_msvcrt.LK_LOCK, 1)
+    assert lock_calls[1] == call.locking(fd, mock_msvcrt.LK_UNLCK, 1)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only locking path")
+def test_acquire_lock_seeks_to_byte_zero_before_locking(tmp_path: Path) -> None:
+    target = tmp_path / "seek_test.bin"
+    target.write_bytes(b"preexisting bytes to push EOF forward")
+
+    mock_msvcrt = MagicMock()
+    mock_msvcrt.LK_LOCK = 2
+    mock_msvcrt.LK_UNLCK = 0
+
+    with patch.dict("sys.modules", {"msvcrt": mock_msvcrt}):
+        with open(target, "ab") as fh:
+            fd = fh.fileno()
+            initial_pos = os.lseek(fd, 0, os.SEEK_CUR)
+            assert initial_pos > 0
+            _acquire_lock(fd)
+            pos_after_acquire = os.lseek(fd, 0, os.SEEK_CUR)
+            assert pos_after_acquire == 0
+            _release_lock(fd)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only locking path")
+def test_acquire_and_release_same_fixed_offset_repeated(tmp_path: Path) -> None:
+    target = tmp_path / "multi_cycle.bin"
+
+    mock_msvcrt = MagicMock()
+    mock_msvcrt.LK_LOCK = 2
+    mock_msvcrt.LK_UNLCK = 0
+
+    with patch.dict("sys.modules", {"msvcrt": mock_msvcrt}):
+        with open(target, "ab") as fh:
+            fd = fh.fileno()
+            for _ in range(3):
+                _acquire_lock(fd)
+                fh.write(b"x" * 50)
+                fh.flush()
+                _release_lock(fd)
+
+    all_locking_calls = [c for c in mock_msvcrt.mock_calls if "locking" in str(c)]
+    assert len(all_locking_calls) == 6
+    for i, c in enumerate(all_locking_calls):
+        expected_mode = mock_msvcrt.LK_LOCK if i % 2 == 0 else mock_msvcrt.LK_UNLCK
+        assert c == call.locking(fd, expected_mode, 1)
+
+
+def test_append_is_atomic_across_multiple_eventlog_instances(tmp_path: Path) -> None:
+    total = 100
+    barrier = threading.Barrier(4)
+
+    def _writer(worker_id: int) -> None:
+        log = EventLog(workspace_root=tmp_path, engagement_id="shared-eng")
+        barrier.wait()
+        for i in range(total // 4):
+            log.append(EventType.TOOL_CALL, {"worker": worker_id, "i": i})
+
+    threads = [threading.Thread(target=_writer, args=(w,)) for w in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    log = EventLog(workspace_root=tmp_path, engagement_id="shared-eng")
+    events = list(log.read())
+    assert len(events) == total
+    for e in events:
+        assert e.type == "tool.call"
+        assert "worker" in e.payload
+        assert "i" in e.payload


### PR DESCRIPTION
## Defect

`msvcrt.locking(fd, LK_LOCK, 1)` locks a 1-byte region at the **current file pointer position**. Opening with `'ab'` positions the pointer at EOF (e.g. byte 10 for a 10-byte file), so `_acquire_lock` locks byte `[EOF, EOF+1)`. After `fh.write()` advances the pointer, `_release_lock` calls `msvcrt.locking(fd, LK_UNLCK, 1)` at the **new** (post-write) position — a different byte than was locked. The unlock raises `OSError` which the original `except OSError: pass` silently swallows. Consequence: the originally-locked byte stays locked until the file handle is closed; meanwhile two separate processes opening the same file at different EOF positions lock **different** byte ranges and therefore do **not** mutually exclude, breaking the module's documented cross-process write-atomicity guarantee.

## Impact

Any multi-process engagement run on Windows where two agents write to the same `events.jsonl` concurrently can interleave or corrupt event lines. The `threading.RLock` in-process guard masks this in single-process unit tests, so CI was green while the cross-process contract was silently broken.

## Fix

Add `os.lseek(fd, 0, os.SEEK_SET)` at the top of both `_acquire_lock` and `_release_lock` on `win32` so both always operate on a **fixed** byte (offset 0). Since the file is opened `'ab'`, each write still goes to EOF regardless of the seek position, so write semantics are unchanged. The silent `OSError` suppression in `_release_lock` is replaced with `log.warning(...)` so future regressions surface.

## Regression test

New file `packages/decepticon/tests/unit/runtime/test_event_log_winlock.py`:
- `test_release_lock_seeks_to_byte_zero_before_unlock` — verifies that after `fh.write()` advances the pointer, `_release_lock` resets to offset 0 and issues `LK_UNLCK` on byte 0 (would fail on the old code as the unlock byte and lock byte differ)
- `test_acquire_lock_seeks_to_byte_zero_before_locking` — verifies `_acquire_lock` resets to offset 0 even when the handle starts at EOF
- `test_acquire_and_release_same_fixed_offset_repeated` — 3-cycle lock/write/unlock, asserts all 6 `locking()` calls target the correct modes in order
- `test_append_is_atomic_across_multiple_eventlog_instances` — 4 threads each with independent `EventLog` instances writing 25 events produce 100 intact JSON lines

All 4 new tests + 11 existing `test_event_log.py` tests pass (15 total green). No interaction with any in-flight coverage PR.