### PR TITLE
fix(agents): wire orphaned reporting tools into specialist agents

### DIFF
--- a/packages/decepticon/decepticon/agents/prompts/standard/analyst.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/analyst.md
@@ -191,6 +191,11 @@ they apply — they update the graph for you and keep your state coherent:
                               — verify finding is in program scope before reporting
 - `format_bounty_report(finding_id, platform, program_name, component_name)`
                               — generate platform-ready bug bounty report from a FINDING node
+- `report_hackerone(finding_id)` — HackerOne-style markdown report for a FINDING / vuln node
+- `report_executive(engagement_name)` — engagement-level executive summary from the graph
+- `report_bugcrowd_csv(min_severity)` — Bugcrowd CSV submission bundle
+- `report_sarif(engagement_id, output_path)` — SARIF v2.1.0 for GitHub code scanning / DefectDojo
+- `report_timeline()` — chronological timeline of graph events for the engagement narrative
 
 ALWAYS call `kg_stats` at iteration start and after any major action. If
 your iteration ends with zero new graph nodes, you wasted it.

--- a/packages/decepticon/decepticon/agents/standard/analyst.py
+++ b/packages/decepticon/decepticon/agents/standard/analyst.py
@@ -7,7 +7,7 @@ Analyst reads source, builds a persistent knowledge graph, and reasons
 about multi-hop paths from entrypoints to crown jewels.
 
 Tool surface (in addition to bash):
