### PR TITLE
fix(tools/research): SARIF export reads Node.props (restores --fail-on severity gate)

### DIFF
--- a/packages/decepticon/decepticon/tools/research/sarif_export.py
+++ b/packages/decepticon/decepticon/tools/research/sarif_export.py
@@ -58,6 +58,7 @@ def _string_or_empty(value: Any) -> str:
 
 def _finding_rule_id(node: Any, props: dict[str, Any]) -> str:
     cwe = props.get("cwe") or ""
+    cwe = cwe[0] if isinstance(cwe, list) and cwe else (cwe or "")
     cve = props.get("cve") or ""
     technique = props.get("mitre_attack") or props.get("technique_id") or ""
     klass = props.get("vuln_class") or ""
@@ -154,7 +155,7 @@ def _iter_findings(graph: Any):
     for node in nodes.values() if hasattr(nodes, "values") else nodes:
         if _kind_label(getattr(node, "kind", None)) not in _FINDING_KINDS:
             continue
-        props = dict(getattr(node, "properties", {}) or {})
+        props = dict(getattr(node, "props", None) or getattr(node, "properties", {}) or {})
         if not props.get("severity"):
             props["severity"] = "medium"
         yield node, props

--- a/packages/decepticon/tests/unit/research/test_sarif_export.py
+++ b/packages/decepticon/tests/unit/research/test_sarif_export.py
@@ -10,6 +10,7 @@ from decepticon.tools.research.sarif_export import (
     severity_threshold_breach,
     write_sarif,
 )
+from decepticon_core.types.kg import KnowledgeGraph, Node, NodeKind
 
 
 class _FakeNode:
@@ -145,3 +146,57 @@ def test_export_default_severity_is_medium_when_missing():
     node = _FakeNode("f", "finding", "f", {})
     doc = export_findings_to_sarif(_FakeGraph([node]))
     assert doc["runs"][0]["results"][0]["level"] == "warning"
+
+
+def _real_finding_graph(**props) -> KnowledgeGraph:
+    g = KnowledgeGraph()
+    g.upsert_node(Node.make(NodeKind.FINDING, props.pop("label", "SQLi in /search"), **props))
+    return g
+
+
+def test_export_reads_real_node_props_for_severity():
+    graph = _real_finding_graph(severity="high")
+    result = export_findings_to_sarif(graph)["runs"][0]["results"][0]
+    assert result["level"] == "error"
+    assert result["properties"]["security-severity"] == "7.0"
+
+
+def test_export_real_node_critical_security_severity():
+    graph = _real_finding_graph(severity="critical")
+    result = export_findings_to_sarif(graph)["runs"][0]["results"][0]
+    assert result["level"] == "error"
+    assert result["properties"]["security-severity"] == "10.0"
+
+
+def test_export_real_node_cwe_list_yields_well_formed_rule_id():
+    graph = _real_finding_graph(severity="high", cwe=["CWE-89"])
+    rule_id = export_findings_to_sarif(graph)["runs"][0]["results"][0]["ruleId"]
+    assert rule_id == "decepticon/CWE-89"
+    assert "[" not in rule_id and "'" not in rule_id
+
+
+def test_export_real_node_first_cwe_wins_when_list():
+    graph = _real_finding_graph(severity="high", cwe=["CWE-78", "CWE-77"])
+    rule_id = export_findings_to_sarif(graph)["runs"][0]["results"][0]["ruleId"]
+    assert rule_id == "decepticon/CWE-78"
+
+
+def test_export_real_node_emits_file_and_line_locations():
+    graph = _real_finding_graph(severity="high", file="src/auth.py", line=42)
+    loc = export_findings_to_sarif(graph)["runs"][0]["results"][0]["locations"][0][
+        "physicalLocation"
+    ]
+    assert loc["artifactLocation"]["uri"] == "src/auth.py"
+    assert loc["region"]["startLine"] == 42
+
+
+def test_severity_threshold_breach_fires_on_real_high_finding():
+    graph = _real_finding_graph(severity="high", cwe=["CWE-89"], file="src/auth.py", line=42)
+    doc = export_findings_to_sarif(graph)
+    assert severity_threshold_breach(doc, fail_on="high")
+
+
+def test_severity_threshold_breach_fires_on_real_critical_finding():
+    graph = _real_finding_graph(severity="critical", cwe=["CWE-918"])
+    doc = export_findings_to_sarif(graph)
+    assert severity_threshold_breach(doc, fail_on="high")


### PR DESCRIPTION
## Summary

The SARIF export silently bypassed the CI security-severity gate because it read finding data from the wrong attribute. This PR fixes the attribute read (plus a CWE-list formatting bug) and adds tests that exercise the **real** `Node` model — the regression that the existing `_FakeNode` double was hiding.

## The bug (HIGH severity)

`packages/decepticon/decepticon/tools/research/sarif_export.py`:

1. **`_iter_findings` read the wrong attribute.** It did `dict(getattr(node, "properties", {}) or {})`, but the real `decepticon_core.types.kg.Node` stores its data in `.props`, not `.properties`. Every real `Node` therefore yielded an empty prop dict:
   - severity collapsed to the `"medium"` default, and
   - `file` / `line` / `cwe` / `cve` were dropped entirely.

2. **`_finding_rule_id` mishandled list-valued CWE.** `cwe` is commonly stored as a list (e.g. `["CWE-89"]`, as produced by the CVE parser and detector prompts), so `f"decepticon/CWE-{cwe}"` emitted a malformed `decepticon/CWE-['CWE-89']`.

### Impact

`export_findings_to_sarif` → `severity_threshold_breach(doc, fail_on="high")` **never tripped** on a genuine CRITICAL/HIGH finding from a real graph. As a result `cli/scan.py::_write_sarif_and_gate` returned `EXIT_OK` and the `decepticon scan ... --fail-on high` pipeline reported success when it should have failed.

The bug was masked by the unit suite's `_FakeNode`, which exposed a `.properties` attribute the production model does not have.

## The fix (minimal, 2 source lines)

- `_iter_findings`: read `.props` first, with a fallback to `.properties` so the legacy duck-typed doubles keep working:
  ```python
  props = dict(getattr(node, "props", None) or getattr(node, "properties", {}) or {})
  ```
- `_finding_rule_id`: normalize a list-valued `cwe` to its first element before formatting:
  ```python
  cwe = cwe[0] if isinstance(cwe, list) and cwe else (cwe or "")
  ```

No unrelated code was refactored.

## Tests

Added real-model tests (`tests/unit/research/test_sarif_export.py`) that build an actual `Node.make(NodeKind.FINDING, ...)` carrying `severity="high"/"critical"`, a list-valued `cwe`, plus `file`/`line`, then assert:

- exported `level` / `security-severity` reflect high/critical (not the default medium),
- the CWE rule id is well-formed (`decepticon/CWE-89`, no `['...']`), with first-CWE-wins for multi-element lists,
- `severity_threshold_breach(doc, fail_on="high")` returns `True`.

All pre-existing `_FakeNode` tests remain green via the `.props or .properties` fallback.

**Regression proof:** with only the source fix reverted, all 7 new tests fail (`level == "warning"` instead of `"error"`); with the fix applied, all 21 tests in the file pass.

## Verification

- `ruff check` → All checks passed
- `ruff format --check` → already formatted
- `basedpyright sarif_export.py` → 0 errors, 0 warnings, 0 notes
- `pytest tests/unit/research/test_sarif_export.py` → 21 passed
