### PR TITLE
build(make): down prior stack before dogfood to avoid container-name conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ help:
 ## launcher version is "dev" so auto-update + config-sync are skipped — the
 ## symlinked .dogfood/ tree is the source of truth.
 dogfood: launcher
+	@echo "[dogfood] Stopping any prior repo-root stack to avoid container-name conflict..."
+	@$(COMPOSE) $(PROFILES_ALL) down --remove-orphans 2>/dev/null; true
 	@mkdir -p $(DOGFOOD_HOME)/workspace
 	@ln -sfn $(CURDIR)/docker-compose.yml $(DOGFOOD_HOME)/docker-compose.yml
 	@ln -sfn $(CURDIR)/config              $(DOGFOOD_HOME)/config


### PR DESCRIPTION
## Summary
Running `make dogfood` right after `make smoke` (or `make dev`) fails with container-name conflicts: the repo-root compose project (`decepticon_new`) is still up, and the launcher's dogfood project tries to recreate identically-named containers (which use `container_name:` in docker-compose.yml).

Caught during the v1.1.4 release dogfood verification. The qa-tester session had to manually `docker compose down` before launching to get past it.

## Changes
- `Makefile`: `dogfood` target now runs `$(COMPOSE) $(PROFILES_ALL) down --remove-orphans` (same flags the `smoke` target uses) before symlinking and building. `2>/dev/null; true` so a clean state (no prior stack) is not an error.

## Testing
- [x] `make -n dogfood` shows the new pre-clean step at the top of the recipe.
- [x] Recipe order is correct: down → symlinks → build → launch.

After this lands, the documented `make quality-strict → make smoke → make dogfood` release flow runs cleanly without an explicit `make clean` in between.

## Related Issues
Follow-up from v1.1.4 release qa-tester verification (no issue filed).