-    RESEARCH_TOOLS, BOUNTY_TOOLS, REFERENCES_TOOLS
+    RESEARCH_TOOLS, BOUNTY_TOOLS, REPORTING_TOOLS, REFERENCES_TOOLS
 
 Middleware stack — mirrors exploit.py. The analyst runs fewer shell
 commands in favour of first-class research tools (semgrep, bandit,
@@ -58,6 +58,7 @@ from decepticon.llm import LLMFactory
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import REFERENCES_TOOLS
+from decepticon.tools.reporting.tools import REPORTING_TOOLS
 from decepticon.tools.research.bounty import BOUNTY_TOOLS
 from decepticon.tools.research.tools import RESEARCH_TOOLS
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
@@ -67,7 +68,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
     # references tools offer payloads + external knowledge lookup;
     # bounty tools provide scope checking and report formatting.
     t.name: t
-    for t in [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
+    for t in [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REPORTING_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
 }
 
 

--- a/packages/decepticon/decepticon/agents/standard/contract_auditor.py
+++ b/packages/decepticon/decepticon/agents/standard/contract_auditor.py
@@ -50,6 +50,7 @@ from decepticon.llm import LLMFactory
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.contracts.tools import CONTRACT_TOOLS
+from decepticon.tools.reporting.tools import report_hackerone
 from decepticon.tools.research.tools import (
     cve_lookup,
     kg_add_edge,
@@ -75,6 +76,8 @@ _STANDARD_TOOLS: dict[str, Any] = {
         kg_ingest_sarif,
         # CVE intelligence
         cve_lookup,
+        # Reporting (prompt REPORT step files a HackerOne-style finding report)
+        report_hackerone,
         # Execution
         *BASH_TOOLS,
     ]

--- a/packages/decepticon/tests/unit/agents/test_reporting_tools_wired.py
+++ b/packages/decepticon/tests/unit/agents/test_reporting_tools_wired.py
@@ -1,0 +1,57 @@
+"""Regression guard: reporting tools must reach the agents that need them.
+
+``REPORTING_TOOLS`` shipped and were unit-tested but reached no agent
+(no agent listed them and ``build_tools`` never received them), while
+``contract_auditor.md`` instructed the model to call ``report_hackerone``
+— a tool the agent did not actually have, so the model would emit a tool
+call that always fails. These tests pin the wiring AND the prompt<->tool
+contract so the regression cannot return.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from decepticon.agents.prompts import load_prompt
+from decepticon.agents.standard import analyst, contract_auditor
+from decepticon.tools.reporting.tools import REPORTING_TOOLS
+
+_REPORTING_NAMES = frozenset(t.name for t in REPORTING_TOOLS)
+
+
+def test_reporting_suite_is_nonempty() -> None:
+    # Guards against the bundle being emptied out from under the wiring tests.
+    assert {"report_hackerone", "report_sarif", "report_executive"} <= _REPORTING_NAMES
+
+
+def test_analyst_exposes_full_reporting_suite() -> None:
+    """The Analyst is the engagement reporting specialist — it gets every report_* tool."""
+    missing = _REPORTING_NAMES - frozenset(analyst._STANDARD_TOOLS)
+    assert not missing, f"analyst is missing reporting tools: {sorted(missing)}"
+
+
+def test_contract_auditor_exposes_report_hackerone() -> None:
+    """contract_auditor.md step 6 (REPORT) calls report_hackerone explicitly."""
+    assert "report_hackerone" in contract_auditor._STANDARD_TOOLS
+
+
+@pytest.mark.parametrize(
+    ("module", "role"),
+    [
+        (analyst, "analyst"),
+        (contract_auditor, "contract_auditor"),
+    ],
+)
+def test_prompt_referenced_reporting_tools_are_wired(module: Any, role: str) -> None:
+    """Any report_* tool a prompt tells the model to call MUST be in its toolset.
+
+    A prompt that references a tool the agent cannot see makes the model
+    emit a tool call that can never resolve — the exact bug this fixes.
+    """
+    prompt = load_prompt(role, shared=["bash"])
+    toolset = frozenset(module._STANDARD_TOOLS)
+    referenced = frozenset(name for name in _REPORTING_NAMES if name in prompt)
+    missing = referenced - toolset
+    assert not missing, f"{role}.md references unreachable reporting tools: {sorted(missing)}"


### PR DESCRIPTION
## What

The reporting tool bundle — `report_hackerone`, `report_sarif`, `report_executive`, `report_bugcrowd_csv`, `report_timeline` (`packages/decepticon/decepticon/tools/reporting/tools.py`) — shipped and is unit-tested, but reached **no agent**:

- no agent listed `REPORTING_TOOLS` in its `_STANDARD_TOOLS`, and
- there is no `decepticon.tools` entry point that would inject them via `build_tools()` (only commented examples in `pyproject.toml`).

So the engagement-deliverable capability (HackerOne / SARIF / executive / Bugcrowd / timeline reports) was unreachable at runtime.

Worse, `agents/prompts/standard/contract_auditor.md` step 6 (`REPORT`) instructs the model to call `report_hackerone` — a tool the `contract_auditor` agent did **not** have. The model would emit a tool call that can never resolve.

## Change

- **analyst** — gains the full `REPORTING_TOOLS` suite. The Analyst is the documented research/reporting specialist; its `<RESEARCH_TOOLS>` prompt section now lists the `report_*` tools so the model actually uses them.
- **contract_auditor** — gains `report_hackerone`, matching its prompt's REPORT step.
- **regression test** (`tests/unit/agents/test_reporting_tools_wired.py`) pins both the wiring *and* the prompt↔tool contract, so a prompt can never again reference a reporting tool the agent cannot see.

`exploit` is intentionally left out: its prompt references no reporting tool, and its output discipline ("Markdown only; never write JSON as a report") conflicts with the JSON-wrapped `report_*` tools.

No dependency, entry-point, or runtime-stack changes — nothing under the `docs/COWORK.md` CODEOWNERS-protected paths is touched.

## Verification

- `uv run pytest -n auto -q -m "not slow"` → **3552 passed**, 3 skipped
- `uv run ruff check .` + `uv run ruff format --check` → clean
- `uv run basedpyright` → 0 errors on changed files

## Scope note

First of several fixes from a tool-wiring audit. Per `docs/COWORK.md` §4.5 (no mega-PRs bundling unrelated work), the remaining findings will land as separate PRs: benchmark `buttercup`/`decepticon-bench` provider wiring, the inert C2 `sliver_*` HITL approval rule, unwired MCP tool loading, uninstrumented OpenTelemetry, and the Blue Cell agent factory.
