### PR TITLE
feat(skills): adversary-emulation playbooks + expanded APT threat-profile catalog

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -166,4 +166,11 @@ extend-exclude = [
     "packages/decepticon/decepticon/skills/standard/supply-chain/**",
     "packages/decepticon/decepticon/skills/standard/osint/**",
     ".omo/plans/**",
+    # Adversary-emulation playbooks + APT/CTI reference cards: dense with
+    # threat-intel jargon typos misreads — "OT" (Operational Technology),
+    # "HPE" (Hewlett Packard Enterprise), product names like "MOVEit".
+    # Scoped to these dirs to match the ics-ot/iot exclusion pattern rather
+    # than globally allow-listing two-letter tokens.
+    "packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/**",
+    "packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/references/**",
 ]

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/SKILL.md
@@ -34,7 +34,7 @@ Ask the user which tier fits. If they're unsure, recommend based on engagement t
 
 ### Step 2: Build the Profile
 
-Gather or derive these fields — see `references/adversary-archetypes.md` for pre-built profiles and `references/apt-groups.md` for known APT group details:
+Gather or derive these fields — see `references/adversary-archetypes.md` for pre-built tier profiles and `references/apt-groups.md` for known APT/eCrime group cards (now 19 actors + a MITRE Group-ID crosswalk). For a **named actor**, load the matching emulation playbook (`emulation/<actor>/SKILL.md`, indexed by `emulation/SKILL.md`) — it ships a ready-to-edit `ThreatProfile` seed **and** the full kill chain mapped to Decepticon skills:
 
 1. **Name/Alias** — Known group or custom archetype
 2. **Sophistication** — low / medium / high / nation-state
@@ -81,3 +81,19 @@ Generate **two** payloads:
 `tier` is the StrEnum value: `"tier-1"` (opportunistic), `"tier-2"` (targeted cybercrime), `"tier-3"` (APT / nation-state), `"tier-4"` (insider). Map to `sophistication` informally — `tier-3` ↔ "nation-state", `tier-2` ↔ "high", `tier-1` ↔ "low/medium".
 
 **(b) Embedded summary** — one-entry `threat_actors` list inside `conops.json` for backward-compat (the legacy `ThreatActor` shape: `name` + `sophistication` + `motivation` + `initial_access` + `ttps`). Skip `tier`/`group_id`/`tools`/`infrastructure` here — those live only in the standalone profile.
