### PR TITLE
fix(release): build heavy images' arm64 under QEMU (unblock v1.1.x publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
           - image: decepticon-sandbox
             dockerfile: containers/sandbox.Dockerfile
             platform: arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: ubuntu-latest  # QEMU arm64 fallback — native ubuntu-24.04-arm runners were unavailable (see CHANGELOG 1.1.6)
           - image: decepticon-c2-sliver
             dockerfile: containers/c2-sliver.Dockerfile
             platform: amd64
@@ -300,10 +300,15 @@ jobs:
           - image: decepticon-c2-sliver
             dockerfile: containers/c2-sliver.Dockerfile
             platform: arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: ubuntu-latest  # QEMU arm64 fallback — native ubuntu-24.04-arm runners were unavailable (see CHANGELOG 1.1.6)
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
+
+      # arm64 legs run here under QEMU emulation because the native
+      # ubuntu-24.04-arm hosted runners were being killed mid-build by a
+      # runner-shutdown outage. Harmless no-op for the native amd64 legs.
+      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v4
 
@@ -459,10 +464,14 @@ jobs:
           - platform: amd64
             runs-on: ubuntu-latest
           - platform: arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: ubuntu-latest  # QEMU arm64 fallback — native ubuntu-24.04-arm runners were unavailable (see CHANGELOG 1.1.6)
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
+
+      # arm64 leg runs here under QEMU emulation — native ubuntu-24.04-arm
+      # hosted runners were unavailable. No-op for the native amd64 leg.
+      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follows [Semantic Versioning](https://semver.org/) from `1.0.0`
 onward (the `0.x` cycle is pre-stable per the core/framework/sdk split
 design spec, §13.4).
 
+## [1.1.6] — 2026-06-01
+
+Release-engineering patch. `v1.1.5` published the PyPI wheels and the
+`skillogy`, `cli`, `langgraph`, and `litellm` images, but its `sandbox`,
+`c2-sliver`, and `web` images never finished: the native `ubuntu-24.04-arm`
+hosted runners that build their arm64 layers were repeatedly killed by a
+runner-shutdown outage, so the multi-arch manifests, `:latest` promotion,
+and release publish never ran. This release ships the identical code with a
+pipeline that no longer depends on those runners.
+
+### Changed
+
+- **Release pipeline** — the arm64 legs of the heavy images (`sandbox`,
+  `c2-sliver`, `web`) now build under QEMU emulation on `ubuntu-latest`
+  instead of native `ubuntu-24.04-arm` runners, which were unavailable.
+  Slower per build, but removes the dependency on the flaky runner pool so
+  the release completes and `:latest` promotes. Revert to native arm64
+  runners once that capacity is restored. (#451)
+
 ## [1.1.5] — 2026-06-01
 
 Patch release. Fixes a release-pipeline gap that broke `decepticon start`


### PR DESCRIPTION
## Why

`v1.1.5` only half-published. The PyPI wheels and the `skillogy`, `cli`, `langgraph`, and `litellm` images shipped, but `sandbox`, `c2-sliver`, and `web` never finished: the native **`ubuntu-24.04-arm`** hosted runners that build their arm64 layers were repeatedly killed mid-build by a runner-shutdown outage (`The runner has received a shutdown signal`, **5 attempts**). Because `docker-heavy`/`docker-web` need all arch legs, the multi-arch *merge* jobs and `publish-release` were skipped — so the `:1.1.5` manifests for those three don't exist, `:latest` was not promoted, and the GitHub release stayed draft.

(`:latest` and the published release still point at 1.1.4, so no user was exposed to the half-release.)

## What

Build the arm64 legs of the heavy images under **QEMU on `ubuntu-latest`** instead of native arm64 runners — the same emulation path that already builds `skillogy`/`cli`/`langgraph`/`litellm` multi-arch successfully:

- `docker-heavy`: flip the `sandbox` + `c2-sliver` **arm64** matrix legs from `runs-on: ubuntu-24.04-arm` to `ubuntu-latest`, add `docker/setup-qemu-action@v4`.
- `docker-web`: same for the `web` **arm64** leg.

The per-arch push-by-digest + manifest-merge structure is **unchanged**; only *where* the arm64 builds run changes. Slower per build, but removes the dependency on the unavailable runner pool so the release completes through the full signed/SBOM'd pipeline.

This is a fallback for the outage — revert to native arm64 runners once that capacity is restored.

## Release

Ships as **v1.1.6** (v1.1.5's PyPI wheels are already public; this is the same code with a working pipeline). After merge I tag `v1.1.6`; `publish-release` then verifies all seven `:1.1.6` images (incl. skillogy), promotes `:latest`, and undrafts the release.

## Verification
- `yaml.safe_load` parses; asserted every `docker-heavy`/`docker-web` matrix leg is `ubuntu-latest` and both jobs include `setup-qemu-action`; no active `runs-on: ubuntu-24.04-arm` remains.
- `actionlint` runs in CI on this PR.
