### PR TITLE
Add dazai dead-man's-switch: tear down the stack on session loss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ export CODEX_AUTH_VOLUME ?= $(shell test -f $(HOME)/.codex/auth.json && echo $(H
         ci-lint ci-test ci-test-coverage \
         web-build web-hotswap web-lint web-migrate \
         status logs health clean \
+        deadman deadman-dry \
         node-install web-db-ensure \
         benchmark recreate-litellm
 
@@ -90,6 +91,10 @@ help:
 	@echo "  make logs [SVC=]  Follow logs (default: langgraph)"
 	@echo "  make health       KG + Neo4j + Web health checks"
 	@echo "  make clean        Full teardown (compose volumes + .dogfood/)"
+	@echo ""
+	@echo "Session security (dazai dead-man's-switch — see docs/dazai-deadman.md):"
+	@echo "  make deadman      Arm: tear down stack + shred .env if the session dies (detached)"
+	@echo "  make deadman-dry  Rehearse the switch (logs what it would do, touches nothing)"
 	@echo ""
 	@echo "Other:"
 	@echo "  make benchmark [ARGS=\"--level 1\"]"
@@ -294,6 +299,25 @@ clean:
 	$(COMPOSE) $(PROFILES_ALL) down --volumes --remove-orphans
 	@rm -rf $(DOGFOOD_HOME)
 	@echo "OK — compose volumes purged, .dogfood/ removed"
+
+# ── Session security: dazai dead-man's-switch ────────────────────
+# A host-side sentinel watches an armed `dazai daemon` tied to your engagement
+# shell (https://github.com/New1Direction/ningen-shikkaku). When the session
+# dies and the daemon self-destructs past its grace window, the sentinel tears
+# this stack down (compose down -v) and shreds .env. See docs/dazai-deadman.md.
+DEADMAN_LOG ?= /tmp/decepticon-deadman.log
+
+## Arm the dead-man's-switch (detached, survives the shell). Requires an armed
+## `dazai daemon` + `dazai client` heartbeat already running in your session.
+deadman:
+	@command -v dazai >/dev/null 2>&1 || { echo "dazai not on PATH — install it and run 'dazai daemon --arm' first (see docs/dazai-deadman.md)"; exit 1; }
+	@nohup python3 scripts/dazai_deadman.py --stack-dir $(CURDIR) --compose-file $(CURDIR)/docker-compose.yml >$(DEADMAN_LOG) 2>&1 &
+	@echo "[deadman] armed — watching the dazai daemon; teardown on session loss. log: $(DEADMAN_LOG)"
+
+## Rehearse the switch in the foreground: logs what it WOULD tear down and
+## shred, never touches the stack or .env. Ctrl-C to disarm.
+deadman-dry:
+	python3 scripts/dazai_deadman.py --stack-dir $(CURDIR) --compose-file $(CURDIR)/docker-compose.yml --dry-run
 
 # ── Internal idempotent helpers ──────────────────────────────────
 

