### PR TITLE
feat(blue-cell): add Defense Brief + ATT&CK Navigator export

### DIFF
--- a/packages/decepticon/decepticon/agents/prompts/standard/blue_cell.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/blue_cell.md
@@ -38,14 +38,14 @@ You are read-only. You observe and report; you never attack.
    severity, why no rule caught it (no rule exists vs. a rule exists but its
    condition was too strict).
 
-3. **Out-brief.** Emit a Defense Brief:
-   - Coverage: N attacks observed, M detected (X%), median/p95 MTTD.
-   - Detected techniques, sorted by MTTD (slowest first — those are the rules
-     a real adversary would beat).
-   - **Missed techniques / detection gaps**, each tagged `no rule` or
-     `rule too strict` with the Finding it left uncovered.
-   - Proposed rule improvements for the `rule too strict` cases.
-   Then STOP and return to the orchestrator. Do not re-scan in a loop.
+3. **Out-brief.** Call `defense_brief(engagement_name=...)` for the factual
+   deliverable — coverage %, median/p95 MTTD, detected techniques (slowest
+   first), the detection-gap list, and the deployed-rule inventory — and
+   `export_attack_navigator(output_path="defense/attack-navigator.json")` so
+   the customer's SOC gets a Navigator layer. Then add the judgement the tool
+   cannot: tag each gap `no rule` vs `rule too strict`, and propose a concrete
+   rule improvement for the `rule too strict` cases. Then STOP and return to
+   the orchestrator. Do not re-scan in a loop.
 </OPERATING_LOOP>
 
 <JUDGMENT_CALLS>

--- a/packages/decepticon/decepticon/agents/standard/blue_cell.py
+++ b/packages/decepticon/decepticon/agents/standard/blue_cell.py
@@ -46,13 +46,17 @@ from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
 from decepticon.tools.defense.blue_cell import blue_cell_scan
+from decepticon.tools.defense.brief import defense_brief, export_attack_navigator
 from decepticon.tools.research.tools import kg_neighbors, kg_query, kg_stats
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
 # Name-keyed baseline tools. Read-only by construction: the detection-coverage
