### PR TITLE
fix(release): build, verify & promote decepticon-skillogy image (fixes decepticon start)

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -40,6 +40,7 @@ jobs:
             decepticon-langgraph
             decepticon-sandbox
             decepticon-cli
+            decepticon-skillogy
             decepticon-c2-sliver
             decepticon-web
           )
@@ -60,6 +61,7 @@ jobs:
             decepticon-langgraph
             decepticon-sandbox
             decepticon-cli
+            decepticon-skillogy
             decepticon-c2-sliver
             decepticon-web
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,14 @@ jobs:
           - image: decepticon-cli
             dockerfile: containers/cli.Dockerfile
             platforms: linux/amd64,linux/arm64
+          # Skillogy server: lean python:3.13-slim (no Kali/heavy apt layers),
+          # so multi-arch under QEMU is cheap like cli/langgraph. The compose
+          # `skillogy` service has no `profiles:`, so it is ALWAYS started by
+          # `decepticon start` — it MUST be published or every start fails to
+          # pull ghcr.io/purpleailab/decepticon-skillogy:<version>.
+          - image: decepticon-skillogy
+            dockerfile: containers/skillogy.Dockerfile
+            platforms: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -635,6 +643,7 @@ jobs:
             decepticon-langgraph
             decepticon-sandbox
             decepticon-cli
+            decepticon-skillogy
             decepticon-c2-sliver
             decepticon-web
           )
@@ -655,6 +664,7 @@ jobs:
             decepticon-langgraph
             decepticon-sandbox
             decepticon-cli
+            decepticon-skillogy
             decepticon-c2-sliver
             decepticon-web
           )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ follows [Semantic Versioning](https://semver.org/) from `1.0.0`
 onward (the `0.x` cycle is pre-stable per the core/framework/sdk split
 design spec, §13.4).
 
+## [1.1.5] — 2026-06-01
+
+Patch release. Fixes a release-pipeline gap that broke `decepticon start`
+for every published install since the Skillogy layer landed in `v1.1.4`.
+
+### Fixed
+
+- **Skillogy image is now published** — the release pipeline never built,
+  pushed, verified, or promoted `ghcr.io/purpleailab/decepticon-skillogy`,
+  even though the always-on compose `skillogy` service pulls it. Every
+  release since `v1.1.4` therefore failed at `decepticon start` with
+  `No such image: ghcr.io/purpleailab/decepticon-skillogy:<version>` /
+  `error from registry: denied`. `decepticon-skillogy` is now part of the
+  multi-arch `docker` build matrix and the `publish-release` verify +
+  `:latest` promote lists (and `release-recover.yml`), so a missing image
+  now fails the release loudly instead of shipping a broken compose file.
+  (#450)
+
+### Changed
+
+- **`make dogfood`** now tears down any prior repo-root stack before
+  starting, to avoid a container-name conflict. (#447)
+- **`.env.example`** — the `LANGSMITH_API_KEY` placeholder is commented
+  out so it no longer triggers 403 tracing-spam when LangSmith tracing is
+  off. (#448)
+
 ## [1.1.4] — 2026-05-30
 
 Capability + safety expansion on top of `v1.1.3`. Lands the Sisyphus

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,10 +40,10 @@ Pushing a `v*` tag triggers `.github/workflows/release.yml`.
 |-----|--------|
 | `publish-pypi` | Builds the wheel + sdist and publishes the `decepticon` package to PyPI via Trusted Publishing (OIDC — no API token). |
 | `launcher` | Builds the Go launcher binaries with GoReleaser (which drafts the GitHub release) and uploads `config-checksums.txt`, a SHA-256 integrity manifest for `docker-compose.yml`, `config/litellm.yaml`, and `.env.example`. |
-| `docker` | Builds and pushes the multi-arch `litellm`, `langgraph`, and `cli` images. |
+| `docker` | Builds and pushes the multi-arch `litellm`, `langgraph`, `cli`, and `skillogy` images. |
 | `docker-heavy` / `docker-heavy-merge` | Builds `sandbox` and `c2-sliver` on native amd64/arm64 runners (the Kali base is too slow under QEMU), then merges the per-arch digests into manifests. |
 | `docker-web` / `docker-web-merge` | Builds and merges the `web` image the same way. |
-| `publish-release` | Verifies all six `:<version>` images exist on GHCR, promotes them to `:latest`, and flips the GitHub release from draft to published. |
+| `publish-release` | Verifies all seven `:<version>` images exist on GHCR, promotes them to `:latest`, and flips the GitHub release from draft to published. |
 
 Every image is signed with Cosign (keyless OIDC) and ships a CycloneDX SBOM.
 The `:latest` tag and the published release appear only *after* every image is


### PR DESCRIPTION
## Problem

`decepticon start` fails for everyone on a published release:

```
✘ Container decepticon-skillogy   No such image: ghcr.io/purpleailab/decepticon-skillogy:1.1.4
! Image ghcr.io/purpleailab/decepticon-skillogy:1.1.4 error from registry: denied
✗ start services: docker compose --profile cli up -d --no-build --wait ...: exit status 1
```

## Root cause

The compose `skillogy` service has **no `profiles:`**, so it is part of the default profile and is **always** started by `decepticon start` (`docker compose --profile cli up -d --no-build`). It pulls `ghcr.io/purpleailab/decepticon-skillogy:${DECEPTICON_VERSION}` (the launcher pins `DECEPTICON_VERSION` from `.version`).

But **`decepticon-skillogy` was never built, pushed, verified, or promoted by the release pipeline.** Of the 7 `ghcr.io/purpleailab/*` images referenced across the compose files, it is the only one missing from `release.yml`:

| image | in build matrix? | on GHCR @1.1.4? |
|---|---|---|
| litellm, langgraph, cli, sandbox, c2-sliver, web | ✅ | ✅ (verified 200) |
| **skillogy** | ❌ | ❌ (403 — package absent) |

So every release v1.1.0–v1.1.4 shipped a compose file that pulls an image that does not exist.

### Why nothing caught it
- The `publish-release` **GHCR-verify gate omitted skillogy**, so the broken release went green.
- `make smoke` / `make dogfood` **cannot** catch this: they run `compose build` first (skillogy has a `build:` block), tag `:dev`, then `up --no-build`. The gate uses a locally-built image and never pulls the published GHCR tag the launcher actually requests.

## Fix
- **`release.yml`**
  - Add `decepticon-skillogy` to the multi-arch `docker` build matrix. It's a lean `python:3.13-slim` image (no Kali/heavy apt layers), so QEMU multi-arch is cheap, same as `cli`/`langgraph`.
  - Add it to the `publish-release` **verify** list (so a future missing image fails the release loudly instead of shipping broken) and the **`:latest` promote** list.
- **`release-recover.yml`**: add `decepticon-skillogy` to the verify + promote lists so manual recovery stays in sync.

## Verification
- `yaml.safe_load` parses both workflows; structural assertions confirm skillogy is present in the matrix and in every verify/promote list.
- Confirmed via the GHCR registry API that all six other images expose `1.1.4` + `latest` manifests while skillogy returns 403 everywhere.

## After merge
- Cutting the next tag (e.g. `v1.1.5`) publishes `decepticon-skillogy:1.1.5`, verifies it, and promotes `:latest`. Existing 1.1.4 installs self-update via `releases/latest`.
- Optional, to heal pinned 1.1.4 installs without forcing an upgrade: build & push `decepticon-skillogy:1.1.4` once (the recover workflow only verifies/promotes, it can't build a missing image).
