### PR TITLE
feat(skills): mobile iOS-dynamic / Flutter / Unity-IL2CPP reversing playbooks

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/mobile/android/il2cpp/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/mobile/android/il2cpp/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: il2cpp
+description: Unity IL2CPP game reversing — Il2CppDumper metadata recovery, global-metadata.dat decryption, IDA/Ghidra symbol restore via generated scripts, Frida method hooking, IAP/license bypass, and zygisk-il2cpp-dumper for obfuscated metadata.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: mobile
+  when_to_use: "unity il2cpp libil2cpp.so global-metadata.dat il2cppdumper il2cppinspector mono game reversing anti-cheat license iap inapp purchase ghidra ida symbol restore zygisk"
+  tags: unity, il2cpp, game, reverse-engineering, il2cppdumper, global-metadata, ghidra, frida, iap, anti-cheat
+  mitre_attack: T1635, T1406, T1407
+---
+
+# Unity IL2CPP Game Reversing Playbook
+
+> Unity IL2CPP compiles C# to C++ then to native `libil2cpp.so`. The
+> managed bytecode is stripped — `jadx` and `apktool` expose only the
+> thin Java bootstrap and reveal nothing of game logic. This playbook
+> recovers readable symbols and hooks runtime methods for license/IAP
+> bypass and vulnerability assessment.
+
+## Prerequisites
+
+- APK obtained (see `mobile/android/SKILL.md` for pull methods).
+- **Il2CppDumper** (Windows .NET or mono CLI):
+  https://github.com/Perfare/Il2CppDumper
+- **Il2CppInspector** (alternative with plugin support):
+  https://github.com/djkaty/Il2CppInspector
+- Ghidra (via MCP `ghidra` server) or IDA (host-side).
+- Frida + Objection for runtime hooking (see `mobile/android/SKILL.md`
+  Frida setup section).
+- **zygisk-il2cpp-dumper** for runtime metadata on protected apps:
+  https://github.com/Perfare/Zygisk-Il2CppDumper
+
+## Step 1: Identify Unity IL2CPP App
+
+```bash
+unzip -o base.apk -d /tmp/apk-out/
+
+# Confirm IL2CPP backend
+ls /tmp/apk-out/lib/arm64-v8a/
+# Must contain: libil2cpp.so
+
+ls /tmp/apk-out/assets/bin/Data/Managed/Metadata/
+# Must contain: global-metadata.dat
+
+# If only libmono.so present → Mono backend (smali/jadx works; this skill N/A)
+# If libil2cpp.so present but no global-metadata.dat → encrypted/obfuscated (go to Step 5)
+
+file /tmp/apk-out/lib/arm64-v8a/libil2cpp.so
+# output: ELF 64-bit LSB shared object, ARM aarch64
+```
+
+## Step 2: Recover Symbols with Il2CppDumper
+
+```bash
+# Extract libs from APK
+cp /tmp/apk-out/lib/arm64-v8a/libil2cpp.so /tmp/
+cp /tmp/apk-out/assets/bin/Data/Managed/Metadata/global-metadata.dat /tmp/
+
+# Run Il2CppDumper (mono CLI on Linux/macOS)
+mono Il2CppDumper.exe /tmp/libil2cpp.so /tmp/global-metadata.dat /tmp/dump-output/
+
+# Windows .NET:
+# Il2CppDumper.exe <libil2cpp.so> <global-metadata.dat> <output-dir>
+```
+
+Output files:
+| File | Content |
+|---|---|
+| `dump.cs` | All C# class/method/field definitions with offsets |
+| `script.json` | Machine-readable symbol map (used by IDA/Ghidra scripts) |
+| `il2cpp.h` | C-style struct definitions for IL2CPP internals |
+| `stringliteral.json` | All managed string literals with addresses |
+
+```bash
+# Quick scan of dump.cs for interesting classes
+grep -i "licen\|premium\|iap\|purchase\|unlock\|cheat\|anti\|integrity" /tmp/dump-output/dump.cs | head -30
+
+# Find method offsets for hooks
+grep -A2 "IsPremium\|CheckLicense\|VerifyReceipt\|IsSubscribed" /tmp/dump-output/dump.cs
+# Output: // RVA: 0x<offset>  — this is the function RVA in libil2cpp.so
+```
+
+## Step 3: Apply Symbols in Ghidra / IDA
+
+### Ghidra (via MCP ghidra server — batch mode)
+
+```
+# 1. Import libil2cpp.so into Ghidra project
+# 2. Run auto-analysis (aarch64)
+# 3. Execute the Il2CppDumper Ghidra script:
+#    Script: ghidra_with_struct.py  (from Il2CppDumper/tools/)
+#    Input: script.json + il2cpp.h
+# 4. All methods now have their managed C# names
+```
+
+```bash
+# Command-line Ghidra headless analysis + script
+"$GHIDRA_HOME/support/analyzeHeadless" /tmp/ghidra-project IL2CPP \
+  -import /tmp/libil2cpp.so \
+  -postScript ghidra_with_struct.py /tmp/dump-output/script.json \
+  -processor AARCH64:LE:64:v8A \
+  -noanalysis
+```
+
+### IDA (host-side)
+
+```python
+# In IDA scripting console (Python):
+# Run ida_with_struct_py3.py from Il2CppDumper/tools/
+# File → Script File → ida_with_struct_py3.py
+# Provide path to script.json when prompted
+# IDA applies all function names + struct types
+```
+
+After symbol restore, navigate to `IsPremiumUser`, `CheckLicense`,
+`VerifyIAP`, `IsCheatDetected`, etc. by name.
+
+## Step 4: Frida Runtime Hooking
+
+### Hook via RVA from dump.cs
+
+```javascript
+// Read RVA from dump.cs comment line: // RVA: 0x<hex>
+// Base address of libil2cpp.so changes per run; use Module.findBaseAddress
+
+var il2cpp_base = Module.findBaseAddress("libil2cpp.so");
+
+// Example: hook IsPremiumUser at RVA 0x1A4F80
+var RVA = 0x1A4F80;
+var isPremium = il2cpp_base.add(RVA);
+
+Interceptor.attach(isPremium, {
+    onEnter: function(args) {
+        console.log("[+] IsPremiumUser called");
+    },
+    onLeave: function(retval) {
+        console.log("[+] Original return:", retval.toInt32());
+        retval.replace(ptr(1));  // return true
+        console.log("[+] Replaced with: 1");
+    }
+});
+```
+
+```bash
+# Load hook script
+frida -U -f com.unity.targetgame -l hook-il2cpp.js --no-pause
+```
+
+### Static libil2cpp.so patch (persistent, no Frida needed)
+
+```bash
+# Patch return value of IsPremiumUser at computed file offset
+python3 - <<'EOF'
+import struct
+
+RVA = 0x1A4F80
+LOAD_OFFSET = 0x0  # verify with readelf -l libil2cpp.so
+
+with open("/tmp/libil2cpp.so", "r+b") as f:
+    file_offset = RVA - LOAD_OFFSET
+    f.seek(file_offset)
+    # AArch64: MOV W0, #1 (0x20008052) + RET (0xC003_5FD6)
+    f.write(b"\x20\x00\x80\x52\xC0\x03\x5F\xD6")
+print(f"[+] Patched at file offset 0x{file_offset:X}")
+EOF
+
+# Repack APK
+apktool b /tmp/apk-smali/ -o /tmp/patched.apk
+# Replace libs/arm64-v8a/libil2cpp.so with patched version
+zip -u /tmp/patched.apk lib/arm64-v8a/libil2cpp.so
+uber-apk-signer.jar --allowResign -a /tmp/patched.apk -o /tmp/
+adb install /tmp/patched-aligned-signed.apk
+```
+
+## Step 5: Encrypted / Obfuscated global-metadata.dat
+
+Some apps (particularly heavily monetized games) encrypt or obfuscate
+`global-metadata.dat` to frustrate IL2CPP reversing.
+
+### Detect obfuscation
+
+```bash
+# Check magic bytes — valid global-metadata starts with: AF 1B B1 FA
+xxd /tmp/global-metadata.dat | head -2
+# If first 4 bytes ≠ AF 1B B1 FA → encrypted/custom header
+```
+
+### Common obfuscation patterns
+
+| Pattern | Detection | Counter |
+|---|---|---|
+| XOR with static key | First 4 bytes XOR'd from AF 1B B1 FA | Brute short key or key in `libil2cpp.so` strings |
+| Custom header / prepended garbage | File larger than expected; magic at offset N | Scan for `\xAF\x1B\xB1\xFA` pattern in file |
+| RC4/AES at init | `libil2cpp.so` contains crypto init before metadata load | Frida hook on `il2cpp_codegen_initialize_method` |
+
+```bash
+# Search libil2cpp.so for crypto key material near metadata init
+r2 -qc 'iz~metadata\|iz~global' /tmp/libil2cpp.so | head -20
+strings /tmp/libil2cpp.so | grep -iE "meta|key|init" | head -20
+```
+
+### zygisk-il2cpp-dumper (runtime dump, bypasses all static obfuscation)
+
+```bash
+# Install Zygisk-Il2CppDumper module via Magisk Manager
+# Flash zip: ZygiskIl2CppDumper-v<version>.zip
+# Configure target package in /data/adb/modules/zygisk_il2cpp_dumper/config.json
+
+cat /data/adb/modules/zygisk_il2cpp_dumper/config.json
+# { "package_name": "com.unity.targetgame" }
+
+# Launch the target app
+adb shell am start -n com.unity.targetgame/.MainActivity
+
+# Dumped files appear in /data/local/tmp/il2cpp_dump/
+adb pull /data/local/tmp/il2cpp_dump/
+ls il2cpp_dump/
+# global-metadata.dat  libil2cpp.so  (decrypted at runtime)
+```
+
+Feed the runtime-dumped files to Il2CppDumper per Step 2.
+
+## Step 6: Il2CppInspector (Alternative — Richer Output)
+
+```bash
+# Il2CppInspector CLI mode
+mono Il2CppInspector.exe \
+  --select-outputs Frida \
+  --output /tmp/frida-hooks.js \
+  /tmp/libil2cpp.so /tmp/global-metadata.dat
+
+# Produces a ready-to-load Frida script with all class/method stubs
+# Load and customize the method of interest
+
+# Also supports IDA, C# pseudo-code, and Roslyn output modes
+```
+
+## Evidence
+
+```python
+kg_add_node(
+    kind="finding",
+    label="Unity IL2CPP client-side IAP bypass",
+    props={
+        "key": f"il2cpp-iap-bypass::{package_id}",
+        "severity": "high",
+        "cvss": 8.1,
+        "package": package_id,
+        "hooked_method": "IsPremiumUser / VerifyReceipt",
+        "rva": "0x<from-dump.cs>",
+        "bypass_proof": "Frida hook returns true; premium features unlocked",
+    },
+)
+
+kg_add_node(
+    kind="finding",
+    label="Unity IL2CPP anti-cheat bypass",
+    props={
+        "key": f"il2cpp-anticheat-bypass::{package_id}",
+        "severity": "medium",
+        "method": "IsCheatDetected",
+        "details": "Client-only check; server-authoritative validation absent",
+    },
+)
+```
+
+## ZFP
+
+1. `dump.cs` excerpt showing `IsPremiumUser` with RVA comment.
+2. Screenshot/screen-recording of the patched/hooked app with
+   premium features unlocked or anti-cheat bypassed.
+3. Frida console output showing hook fired + return value replaced.
+
+## OPSEC Notes
+
+- Il2CppDumper runs entirely offline on extracted APK files. No
+  network activity required for analysis.
+- Static patching changes the APK signature; Play Integrity / SafetyNet
+  will flag it. Use Frida hooks on a rooted device for non-persistent
+  testing.
+- zygisk-il2cpp-dumper requires Zygisk (Magisk Delta or native Zygisk).
+  It runs in the app process at startup and can be detected by some
+  anti-cheat engines (EAC, BattlEye mobile). Use only in scope.
+- Dumped `dump.cs` may contain plaintext user-data class names that
+  reveal the developer's internal naming conventions — treat as
+  sensitive during an engagement.
+
+## Severity Table
+
+| Bug | Severity |
+|---|---|
+| Client-side IAP bypass (server trusts client result) | High 8.1 |
+| License check entirely client-side | High 7.5 |
+| Anti-cheat only client-side (game balance impact) | Medium 5.5 |
+| Encrypted metadata recovered via runtime dump | Informational (enables further bugs) |
+| Hardcoded API key / secret in `dump.cs` string literals | Critical 9.0 |
+
+## References
+
+- Il2CppDumper: https://github.com/Perfare/Il2CppDumper
+- Zygisk-Il2CppDumper: https://github.com/Perfare/Zygisk-Il2CppDumper
+- Il2CppInspector: https://github.com/djkaty/Il2CppInspector
+- Cross-ref: `mobile/android/SKILL.md` (Frida setup, APK pull)
+- Cross-ref: `mobile/flutter/SKILL.md` (Dart AOT — different toolchain)
+- Cross-ref: `reverser/triage/SKILL.md` (binary triage)