-# scanner plus the KG query subset — no bash, no kg_add_node/kg_add_edge.
+# scanner + Defense Brief deliverables plus the KG query subset — no bash, no
+# kg_add_node/kg_add_edge.
 _STANDARD_TOOLS: dict[str, Any] = {
     "blue_cell_scan": blue_cell_scan,
+    "defense_brief": defense_brief,
+    "export_attack_navigator": export_attack_navigator,
     "kg_query": kg_query,
     "kg_neighbors": kg_neighbors,
     "kg_stats": kg_stats,

--- a/packages/decepticon/decepticon/tools/defense/blue_cell.py
+++ b/packages/decepticon/decepticon/tools/defense/blue_cell.py
@@ -53,7 +53,7 @@ def _resolve_workspace(workspace_path: str, config: RunnableConfig | None) -> st
     return os.environ.get("DECEPTICON_WORKSPACE_PATH", "/workspace")
 
 
-def _node_techniques(node: Node) -> set[str]:
+def node_techniques(node: Node) -> set[str]:
     """MITRE technique IDs a node carries, across the prop spellings in use."""
     out: set[str] = set()
     for key in ("technique_id", "technique", "mitre", "mitre_techniques"):
@@ -70,7 +70,7 @@ def _attribution_targets(graph: KnowledgeGraph, technique: str) -> list[Node]:
     return [
         node
         for node in graph.nodes.values()
-        if node.kind in _ATTRIBUTABLE and technique in _node_techniques(node)
+        if node.kind in _ATTRIBUTABLE and technique in node_techniques(node)
     ]
 
 

--- a/packages/decepticon/decepticon/tools/defense/brief.py
+++ b/packages/decepticon/decepticon/tools/defense/brief.py
@@ -1,0 +1,262 @@
+"""Defense Brief — the customer-facing detection-coverage deliverable.
+
+Reads the engagement knowledge graph that Blue Cell (``DetectionFired`` /
+``DETECTED``) and the Defender (``DefenseAction``) populated, and renders the
+proven-coverage report documented in ``docs/features/blue-cell.md``: coverage
+%, MTTD stats, the detected-technique table (slowest first), the detection-gap
+list (Findings nothing caught), and the deployed-rule inventory — plus an
+ATT&CK Navigator layer the customer's SOC can open directly.
+
+The numbers are computed deterministically from the graph; the Blue Cell agent
+adds the judgement layer (no-rule vs rule-too-strict, proposed improvements).
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+from langchain_core.tools import tool
+
+from decepticon.tools.defense.blue_cell import node_techniques
+from decepticon.tools.research._state import _json, _load
+from decepticon_core.types.kg import EdgeKind, KnowledgeGraph, NodeKind
+
+# ATT&CK Navigator layer colours: detection fired vs detection gap.
+_NAV_DETECTED = "#2ecc71"
+_NAV_GAP = "#e74c3c"
+
+
+def _percentile(values: list[float], q: float) -> float:
+    """Linear-interpolated percentile (q in [0, 1]). Empty → 0.0."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    idx = q * (len(ordered) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(ordered) - 1)
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (idx - lo)
+
+
+def _is_detected(graph: KnowledgeGraph, finding_id: str) -> bool:
+    return bool(graph.neighbors(finding_id, edge_kind=EdgeKind.DETECTED, direction="in"))
+
+
+def build_defense_brief(
+    graph: KnowledgeGraph, *, engagement_name: str = "Engagement"
+) -> dict[str, Any]:
+    """Compute the structured detection-coverage brief from the graph."""
+    findings = graph.by_kind(NodeKind.FINDING)
+    detected_ids = {f.id for f in findings if _is_detected(graph, f.id)}
+    detected_findings = [f for f in findings if f.id in detected_ids]
+    gap_findings = [f for f in findings if f.id not in detected_ids]
+
+    # Detected techniques: from the rules that actually fired. Keep the
+    # fastest (min MTTD) detection per technique.
+    detected_tech: dict[str, dict[str, Any]] = {}
+    mttds: list[float] = []
+    event_ts: list[float] = []
+    for fired in graph.by_kind(NodeKind.DETECTION_FIRED):
+        mttd = float(fired.props.get("mttd_seconds", 0.0) or 0.0)
+        mttds.append(mttd)
+        if "event_ts" in fired.props:
+            event_ts.append(float(fired.props["event_ts"]))
+        rule_id = str(fired.props.get("rule_id", ""))
+        for technique in fired.props.get("mitre", []) or []:
+            technique = str(technique)
+            current = detected_tech.get(technique)
+            if current is None or mttd < current["mttd_seconds"]:
+                detected_tech[technique] = {
+                    "technique": technique,
+                    "mttd_seconds": round(mttd, 2),
+                    "rule_id": rule_id,
+                }
+
+    gap_techniques: set[str] = set()
+    for finding in gap_findings:
+        gap_techniques |= node_techniques(finding)
+    gap_techniques -= set(detected_tech)
+
+    observed = len(findings)
+    return {
+        "engagement": engagement_name,
+        "window": ({"start": min(event_ts), "end": max(event_ts)} if event_ts else None),
+        "coverage": {
+            "findings_observed": observed,
+            "findings_detected": len(detected_findings),
+            "findings_missed": len(gap_findings),
+            "detected_pct": round(len(detected_findings) / observed * 100, 1) if observed else 0.0,
+        },
+        "mttd": {
+            "median_seconds": round(statistics.median(mttds), 2) if mttds else None,
+            "p95_seconds": round(_percentile(mttds, 0.95), 2) if mttds else None,
+            "max_seconds": round(max(mttds), 2) if mttds else None,
+        },
+        "detected_techniques": sorted(
+            detected_tech.values(), key=lambda d: d["mttd_seconds"], reverse=True
+        ),
+        "missed_techniques": sorted(gap_techniques),
+        "detection_gaps": [
+            {
+                "finding": f.label,
+                "techniques": sorted(node_techniques(f)),
+                "severity": str(f.props.get("severity", "")),
+            }
+            for f in gap_findings
+        ],
+        "deployed_rules": [
+            {
+                "rule_id": str(a.props.get("rule_id", "")),
+                "title": a.label,
+                "mitre": [str(t) for t in (a.props.get("mitre", []) or [])],
+                "siem_target": str(a.props.get("siem_target", "")),
+                "status": str(a.props.get("status", "")),
+            }
+            for a in graph.by_kind(NodeKind.DEFENSE_ACTION)
+        ],
+    }
+
+
+def render_brief_markdown(brief: dict[str, Any]) -> str:
+    """Render the brief in the text form from docs/features/blue-cell.md."""
+    cov, mttd = brief["coverage"], brief["mttd"]
+    lines = [f"Engagement: {brief['engagement']}"]
+    if brief["window"]:
+        lines.append(f"Time window: {brief['window']['start']} -> {brief['window']['end']}")
+    lines += [
+        "",
+        "Detection coverage:",
+        f"   {cov['findings_observed']} findings observed",
+        f"   {cov['findings_detected']} detected ({cov['detected_pct']}%)",
+        f"   {cov['findings_missed']} missed",
+    ]
+    if mttd["median_seconds"] is not None:
+        lines += [
+            f"   median MTTD: {mttd['median_seconds']}s",
+            f"   p95 MTTD: {mttd['p95_seconds']}s",
+        ]
+
+    lines += ["", "Detected techniques (slowest first):"]
+    lines += [
+        f"   {d['technique']} — fired in {d['mttd_seconds']}s (rule {d['rule_id']})"
+        for d in brief["detected_techniques"]
+    ] or ["   (none)"]
+
+    lines += ["", "Detection gaps:"]
+    lines += [
+        f"   {g['finding']} [{', '.join(g['techniques']) or 'no technique mapped'}] — no detection fired"
+        for g in brief["detection_gaps"]
+    ] or ["   (none — full coverage)"]
+
+    if brief["deployed_rules"]:
+        lines += ["", "Deployed detections:"]
+        lines += [
+            f"   {r['rule_id']} -> {r['siem_target'] or 'unsent'} ({r['status'] or '?'})"
+            for r in brief["deployed_rules"]
+        ]
+    return "\n".join(lines)
+
+
+def build_navigator_layer(brief: dict[str, Any]) -> dict[str, Any]:
+    """Build an ATT&CK Navigator layer: detected techniques green, gaps red."""
+    techniques = [
+        {
+            "techniqueID": d["technique"],
+            "score": 100,
+            "color": _NAV_DETECTED,
+            "comment": f"detected in {d['mttd_seconds']}s by {d['rule_id']}",
+            "enabled": True,
+        }
+        for d in brief["detected_techniques"]
+    ] + [
+        {
+            "techniqueID": technique,
+            "score": 0,
+            "color": _NAV_GAP,
+            "comment": "detection gap — no rule fired",
+            "enabled": True,
+        }
+        for technique in brief["missed_techniques"]
+    ]
+    return {
+        "name": f"Decepticon Detection Coverage — {brief['engagement']}",
+        "versions": {"layer": "4.5", "navigator": "4.9.5", "attack": "15"},
+        "domain": "enterprise-attack",
+        "description": (
+            "Proven detection coverage from the Decepticon Offensive Vaccine loop. "
+            "Green = a detection rule fired on this technique during the engagement; "
+            "red = the technique ran but nothing detected it."
+        ),
+        "techniques": techniques,
+        "legendItems": [
+            {"label": "detection fired", "color": _NAV_DETECTED},
+            {"label": "detection gap", "color": _NAV_GAP},
+        ],
+    }
+
+
+@tool
+def defense_brief(engagement_name: str = "Engagement") -> str:
+    """Render the engagement's proven detection-coverage brief from the graph.
+
+    Reads the DetectionFired / DETECTED / DefenseAction state Blue Cell and the
+    Defender wrote, and returns the coverage %, MTTD stats, detected-technique
+    table, detection-gap list, and deployed-rule inventory — both as structured
+    fields and as a ready-to-paste markdown brief.
+
+    WHEN TO USE: at engagement out-brief, after ``blue_cell_scan`` has recorded
+    coverage, to produce the customer's Detection Coverage deliverable.
+
+    Args:
+        engagement_name: Name shown in the brief header.
+
+    Returns:
+        JSON with ``markdown`` plus ``coverage`` / ``mttd`` /
+        ``detected_techniques`` / ``detection_gaps`` / ``deployed_rules``.
+    """
+    graph, _ = _load()
+    brief = build_defense_brief(graph, engagement_name=engagement_name)
+    return _json({**brief, "markdown": render_brief_markdown(brief)})
+
+
+@tool
+def export_attack_navigator(output_path: str, engagement_name: str = "Engagement") -> str:
+    """Write an ATT&CK Navigator layer of the engagement's detection coverage.
+
+    Produces a Navigator-importable JSON layer (detected techniques green,
+    detection gaps red) so the customer's SOC can see exactly what the kill
+    chain exercised and what their detections caught. Writes UTF-8 to
+    ``output_path`` (parent dirs created).
+
+    Args:
+        output_path: Destination ``.json`` path for the layer.
+        engagement_name: Name shown in the layer title.
+
+    Returns:
+        JSON summary: written path, technique count, and byte size.
+    """
+    graph, _ = _load()
+    layer = build_navigator_layer(build_defense_brief(graph, engagement_name=engagement_name))
+    payload = json.dumps(layer, indent=2, ensure_ascii=False)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload, encoding="utf-8")
+    return _json(
+        {"path": str(path), "techniques": len(layer["techniques"]), "bytes": len(payload.encode())}
+    )
+
+
+DEFENSE_BRIEF_TOOLS = [defense_brief, export_attack_navigator]
+
+__all__ = [
+    "DEFENSE_BRIEF_TOOLS",
+    "build_defense_brief",
+    "build_navigator_layer",
+    "defense_brief",
+    "export_attack_navigator",
+    "render_brief_markdown",
+]

