### PR TITLE
feat(tools/research): semantic finding deduplication (report-only, opt-in)

### DIFF
--- a/packages/decepticon/decepticon/tools/research/dedupe.py
+++ b/packages/decepticon/decepticon/tools/research/dedupe.py
@@ -1,0 +1,342 @@
+"""Semantic deduplication for knowledge-graph finding/vulnerability nodes.
+
+Decepticon's graph dedups writes by deterministic node ID (SHA1 of kind +
+canonical key — see :mod:`decepticon_core.types.kg`). That collapses
+*byte-identical* writes, but the multi-agent design (recon / exploit /
+analyst / vulnresearch each running with fresh context) structurally
+produces SEPARATE nodes for the SAME underlying vulnerability when it is
+reached via different routes or described with different wording. Those
+near-duplicates survive ID-based dedup and surface as repeated entries in
+reports.
+
+This module adds a second, *semantic* layer on top of ID dedup. It is:
+
+- **Pure**: :func:`find_duplicate` takes the candidate, the existing nodes,
+  and an INJECTED ``judge`` callable. No LLM client is imported here, so
+  the decision logic is fully testable with a stubbed judge.
+- **Cheap-first**: a deterministic :func:`prefilter` (same
+  :class:`~decepticon_core.types.kg.NodeKind` plus normalized host /
+  endpoint / CWE overlap) runs BEFORE the judge, so obvious non-candidates
+  are rejected without ever invoking it.
+- **Report-only**: the :func:`kg_dedupe_findings` tool clusters likely
+  duplicates and returns a JSON summary. It never deletes or mutates graph
+  nodes — merging is a deliberate follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from langchain_core.tools import tool
+
+from decepticon.tools.research._state import _json, graph_transaction
+from decepticon_core.types.kg import KnowledgeGraph, Node, NodeKind
+
+Judge = Callable[[Node, Node], dict[str, Any]]
+
+_FINDING_KINDS: frozenset[NodeKind] = frozenset({NodeKind.FINDING, NodeKind.VULNERABILITY})
+
+_HOST_PROP_KEYS: tuple[str, ...] = ("host", "hostname", "target", "ip")
+_ENDPOINT_PROP_KEYS: tuple[str, ...] = ("endpoint", "url", "matched_at", "message", "file")
+
+_CWE_RE = re.compile(r"cwe[-_ ]?(\d+)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class DuplicateVerdict:
+    """Outcome of a duplicate check.
+
+    Attributes:
+        is_duplicate: True when ``candidate`` is judged the same underlying
+            finding as some already-known node.
+        canonical_id: The id of the matched canonical node when
+            ``is_duplicate`` is True, else ``None``.
+        reason: Short human-readable explanation (prefilter miss, judge
+            verdict, etc.).
+    """
+
+    is_duplicate: bool
+    canonical_id: str | None
+    reason: str
+
+
+@dataclass(frozen=True)
+class _Signature:
+    """Normalized, comparable signal extracted from a finding node."""
+
+    kind: NodeKind
+    host: str
+    endpoint: str
+    cwes: frozenset[str]
+
+
+def _first_str_prop(node: Node, keys: Sequence[str]) -> str:
+    """Return the first non-empty string prop among ``keys`` (lowered)."""
+    for key in keys:
+        value = node.props.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _normalize_host(raw: str) -> str:
+    """Reduce a host-ish string to a bare, comparable hostname.
+
+    Strips a URL scheme, any ``user@`` prefix, a path/query tail, and a
+    trailing ``:port`` so ``https://API.example.com:443/x`` and
+    ``api.example.com`` collapse to the same token.
+    """
+    if not raw:
+        return ""
+    value = raw.strip().lower()
+    value = re.sub(r"^[a-z][a-z0-9+.\-]*://", "", value)
+    value = value.split("@", 1)[-1]
+    value = value.split("/", 1)[0]
+    value = value.split("?", 1)[0]
+    if value.count(":") == 1:
+        value = value.split(":", 1)[0]
+    return value.rstrip(".")
+
+
+def _normalize_endpoint(raw: str) -> str:
+    """Reduce an endpoint-ish string to ``host/path`` without scheme/port/query.
+
+    Query strings and fragments are dropped (different agents word the same
+    endpoint with different parameter values) so the path identity is what
+    drives overlap.
+    """
+    if not raw:
+        return ""
+    value = raw.strip().lower()
+    value = re.sub(r"^[a-z][a-z0-9+.\-]*://", "", value)
+    value = value.split("@", 1)[-1]
+    value = value.split("?", 1)[0]
+    value = value.split("#", 1)[0]
+    if "/" in value:
+        authority, _, path = value.partition("/")
+        if authority.count(":") == 1:
+            authority = authority.split(":", 1)[0]
+        value = f"{authority}/{path}"
+    elif value.count(":") == 1:
+        value = value.split(":", 1)[0]
+    return value.rstrip("/")
+
+
+def _extract_cwes(node: Node) -> frozenset[str]:
+    """Collect CWE identifiers from props and label as ``CWE-<n>`` tokens."""
+    found: set[str] = set()
+
+    raw = node.props.get("cwe")
+    candidates: list[str] = []
+    if isinstance(raw, str):
+        candidates.append(raw)
+    elif isinstance(raw, (list, tuple)):
+        candidates.extend(str(item) for item in raw)  # pyright: ignore[reportUnknownArgumentType]
+
+    haystack = " ".join([*candidates, node.label or "", str(node.props.get("message") or "")])
+    for match in _CWE_RE.finditer(haystack):
+        found.add(f"CWE-{int(match.group(1))}")
+    return frozenset(found)
+
+
+def _signature(node: Node) -> _Signature:
+    """Build the normalized comparison signature for a node."""
+    host = _normalize_host(_first_str_prop(node, _HOST_PROP_KEYS))
+    endpoint = _normalize_endpoint(_first_str_prop(node, _ENDPOINT_PROP_KEYS))
+    if not host and endpoint:
+        host = _normalize_host(endpoint)
+    return _Signature(kind=node.kind, host=host, endpoint=endpoint, cwes=_extract_cwes(node))
+
+
+def prefilter(candidate: Node, other: Node) -> bool:
+    """Cheap deterministic gate: could these be the same finding?
+
+    Returns True only when both nodes share a finding-like
+    :class:`NodeKind` AND have at least one locational signal in common:
+    overlapping CWE, the same normalized host, or the same normalized
+    endpoint path. This runs BEFORE any judge so non-candidates never reach
+    an LLM.
+    """
+    if candidate.id == other.id:
+        return False
+    sig_a = _signature(candidate)
+    sig_b = _signature(other)
+    if sig_a.kind != sig_b.kind:
+        return False
+    if sig_a.kind not in _FINDING_KINDS:
+        return False
+    if sig_a.cwes and sig_b.cwes and (sig_a.cwes & sig_b.cwes):
+        return True
+    if sig_a.host and sig_a.host == sig_b.host:
+        return True
+    if sig_a.endpoint and sig_a.endpoint == sig_b.endpoint:
+        return True
+    return False
+
+
+def _judge_says_duplicate(verdict: dict[str, Any]) -> tuple[bool, str]:
+    """Interpret a judge's raw dict into ``(is_duplicate, reason)``."""
+    is_dup = bool(verdict.get("is_duplicate") or verdict.get("duplicate"))
+    reason = verdict.get("reason")
+    reason_text = reason.strip() if isinstance(reason, str) and reason.strip() else "judge verdict"
+    return is_dup, reason_text
+
+
+def find_duplicate(
+    candidate: Node,
+    existing: Sequence[Node],
+    judge: Judge,
+) -> DuplicateVerdict:
+    """Decide whether ``candidate`` duplicates any node in ``existing``.
+
+    The deterministic :func:`prefilter` runs first; only nodes that survive
+    it are passed to ``judge``. The first node the judge confirms as a
+    duplicate wins and its id becomes the canonical id.
+
+    Args:
+        candidate: The newly-observed finding node under test.
+        existing: Already-known finding nodes to compare against.
+        judge: Injected ``(candidate, other) -> dict`` callable. The dict is
+            interpreted via ``is_duplicate``/``duplicate`` (bool) and an
+            optional ``reason`` (str). No LLM call happens inside this
+            module — the caller supplies the judge.
+
+    Returns:
+        A :class:`DuplicateVerdict`. ``is_duplicate`` is False when nothing
+        passes the prefilter or the judge rejects every candidate.
+    """
+    considered = 0
+    for other in existing:
+        if not prefilter(candidate, other):
+            continue
+        considered += 1
+        is_dup, reason = _judge_says_duplicate(judge(candidate, other))
+        if is_dup:
+            return DuplicateVerdict(is_duplicate=True, canonical_id=other.id, reason=reason)
+
+    if considered == 0:
+        return DuplicateVerdict(
+            is_duplicate=False,
+            canonical_id=None,
+            reason="no prefilter candidates",
+        )
+    return DuplicateVerdict(
+        is_duplicate=False,
+        canonical_id=None,
+        reason="judge rejected all candidates",
+    )
+
+
+def _cluster_by_prefilter(nodes: Sequence[Node]) -> list[list[Node]]:
+    """Group finding nodes into prefilter-connected clusters.
+
+    Two nodes land in the same cluster when :func:`prefilter` links them
+    (directly or transitively). Singletons are dropped — only clusters with
+    a likely duplicate are interesting for a dedup report.
+    """
+    finding_nodes = [n for n in nodes if n.kind in _FINDING_KINDS]
+    parent: dict[str, str] = {n.id: n.id for n in finding_nodes}
+
+    def _find(node_id: str) -> str:
+        root = node_id
+        while parent[root] != root:
+            root = parent[root]
+        while parent[node_id] != root:
+            parent[node_id], node_id = root, parent[node_id]
+        return root
+
+    def _union(a: str, b: str) -> None:
+        ra, rb = _find(a), _find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for i, left in enumerate(finding_nodes):
+        for right in finding_nodes[i + 1 :]:
+            if prefilter(left, right):
+                _union(left.id, right.id)
+
+    grouped: dict[str, list[Node]] = {}
+    for node in finding_nodes:
+        grouped.setdefault(_find(node.id), []).append(node)
+
+    return [members for members in grouped.values() if len(members) > 1]
+
+
+def _cluster_summary(members: Sequence[Node]) -> dict[str, Any]:
+    """Build a compact, stable JSON summary for one duplicate cluster.
+
+    The lowest node id is chosen as the canonical anchor purely so the
+    report is deterministic; this tool does not persist that choice.
+    """
+    ordered = sorted(members, key=lambda n: n.id)
+    canonical = ordered[0]
+    sig = _signature(canonical)
+    return {
+        "canonical_id": canonical.id,
+        "kind": canonical.kind.value,
+        "host": sig.host,
+        "endpoint": sig.endpoint,
+        "cwes": sorted(sig.cwes),
+        "size": len(ordered),
+        "members": [
+            {
+                "id": n.id,
+                "kind": n.kind.value,
+                "label": n.label,
+                "severity": n.props.get("severity"),
+            }
+            for n in ordered
+        ],
+    }
+
+
+@tool
+def kg_dedupe_findings(min_cluster_size: int = 2) -> str:
+    """Report likely-duplicate finding/vulnerability clusters (read-only).
+
+    WHEN TO USE: Before writing a report, to surface findings that describe
+    the SAME underlying bug but were recorded as separate nodes by
+    different agents (recon / exploit / analyst / vulnresearch). Decepticon
+    already dedups byte-identical writes by node id; this catches semantic
+    duplicates — same host/endpoint/CWE, different wording.
+
+    HOW IT WORKS: walks Finding and Vulnerability nodes and groups them with
+    a cheap deterministic pre-filter (same kind plus overlapping CWE,
+    normalized host, or normalized endpoint). It is REPORT-ONLY: no nodes
+    are deleted or mutated. Merging duplicates is a deliberate follow-up.
+
+    Args:
+        min_cluster_size: Minimum members for a cluster to be reported
+            (default 2; values below 2 are clamped to 2).
+
+    Returns:
+        JSON with the number of finding nodes scanned, the duplicate
+        clusters found, and how many nodes are involved in duplicates.
+    """
+    threshold = max(min_cluster_size, 2)
+    with graph_transaction() as graph:
+        return _json(_dedupe_report(graph, threshold))
+
+
+def _dedupe_report(graph: KnowledgeGraph, threshold: int) -> dict[str, Any]:
+    """Compute the report-only duplicate summary for ``graph``.
+
+    Split out from the tool wrapper so it stays a pure function over a
+    :class:`KnowledgeGraph` (no graph mutation, easy to unit test).
+    """
+    finding_nodes = [n for n in graph.nodes.values() if n.kind in _FINDING_KINDS]
+    clusters = [c for c in _cluster_by_prefilter(finding_nodes) if len(c) >= threshold]
+    summaries = sorted(
+        (_cluster_summary(c) for c in clusters),
+        key=lambda s: (-s["size"], s["canonical_id"]),
+    )
+    duplicate_nodes = sum(s["size"] for s in summaries)
+    return {
+        "scanned_findings": len(finding_nodes),
+        "duplicate_clusters": len(summaries),
+        "duplicate_nodes": duplicate_nodes,
+        "clusters": summaries,
+    }

