### PR TITLE
feat(kg): add Blue Cell detection vocabulary to knowledge graph

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/kg.py
+++ b/packages/decepticon-core/decepticon_core/types/kg.py
@@ -8,12 +8,12 @@ reasoning while the authoritative store lives in Neo4j.
 
 Schema
 ------
-Nodes span five layers — Infrastructure (Host, Network, Domain, Service,
+Nodes span seven layers — Infrastructure (Host, Network, Domain, Service,
 URL, CloudResource, Container), Identity (User, Group, Credential, Secret,
 Session), Vulnerability (Vulnerability, CVE, Misconfiguration, Weakness),
 Code (Repository, SourceFile, CodeLocation, Contract), Attack Progression
-(Technique, Entrypoint, CrownJewel, AttackPath, Finding), and Analysis
-(Candidate, Hypothesis, Patch).
+(Technique, Entrypoint, CrownJewel, AttackPath, Finding), Analysis
+(Candidate, Hypothesis, Patch), and Defense (DetectionFired, DefenseAction).
 
 Edges carry a ``kind`` (Neo4j relationship type) plus optional ``weight``
 used by the path planner (lower = easier exploitation).
@@ -83,6 +83,9 @@ class NodeKind(StrEnum):
     CANDIDATE = "Candidate"
     HYPOTHESIS = "Hypothesis"
     PATCH = "Patch"
+    # Defense (Blue Cell — proven detection coverage)
+    DETECTION_FIRED = "DetectionFired"
+    DEFENSE_ACTION = "DefenseAction"
 
 
 class EdgeKind(StrEnum):
@@ -128,6 +131,9 @@ class EdgeKind(StrEnum):
     DERIVED_FROM = "DERIVED_FROM"
     PATCHES = "PATCHES"
     MAPS_TO = "MAPS_TO"
+    # Defense (Blue Cell — links a fired detection to what it caught)
+    DETECTED = "DETECTED"
+    USES_RULE = "USES_RULE"
 
 
 class Severity(StrEnum):

--- a/packages/decepticon-core/tests/test_kg_detection_types.py
+++ b/packages/decepticon-core/tests/test_kg_detection_types.py
@@ -1,0 +1,76 @@
+"""Regression tests for the Blue Cell defensive KG vocabulary.
+
+The Offensive Vaccine / Blue Cell loop (``docs/features/blue-cell.md``)
+records *proven* detection coverage in the engagement knowledge graph:
+each fired detection becomes a ``DetectionFired`` node linked
+``-[:DETECTED]->`` the offensive ``Finding`` it caught and
+``-[:USES_RULE]->`` the ``DefenseAction`` (Sigma/YARA artifact) that
+produced it.
+
+``NodeKind`` values are Neo4j labels and ``EdgeKind`` values are Neo4j
+relationship types (1:1, per the ``kg`` module docstring), so the exact
+strings below are a persistence wire contract the Blue Cell agent, the
+Neo4j store, and the Defense Brief generator all build Cypher against.
+Pin them here so a rename can't silently break the downstream loop.
+"""
+
+from __future__ import annotations
+
+from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
+
+
+def test_detection_node_kinds_have_neo4j_labels() -> None:
+    assert NodeKind.DETECTION_FIRED == "DetectionFired"
+    assert NodeKind.DEFENSE_ACTION == "DefenseAction"
+
+
+def test_detection_edge_kinds_have_neo4j_relationship_types() -> None:
+    assert EdgeKind.DETECTED == "DETECTED"
+    assert EdgeKind.USES_RULE == "USES_RULE"
+
+
+def test_graph_records_detection_coverage_topology() -> None:
+    """DetectionFired -[:DETECTED]-> Finding and -[:USES_RULE]-> DefenseAction."""
+    graph = KnowledgeGraph()
+    finding = graph.upsert_node(Node.make(NodeKind.FINDING, "Kerberoast on DC01", key="FIND-001"))
+    rule = graph.upsert_node(
+        Node.make(NodeKind.DEFENSE_ACTION, "DCEP-T1558.003-kerberoast", key="rule::DCEP-T1558.003")
+    )
+    fired = graph.upsert_node(
+        Node.make(
+            NodeKind.DETECTION_FIRED,
+            "Kerberoast detection",
+            key="detection::DCEP-T1558.003::1700000000.0",
+            mttd_seconds=1.2,
+        )
+    )
+    graph.upsert_edge(Edge.make(fired.id, finding.id, EdgeKind.DETECTED))
+    graph.upsert_edge(Edge.make(fired.id, rule.id, EdgeKind.USES_RULE))
+
+    detected = graph.neighbors(fired.id, edge_kind=EdgeKind.DETECTED)
+    assert [n.id for _, n in detected] == [finding.id]
+
+    uses_rule = graph.neighbors(fired.id, edge_kind=EdgeKind.USES_RULE)
+    assert [n.id for _, n in uses_rule] == [rule.id]
+
+
+def test_detection_gap_query_finds_undetected_findings() -> None:
+    """A Finding with no inbound DETECTED edge is a detection gap.
+
+    Surfacing these blind spots is the headline Blue Cell deliverable, so
+    the vocabulary must make the query expressible.
+    """
+    graph = KnowledgeGraph()
+    caught = graph.upsert_node(Node.make(NodeKind.FINDING, "DCSync", key="FIND-001"))
+    graph.upsert_node(Node.make(NodeKind.FINDING, "DLL side-load", key="FIND-002"))
+    fired = graph.upsert_node(
+        Node.make(NodeKind.DETECTION_FIRED, "DCSync detection", key="detection::x::1.0")
+    )
+    graph.upsert_edge(Edge.make(fired.id, caught.id, EdgeKind.DETECTED))
+
+    gaps = [
+        node.label
+        for node in graph.by_kind(NodeKind.FINDING)
+        if not graph.neighbors(node.id, edge_kind=EdgeKind.DETECTED, direction="in")
+    ]
+    assert gaps == ["DLL side-load"]


### PR DESCRIPTION
## What

Adds the defensive vocabulary the Blue Cell / Offensive-Vaccine loop needs in the engagement knowledge graph:

| Kind | Neo4j label / relationship type |
|------|---------------------------------|
| `NodeKind.DETECTION_FIRED` | `DetectionFired` |
| `NodeKind.DEFENSE_ACTION` | `DefenseAction` |
| `EdgeKind.DETECTED` | `DETECTED` |
| `EdgeKind.USES_RULE` | `USES_RULE` |

Plus a focused regression test and a one-word docstring fix (the layer count said "five" but listed six).

## Why

`docs/features/blue-cell.md` specifies the loop's KG integration as:

- `DetectionFired -[:DETECTED]-> Finding` — the offensive finding the rule caught
- `DetectionFired -[:USES_RULE]-> DefenseAction` — the Sigma/YARA artifact that fired

…but `types/kg.py` had no node/edge kinds for any of it. The graph literally could not record "attack X was caught by rule Y", which blocks the single most valuable blue-team query — **Findings with no inbound `DETECTED` edge = the engagement's detection gaps**. This is the foundational vocabulary that unblocks that loop.

## Scope / safety

- Purely additive enum members. `Node`/`Edge` (Pydantic) accept them, the `KnowledgeGraph` query helpers are generic, and `neo4j_store._ALL_NODE_LABELS` / `kg_add_node` / `kg_add_edge` derive their accept-lists from the enums — so no further wiring is required and `test_neo4j_store.py`'s label-set assertion stays consistent.
- **Nothing writes these nodes yet.** The `BlueCellAgent` that consumes the existing `blue_cell/tap.py` + `rule_match.py` scaffolding lands in a follow-up PR. Per COWORK §3 this change is inert on `main` (unimplemented entry point), so it lands independently without behaviour change.
- Touches only `packages/decepticon-core/decepticon_core/types/` — outside the CODEOWNERS-protected `contracts/**` / `protocols/**` / `registry/**` paths.

## Tests

- `packages/decepticon-core/tests/test_kg_detection_types.py` — 4 new tests: the label/relationship-type wire contract, the `DetectionFired → Finding` / `DefenseAction` topology, and the detection-gap query.
- Re-ran the consistency-sensitive suites (`test_neo4j_store.py`, `test_public_api_stability.py`, `test_graph.py`) — green (163 passed).
- `ruff check` / `ruff format --check` / `basedpyright` clean on the changed files.
