### PR TITLE
fix(tools/cloud): correct IAM NotAction semantics (near-wildcard) and empty-Action handling

### DIFF
--- a/packages/decepticon/decepticon/tools/cloud/aws.py
+++ b/packages/decepticon/decepticon/tools/cloud/aws.py
@@ -134,7 +134,36 @@ def analyze_iam_policy(policy: str | dict[str, Any]) -> list[IAMFinding]:
         effect = (stmt.get("Effect") or "Allow").lower()
         if effect != "allow":
             continue
-        for action in _as_list(stmt.get("Action") or stmt.get("NotAction") or "*"):
+        resources = _as_list(stmt.get("Resource") or "*")
+        broad_resource = any(str(r) == "*" for r in resources)
+        # Security: NotAction inverts an Allow (grants every action EXCEPT the
+        # listed ones), so it must not be iterated like an Action allow-list.
+        # Branch on key presence (not truthiness) so an explicit empty Action
+        # grants nothing instead of falling through to a phantom wildcard.
+        if "Action" in stmt:
+            actions = _as_list(stmt["Action"])
+        elif "NotAction" in stmt:
+            if broad_resource:
+                idx += 1
+                excluded = ", ".join(str(a) for a in _as_list(stmt["NotAction"])) or "(none)"
+                findings.append(
+                    IAMFinding(
+                        id=f"iam-{idx:04d}",
+                        severity="high",
+                        title="Allow NotAction on all resources (near-wildcard)",
+                        detail=(
+                            "Effect=Allow with NotAction on Resource=* grants every "
+                            f"action except: {excluded} — effectively a near-wildcard "
+                            "privilege over the account."
+                        ),
+                        action="*",
+                        resource="*",
+                    )
+                )
+            continue
+        else:
+            actions = ["*"]
+        for action in actions:
             act = str(action).lower()
             for resource in _as_list(stmt.get("Resource") or "*"):
                 res = str(resource)

--- a/packages/decepticon/tests/unit/cloud/test_cloud.py
+++ b/packages/decepticon/tests/unit/cloud/test_cloud.py
@@ -42,6 +42,32 @@ class TestIAMPolicy:
         findings = analyze_iam_policy(policy)
         assert any("Wildcard s3:*" in f.title for f in findings)
 
+    def test_notaction_allow_flagged_as_near_wildcard(self) -> None:
+        policy = {
+            "Statement": [{"Effect": "Allow", "NotAction": ["iam:CreateUser"], "Resource": "*"}]
+        }
+        findings = analyze_iam_policy(policy)
+        assert any("near-wildcard" in f.title for f in findings)
+        assert any(f.severity == "high" for f in findings)
+
+    def test_notaction_does_not_match_privesc_primitive(self) -> None:
+        policy = {
+            "Statement": [
+                {"Effect": "Allow", "NotAction": ["iam:CreateAccessKey"], "Resource": "*"}
+            ]
+        }
+        findings = analyze_iam_policy(policy)
+        assert not any("CreateAccessKey" in f.title for f in findings)
+
+    def test_empty_action_produces_no_phantom_wildcard(self) -> None:
+        policy = {"Statement": [{"Effect": "Allow", "Action": [], "Resource": "*"}]}
+        assert analyze_iam_policy(policy) == []
+
+    def test_privesc_passrole_still_flagged(self) -> None:
+        policy = {"Statement": [{"Effect": "Allow", "Action": ["iam:PassRole"], "Resource": "*"}]}
+        findings = analyze_iam_policy(policy)
+        assert any("PassRole" in f.title for f in findings)
+
 
 class TestBucketScan:
     def test_s3_scheme(self) -> None:


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity correctness bug in `analyze_iam_policy`
(`packages/decepticon/decepticon/tools/cloud/aws.py`) that caused dangerous IAM
policies to be misclassified.

The action loop iterated:

```python
for action in _as_list(stmt.get("Action") or stmt.get("NotAction") or "*"):
```

which conflated two opposite IAM constructs:

1. **`NotAction` treated as `Action`.** A statement like
   `{"Effect":"Allow","NotAction":["iam:CreateUser"],"Resource":"*"}` allows
   **every** action *except* the listed ones — effectively a near-wildcard grant.
   The analyzer instead checked only the *excluded* action against the privesc
   primitive table, found nothing, and cleared a dangerous policy as harmless.
2. **Empty `Action` fell through.** `{"Effect":"Allow","Action":[]}` is falsy, so
   the `or` chain skipped to `NotAction`/`"*"` and emitted a phantom
   Wildcard-on-Wildcard finding for a statement that grants nothing.

## Fix

Branch on key **presence** instead of truthiness:

- `"Action" in stmt` → iterate the (possibly empty) action list — empty grants
  nothing, no phantom wildcard.
- `"NotAction" in stmt` → on `Allow` with a broad (`Resource=*`) scope, emit a
  dedicated **HIGH** `Allow NotAction on all resources (near-wildcard)` finding
  and skip the action loop; otherwise grant nothing.
- neither key → default `["*"]` (unchanged).

`Deny` statements remain ignored, and normal `Action` privesc detection is
behaviorally unchanged.

## Tests

Added to `packages/decepticon/tests/unit/cloud/test_cloud.py`:

- `NotAction` Allow on `Resource=*` produces a HIGH near-wildcard finding.
- Empty `Action` produces no phantom wildcard finding.
- `NotAction` does not match a privesc primitive by the excluded action.
- Normal `iam:PassRole` privesc case still flagged (regression).
- `test_deny_statements_ignored` still passes.

## Gate evidence

- `uv run ruff check <files>` → All checks passed
- `uv run ruff format <files> --check` → 2 files already formatted
- `uv run basedpyright .../tools/cloud/aws.py` → 0 errors, 0 warnings, 0 notes
- `uv run pytest packages/decepticon/tests/unit/cloud -q` → 27 passed