--- a/packages/decepticon/tests/unit/agents/test_blue_cell_agent.py
+++ b/packages/decepticon/tests/unit/agents/test_blue_cell_agent.py
@@ -29,6 +29,7 @@ def test_role_registered_as_readonly_base_slots() -> None:
 def test_standard_tools_are_readonly() -> None:
     names = set(agent_mod._STANDARD_TOOLS)
     assert "blue_cell_scan" in names
+    assert {"defense_brief", "export_attack_navigator"} <= names  # Defense Brief deliverables
     assert {"kg_query", "kg_neighbors", "kg_stats"} <= names
     # No attack surface and no hand-written graph mutation.
     assert "bash" not in names

--- a/packages/decepticon/tests/unit/blue_cell/test_brief.py
+++ b/packages/decepticon/tests/unit/blue_cell/test_brief.py
@@ -1,0 +1,186 @@
+"""Tests for the Defense Brief deliverable (tools/defense/brief.py).
+
+Exercises the coverage math, MTTD stats, detected/gap technique split, the
+ATT&CK Navigator layer, and both @tools over an in-memory graph. No Neo4j.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from decepticon.tools.defense.brief import (
+    _percentile,
+    build_defense_brief,
+    build_navigator_layer,
+    defense_brief,
+    export_attack_navigator,
+    render_brief_markdown,
+)
+from decepticon.tools.research import _state as state
+from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
+
+
+def _seed(graph: KnowledgeGraph) -> None:
+    """2 detected findings (fast + slow) + 1 gap + 1 deployed rule."""
+    kerb = graph.upsert_node(
+        Node.make(
+            NodeKind.FINDING, "Kerberoast SPN", key="F1", technique="T1558.003", severity="high"
+        )
+    )
+    fired_fast = graph.upsert_node(
+        Node.make(
+            NodeKind.DETECTION_FIRED,
+            "Kerberoast",
+            key="d::1",
+            rule_id="DCEP-T1558.003-kerberoast",
+            mitre=["T1558.003"],
+            mttd_seconds=1.2,
+            event_ts=100.0,
+        )
+    )
+    graph.upsert_edge(Edge.make(fired_fast.id, kerb.id, EdgeKind.DETECTED))
+
+    dcsync = graph.upsert_node(
+        Node.make(NodeKind.FINDING, "DCSync", key="F3", technique="T1003.006", severity="critical")
+    )
+    fired_slow = graph.upsert_node(
+        Node.make(
+            NodeKind.DETECTION_FIRED,
+            "DCSync",
+            key="d::2",
+            rule_id="DCEP-T1003.006-dcsync",
+            mitre=["T1003.006"],
+            mttd_seconds=12.0,
+            event_ts=200.0,
+        )
+    )
+    graph.upsert_edge(Edge.make(fired_slow.id, dcsync.id, EdgeKind.DETECTED))
+
+    # Gap: ran but nothing detected it.
+    graph.upsert_node(
+        Node.make(
+            NodeKind.FINDING, "DLL side-load", key="F2", technique="T1574.002", severity="medium"
+        )
+    )
+    # A rule the Defender deployed.
+    graph.upsert_node(
+        Node.make(
+            NodeKind.DEFENSE_ACTION,
+            "DCSync rule",
+            key="rule::DCEP-T1003.006-dcsync",
+            rule_id="DCEP-T1003.006-dcsync",
+            mitre=["T1003.006"],
+            siem_target="sentinel",
+            status="deployed",
+        )
+    )
+
+
+# ── coverage math ──────────────────────────────────────────────────────────
+
+
+def test_coverage_counts_and_percentage() -> None:
+    graph = KnowledgeGraph()
+    _seed(graph)
+    cov = build_defense_brief(graph)["coverage"]
+    assert cov == {
+        "findings_observed": 3,
+        "findings_detected": 2,
+        "findings_missed": 1,
+        "detected_pct": 66.7,
+    }
+
+
+def test_detected_techniques_sorted_slowest_first() -> None:
+    brief = build_defense_brief(_seeded_graph())
+    assert [d["technique"] for d in brief["detected_techniques"]] == ["T1003.006", "T1558.003"]
+    assert brief["mttd"]["median_seconds"] == 6.6
+    assert brief["mttd"]["max_seconds"] == 12.0
+
+
+def test_gaps_and_deployed_inventory() -> None:
+    brief = build_defense_brief(_seeded_graph())
+    assert brief["missed_techniques"] == ["T1574.002"]
+    assert [g["finding"] for g in brief["detection_gaps"]] == ["DLL side-load"]
+    assert brief["deployed_rules"][0]["siem_target"] == "sentinel"
+
+
+# ── navigator layer ─────────────────────────────────────────────────────────
+
+
+def test_navigator_layer_colours_detected_and_gaps() -> None:
+    layer = build_navigator_layer(build_defense_brief(_seeded_graph()))
+    assert layer["domain"] == "enterprise-attack"
+    by_id = {t["techniqueID"]: t for t in layer["techniques"]}
+    assert by_id["T1003.006"]["score"] == 100 and by_id["T1003.006"]["color"] == "#2ecc71"
+    assert by_id["T1574.002"]["score"] == 0 and by_id["T1574.002"]["color"] == "#e74c3c"
+
+
+def test_markdown_contains_headline_numbers() -> None:
+    md = render_brief_markdown(build_defense_brief(_seeded_graph(), engagement_name="ACME"))
+    assert "Engagement: ACME" in md
+    assert "2 detected (66.7%)" in md
+    assert "T1003.006 — fired in 12.0s" in md
+    assert "DLL side-load" in md
+
+
+def test_percentile_interpolates() -> None:
+    assert _percentile([], 0.95) == 0.0
+    assert _percentile([5.0], 0.95) == 5.0
+    assert _percentile([0.0, 10.0], 0.5) == 5.0
+
+
+# ── @tools over the store ────────────────────────────────────────────────────
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.graph = KnowledgeGraph()
+
+    def load_graph(self) -> KnowledgeGraph:
+        return self.graph.model_copy(deep=True)
+
+    def batch_upsert_nodes(self, nodes) -> int:
+        for n in nodes:
+            self.graph.upsert_node(n)
+        return 0
+
+    def batch_upsert_edges(self, edges) -> int:
+        for e in edges:
+            self.graph.upsert_edge(e)
+        return 0
+
+
+def test_defense_brief_tool_returns_markdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeStore()
+    _seed(fake.graph)
+    monkeypatch.setattr(state, "_store", fake)
+    result = json.loads(defense_brief.invoke({"engagement_name": "ACME"}))
+    assert result["coverage"]["detected_pct"] == 66.7
+    assert "Engagement: ACME" in result["markdown"]
+
+
+def test_export_navigator_tool_writes_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeStore()
+    _seed(fake.graph)
+    monkeypatch.setattr(state, "_store", fake)
+    out = tmp_path / "nav" / "layer.json"
+    summary = json.loads(export_attack_navigator.invoke({"output_path": str(out)}))
+    assert summary["techniques"] == 3
+    layer = json.loads(out.read_text(encoding="utf-8"))
+    assert {t["techniqueID"] for t in layer["techniques"]} == {
+        "T1003.006",
+        "T1558.003",
+        "T1574.002",
+    }
+
+
+def _seeded_graph() -> KnowledgeGraph:
+    graph = KnowledgeGraph()
+    _seed(graph)
+    return graph


### PR DESCRIPTION
## What

Implements the two follow-ups `docs/features/blue-cell.md` explicitly tracks — the **customer-deliverable Defense Brief generator** and the **ATT&CK Navigator JSON export**.

PR2 made Blue Cell *measure* coverage and PR3 made the Defender *deploy* rules, so the graph now holds the `DetectionFired` / `DETECTED` / `DefenseAction` state — but nothing turned it into the deliverable the customer's SOC consumes. This adds two read-only tools, wired into the Blue Cell agent:

- **`defense_brief(engagement_name)`** — renders the coverage report documented in `blue-cell.md`: coverage % (detected vs missed Findings), median/p95 MTTD, the **detected-technique table** (slowest first — the rules a real adversary beats), the **detection-gap list** (Findings nothing caught), and the **deployed-rule inventory**. Returns both structured fields and ready-to-paste markdown.
- **`export_attack_navigator(output_path)`** — writes a Navigator-importable layer: detected techniques green, gaps red, with per-technique MTTD/rule comments.

The numbers are computed deterministically from the graph; the agent adds the judgement the tool can't (no-rule vs rule-too-strict, proposed improvements). Blue Cell's prompt out-brief step now calls these tools.

## Example brief

```
Engagement: ACME-Q2
Detection coverage:
   3 findings observed
   2 detected (66.7%)
   1 missed
   median MTTD: 6.6s
   p95 MTTD: 11.46s
Detected techniques (slowest first):
   T1003.006 — fired in 12.0s (rule DCEP-T1003.006-dcsync)
   T1558.003 — fired in 1.2s (rule DCEP-T1558.003-kerberoast)
Detection gaps:
   DLL side-load [T1574.002] — no detection fired
Deployed detections:
   DCEP-T1003.006-dcsync -> sentinel (deployed)
```

## Design

- Follows the existing `report_*` deliverable pattern (pure renderer + `@tool` over a **read-only** `_load()` graph). These tools are **not** added to `REPORTING_TOOLS`, so the offensive reporting agents (analyst/contract_auditor) are untouched.
- Promotes `blue_cell.node_techniques` to public so the brief and the scanner share one MITRE-extraction helper instead of duplicating the prop-key logic.

## Stacked on #459 → #458 → #456

Merge order: **#456 → #458 → #459 → this**. Diff shows the stack until they land, then reduces to the 6 brief files.

**CODEOWNERS:** touches **no** protected path → self-mergeable on green CI.

## Tests

`tests/unit/blue_cell/test_brief.py` (8): coverage counts + %, detected-technique ordering by MTTD, median/max MTTD, gap + deployed-rule inventory, the Navigator layer's green/red scoring, the markdown headline numbers, the percentile helper, and both `@tool`s over an in-memory store (one writing + re-reading the layer file).

Full CI-mirror suite green locally: **3576 passed, 3 skipped**; `ruff`/`basedpyright` clean (0 errors).

## Follow-up

The last piece of the loop: the **adaptive blue→red OPSEC hook** (orchestrator reads recent `DetectionFired`, injects a SystemMessage, and downgrades `opsec_level` loud→stealth when a technique is caught fast).
