### PR TITLE
feat(llm): add OpenCode Zen + 8 OpenAI-compatible provider gateways (oh-my-pi parity)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,27 @@ DASHSCOPE_API_KEY=your-dashscope-key-here
 # Generate at github.com/settings/personal-access-tokens.
 GITHUB_TOKEN=your-github-token-here
 
+# --- OpenAI-compatible gateways / aggregators (oh-my-pi parity) ---
+# Each routes through LiteLLM's openai/ provider with a fixed api_base
+# override (see config/litellm.yaml). Set only the gateways you use; a
+# placeholder key is skipped at credentials-resolution time. Order in the
+# default fallback chain follows _DEFAULT_AUTH_PRIORITY (factory.py).
+OPENCODE_API_KEY=your-opencode-zen-key-here          # opencode.ai/zen
+# Vercel names this AI_GATEWAY_API_KEY; the Decepticon-namespaced alias is
+# passed explicitly to LiteLLM, so set THIS var (not Vercel's bare name).
+VERCEL_AI_GATEWAY_API_KEY=your-vercel-ai-gateway-key-here  # vercel.com/ai-gateway
+HF_TOKEN=your-hf-token-here                           # huggingface.co/settings/tokens
+VENICE_API_KEY=your-venice-key-here                   # venice.ai/settings/api
+NANOGPT_API_KEY=your-nanogpt-key-here                 # nano-gpt.com
+SYNTHETIC_API_KEY=your-synthetic-key-here             # synthetic.new
+ZENMUX_API_KEY=your-zenmux-key-here                   # zenmux.ai
+QIANFAN_API_KEY=your-qianfan-key-here                 # qianfan.baidubce.com (Baidu ERNIE)
+# Cloudflare AI Gateway is per-account: set BOTH the key and the
+# OpenAI-compat base URL (the gateway's `…/compat` path). A key without
+# the base URL 404s at call time.
+CLOUDFLARE_AI_GATEWAY_API_KEY=your-cloudflare-ai-gateway-key-here
+# CLOUDFLARE_AI_GATEWAY_API_BASE=https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/compat
+
 # --- AWS Bedrock ---
 # IAM access key + secret + region. The region must have your chosen
 # Anthropic models enabled (us-east-1 / us-west-2 are typical).

--- a/clients/cli/src/commands/model.ts
+++ b/clients/cli/src/commands/model.ts
@@ -126,6 +126,53 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
     "dashscope/qwen-turbo",
   ],
   "GitHub Models": ["github/gpt-5.5", "github/gpt-5.4", "github/gpt-5-nano"],
+  // OpenAI-compatible gateways / aggregators (oh-my-pi parity).
+  // Routed via openai/ + api_base override; alias keeps the gateway prefix.
+  "OpenCode Zen": [
+    "opencode/claude-opus-4-6",
+    "opencode/gpt-5.4",
+    "opencode/glm-5-free",
+  ],
+  "Vercel AI Gateway": [
+    "vercel/anthropic/claude-opus-4.6",
+    "vercel/anthropic/claude-sonnet-4.6",
+    "vercel/anthropic/claude-haiku-4.5",
+  ],
+  "Hugging Face Router": [
+    "hf/deepseek-ai/DeepSeek-V3.1",
+    "hf/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    "hf/openai/gpt-oss-120b",
+  ],
+  "Venice AI": [
+    "venice/claude-opus-4-6",
+    "venice/claude-sonnet-4-6",
+    "venice/deepseek-v4-flash",
+  ],
+  "NanoGPT": [
+    "nanogpt/anthropic/claude-opus-4.6",
+    "nanogpt/anthropic/claude-sonnet-4.6",
+    "nanogpt/anthropic/claude-3-5-haiku-20241022",
+  ],
+  "Synthetic": [
+    "synthetic/hf:deepseek-ai/DeepSeek-V3.2",
+    "synthetic/hf:meta-llama/Llama-3.3-70B-Instruct",
+    "synthetic/hf:openai/gpt-oss-120b",
+  ],
+  "ZenMux": [
+    "zenmux/anthropic/claude-opus-4.6",
+    "zenmux/anthropic/claude-sonnet-4.6",
+    "zenmux/anthropic/claude-haiku-4.5",
+  ],
+  "Baidu Qianfan (ERNIE)": [
+    "qianfan/ernie-4.5-turbo-128k",
+    "qianfan/ernie-4.5-turbo-32k",
+    "qianfan/ernie-speed-pro-128k",
+  ],
+  "Cloudflare AI Gateway": [
+    "cfgateway/anthropic/claude-opus-4-6",
+    "cfgateway/anthropic/claude-sonnet-4-6",
+    "cfgateway/anthropic/claude-haiku-4-5",
+  ],
   // Local
   "Ollama (local)": ["ollama_chat/qwen3-coder:30b (or your OLLAMA_MODEL)"],
   "Ollama Cloud": ["ollama_chat/<your OLLAMA_CLOUD_MODEL>"],

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -392,6 +392,254 @@ model_list:
       input_cost_per_token: 0
       output_cost_per_token: 0
 