--- a/docs/dazai-deadman.md
+++ b/docs/dazai-deadman.md
@@ -1,0 +1,133 @@
+# Session-bound teardown — the dazai dead-man's-switch
+
+Tie a Decepticon engagement to your shell session: if that session dies — you
+log out, the SSH connection drops, the box is seized — the **entire stack is
+torn down and the secrets it leaves behind are purged**, automatically, within
+seconds.
+
+This integrates [**dazai**](https://github.com/New1Direction/ningen-shikkaku), a
+host-side, memory-zeroizing dead-man's-switch, as the liveness oracle. The glue
+is one small host script: [`scripts/dazai_deadman.py`](../scripts/dazai_deadman.py).
+
+## Why a teardown, not a PID kill
+
+dazai's native mechanism is "SIGKILL a registered **host** PID when the session
+dies." Decepticon doesn't fit that shape:
+
+- it runs as a **Docker stack** (`langgraph`, `neo4j`, `postgres`, `litellm`,
+  `web`, `sandbox`, …) — container PIDs live in their own namespace and aren't
+  killable by a host daemon;
+- the sensitive state isn't in one process — it's in **container memory**, in
+  the **`neo4j` / `postgres` volumes** (findings, target data, creds), and in
+  the host **`.env`** (provider API keys).
+
+So the dead-man's action is `docker compose down -v` (stop every container **and
+purge the volumes**) plus a secure wipe of `.env`. That destroys the live
+processes *and* the data-at-rest — which a PID kill would leave on disk.
+
+## How it works
+
+```
+your shell ──heartbeat──▶ dazai daemon (armed)        scripts/dazai_deadman.py
+  (dazai client)             │  self-destructs when         │  polls daemon STATUS
+                             │  the heartbeat is lost        │  daemon gone ⇒ teardown
+                             ▼                               ▼
+                     wipes its locked buffers      docker compose down -v
+                     + exits (past --grace)         + shred .env
+```
+
+dazai is the session-liveness engine (heartbeat drop, ping-timeout, panic
+signals, grace window, reconnect-cancel — all its logic). The sentinel is a thin
+**reactor**: it watches the daemon over the daemon's UNIX control socket and,
+the instant the daemon vanishes (a session-loss panic that committed past its
+grace window), runs the teardown. dazai's SIGKILL can't be trapped to run
+cleanup, so reacting to its death is the correct coupling.
+
+## Setup
+
+**1. Install dazai** (once) and put the `dazai` binary on your `PATH` — see its
+[repo](https://github.com/New1Direction/ningen-shikkaku).
+
+**2. Start the Decepticon stack** as usual (`make dogfood`, `make dev`, or the
+launcher).
+
+**3. Arm dazai, tied to your engagement shell.** In the shell you'll run the
+engagement from:
+
+```bash
+dazai daemon --arm --grace 5 --ping-timeout 20   # detached/own terminal
+dazai client --interval 5                         # holds the heartbeat for THIS shell
+```
+
+**4. Arm the teardown sentinel:**
+
+```bash
+make deadman          # detached; survives the shell, logs to /tmp/decepticon-deadman.log
+```
+
+That's it. Now if the shell/session dies, dazai self-destructs and the sentinel
+tears the stack down and shreds `.env`.
+
+## What gets destroyed on trigger
+
+| Target | Action |
+|---|---|
+| All Decepticon containers | `docker compose down -v --remove-orphans` |
+| `neo4j` + `postgres` volumes (findings, target data, creds) | purged by `-v` |
+| Host `.env` (provider API keys) | securely overwritten + removed |
+
+```admonish danger
+This is destructive on purpose. Keep your `.env` recoverable (a sealed copy / a
+password manager) so the next engagement can re-create it. Pass `--keep-env` to
+the script if you want to preserve `.env`.
+```
+
+## Safety properties
+
+The sentinel is fail-safe by construction (all verified):
+
+- **Arms only after seeing the daemon alive at least once** — it can't fire
+  before the engagement has started; a missing daemon at startup is "not up
+  yet," not a trigger.
+- **Debounced** — `--confirm-checks` (default 3) consecutive missed polls are
+  required before teardown, so a momentary socket hiccup never nukes the stack.
+- **Clean disarm** — a `SIGINT` / `SIGTERM` (you stop the sentinel yourself)
+  exits **without** teardown. To shut down cleanly: stop the sentinel first
+  (`Ctrl-C` or `kill`), *then* tear the stack down on your own terms.
+
+## Rehearse it first
+
+```bash
+make deadman-dry      # foreground; logs exactly what it WOULD run/shred, touches nothing
+```
+
+Then, in another terminal, kill the dazai daemon to simulate session loss and
+watch the dry-run sentinel log the teardown it *would* perform, and exit. Only
+arm the real `make deadman` once you've seen the rehearsal behave.
+
+## Options
+
+`python scripts/dazai_deadman.py --help`:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--socket PATH` | `${XDG_RUNTIME_DIR:-/tmp}/dazai-$UID.sock` | dazai daemon control socket |
+| `--stack-dir DIR` | repo root | directory containing `docker-compose.yml` |
+| `--compose-file F` | `<stack-dir>/docker-compose.yml` | compose file to tear down |
+| `--env-file F` | `<stack-dir>/.env` | secrets file to shred |
+| `--keep-env` | off | do **not** shred `.env` on teardown |
+| `--interval N` | `2.0` | poll interval, seconds |
+| `--confirm-checks N` | `3` | consecutive missed polls before teardown |
+| `--dry-run` | off | log only; never tear down or shred |
+
+## Limitations
+
+- The sentinel must run **detached** from the session it protects (so it
+  outlives the shell). `make deadman` uses `nohup … &`; if you launch the script
+  by hand, do the same.
+- It tears down on **any** daemon disappearance, including a clean `dazai`
+  shutdown — hence the "stop the sentinel first" disarm protocol above.
+- It does not protect against an attacker who reads the volumes/`.env` *before*
+  the session ends — it bounds the window, it doesn't encrypt data at rest.
+  dazai's own [threat model](https://new1direction.github.io/ningen-shikkaku/threat-model.html)
+  applies to the host secrets it holds directly.

--- a/scripts/dazai_deadman.py
+++ b/scripts/dazai_deadman.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Decepticon ⇄ dazai dead-man's-switch — tear down the stack when the session dies.
+
+Decepticon runs as a Docker stack (``langgraph``, ``neo4j``, ``postgres``, …).
+Its secrets do not live in one host process you can register a PID for — they
+live in container memory and in the ``neo4j`` / ``postgres`` volumes, and the
+provider API keys live in the host ``.env``. So the dead-man's-switch is not
+"SIGKILL a PID"; it is "tear the whole stack down and purge what it leaves
+behind".
+
+`dazai <https://github.com/New1Direction/ningen-shikkaku>`_ is a host-side
+dead-man's-switch tied to the operator's shell / SSH session: an *armed* dazai
+daemon, fed a heartbeat by ``dazai client`` from your engagement shell, wipes
+its own locked buffers and self-destructs the moment that heartbeat is lost
+(past its grace window).
+
+This sentinel turns that daemon-death into a full engagement teardown. It
+watches the daemon's liveness over the daemon's UNIX control socket; the instant
+the daemon vanishes — i.e. a session-loss panic fired and committed — it runs::
+
+    docker compose -f <stack>/docker-compose.yml down -v --remove-orphans
+
+stopping every container **and purging the volumes** that hold findings and
+credentials, then securely overwrites and removes the host ``.env``.
+
+Fail-safe by construction:
+
+* it arms only *after* confirming the daemon alive at least once, so it can
+  never tear down before the engagement has started;
+* a missing daemon at startup is "not up yet", not a trigger;
+* ``--confirm-checks`` consecutive misses are required, so a momentary socket
+  hiccup never nukes the stack;
+* a clean ``SIGINT`` / ``SIGTERM`` (you stop the sentinel yourself) exits
+  **without** teardown — that is the disarm path.
+
+Run it DETACHED from the session it protects, so it outlives the shell::
+
+    nohup python scripts/dazai_deadman.py --stack-dir . >/tmp/deadman.log 2>&1 &
+    disown
+
+or use ``make deadman``. Rehearse first with ``--dry-run``: it logs exactly what
+it *would* run and wipe, and touches nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+from types import FrameType
+
+# dazai's control protocol: connect to the socket, send "<VERB>\n", read one
+# reply line. A live daemon answers "STATUS alive=1 armed=… grace=… registered=…".
+_STATUS_TIMEOUT_S = 3.0
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _log(msg: str) -> None:
+    """Emit a timestamped line to stderr (stdout is reserved for nothing here,
+    but stderr keeps logs out of any pipe a caller might read)."""
+    print(f"[dazai-deadman] {msg}", file=sys.stderr, flush=True)
+
+
+def default_socket_path() -> str:
+    """Mirror dazai's default: ``${XDG_RUNTIME_DIR:-/tmp}/dazai-$UID.sock``."""
+    base = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    return os.path.join(base, f"dazai-{os.getuid()}.sock")
+
+
+def daemon_alive(sock_path: str) -> bool:
+    """True iff an armed dazai daemon answers ``STATUS`` on ``sock_path``.
+
+    Any failure to connect or read (daemon gone, socket removed, connection
+    refused, timeout) is reported as *not alive* — that is the death signal.
+    """
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(_STATUS_TIMEOUT_S)
+            s.connect(sock_path)
+            s.sendall(b"STATUS\n")
+            data = b""
+            while b"\n" not in data:
+                chunk = s.recv(256)
+                if not chunk:
+                    break
+                data += chunk
+    except OSError:
+        return False
+    line = data.split(b"\n", 1)[0].decode(errors="replace")
+    return "alive=1" in line.split()
+
+
+def shred_file(path: Path, *, dry_run: bool) -> None:
+    """Overwrite ``path`` with random bytes, fsync, then unlink. Best-effort."""
+    if not path.exists():
+        _log(f"env file {path} not present — nothing to wipe")
+        return
+    if dry_run:
+        _log(f"DRY-RUN would shred + remove {path}")
+        return
+    try:
+        size = path.stat().st_size
+        with open(path, "r+b", buffering=0) as fh:
+            fh.write(os.urandom(max(size, 1)))
+            fh.flush()
+            os.fsync(fh.fileno())
+        path.unlink()
+        _log(f"shredded + removed {path}")
+    except OSError as exc:
+        _log(f"WARN: could not shred {path}: {exc}")
+
+
+def teardown(*, stack_dir: Path, compose_file: Path, env_file: Path | None, dry_run: bool) -> None:
+    """Purge the engagement: ``compose down -v`` then shred ``.env``."""
+    import subprocess  # local import: only needed on the trigger path
+
+    cmd = [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "down",
+        "-v",
+        "--remove-orphans",
+    ]
+    _log("=== SESSION LOST — tearing down Decepticon engagement stack ===")
+    if dry_run:
+        _log(f"DRY-RUN would run: {' '.join(cmd)}  (cwd={stack_dir})")
+    else:
+        _log(f"running: {' '.join(cmd)}")
+        try:
+            result = subprocess.run(cmd, cwd=stack_dir, check=False)  # noqa: S603
+            _log(f"compose down exited {result.returncode}")
+        except OSError as exc:
+            _log(f"WARN: compose down failed to launch: {exc}")
+    if env_file is not None:
+        shred_file(env_file, dry_run=dry_run)
+    _log("=== teardown complete ===")
+
+
+class _Stop(Exception):
+    """Raised from the signal handler to break the watch loop cleanly."""
+
+
+def _install_disarm_handlers() -> None:
+    def handler(signum: int, _frame: FrameType | None) -> None:
+        raise _Stop(signal.Signals(signum).name)
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+
+def watch(
+    *,
+    sock_path: str,
+    stack_dir: Path,
+    compose_file: Path,
+    env_file: Path | None,
+    interval: float,
+    confirm_checks: int,
+    dry_run: bool,
+) -> int:
+    """Watch the daemon; tear down once it dies after having been seen alive."""
+    _install_disarm_handlers()
+    _log(
+        f"watching dazai daemon at {sock_path} "
+        f"(interval={interval}s, confirm={confirm_checks}, "
+        f"dry_run={dry_run})"
+    )
+    _log(f"teardown target: {compose_file}" + (f" + shred {env_file}" if env_file else ""))
+    _log("waiting for the daemon to come alive before arming…")
+
+    seen_alive = False
+    misses = 0
+    try:
+        while True:
+            if daemon_alive(sock_path):
+                if not seen_alive:
+                    seen_alive = True
+                    _log("daemon ALIVE — sentinel ARMED. teardown will fire if it dies.")
+                misses = 0
+            elif seen_alive:
+                misses += 1
+                _log(f"daemon not responding ({misses}/{confirm_checks})")
+                if misses >= confirm_checks:
+                    teardown(
+                        stack_dir=stack_dir,
+                        compose_file=compose_file,
+                        env_file=env_file,
+                        dry_run=dry_run,
+                    )
+                    return 0
+            time.sleep(interval)
+    except _Stop as why:
+        _log(f"{why} received — DISARMED, exiting without teardown")
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="dazai_deadman.py",
+        description="Tear down the Decepticon stack when the dazai-watched session dies.",
+    )
+    parser.add_argument(
+        "--socket",
+        default=default_socket_path(),
+        help="dazai daemon control socket (default: ${XDG_RUNTIME_DIR:-/tmp}/dazai-$UID.sock)",
+    )
+    parser.add_argument(
+        "--stack-dir",
+        type=Path,
+        default=_REPO_ROOT,
+        help="directory containing docker-compose.yml (default: repo root)",
+    )
+    parser.add_argument(
+        "--compose-file",
+        type=Path,
+        default=None,
+        help="compose file to tear down (default: <stack-dir>/docker-compose.yml)",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=None,
+        help="host secrets file to shred on teardown (default: <stack-dir>/.env)",
+    )
+    parser.add_argument(
+        "--keep-env",
+        action="store_true",
+        help="do NOT shred .env on teardown (keep provider keys for the next run)",
+    )
+    parser.add_argument("--interval", type=float, default=2.0, help="poll interval, seconds")
+    parser.add_argument(
+        "--confirm-checks",
+        type=int,
+        default=3,
+        help="consecutive missed polls required before teardown (debounce)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="log what would happen; never run compose down or shred anything",
+    )
+    args = parser.parse_args(argv)
+
+    stack_dir: Path = args.stack_dir.resolve()
+    compose_file: Path = (args.compose_file or stack_dir / "docker-compose.yml").resolve()
+    env_file: Path | None = None if args.keep_env else (args.env_file or stack_dir / ".env")
+
+    if not compose_file.exists():
+        _log(f"ERROR: compose file not found: {compose_file}")
+        return 2
+
+    return watch(
+        sock_path=args.socket,
+        stack_dir=stack_dir,
+        compose_file=compose_file,
+        env_file=env_file,
+        interval=args.interval,
+        confirm_checks=max(1, args.confirm_checks),
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds an **opt-in** session-bound teardown: tie a Decepticon engagement to your shell / SSH session so that if the session dies — logout, dropped connection, a seized box — the whole stack is torn down and the secrets it leaves behind are purged, automatically, within seconds.

It integrates [**dazai**](https://github.com/New1Direction/ningen-shikkaku), a host-side, memory-zeroizing dead-man's-switch, as the liveness oracle.

## Why a teardown, not a PID kill

Decepticon runs as a Docker stack (`langgraph`, `neo4j`, `postgres`, `litellm`, `web`, `sandbox`, …). The sensitive state isn't one process:

- container memory (not a host PID),
- the `neo4j` / `postgres` volumes (findings, target data, creds),
- the host `.env` (provider API keys).

So registering a PID doesn't fit — container PIDs aren't killable from the host, and a kill would leave the data-at-rest behind. The dead-man's action is `docker compose down -v` (stop every container **and** purge the volumes) plus a secure wipe of `.env`.

## How it works

dazai is the session-liveness engine (heartbeat drop, ping-timeout, panic signals, grace window, reconnect-cancel). Because its `SIGKILL` can't be trapped to run cleanup, the new sentinel reacts to the daemon's **death**: it polls the daemon's UNIX control socket and, the instant the armed daemon self-destructs past its grace window, runs the teardown.

```
your shell ──heartbeat──▶ dazai daemon (armed)        scripts/dazai_deadman.py
  (dazai client)             │ self-destructs on            │ polls STATUS
                             │ session loss                 │ daemon gone ⇒ teardown
                             ▼                              ▼
                     wipes locked buffers          docker compose down -v
                                                    + shred .env
```

## Files

- **`scripts/dazai_deadman.py`** — the sentinel. Stdlib-only, best-effort.
- **`Makefile`** — `make deadman` (arm, detached) / `make deadman-dry` (rehearse).
- **`docs/dazai-deadman.md`** — operator workflow, what's destroyed, safety, limitations.

## Safety / fail-safe

- **Arms only after** confirming the daemon alive at least once — it can't fire before the engagement starts; a missing daemon at startup is "not up yet," not a trigger.
- **Debounced** (`--confirm-checks`, default 3) — a momentary socket blip can't trigger teardown.
- **`SIGINT` / `SIGTERM` disarms without teardown** — so the clean-shutdown path is "stop the sentinel, then tear down on your own terms."
- **`--dry-run`** logs exactly what it would run/shred and touches nothing.
- **Fully additive** — zero behavior change unless an operator runs a dazai daemon and `make deadman`.

## Testing

Verified end-to-end against a live dazai daemon: the sentinel arms while the daemon is alive, fires the exact `compose down -v --remove-orphans` teardown on the daemon's death and exits cleanly; `SIGTERM` disarms with no teardown. `ruff check` (`E,F,I,W,TID251`) and `ruff format --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