--- a/packages/decepticon/decepticon/skills/standard/mobile/flutter/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/mobile/flutter/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: flutter
+description: Flutter app reversing and SSL pinning bypass — reFlutter Dart-AOT patching, BoringSSL bypass, libapp.so static analysis in Ghidra/radare2, Dart snapshot dump, and iOS Flutter.framework notes.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: mobile
+  when_to_use: "flutter dart aot libapp.so libflutter reflutter boringssl ssl pinning bypass snapshot dump cross-platform jadx-useless tunproxy uber-apk-signer"
+  tags: flutter, dart, reflutter, ssl-pinning, reverse-engineering, libapp, boringssl
+  mitre_attack: T1635, T1521.003, T1406
+---
+
+# Flutter App Reversing Playbook
+
+> Flutter compiles Dart AOT to a native shared library (`libapp.so` /
+> `Flutter.framework`). `jadx` / `apktool` show only the thin Java/ObjC
+> shell and are useless for app logic. Use this playbook when static
+> Android or iOS skills yield nothing but an empty Java wrapper.
+
+## Prerequisites
+
+- APK / IPA obtained (see `mobile/android/SKILL.md` Path 1 for APK pull).
+- Tools: `reflutter` (`pip install reflutter`), `uber-apk-signer`
+  (download JAR from GitHub releases), `adb` + device or emulator,
+  `jadx` (identification only), Burp Suite proxy.
+- For iOS: `reFlutter` also patches `Flutter.framework`; use
+  `objection patchipa` or direct framework patching workflow.
+
+## Step 1: Identify a Flutter App
+
+```bash
+# Unzip APK, look for the telltale Flutter artifacts
+unzip -o base.apk -d /tmp/apk-out/
+
+ls /tmp/apk-out/lib/arm64-v8a/
+# Flutter app: libflutter.so  libapp.so
+# Present:     flutter_assets/   kernel_blob.bin (optional, debug)
+
+# jadx shows only the Java bootstrap:
+jadx -d /tmp/apk-java /tmp/base.apk
+# Expect: ~1 class, LoadLibrary("app"), nothing useful
+
+# Confirm with strings:
+strings /tmp/apk-out/lib/arm64-v8a/libflutter.so | grep -i "flutter"
+strings /tmp/apk-out/lib/arm64-v8a/libapp.so | grep -E "https?://"
+```
+
+Key tell: `libapp.so` size > 5 MB with no dex business logic; the
+`kernel_blob.bin` in `flutter_assets/` indicates a debug/JIT build
+(rare in production; can extract Dart directly with `dart_vm`).
+
+## Step 2: reFlutter Workflow — Patch BoringSSL Pinning
+
+reFlutter patches the `ssl_crypto_x509_session_verify_cert_chain`
+function in `libflutter.so` to always return `true`, bypassing all
+BoringSSL-based certificate validation (covers both custom pinning
+and system trust).
+
+### Flutter <= 3.23.x (hardcoded proxy IP)
+
+```bash
+# Patch: supply your Burp listener IP
+reflutter base.apk
+
+# reFlutter prompts for IP — enter your Burp machine IP (e.g. 192.168.1.100)
+# Output: release.RE.apk (patched, unsigned)
+
+# Sign with uber-apk-signer
+java -jar uber-apk-signer.jar --allowResign -a release.RE.apk -o /tmp/
+
+# Install on device
+adb install /tmp/release.RE-aligned-signed.apk
+
+# Configure Burp proxy listener on 0.0.0.0:8083 (reFlutter default port is 8083)
+# Launch app — HTTPS traffic appears in Burp
+```
+
+### Flutter >= 3.24.0 (no hardcoded proxy IP — breaking change)
+
+Starting Flutter 3.24.0 (August 2024), the hardcoded proxy IP was
+removed from the patched BoringSSL stub. Traffic is no longer
+redirected to a fixed IP. Two options:
+
+**Option A: Device-level proxy**
+```bash
+# Patch as above (no IP prompt in 3.24+)
+reflutter base.apk
+java -jar uber-apk-signer.jar --allowResign -a release.RE.apk -o /tmp/
+
+# Install and configure device proxy manually:
+# Android Settings → Wi-Fi → [SSID] → Proxy → Manual
+# Host: <Burp-IP>  Port: 8080
+
+# Or use TunProxy for non-proxy-aware processes:
+adb install TunProxy.apk
+# Launch TunProxy, set server to <Burp-IP>:8080, toggle VPN
+# Then launch patched app
+```
+
+**Option B: Per-app proxy injection via Frida**
+```bash
+# Run patched APK + Frida script to redirect all socket connections
+frida -U -f com.target.app -l proxy-redirect.js --no-pause
+# proxy-redirect.js: hooks connect() syscall, redirects to Burp IP
+```
+
+### iOS Flutter.framework patching
+
+```bash
+# Extract IPA
+unzip target.ipa -d /tmp/ipa-out/
+# Locate Flutter.framework
+ls /tmp/ipa-out/Payload/TargetApp.app/Frameworks/Flutter.framework/Flutter
+
+# reFlutter iOS (experimental — check reFlutter README for current support)
+reflutter target.ipa
+# Sign with codesign + adhoc or with valid mobileprovision
+codesign --force --sign - /tmp/ipa-out/Payload/TargetApp.app/Frameworks/Flutter.framework/Flutter
+# Repack + install with ios-deploy or Sideloadly
+```
+
+## Step 3: BoringSSL Bypass Mechanism
+
+reFlutter patches `ssl_crypto_x509_session_verify_cert_chain` to
+unconditionally return `1` (success). This function is the central
+chain verification entry point in BoringSSL (the TLS library embedded
+in `libflutter.so`) — no root CA, no pinning config, and no custom
+validator override this patch because the chain evaluation never runs.
+
+**Manual binary patch (if reFlutter fails on a specific version):**
+```bash
+# Find the function offset in libflutter.so
+r2 -A /tmp/apk-out/lib/arm64-v8a/libflutter.so
+# In r2: afl~ssl_crypto_x509
+# Or: /c ret  in data section near ssl_crypto_x509_session_verify_cert_chain
+
+# Patch: overwrite function prologue with MOV W0, #1 / RET (AArch64)
+# MOV W0, 1 = 20 00 80 52
+# RET        = C0 03 5F D6
+python3 -c "
+import struct
+with open('libflutter.so', 'r+b') as f:
+    f.seek(<offset>)
+    f.write(b'\x20\x00\x80\x52\xC0\x03\x5F\xD6')
+"
+```
+
+## Step 4: Static Native RE — libapp.so in Ghidra / radare2
+
+```bash
+# Load libapp.so in radare2 for quick triage
+r2 -A /tmp/apk-out/lib/arm64-v8a/libapp.so
+
+# Strings — API endpoints, Firebase config, hardcoded keys
+r2 -qc 'iz~https' /tmp/apk-out/lib/arm64-v8a/libapp.so
+r2 -qc 'iz~firebase' /tmp/apk-out/lib/arm64-v8a/libapp.so
+r2 -qc 'iz~AIza' /tmp/apk-out/lib/arm64-v8a/libapp.so   # Firebase API key prefix
+
+# Imports — identify Flutter plugins with native bridges
+r2 -qc 'ii' /tmp/apk-out/lib/arm64-v8a/libapp.so | head -40
+```
+
+In Ghidra (MCP-connected via `ghidra` server):
+```
+# connect_instance first, then batch analyze
+# Load libapp.so → auto-analyze
+# Search defined strings for URL patterns, credential patterns
+# Dart AOT functions are not named — use string xrefs to find handlers
+```
+
+Dart AOT functions lack names (no symbol table in release builds) but
+the Dart snapshot contains type metadata that `Il2CppDumper`-style
+tools and `dart_vm` snapshot parsers can partially recover (see
+snapshot dump section below).
+
+## Step 5: Dart Snapshot Dump (Hit-or-Miss)
+
+```bash
+# Option 1: runtime adb pull from memory-mapped snapshot
+adb shell "run-as com.target.app cat /data/data/com.target.app/app_flutter/snapshot_blob.bin" \
+  > /tmp/snapshot_blob.bin 2>/dev/null
+
+# Option 2: use Dart VM snapshot reader tools
+# dart_snapshot_parser (community; partial support for Dart 2.x-3.x)
+pip install dart-snapshot-parser 2>/dev/null || true
+
+# Option 3: reFlutter's snapshot output
+# After running reFlutter and launching the patched app once,
+# reFlutter dumps snapshot_hash.txt which can seed symbol recovery tools
+```
+
+**Caveats**: Dart snapshot format changed in Dart 2.15, 3.0, and 3.4.
+Community parsers (snapshot_inspector, etc.) are often version-specific
+and may produce partial or no output on latest Flutter. Treat snapshot
+dump as a best-effort step; static string analysis is more reliable.
+
+## Step 6: Flutter Plugin Identification
+
+Flutter plugins use platform channels with predictable naming:
+
+```bash
+# Find channel names in libapp.so strings
+strings /tmp/apk-out/lib/arm64-v8a/libapp.so | grep -E "plugins\.|flutter\." | sort -u
+
+# Channel names like:
+#   com.google.firebase.messaging       → push tokens
+#   plugins.flutter.io/path_provider   → storage paths
+#   flutter.baseflow.com/geolocator    → GPS
+#   plugins.flutter.io/local_auth      → biometric
+
+# Cross-reference with flutter_assets/AssetManifest.json
+cat /tmp/apk-out/flutter_assets/AssetManifest.json | python3 -m json.tool | head
+```
+
+## Evidence
+
+```python
+kg_add_node(
+    kind="finding",
+    label="Flutter BoringSSL pinning bypassed",
+    props={
+        "key": f"flutter-boringssl-bypass::{package_id}",
+        "severity": "high",
+        "cvss": 7.4,
+        "package": package_id,
+        "flutter_version": "<version-from-libflutter-strings>",
+        "bypass_method": "reFlutter",
+        "proxy_verified": True,
+    },
+)
+```
+
+## ZFP
+
+1. Burp HTTP history showing decrypted HTTPS from patched Flutter app.
+2. `strings libapp.so | grep https` output showing extracted endpoints.
+3. Screenshot of reFlutter build output + uber-apk-signer signing
+   confirming the patched APK was installed.
+
+## OPSEC Notes
+
+- reFlutter requires re-signing the APK; app integrity checks (Google
+  Play Integrity API, SafetyNet) will flag the modified signature.
+  Use emulator or device without Play Store for testing.
+- The patched APK has a different certificate than the original; side-
+  load via `adb install` or `adb install --bypass-low-target-sdk-block`.
+- For production devices, TunProxy routes traffic at the VPN layer
+  without modifying the APK signature.
+- libflutter.so binary patching is version-specific; wrong offset
+  crashes the app. Always test on a throwaway device/emulator first.
+
+## Severity Table
+
+| Bug | Severity |
+|---|---|
+| No certificate validation (BoringSSL patched trivially) | High 7.4 |
+| Hardcoded API key / Firebase config in libapp.so strings | Critical 9.0 |
+| Sensitive data in Dart snapshot / kernel_blob | High 7.5 |
+| Flutter plugin channel unauthenticated method call | Medium-High |
+
+## References
+
+- reFlutter: https://github.com/ptswarm/reFlutter
+- Flutter 3.24.0 proxy change: https://github.com/ptswarm/reFlutter/issues/107
+- TunProxy (Android): https://github.com/raise-isayan/TunProxy
+- uber-apk-signer: https://github.com/patrickfav/uber-apk-signer
+- kayssel "Breaking Flutter" guide: https://blog.nviso.eu/2022/08/18/intercept-flutter-traffic-on-ios-and-android-http-https-edition/
+- Cross-ref: `mobile/android/SKILL.md` (APK pull), `mobile/ios/dynamic/SKILL.md` (iOS BoringSSL path)

