### PR TITLE
chore(env): comment out LANGSMITH_API_KEY placeholder to silence 403 spam when tracing is off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,10 +198,15 @@ CHATGPT_SESSION_TOKEN=
 BENCHMARK_MODE=
 
 # --- LangSmith Tracing (optional) ---
-# Set LANGSMITH_TRACING=true to enable. The wizard rewrites both keys
-# when you opt in.
+# Set LANGSMITH_TRACING=true AND fill LANGSMITH_API_KEY to enable.
+# The onboard wizard handles both when you opt in.
+#
+# LANGSMITH_API_KEY is intentionally left unset (commented out) — leaving
+# a placeholder value here causes the LangChain SDK to attempt metadata
+# uploads to api.smith.langchain.com and spam the langgraph container
+# logs with 403 Forbidden, even when LANGSMITH_TRACING=false.
 LANGSMITH_TRACING=false
-LANGSMITH_API_KEY=your-langsmith-key-here
+# LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=decepticon
 
 # --- Ports (optional) ---


### PR DESCRIPTION
## Summary
`.env.example` shipped `LANGSMITH_API_KEY=your-langsmith-key-here` as a placeholder. Even with `LANGSMITH_TRACING=false`, the LangChain SDK treats any non-empty `LANGSMITH_API_KEY` as a signal to attempt metadata uploads, which spam the langgraph container logs with `403 Forbidden` from `api.smith.langchain.com`.

Caught during the v1.1.4 release dogfood verification (qa-tester logs).

## Changes
- `.env.example`: comment out `LANGSMITH_API_KEY=` (leave it unset by default) and expand the inline comment to explain why. `LANGSMITH_TRACING=false` and `LANGSMITH_PROJECT=decepticon` remain set.

## Behavior
- **Default (no edits)**: tracing disabled, no LangSmith network traffic, no 403 logs.
- **Opt-in**: uncomment `LANGSMITH_API_KEY=`, fill the key, set `LANGSMITH_TRACING=true`. Or use `decepticon onboard` which handles both.

## Testing
- [x] Manual review of the diff — only the LangSmith block changes.
- [x] Existing onboard wizard logic is unaffected (still rewrites both keys when the operator opts in).

## Related Issues
Follow-up from v1.1.4 release qa-tester verification.