+
+### Step 5: Named-actor kill chain (optional but recommended)
+
+When the operator picked a known actor, don't hand-build the TTP sequence — load the
+emulation catalog and copy the per-actor plan:
+
+```text
+load_skill("/skills/standard/soundwave/threat-profile/emulation/SKILL.md")   # routing table
+load_skill("/skills/standard/soundwave/threat-profile/emulation/apt29/SKILL.md")  # e.g. APT29
+```
+
+Each playbook gives you (a) the `ThreatProfile` seed for `plan/threat-profile.json`, (b) the
+ordered `kill_chain` to copy into `conops.json` (mapped to the 5 `ObjectivePhase` buckets),
+and (c) the actor-specific RoE/safety gates to carry into `abort.json` + `deconfliction.json`.
+Prune any technique the RoE forbids (Step 3) before writing. Available: `apt29`, `sandworm`,
+`scattered-spider`, `volt-typhoon`, `lazarus`, `fin7`, `lockbit`.

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: emulation-overview
+description: "Adversary-emulation playbook catalog — per-actor kill chains that turn an APT/eCrime threat profile into Decepticon CONOPS phases + OPPLAN objectives. Routing skill: pick the actor, seed plan/threat-profile.json, then map each kill-chain phase to the operational skill the executing agent runs. Triggers on: 'emulate', 'adversary emulation', 'APT playbook', 'threat actor playbook', 'emulation plan', 'attack flow'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate, adversary emulation, APT playbook, threat actor playbook, emulation plan, attack flow, kill chain for actor, which TTPs, how would APT29/Sandworm/Lazarus/Scattered Spider attack"
+  tags: adversary-emulation, apt, ecrime, mitre-attack, kill-chain, planning
+---
+
+# Adversary Emulation Playbook Catalog
+
+This is a **planning** routing skill for Soundwave. Each leaf playbook below converts
+a named threat actor into a concrete, RoE-bounded kill chain: a `ThreatProfile` seed, an
+ordered CONOPS `kill_chain`, and a phase→technique→skill map that the orchestrator turns
+into OPPLAN objectives.
+
+> **These playbooks reference operational skills (`/skills/standard/ad/...`, `/skills/standard/cloud/...`, etc.)
+> that the EXECUTING agents load — not Soundwave.** Soundwave is a planning agent; its
+> `load_skill` allowlist is `/skills/standard/soundwave/`. The skill paths in each
+> playbook tell the orchestrator which agent + skill each objective maps to. Soundwave
+> only reads them to author `plan/threat-profile.json` and the `conops.json` kill chain.
+
+## Playbooks
+
+| Actor | Playbook | Tier | Profile | Skills it exercises |
+|---|---|---|---|---|
+| **APT29** (Cozy Bear / Midnight Blizzard) | `emulation/apt29/SKILL.md` | tier-3 | Cloud-identity espionage, OAuth abuse, supply chain | recon, cloud, web (oauth/saml), post-exploit |
+| **Sandworm** (APT44 / Seashell Blizzard) | `emulation/sandworm/SKILL.md` | tier-3 | ICS/OT disruption, destructive ops, LOTL | recon, exploit/cve, ics-ot, post-exploit |
+| **Scattered Spider** (UNC3944 / Octo Tempest) | `emulation/scattered-spider/SKILL.md` | tier-2 | Help-desk social engineering → cloud/SaaS → ransomware | phish, cloud, ad, post-exploit |
+| **Volt Typhoon** (Vanguard Panda) | `emulation/volt-typhoon/SKILL.md` | tier-3 | Edge-device access, LOTL, long-dwell pre-positioning | recon, exploit/cve, ad, post-exploit |
+| **Lazarus** (Hidden Cobra) | `emulation/lazarus/SKILL.md` | tier-3 | Financial/crypto/DeFi theft, supply-chain, social | osint, phish, contracts, web, post-exploit |
+| **FIN7** (Carbon Spider / Sangria Tempest) | `emulation/fin7/SKILL.md` | tier-2 | Spearphishing → big-game-hunting ransomware | phish, ad, post-exploit, exploit |
+| **LockBit / RaaS affiliate** | `emulation/lockbit/SKILL.md` | tier-2 | Generic ransomware affiliate kill chain | recon, exploit/cve, ad, post-exploit |
+
+For the one-card quick reference (attribution, targets, full TTP table) on any actor, see
+`../references/apt-groups.md`. For tier archetypes when no named actor fits, see
+`../references/adversary-archetypes.md`.
+
+## How to use a playbook (Soundwave Phase 2)
+
+1. **Pick the actor** from the operator's intake answer (or from the industry → actor map
+   in `../references/apt-groups.md`). One dominant actor per engagement.
+2. **Load the leaf**: `load_skill("/skills/standard/soundwave/threat-profile/emulation/<actor>/SKILL.md")`.
+3. **Copy the `ThreatProfile` seed** into `plan/threat-profile.json`, then prune any
+   `key_ttps` / `initial_access` techniques the RoE forbids (Step 3 of the `threat-profile`
+   skill). A pruned technique whose whole phase is now empty drops that kill-chain row.
+4. **Lift the kill chain** into `conops.json` → `kill_chain` (one `KillChainPhase` per
+   surviving phase), and embed the one-entry `threat_actors` summary.
+5. **Carry the safety gates** from the playbook's *RoE / safety gates* section into
+   `abort.json` (destructive / ICS / identity-takeover actors need at least one
+   `EMERGENCY` trigger) and the deconfliction identifiers into `deconfliction.json`.
+6. Hand off. The orchestrator's OPPLAN-builder reads `threat-profile.json` + `conops.json`
+   and emits `add_objective` calls; each objective's executing agent loads the skill named
+   in that kill-chain row.
+
+## Playbook anatomy (every leaf has these)
+
+- **ThreatProfile seed** — a valid `decepticon.core.schemas.ThreatProfile` JSON (drop your
+  `engagement_name`).
+- **Kill-chain emulation table** — `# | phase | MITRE | emulated action | executing agent → skill`.
+- **CONOPS kill_chain** — the phase order to copy into `conops.json`.
+- **OPSEC & signature fidelity** — what to mirror so the emulation *reads* like the actor.
+- **RoE / safety gates** — actor-specific authorizations and abort triggers.
+- **Deconfliction** — identifiers so blue team can separate the exercise from a real intrusion.
+- **Fidelity notes (deviations)** — where the emulation intentionally diverges (e.g. canary
+  data instead of real destruction) and why.
+
+## Discipline
+
+- **Emulate behavior, not malware.** Decepticon reproduces an actor's *TTPs and sequencing*
+  with its own tooling (Sliver, NetExec, certipy, etc.) — it does not run the actor's real
+  implants. Fidelity comes from technique order + OPSEC posture, not from sample reuse.
+- **RoE wins every tie.** If the actor's signature move (spearphishing, deauth, ICS write,
+  encryption-for-impact) isn't authorized, drop it — never "emulate harder" past scope.
+- **One actor per profile.** Multi-actor scenarios pick the dominant emulation target;
+  note the secondary in `recent_cti_delta`.

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/apt29/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/apt29/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: apt29
+description: "APT29 (Cozy Bear / Midnight Blizzard, SVR) adversary-emulation playbook — malware-light cloud-identity espionage: no-MFA password spray, OAuth consent/token abuse, Golden SAML, mailbox collection over residential proxies. Use when emulating APT29 against an M365/Entra/AWS-identity estate. Triggers on: 'emulate APT29', 'Cozy Bear', 'Midnight Blizzard', 'NOBELIUM', 'OAuth abuse', 'cloud identity espionage', 'Golden SAML'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate APT29, Cozy Bear, Midnight Blizzard, NOBELIUM, The Dukes, SVR, cloud identity espionage, OAuth consent abuse, token theft, Golden SAML, M365 Entra espionage, supply chain"
+  tags: adversary-emulation, apt29, cozy-bear, cloud-identity, oauth, espionage
+  mitre_attack: T1078.004, T1528, T1550.001, T1098.001, T1606.002, T1114.002, T1071.001
+---
+
+# APT29 — Adversary Emulation Playbook
+
+> Tier-3 Russian SVR espionage actor. Emulate **stealth cloud-identity tradecraft**, not
+> malware: APT29's modern signature is compromising identity (no-MFA password spray,
+> device-code/consent phishing), abusing OAuth applications and tokens for persistence, and
+> collecting mail/documents over residential proxies with a near-zero endpoint footprint.
+> Authorized red-team emulation only — every action runs under the engagement RoE.
+
+## When to emulate APT29
+
+- Target is a cloud-first / hybrid-identity estate (Microsoft 365 + Entra ID, Okta, AWS IAM
+  Identity Center, Google Workspace) and the client wants their **identity blast radius**
+  tested the way a top-tier espionage actor would.
+- Government, diplomatic, defense, think-tank, technology, or MSP targets (see the
+  industry → actor map in `../../references/apt-groups.md`).
+- The objective is quiet, long-dwell collection — *not* smash-and-grab.
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "APT29-like (Cozy Bear / Midnight Blizzard)",
+  "actor_aliases": ["Cozy Bear", "Midnight Blizzard", "NOBELIUM", "The Dukes", "UNC2452"],
+  "group_id": "G0016",
+  "tier": "tier-3",
+  "sophistication": "nation-state",
+  "motivation": "espionage",
+  "initial_access": ["T1078.004", "T1110.003", "T1566.002", "T1195.002"],
+  "key_ttps": ["T1528", "T1550.001", "T1098.001", "T1098.003", "T1606.002", "T1114.002", "T1071.001", "T1090.003", "T1070.004"],
+  "tools": ["AADInternals", "ROADtools", "TokenTactics", "Sliver", "residential proxies"],
+  "infrastructure": ["Engagement-owned OAuth apps (consent abuse)", "Residential proxy egress", "Low-and-slow Graph/API calls"],
+  "recent_cti_delta": "2024-2026: malware-light cloud tradecraft — malicious OAuth app consent, device-code phishing, password spray against legacy/no-MFA tenants (Microsoft + HPE corporate breaches); SolarWinds-style CI/CD supply-chain remains in repertoire.",
+  "confidence": "probable"
+}
+```
+
+Prune to RoE: if social engineering is out of scope, drop `T1566.002`; if only one cloud is
+in scope, drop the others. A phase whose techniques are all pruned drops its kill-chain row.
+
+## Kill-chain emulation
+
+Each row is a candidate OPPLAN objective. The orchestrator's OPPLAN-builder turns surviving
+rows into `add_objective` calls; the **executing agent** loads the named skill.
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Recon | T1593 / T1589.002 | Map tenant, federation, employees, exposed apps/OWA, email format | recon → `/skills/standard/recon/osint/SKILL.md`, `/skills/standard/recon/cloud-recon/SKILL.md` |
+| 2 | Initial Access | T1110.003 | Slow password spray against legacy/no-MFA cloud auth | exploit → `/skills/standard/exploit/web/ato-methodology/SKILL.md` |
+| 3 | Initial Access (alt) | T1566.002 | Device-code / consent phishing (Teams/email lure) | phisher → `/skills/standard/phish/SKILL.md` |
+| 4 | Initial Access (alt) | T1195.002 | CI/CD or dependency supply-chain foothold | exploit → `/skills/standard/exploit/supplychain/dep-confusion/SKILL.md` |
+| 5 | Credential/Token | T1528 / T1550.001 | Steal & replay OAuth app access tokens (skip password+MFA) | exploit → `/skills/standard/exploit/web/oauth/SKILL.md` |
+| 6 | Persistence (cloud) | T1098.001 / T1098.003 | Add app credentials + high Graph roles; consent malicious OAuth app | cloud → `/skills/standard/cloud/azure-managed-identity/SKILL.md`, `/skills/standard/cloud/aws-iam-passrole-chain/SKILL.md` |
+| 7 | Lateral (identity) | T1606.002 | Golden SAML / federation-trust token forgery | exploit → `/skills/standard/exploit/web/saml/SKILL.md` |
+| 8 | Collection | T1114.002 | Mailbox / document collection via Graph (canary mailbox) | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md` |
+| 9 | C2 | T1071.001 / T1090.003 | Sliver beacon over HTTPS via residential proxy | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 10 | Exfiltration | T1567.002 | Low-and-slow exfil of scoped collection set | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+
+Defense evasion (T1070.004 log/file cleanup, blending with admin activity) is cross-cutting —
+the shared `defense-evasion` / `opsec` skills are auto-injected into every operational agent.
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+Collapse the table into the 5-phase `ObjectivePhase` model:
+
+1. `recon` — tenant/identity/federation enumeration (rows 1).
+2. `initial-access` — no-MFA password spray + consent phishing + optional supply-chain (2-4).
+3. `post-exploit` — token theft, cloud role/cred persistence, Golden SAML, mailbox collection (5-8).
+4. `c2` — Sliver over HTTPS via residential proxy (9).
+5. `exfiltration` — scoped, throttled collection exfil (10).
+
+## OPSEC & signature fidelity
+
+- **Low and slow.** Spread the password spray over hours, one attempt per account; APT29 is
+  patient. No bursty auth.
+- **Egress from residential / reputable IP space**, not a datacenter VPS, to defeat IOC-based
+  detection (mirror the real actor's residential-proxy obfuscation).
+- **Prefer tokens over passwords.** Once an app token is held, stop touching passwords/MFA —
+  that is the whole point of the OAuth tradecraft.
+- **Blend with admin activity.** Use Graph/PowerShell the way a tenant admin would; avoid
+  noisy endpoint tooling.
+- **Clean up** consent grants and added credentials at engagement end (feeds `cleanup.json`).
+
+## RoE / safety gates
+
+- **Identity takeover is high blast-radius.** OAuth consent + added cloud roles can affect a
+  production tenant globally — require explicit, written cloud-tenant authorization. Prefer a
+  **dedicated test tenant** or a sandboxed app registration.
+- **Phishing requires social-engineering authorization** and a lure-deconfliction pass
+  (`/skills/standard/phisher/lure-deconfliction/SKILL.md`).
+- Add an `EMERGENCY` abort trigger to `abort.json`: *"real (non-canary) user mailbox or
+  document collected, or consent granted on a non-engagement OAuth app."*
+
+## Deconfliction
+
+- Name every engagement OAuth app `redteam-<engagement-id>-*` and record the app/client IDs
+  in `deconfliction.json`.
+- Pin a known deconfliction egress IP range + a marker User-Agent string so the identity team
+  can separate the exercise from a real Midnight Blizzard sign-in.
+- Pre-brief the identity/SOC team that no-MFA spray + consent grants are *expected*.
+
+## Fidelity notes (deviations)
+
+- Emulate consent/token abuse with an **engagement-owned** app registration — never publish a
+  real malicious multi-tenant app.
+- Use a **canary mailbox/SharePoint site** seeded with marked documents for the collection and
+  exfil phases; do not collect real PII or classified mail.
+- Sliver replaces APT29's bespoke implants (WINELOADER, etc.); fidelity is the C2 *channel
+  shape* (HTTPS, jittered beacon, residential egress), not the binary.

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/fin7/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/fin7/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: fin7
+description: "FIN7 (Carbon Spider / Sangria Tempest) adversary-emulation playbook — revenue-targeted spearphishing with phone follow-up, EDR-evasion tradecraft, AD compromise, and big-game-hunting ransomware. Use when emulating a high-end financially-motivated crew that graduated from POS theft to ransomware. Triggers on: 'emulate FIN7', 'Carbanak', 'Carbon Spider', 'Sangria Tempest', 'big game hunting', 'EDR evasion', 'AvNeutralizer'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate FIN7, Carbanak, Carbon Spider, Sangria Tempest, GOLD NIAGARA, big game hunting ransomware, EDR evasion, AvNeutralizer, spearphishing with phone follow-up, revenue targeting"
+  tags: adversary-emulation, fin7, ecrime, ransomware, edr-evasion, phishing
+  mitre_attack: T1566.001, T1059.001, T1562.001, T1003.001, T1486, T1567.002
+---
+
+# FIN7 — Adversary Emulation Playbook
+
+> Tier-2 financially-motivated crew that evolved from point-of-sale theft to **big-game-hunting
+> ransomware** (REvil / DarkSide / Black Basta links). Signature traits: revenue-selected
+> targets, convincing business-themed spearphishing reinforced by **phone calls**, and mature
+> **EDR-evasion** tooling (AvNeutralizer / AuKill). Authorized red-team emulation only.
+
+## When to emulate FIN7
+
+- The client wants a realistic **ransomware-precursor** test: phishing resilience, EDR
+  tamper-resistance, AD attack-path hardening, and backup/recovery readiness.
+- Retail, hospitality, financial, software, medical, or other high-revenue targets (see the
+  industry → actor map in `../../references/apt-groups.md`).
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "FIN7-like (Carbon Spider / Sangria Tempest)",
+  "actor_aliases": ["Carbon Spider", "Sangria Tempest", "GOLD NIAGARA", "ELBRUS", "ITG14"],
+  "group_id": "G0046",
+  "tier": "tier-2",
+  "sophistication": "high",
+  "motivation": "financial",
+  "initial_access": ["T1566.001", "T1566.002", "T1204.002"],
+  "key_ttps": ["T1059.001", "T1547.001", "T1053.005", "T1562.001", "T1003.001", "T1558.003", "T1021.001", "T1486", "T1567.002"],
+  "tools": ["Phishing kit + phone follow-up", "Sliver", "NetExec", "Impacket", "EDR-test/BYOVD (authorized)", "canary encryptor"],
+  "infrastructure": ["Business-themed lure domains", "Sliver HTTPS C2", "Engagement-owned exfil bucket"],
+  "recent_cti_delta": "Since 2020 shifted to big-game-hunting ransomware (REvil/DarkSide; Black Basta TTP overlap); AvNeutralizer/AuKill EDR-killer; targets shortlisted by revenue via Crunchbase/D&B/ZoomInfo, ransom sized to revenue.",
+  "confidence": "probable"
+}
+```
+
+## Kill-chain emulation
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Recon | T1591 | Revenue-based target + staff shortlist (Crunchbase/D&B/ZoomInfo) | recon → `/skills/standard/recon/osint/SKILL.md`, `/skills/standard/osint/SKILL.md` |
+| 2 | Initial Access | T1566.001 | Business-themed spearphish attachment + phone follow-up | phisher → `/skills/standard/phish/SKILL.md` |
+| 3 | Execution / C2 | T1204.002 / T1059.001 | Macro → loader → Sliver beacon | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 4 | Persistence | T1547.001 / T1053.005 | Run key + scheduled task | post-exploit → `/skills/standard/post-exploit/privilege-escalation/SKILL.md` |
+| 5 | Defense Evasion | T1562.001 | EDR tamper / BYOVD (AvNeutralizer pattern, authorized) | post-exploit → `/skills/standard/post-exploit/privilege-escalation/SKILL.md` (shared `defense-evasion` auto-loaded) |
+| 6 | Credential Access | T1003.001 | LSASS dump | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md` |
+| 7 | Discovery / AD | T1558.003 | BloodHound the domain; Kerberoast | ad → `/skills/standard/ad/bloodhound-query/SKILL.md`, `/skills/standard/ad/kerberoasting/SKILL.md` |
+| 8 | Lateral | T1021.001 / T1570 | RDP/SMB + lateral tool transfer | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md`; `/skills/standard/ad/netexec/SKILL.md` |
+| 9 | Priv Esc to DA | T1003.006 | DCSync to domain dominance | ad → `/skills/standard/ad/dcsync/SKILL.md` |
+| 10 | Exfiltration | T1567.002 | Stage + exfil to engagement bucket | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+| 11 | Impact **(CANARY)** | T1486 | Demonstrate ransomware capability on canary only | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+1. `recon` — revenue-based target + staff selection (1).
+2. `initial-access` — spearphish attachment + phone follow-up (2).
+3. `post-exploit` — loader exec, EDR tamper, LSASS, AD recon/Kerberoast, lateral, DA via DCSync (3-9).
+4. `c2` — Sliver (within 3).
+5. `exfiltration` — data theft + canary ransomware impact (10-11).
+
+## OPSEC & signature fidelity
+
+- **Phone-reinforced phishing** is the fidelity-defining move — pair the email lure with a
+  follow-up call (authorized) to mirror FIN7's hands-on approach.
+- **EDR evasion is the headline.** The test is whether the EDR survives a BYOVD/tamper attempt;
+  mirror AvNeutralizer's intent (disable endpoint telemetry) using an authorized test driver.
+- Dwell days-to-weeks; double extortion (exfil before encrypt).
+
+## RoE / safety gates
+
+- Phishing + phone pretext require explicit authorization + lure-deconfliction
+  (`/skills/standard/phisher/lure-deconfliction/SKILL.md`); name in-scope staff.
+- **EDR tampering / BYOVD can destabilize endpoints** — authorize it, run on a lab/canary host
+  first, and confirm rollback. Add an `EMERGENCY` abort: *"production endpoint protection
+  disabled outside the authorized test host, or production data encrypted/exfiltrated."*
+- Ransomware impact is **canary-only**.
+
+## Deconfliction
+
+- Record lure domains, the Sliver implant, EDR-tamper test host, and exfil destination in
+  `deconfliction.json` + `cleanup.json`.
+- Agree an EDR-tamper window with the SOC; the DA-path and ransomware-readiness findings are
+  the deliverable, not a surprise outage.
+
+## Fidelity notes (deviations)
+
+- **No real Carbanak/AvNeutralizer binaries** — emulate the loader chain with Sliver and the
+  EDR-tamper with an authorized test, or simulate when no lab host is available.
+- Impact is a canary marker proving DA + deploy capability; the deliverable distinguishes
+  "ransomware-ready (canary proven)" from "production encryption" (never the latter).

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/lazarus/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/lazarus/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: lazarus
+description: "Lazarus Group (Hidden Cobra, DPRK RGB) adversary-emulation playbook — financially-motivated crypto/DeFi theft and supply-chain intrusion: fake-job social engineering, trojanized apps, wallet/key theft, and on-chain DeFi/bridge exploitation (testnet/fork only). Use when emulating DPRK financial actors against a crypto/exchange/DeFi target. Triggers on: 'emulate Lazarus', 'Hidden Cobra', 'DPRK crypto', 'AppleJeus', '3CX supply chain', 'DeFi bridge attack', 'crypto theft'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate Lazarus, Hidden Cobra, ZINC, Diamond Sleet, DPRK, cryptocurrency theft, DeFi protocol attack, bridge exploit, AppleJeus, 3CX supply chain, fake job social engineering, wallet key theft, exchange compromise"
+  tags: adversary-emulation, lazarus, dprk, cryptocurrency, defi, supply-chain
+  mitre_attack: T1566.003, T1195.002, T1574.002, T1555, T1657, T1071.001
+---
+
+# Lazarus Group — Adversary Emulation Playbook
+
+> Tier-3 DPRK (RGB) actor whose modern mission is **revenue generation** — North Korea-linked
+> actors have stolen well over $3B in crypto. Two converging tracks: (a) enterprise intrusion
+> via fake-job social engineering, trojanized trading apps (AppleJeus), and software
+> supply-chain (3CX); (b) **on-chain DeFi/bridge exploitation** to drain protocols. Authorized
+> red-team emulation only; on-chain steps run on **testnet or a mainnet fork** — never real funds.
+
+## When to emulate Lazarus
+
+- Target is a cryptocurrency exchange, DeFi protocol, cross-chain bridge, wallet provider, or
+  a fintech/blockchain firm and the client wants the full DPRK money-theft kill chain tested.
+- The engagement spans both the **enterprise estate** (devs, build pipeline, cloud) and the
+  **smart-contract surface** — Decepticon's contract-audit lane is what makes this actor a
+  good fit (see `../../references/apt-groups.md`).
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "Lazarus-like (Hidden Cobra)",
+  "actor_aliases": ["Hidden Cobra", "ZINC", "Diamond Sleet", "Labyrinth Chollima", "NICKEL ACADEMY"],
+  "group_id": "G0032",
+  "tier": "tier-3",
+  "sophistication": "nation-state",
+  "motivation": "financial",
+  "initial_access": ["T1566.003", "T1195.002", "T1199", "T1204.002"],
+  "key_ttps": ["T1574.002", "T1027", "T1059.006", "T1555", "T1552.001", "T1657", "T1071.001", "T1567.002"],
+  "tools": ["Engagement-owned trojanized app + Sliver", "Foundry / Anvil (forked mainnet PoC)", "canary wallets", "NetExec"],
+  "infrastructure": ["Fake-recruiter persona + lure docs", "Supply-chain build-step foothold", "Testnet/fork RPC endpoints"],
+  "recent_cti_delta": "$3B+ crypto stolen; targets entire blockchain ecosystems (cross-chain bridges, DeFi, identity providers); Operation Dream Job fake-job social engineering vs developers; 3CX double software supply chain; AppleJeus trojanized trading apps.",
+  "confidence": "probable"
+}
+```
+
+## Kill-chain emulation
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Recon | T1591 / T1589 | Profile devs, the DeFi protocol, and the bridge/contract surface | recon → `/skills/standard/recon/osint/SKILL.md`, `/skills/standard/osint/SKILL.md` |
+| 2 | Initial Access | T1566.003 | Fake-job / DeFi-collab social engineering with a lure doc | phisher → `/skills/standard/phish/SKILL.md` |
+| 3 | Initial Access (alt) | T1195.002 / T1199 | Trojanized dependency or build-step (3CX pattern) | exploit → `/skills/standard/exploit/supplychain/dep-confusion/SKILL.md`; `/skills/standard/supply-chain/SKILL.md` |
+| 4 | Execution | T1204.002 / T1574.002 | Trojanized app + DLL side-load into a trusted process | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 5 | Credential / Key theft | T1555 / T1552.001 | Steal wallet keys, seed phrases, cloud creds, signing keys | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md` |
+| 6 | Web/API (exchange) | T1190 | Exchange web/API abuse (authz, IDOR, JWT) | exploit → `/skills/standard/exploit/web/SKILL.md` (route to `idor` / `jwt` / `api`) |
+| 7 | On-chain (bridge) | — (DeFi) | Drain a cross-chain bridge via logic/validator flaw (fork) | contracts → `/skills/standard/contracts/bridge-exploit/SKILL.md` |
+| 8 | On-chain (sig) | — (DeFi) | Signature replay / ecrecover abuse on the protocol (fork) | contracts → `/skills/standard/contracts/signature-replay/SKILL.md` |
+| 9 | On-chain (authz) | — (DeFi) | Missing-modifier / wrong-owner privileged call (fork) | contracts → `/skills/standard/contracts/access-control/SKILL.md` |
+| 10 | C2 | T1071.001 | Sliver HTTPS beacon for the enterprise foothold | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 11 | Exfil / Theft | T1657 / T1567.002 | Simulated fund movement to a canary address (testnet/fork) | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+1. `recon` — devs + protocol + bridge/contract surface (1).
+2. `initial-access` — fake-job social engineering / trojanized supply chain (2-3).
+3. `post-exploit` — trojan execution, wallet-key/cred theft, exchange web/API abuse, **on-chain DeFi exploitation on a fork** (4-9).
+4. `c2` — Sliver (10).
+5. `exfiltration` — simulated theft to canary address on testnet/fork (11).
+
+## OPSEC & signature fidelity
+
+- **Patient grooming.** Operation Dream Job runs for weeks — the social-engineering relationship
+  is built slowly with benign files first.
+- **Obfuscated, side-loaded execution** into trusted processes (mirror the DLL side-load chain).
+- **On-chain moves are irreversible on mainnet** — fidelity comes from a *working PoC on a
+  forked mainnet*, not from touching production funds.
+
+## RoE / safety gates
+
+- **On-chain exploitation MUST run on testnet or a forked-mainnet (Anvil) RPC.** Never sign a
+  real mainnet transaction. Add an `EMERGENCY` abort: *"a transaction signed against a
+  production/mainnet RPC or a real wallet key used."*
+- Developer-targeted social engineering requires authorization + lure-deconfliction
+  (`/skills/standard/phisher/lure-deconfliction/SKILL.md`).
+- Key/seed theft is simulated against **canary wallets** seeded for the exercise.
+
+## Deconfliction
+
+- Record fork/testnet RPC URLs, canary wallet addresses, and the trojanized-app hash in
+  `deconfliction.json` + `cleanup.json`.
+- Mark the recruiter persona and lure documents so they can be distinguished from a real
+  Dream Job approach.
+
+## Fidelity notes (deviations)
+
+- **No real AppleJeus/3CX samples** — emulate the trojanized-app + supply-chain *delivery
+  pattern* with an engagement-owned dropper + Sliver.
+- DeFi exploitation reproduces the real bug classes (bridge validator bypass, signature
+  replay, access-control) with Foundry PoCs on a fork; the proof is a drained canary balance
+  on the fork, never a real protocol.
+- Theft is demonstrated as a fund move to a canary address on testnet/fork; the deliverable
+  distinguishes "drained on fork" from "production funds" (never the latter).

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/lockbit/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/lockbit/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: lockbit
+description: "LockBit / generic RaaS-affiliate adversary-emulation playbook — broker/edge/RDP initial access, beacon, AD compromise to Domain Admin, defense evasion (Defender-disable via GPO, shadow-copy deletion), bulk exfil, then canary double-extortion encryption (Windows + ESXi). Reusable template for any ransomware affiliate (ALPHV, Akira, Black Basta). Triggers on: 'emulate LockBit', 'ransomware affiliate', 'RaaS', 'double extortion', 'StealBit', 'domain-wide ransomware', 'ESXi locker'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate LockBit, ransomware affiliate, RaaS, double extortion, StealBit, domain wide ransomware, ESXi locker, ALPHV, BlackCat, Akira, Black Basta, shadow copy deletion, GPO Defender disable, backup resilience test"
+  tags: adversary-emulation, lockbit, ransomware, raas, double-extortion, ecrime
+  mitre_attack: T1190, T1486, T1490, T1562.001, T1567.002, T1021.001
+---
+
+# LockBit / RaaS Affiliate — Adversary Emulation Playbook
+
+> Tier-2 ransomware-affiliate kill chain. Modeled on LockBit (most prolific RaaS of 2022-2023,
+> disrupted by Operation Cronos in Feb 2024) but written as the **generic double-extortion
+> template** — swap `actor_name`/`group_id` to retarget ALPHV/BlackCat, Akira, or Black Basta.
+> The flow: cheap initial access (broker/edge/RDP) → AD compromise to Domain Admin → disable
+> defenses + delete backups → bulk exfil → encrypt Windows + ESXi. Encryption and recovery
+> sabotage are **canary/lab-only**. Authorized red-team emulation only.
+
+## When to emulate a RaaS affiliate
+
+- The client's top concern is **ransomware resilience**: time-to-Domain-Admin, EDR survival,
+  backup/shadow-copy protection, ESXi exposure, and exfil detection.
+- Any sector — RaaS is opportunistic and cross-industry (see the industry → actor map in
+  `../../references/apt-groups.md`).
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "LockBit-like (RaaS affiliate)",
+  "actor_aliases": ["LockBit 3.0 / Black", "RaaS affiliate", "(retarget: ALPHV / Akira / Black Basta)"],
+  "group_id": "",
+  "tier": "tier-2",
+  "sophistication": "high",
+  "motivation": "financial",
+  "initial_access": ["T1190", "T1133", "T1566", "T1078"],
+  "key_ttps": ["T1059.001", "T1003.001", "T1558.003", "T1484.001", "T1562.001", "T1490", "T1021.001", "T1567.002", "T1486"],
+  "tools": ["Initial-access-broker creds", "Sliver / Cobalt-style beacon", "NetExec", "Impacket / PsExec", "rclone (exfil)", "canary encryptor (lab)"],
+  "infrastructure": ["RDP/VPN edge foothold", "GPO-based deployment", "Engagement-owned exfil bucket"],
+  "recent_cti_delta": "LockBit: StealBit/MEGA exfil, Windows + VMware ESXi lockers, GPO-pushed deployment; affiliate model persists post-Operation-Cronos. Template applies to ALPHV/BlackCat (Rust, ESXi), Akira, Black Basta.",
+  "confidence": "probable"
+}
+```
+
+## Kill-chain emulation
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Initial Access | T1190 / T1133 / T1078 | Broker creds / edge exploit / RDP-VPN logon | exploit → `/skills/standard/exploit/web/cve/SKILL.md`, `/skills/standard/exploit/web/ato-methodology/SKILL.md` |
+| 2 | Initial Access (alt) | T1566 | Phishing loader | phisher → `/skills/standard/phish/SKILL.md` |
+| 3 | C2 | T1071.001 | Beacon for hands-on-keyboard ops | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 4 | Discovery / AD | T1018 / T1083 | Enumerate hosts, shares, AD attack paths | ad → `/skills/standard/ad/bloodhound-query/SKILL.md` |
+| 5 | Credential Access | T1003.001 / T1558.003 | LSASS dump; Kerberoast | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md`; `/skills/standard/ad/kerberoasting/SKILL.md` |
+| 6 | Priv Esc to DA | T1003.006 | DCSync to domain dominance | ad → `/skills/standard/ad/dcsync/SKILL.md` |
+| 7 | Defense Evasion **(GATED)** | T1484.001 / T1562.001 / T1490 | GPO disable Defender; delete shadow copies (lab) | post-exploit → `/skills/standard/post-exploit/privilege-escalation/SKILL.md` (shared `defense-evasion` auto-loaded) |
+| 8 | Lateral | T1021.001 / T1570 | PsExec/GPO push across the estate | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md`; `/skills/standard/ad/netexec/SKILL.md` |
+| 9 | Exfiltration | T1567.002 | Bulk exfil (StealBit/rclone) of the canary data set | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+| 10 | Impact **(CANARY)** | T1486 | Deploy canary encryptor (Windows + ESXi) via GPO/PsExec | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+1. `recon` — quick AD/host/share discovery (affiliates often buy access, so recon is light) (4).
+2. `initial-access` — broker creds / edge exploit / RDP / phishing (1-2).
+3. `post-exploit` — beacon, cred access, DA via DCSync, **gated** defense evasion + backup sabotage, lateral push (3-8).
+4. `c2` — Sliver (3).
+5. `exfiltration` — bulk exfil then **canary** double-extortion encryption (9-10).
+
+## OPSEC & signature fidelity
+
+- **Fast and loud at the end.** Affiliates exfil first (double extortion), then deploy
+  domain-wide in one push — mirror that sequencing so backup/EDR/segmentation are exercised.
+- **GPO/PsExec mass deployment** is the fidelity-defining move; the test is whether one
+  Domain-Admin compromise really equals estate-wide encryption.
+- Hit **ESXi** as well as Windows — RaaS crews target hypervisors for maximum impact.
+
+## RoE / safety gates
+
+- Defense-evasion (Defender-disable via GPO), **shadow-copy/backup deletion**, mass deployment,
+  and encryption are **destructive** — lab/canary only, with explicit authorization. Add an
+  `EMERGENCY` abort: *"production endpoint protection disabled, production backups/shadow copies
+  deleted, real data exfiltrated, or a production host encrypted."*
+- Exfil destination is an **engagement-controlled** bucket seeded with **canary** data only.
+
+## Deconfliction
+
+- Record broker/edge foothold, beacon, GPO changes (and their rollback), exfil destination, and
+  the canary encryptor hash in `deconfliction.json` + `cleanup.json`.
+- Agree the defense-evasion + deployment window with the SOC; the deliverable is the
+  time-to-DA, backup-resilience, and exfil-detection findings — not a real outage.
+
+## Fidelity notes (deviations)
+
+- **No real LockBit/ALPHV locker.** The impact step runs a canary encryptor against a
+  lab/canary host set; StealBit is replaced by rclone to an engagement bucket.
+- This playbook is the reusable RaaS template: to emulate ALPHV/BlackCat (Rust, ESXi-first),
+  Akira, or Black Basta, change `actor_name`/`actor_aliases`, leave `group_id` empty (MITRE
+  tracks these as software, not groups — see `../../references/apt-groups.md` crosswalk), and
+  adjust the initial-access row to the crew's preferred vector.

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/sandworm/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/sandworm/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: sandworm
+description: "Sandworm (APT44 / Seashell Blizzard, GRU Unit 74455) adversary-emulation playbook — IT→OT intrusion ending in ICS manipulation or destructive impact, executed with living-off-the-land Windows tooling. SAFETY-CRITICAL: destructive and ICS-write steps are canary/lab-only and gated on explicit OT authorization. Use when emulating Sandworm against an ICS/OT or critical-infrastructure estate. Triggers on: 'emulate Sandworm', 'APT44', 'Seashell Blizzard', 'Voodoo Bear', 'ICS attack', 'OT destructive', 'Industroyer', 'NotPetya'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate Sandworm, APT44, Seashell Blizzard, Voodoo Bear, Telebots, GRU 74455, ICS OT attack, destructive wiper, Industroyer, NotPetya, critical infrastructure disruption, IT to OT pivot"
+  tags: adversary-emulation, sandworm, apt44, ics-ot, destructive, critical-infrastructure
+  mitre_attack: T1190, T1059.003, T1485, T1561.002, T0831, T0816
+---
+
+# Sandworm — Adversary Emulation Playbook
+
+> Tier-3 Russian GRU (Unit 74455) sabotage actor. Sandworm's signature is a patient,
+> living-off-the-land IT intrusion that **crosses the IT/OT boundary and ends in physical or
+> data destruction** (Ukraine grid via Industroyer; NotPetya pseudo-ransomware wiper).
+> **This is the highest-risk emulation in the catalog.** Every ICS-write and destructive step
+> is canary/lab-only and gated on explicit operator + OT-engineer authorization.
+
+## When to emulate Sandworm
+
+- Target operates **ICS/OT** or critical infrastructure (energy, water, manufacturing,
+  transportation) and the client wants the IT→OT kill chain and destructive-impact resilience
+  tested — typically as a tabletop-plus or against a dedicated OT lab segment.
+- The client's threat model includes destructive/disruptive nation-state actors (see the
+  industry → actor map in `../../references/apt-groups.md`).
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "Sandworm-like (APT44 / Seashell Blizzard)",
+  "actor_aliases": ["Voodoo Bear", "Telebots", "IRON VIKING", "Seashell Blizzard", "APT44"],
+  "group_id": "G0034",
+  "tier": "tier-3",
+  "sophistication": "nation-state",
+  "motivation": "disruption",
+  "initial_access": ["T1190", "T1566.001", "T1195.002", "T1133"],
+  "key_ttps": ["T1059.003", "T1003.001", "T1021.002", "T1570", "T1485", "T1561.002", "T1486", "T0831", "T0816", "T0855"],
+  "tools": ["NetExec", "Impacket", "Sliver", "pymodbus / python-snap7 (read-first)", "marked canary wiper (lab only)"],
+  "infrastructure": ["Compromised edge/VPN foothold", "Engineering-workstation jump host (IT->OT pivot)", "Sliver HTTPS C2"],
+  "recent_cti_delta": "2022 Industroyer2 against the Ukrainian power grid; sustained destructive operations vs Ukraine/NATO; LOTL with native Windows tools (vssadmin, wbadmin, bcdedit) before detonation.",
+  "confidence": "probable"
+}
+```
+
+## Kill-chain emulation
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Recon | T1590 / T1595 | Map external surface + IT/OT (Purdue) boundary; fingerprint ICS protocols | recon → `/skills/standard/recon/active-recon/SKILL.md`; route ICS via `/skills/standard/exploit/ics-ot/SKILL.md` |
+| 2 | Initial Access | T1190 | Exploit edge/VPN/public-facing app | exploit → `/skills/standard/exploit/web/cve/SKILL.md` |
+| 3 | Initial Access (alt) | T1566.001 | Spearphishing attachment to IT staff | phisher → `/skills/standard/phish/SKILL.md` |
+| 4 | Initial Access (alt) | T1195.002 | Trojanized software-update / supply chain (NotPetya pattern) | exploit → `/skills/standard/exploit/supplychain/dep-confusion/SKILL.md` |
+| 5 | Credential Access | T1003.001 | LSASS dump on IT hosts (LOTL) | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md` |
+| 6 | Lateral (IT) | T1021.002 / T1570 | SMB admin-share spread + lateral tool transfer | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md`; `/skills/standard/ad/netexec/SKILL.md` |
+| 7 | IT→OT pivot | T1021 | Reach engineering workstation / OT jump host across the boundary | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md` |
+| 8 | ICS Impact **(GATED)** | T0855 / T0831 / T0816 | Read PLC state; **authorized single benign write** to a lab test point | exploit → `/skills/standard/exploit/ics-ot/modbus/SKILL.md` (or `s7comm` / `dnp3` / `bacnet`) |
+| 9 | Destructive **(CANARY)** | T1485 / T1561.002 / T1486 | Marked canary wipe / pseudo-ransom on a lab host only | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` (evidence) |
+| 10 | C2 | T1071.001 | Sliver HTTPS beacon for the IT-side foothold | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+1. `recon` — external surface + Purdue/IT-OT mapping + ICS fingerprint (row 1).
+2. `initial-access` — edge exploit / spearphish / supply chain (2-4).
+3. `post-exploit` — LSASS, IT lateral, IT→OT pivot, **gated** ICS read/write, **canary** destruction (5-9).
+4. `c2` — Sliver HTTPS (10).
+5. `exfiltration` — optional espionage subset (engineering docs, PLC logic) if in scope.
+
+## OPSEC & signature fidelity
+
+- **Quiet until detonation.** Sandworm stages with native Windows tools (cmd, vssadmin,
+  wbadmin, bcdedit) and only becomes loud at the impact phase — mirror that: blend during
+  staging, then a single controlled, authorized impact event.
+- **Mirror the IT→OT pivot.** The fidelity-defining behavior is crossing the boundary via an
+  engineering workstation, not the wiper binary.
+- ICS reconnaissance is read-only and OPSEC-safe; the noise/risk is entirely in the write.
+
+## RoE / safety gates — READ BEFORE PLANNING
+
+- **ICS writes move physical actuators.** Default to **read-only** enumeration. Any write/
+  control-class action requires explicit written OT-write authorization in the RoE and an
+  **OT safety engineer on the contact plan**, per `/skills/standard/exploit/ics-ot/SKILL.md`
+  ("SAFETY FIRST").
+- **Destruction is lab/canary only.** Never run a real wiper or encryptor against production.
+  Use a marked canary file set on an isolated lab host.
+- `abort.json` MUST carry an `EMERGENCY` trigger (see `/skills/standard/soundwave/abort-template/SKILL.md`):
+  *"Tier-3 destructive emulation against critical infrastructure — halt + operator-page +
+  1hr cooldown"* — plus *"any ICS write outside the named lab test point."*
+- Schedule a maintenance window with physical safety standby before any OT step.
+
+## Deconfliction
+
+- Notify the OT/SOC team and name the exact ICS test device(s) and coil/register addresses in
+  `deconfliction.json`; nothing outside that list may be written.
+- Tag the canary wiper artifact and Sliver implant with the engagement ID; record the lab
+  host inventory in `cleanup.json`.
+
+## Fidelity notes (deviations)
+
+- **No real Industroyer/BlackEnergy/NotPetya samples.** Emulate the *sequence* — IT foothold →
+  LOTL lateral → engineering-workstation pivot → ICS command — with pymodbus/python-snap7
+  (read-first) and Sliver.
+- The "manipulation of control" step is a single authorized benign write to a lab test point
+  (e.g., toggle a non-safety-critical coil) **with the OT engineer present**, or fully
+  simulated when no lab is available.
+- The destructive finale is a canary-only proof that the access *would* allow impact — the
+  deliverable distinguishes "impact demonstrated on canary" from "production impact" (never the latter).

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/scattered-spider/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/scattered-spider/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: scattered-spider
+description: "Scattered Spider (UNC3944 / Octo Tempest) adversary-emulation playbook — help-desk vishing → MFA takeover → cloud/SaaS/identity privilege expansion → RMM persistence → data-theft extortion. Use when emulating identity-first social-engineering eCrime against a help-desk/IdP estate. Triggers on: 'emulate Scattered Spider', 'UNC3944', 'Octo Tempest', '0ktapus', 'help desk social engineering', 'MFA fatigue', 'SIM swap', 'identity attack'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate Scattered Spider, UNC3944, Octo Tempest, Muddled Libra, Roasted 0ktapus, help desk social engineering, vishing, MFA fatigue, SIM swap, Okta abuse, cloud identity takeover, RMM persistence, ransomware affiliate"
+  tags: adversary-emulation, scattered-spider, unc3944, social-engineering, identity, ecrime
+  mitre_attack: T1656, T1598, T1621, T1078.004, T1219, T1486
+---
+
+# Scattered Spider — Adversary Emulation Playbook
+
+> Tier-2 native-English-speaking eCrime collective. Their edge is **social engineering**:
+> impersonating employees to the IT help desk to drive password resets and MFA transfers,
+> then pivoting fast through the identity provider (Okta / Entra ID) into cloud and SaaS,
+> deploying legitimate RMM for persistence, and finishing with data-theft extortion /
+> ransomware. Authorized red-team emulation only — every action runs under the engagement RoE.
+
+## When to emulate Scattered Spider
+
+- The client wants their **human + identity perimeter** tested: help-desk verification
+  process, IdP admin controls, MFA resilience, RMM allow-listing.
+- Telecom, BPO/CRM, technology, gaming, hospitality, retail, financial, or MSP targets.
+- The scenario is fast and brazen extortion — the opposite of APT29's low-and-slow.
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "Scattered Spider-like (UNC3944 / Octo Tempest)",
+  "actor_aliases": ["UNC3944", "Octo Tempest", "Muddled Libra", "Roasted 0ktapus", "Scatter Swine"],
+  "group_id": "G1015",
+  "tier": "tier-2",
+  "sophistication": "high",
+  "motivation": "financial",
+  "initial_access": ["T1656", "T1598", "T1566.004", "T1078.004"],
+  "key_ttps": ["T1621", "T1556.006", "T1098.005", "T1078.004", "T1219", "T1213", "T1486", "T1657"],
+  "tools": ["Authorized test persona (vishing)", "AnyDesk / ConnectWise (engagement-owned)", "Sliver", "NetExec", "Impacket"],
+  "infrastructure": ["Spoofed/marked caller-ID test line", "Look-alike SSO phishing page", "Attacker-registered MFA device (engagement-controlled)", "Rogue VM in victim vSphere/Azure"],
+  "recent_cti_delta": "2023-2025: help-desk impersonation + MFA fatigue + SIM swap; registers its own MFA, creates rogue VMs in vSphere/Azure; pivoted to impersonating employees against third-party IT; ransomware affiliate ALPHV -> RansomHub -> DragonForce.",
+  "confidence": "probable"
+}
+```
+
+## Kill-chain emulation
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Recon (PII) | T1589 | Harvest employee names, roles, phone numbers, help-desk reset process | recon → `/skills/standard/recon/osint/SKILL.md`, `/skills/standard/osint/SKILL.md` |
+| 2 | Initial Access | T1656 / T1598 / T1566.004 | Vish the help desk as a target employee → password reset + MFA transfer | phisher → `/skills/standard/phish/SKILL.md` |
+| 3 | MFA bypass | T1621 / T1556.006 | MFA-fatigue push OR register attacker-controlled MFA device | phisher/exploit → `/skills/standard/phish/SKILL.md`, `/skills/standard/exploit/web/oauth/SKILL.md` |
+| 4 | Cloud foothold | T1078.004 | Sign in to Okta/Entra/AWS as the reset account | cloud → `/skills/standard/cloud/aws-iam-enum/SKILL.md`, `/skills/standard/cloud/azure-managed-identity/SKILL.md` |
+| 5 | Scope expansion | T1098.003 / T1098.005 | Self-assign apps in Okta; add roles/credentials; passrole chains | cloud → `/skills/standard/cloud/aws-iam-passrole-chain/SKILL.md` |
+| 6 | Persistence | T1219 | Deploy engagement-owned RMM (AnyDesk/ConnectWise); create rogue VM | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md`, `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 7 | On-prem pivot (hybrid) | T1558.003 / T1003 | BloodHound the AD; Kerberoast; dump creds | ad → `/skills/standard/ad/bloodhound-query/SKILL.md`, `/skills/standard/ad/kerberoasting/SKILL.md` |
+| 8 | Collection | T1213 | Mine SharePoint/Confluence/Slack for secrets + PII (canary) | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md` |
+| 9 | Exfiltration | T1567.002 | Stage + exfil the scoped/canary data set | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+| 10 | Impact **(CANARY)** | T1486 / T1657 | Demonstrate ransomware/financial-theft capability on canary only | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+1. `recon` — OSINT/PII + help-desk reset-process recon (1).
+2. `initial-access` — vishing → password reset + MFA takeover → cloud login (2-4).
+3. `post-exploit` — Okta/IAM scope expansion, RMM persistence, optional on-prem AD pivot, SaaS collection (5-8).
+4. `c2` — Sliver / RMM session (within row 6).
+5. `exfiltration` — data theft → extortion demonstration on canary (9-10).
+
+## OPSEC & signature fidelity
+
+- **Brazen, not stealthy.** Scattered Spider moves in minutes-to-hours and leans on
+  *legitimate* identity + RMM, so the detection signature is behavioral: a help-desk reset
+  anomaly, a new MFA device, an unexpected RMM install, a new VM. Mirror that pattern so the
+  blue team's detections are exercised.
+- **Live off the victim's own tooling** (vSphere, Azure portal) to create infrastructure.
+- Persistence = own MFA token + RMM, not malware implants.
+
+## RoE / safety gates
+
+- **Social engineering of real staff/help desk requires explicit, written authorization**
+  plus HR/legal sign-off and a lure-deconfliction pass
+  (`/skills/standard/phisher/lure-deconfliction/SKILL.md`). Name exactly which staff/roles are
+  in scope.
+- **No real SIM swaps** against personal numbers (illegal). Simulate the SIM-swap effect with
+  an authorized engagement-controlled test number only.
+- Ransomware/financial-theft impact is **canary-only**; add an `EMERGENCY` abort trigger:
+  *"real customer data exfiltrated, real funds moved, or production system encrypted."*
+
+## Deconfliction
+
+- Brief a single deconfliction POC (NOT the help desk under test) and use a marked test
+  persona + caller-ID so the activity can be separated from a real Octo Tempest call post-hoc.
+- Record the attacker-registered MFA device, RMM install IDs, and any rogue VM in
+  `deconfliction.json` + `cleanup.json`.
+- Time-box vishing windows; never call outside the agreed hours.
+
+## Fidelity notes (deviations)
+
+- The vishing is performed by an **authorized tester** against a **scoped** help desk; the
+  point is to measure the reset/verification process, not to deceive arbitrary staff.
+- MFA registration uses an **engagement-controlled** device; RMM is an **engagement-owned**
+  AnyDesk/ConnectWise tenant.
+- Impact is a canary marker proving the access would allow encryption/theft — never a real locker.

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/volt-typhoon/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/emulation/volt-typhoon/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: volt-typhoon
+description: "Volt Typhoon (Vanguard Panda, PRC) adversary-emulation playbook — edge-device initial access, living-off-the-land-only operations, NTDS/credential theft, long-dwell pre-positioning toward critical infrastructure, multi-hop proxy egress. Use when emulating stealthy LOTL pre-positioning. Triggers on: 'emulate Volt Typhoon', 'Vanguard Panda', 'BRONZE SILHOUETTE', 'living off the land', 'edge device', 'pre-positioning', 'critical infrastructure persistence'."
+allowed-tools: Read Write Edit
+metadata:
+  subdomain: planning
+  when_to_use: "emulate Volt Typhoon, Vanguard Panda, BRONZE SILHOUETTE, Insidious Taurus, living off the land, LOTL, edge device exploitation, SOHO router proxy, long dwell, pre-positioning, critical infrastructure persistence, NTDS dump"
+  tags: adversary-emulation, volt-typhoon, lotl, critical-infrastructure, edge-devices, espionage
+  mitre_attack: T1190, T1078, T1059.001, T1003.003, T1070.001, T1090.003
+---
+
+# Volt Typhoon — Adversary Emulation Playbook
+
+> Tier-3 PRC actor specializing in **undetected long-dwell pre-positioning** inside critical
+> infrastructure. The defining trait is **living-off-the-land only**: almost no malware,
+> built-in OS tooling for everything, credentials harvested from edge devices, log tampering,
+> and egress proxied through compromised SOHO routers. The deliverable is proving *quiet,
+> persistent access* — not data theft. Authorized red-team emulation only; runs under the RoE.
+
+## When to emulate Volt Typhoon
+
+- The client wants to test **detection of stealthy, malware-free intrusions** and dwell time —
+  can the SOC catch an actor that only uses built-ins?
+- Communications, energy, water, transportation, or other critical-infrastructure targets
+  (see the industry → actor map in `../../references/apt-groups.md`).
+- Topical: CISA BOD 26-02 (Feb 2026) prioritizes end-of-support edge-device risk — exactly
+  Volt Typhoon's initial-access surface.
+
+## ThreatProfile seed (`plan/threat-profile.json`)
+
+```json
+{
+  "engagement_name": "<fill>",
+  "actor_name": "Volt Typhoon-like (Vanguard Panda)",
+  "actor_aliases": ["Vanguard Panda", "BRONZE SILHOUETTE", "Insidious Taurus", "DEV-0391", "Voltzite"],
+  "group_id": "G1017",
+  "tier": "tier-3",
+  "sophistication": "nation-state",
+  "motivation": "espionage",
+  "initial_access": ["T1190", "T1133", "T1078"],
+  "key_ttps": ["T1059.001", "T1059.003", "T1003.003", "T1552.001", "T1018", "T1021.001", "T1070.001", "T1090.003"],
+  "tools": ["Native LOLBins (netsh, wmic, ntdsutil, vssadmin, reg)", "Impacket", "FRP / Fast Reverse Proxy", "NetExec (low-noise modules)"],
+  "infrastructure": ["Compromised edge appliance foothold", "Multi-hop proxy via engagement SOHO hop", "No persistent malware - valid accounts only"],
+  "recent_cti_delta": "CISA AA24-038A: multi-year dwell in US critical infrastructure; KV-botnet of compromised SOHO routers for proxying; pre-positioning toward OT; edge-device (Fortinet/Ivanti/Citrix/router) initial access.",
+  "confidence": "probable"
+}
+```
+
+## Kill-chain emulation
+
+| # | Phase | MITRE | Emulated action | Executing agent → skill |
+|---|-------|-------|-----------------|-------------------------|
+| 1 | Recon | T1590 / T1595 | Identify internet-facing edge appliances (firewall/VPN/router) | recon → `/skills/standard/recon/passive-recon/SKILL.md`, `/skills/standard/recon/active-recon/SKILL.md` |
+| 2 | Initial Access | T1190 | Exploit n-day/0-day on the edge appliance | exploit → `/skills/standard/exploit/web/cve/SKILL.md` |
+| 3 | Initial Access (alt) | T1078 / T1133 | Reuse admin creds pulled from the device config | exploit → `/skills/standard/exploit/web/ato-methodology/SKILL.md` |
+| 4 | C2 / Proxy | T1090.003 | Multi-hop proxy egress (FRP) through an engagement SOHO hop | post-exploit → `/skills/standard/post-exploit/c2-sliver/SKILL.md` |
+| 5 | Discovery (LOTL) | T1018 / T1016 | Map the network with built-ins only (no scanners) | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md`; `/skills/standard/ad/netexec/SKILL.md` (low-noise) |
+| 6 | Credential Access | T1003.003 / T1552.001 | NTDS dump via ntdsutil/vssadmin; creds from files/configs | post-exploit → `/skills/standard/post-exploit/credential-access/SKILL.md`; `/skills/standard/ad/dcsync/SKILL.md` |
+| 7 | Lateral | T1021.001 | RDP with valid accounts; no exploit tooling | post-exploit → `/skills/standard/post-exploit/lateral-movement/SKILL.md` |
+| 8 | Pre-position | T1078 | Map OT/critical systems, document footholds — **no impact** | post-exploit → `/skills/standard/post-exploit/reporting/SKILL.md` |
+
+Defense evasion is the headline behavior: T1070.001 (clear Windows event logs) and strict
+LOTL are enforced by the shared `defense-evasion` / `opsec` skills auto-injected into every
+operational agent.
+
+## CONOPS kill_chain (copy into `conops.json`)
+
+1. `recon` — edge-appliance + network identification (1).
+2. `initial-access` — edge exploit / device-cred reuse (2-3).
+3. `post-exploit` — LOTL discovery, NTDS/cred theft, RDP lateral, pre-positioning + log cleanup (5-8).
+4. `c2` — FRP/Sliver multi-hop via SOHO proxy hop (4).
+5. `exfiltration` — minimal/none; pre-positioning only. Add an espionage subset only if explicitly in scope.
+
+## OPSEC & signature fidelity
+
+- **LOTL or it isn't Volt Typhoon.** Built-ins only: `netsh`, `wmic`, `ntdsutil`, `vssadmin`,
+  `reg`, `dnscmd`, PowerShell. No port scanners, no Cobalt/Metasploit, no dropped binaries.
+- **Proxy egress** through a residential/SOHO hop, never a datacenter IP.
+- **Clear logs** after each action; the whole exercise tests whether the SOC can detect a
+  malware-free, log-minimized intruder.
+- **Maximum patience.** Pace actions over days; success metric is dwell time before detection.
+
+## RoE / safety gates
+
+- The objective is **access, not impact** — default to no destructive or OT-write action.
+- Edge-device exploitation can **brick appliances**; require device-write authorization and
+  confirm a config backup exists before exploiting.
+- Add an `EMERGENCY` abort trigger: *"any action against OT/safety systems"* — pre-positioning
+  stops at the IT/OT boundary unless OT is explicitly authorized (then see the `sandworm`
+  playbook's ICS gates).
+
+## Deconfliction
+
+- Record the engagement proxy hop(s), edge-device foothold, and NTDS-dump artifact in
+  `deconfliction.json` + `cleanup.json`.
+- Brief the network team that valid-account RDP + NTDS access are expected; the value is
+  measuring time-to-detect, so keep the deconfliction list tight and SOC-blind where lawful.
+
+## Fidelity notes (deviations)
+
+- **No real SOHO botnet.** Emulate multi-hop proxying with a single engagement-owned hop +
+  FRP/Sliver.
+- LOTL tradecraft is reproduced faithfully and safely — this is the rare actor whose real
+  TTPs are also the safe-to-emulate ones.
+- Pre-positioning ends at documented footholds; the deliverable proves dwell + reachability,
+  never live disruption.

--- a/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/references/apt-groups.md
+++ b/packages/decepticon/decepticon/skills/standard/soundwave/threat-profile/references/apt-groups.md
@@ -112,17 +112,355 @@ Reference for selecting specific APT groups to emulate. Use this when the client
 
 ---
 
+## Sandworm (APT44 / Voodoo Bear / Telebots / Seashell Blizzard) — G0034
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | Russia (GRU Unit 74455, GTsST) |
+| **Targets** | Energy/utilities, ICS/OT, government, NATO-aligned (esp. Ukraine) |
+| **Motivation** | Disruption / sabotage + espionage |
+| **Sophistication** | Nation-state |
+| **Notable** | 2015/2016 Ukraine grid (BlackEnergy/Industroyer), NotPetya (2017), Olympic Destroyer (2018), Industroyer2 (2022) |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1190 | Exploit Public-Facing Application |
+| T1566.001 | Phishing: Spearphishing Attachment |
+| T1059.003 | Windows Command Shell (LOLBins: vssadmin, wbadmin, bcdedit) |
+| T1485 | Data Destruction |
+| T1561.002 | Disk Wipe: Disk Structure Wipe |
+| T0831 | Manipulation of Control (ICS) |
+
+---
+
+## Volt Typhoon (Vanguard Panda / BRONZE SILHOUETTE / Insidious Taurus) — G1017
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | China (PRC state-sponsored) |
+| **Targets** | US critical infrastructure — communications, energy, water, transportation; pre-positioning toward OT |
+| **Motivation** | Espionage / pre-positioning for disruptive effect |
+| **Sophistication** | Nation-state |
+| **Notable** | Living-off-the-land only (minimal malware), multi-year dwell, KV-botnet of compromised SOHO routers, edge-device exploitation |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1190 | Exploit Public-Facing Application (edge appliances) |
+| T1078 | Valid Accounts |
+| T1059.001 | PowerShell (LOTL) |
+| T1003.003 | OS Credential Dumping: NTDS (ntdsutil / vssadmin) |
+| T1070.001 | Indicator Removal: Clear Windows Event Logs |
+| T1090.003 | Proxy: Multi-hop Proxy (SOHO router botnet) |
+
+---
+
+## Salt Typhoon (GhostEmperor / FamousSparrow / UNC2286) — G1045
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | China (PRC state-sponsored) |
+| **Targets** | Telecommunications / ISPs, lawful-intercept systems, government |
+| **Motivation** | Espionage (long-term collection) |
+| **Sophistication** | Nation-state |
+| **Notable** | 2024 US telecom breaches (carrier backbones), network-edge persistence, custom web shells, log tampering |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1190 | Exploit Public-Facing Application (routers / firewalls / VPN) |
+| T1098.004 | Account Manipulation: SSH Authorized Keys |
+| T1021.004 | Remote Services: SSH |
+| T1571 | Non-Standard Port |
+| T1505.003 | Server Software Component: Web Shell |
+| T1070 | Indicator Removal (log clearing) |
+
+---
+
+## Scattered Spider (UNC3944 / Octo Tempest / Roasted 0ktapus / Muddled Libra) — G1015
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | eCrime (native English-speaking, US/UK) |
+| **Targets** | Telecom, BPO/CRM, technology, gaming, hospitality, retail, financial, MSP |
+| **Motivation** | Financial (extortion + ransomware) |
+| **Sophistication** | High (social-engineering specialists) |
+| **Notable** | MGM/Caesars (2023), help-desk vishing, MFA fatigue, SIM-swap, ALPHV→RansomHub→DragonForce affiliate |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1656 | Impersonation (help-desk / employee) |
+| T1598 | Phishing for Information (vishing / smishing) |
+| T1621 | Multi-Factor Authentication Request Generation (MFA fatigue) |
+| T1078.004 | Valid Accounts: Cloud Accounts (Okta / Entra ID / AWS) |
+| T1219 | Remote Access Software (AnyDesk / LogMeIn / ConnectWise) |
+| T1486 | Data Encrypted for Impact |
+
+---
+
+## APT40 (Leviathan / Kryptonite Panda / Gingham Typhoon / TA423) — G0065
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | China (MSS — Hainan State Security Dept.) |
+| **Targets** | Maritime, defense, aerospace, government, critical infrastructure (APAC + US) |
+| **Motivation** | Espionage |
+| **Sophistication** | Nation-state |
+| **Notable** | Rapid PoC weaponization (Log4Shell, ProxyShell, Confluence), compromised SOHO devices as C2 proxies, web shells |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1190 | Exploit Public-Facing Application |
+| T1133 | External Remote Services |
+| T1505.003 | Server Software Component: Web Shell |
+| T1078 | Valid Accounts |
+| T1090 | Proxy (compromised SOHO devices) |
+| T1119 | Automated Collection |
+
+---
+
+## APT10 (Stone Panda / menuPass / Cicada / Red Apollo) — G0045
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | China (MSS — Tianjin bureau) |
+| **Targets** | Managed service providers (MSP), aerospace, government, healthcare, telecom |
+| **Motivation** | Espionage |
+| **Sophistication** | Nation-state |
+| **Notable** | Operation Cloud Hopper (MSP supply-chain), PlugX / QuasarRAT, DLL side-loading, MSP→client pivot abusing trusted relationships |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1199 | Trusted Relationship (MSP pivot) |
+| T1566.001 | Phishing: Spearphishing Attachment |
+| T1574.002 | Hijack Execution Flow: DLL Side-Loading |
+| T1053.005 | Scheduled Task |
+| T1003.001 | OS Credential Dumping: LSASS Memory |
+| T1021.001 | Remote Services: Remote Desktop Protocol |
+
+---
+
+## OilRig (APT34 / Helix Kitten / Cobalt Gypsy / Hazel Sandstorm) — G0049
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | Iran (MOIS) |
+| **Targets** | Energy / oil & gas, financial, government, telecom, chemical (Middle East) |
+| **Motivation** | Espionage |
+| **Sophistication** | Nation-state |
+| **Notable** | DNS-tunneling C2 specialists, custom backdoors (Helminth / QUADAGENT / Karkoff), web shells, heavy LOTL |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1566.001 | Phishing: Spearphishing Attachment |
+| T1505.003 | Server Software Component: Web Shell |
+| T1071.004 | Application Layer Protocol: DNS |
+| T1572 | Protocol Tunneling (DNS tunneling) |
+| T1059.001 | PowerShell |
+| T1078 | Valid Accounts |
+
+---
+
+## MuddyWater (Mango Sandstorm / Static Kitten / Seedworm / TEMP.Zagros) — G0069
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | Iran (MOIS) |
+| **Targets** | Telecom, government, oil & gas, defense (Middle East); also an initial-access broker |
+| **Motivation** | Espionage |
+| **Sophistication** | High |
+| **Notable** | Spearphishing → legitimate RMM (Atera / ScreenConnect / SimpleHelp), PowerShell-heavy tradecraft, BugSleep backdoor |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1566.002 | Phishing: Spearphishing Link |
+| T1219 | Remote Access Software (RMM abuse) |
+| T1059.001 | PowerShell |
+| T1105 | Ingress Tool Transfer |
+| T1534 | Internal Spearphishing |
+| T1056.001 | Input Capture: Keylogging |
+
+---
+
+## Kimsuky (APT43 / Velvet Chollima / Emerald Sleet / THALLIUM) — G0094
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | North Korea (RGB) |
+| **Targets** | Think tanks, academia, nuclear / foreign-policy bodies, government, defense |
+| **Motivation** | Espionage (+ crypto theft to fund operations) |
+| **Sophistication** | High |
+| **Notable** | Deep target recon, impersonation of journalists/academics, CHM lures, credential harvesting, email/session theft |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1598.003 | Phishing for Information: Spearphishing Link |
+| T1566.002 | Phishing: Spearphishing Link |
+| T1204.002 | User Execution: Malicious File (CHM) |
+| T1056.001 | Input Capture: Keylogging |
+| T1114 | Email Collection |
+| T1539 | Steal Web Session Cookie |
+
+---
+
+## LockBit (RaaS) — no MITRE Group ID (tracked as software S1202)
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | eCrime — Ransomware-as-a-Service (affiliate model) |
+| **Targets** | Cross-sector — manufacturing, healthcare, financial, government, construction |
+| **Motivation** | Financial (double extortion) |
+| **Sophistication** | High (developer core + affiliates) |
+| **Notable** | Most prolific RaaS of 2022–2023; StealBit/MEGA exfil; Windows + VMware ESXi lockers; disrupted by Operation Cronos (Feb 2024) |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1190 | Exploit Public-Facing Application |
+| T1133 | External Remote Services (RDP / VPN) |
+| T1486 | Data Encrypted for Impact |
+| T1490 | Inhibit System Recovery (delete shadow copies) |
+| T1562.001 | Impair Defenses: Disable or Modify Tools |
+| T1567.002 | Exfiltration to Cloud Storage (StealBit / MEGA) |
+
+---
+
+## ALPHV / BlackCat (RaaS) — no MITRE Group ID (tracked as software S1068)
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | eCrime — Ransomware-as-a-Service (DarkSide / BlackMatter successor) |
+| **Targets** | Cross-sector incl. healthcare (Change Healthcare, 2024), energy, financial |
+| **Motivation** | Financial (triple extortion) |
+| **Sophistication** | High |
+| **Notable** | Rust cross-platform locker (Windows / Linux / ESXi); stealer-sourced creds; Kerberoasting; AnyDesk / Splashtop / MEGAsync |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1078 | Valid Accounts (stealer-sourced credentials) |
+| T1558.003 | Steal or Forge Kerberos Tickets: Kerberoasting |
+| T1021.001 | Remote Services: Remote Desktop Protocol |
+| T1486 | Data Encrypted for Impact |
+| T1490 | Inhibit System Recovery |
+| T1567.002 | Exfiltration to Cloud Storage |
+
+---
+
+## Cl0p (TA505 / FIN11 overlap) — G0092 (software S0611)
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | eCrime (TA505-linked) |
+| **Targets** | Mass cross-sector via managed file transfer — financial, healthcare, government, education |
+| **Motivation** | Financial (data-theft extortion) |
+| **Sophistication** | High |
+| **Notable** | Mass 0-day of MFT appliances (MOVEit CVE-2023-34362, GoAnywhere CVE-2023-0669, Accellion FTA, Cleo); LEMURLOOT web shell; shift to extortion-only |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1190 | Exploit Public-Facing Application (MFT 0-days) |
+| T1505.003 | Server Software Component: Web Shell (LEMURLOOT) |
+| T1567 | Exfiltration Over Web Service |
+| T1486 | Data Encrypted for Impact |
+| T1078 | Valid Accounts |
+| T1133 | External Remote Services |
+
+---
+
+## Turla (Snake / Venomous Bear / Waterbug / Secret Blizzard) — G0010
+
+| Field | Detail |
+|-------|--------|
+| **Attribution** | Russia (FSB Center 16) |
+| **Targets** | Government, diplomatic, military, research — 50+ countries |
+| **Motivation** | Espionage |
+| **Sophistication** | Nation-state |
+| **Notable** | Snake/Uroburos implant (FBI Operation MEDUSA takedown, 2023), satellite-link C2, watering holes, hijacks other actors' infrastructure |
+
+**Key TTPs:**
+| ID | Technique |
+|----|-----------|
+| T1584.004 | Compromise Infrastructure: Server (hijacked relays) |
+| T1189 | Drive-by Compromise (watering hole) |
+| T1071.001 | Application Layer Protocol: Web Protocols |
+| T1505.003 | Server Software Component: Web Shell |
+| T1027 | Obfuscated Files or Information |
+| T1070 | Indicator Removal |
+
+---
+
 ## Industry → Likely Threat Actors
 
 Quick lookup for engagement scoping:
 
 | Target Industry | Primary Threat | Secondary Threat |
 |----------------|---------------|-----------------|
-| Financial | FIN7, Lazarus | APT41 |
-| Government | APT29, APT28 | Lazarus |
-| Technology | APT41, APT29 | FIN7 |
-| Healthcare | APT41 | Opportunistic ransomware |
-| Defense | APT28, Lazarus | APT29 |
-| Retail/Hospitality | FIN7 | Opportunistic |
-| Cryptocurrency | Lazarus | Opportunistic |
-| Energy/Utilities | APT28 | APT41 |
+| Financial / banking | FIN7, Lazarus (APT38) | LockBit, Cl0p, ALPHV |
+| Government / diplomatic | APT29, APT28 | Turla, Volt Typhoon, Kimsuky |
+| Technology / SaaS | APT41, APT29 | Scattered Spider, FIN7 |
+| Healthcare / pharma | ALPHV, LockBit | APT41, Cl0p |
+| Defense / aerospace | APT28, APT40 | Lazarus, APT10, Turla |
+| Maritime / shipping | APT40 | APT41 |
+| Retail / hospitality / gaming | FIN7, Scattered Spider | LockBit |
+| Cryptocurrency / DeFi | Lazarus (incl. AppleJeus) | Kimsuky |
+| Energy / utilities | Sandworm, OilRig | APT28, Volt Typhoon |
+| ICS / OT / critical infra | Sandworm, Volt Typhoon | APT40 |
+| Telecom / ISP | Salt Typhoon, MuddyWater | APT41, APT10 |
+| Manufacturing / industrial | LockBit, ALPHV | APT41 |
+| MSP / IT services / supply chain | APT10, APT29 | Cl0p, Scattered Spider |
+| Education / research | Cl0p, Kimsuky | APT41 |
+| Think tanks / NGO / policy | Kimsuky, APT29 | APT28, Turla |
+
+---
+
+## MITRE ATT&CK Group ID crosswalk
+
+Fill `threat-profile.json` → `group_id` from this table. Ransomware crews tracked
+by MITRE as *software* rather than a *group* have no `Gxxxx`; leave `group_id` empty
+and set `actor_name` to the crew name + software ID.
+
+| Actor | MITRE ID | Attribution | Type |
+|-------|----------|-------------|------|
+| APT29 | G0016 | Russia (SVR) | Nation-state espionage |
+| APT28 | G0007 | Russia (GRU 26165) | Nation-state espionage/disruption |
+| Sandworm | G0034 | Russia (GRU 74455) | Nation-state disruption/ICS |
+| Turla | G0010 | Russia (FSB) | Nation-state espionage |
+| APT41 | G0096 | China (MSS) | Nation-state + financial |
+| APT40 | G0065 | China (MSS Hainan) | Nation-state espionage |
+| APT10 | G0045 | China (MSS Tianjin) | Nation-state / supply chain |
+| Volt Typhoon | G1017 | China (PRC) | Nation-state / critical infra |
+| Salt Typhoon | G1045 | China (PRC) | Nation-state / telecom |
+| OilRig (APT34) | G0049 | Iran (MOIS) | Nation-state espionage |
+| MuddyWater | G0069 | Iran (MOIS) | Nation-state / access broker |
+| Lazarus Group | G0032 | North Korea (RGB) | Nation-state + financial |
+| APT38 (BlueNoroff) | G0082 | North Korea (RGB) | Nation-state financial |
+| AppleJeus | G1049 | North Korea (RGB) | Crypto theft (Lazarus umbrella) |
+| Kimsuky (APT43) | G0094 | North Korea (RGB) | Nation-state espionage |
+| FIN7 | G0046 | eCrime | Financial → ransomware (BGH) |
+| Scattered Spider | G1015 | eCrime | Social-engineering extortion |
+| Cl0p (TA505) | G0092 | eCrime | MFT mass-exploitation extortion |
+| LockBit | — (software S1202) | eCrime RaaS | Ransomware (affiliate) |
+| ALPHV / BlackCat | — (software S1068) | eCrime RaaS | Ransomware (affiliate) |
+
+## Tier mapping & emulation playbooks
+
+Map each actor to a `ThreatProfile.tier` before writing the profile:
+
+| Tier | Value | Fits |
+|------|-------|------|
+| 3 | `tier-3` | All nation-state actors above (APT29/28, Sandworm, Turla, APT41/40/10, Volt/Salt Typhoon, OilRig, MuddyWater, Lazarus, Kimsuky) |
+| 2 | `tier-2` | Targeted eCrime (FIN7, Scattered Spider, LockBit/ALPHV/Cl0p affiliates) |
+| 1 | `tier-1` | Opportunistic / commodity (see `adversary-archetypes.md`) |
+
+For full kill-chain emulation plans that translate these profiles into Decepticon
+OPPLAN objectives + the operational skills each phase uses, load the emulation
+catalog: `load_skill("/skills/standard/soundwave/threat-profile/emulation/SKILL.md")`.


### PR DESCRIPTION
## Summary

Adds a per-actor **adversary-emulation** lane under `soundwave/threat-profile/` and expands the APT/eCrime reference catalog the `threat-profile` planning skill consults. Each emulation playbook converts a named threat actor into an RoE-bounded Decepticon kill chain — a `ThreatProfile` seed, an ordered CONOPS `kill_chain`, and a phase → technique → skill map the orchestrator turns into OPPLAN objectives for the operational agents.

Fills the gap left open by the (unmerged) `feat/skills-adversary-emulation` branch referenced in #431's collision check — `emulation/` is not present on `main`.

**Additive markdown only — no Python/source changes.**

## New skills (8)

| File | What it adds |
|---|---|
| `…/threat-profile/emulation/SKILL.md` | Catalog/routing hub: actor → playbook, tier, skills exercised; how Soundwave consumes a playbook (and that the referenced operational skills are loaded by the **executing** agents, not Soundwave) |
| `…/emulation/apt29/SKILL.md` | **APT29** (Cozy Bear / Midnight Blizzard) — cloud-identity espionage: no-MFA password spray, OAuth/token abuse, Golden SAML, mailbox collection |
| `…/emulation/sandworm/SKILL.md` | **Sandworm** (APT44) — IT→OT intrusion ending in ICS manipulation / destructive impact; ICS-write + destructive steps are canary/lab-only and gated on explicit OT authorization |
| `…/emulation/scattered-spider/SKILL.md` | **Scattered Spider** (UNC3944) — help-desk vishing → MFA takeover → cloud/SaaS privilege expansion → RMM persistence → extortion |
| `…/emulation/volt-typhoon/SKILL.md` | **Volt Typhoon** — edge-device access, living-off-the-land-only, long-dwell pre-positioning, multi-hop proxy egress |
| `…/emulation/lazarus/SKILL.md` | **Lazarus** — crypto/DeFi theft + supply chain; on-chain DeFi/bridge steps run on testnet/fork only |
| `…/emulation/fin7/SKILL.md` | **FIN7** — revenue-targeted spearphishing + EDR evasion → big-game-hunting ransomware |
| `…/emulation/lockbit/SKILL.md` | **LockBit / generic RaaS-affiliate** kill chain — reusable template (retarget ALPHV/Akira/Black Basta) |

## Changed files (3)

- `…/threat-profile/references/apt-groups.md` — **5 → 19 actor cards** (adds Sandworm, Volt/Salt Typhoon, Scattered Spider, APT40, APT10, OilRig, MuddyWater, Kimsuky, Turla, LockBit, ALPHV/BlackCat, Cl0p), a **MITRE Group-ID crosswalk** (feeds `threat-profile.json.group_id`), and an industry → actor map expanded 8 → 15 rows. LockBit/ALPHV are recorded as `—` because MITRE tracks them as *software* (S1202 / S1068), not group pages.
- `…/threat-profile/SKILL.md` — Step 2 + a new Step 5 route named actors to the emulation catalog.
- `.typos.toml` — scope-exclude the jargon-dense `emulation/` + `references/` dirs (matches the existing `ics-ot` / `iot` exclusion pattern; `OT`, `HPE`, `MOVEit` are correct terms, not typos).

All MITRE technique IDs were verified against MITRE ATT&CK Groups pages + CISA advisories.

## Verification

- `uv run pytest packages/decepticon/tests/unit/tools/test_skills_registry.py packages/decepticon/tests/unit/backends/test_skills_path.py -q` → **33 passed**
- Production `iter_skill_records` walks the real skills tree → all 8 new skills discovered, `slug == name == dir`, 0 parse errors
- **All 34** `/skills/standard/...` cross-references resolve (no dangling links); no new slug collisions
- `typos` → clean (exit 0) after the scoped exclude; no trailing whitespace / CRLF; final newlines OK; `.markdownlint.yaml` (`MD013`/`MD022` off) matches the additions
- `ruff` N/A — no `.py` files changed

## Notes

- Frontmatter follows the house schema (`name`, `description`, `allowed-tools`, `metadata.{subdomain, when_to_use, tags, mitre_attack}`); leaf `name` matches its directory, the hub uses the `-overview` suffix (like `ics-ot-overview` / `cloud-overview`).
- Merge is manual per operator convention.

## Related Issues

<!-- none -->