--- a/packages/decepticon/decepticon/skills/standard/mobile/ios/dynamic/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/mobile/ios/dynamic/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: dynamic
+description: iOS dynamic instrumentation on jailbroken device — Frida/Objection setup, SSL Kill Switch pinning bypass, jailbreak-detection bypass, keychain dump, biometric/LAContext bypass, and ObjC runtime method hooking.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: mobile
+  when_to_use: "ios dynamic frida objection jailbreak ssl kill switch pinning bypass keychain dump biometric faceid touchid lacontext jailbreak-detection palera1n unc0ver checkra1n cycript"
+  tags: ios, frida, objection, ssl-pinning, jailbreak, keychain, biometric, lacontext
+  mitre_attack: T1635, T1521.003, T1517, T1633
+---
+
+# iOS Dynamic Instrumentation Playbook
+
+> Jailbroken device required for full Frida/Objection access. Most
+> enterprise and bounty-program iOS testing falls here. For static-only
+> analysis (no jailbreak) see `reverser/ios-static/SKILL.md`.
+
+## Prerequisites
+
+- iOS device jailbroken with **palera1n** (A8-A11 on iOS 16+),
+  **checkra1n** (A5-A11, up to iOS 14.8), or **unc0ver** (A12+ up to
+  iOS 14.8 with supported blobs). Confirm with `uname -v` in SSH.
+- Frida server installed via Cydia / Sileo (search "Frida") or manually:
+
+```bash
+# SSH to device (default Cydia SSH cred: alpine)
+ssh root@<device-ip>
+
+# Verify jailbreak + SSH works
+id   # should return uid=0(root)
+uname -v
+```
+
+- Host side: `pip install frida-tools objection`
+- Confirm connectivity:
+
+```bash
+frida-ps -U   # lists processes on USB-connected device
+```
+
+## Path A: SSL Pinning Bypass
+
+### SSL Kill Switch 2 / 3
+
+Install via Cydia/Sileo (search "SSL Kill Switch 2" or "SSL Kill
+Switch 3" for iOS 15+). Toggle per-app in Settings → SSL Kill Switch.
+Relaunch the app; verify traffic appears in Burp (set device proxy to
+Burp listener IP:8080, install Burp CA as trusted profile via
+Settings → General → VPN & Device Management).
+
+### Objection pinning disable (preferred for on-demand toggle)
+
+```bash
+# Attach to running app
+objection --gadget "TargetApp" explore
+
+# In the Objection REPL:
+ios sslpinning disable
+
+# Verify: open the app, check Burp proxy for decrypted HTTPS
+```
+
+### Frida codeshare scripts (NSURLSession / AFNetworking / TrustKit)
+
+```bash
+# Universal iOS pinning bypass (covers NSURLSession, Alamofire, AFNetworking)
+frida -U -f com.target.bundle \
+  --codeshare "wan-make/ios-ssl-pinning-bypass" \
+  --no-pause
+
+# TrustKit-specific bypass
+frida -U -f com.target.bundle \
+  --codeshare "machorka/trustkit-bypass" \
+  --no-pause
+```
+
+### Manual Frida script for custom pinners
+
+```javascript
+// Hook SecTrustEvaluate + SecTrustEvaluateWithError
+// Load with: frida -U -f com.target -l bypass-pin.js
+if (ObjC.available) {
+    var SecTrustEvaluateWithError = Module.findExportByName(
+        "Security", "SecTrustEvaluateWithError");
+    if (SecTrustEvaluateWithError) {
+        Interceptor.replace(SecTrustEvaluateWithError,
+            new NativeCallback(function(trust, error) {
+                if (error !== 0) Memory.writePointer(error, ptr(0));
+                return 1;  // errSecSuccess
+            }, 'int', ['pointer', 'pointer']));
+    }
+}
+```
+
+Verify in Burp: `HTTPS` traffic from the target app appears decrypted.
+
+## Path B: Jailbreak-Detection Bypass
+
+### Objection built-in
+
+```bash
+objection --gadget "TargetApp" explore
+
+# Disable JB detection (covers fileExistsAtPath Cydia checks + fork())
+ios jailbreak disable
+```
+
+### Common detection patterns to hook manually
+
+| Pattern | API to hook |
+|---|---|
+| File presence (`/Applications/Cydia.app`, `/bin/bash`) | `NSFileManager fileExistsAtPath:` |
+| URL scheme (`cydia://`) | `UIApplication canOpenURL:` |
+| `fork()` syscall return | `fork` (libc) |
+| `/proc/self/maps` inspection | `open` / `fopen` |
+| Dyld image name scan | `_dyld_get_image_name` |
+
+```javascript
+// Frida: hook fileExistsAtPath to suppress JB file checks
+var NSFileManager = ObjC.classes.NSFileManager;
+var orig = NSFileManager["- fileExistsAtPath:"].implementation;
+Interceptor.replace(orig, ObjC.implement(
+    NSFileManager["- fileExistsAtPath:"],
+    function(self, sel, path) {
+        var p = ObjC.Object(path).toString();
+        var jbPaths = ["/Applications/Cydia.app", "/bin/bash",
+                       "/usr/sbin/sshd", "/etc/apt", "/private/var/lib/apt/"];
+        for (var i = 0; i < jbPaths.length; i++) {
+            if (p.indexOf(jbPaths[i]) !== -1) return 0;  // false
+        }
+        return orig(self, sel, path);
+    }
+));
+```
+
+### Liberty Lite / A-Bypass (tweak-side)
+
+Install Liberty Lite or A-Bypass from Cydia/Sileo → enable per-app
+toggle before launch. Faster than scripting for commodity JB checks.
+
+## Path C: Keychain Dump
+
+### Objection keychain dump
+
+```bash
+objection --gadget "TargetApp" explore
+
+# Dump all items accessible in app context
+ios keychain dump
+
+# Output: account, service, access group, kSecAttrAccessible class, value
+```
+
+### Frida hook on SecItemCopyMatching
+
+```javascript
+// Log every keychain query result
+var SecItemCopyMatching = Module.findExportByName(
+    "Security", "SecItemCopyMatching");
+Interceptor.attach(SecItemCopyMatching, {
+    onEnter: function(args) { this.result = args[1]; },
+    onLeave: function(retval) {
+        if (retval.toInt32() === 0 && !this.result.isNull()) {
+            var items = new ObjC.Object(this.result.readPointer());
+            console.log("[KC]", items.toString());
+        }
+    }
+});
+```
+
+### `kSecAttrAccessible` misconfig findings
+
+| Value | Finding |
+|---|---|
+| `kSecAttrAccessibleAlways` | Critical — readable without unlock, even after reboot |
+| `kSecAttrAccessibleAlwaysThisDeviceOnly` | High — readable without unlock |
+| `kSecAttrAccessibleAfterFirstUnlock` | Medium if secrets are high-value |
+| `kSecAttrAccessibleWhenUnlocked` | Acceptable baseline |
+| `kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly` | Secure — requires passcode |
+
+## Path D: Biometric / LAContext Bypass
+
+### Hook evaluatePolicy to always succeed
+
+```javascript
+// Bypass LAContext biometric prompt — returns kLAErrorSuccess
+var LAContext = ObjC.classes.LAContext;
+Interceptor.attach(
+    LAContext["- evaluatePolicy:localizedReason:reply:"].implementation,
+    {
+        onEnter: function(args) {
+            // args[3] = reply block (id, NSError*)
+            var replyBlock = new ObjC.Block(args[3]);
+            var origImpl = replyBlock.implementation;
+            replyBlock.implementation = function(success, error) {
+                origImpl(1, null);  // force success=YES, error=nil
+            };
+        }
+    }
+);
+```
+
+### Objection biometric bypass
+
+```bash
+objection --gadget "TargetApp" explore
+ios ui biometrics_bypass
+```
+
+## Path E: ObjC Runtime Method Swizzling (License / Auth Checks)
+
+```javascript
+// Example: patch -[LicenseManager isPremiumUser] to return YES
+Java.perform(function() {});  // no-op; use ObjC.available block
+
+var LicenseMgr = ObjC.classes.LicenseManager;
+if (LicenseMgr && LicenseMgr["- isPremiumUser"]) {
+    Interceptor.replace(
+        LicenseMgr["- isPremiumUser"].implementation,
+        ObjC.implement(LicenseMgr["- isPremiumUser"], function(self, sel) {
+            console.log("[+] isPremiumUser hooked -> returning YES");
+            return 1;
+        })
+    );
+}
+```
+
+```bash
+# One-liner attach to running process
+frida -U -n TargetApp -e "ObjC.classes.LicenseManager['- isPremiumUser'].implementation = ObjC.implement(ObjC.classes.LicenseManager['- isPremiumUser'], function(self,sel){return 1;});"
+```
+
+## Evidence
+
+Capture Burp traffic screenshot showing decrypted HTTPS after pinning
+bypass. Save keychain dump to `/workspace/evidence/mobile/<bundle-id>/keychain.txt`.
+
+```python
+kg_add_node(
+    kind="finding",
+    label="iOS SSL pinning bypassable",
+    props={
+        "key": f"ios-ssl-pin::{bundle_id}",
+        "severity": "high",
+        "cvss": 7.4,
+        "bundle_id": bundle_id,
+        "bypass_method": "objection+ssl-kill-switch",
+        "traffic_captured": True,
+    },
+)
+
+kg_add_node(
+    kind="finding",
+    label="iOS keychain kSecAttrAccessibleAlways item",
+    props={
+        "key": f"ios-keychain-acl::{bundle_id}",
+        "severity": "critical",
+        "service": "<service-name>",
+        "account": "<account-name>",
+        "accessible_class": "kSecAttrAccessibleAlways",
+    },
+)
+```
+
+## ZFP
+
+Two-method evidence per finding:
+
+1. **Pinning bypass**: Burp HTTP history screenshot with decrypted HTTPS
+   requests from the target app visible.
+2. **Keychain misconfig**: `ios keychain dump` output showing
+   `kSecAttrAccessibleAlways` class + sensitive value.
+3. **Biometric bypass**: screen recording of the app unlocking without
+   presenting a Face ID prompt after the hook fires.
+
+## OPSEC Notes
+
+- Jailbreaking leaves fingerprints: jailbroken device connects to
+  Apple ID — use a dedicated Apple ID for testing; avoid using personal
+  iCloud account.
+- Frida injects a Gadget dylib; some apps detect `frida-agent` in
+  the dyld image list. Counter: Frida Gadget injection via
+  `objection patchipa` or `optool` (embed Gadget, re-sign with
+  `codesign`).
+- SSL Kill Switch modifies a system library; some app-layer integrity
+  checks may detect it. Script-based bypass (injected Frida) leaves
+  fewer static artifacts than a system tweak.
+- `palera1n` tethered jailbreak: device reboots to unjailbroken state;
+  re-jailbreak each power cycle during long engagements.
+
+## Severity Table
+
+| Bug | Severity |
+|---|---|
+| Keychain `kSecAttrAccessibleAlways` with auth token | Critical 9.5 |
+| SSL pinning fully absent or bypassable without JB | High 8.0 |
+| Jailbreak detection absent | Informational |
+| Biometric bypass exposing auth flow | High 7.5 |
+| `kSecAttrAccessibleAfterFirstUnlock` with secrets | Medium 5.5 |
+
+## References
+
+- palera1n: https://github.com/palera1n/palera1n
+- Frida: https://frida.re/docs/ios/
+- Objection: https://github.com/sensepost/objection
+- SSL Kill Switch 3: https://github.com/Tym0n/SSL-Kill-Switch3
+- Codeshare universal bypass: https://codeshare.frida.re/@wan-make/ios-ssl-pinning-bypass/
+- Cross-ref static analysis: `reverser/ios-static/SKILL.md`


### PR DESCRIPTION
## Summary

Adds three mobile-pentest skill playbooks to fill documented gaps in the `standard/mobile/` skill tree. All changes are additive markdown-only SKILL.md files — no Python source modifications.

### New playbooks

| Path | Gap filled |
|---|---|
| `packages/decepticon/decepticon/skills/standard/mobile/ios/dynamic/SKILL.md` | `mobile/SKILL.md` catalog advertises `ios/frida-trust-killer` + `ios/jailbreak-detect-bypass` but neither directory existed. This single playbook covers the full iOS dynamic surface: SSL Kill Switch + NSURLSession pinning bypass, jailbreak-detection bypass (fileExistsAtPath / fork / cydia:// patterns), keychain dump with kSecAttrAccessible misconfig triage, LAContext biometric bypass, and ObjC method swizzling for license/auth checks. |
| `packages/decepticon/decepticon/skills/standard/mobile/flutter/SKILL.md` | The Android playbook covers jadx/smali but is entirely useless against Flutter's Dart-AOT `libapp.so`. This playbook adds the reFlutter BoringSSL bypass workflow (both ≤3.23.x hardcoded-proxy and the 3.24.0+ breaking change that requires TunProxy/device-proxy), libapp.so static analysis with radare2/Ghidra, Dart snapshot dump caveats, and Flutter plugin channel identification. |
| `packages/decepticon/decepticon/skills/standard/mobile/android/il2cpp/SKILL.md` | No IL2CPP skill anywhere in the tree. Unity IL2CPP apps compile C# to `libil2cpp.so`; jadx/apktool reveal nothing. This playbook covers Il2CppDumper metadata recovery (`global-metadata.dat` → `dump.cs` + `script.json`), Ghidra/IDA symbol restore via generated scripts, Frida hook at RVA offset for IAP/license bypass, AArch64 static patching, obfuscated-metadata detection + zygisk-il2cpp-dumper runtime dump path, and Il2CppInspector Frida-stub generation mode. |

## Verification gates (all green)

- `ruff check .` — passed (no Python files added)
- `ruff format --check .` — 398 files already formatted
- `pytest test_skills_registry.py test_skills_path.py` — 33 passed

## Notes

- Additive markdown skills only; no source code changes.
- Each SKILL.md begins with a valid `---` frontmatter block with `name`, `description`, `allowed-tools`, and `metadata` (`subdomain`, `when_to_use`, `tags`, `mitre_attack`) matching the house schema.
- `metadata.when_to_use` on each leaf contains its routing keywords for SkillsMiddleware auto-routing.