--- a/packages/decepticon/decepticon/tools/research/tools.py
+++ b/packages/decepticon/decepticon/tools/research/tools.py
@@ -31,6 +31,7 @@ from decepticon.tools.contracts.slither import ingest_slither_file
 from decepticon.tools.research import cve as cve_mod
 from decepticon.tools.research import fuzz as fuzz_mod
 from decepticon.tools.research.chain import critical_path_score, plan_chains, promote_chain
+from decepticon.tools.research.dedupe import kg_dedupe_findings
 from decepticon.tools.research.health import backend_health
 from decepticon.tools.research.patch import PATCH_TOOLS
 from decepticon.tools.research.sarif import ingest_sarif_file
@@ -2352,6 +2353,7 @@ RESEARCH_TOOLS = [
     kg_neighbors,
     kg_stats,
     kg_backend_health,
+    kg_dedupe_findings,
     kg_ingest_nmap_xml,
     kg_ingest_nuclei_jsonl,
     kg_ingest_subfinder,

--- a/packages/decepticon/tests/unit/research/test_dedupe.py
+++ b/packages/decepticon/tests/unit/research/test_dedupe.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from decepticon.tools.research import _state as state
+from decepticon.tools.research import tools as research_tools
+from decepticon.tools.research.dedupe import (
+    DuplicateVerdict,
+    find_duplicate,
+    prefilter,
+)
+from decepticon_core.types.kg import KnowledgeGraph, Node, NodeKind
+
+
+class _FakeStore:
+    def __init__(self, graph: KnowledgeGraph) -> None:
+        self.graph = graph
+        self.upsert_node_calls = 0
+        self.upsert_edge_calls = 0
+
+    def load_graph(self) -> KnowledgeGraph:
+        return self.graph.model_copy(deep=True)
+
+    def batch_upsert_nodes(self, nodes: list[Node]) -> int:
+        for n in nodes:
+            self.graph.upsert_node(n)
+            self.upsert_node_calls += 1
+        return len(nodes)
+
+    def batch_upsert_edges(self, edges: list[Any]) -> int:
+        for e in edges:
+            self.graph.upsert_edge(e)
+            self.upsert_edge_calls += 1
+        return len(edges)
+
+    def ensure_schema(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def stats(self) -> dict[str, int]:
+        return self.graph.stats()
+
+
+def _sqli_finding(label: str, host: str, *, cwe: str = "CWE-89", **extra: Any) -> Node:
+    return Node.make(
+        NodeKind.VULNERABILITY,
+        label,
+        key=f"vuln::{label}",
+        host=host,
+        cwe=[cwe],
+        severity="high",
+        **extra,
+    )
+
+
+def _same_bug_graph() -> KnowledgeGraph:
+    graph = KnowledgeGraph()
+    graph.upsert_node(
+        _sqli_finding(
+            "SQL injection in login form",
+            "api.example.com",
+            message="error-based SQLi on /login id param",
+        )
+    )
+    graph.upsert_node(
+        _sqli_finding(
+            "Database injection via authentication endpoint",
+            "https://API.example.com:443/login",
+            message="union-based injection reachable from auth flow",
+        )
+    )
+    return graph
+
+
+def _distinct_pair_graph() -> KnowledgeGraph:
+    graph = KnowledgeGraph()
+    graph.upsert_node(_sqli_finding("SQL injection in login form", "api.example.com"))
+    graph.upsert_node(
+        Node.make(
+            NodeKind.VULNERABILITY,
+            "Reflected XSS in search box",
+            key="vuln::xss-search",
+            host="shop.other-site.net",
+            cwe=["CWE-79"],
+            severity="medium",
+        )
+    )
+    return graph
+
+
+def _always_duplicate(_a: Node, _b: Node) -> dict[str, Any]:
+    return {"is_duplicate": True, "reason": "same root cause"}
+
+
+def _never_duplicate(_a: Node, _b: Node) -> dict[str, Any]:
+    return {"is_duplicate": False, "reason": "unrelated"}
+
+
+def _exploding_judge(_a: Node, _b: Node) -> dict[str, Any]:
+    raise AssertionError("judge must not be called when prefilter rejects")
+
+
+def _configure_store(monkeypatch: pytest.MonkeyPatch, graph: KnowledgeGraph) -> _FakeStore:
+    fake = _FakeStore(graph)
+    monkeypatch.setattr(state, "_store", fake)
+    return fake
+
+
+class TestPrefilter:
+    def test_pairs_same_host_and_cwe_findings(self) -> None:
+        nodes = list(_same_bug_graph().nodes.values())
+        assert prefilter(nodes[0], nodes[1]) is True
+
+    def test_rejects_distinct_findings(self) -> None:
+        nodes = list(_distinct_pair_graph().nodes.values())
+        assert prefilter(nodes[0], nodes[1]) is False
+
+    def test_rejects_identical_node(self) -> None:
+        node = _sqli_finding("SQL injection in login form", "api.example.com")
+        assert prefilter(node, node) is False
+
+    def test_rejects_non_finding_kinds(self) -> None:
+        a = Node.make(NodeKind.HOST, "api.example.com", host="api.example.com")
+        b = Node.make(NodeKind.HOST, "api.example.com", key="other", host="api.example.com")
+        assert prefilter(a, b) is False
+
+    def test_endpoint_overlap_without_explicit_host(self) -> None:
+        a = Node.make(
+            NodeKind.FINDING,
+            "IDOR on order endpoint",
+            key="f::a",
+            url="https://shop.example.com/api/orders/1?token=aaa",
+        )
+        b = Node.make(
+            NodeKind.FINDING,
+            "Broken access control reading orders",
+            key="f::b",
+            url="http://shop.example.com/api/orders/1?token=bbb",
+        )
+        assert prefilter(a, b) is True
+
+
+class TestFindDuplicate:
+    def test_returns_duplicate_when_judge_confirms(self) -> None:
+        nodes = list(_same_bug_graph().nodes.values())
+        verdict = find_duplicate(nodes[1], [nodes[0]], _always_duplicate)
+        assert isinstance(verdict, DuplicateVerdict)
+        assert verdict.is_duplicate is True
+        assert verdict.canonical_id == nodes[0].id
+        assert verdict.reason == "same root cause"
+
+    def test_returns_not_duplicate_when_judge_rejects(self) -> None:
+        nodes = list(_same_bug_graph().nodes.values())
+        verdict = find_duplicate(nodes[1], [nodes[0]], _never_duplicate)
+        assert verdict.is_duplicate is False
+        assert verdict.canonical_id is None
+        assert verdict.reason == "judge rejected all candidates"
+
+    def test_distinct_findings_skip_judge_entirely(self) -> None:
+        nodes = list(_distinct_pair_graph().nodes.values())
+        verdict = find_duplicate(nodes[1], [nodes[0]], _exploding_judge)
+        assert verdict.is_duplicate is False
+        assert verdict.canonical_id is None
+        assert verdict.reason == "no prefilter candidates"
+
+    def test_empty_existing_returns_not_duplicate(self) -> None:
+        node = _sqli_finding("SQL injection in login form", "api.example.com")
+        verdict = find_duplicate(node, [], _exploding_judge)
+        assert verdict.is_duplicate is False
+        assert verdict.reason == "no prefilter candidates"
+
+
+class TestKgDedupeFindingsTool:
+    def test_reports_duplicate_cluster_for_same_bug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _configure_store(monkeypatch, _same_bug_graph())
+
+        payload = json.loads(research_tools.kg_dedupe_findings.invoke({}))
+
+        assert payload["scanned_findings"] == 2
+        assert payload["duplicate_clusters"] == 1
+        assert payload["duplicate_nodes"] == 2
+        cluster = payload["clusters"][0]
+        assert cluster["size"] == 2
+        assert cluster["host"] == "api.example.com"
+        assert cluster["cwes"] == ["CWE-89"]
+        member_ids = {m["id"] for m in cluster["members"]}
+        assert member_ids == set(fake.graph.nodes.keys())
+
+    def test_reports_no_clusters_for_distinct_findings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_store(monkeypatch, _distinct_pair_graph())
+
+        payload = json.loads(research_tools.kg_dedupe_findings.invoke({}))
+
+        assert payload["scanned_findings"] == 2
+        assert payload["duplicate_clusters"] == 0
+        assert payload["duplicate_nodes"] == 0
+        assert payload["clusters"] == []
+
+    def test_does_not_mutate_graph(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _configure_store(monkeypatch, _same_bug_graph())
+        before_nodes = {nid: n.model_copy(deep=True) for nid, n in fake.graph.nodes.items()}
+        before_edge_count = len(fake.graph.edges)
+
+        research_tools.kg_dedupe_findings.invoke({})
+
+        assert set(fake.graph.nodes.keys()) == set(before_nodes.keys())
+        assert len(fake.graph.edges) == before_edge_count
+        for nid, original in before_nodes.items():
+            assert fake.graph.nodes[nid].props == original.props
+            assert fake.graph.nodes[nid].label == original.label
+
+
+class TestRegistry:
+    def test_tool_is_registered_in_research_tools(self) -> None:
+        names = {getattr(t, "name", None) for t in research_tools.RESEARCH_TOOLS}
+        assert "kg_dedupe_findings" in names


### PR DESCRIPTION
## What

Adds a **semantic finding deduplication** layer to the research tools. It is **additive, opt-in, and report-only** — no existing flow changes behavior, and no nodes are deleted or mutated.

### Why

The knowledge graph dedups writes only by deterministic node ID (`SHA1(kind + canonical key)` — see `decepticon_core/types/kg.py` and `tools/research/neo4j_store.py`). The multi-agent design (recon / exploit / analyst / vulnresearch, each running with fresh context) structurally produces **separate** nodes for the **same** underlying vulnerability when it is reached via a different route or described with different wording. Those near-duplicates survive ID-based dedup and surface as repeated entries in reports. Peers (Strix `report/dedupe.py`, RedAmon, CAI) ship an LLM-judge dedup layer; this adds a clean, pure, testable equivalent.

## How

New module `packages/decepticon/decepticon/tools/research/dedupe.py`:

- **`find_duplicate(candidate, existing, judge) -> DuplicateVerdict`** — a pure function. The `judge` is an **injected** callable `(a, b) -> dict`, so tests stub it and **no LLM client is imported in the module**. A **cheap deterministic pre-filter** (same `NodeKind` + normalized host / endpoint / CWE overlap) runs **before** the judge, so non-candidates are rejected without invoking it. `DuplicateVerdict` is a small frozen dataclass (`is_duplicate: bool`, `canonical_id: str | None`, `reason: str`).
- **`kg_dedupe_findings` `@tool`** — walks `Finding`/`Vulnerability` nodes, groups likely-duplicates via the pre-filter (union-find over pairwise pre-filter hits), and returns a structured JSON summary of duplicate clusters. It is **report-only**: it never deletes or mutates nodes. It defaults to the deterministic pre-filter (no LLM wiring) to stay simple and green; a live judge is a clean follow-up via `find_duplicate`'s injectable seam.
- Registered in `RESEARCH_TOOLS` exactly like the sibling `kg_*` tools.

## Scope / isolation

- Does **not** touch reporting renderers or existing dedup/merge code.
- `tools.py` change is **2 lines** (one import + one list entry).
- No `package-lock.json` / `uv.lock` changes.

## Tests

`packages/decepticon/tests/unit/research/test_dedupe.py` (13 tests) builds fixture `KnowledgeGraph`s — two findings describing the same bug (same host + CWE, different wording) and two clearly-distinct findings — and, with a **fake judge**, asserts:

- the pre-filter pairs the same-host+CWE candidates and not the distinct ones (and skips the judge entirely for non-candidates, verified with an exploding judge);
- `find_duplicate` returns `is_duplicate` True/False correctly with the right `canonical_id`/`reason`;
- `kg_dedupe_findings` returns the expected cluster summary and **does not mutate** the graph.

No Docker / Neo4j / live-LLM.

## Gate evidence

- `ruff check` — clean
- `ruff format --check` — clean
- `basedpyright dedupe.py tools.py` — **0 errors, 0 warnings, 0 notes**
- `pytest tests/unit/research tests/unit/tools/test_skills_registry.py` — **264 passed** (13 new; registry test confirms clean registration)
