### PR TITLE
feat(blue-cell): add read-only detection-coverage agent

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -10,7 +10,8 @@
     "reverser": "./packages/decepticon/decepticon/agents/standard/reverser.py:graph",
     "contract_auditor": "./packages/decepticon/decepticon/agents/standard/contract_auditor.py:graph",
     "cloud_hunter": "./packages/decepticon/decepticon/agents/standard/cloud_hunter.py:graph",
-    "ad_operator": "./packages/decepticon/decepticon/agents/standard/ad_operator.py:graph"
+    "ad_operator": "./packages/decepticon/decepticon/agents/standard/ad_operator.py:graph",
+    "blue_cell": "./packages/decepticon/decepticon/agents/standard/blue_cell.py:graph"
   },
   "env": ".env",
   "python_version": "3.13",

--- a/packages/decepticon-core/decepticon_core/contracts/slots.py
+++ b/packages/decepticon-core/decepticon_core/contracts/slots.py
@@ -156,6 +156,8 @@ SLOTS_PER_ROLE: dict[str, frozenset[MiddlewareSlot]] = {
     },
     # ── Standard non-bash agent (planning + interview) ──
     "soundwave": _BASE_SLOTS | {MiddlewareSlot.ENGAGEMENT_CONTEXT},
+    # ── Standard read-only agent (Blue Cell — detection coverage, no bash) ──
+    "blue_cell": _BASE_SLOTS,
     # ── Standard bash-executing specialists ──
     "recon": _BASH_AGENT_SLOTS,
     "exploit": _BASH_AGENT_SLOTS,

