### PR TITLE
revert(release): restore native arm64 runners; cut v1.1.6 (coherence re-cut)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
           - image: decepticon-sandbox
             dockerfile: containers/sandbox.Dockerfile
             platform: arm64
-            runs-on: ubuntu-latest  # QEMU arm64 fallback — native ubuntu-24.04-arm runners were unavailable (see CHANGELOG 1.1.6)
+            runs-on: ubuntu-24.04-arm
           - image: decepticon-c2-sliver
             dockerfile: containers/c2-sliver.Dockerfile
             platform: amd64
@@ -300,15 +300,10 @@ jobs:
           - image: decepticon-c2-sliver
             dockerfile: containers/c2-sliver.Dockerfile
             platform: arm64
-            runs-on: ubuntu-latest  # QEMU arm64 fallback — native ubuntu-24.04-arm runners were unavailable (see CHANGELOG 1.1.6)
+            runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
-
-      # arm64 legs run here under QEMU emulation because the native
-      # ubuntu-24.04-arm hosted runners were being killed mid-build by a
-      # runner-shutdown outage. Harmless no-op for the native amd64 legs.
-      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v4
 
@@ -464,14 +459,10 @@ jobs:
           - platform: amd64
             runs-on: ubuntu-latest
           - platform: arm64
-            runs-on: ubuntu-latest  # QEMU arm64 fallback — native ubuntu-24.04-arm runners were unavailable (see CHANGELOG 1.1.6)
+            runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
-
-      # arm64 leg runs here under QEMU emulation — native ubuntu-24.04-arm
-      # hosted runners were unavailable. No-op for the native amd64 leg.
-      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,14 @@ design spec, §13.4).
 
 ## [1.1.6] — 2026-06-01
 
-Release-engineering patch. `v1.1.5` published the PyPI wheels and the
-`skillogy`, `cli`, `langgraph`, and `litellm` images, but its `sandbox`,
-`c2-sliver`, and `web` images never finished: the native `ubuntu-24.04-arm`
-hosted runners that build their arm64 layers were repeatedly killed by a
-runner-shutdown outage, so the multi-arch manifests, `:latest` promotion,
-and release publish never ran. This release ships the identical code with a
-pipeline that no longer depends on those runners.
-
-### Changed
-
-- **Release pipeline** — the arm64 legs of the heavy images (`sandbox`,
-  `c2-sliver`, `web`) now build under QEMU emulation on `ubuntu-latest`
-  instead of native `ubuntu-24.04-arm` runners, which were unavailable.
-  Slower per build, but removes the dependency on the flaky runner pool so
-  the release completes and `:latest` promotes. Revert to native arm64
-  runners once that capacity is restored. (#451)
+Re-cut of `v1.1.5` to restore version coherence — no functional change.
+During the `v1.1.5` release the PyPI wheels published, but the container
+publish was interrupted by a transient GitHub-hosted `ubuntu-24.04-arm`
+runner outage; recovery attempts also pushed `1.1.6` wheels to PyPI. With
+the outage resolved, `v1.1.6` re-runs the full pipeline on the native arm64
+runners so the PyPI wheels, all seven signed multi-arch images, and the
+GitHub release are consistent at the highest published version. Carries the
+same Skillogy publish fix as `v1.1.5`. (#452)
 
 ## [1.1.5] — 2026-06-01
 


### PR DESCRIPTION
Reverts the QEMU fallback (#451): QEMU can't build the Kali `sandbox` arm64 image (systemd postinst SIGSEGVs under qemu-aarch64), so native `ubuntu-24.04-arm` runners are required — and they've recovered from the transient outage that motivated #451.

Adds the `[1.1.6]` CHANGELOG entry. **v1.1.6 is a coherence re-cut of v1.1.5** (no functional change): the interrupted v1.1.5 release left `1.1.6` wheels on PyPI without matching container images or a published GitHub release. After merge I delete the stale `v1.1.6` draft+tag and re-tag `v1.1.6` on this commit so the full **native** pipeline rebuilds all seven signed multi-arch images, promotes `:latest`, and publishes the release — making PyPI + GHCR + the release consistent at 1.1.6.

(v1.1.5 is already fully published and is the current `latest`; this supersedes it coherently.)