+  # ── OpenAI-compatible gateways / aggregators (oh-my-pi parity) ─────────
+  # None ship a native LiteLLM provider, so each is registered through the
+  # ``openai/`` provider with an explicit api_base override (mirrors the
+  # Xiaomi MiMo block above). The user-facing model_name keeps the gateway
+  # prefix so two gateways exposing the same upstream slug never collide.
+  # These mirror config/litellm_dynamic_config.OPENAI_COMPAT_GATEWAYS and
+  # decepticon_core.types.llm.METHOD_MODELS. Per-1M USD costs come from the
+  # gateway's published rate card; subscription / flat-plan / region-priced
+  # gateways are pinned to $0 (honest — not per-token billed).
+
+  # OpenCode Zen — https://opencode.ai/zen/v1
+  - model_name: opencode/claude-opus-4-6
+    litellm_params:
+      model: openai/claude-opus-4-6
+      api_base: https://opencode.ai/zen/v1
+      api_key: os.environ/OPENCODE_API_KEY
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+  - model_name: opencode/gpt-5.4
+    litellm_params:
+      model: openai/gpt-5.4
+      api_base: https://opencode.ai/zen/v1
+      api_key: os.environ/OPENCODE_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.000015
+  - model_name: opencode/glm-5-free
+    litellm_params:
+      model: openai/glm-5-free
+      api_base: https://opencode.ai/zen/v1
+      api_key: os.environ/OPENCODE_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  # Vercel AI Gateway — https://ai-gateway.vercel.sh/v1
+  - model_name: vercel/anthropic/claude-opus-4.6
+    litellm_params:
+      model: openai/anthropic/claude-opus-4.6
+      api_base: https://ai-gateway.vercel.sh/v1
+      api_key: os.environ/VERCEL_AI_GATEWAY_API_KEY
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+  - model_name: vercel/anthropic/claude-sonnet-4.6
+    litellm_params:
+      model: openai/anthropic/claude-sonnet-4.6
+      api_base: https://ai-gateway.vercel.sh/v1
+      api_key: os.environ/VERCEL_AI_GATEWAY_API_KEY
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+  - model_name: vercel/anthropic/claude-haiku-4.5
+    litellm_params:
+      model: openai/anthropic/claude-haiku-4.5
+      api_base: https://ai-gateway.vercel.sh/v1
+      api_key: os.environ/VERCEL_AI_GATEWAY_API_KEY
+    model_info:
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
+
+  # Hugging Face Router — https://router.huggingface.co/v1 (HF_TOKEN)
+  - model_name: hf/deepseek-ai/DeepSeek-V3.1
+    litellm_params:
+      model: openai/deepseek-ai/DeepSeek-V3.1
+      api_base: https://router.huggingface.co/v1
+      api_key: os.environ/HF_TOKEN
+    model_info:
+      input_cost_per_token: 0.0000006
+      output_cost_per_token: 0.00000125
+  - model_name: hf/meta-llama/Llama-3.3-70B-Instruct-Turbo
+    litellm_params:
+      model: openai/meta-llama/Llama-3.3-70B-Instruct-Turbo
+      api_base: https://router.huggingface.co/v1
+      api_key: os.environ/HF_TOKEN
+    model_info:
+      input_cost_per_token: 0.00000088
+      output_cost_per_token: 0.00000088
+  - model_name: hf/openai/gpt-oss-120b
+    litellm_params:
+      model: openai/openai/gpt-oss-120b
+      api_base: https://router.huggingface.co/v1
+      api_key: os.environ/HF_TOKEN
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  # Venice AI — https://api.venice.ai/api/v1 (subscription/credits → $0)
+  - model_name: venice/claude-opus-4-6
+    litellm_params:
+      model: openai/claude-opus-4-6
+      api_base: https://api.venice.ai/api/v1
+      api_key: os.environ/VENICE_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+  - model_name: venice/claude-sonnet-4-6
+    litellm_params:
+      model: openai/claude-sonnet-4-6
+      api_base: https://api.venice.ai/api/v1
+      api_key: os.environ/VENICE_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+  - model_name: venice/deepseek-v4-flash
+    litellm_params:
+      model: openai/deepseek-v4-flash
+      api_base: https://api.venice.ai/api/v1
+      api_key: os.environ/VENICE_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  # NanoGPT — https://nano-gpt.com/api/v1
+  - model_name: nanogpt/anthropic/claude-opus-4.6
+    litellm_params:
+      model: openai/anthropic/claude-opus-4.6
+      api_base: https://nano-gpt.com/api/v1
+      api_key: os.environ/NANOGPT_API_KEY
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+  - model_name: nanogpt/anthropic/claude-sonnet-4.6
+    litellm_params:
+      model: openai/anthropic/claude-sonnet-4.6
+      api_base: https://nano-gpt.com/api/v1
+      api_key: os.environ/NANOGPT_API_KEY
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+  - model_name: nanogpt/anthropic/claude-3-5-haiku-20241022
+    litellm_params:
+      model: openai/anthropic/claude-3-5-haiku-20241022
+      api_base: https://nano-gpt.com/api/v1
+      api_key: os.environ/NANOGPT_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000008
+      output_cost_per_token: 0.000004
+
+  # Synthetic — https://api.synthetic.new/openai/v1 (flat plan → $0)
+  - model_name: synthetic/hf:deepseek-ai/DeepSeek-V3.2
+    litellm_params:
+      model: openai/hf:deepseek-ai/DeepSeek-V3.2
+      api_base: https://api.synthetic.new/openai/v1
+      api_key: os.environ/SYNTHETIC_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+  - model_name: synthetic/hf:meta-llama/Llama-3.3-70B-Instruct
+    litellm_params:
+      model: openai/hf:meta-llama/Llama-3.3-70B-Instruct
+      api_base: https://api.synthetic.new/openai/v1
+      api_key: os.environ/SYNTHETIC_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+  - model_name: synthetic/hf:openai/gpt-oss-120b
+    litellm_params:
+      model: openai/hf:openai/gpt-oss-120b
+      api_base: https://api.synthetic.new/openai/v1
+      api_key: os.environ/SYNTHETIC_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  # ZenMux — https://zenmux.ai/api/v1
+  - model_name: zenmux/anthropic/claude-opus-4.6
+    litellm_params:
+      model: openai/anthropic/claude-opus-4.6
+      api_base: https://zenmux.ai/api/v1
+      api_key: os.environ/ZENMUX_API_KEY
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+  - model_name: zenmux/anthropic/claude-sonnet-4.6
+    litellm_params:
+      model: openai/anthropic/claude-sonnet-4.6
+      api_base: https://zenmux.ai/api/v1
+      api_key: os.environ/ZENMUX_API_KEY
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+  - model_name: zenmux/anthropic/claude-haiku-4.5
+    litellm_params:
+      model: openai/anthropic/claude-haiku-4.5
+      api_base: https://zenmux.ai/api/v1
+      api_key: os.environ/ZENMUX_API_KEY
+    model_info:
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
+
+  # Baidu Qianfan v2 — https://qianfan.baidubce.com/v2 (region-priced → $0)
+  - model_name: qianfan/ernie-4.5-turbo-128k
+    litellm_params:
+      model: openai/ernie-4.5-turbo-128k
+      api_base: https://qianfan.baidubce.com/v2
+      api_key: os.environ/QIANFAN_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+  - model_name: qianfan/ernie-4.5-turbo-32k
+    litellm_params:
+      model: openai/ernie-4.5-turbo-32k
+      api_base: https://qianfan.baidubce.com/v2
+      api_key: os.environ/QIANFAN_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+  - model_name: qianfan/ernie-speed-pro-128k
+    litellm_params:
+      model: openai/ernie-speed-pro-128k
+      api_base: https://qianfan.baidubce.com/v2
+      api_key: os.environ/QIANFAN_API_KEY
+    model_info:
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  # Cloudflare AI Gateway — per-account base URL via
+  # CLOUDFLARE_AI_GATEWAY_API_BASE. Point it at the OpenAI-compat
+  # ``…/compat`` path; that path is Cloudflare-deprecated (still works for
+  # existing integrations) — the newer REST endpoint
+  # ``…/accounts/<id>/ai/v1`` is an alternative the operator can use instead.
+  - model_name: cfgateway/anthropic/claude-opus-4-6
+    litellm_params:
+      model: openai/anthropic/claude-opus-4-6
+      api_base: os.environ/CLOUDFLARE_AI_GATEWAY_API_BASE
+      api_key: os.environ/CLOUDFLARE_AI_GATEWAY_API_KEY
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+  - model_name: cfgateway/anthropic/claude-sonnet-4-6
+    litellm_params:
+      model: openai/anthropic/claude-sonnet-4-6
+      api_base: os.environ/CLOUDFLARE_AI_GATEWAY_API_BASE
+      api_key: os.environ/CLOUDFLARE_AI_GATEWAY_API_KEY
+    model_info:
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+  - model_name: cfgateway/anthropic/claude-haiku-4-5
+    litellm_params:
+      model: openai/anthropic/claude-haiku-4-5
+      api_base: os.environ/CLOUDFLARE_AI_GATEWAY_API_BASE
+      api_key: os.environ/CLOUDFLARE_AI_GATEWAY_API_KEY
+    model_info:
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
+
   # ── Subscription OAuth routes ──────────────────────────────────────────
   # ChatGPT (auth/gpt-*), Gemini Advanced (gemini-sub/*), Copilot
   # (copilot/*), SuperGrok (grok-sub/*), and Perplexity Pro (pplx-sub/*)