--- a/packages/decepticon-core/decepticon_core/types/llm.py
+++ b/packages/decepticon-core/decepticon_core/types/llm.py
@@ -523,6 +523,7 @@ AGENT_TIERS: dict[str, Tier] = {
     # Tool-heavy with moderate iteration.
     "detector": Tier.MID,
     "verifier": Tier.MID,
+    "blue_cell": Tier.MID,
     "postexploit": Tier.MID,
     "ad_operator": Tier.MID,
     "cloud_hunter": Tier.MID,
@@ -543,6 +544,7 @@ AGENT_TEMPERATURES: dict[str, float] = {
     "exploiter": 0.2,
     "detector": 0.2,
     "verifier": 0.2,
+    "blue_cell": 0.2,
     "patcher": 0.2,
     "postexploit": 0.3,
     "ad_operator": 0.2,

--- a/packages/decepticon/decepticon/agents/__init__.py
+++ b/packages/decepticon/decepticon/agents/__init__.py
@@ -9,6 +9,7 @@ from decepticon.agents.plugins.verifier import create_verifier_agent
 from decepticon.agents.plugins.vulnresearch import create_vulnresearch_agent
 from decepticon.agents.standard.ad_operator import create_ad_operator_agent
 from decepticon.agents.standard.analyst import create_analyst_agent
+from decepticon.agents.standard.blue_cell import create_blue_cell_agent
 from decepticon.agents.standard.cloud_hunter import create_cloud_hunter_agent
 from decepticon.agents.standard.contract_auditor import create_contract_auditor_agent
 from decepticon.agents.standard.decepticon import create_decepticon_agent
@@ -35,6 +36,7 @@ __all__ = [
     "create_phisher_agent",
     "create_mobile_operator_agent",
     "create_wireless_operator_agent",
+    "create_blue_cell_agent",
     # Vulnresearch pipeline (five-stage modular)
     "create_scanner_agent",
     "create_detector_agent",

--- a/packages/decepticon/decepticon/agents/prompts/standard/blue_cell.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/blue_cell.md
@@ -1,0 +1,60 @@
+<IDENTITY>
+You are the Decepticon Blue Cell — the defensive sibling of the Red Cell. The
+offensive agents attacked this engagement and the Detector wrote detection
+rules. Your job is to PROVE those rules fire: score them against Red Cell's
+own activity, record what was caught, and — most importantly — surface what was
+MISSED. You turn "we wrote some Sigma rules" into "we wrote some Sigma rules AND
+validated them end-to-end against the same kill chain we ran."
+
+You are read-only. You observe and report; you never attack.
+</IDENTITY>
+
+<CRITICAL_RULES>
+- You are READ-ONLY at runtime. You do NOT have a `bash` tool and you do NOT
+  write nodes by hand. If you think you need shell access or `kg_add_node`,
+  you are out of scope — hand back to the orchestrator.
+- Detection coverage is recorded by `blue_cell_scan`, not by you. The rule
+  matcher — not your judgement — decides what fired. Never claim a detection
+  the tool did not record, and never invent an MTTD.
+- The headline deliverable is the GAP list: Findings with no `DETECTED` edge.
+  An undetected critical Finding is worth more to the customer than ten
+  detected low-severity ones. Lead with the gaps.
+- Ground every number in the `blue_cell_scan` summary and the knowledge graph.
+  No estimates, no rounding up coverage, no hedging.
+</CRITICAL_RULES>
+
+<OPERATING_LOOP>
+1. **Scan.** Call `blue_cell_scan()`. It replays `.sessions/` activity through
+   the detection ruleset and records a `DetectionFired` node per hit (linked to
+   the rule and to the Finding/Technique it caught). For a real engagement pass
+   `rules_path` pointing at the Detector's ruleset; otherwise it uses the
+   bundled baseline. Re-running is safe — detection timing is preserved from
+   first sighting, so periodic scans never inflate MTTD.
+
+2. **Read the coverage.** The summary returns `detections`,
+   `techniques_detected`, `median_mttd_seconds`, `findings_total`,
+   `findings_detected`, and `detection_gaps`. Use `kg_query(kind="finding")`
+   and `kg_neighbors` to inspect the gap Findings: what technique, what
+   severity, why no rule caught it (no rule exists vs. a rule exists but its
+   condition was too strict).
+
+3. **Out-brief.** Emit a Defense Brief:
+   - Coverage: N attacks observed, M detected (X%), median/p95 MTTD.
+   - Detected techniques, sorted by MTTD (slowest first — those are the rules
+     a real adversary would beat).
+   - **Missed techniques / detection gaps**, each tagged `no rule` or
+     `rule too strict` with the Finding it left uncovered.
+   - Proposed rule improvements for the `rule too strict` cases.
+   Then STOP and return to the orchestrator. Do not re-scan in a loop.
+</OPERATING_LOOP>
+
+<JUDGMENT_CALLS>
+- A gap is `no rule` when no detection rule names the Finding's technique at
+  all, and `rule too strict` when a rule for that technique exists but its
+  condition or field match did not fire on the observed command line. Inspect
+  the matched_fields on nearby `DetectionFired` nodes to tell them apart.
+- A high `median_mttd_seconds` is itself a finding: a rule that fires slowly is
+  a rule an adversary completes their action before. Call it out.
+- When `detections == 0` but Findings exist, that is the strongest possible
+  blue-team signal — the entire kill chain went unseen. Say so plainly.
+</JUDGMENT_CALLS>

--- a/packages/decepticon/decepticon/agents/standard/blue_cell.py
+++ b/packages/decepticon/decepticon/agents/standard/blue_cell.py
@@ -1,0 +1,168 @@
+"""Blue Cell Agent — the defensive sibling that closes the Offensive Vaccine loop.
+
+Red Cell attacks; the Detector writes Sigma rules. Blue Cell is the runtime
+that proves those rules actually fire: it replays the engagement's own
+activity through ``blue_cell_scan`` (tap + rule matcher), records each hit as a
+``DetectionFired`` node in the knowledge graph — linked ``-[:USES_RULE]->`` the
+rule and ``-[:DETECTED]->`` the Finding/Technique it caught — and reports the
+**detection gaps** (Findings nothing detected) as the headline blue-team
+deliverable. See ``docs/features/blue-cell.md``.
+
+Key design choices — enforced by the tool surface, not just the prompt:
+
+- **Read-only at runtime.** No ``bash`` tool, no ``SandboxNotification`` slot
+  (``SLOTS_PER_ROLE["blue_cell"]`` maps to ``_BASE_SLOTS``, like ``detector``).
+  Blue Cell observes the engagement; it never attacks.
+- **No ``kg_add_node`` / ``kg_add_edge``.** Detections are recorded
+  deterministically by ``blue_cell_scan`` (the matcher decides what fired) —
+  the agent cannot fabricate detection coverage. It gets the read-only KG
+  query subset to inspect Findings and narrate the gap report.
+
+Library API
+-----------
+Factory shape mirrors ``langchain.agents.create_agent`` /
+``deepagents.create_deep_agent`` — every keyword is optional, and explicit
+values fully replace the OSS baseline:
+
+  - ``tools=[...]``         full tool list (overrides the standard set)
+  - ``middleware=[...]``    full middleware list (overrides the slot stack)
+  - ``system_prompt="..."`` full prompt (overrides the loaded baseline)
+
+When a keyword is ``None`` (default), the factory builds the OSS baseline AND
+applies any plugin overrides discovered via the ``decepticon.bundles``
+entry-point group.
+
+No SandboxNotification (no bash tool). No SubAgent / OPPLAN (specialist).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.agents import create_agent
+
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
+from decepticon.backends import build_sandbox_backend, make_agent_backend
+from decepticon.llm import LLMFactory
+from decepticon.tools.defense.blue_cell import blue_cell_scan
+from decepticon.tools.research.tools import kg_neighbors, kg_query, kg_stats
+from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
+
+# Name-keyed baseline tools. Read-only by construction: the detection-coverage
+# scanner plus the KG query subset — no bash, no kg_add_node/kg_add_edge.
+_STANDARD_TOOLS: dict[str, Any] = {
+    "blue_cell_scan": blue_cell_scan,
+    "kg_query": kg_query,
+    "kg_neighbors": kg_neighbors,
+    "kg_stats": kg_stats,
+}
+
+
+_ROLE = "blue_cell"
+_RECURSION_LIMIT = 120
+
+
+def create_blue_cell_agent(
+    *,
+    # ── Dependencies (injected for testing / library composition) ────
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    # ── langchain-style composition (full replace when provided) ─────
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    # ── Tuning ───────────────────────────────────────────────────────
+    recursion_limit: int | None = None,
+):
+    """Build the Blue Cell agent.
+
+    Notes:
+      - Read-only: no sandbox bash access (no ``sandbox=`` arg, no
+        ``set_sandbox()`` call, no ``SandboxNotification`` slot).
+      - ``blue_cell_scan`` resolves the engagement workspace from the
+        runnable config / ``DECEPTICON_WORKSPACE_PATH`` and reads
+        ``.sessions/`` logs; the agent does not shell out.
+
+    Args:
+        backend: deepagents-style filesystem backend. Defaults to
+            ``make_agent_backend(build_sandbox_backend())``.
+        llm: bound chat model. Defaults to ``LLMFactory().get_model("blue_cell")``.
+        fallback_models: passed to ``ModelFallbackMiddleware``. Defaults to
+            ``LLMFactory().get_fallback_models("blue_cell")``.
+        tools: full tool list — when provided, replaces the standard registry
+            entirely. When ``None`` (default), the OSS baseline is built and
+            plugin overrides (via ``decepticon.bundles``) are applied.
+        middleware: full middleware list — when provided, replaces the OSS slot
+            stack entirely. When ``None``, the baseline is assembled with plugin
+            slot overrides applied.
+        system_prompt: full prompt — when provided, replaces the baseline. When
+            ``None``, the standard prompt is loaded and plugin prompt overrides
+            are applied.
+        recursion_limit: ``with_config({"recursion_limit": ...})`` override.
+            Defaults to 120.
+
+    Returns:
+        Compiled LangGraph agent.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+
+    # No set_sandbox() here — Blue Cell intentionally has no bash tool.
+    sandbox = build_sandbox_backend()
+
+    if backend is None:
+        backend = make_agent_backend(sandbox)
+
+    if tools is None:
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+    if middleware is None:
+        middleware = build_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+            sandbox=None,  # no SandboxNotification for the read-only Blue Cell
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt(_ROLE, shared=[])
+
+    return create_agent(
+        llm,
+        system_prompt=system_prompt,
+        tools=tools,
+        middleware=middleware,
+        name=_ROLE,
+    ).with_config(
+        {
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
+        }
+    )
+
+
+# Module-level graph for LangGraph Platform (langgraph serve)
+if is_bundle_enabled("standard"):
+    graph = create_blue_cell_agent()
+
+
+SUBAGENT_SPEC = SubAgentSpec(
+    name="blue_cell",
+    description=(
+        "Blue Cell — read-only detection-coverage agent. Replays the "
+        "engagement's own activity through the detection ruleset, records "
+        "which techniques were caught (with MTTD) as DetectionFired nodes, "
+        "and reports the detection gaps (Findings nothing detected). "
+        "Run after offensive activity to produce the Defense Brief. "
+        "Read-only (no bash)."
+    ),
+    factory=create_blue_cell_agent,
+    parent_agents=("decepticon",),
+    bundle="standard",
+    priority=90,
+)

--- a/packages/decepticon/decepticon/graph_registry.py
+++ b/packages/decepticon/decepticon/graph_registry.py
@@ -40,6 +40,7 @@ STANDARD_GRAPHS: dict[str, str] = {
     "contract_auditor": "./decepticon/agents/standard/contract_auditor.py:graph",
     "cloud_hunter": "./decepticon/agents/standard/cloud_hunter.py:graph",
     "ad_operator": "./decepticon/agents/standard/ad_operator.py:graph",
+    "blue_cell": "./decepticon/agents/standard/blue_cell.py:graph",
 }
 
 # Plugins bundle — vulnresearch family (community-plugin shape demonstrated

--- a/packages/decepticon/decepticon/tools/defense/blue_cell.py
+++ b/packages/decepticon/decepticon/tools/defense/blue_cell.py
@@ -1,0 +1,229 @@
+"""Blue Cell detection-coverage tool — the runtime that closes the loop.
+
+The Offensive Vaccine pipeline documents a ``Defender`` that writes Sigma
+rules, but nothing in the OSS ever ran those rules against the agent's own
+activity (``docs/features/blue-cell.md``). ``blue_cell_scan`` is that missing
+runtime: it replays the engagement's sandbox session logs through the shipped
+:class:`~decepticon.blue_cell.tap.BlueCellTap` +
+:class:`~decepticon.blue_cell.rule_match.RuleMatcher`, and records every rule
+that fires as a ``DetectionFired`` node in the knowledge graph — linked
+``-[:USES_RULE]->`` the ``DefenseAction`` (the rule artifact) and
+``-[:DETECTED]->`` the offensive ``Finding`` / ``Technique`` it caught.
+
+Recording is deterministic and idempotent (matching, not the LLM, decides
+what fired), and detection timing is write-once so repeated scans never
+inflate MTTD. The agent narrates the returned coverage summary — including
+the **detection gaps** (Findings with no ``DETECTED`` edge) — into a Defense
+Brief.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+
+from decepticon.blue_cell.rule_match import RuleMatcher, load_rules
+from decepticon.blue_cell.tap import BlueCellTap
+from decepticon.tools.research._state import _json, graph_transaction
+from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
+
+# Bundled baseline ruleset — schema reference + bootstrap coverage. Operators
+# point ``rules_path`` at their Detector-produced ruleset for real engagements.
+_BUNDLED_RULES: Path = Path(__file__).resolve().parents[2] / "blue_cell" / "sample_rules.jsonl"
+
+# Node kinds whose technique tags a fired rule can be attributed to.
+_ATTRIBUTABLE: tuple[NodeKind, ...] = (NodeKind.FINDING, NodeKind.TECHNIQUE)
+
+
+def _resolve_workspace(workspace_path: str, config: RunnableConfig | None) -> str:
+    """Explicit arg → runnable config → env → ``/workspace`` (bash-tool order)."""
+    if workspace_path:
+        return workspace_path
+    configurable = (config or {}).get("configurable", {}) if config else {}
+    from_config = configurable.get("workspace_path") if isinstance(configurable, dict) else None
+    if from_config:
+        return str(from_config)
+    return os.environ.get("DECEPTICON_WORKSPACE_PATH", "/workspace")
+
+
+def _node_techniques(node: Node) -> set[str]:
+    """MITRE technique IDs a node carries, across the prop spellings in use."""
+    out: set[str] = set()
+    for key in ("technique_id", "technique", "mitre", "mitre_techniques"):
+        val = node.props.get(key)
+        if isinstance(val, str):
+            out.add(val)
+        elif isinstance(val, (list, tuple)):
+            out.update(str(v) for v in val)
+    return out
+
+
+def _attribution_targets(graph: KnowledgeGraph, technique: str) -> list[Node]:
+    """Finding/Technique nodes a detection for ``technique`` should link to."""
+    return [
+        node
+        for node in graph.nodes.values()
+        if node.kind in _ATTRIBUTABLE and technique in _node_techniques(node)
+    ]
+
+
+def _detection_key(rule_id: str, source: str, raw_line: str, seq: int) -> str:
+    """Stable, scan-independent identity for one detected event.
+
+    The DetectionFired node MUST key on the underlying *event content*, not on
+    ``event_ts``: for un-timestamped session logs (the default — the sandbox
+    pipes raw pane output verbatim) ``BlueCellTap`` stamps each line with the
+    scan's wall-clock, so keying on ``event_ts`` minted a brand-new node on
+    every re-scan and inflated counts/MTTD. Hashing ``(source, raw line)``
+    makes a re-scan of the same log idempotent and gives two distinct command
+    lines that fire the same rule two distinct nodes. ``seq`` disambiguates a
+    byte-identical line that legitimately recurs in the same source (stable
+    because logs are append-only and replayed in full each scan).
+    """
+    digest = hashlib.sha1(f"{source}\x00{raw_line}".encode("utf-8", "replace")).hexdigest()[:16]
+    return f"detection::{rule_id}::{digest}::{seq}"
+
+
+def _record_hit(graph: KnowledgeGraph, source: str, detection: Any, *, key: str) -> float:
+    """Upsert the DefenseAction + DetectionFired pair and edges for one hit.
+
+    Detection timing is write-once: a re-scan of the same logged event (same
+    content ``key``) preserves the first-seen ``detection_ts`` / ``mttd_seconds``
+    so periodic scanning never inflates MTTD. Returns the recorded MTTD in
+    seconds. (MTTD is only meaningful when the session log line carried its own
+    leading timestamp; for un-timestamped lines ``event_ts`` is the scan time,
+    so MTTD reflects first-sighting latency, not true time-to-detect.)
+    """
+    rule = detection.rule
+    action = graph.upsert_node(
+        Node.make(
+            NodeKind.DEFENSE_ACTION,
+            rule.title,
+            key=f"rule::{rule.id}",
+            rule_id=rule.id,
+            level=rule.level,
+            mitre=list(rule.mitre),
+        )
+    )
+    fired = Node.make(
+        NodeKind.DETECTION_FIRED,
+        rule.title,
+        key=key,
+        rule_id=rule.id,
+        rule_title=rule.title,
+        rule_level=rule.level,
+        mitre=list(rule.mitre),
+        matched_fields=dict(detection.matched_fields),
+        event_ts=detection.event_ts,
+        detection_ts=detection.detection_ts,
+        mttd_seconds=detection.mttd_seconds,
+        source=source,
+    )
+    prior = graph.nodes.get(fired.id)
+    if prior is not None and "detection_ts" in prior.props:
+        fired.props["detection_ts"] = prior.props["detection_ts"]
+        fired.props["mttd_seconds"] = prior.props["mttd_seconds"]
+    fired = graph.upsert_node(fired)
+    graph.upsert_edge(Edge.make(fired.id, action.id, EdgeKind.USES_RULE))
+    for technique in rule.mitre:
+        for target in _attribution_targets(graph, technique):
+            graph.upsert_edge(Edge.make(fired.id, target.id, EdgeKind.DETECTED, key=technique))
+    return float(fired.props["mttd_seconds"])
+
+
+def _scan_and_record(
+    graph: KnowledgeGraph, *, workspace_path: str, rules_path: str, now_ts: float
+) -> dict[str, Any]:
+    """Replay the tap, evaluate rules, record detections, return coverage."""
+    rules_path = rules_path or str(_BUNDLED_RULES)
+    rules = load_rules(rules_path)
+    matcher = RuleMatcher(rules)
+    events = BlueCellTap(workspace_path).read_batch()
+
+    detections = 0
+    techniques: set[str] = set()
+    mttds: list[float] = []
+    seen: dict[str, int] = {}
+    for event in events:
+        payload = event.to_dict()
+        source = str(payload["source"])
+        raw_line = str(payload.get("raw") or payload["actor"]["command_line"] or "")
+        for hit in matcher.match(payload, now_ts=now_ts):
+            base = f"{hit.rule.id}::{source}::{raw_line}"
+            seq = seen.get(base, 0)
+            seen[base] = seq + 1
+            key = _detection_key(hit.rule.id, source, raw_line, seq)
+            mttds.append(_record_hit(graph, source, hit, key=key))
+            techniques.update(hit.rule.mitre)
+            detections += 1
+
+    findings = graph.by_kind(NodeKind.FINDING)
+    gaps = [
+        f.label
+        for f in findings
+        if not graph.neighbors(f.id, edge_kind=EdgeKind.DETECTED, direction="in")
+    ]
+    return {
+        "rules_loaded": len(rules),
+        "rules_path": rules_path,
+        "events_scanned": len(events),
+        "detections": detections,
+        "techniques_detected": sorted(techniques),
+        "median_mttd_seconds": round(statistics.median(mttds), 2) if mttds else None,
+        "findings_total": len(findings),
+        "findings_detected": len(findings) - len(gaps),
+        "detection_gaps": gaps,
+    }
+
+
+@tool
+def blue_cell_scan(
+    workspace_path: str = "",
+    rules_path: str = "",
+    config: RunnableConfig | None = None,
+) -> str:
+    """Score detection rules against Red Cell's own activity and record coverage.
+
+    Replays the engagement's sandbox session logs, evaluates every detection
+    rule against them, and writes a ``DetectionFired`` node per hit (linked to
+    the rule and to the offensive Finding/Technique it caught). Re-running is
+    safe and idempotent — detection timing is preserved from first sighting.
+
+    WHEN TO USE: after offensive activity has run, to produce the engagement's
+    proven detection-coverage picture (what fired, how fast, and — most
+    importantly — which Findings nothing detected).
+
+    Args:
+        workspace_path: Engagement workspace root holding ``.sessions/``.
+            Defaults to the runnable config / ``DECEPTICON_WORKSPACE_PATH`` /
+            ``/workspace``.
+        rules_path: JSONL file or directory of detection rules. Defaults to
+            the bundled baseline ruleset; point this at the Detector's output
+            for a real engagement.
+
+    Returns:
+        JSON coverage summary: rules loaded, events scanned, detections,
+        techniques detected, median MTTD, and the detection-gap Finding list.
+    """
+    resolved_workspace = _resolve_workspace(workspace_path, config)
+    with graph_transaction() as graph:
+        return _json(
+            _scan_and_record(
+                graph,
+                workspace_path=resolved_workspace,
+                rules_path=rules_path,
+                now_ts=time.time(),
+            )
+        )
+
+
+BLUE_CELL_TOOLS = [blue_cell_scan]
+
+__all__ = ["BLUE_CELL_TOOLS", "blue_cell_scan"]

--- a/packages/decepticon/pyproject.toml
+++ b/packages/decepticon/pyproject.toml
@@ -145,6 +145,7 @@ postexploit = "decepticon.agents.standard.postexploit:SUBAGENT_SPEC"
 phisher = "decepticon.agents.standard.phisher:SUBAGENT_SPEC"
 mobile_operator = "decepticon.agents.standard.mobile_operator:SUBAGENT_SPEC"
 wireless_operator = "decepticon.agents.standard.wireless_operator:SUBAGENT_SPEC"
+blue_cell = "decepticon.agents.standard.blue_cell:SUBAGENT_SPEC"
 # Plugins bundle — vulnresearch family, attached to the ``vulnresearch`` main agent.
 scanner = "decepticon.agents.plugins.scanner:SUBAGENT_SPEC"
 detector = "decepticon.agents.plugins.detector:SUBAGENT_SPEC"

--- a/packages/decepticon/tests/unit/agents/test_blue_cell_agent.py
+++ b/packages/decepticon/tests/unit/agents/test_blue_cell_agent.py
@@ -1,0 +1,73 @@
+"""Wiring tests for the Blue Cell standard agent.
+
+Pin the contract PR2 establishes: the role is registered end-to-end (slots,
+tools, langgraph graph, subagent spec) and is READ-ONLY by construction — no
+bash, no SANDBOX_NOTIFICATION slot, no graph-mutating KG tools.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from decepticon.agents import build
+from decepticon.agents.standard import blue_cell as agent_mod
+from decepticon_core.contracts.slots import SLOTS_PER_ROLE, MiddlewareSlot
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def test_role_registered_as_readonly_base_slots() -> None:
+    slots = SLOTS_PER_ROLE["blue_cell"]
+    # Read-only profile: no bash-agent slots.
+    assert MiddlewareSlot.SANDBOX_NOTIFICATION not in slots
+    assert MiddlewareSlot.HITL_APPROVAL not in slots
+    # Mirrors the detector read-only profile exactly.
+    assert slots == SLOTS_PER_ROLE["detector"]
+
+
+def test_standard_tools_are_readonly() -> None:
+    names = set(agent_mod._STANDARD_TOOLS)
+    assert "blue_cell_scan" in names
+    assert {"kg_query", "kg_neighbors", "kg_stats"} <= names
+    # No attack surface and no hand-written graph mutation.
+    assert "bash" not in names
+    assert "kg_add_node" not in names
+    assert "kg_add_edge" not in names
+
+
+def test_build_tools_resolves_role_without_attack_tools() -> None:
+    tools = build.build_tools(role="blue_cell", standard_tools=agent_mod._STANDARD_TOOLS)
+    names = {t.name for t in tools}
+    assert "blue_cell_scan" in names
+    assert "bash" not in names
+
+
+def test_subagent_spec_targets_orchestrator() -> None:
+    spec = agent_mod.SUBAGENT_SPEC
+    assert spec.name == "blue_cell"
+    assert spec.factory is agent_mod.create_blue_cell_agent
+    assert spec.parent_agents == ("decepticon",)
+    assert spec.bundle == "standard"
+
+
+def test_langgraph_registers_blue_cell_graph() -> None:
+    config = json.loads((_REPO_ROOT / "langgraph.json").read_text(encoding="utf-8"))
+    assert (
+        config["graphs"]["blue_cell"]
+        == "./packages/decepticon/decepticon/agents/standard/blue_cell.py:graph"
+    )
+
+
+def test_blue_cell_published_as_decepticon_subagent() -> None:
+    """The orchestrator only delegates to specs published under the
+    ``decepticon.subagents`` entry-point group (load_subagents_for_parent).
+    Without this line Blue Cell is graph-served but never delegated — the
+    Defense Brief workflow it advertises is unreachable. Parsed from pyproject
+    so it is independent of editable-install metadata refresh."""
+    import tomllib
+
+    pyproject = _REPO_ROOT / "packages" / "decepticon" / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    subagents = data["project"]["entry-points"]["decepticon.subagents"]
+    assert subagents.get("blue_cell") == "decepticon.agents.standard.blue_cell:SUBAGENT_SPEC"

--- a/packages/decepticon/tests/unit/blue_cell/test_scan.py
+++ b/packages/decepticon/tests/unit/blue_cell/test_scan.py
@@ -1,0 +1,186 @@
+"""Tests for the blue_cell_scan detection-coverage tool.
+
+Exercises the real BlueCellTap + RuleMatcher against the bundled ruleset and
+asserts the knowledge-graph effects that close the Offensive Vaccine loop:
+DetectionFired/DefenseAction nodes, USES_RULE/DETECTED edges, the detection-gap
+list, and idempotent write-once MTTD on re-scan. No Neo4j, no network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from decepticon.blue_cell.rule_match import DetectionEvent, DetectionRule
+from decepticon.tools.defense.blue_cell import _record_hit, _scan_and_record, blue_cell_scan
+from decepticon.tools.research import _state as state
+from decepticon_core.types.kg import EdgeKind, KnowledgeGraph, Node, NodeKind
+
+_KERBEROAST = "$ GetUserSPNs.py -request -dc-ip 10.0.0.1 corp.local/svc"
+_DCSYNC = "$ secretsdump.py -just-dc corp.local/admin@10.0.0.1"
+
+
+def _workspace_with(tmp_path: Path, *lines: str) -> str:
+    sessions = tmp_path / ".sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "main.log").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(tmp_path)
+
+
+def _scan(graph: KnowledgeGraph, tmp_path: Path, *lines: str, now_ts: float = 1_000.0) -> dict:
+    workspace = _workspace_with(tmp_path, *lines)
+    return _scan_and_record(graph, workspace_path=workspace, rules_path="", now_ts=now_ts)
+
+
+# ── recording ────────────────────────────────────────────────────────────
+
+
+def test_scan_records_detection_fired_and_uses_rule(tmp_path: Path) -> None:
+    graph = KnowledgeGraph()
+    summary = _scan(graph, tmp_path, _KERBEROAST)
+
+    fired = graph.by_kind(NodeKind.DETECTION_FIRED)
+    actions = graph.by_kind(NodeKind.DEFENSE_ACTION)
+    assert len(fired) == 1
+    assert len(actions) == 1
+    assert fired[0].props["rule_id"] == "DCEP-T1558.003-kerberoast"
+    assert fired[0].props["mitre"] == ["T1558.003"]
+    assert fired[0].props["source"] == "sandbox.tmux.main"
+    # DetectionFired -[:USES_RULE]-> DefenseAction
+    rule_edges = graph.neighbors(fired[0].id, edge_kind=EdgeKind.USES_RULE)
+    assert [n.id for _, n in rule_edges] == [actions[0].id]
+    assert summary["detections"] == 1
+    assert "T1558.003" in summary["techniques_detected"]
+    assert summary["rules_loaded"] == 10  # bundled baseline ruleset
+
+
+def test_scan_fires_multiple_rules_across_events(tmp_path: Path) -> None:
+    graph = KnowledgeGraph()
+    summary = _scan(graph, tmp_path, _KERBEROAST, _DCSYNC)
+    assert summary["detections"] == 2
+    assert set(summary["techniques_detected"]) == {"T1558.003", "T1003.006"}
+
+
+# ── attribution + gaps ─────────────────────────────────────────────────────
+
+
+def test_scan_links_detected_to_matching_finding_and_reports_gaps(tmp_path: Path) -> None:
+    graph = KnowledgeGraph()
+    caught = graph.upsert_node(
+        Node.make(NodeKind.FINDING, "Kerberoastable SPN", key="FIND-1", technique="T1558.003")
+    )
+    graph.upsert_node(Node.make(NodeKind.FINDING, "Open redirect", key="FIND-2"))
+
+    summary = _scan(graph, tmp_path, _KERBEROAST)
+
+    fired = graph.by_kind(NodeKind.DETECTION_FIRED)[0]
+    detected = graph.neighbors(fired.id, edge_kind=EdgeKind.DETECTED)
+    assert [n.id for _, n in detected] == [caught.id]
+    assert summary["findings_total"] == 2
+    assert summary["findings_detected"] == 1
+    assert summary["detection_gaps"] == ["Open redirect"]
+
+
+def test_scan_empty_workspace_reports_zero_but_still_lists_gaps(tmp_path: Path) -> None:
+    graph = KnowledgeGraph()
+    graph.upsert_node(Node.make(NodeKind.FINDING, "Undetected RCE", key="FIND-1"))
+    summary = _scan_and_record(graph, workspace_path=str(tmp_path), rules_path="", now_ts=1_000.0)
+    assert summary["events_scanned"] == 0
+    assert summary["detections"] == 0
+    assert summary["detection_gaps"] == ["Undetected RCE"]
+
+
+# ── write-once MTTD ─────────────────────────────────────────────────────────
+
+
+def _kerberoast_hit(detection_ts: float) -> DetectionEvent:
+    rule = DetectionRule(
+        id="DCEP-T1558.003-kerberoast",
+        title="Kerberoast",
+        level="high",
+        mitre=("T1558.003",),
+    )
+    return DetectionEvent(rule=rule, matched_fields={}, event_ts=100.0, detection_ts=detection_ts)
+
+
+_DETECT_KEY = "detection::DCEP-T1558.003-kerberoast::deadbeefdeadbeef::0"
+
+
+def test_rescan_preserves_first_seen_mttd(tmp_path: Path) -> None:
+    graph = KnowledgeGraph()
+    _record_hit(graph, "sandbox.tmux.main", _kerberoast_hit(detection_ts=105.0), key=_DETECT_KEY)
+    first = graph.by_kind(NodeKind.DETECTION_FIRED)[0]
+    assert first.props["mttd_seconds"] == 5.0
+
+    # Same logged event (same content key) re-detected far later — must not inflate.
+    _record_hit(graph, "sandbox.tmux.main", _kerberoast_hit(detection_ts=900.0), key=_DETECT_KEY)
+    fired = graph.by_kind(NodeKind.DETECTION_FIRED)
+    assert len(fired) == 1  # idempotent: same content key
+    assert fired[0].props["mttd_seconds"] == 5.0
+    assert fired[0].props["detection_ts"] == 105.0
+
+
+def test_rescan_of_untimestamped_log_is_idempotent(tmp_path: Path) -> None:
+    """The default case: session logs have no leading timestamp, so the tap
+    stamps each line with scan wall-clock. Re-scanning at a *different* wall
+    clock must NOT create new DetectionFired nodes or inflate detections —
+    the regression the old event_ts-based key caused."""
+    graph = KnowledgeGraph()
+    first = _scan(graph, tmp_path, _KERBEROAST, _DCSYNC, now_ts=1_000.0)
+    assert first["detections"] == 2
+    n_after_first = len(graph.by_kind(NodeKind.DETECTION_FIRED))
+    assert n_after_first == 2
+
+    # Re-scan the identical logs much later (fresh synthetic event_ts).
+    second = _scan(graph, tmp_path, _KERBEROAST, _DCSYNC, now_ts=9_999.0)
+    assert second["detections"] == 2
+    assert len(graph.by_kind(NodeKind.DETECTION_FIRED)) == 2  # not 4
+
+
+def test_distinct_lines_firing_same_rule_get_distinct_nodes(tmp_path: Path) -> None:
+    """Two different commands that trip the same rule must be two nodes — the
+    old key collapsed them whenever they shared a (synthetic) event_ts."""
+    graph = KnowledgeGraph()
+    other_kerberoast = "$ GetUserSPNs.py -request -dc-ip 10.0.0.2 other.local/svc2"
+    summary = _scan(graph, tmp_path, _KERBEROAST, other_kerberoast, now_ts=1_000.0)
+    fired = graph.by_kind(NodeKind.DETECTION_FIRED)
+    assert summary["detections"] == 2
+    assert len(fired) == 2
+    assert len({n.props["key"] for n in fired}) == 2
+
+
+# ── tool wrapper (transaction + workspace resolution) ───────────────────────
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.graph = KnowledgeGraph()
+
+    def load_graph(self) -> KnowledgeGraph:
+        return self.graph.model_copy(deep=True)
+
+    def batch_upsert_nodes(self, nodes) -> int:
+        for n in nodes:
+            self.graph.upsert_node(n)
+        return len(list(nodes))
+
+    def batch_upsert_edges(self, edges) -> int:
+        for e in edges:
+            self.graph.upsert_edge(e)
+        return len(list(edges))
+
+
+def test_blue_cell_scan_tool_persists_through_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeStore()
+    monkeypatch.setattr(state, "_store", fake)
+    workspace = _workspace_with(tmp_path, _DCSYNC)
+
+    result = json.loads(blue_cell_scan.invoke({"workspace_path": workspace}))
+
+    assert result["detections"] == 1
+    assert result["techniques_detected"] == ["T1003.006"]
+    assert len(fake.graph.by_kind(NodeKind.DETECTION_FIRED)) == 1


### PR DESCRIPTION
## What

Adds the **Blue Cell agent** — the runtime that closes the Offensive Vaccine loop. The Detector writes Sigma rules, but nothing in the OSS ever ran them against the agent's own activity (`docs/features/blue-cell.md`). This wires the missing piece:

- **`blue_cell_scan`** (`tools/defense/blue_cell.py`): replays the engagement's `.sessions/` logs through the already-shipped `BlueCellTap` + `RuleMatcher` and records each hit as a `DetectionFired` node, linked `-[:USES_RULE]->` the `DefenseAction` (rule artifact) and `-[:DETECTED]->` the `Finding`/`Technique` it caught. Returns a coverage summary including the **detection gaps** (Findings with no `DETECTED` edge — the headline blue-team deliverable).
- **`create_blue_cell_agent`** (`agents/standard/blue_cell.py`): the read-only agent that drives the scan and narrates the Defense Brief.
- Prompt, role registration, graph manifests, Neo4j constraints, and tests.

## Why

This is the one capability **no competitor has** (CAI/PentestGPT/Strix/XBOW are offense-only): proving, against the same kill chain you ran, *which detections fired, how fast (MTTD), and — most importantly — what was missed*. The expensive parts (the tap, the matcher, the KG) already shipped; this is the connective tissue.

## Design — read-only and deterministic by construction

- **Recording is deterministic & idempotent.** The matcher (not the LLM) decides what fired. Detection timing is **write-once**, so periodic re-scans never inflate MTTD.
- **The agent cannot fabricate coverage.** Its tool surface is the scanner + the read-only KG query subset — **no `bash`, no `kg_add_node`/`kg_add_edge`**, and no `SANDBOX_NOTIFICATION` slot. `SLOTS_PER_ROLE["blue_cell"]` mirrors the read-only `detector` profile exactly.

## Wiring (all parallel registries kept in sync)

| Surface | Change |
|---|---|
| `contracts/slots.py` | `"blue_cell": _BASE_SLOTS` (read-only, mirrors `detector`) |
| `types/llm.py` | `AGENT_TIERS`/`AGENT_TEMPERATURES` → `MID` / `0.2` |
| `langgraph.json` + `graph_registry.py` | register the `blue_cell` graph (both manifests) |
| `agents/__init__.py` | export `create_blue_cell_agent` |
| `SUBAGENT_SPEC` | `parent_agents=("decepticon",)` — orchestrator can delegate to it |
| `neo4j_store.py` | `DetectionFired.key` / `DefenseAction.key` uniqueness constraints |

## Stacked on #456

This needs the `DetectionFired`/`DefenseAction`/`DETECTED`/`USES_RULE` KG kinds from **#456** — merge that first. Until then this PR's diff includes #456's commit; it reduces to the Blue Cell files once #456 lands (rebase on merge).

**CODEOWNERS:** touches one protected path — `contracts/slots.py` (a single additive role line). Everything else is outside the protected surface.

## Tests

- `tests/unit/blue_cell/test_scan.py` — real tap+matcher against the bundled ruleset: records `DetectionFired`/`DefenseAction` + `USES_RULE`/`DETECTED`, links to matching Findings, reports gaps, and proves write-once MTTD on re-scan.
- `tests/unit/agents/test_blue_cell_agent.py` — read-only tool surface, the registered slot profile (no bash/sandbox), `SUBAGENT_SPEC`, and the langgraph registration.
- Full CI-mirror suite green locally: **3562 passed, 3 skipped**; `ruff`/`basedpyright` clean (0 errors).

## Follow-ups (separate PRs)

The Detector→rules handoff, the structured Defense Brief + ATT&CK Navigator export, and the adaptive blue→red OPSEC hook (downgrade `opsec_level` when a technique fires a detection fast).
