### PR TITLE
build(ci): make Makefile single source of truth for CI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,36 +177,11 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock', 'pyproject.toml') }}
       - run: uv sync --dev --locked
-      - name: Ruff lint
-        run: uv run ruff check .
-      - name: Ruff format
-        run: uv run ruff format --check .
-      - name: basedpyright (errors only)
-        run: |
-          # Fail on errors only — pre-existing warnings on langchain dynamic
-          # interfaces are tracked but non-blocking. Ratchet up over time.
-          uv run basedpyright --outputjson > bp.json || true
-          uv run python -c "
-          import json, sys
-          d = json.load(open('bp.json'))
-          s = d['summary']
-          print(f\"basedpyright: {s['errorCount']} errors, {s['warningCount']} warnings, {s['informationCount']} info\")
-          if s['errorCount']:
-              print()
-              print('=== error-level diagnostics ===')
-              for diag in d.get('generalDiagnostics', []):
-                  if diag.get('severity') != 'error':
-                      continue
-                  loc = diag.get('range', {}).get('start', {})
-                  line = loc.get('line', 0)
-                  if isinstance(line, int):
-                      line += 1
-                  print(f\"  {diag.get('file', '?')}:{line}\")
-                  print(f\"    {diag.get('message', '')}\")
-                  if diag.get('rule'):
-                      print(f\"    rule: {diag['rule']}\")
-              sys.exit(1)
-          "
+      # Lint + typecheck are dispatched through the Makefile so the
+      # Makefile remains the single source of truth for what CI runs.
+      # See `make ci-lint` and scripts/check_basedpyright_errors.py.
+      - name: Lint + typecheck (CI mirror — `make ci-lint`)
+        run: make ci-lint
       - name: Upload basedpyright JSON (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -217,15 +192,15 @@ jobs:
       # PRs run tests without coverage instrumentation — coverage adds ~3x
       # runtime and PR feedback latency matters more than coverage tracking
       # on every change. Coverage is enforced on main pushes (next step).
-      - name: Pytest (PRs — fast, no coverage)
+      - name: Pytest (PRs — fast, no coverage; mirrors `make ci-test`)
         if: github.event_name == 'pull_request'
         # Deselect tests marked `slow` (e.g. benchmark/test_harness wall-clock
         # timeout cases) so PR feedback stays under a minute. Main coverage
         # lane below still runs them.
-        run: uv run pytest -n auto -q -m "not slow"
-      - name: Pytest with coverage (main — enforces threshold)
+        run: make ci-test
+      - name: Pytest with coverage (main — mirrors `make ci-test-coverage`)
         if: github.event_name == 'push'
-        run: uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=35
+        run: make ci-test-coverage
       - name: Upload coverage artifact
         if: github.event_name == 'push' && always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ CLAUDE.md
 references/octogent
 clients/launcher/decepticon
 
+# basedpyright JSON output from `make ci-lint` (CI uploads as artifact on failure)
+bp.json
+
 # Benchmark
 # Per-run artefacts (timestamped batch + evidence/ + reports/) are local-only.
 # Curated per-challenge results (XBEN-*-24/) and the LEVEL3 index are committed.

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ export CODEX_AUTH_VOLUME ?= $(shell test -f $(HOME)/.codex/auth.json && echo $(H
 .PHONY: help \
         dogfood launcher smoke \
         dev cli-dev web-dev infra \
-        quality quality-cli test test-local lint lint-fix \
+        quality quality-strict quality-cli test test-local lint lint-fix \
+        ci-lint ci-test ci-test-coverage \
         web-build web-hotswap web-lint web-migrate \
         status logs health clean \
         node-install web-db-ensure \
@@ -68,11 +69,15 @@ help:
 	@echo "  make web-dev      Web (Next.js) locally + backend hot-reload"
 	@echo ""
 	@echo "Quality gates (PR readiness):"
-	@echo "  make quality      Full gate (Python + CLI + Web)"
-	@echo "  make test         pytest in container"
-	@echo "  make test-local   pytest locally (uv sync --dev)"
-	@echo "  make lint         Python lint + format check + typecheck"
-	@echo "  make lint-fix     Auto-fix Python lint + format"
+	@echo "  make quality        PR gate — mirrors CI PR lane (fast, no slow tests, errors-only typecheck)"
+	@echo "  make quality-strict Release gate — mirrors CI main-push lane + full basedpyright warning audit"
+	@echo "  make ci-lint        Lint + format + basedpyright errors-only (CI mirror)"
+	@echo "  make ci-test        pytest fast lane (-n auto -m \"not slow\", no coverage)"
+	@echo "  make ci-test-coverage  pytest with coverage gate (--cov-fail-under=35)"
+	@echo "  make test           pytest in container"
+	@echo "  make test-local     pytest locally (uv sync --dev; takes ARGS=)"
+	@echo "  make lint           Python lint + format check + basedpyright (all levels, local exploratory)"
+	@echo "  make lint-fix       Auto-fix Python lint + format"
 	@echo ""
 	@echo "Web dashboard (single checks):"
 	@echo "  make web-build    Prisma generate + Next build"
@@ -197,6 +202,29 @@ lint-fix:
 	uv run ruff check --fix .
 	uv run ruff format .
 
+# ── CI mirror targets ─────────────────────────────────────────────
+# These are the exact commands CI runs. .github/workflows/ci.yml
+# dispatches via `make ci-lint` / `make ci-test{,-coverage}` so this
+# Makefile stays the single source of truth — no drift between local
+# and CI is possible by construction.
+
+ci-lint:
+	@echo "==> ruff check"
+	uv run ruff check .
+	@echo "==> ruff format --check"
+	uv run ruff format --check .
+	@echo "==> basedpyright (errors only — pre-existing warnings tracked but non-blocking)"
+	uv run basedpyright --outputjson > bp.json || true
+	uv run python scripts/check_basedpyright_errors.py bp.json
+
+## PR lane: fast, no coverage, slow tests excluded.
+ci-test:
+	uv run pytest -n auto -q -m "not slow"
+
+## main-push lane: slow included, coverage 35% gate.
+ci-test-coverage:
+	uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=35
+
 quality-cli: node-install
 	# streaming workspace must be built first — its package.json main
 	# resolves to dist/, which cli's typecheck + build consume.
@@ -205,10 +233,20 @@ quality-cli: node-install
 	npm run build --workspace=@decepticon/cli
 	npm run test --workspace=@decepticon/cli
 
-## Full PR gate — Python + CLI + Web. Run before opening a PR.
-quality: lint test-local quality-cli web-lint web-build
+## PR gate — mirrors CI PR lane (errors-only typecheck + fast pytest + CLI + Web).
+## Use before opening a PR; passing this guarantees CI will pass.
+quality: ci-lint ci-test quality-cli web-lint web-build
 	@echo ""
-	@echo "OK — all quality gates passed (python + cli + web)"
+	@echo "OK — PR gates passed (mirrors CI PR lane)"
+
+## Release gate — mirrors CI main-push lane (coverage 35%) + full basedpyright
+## audit (warnings + info). Run before tagging a release.
+quality-strict: ci-lint ci-test-coverage quality-cli web-lint web-build
+	@echo ""
+	@echo "==> basedpyright (full — warning + info audit, non-blocking)"
+	uv run basedpyright
+	@echo ""
+	@echo "OK — release gate passed (mirrors CI main lane + warning audit)"
 
 # ── Web Dashboard (single checks) ────────────────────────────────
 # All web targets share the root `node-install` so workspace deps hoist

--- a/packages/decepticon/tests/unit/backends/test_session_log.py
+++ b/packages/decepticon/tests/unit/backends/test_session_log.py
@@ -29,6 +29,8 @@ def test_initialize_does_not_create_root_workspace_sessions_log():
             "",
             "",
             "",
+            "",  # _sync_passthrough_env -> _send -> send-keys -l
+            "",  # _sync_passthrough_env -> _send -> send-keys Enter
         ]
         mock_run.return_value.returncode = 0
         mgr.initialize()
@@ -59,6 +61,8 @@ def test_initialize_pipes_pane_to_engagement_scoped_sessions_log():
             "",
             "",
             "",
+            "",  # _sync_passthrough_env -> _send -> send-keys -l
+            "",  # _sync_passthrough_env -> _send -> send-keys Enter
         ]
         mock_run.return_value.returncode = 0
         mgr.initialize()
@@ -87,7 +91,17 @@ def test_initialize_creates_sessions_directory_inside_engagement_workspace():
         patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
         patch("time.sleep"),
     ):
-        mock_tmux.side_effect = [RuntimeError("session not found"), "", "", "", "", "", ""]
+        mock_tmux.side_effect = [
+            RuntimeError("session not found"),
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",  # _sync_passthrough_env -> _send -> send-keys -l
+            "",  # _sync_passthrough_env -> _send -> send-keys Enter
+        ]
         mock_run.return_value.returncode = 0
         mgr.initialize()
 
@@ -120,7 +134,17 @@ def test_initialize_warns_when_mkdir_fails(caplog):
             patch("decepticon.sandbox_kernel.base.subprocess.run") as mock_run,
             patch("time.sleep"),
         ):
-            mock_tmux.side_effect = [RuntimeError("session not found"), "", "", "", "", "", ""]
+            mock_tmux.side_effect = [
+                RuntimeError("session not found"),
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",  # _sync_passthrough_env -> _send -> send-keys -l
+                "",  # _sync_passthrough_env -> _send -> send-keys Enter
+            ]
             mock_run.side_effect = [None, CalledProcessError(1, ["docker", "exec"])]
             with caplog.at_level(logging.WARNING):
                 mgr.initialize()
@@ -512,6 +536,8 @@ def test_initialize_recreates_stale_cached_pane_without_error_string_matching():
             "",  # send-keys C-l
             "",  # clear-history
             "",  # pipe-pane
+            "",  # _sync_passthrough_env -> _send -> send-keys -l
+            "",  # _sync_passthrough_env -> _send -> send-keys Enter
         ]
         mock_run.return_value.returncode = 0
         mgr.initialize()

--- a/scripts/check_basedpyright_errors.py
+++ b/scripts/check_basedpyright_errors.py
@@ -1,0 +1,59 @@
+"""Parse a basedpyright JSON report and fail iff there are error-level diagnostics.
+
+Warnings and information are reported as a count but do not fail the gate —
+the codebase carries pre-existing warnings on langchain dynamic interfaces
+that are tracked but non-blocking. The error-count is ratcheted up over time.
+
+Usage:
+    uv run basedpyright --outputjson > bp.json
+    uv run python scripts/check_basedpyright_errors.py bp.json
+
+Exits 0 if no errors, 1 if any error-level diagnostic is present.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <bp.json>", file=sys.stderr)
+        return 2
+
+    bp_path = Path(argv[1])
+    if not bp_path.exists():
+        print(f"basedpyright JSON not found: {bp_path}", file=sys.stderr)
+        return 2
+
+    data = json.loads(bp_path.read_text())
+    summary = data["summary"]
+    print(
+        f"basedpyright: {summary['errorCount']} errors, "
+        f"{summary['warningCount']} warnings, "
+        f"{summary['informationCount']} info"
+    )
+
+    if not summary["errorCount"]:
+        return 0
+
+    print()
+    print("=== error-level diagnostics ===")
+    for diag in data.get("generalDiagnostics", []):
+        if diag.get("severity") != "error":
+            continue
+        loc = diag.get("range", {}).get("start", {})
+        line = loc.get("line", 0)
+        if isinstance(line, int):
+            line += 1
+        print(f"  {diag.get('file', '?')}:{line}")
+        print(f"    {diag.get('message', '')}")
+        if diag.get("rule"):
+            print(f"    rule: {diag['rule']}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
Eliminate drift between local `make quality` and CI by making the Makefile the single source of truth — `ci.yml` now dispatches via `make ci-lint`, `make ci-test`, `make ci-test-coverage`. Add a 2-tier gate: `quality` (mirrors CI PR lane) for PRs, `quality-strict` (mirrors CI main-push lane + full basedpyright audit) for releases.

Also fixes 5 `test_initialize_*` mocks in `test_session_log.py` that exhausted their iterators after #296 added `_sync_passthrough_env()` calls into `TmuxSessionManager.initialize()`. Without this, every initialize test raises `StopIteration` under the new (stricter) gate, blocking release.

## Changes
- **`Makefile`**: new `ci-lint`, `ci-test`, `ci-test-coverage` targets (CI lane mirror); `quality` redefined to mirror CI PR lane; `quality-strict` added for the release gate. Legacy `lint`/`test-local` preserved for local exploratory use.
- **`.github/workflows/ci.yml`**: 3 lint steps → 1 `make ci-lint`; pytest steps → `make ci-test{,-coverage}`. Inline command definitions removed.
- **`scripts/check_basedpyright_errors.py`**: extracted from the inline Python in ci.yml so the errors-only gate is a real, testable script.
- **`tests/.../test_session_log.py`**: +2 trailing `""` per `mock_tmux.side_effect` to cover the `_sync_passthrough_env() → _send() → 2× _tmux()` chain.
- **`.gitignore`**: `bp.json` (basedpyright JSON output; CI uploads as artifact on failure).

## Testing
- [x] `make quality` passes (PR lane mirror)
- [x] `make quality-strict` passes (release gate, full basedpyright: 0 errors, 167 warnings non-blocking)
- [x] `pytest -k test_initialize` — 5/5 pass

## Related Issues
Follows up on the test mock gap from #296 (`fix(tools/bash): inherit proxy env vars into sandbox tmux sessions`).