@@ -482,6 +730,27 @@ litellm_settings:
     # Xiaomi MiMo — routed via openai/ provider with api_base override
     - {"openai/mimo-vl": ["openai/mimo-rl"]}
     - {"openai/mimo-rl": ["openai/mimo-7b"]}
+    # OpenAI-compatible gateways (oh-my-pi parity) — HIGH → MID → LOW
+    # within each gateway so a primary failure degrades on the same key
+    # before ModelFallbackMiddleware crosses to another provider.
+    - {"opencode/claude-opus-4-6": ["opencode/gpt-5.4"]}
+    - {"opencode/gpt-5.4": ["opencode/glm-5-free"]}
+    - {"vercel/anthropic/claude-opus-4.6": ["vercel/anthropic/claude-sonnet-4.6"]}
+    - {"vercel/anthropic/claude-sonnet-4.6": ["vercel/anthropic/claude-haiku-4.5"]}
+    - {"hf/deepseek-ai/DeepSeek-V3.1": ["hf/meta-llama/Llama-3.3-70B-Instruct-Turbo"]}
+    - {"hf/meta-llama/Llama-3.3-70B-Instruct-Turbo": ["hf/openai/gpt-oss-120b"]}
+    - {"venice/claude-opus-4-6": ["venice/claude-sonnet-4-6"]}
+    - {"venice/claude-sonnet-4-6": ["venice/deepseek-v4-flash"]}
+    - {"nanogpt/anthropic/claude-opus-4.6": ["nanogpt/anthropic/claude-sonnet-4.6"]}
+    - {"nanogpt/anthropic/claude-sonnet-4.6": ["nanogpt/anthropic/claude-3-5-haiku-20241022"]}
+    - {"synthetic/hf:deepseek-ai/DeepSeek-V3.2": ["synthetic/hf:meta-llama/Llama-3.3-70B-Instruct"]}
+    - {"synthetic/hf:meta-llama/Llama-3.3-70B-Instruct": ["synthetic/hf:openai/gpt-oss-120b"]}
+    - {"zenmux/anthropic/claude-opus-4.6": ["zenmux/anthropic/claude-sonnet-4.6"]}
+    - {"zenmux/anthropic/claude-sonnet-4.6": ["zenmux/anthropic/claude-haiku-4.5"]}
+    - {"qianfan/ernie-4.5-turbo-128k": ["qianfan/ernie-4.5-turbo-32k"]}
+    - {"qianfan/ernie-4.5-turbo-32k": ["qianfan/ernie-speed-pro-128k"]}
+    - {"cfgateway/anthropic/claude-opus-4-6": ["cfgateway/anthropic/claude-sonnet-4-6"]}
+    - {"cfgateway/anthropic/claude-sonnet-4-6": ["cfgateway/anthropic/claude-haiku-4-5"]}
     # Copilot, SuperGrok, Perplexity fallbacks (registered dynamically)
   num_retries: 3
   retry_after: 30

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -77,6 +77,34 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     "xiaomi_mimo": "XIAOMI_MIMO_API_KEY",
 }
 
