### PR TITLE
fix(tools/defense): quote values in Splunk SPL converter

### DIFF
--- a/packages/decepticon/decepticon/tools/defense/splunk.py
+++ b/packages/decepticon/decepticon/tools/defense/splunk.py
@@ -35,6 +35,14 @@ def _quote_spl(value: Any) -> str:
     return str(value)
 
 
+def _spl_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _needs_spl_quoting(value: str) -> bool:
+    return " " in value or '"' in value
+
+
 def _selection_to_spl(selection: dict[str, Any]) -> str:
     clauses: list[str] = []
     for field, value in selection.items():
@@ -53,11 +61,20 @@ def _selection_to_spl(selection: dict[str, Any]) -> str:
 def _field_clause(field: str, modifier: str, value: Any) -> str:
     quoted = _quote_spl(value)
     if modifier == "contains":
-        return f"{field}=*{value}*" if isinstance(value, str) else f"{field}={quoted}"
+        if isinstance(value, str):
+            inner = _spl_escape(value) if _needs_spl_quoting(value) else value
+            return f'{field}="*{inner}*"' if _needs_spl_quoting(value) else f"{field}=*{inner}*"
+        return f"{field}={quoted}"
     if modifier == "startswith":
-        return f"{field}={value}*" if isinstance(value, str) else f"{field}={quoted}"
+        if isinstance(value, str):
+            inner = _spl_escape(value) if _needs_spl_quoting(value) else value
+            return f'{field}="{inner}*"' if _needs_spl_quoting(value) else f"{field}={inner}*"
+        return f"{field}={quoted}"
     if modifier == "endswith":
-        return f"{field}=*{value}" if isinstance(value, str) else f"{field}={quoted}"
+        if isinstance(value, str):
+            inner = _spl_escape(value) if _needs_spl_quoting(value) else value
+            return f'{field}="*{inner}"' if _needs_spl_quoting(value) else f"{field}=*{inner}"
+        return f"{field}={quoted}"
     if modifier in ("", "equals"):
         return f"{field}={quoted}"
     raise SigmaConversionError(f"unsupported Sigma modifier ``{modifier}``")

--- a/packages/decepticon/tests/unit/tools/test_splunk_spl_quoting.py
+++ b/packages/decepticon/tests/unit/tools/test_splunk_spl_quoting.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from decepticon.tools.defense.splunk import (
+    _needs_spl_quoting,
+    _spl_escape,
+    sigma_to_spl,
+)
+
+
+def _rule_contains(value: str) -> dict:
+    return {
+        "detection": {
+            "sel": {"CommandLine|contains": value},
+            "condition": "sel",
+        }
+    }
+
+
+def _rule_startswith(value: str) -> dict:
+    return {
+        "detection": {
+            "sel": {"Image|startswith": value},
+            "condition": "sel",
+        }
+    }
+
+
+def _rule_endswith(value: str) -> dict:
+    return {
+        "detection": {
+            "sel": {"Image|endswith": value},
+            "condition": "sel",
+        }
+    }
+
+
+def test_contains_with_space_produces_quoted_wildcard():
+    spl = sigma_to_spl(_rule_contains("Invoke-Mimikatz -DumpCreds"))
+    assert 'CommandLine="*Invoke-Mimikatz -DumpCreds*"' in spl
+
+
+def test_startswith_with_space_produces_quoted_wildcard():
+    spl = sigma_to_spl(_rule_startswith("C:\\Program Files\\evil.exe"))
+    assert 'Image="C:\\\\Program Files\\\\evil.exe*"' in spl
+
+
+def test_endswith_with_space_produces_quoted_wildcard():
+    spl = sigma_to_spl(_rule_endswith("\\program files\\x.exe"))
+    assert 'Image="*\\\\program files\\\\x.exe"' in spl
+
+
+def test_contains_space_value_is_single_spl_term():
+    spl = sigma_to_spl(_rule_contains("foo bar"))
+    assert " ".join(spl.split()).count("CommandLine=") == 1
+    assert '"*foo bar*"' in spl
+
+
+def test_contains_with_embedded_quote_is_escaped():
+    spl = sigma_to_spl(_rule_contains('say "hello" now'))
+    assert '\\"hello\\"' in spl or 'say \\"hello\\"' in spl
+
+
+def test_contains_simple_value_unchanged():
+    spl = sigma_to_spl(_rule_contains("DownloadString"))
+    assert "CommandLine=*DownloadString*" in spl
+
+
+def test_endswith_simple_value_unchanged():
+    spl = sigma_to_spl(_rule_endswith("\\powershell.exe"))
+    assert "Image=*\\powershell.exe" in spl
+
+
+def test_spl_escape_backslash_and_quote():
+    assert _spl_escape("a\\b") == "a\\\\b"
+    assert _spl_escape('a"b') == 'a\\"b'
+
+
+def test_needs_spl_quoting_detects_space_and_quote():
+    assert _needs_spl_quoting("foo bar")
+    assert _needs_spl_quoting('foo"bar')
+    assert not _needs_spl_quoting("foobar")
+    assert not _needs_spl_quoting("foo\\bar")


### PR DESCRIPTION
## Defect

`_field_clause` in `splunk.py` interpolated raw string values (not `quoted`) into wildcard SPL terms for `contains`, `startswith`, and `endswith` modifiers. A value like `Invoke-Mimikatz -DumpCreds` produced `CommandLine=*Invoke-Mimikatz -DumpCreds*`, which Splunk parses as two separate terms (`CommandLine=*Invoke-Mimikatz` AND bare `-DumpCreds*`), silently changing the detection logic. Values containing `"` were similarly unescaped. `push_savedsearch` then posted this broken SPL as a live enabled saved search, so blue-team detections the agent claimed to deploy did not actually match.

## Impact

Any Sigma rule with a multi-word wildcard value (common in real detection content — command lines, file paths with spaces, process names) produced a semantically wrong SPL query without error. The `equals` path and non-string values correctly used `_quote_spl`; only the three wildcard modifier branches were wrong.

## Fix

Added `_spl_escape` (escape-only, no outer quotes) and `_needs_spl_quoting` (detects space or `"` in value). Wildcard branches now wrap values containing special chars in double-quoted SPL phrases (`field="*escaped_value*"`), preserving the unquoted form for simple values to maintain compatibility with existing tests.

## Regression test

New file `packages/decepticon/tests/unit/tools/test_splunk_spl_quoting.py` covers:
- `contains`/`startswith`/`endswith` with space-containing values produce quoted wildcard terms
- space-containing value is a single SPL term (not split by Splunk parser)
- embedded double-quote in value is backslash-escaped
- simple values (no spaces/quotes) stay in the pre-existing unquoted form

No interaction with any known in-flight coverage PR.