+# OpenAI-compatible gateways / aggregators with no native LiteLLM provider
+# (oh-my-pi parity). Each is reached through LiteLLM's ``openai/`` provider
+# with an explicit api_base override — identical to the xiaomi_mimo / custom
+# path but table-driven so a batch of gateways shares one code path. The
+# model alias keeps the gateway prefix (``opencode/claude-opus-4-6``) so two
+# gateways exposing the same upstream slug never collide in the model_list;
+# ``build_model_entry`` rewrites the prefix to ``openai/`` and pins the base.
+#
+# Mapping: provider_prefix -> (api_base, api_key_env). ``api_base`` is a
+# literal URL for fixed-endpoint gateways, or an ``os.environ/<NAME>`` ref
+# for per-account gateways (Cloudflare) whose URL the operator supplies.
+# ``api_key_env`` is the env var holding the bearer token.
+OPENAI_COMPAT_GATEWAYS: dict[str, tuple[str, str]] = {
+    "opencode": ("https://opencode.ai/zen/v1", "OPENCODE_API_KEY"),
+    "vercel": ("https://ai-gateway.vercel.sh/v1", "VERCEL_AI_GATEWAY_API_KEY"),
+    "hf": ("https://router.huggingface.co/v1", "HF_TOKEN"),
+    "venice": ("https://api.venice.ai/api/v1", "VENICE_API_KEY"),
+    "nanogpt": ("https://nano-gpt.com/api/v1", "NANOGPT_API_KEY"),
+    "synthetic": ("https://api.synthetic.new/openai/v1", "SYNTHETIC_API_KEY"),
+    "zenmux": ("https://zenmux.ai/api/v1", "ZENMUX_API_KEY"),
+    "qianfan": ("https://qianfan.baidubce.com/v2", "QIANFAN_API_KEY"),
+    # Per-account base URL: the operator sets it to their Cloudflare AI
+    # Gateway OpenAI-compat endpoint (``…/compat``). Resolved by LiteLLM at
+    # request time, so an unset base only fails the call (with a clear 404),
+    # never proxy startup.
+    "cfgateway": ("os.environ/CLOUDFLARE_AI_GATEWAY_API_BASE", "CLOUDFLARE_AI_GATEWAY_API_KEY"),
+}
+
 ALLOWED_DYNAMIC_PROVIDERS = frozenset(
     {
         *PROVIDER_API_KEY_ENV,
@@ -105,6 +133,12 @@ ALLOWED_DYNAMIC_PROVIDERS = frozenset(
 # directly. Keep a defensive alias entry — the spread above only covers
 # what's in PROVIDER_API_KEY_ENV with the same casing.
 ALLOWED_DYNAMIC_PROVIDERS = frozenset(ALLOWED_DYNAMIC_PROVIDERS | {"vertex_ai"})
+# OpenAI-compatible gateway prefixes (opencode, vercel, hf, …) are not in
+# PROVIDER_API_KEY_ENV — their api_base + key come from OPENAI_COMPAT_GATEWAYS
+# and build_model_entry rewrites them to ``openai/`` — so register them
+# explicitly or validate_model_name would reject the alias as an unknown
+# provider before the gateway branch runs.
+ALLOWED_DYNAMIC_PROVIDERS = frozenset(ALLOWED_DYNAMIC_PROVIDERS | set(OPENAI_COMPAT_GATEWAYS))
 
 # Environment variables that are model-selection controls, not model names.
 _MODEL_CONTROL_SUFFIXES = (
@@ -328,6 +362,23 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
             "model": f"openai/{actual_model}",
             "api_key": "os.environ/XIAOMI_MIMO_API_KEY",
             "api_base": "os.environ/XIAOMI_MIMO_API_BASE",
+        }
+    elif provider in OPENAI_COMPAT_GATEWAYS:
+        # OpenAI-compatible gateway / aggregator (OpenCode Zen, Vercel AI
+        # Gateway, Hugging Face Router, Venice, NanoGPT, Synthetic, ZenMux,
+        # Kimi-for-Coding, Qianfan, Cloudflare AI Gateway). Strip the gateway
+        # prefix from the alias, remap to ``openai/<slug>``, and pin the
+        # gateway's base URL + bearer key. The slug may itself contain
+        # slashes (``vercel/anthropic/claude-opus-4.6`` →
+        # ``openai/anthropic/claude-opus-4.6``) — LiteLLM forwards everything
+        # after ``openai/`` to the endpoint verbatim, which is exactly what
+        # the gateway's ``creator/model`` ids expect.
+        api_base, api_key_env = OPENAI_COMPAT_GATEWAYS[provider]
+        actual_model = model_name.split("/", 1)[1]
+        params = {
+            "model": f"openai/{actual_model}",
+            "api_key": f"os.environ/{api_key_env}",
+            "api_base": api_base,
         }
     else:
         params = {"model": model_name}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -306,6 +306,29 @@ OPENAI_API_KEY=sk-proj-...
 | LM Studio (local) | `LMSTUDIO_API_BASE` + `LMSTUDIO_MODEL` (server on port 1234) |
 | Custom gateway | `CUSTOM_OPENAI_API_KEY`, `CUSTOM_OPENAI_API_BASE`, `CUSTOM_OPENAI_MODEL` |
 
+**OpenAI-compatible gateways / aggregators:**
+
+Each routes through LiteLLM's `openai/` provider with a fixed base URL
+(no extra config beyond the key). Set the key and the gateway joins the
+default fallback chain; pick a specific route at runtime with `/model`
+(e.g. `/model opencode/claude-opus-4-6`).
+
+| Provider | Env Var | Console |
+|----------|---------|---------|
+| OpenCode Zen | `OPENCODE_API_KEY` | [opencode.ai/docs/zen](https://opencode.ai/docs/zen/) |
+| Vercel AI Gateway | `VERCEL_AI_GATEWAY_API_KEY` | [vercel.com/docs/ai-gateway](https://vercel.com/docs/ai-gateway) |
+| Hugging Face Router | `HF_TOKEN` | [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) |
+| Venice AI | `VENICE_API_KEY` | [venice.ai/settings/api](https://venice.ai/settings/api) |
+| NanoGPT | `NANOGPT_API_KEY` | [nano-gpt.com](https://nano-gpt.com) |
+| Synthetic | `SYNTHETIC_API_KEY` | [synthetic.new](https://synthetic.new) |
+| ZenMux | `ZENMUX_API_KEY` | [zenmux.ai](https://zenmux.ai) |
+| Baidu Qianfan (ERNIE) | `QIANFAN_API_KEY` | [console.bce.baidu.com/qianfan](https://console.bce.baidu.com/qianfan) |
+| Cloudflare AI Gateway | `CLOUDFLARE_AI_GATEWAY_API_KEY` + `CLOUDFLARE_AI_GATEWAY_API_BASE` | [dash.cloudflare.com](https://dash.cloudflare.com) |
+
+> Cloudflare's base URL is per-account — set it to your gateway's
+> OpenAI-compat `…/compat` path. Qianfan model ids drift; override per
+> role with `DECEPTICON_MODEL_<ROLE>` if a default 404s.
+
 ---
 
 ### Local LLM (Ollama)

--- a/packages/decepticon-core/decepticon_core/types/llm.py
+++ b/packages/decepticon-core/decepticon_core/types/llm.py
@@ -47,6 +47,25 @@ Tier × AuthMethod matrix
   grok_oauth       grok-sub/grok-4.3             grok-sub/grok-4-1-fast-reasoning — (falls through)
   pplx_oauth       pplx-sub/sonar-pro            pplx-sub/sonar                 — (falls through)
 
+OpenAI-compatible gateways / aggregators (oh-my-pi parity)
+----------------------------------------------------------
+None ship a native LiteLLM provider, so each routes through ``openai/``
+with an api_base override (table-driven in
+``litellm_dynamic_config.OPENAI_COMPAT_GATEWAYS``). The model alias keeps
+the gateway prefix so two gateways exposing the same upstream slug never
+collide in the model_list.
+
+                    HIGH                          MID                            LOW
+  opencode_api     opencode/claude-opus-4-6      opencode/gpt-5.4               opencode/glm-5-free
+  vercel_gateway   vercel/anthropic/…opus-4.6    vercel/anthropic/…sonnet-4.6  vercel/anthropic/…haiku-4.5
+  huggingface_api  hf/…/DeepSeek-V3.1            hf/…/Llama-3.3-70B-…Turbo     hf/openai/gpt-oss-120b
+  venice_api       venice/claude-opus-4-6        venice/claude-sonnet-4-6      venice/deepseek-v4-flash
+  nanogpt_api      nanogpt/…/claude-opus-4.6     nanogpt/…/claude-sonnet-4.6   nanogpt/…/claude-3-5-haiku
+  synthetic_api    synthetic/hf:…/DeepSeek-V3.2  synthetic/hf:…/Llama-3.3-70B  synthetic/hf:openai/gpt-oss
+  zenmux_api       zenmux/anthropic/…opus-4.6    zenmux/anthropic/…sonnet-4.6  zenmux/anthropic/…haiku-4.5
+  qianfan_api      qianfan/ernie-4.5-turbo-128k  qianfan/ernie-4.5-turbo-32k   qianfan/ernie-speed-pro-128k
+  cloudflare_gw    cfgateway/anthropic/…opus     cfgateway/anthropic/…sonnet   cfgateway/anthropic/…haiku
+
 Code-heavy override
 -------------------
 For roles that benefit from OpenAI's agentic coding specialization (patcher,
@@ -129,6 +148,22 @@ class AuthMethod(StrEnum):
     CUSTOM_OPENAI_API = "custom_openai_api"  # Custom OpenAI-compatible endpoint
     CEREBRAS_API = "cerebras_api"  # Cerebras Inference (OpenAI-compatible)
     XIAOMI_MIMO_API = "xiaomi_mimo_api"  # Xiaomi MiMo (OpenAI-compatible)
+    # ── OpenAI-compatible gateways / aggregators (oh-my-pi parity) ──
+    # None ship a native LiteLLM provider, so each is reached through the
+    # ``openai/`` provider with an explicit api_base override — the same
+    # path xiaomi_mimo / custom already use, table-driven in
+    # ``litellm_dynamic_config.OPENAI_COMPAT_GATEWAYS``. The model alias
+    # keeps the gateway prefix (``opencode/claude-opus-4-6``) so routes
+    # never collide when two gateways expose the same upstream slug.
+    OPENCODE_API = "opencode_api"  # OpenCode Zen gateway (opencode.ai)
+    VERCEL_GATEWAY_API = "vercel_gateway_api"  # Vercel AI Gateway
+    HUGGINGFACE_API = "huggingface_api"  # Hugging Face Router (Inference Providers)
+    VENICE_API = "venice_api"  # Venice AI (privacy-first, no logs)
+    NANOGPT_API = "nanogpt_api"  # NanoGPT (pay-as-you-go aggregator)
+    SYNTHETIC_API = "synthetic_api"  # Synthetic (synthetic.new)
+    ZENMUX_API = "zenmux_api"  # ZenMux multi-vendor gateway
+    QIANFAN_API = "qianfan_api"  # Baidu Qianfan (ERNIE) v2 OpenAI-compatible
+    CLOUDFLARE_GATEWAY_API = "cloudflare_gateway_api"  # Cloudflare AI Gateway
 
 
 # ── Tier × AuthMethod → model_id matrix ─────────────────────────────────
@@ -390,6 +425,82 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.HIGH: "openai/mimo-vl",
         Tier.MID: "openai/mimo-rl",
         Tier.LOW: "openai/mimo-7b",
+    },
+    # ── OpenAI-compatible gateways / aggregators (oh-my-pi parity) ──
+    # Model slugs below are grounded in oh-my-pi's published provider
+    # catalog (packages/ai/src/models.json) as of 2026-06. Each route is
+    # rewritten to ``openai/<slug>`` + the gateway's api_base by
+    # ``litellm_dynamic_config.build_model_entry`` and mirrored as a
+    # static entry in ``config/litellm.yaml``.
+    AuthMethod.OPENCODE_API: {
+        # OpenCode Zen — https://opencode.ai/zen/v1. Catalog spans Claude,
+        # GPT-5.x, GLM, Kimi. LOW uses the free GLM tier.
+        Tier.HIGH: "opencode/claude-opus-4-6",
+        Tier.MID: "opencode/gpt-5.4",
+        Tier.LOW: "opencode/glm-5-free",
+    },
+    AuthMethod.VERCEL_GATEWAY_API: {
+        # Vercel AI Gateway — https://ai-gateway.vercel.sh/v1. Model ids
+        # are ``creator/model``; route the Anthropic family for tool-call
+        # reliability parity with the native anthropic path.
+        Tier.HIGH: "vercel/anthropic/claude-opus-4.6",
+        Tier.MID: "vercel/anthropic/claude-sonnet-4.6",
+        Tier.LOW: "vercel/anthropic/claude-haiku-4.5",
+    },
+    AuthMethod.HUGGINGFACE_API: {
+        # Hugging Face Router — https://router.huggingface.co/v1, HF_TOKEN
+        # bearer auth. gpt-oss-120b is the free serverless tier at LOW.
+        Tier.HIGH: "hf/deepseek-ai/DeepSeek-V3.1",
+        Tier.MID: "hf/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        Tier.LOW: "hf/openai/gpt-oss-120b",
+    },
+    AuthMethod.VENICE_API: {
+        # Venice AI — https://api.venice.ai/api/v1. Subscription/credits
+        # model (per-token cost not published → model_info pinned to $0).
+        Tier.HIGH: "venice/claude-opus-4-6",
+        Tier.MID: "venice/claude-sonnet-4-6",
+        Tier.LOW: "venice/deepseek-v4-flash",
+    },
+    AuthMethod.NANOGPT_API: {
+        # NanoGPT — https://nano-gpt.com/api/v1, pay-as-you-go aggregator
+        # exposing ``creator/model`` slugs across most major vendors.
+        Tier.HIGH: "nanogpt/anthropic/claude-opus-4.6",
+        Tier.MID: "nanogpt/anthropic/claude-sonnet-4.6",
+        Tier.LOW: "nanogpt/anthropic/claude-3-5-haiku-20241022",
+    },
+    AuthMethod.SYNTHETIC_API: {
+        # Synthetic — https://api.synthetic.new/openai/v1. Open-weight
+        # models behind an ``hf:`` slug prefix; flat plan → cost $0.
+        Tier.HIGH: "synthetic/hf:deepseek-ai/DeepSeek-V3.2",
+        Tier.MID: "synthetic/hf:meta-llama/Llama-3.3-70B-Instruct",
+        Tier.LOW: "synthetic/hf:openai/gpt-oss-120b",
+    },
+    AuthMethod.ZENMUX_API: {
+        # ZenMux — https://zenmux.ai/api/v1. Multi-vendor gateway; route
+        # the Anthropic family for tool-call parity.
+        Tier.HIGH: "zenmux/anthropic/claude-opus-4.6",
+        Tier.MID: "zenmux/anthropic/claude-sonnet-4.6",
+        Tier.LOW: "zenmux/anthropic/claude-haiku-4.5",
+    },
+    AuthMethod.QIANFAN_API: {
+        # Baidu Qianfan v2 — https://qianfan.baidubce.com/v2, OpenAI-
+        # compatible. Model ids verified against the Qianfan platform doc
+        # (cloud.baidu.com/doc/qianfan/s/rmh4stp0j) which matches this base
+        # URL — note ERNIE Speed 128k is ``ernie-speed-pro-128k`` there.
+        # Pricing is region/currency-dependent → cost $0 (not per-token
+        # enforced). Ids drift; override per role via DECEPTICON_MODEL_<ROLE>.
+        Tier.HIGH: "qianfan/ernie-4.5-turbo-128k",
+        Tier.MID: "qianfan/ernie-4.5-turbo-32k",
+        Tier.LOW: "qianfan/ernie-speed-pro-128k",
+    },
+    AuthMethod.CLOUDFLARE_GATEWAY_API: {
+        # Cloudflare AI Gateway — per-account base URL, so the endpoint
+        # comes from CLOUDFLARE_AI_GATEWAY_API_BASE (the OpenAI-compat
+        # ``.../compat`` path). Model slugs are the gateway's
+        # ``provider/model`` form proxied to Anthropic.
+        Tier.HIGH: "cfgateway/anthropic/claude-opus-4-6",
+        Tier.MID: "cfgateway/anthropic/claude-sonnet-4-6",
+        Tier.LOW: "cfgateway/anthropic/claude-haiku-4-5",
     },
 }
 

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -137,6 +137,19 @@ _DEFAULT_AUTH_PRIORITY: tuple[AuthMethod, ...] = (
     AuthMethod.CUSTOM_OPENAI_API,
     AuthMethod.CEREBRAS_API,
     AuthMethod.XIAOMI_MIMO_API,
+    # OpenAI-compatible gateways / aggregators (oh-my-pi parity). Placed
+    # after the first-party API providers and before the local endpoints:
+    # a hosted gateway is a reasonable fallback but shouldn't preempt a
+    # direct vendor key the user also configured.
+    AuthMethod.OPENCODE_API,
+    AuthMethod.VERCEL_GATEWAY_API,
+    AuthMethod.ZENMUX_API,
+    AuthMethod.NANOGPT_API,
+    AuthMethod.VENICE_API,
+    AuthMethod.SYNTHETIC_API,
+    AuthMethod.HUGGINGFACE_API,
+    AuthMethod.QIANFAN_API,
+    AuthMethod.CLOUDFLARE_GATEWAY_API,
     AuthMethod.OLLAMA_LOCAL,
     AuthMethod.OLLAMA_CLOUD,
 )
@@ -174,6 +187,20 @@ _API_METHOD_ENV: dict[AuthMethod, str] = {
     AuthMethod.AZURE_API: "AZURE_API_KEY",
     AuthMethod.CEREBRAS_API: "CEREBRAS_API_KEY",
     AuthMethod.XIAOMI_MIMO_API: "XIAOMI_MIMO_API_KEY",
+    # OpenAI-compatible gateways / aggregators (oh-my-pi parity). Each is
+    # detected by the presence of a non-placeholder bearer key. The base
+    # URL is fixed per gateway (see config/litellm.yaml) except Cloudflare,
+    # whose per-account CLOUDFLARE_AI_GATEWAY_API_BASE must also be set —
+    # documented in .env.example; a key without the base 404s at call time.
+    AuthMethod.OPENCODE_API: "OPENCODE_API_KEY",
+    AuthMethod.VERCEL_GATEWAY_API: "VERCEL_AI_GATEWAY_API_KEY",
+    AuthMethod.HUGGINGFACE_API: "HF_TOKEN",
+    AuthMethod.VENICE_API: "VENICE_API_KEY",
+    AuthMethod.NANOGPT_API: "NANOGPT_API_KEY",
+    AuthMethod.SYNTHETIC_API: "SYNTHETIC_API_KEY",
+    AuthMethod.ZENMUX_API: "ZENMUX_API_KEY",
+    AuthMethod.QIANFAN_API: "QIANFAN_API_KEY",
+    AuthMethod.CLOUDFLARE_GATEWAY_API: "CLOUDFLARE_AI_GATEWAY_API_KEY",
 }
 
 _OAUTH_METHOD_ENV: dict[AuthMethod, str] = {
@@ -584,6 +611,15 @@ _METHOD_LABEL: dict[AuthMethod, str] = {
     AuthMethod.AZURE_API: "Azure OpenAI — API key",
     AuthMethod.CEREBRAS_API: "Cerebras — API key",
     AuthMethod.XIAOMI_MIMO_API: "Xiaomi MiMo — API key",
+    AuthMethod.OPENCODE_API: "OpenCode Zen — API key",
+    AuthMethod.VERCEL_GATEWAY_API: "Vercel AI Gateway — API key",
+    AuthMethod.HUGGINGFACE_API: "Hugging Face Router — token",
+    AuthMethod.VENICE_API: "Venice AI — API key",
+    AuthMethod.NANOGPT_API: "NanoGPT — API key",
+    AuthMethod.SYNTHETIC_API: "Synthetic — API key",
+    AuthMethod.ZENMUX_API: "ZenMux — API key",
+    AuthMethod.QIANFAN_API: "Baidu Qianfan (ERNIE) — API key",
+    AuthMethod.CLOUDFLARE_GATEWAY_API: "Cloudflare AI Gateway — API key + base URL",
     AuthMethod.COPILOT_OAUTH: "GitHub Copilot — Pro subscription",
     AuthMethod.GROK_OAUTH: "xAI SuperGrok — X Premium+",
     AuthMethod.PERPLEXITY_OAUTH: "Perplexity — Pro subscription",

--- a/packages/decepticon/tests/unit/cli/test_auth.py
+++ b/packages/decepticon/tests/unit/cli/test_auth.py
@@ -64,6 +64,19 @@ def test_inventory_api_key_active(clean_env):
     assert inv.any_active
 
 
+def test_gateway_key_activates_method(clean_env):
+    # An OpenAI-compatible gateway key (oh-my-pi parity) is detected and
+    # routed exactly like any first-party API key — it is in the default
+    # priority, so a lone OpenCode key produces an active chain.
+    clean_env.setenv("OPENCODE_API_KEY", "sk-" + "o" * 40)
+    inv = factory.auth_inventory()
+    opencode = next(s for s in inv.statuses if s.method == AuthMethod.OPENCODE_API)
+    assert opencode.configured
+    assert opencode.active
+    assert opencode.kind == "api"
+    assert AuthMethod.OPENCODE_API in inv.resolved_chain
+
+
 def test_placeholder_key_is_not_configured(clean_env):
     clean_env.setenv("ANTHROPIC_API_KEY", "your-anthropic-key-here")
     inv = factory.auth_inventory()

--- a/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
@@ -18,6 +18,8 @@ collect_requested_models = _module.collect_requested_models
 build_model_entry = _module.build_model_entry
 merge_dynamic_models = _module.merge_dynamic_models
 validate_model_name = _module.validate_model_name
+OPENAI_COMPAT_GATEWAYS = _module.OPENAI_COMPAT_GATEWAYS
+ALLOWED_DYNAMIC_PROVIDERS = _module.ALLOWED_DYNAMIC_PROVIDERS
 
 
 def test_collect_requested_models_includes_global_and_role_overrides() -> None:
@@ -259,3 +261,87 @@ def test_validate_model_name_rejects_llamacpp_without_model_slug() -> None:
     """
     with pytest.raises(ValueError, match="provider/model"):
         validate_model_name("llamacpp")
+
+
+# ── OpenAI-compatible gateways / aggregators (oh-my-pi parity) ──────────
+
+
+def test_every_gateway_prefix_is_an_allowed_dynamic_provider() -> None:
+    """Each OPENAI_COMPAT_GATEWAYS prefix must be in ALLOWED_DYNAMIC_PROVIDERS
+    or validate_model_name would reject the alias before build_model_entry's
+    gateway branch runs.
+    """
+    for prefix in OPENAI_COMPAT_GATEWAYS:
+        assert prefix in ALLOWED_DYNAMIC_PROVIDERS, prefix
+
+
+def test_build_model_entry_routes_gateway_to_openai_with_api_base() -> None:
+    """A gateway alias is rewritten to ``openai/<slug>`` + the gateway's
+    fixed base URL and bearer key, mirroring the xiaomi_mimo / custom path.
+    """
+    entry = build_model_entry("opencode/claude-opus-4-6")
+
+    assert entry["model_name"] == "opencode/claude-opus-4-6", (
+        "model_name must stay the agent-facing alias unchanged — per-role "
+        "DECEPTICON_MODEL_<ROLE> overrides depend on this passthrough"
+    )
+    assert entry["litellm_params"] == {
+        "model": "openai/claude-opus-4-6",
+        "api_key": "os.environ/OPENCODE_API_KEY",
+        "api_base": "https://opencode.ai/zen/v1",
+    }
+
+
+def test_build_model_entry_gateway_preserves_multi_slash_slug() -> None:
+    """Gateways whose ids embed slashes (``creator/model``) keep the full
+    slug after ``openai/`` so the gateway receives the id it expects.
+    """
+    entry = build_model_entry("vercel/anthropic/claude-opus-4.6")
+
+    assert entry["litellm_params"] == {
+        "model": "openai/anthropic/claude-opus-4.6",
+        "api_key": "os.environ/VERCEL_AI_GATEWAY_API_KEY",
+        "api_base": "https://ai-gateway.vercel.sh/v1",
+    }
+
+
+def test_build_model_entry_gateway_preserves_hf_colon_slug() -> None:
+    """Synthetic's ``hf:`` slug prefix survives the openai/ rewrite."""
+    entry = build_model_entry("synthetic/hf:openai/gpt-oss-120b")
+
+    assert entry["litellm_params"]["model"] == "openai/hf:openai/gpt-oss-120b"
+    assert entry["litellm_params"]["api_base"] == "https://api.synthetic.new/openai/v1"
+    assert entry["litellm_params"]["api_key"] == "os.environ/SYNTHETIC_API_KEY"
+
+
+def test_build_model_entry_cloudflare_uses_env_base_url() -> None:
+    """Cloudflare AI Gateway is per-account, so its api_base is an
+    ``os.environ`` ref the operator supplies — not a literal URL.
+    """
+    entry = build_model_entry("cfgateway/anthropic/claude-opus-4-6")
+
+    assert entry["litellm_params"] == {
+        "model": "openai/anthropic/claude-opus-4-6",
+        "api_key": "os.environ/CLOUDFLARE_AI_GATEWAY_API_KEY",
+        "api_base": "os.environ/CLOUDFLARE_AI_GATEWAY_API_BASE",
+    }
+
+
+def test_validate_model_name_accepts_every_gateway_prefix() -> None:
+    """Every gateway prefix must validate with a model slug attached."""
+    for prefix in OPENAI_COMPAT_GATEWAYS:
+        validate_model_name(f"{prefix}/some-model")  # must not raise
+
+
+def test_merge_dynamic_models_registers_gateway_override() -> None:
+    """A per-role gateway override flows through merge → build_model_entry."""
+    merged = merge_dynamic_models(
+        {"model_list": [], "litellm_settings": {"fallbacks": []}},
+        {"DECEPTICON_MODEL_PATCHER": "zenmux/anthropic/claude-opus-4.6"},
+    )
+    entries = {e["model_name"]: e["litellm_params"] for e in merged["model_list"]}
+    assert entries["zenmux/anthropic/claude-opus-4.6"] == {
+        "model": "openai/anthropic/claude-opus-4.6",
+        "api_key": "os.environ/ZENMUX_API_KEY",
+        "api_base": "https://zenmux.ai/api/v1",
+    }

--- a/packages/decepticon/tests/unit/llm/test_models.py
+++ b/packages/decepticon/tests/unit/llm/test_models.py
@@ -218,6 +218,69 @@ class TestResolveChain:
         ]
 
 
+# ── OpenAI-compatible gateways / aggregators (oh-my-pi parity) ──────────
+
+
+class TestGatewayChains:
+    """The gateway AuthMethods have fixed catalogs (no env-driven model),
+    so resolve_chain just reads METHOD_MODELS. Every tier must resolve to
+    a gateway-prefixed alias so routes never collide across gateways."""
+
+    GATEWAYS = (
+        AuthMethod.OPENCODE_API,
+        AuthMethod.VERCEL_GATEWAY_API,
+        AuthMethod.HUGGINGFACE_API,
+        AuthMethod.VENICE_API,
+        AuthMethod.NANOGPT_API,
+        AuthMethod.SYNTHETIC_API,
+        AuthMethod.ZENMUX_API,
+        AuthMethod.QIANFAN_API,
+        AuthMethod.CLOUDFLARE_GATEWAY_API,
+    )
+
+    def test_opencode_high_resolves_to_prefixed_alias(self):
+        creds = Credentials(methods=[AuthMethod.OPENCODE_API])
+        assert resolve_chain(Tier.HIGH, creds) == ["opencode/claude-opus-4-6"]
+
+    def test_every_gateway_has_all_three_tiers(self):
+        # Unlike MiniMax/Mistral (no LOW), the gateways expose HIGH/MID/LOW,
+        # so a single-gateway inventory yields a non-empty chain at every tier.
+        for method in self.GATEWAYS:
+            creds = Credentials(methods=[method])
+            for tier in (Tier.HIGH, Tier.MID, Tier.LOW):
+                chain = resolve_chain(tier, creds)
+                assert len(chain) == 1, (method, tier)
+                assert "/" in chain[0]
+
+    def test_gateway_aliases_keep_gateway_prefix(self):
+        # The leading prefix of each alias must match the gateway's own
+        # routing prefix (opencode/, vercel/, hf/, …) — the property that
+        # keeps two gateways sharing an upstream slug from colliding.
+        expected_prefix = {
+            AuthMethod.OPENCODE_API: "opencode/",
+            AuthMethod.VERCEL_GATEWAY_API: "vercel/",
+            AuthMethod.HUGGINGFACE_API: "hf/",
+            AuthMethod.VENICE_API: "venice/",
+            AuthMethod.NANOGPT_API: "nanogpt/",
+            AuthMethod.SYNTHETIC_API: "synthetic/",
+            AuthMethod.ZENMUX_API: "zenmux/",
+            AuthMethod.QIANFAN_API: "qianfan/",
+            AuthMethod.CLOUDFLARE_GATEWAY_API: "cfgateway/",
+        }
+        for method, prefix in expected_prefix.items():
+            creds = Credentials(methods=[method])
+            chain = resolve_chain(Tier.HIGH, creds)
+            assert chain[0].startswith(prefix), (method, chain)
+
+    def test_gateway_falls_back_to_next_method(self):
+        # A gateway primary with a vendor-API fallback resolves both, in order.
+        creds = Credentials(methods=[AuthMethod.OPENCODE_API, AuthMethod.OPENAI_API])
+        assert resolve_chain(Tier.HIGH, creds) == [
+            "opencode/claude-opus-4-6",
+            "openai/gpt-5.5",
+        ]
+
+
 # ── OLLAMA_LOCAL dynamic resolution (issue #106) ────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds **9 credentials-aware `AuthMethod`s** for OpenAI-compatible LLM gateways / aggregators, bringing Decepticon closer to [oh-my-pi](https://github.com/can1357/oh-my-pi)'s provider breadth. Headlined by **OpenCode Zen** (`opencode.ai/zen`).

Each new provider routes through LiteLLM's `openai/` provider with a fixed `api_base` override — the proven `xiaomi_mimo` / `custom` pattern, now **table-driven** via a single `OPENAI_COMPAT_GATEWAYS` map so the whole batch shares one code path.

| Method | Gateway | Base URL |
|---|---|---|
| `opencode_api` | OpenCode Zen | `https://opencode.ai/zen/v1` |
| `vercel_gateway_api` | Vercel AI Gateway | `https://ai-gateway.vercel.sh/v1` |
| `huggingface_api` | Hugging Face Router | `https://router.huggingface.co/v1` |
| `venice_api` | Venice AI | `https://api.venice.ai/api/v1` |
| `nanogpt_api` | NanoGPT | `https://nano-gpt.com/api/v1` |
| `synthetic_api` | Synthetic | `https://api.synthetic.new/openai/v1` |
| `zenmux_api` | ZenMux | `https://zenmux.ai/api/v1` |
| `qianfan_api` | Baidu Qianfan (ERNIE) | `https://qianfan.baidubce.com/v2` |
| `cloudflare_gateway_api` | Cloudflare AI Gateway | per-account base URL |

The model alias **keeps the gateway prefix** (`opencode/claude-opus-4-6`, `venice/claude-opus-4-6`) so two gateways exposing the same upstream slug never collide in the LiteLLM `model_list`; `build_model_entry` rewrites the prefix to `openai/` and pins the base.

## Wired end-to-end (mirrors existing providers)

- **`types/llm.py`** — `AuthMethod` enum + `METHOD_MODELS` HIGH/MID/LOW matrix + docstring
- **`litellm_dynamic_config.py`** — `OPENAI_COMPAT_GATEWAYS` table + one `build_model_entry` branch; prefixes registered in `ALLOWED_DYNAMIC_PROVIDERS`
- **`litellm.yaml`** — 27 static `model_list` entries (3 tiers × 9) with cost `model_info` + within-gateway HIGH→MID→LOW fallback chains
- **`factory.py`** — env-var credential auto-detection (`_API_METHOD_ENV`), default fallback priority, CLI labels. `auth_inventory()` / `decepticon-cli auth` pick them up automatically (data-driven over `AuthMethod`)
- **`.env.example`**, `/model` catalog (`model.ts`), `docs/setup-guide.md` table

Set a key and the gateway joins the default fallback chain; pick a specific route at runtime with `/model opencode/claude-opus-4-6`, or per role via `DECEPTICON_MODEL_<ROLE>`.

## Accuracy & scope notes

- Base URLs + model ids verified against each provider's **current public docs** and oh-my-pi's maintained provider catalog. (ZenMux uses the OpenAI-compat `/api/v1` path, not the Anthropic path; Cloudflare's per-account `…/compat` path is operator-supplied via `CLOUDFLARE_AI_GATEWAY_API_BASE`; Qianfan ids per the Qianfan-platform doc, with a `DECEPTICON_MODEL_<ROLE>` override note since they drift.)
- **Kimi-for-Coding was evaluated and dropped**: its `coding/v1` endpoint enforces a coding-agent client whitelist and requires the `kimi-for-coding` model id, so it isn't usable through a generic LiteLLM proxy. Moonshot is already covered by the existing `moonshot_api`.
- **Cursor / GitLab Duo / Qwen Portal deferred** — they need proprietary or OAuth-device protocols that don't fit the OpenAI-compatible-via-LiteLLM path.
- Like the existing `cerebras` / `xiaomi_mimo` additions, these are configured via `.env`, **not** the Go onboard wizard (which covers the headline providers).

## Test plan

New tests added:
- `test_litellm_dynamic_config.py` — gateway routing, multi-slash / `hf:` slug preservation, Cloudflare env-base, every-prefix-allowed, validation, merge override
- `test_models.py` — `TestGatewayChains`: tier resolution, alias-prefix invariants, fallthrough
- `test_auth.py` — gateway key activates the method

Verified locally: affected `pytest` suites green (llm / cli / core / factory / middleware), `ruff check` + `format` clean, `litellm.yaml` parses with no duplicate `model_name`s and all fallback targets registered, and a cross-consistency audit confirms each method is wired identically across all 7 integration points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
