### PR TITLE
fix(kg): scope Neo4jStore reads + transaction save-back to the active engagement

### DIFF
--- a/packages/decepticon/decepticon/tools/research/_engagement_scope.py
+++ b/packages/decepticon/decepticon/tools/research/_engagement_scope.py
@@ -93,14 +93,18 @@ def get_active_engagement() -> str | None:
 
 
 def with_engagement_property(props: dict | None, *, override: str | None = None) -> dict:
-    """Return ``props`` with an ``engagement`` key set to the active label.
+    """Return ``props`` with an ``engagement`` key set to the right label.
 
-    ``override`` lets callers explicitly set the engagement for a single
-    write (e.g. when ingesting historical data into a specific
-    engagement). If neither override nor active engagement is set, the
-    legacy label is used so the property always exists on every write.
+    Precedence (first non-empty wins): ``override`` (caller pins it) → an
+    ``engagement`` already on ``props`` → the active engagement → the legacy
+    label. Preserving an existing ``engagement`` is the multi-tenant safety
+    invariant: it stops a ``graph_transaction`` save-back from relabelling a
+    loaded node onto the current (or ``_legacy``) engagement on a shared
+    Neo4j. See docs/security/neo4j-hardening.md.
     """
     out = dict(props or {})
-    engagement = override or get_active_engagement() or _LEGACY_ENGAGEMENT_LABEL
+    engagement = (
+        override or out.get("engagement") or get_active_engagement() or _LEGACY_ENGAGEMENT_LABEL
+    )
     out["engagement"] = engagement
     return out

--- a/packages/decepticon/decepticon/tools/research/neo4j_store.py
+++ b/packages/decepticon/decepticon/tools/research/neo4j_store.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from decepticon.tools.research._engagement_scope import (
+    get_active_engagement,
     with_engagement_property,
 )
 from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
@@ -106,6 +107,20 @@ def _encode_props(props: dict[str, Any]) -> str:
         return json.dumps(props, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         return "{}"
+
+
+def _read_engagement(all_engagements: bool) -> str | None:
+    """Engagement label to constrain a read to, or ``None`` to read unscoped.
+
+    ``None`` (legacy unscoped behaviour) covers two cases: the caller opted
+    out via ``all_engagements``, or no engagement is configured at all (the
+    single-tenant/local default, where there is nothing to isolate). A
+    configured engagement otherwise scopes the read so a shared/SaaS Neo4j
+    cannot leak one engagement's graph into another's.
+    """
+    if all_engagements:
+        return None
+    return get_active_engagement()
 
 
 class Neo4jStore:
@@ -393,11 +408,17 @@ class Neo4jStore:
         node_id: str,
         edge_kind: str | None = None,
         direction: str = "out",
+        *,
+        all_engagements: bool = False,
     ) -> list[dict[str, Any]]:
         """Query neighbors of a node using Cypher, optionally filtering by edge kind.
 
         direction: "out" (outgoing), "in" (incoming), or "both".
         Returns a list of dicts with edge and neighbor node properties.
+
+        Scoped to the active engagement unless ``all_engagements`` is set
+        (see :func:`_read_engagement`): the edge and the neighbour must both
+        belong to the engagement, mirroring the dashboard graph route.
         """
         if direction not in ("out", "in", "both"):
             raise ValueError("direction must be out/in/both")
@@ -409,14 +430,19 @@ class Neo4jStore:
         else:
             pattern = "(src {id: $node_id})-[r]-(nbr)"
 
-        where_clause = ""
+        conditions: list[str] = []
         params: dict[str, Any] = {"node_id": node_id}
         if edge_kind:
             # Parameter-bind the relationship type instead of interpolating it
             # into a Cypher string literal (Cypher does allow $-params in
             # ``type(r) = $x``), closing a Cypher-injection vector.
-            where_clause = "WHERE type(r) = $edge_kind"
+            conditions.append("type(r) = $edge_kind")
             params["edge_kind"] = edge_kind.upper()
+        engagement = _read_engagement(all_engagements)
+        if engagement:
+            conditions.append("r.engagement = $engagement AND nbr.engagement = $engagement")
+            params["engagement"] = engagement
+        where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
         query = f"""
         MATCH {pattern}
@@ -457,7 +483,7 @@ class Neo4jStore:
                 )
         return results
 
-    def query_by_kind(self, kind: str) -> list[dict[str, Any]]:
+    def query_by_kind(self, kind: str, *, all_engagements: bool = False) -> list[dict[str, Any]]:
         """Query all nodes of a given kind using native Neo4j labels.
 
         ``kind`` can be either a NodeKind value (e.g. "host") or a Neo4j
@@ -465,6 +491,9 @@ class Neo4jStore:
         ``ValueError`` - the label is interpolated into the Cypher template
         (Neo4j Cypher does not parameter-bind labels), so an unvalidated
         caller-supplied label would be a direct Cypher-injection vector.
+
+        Scoped to the active engagement unless ``all_engagements`` is set
+        (see :func:`_read_engagement`).
         """
         try:
             nk = NodeKind(kind)
@@ -478,8 +507,11 @@ class Neo4jStore:
                 ) from None
             label = kind
 
+        engagement = _read_engagement(all_engagements)
+        where = "WHERE n.engagement = $engagement" if engagement else ""
         query = f"""
         MATCH (n:{label})
+        {where}
         RETURN n.id AS id,
                n.kind AS kind,
                n.label AS label,
@@ -487,9 +519,10 @@ class Neo4jStore:
                coalesce(n.created_at, 0.0) AS created_at,
                coalesce(n.updated_at, 0.0) AS updated_at
         """
+        params = {"engagement": engagement} if engagement else {}
         results: list[dict[str, Any]] = []
         with self._driver.session(database=self._database) as session:
-            for row in session.run(query):
+            for row in session.run(query, **params):
                 results.append(
                     {
                         "id": row["id"],
@@ -509,6 +542,12 @@ class Neo4jStore:
 
         Intended for agent tools that need ad-hoc graph queries (attack path
         analysis, neighbor traversal, etc.).
+
+        Unlike the structured reads, this raw escape hatch is NOT
+        engagement-scoped: the caller owns the Cypher and must add its own
+        ``.engagement = $engagement`` filter (from :func:`get_active_engagement`)
+        when isolation is required. Scoping the chain-planner queries that run
+        through here is a tracked follow-up.
         """
         results: list[dict[str, Any]] = []
         with self._driver.session(database=self._database) as session:
@@ -575,28 +614,44 @@ class Neo4jStore:
 
     # ── Backward-compatible full-graph load ──────────────────────────────
 
-    def load_graph(self) -> KnowledgeGraph:
+    def load_graph(self, *, all_engagements: bool = False) -> KnowledgeGraph:
         """Load the entire graph into a KnowledgeGraph Pydantic model.
 
         Queries by individual labels (not the old KGNode label).
         Kept for backward compatibility during migration, used by tests
         and one-shot operations.
+
+        Scoped to the active engagement unless ``all_engagements`` is set
+        (see :func:`_read_engagement`). This is the load path behind
+        ``graph_transaction``; scoping it keeps a transaction's save-back
+        from re-tagging another engagement's nodes onto the current one.
         """
         graph = KnowledgeGraph()
 
+        engagement = _read_engagement(all_engagements)
+        node_where = "WHERE any(l IN labels(n) WHERE l IN $labels)"
+        edge_where = "WHERE r.id IS NOT NULL"
+        node_params: dict[str, Any] = {"labels": _ALL_NODE_LABELS}
+        edge_params: dict[str, Any] = {}
+        if engagement:
+            node_where += " AND n.engagement = $engagement"
+            edge_where += " AND r.engagement = $engagement"
+            node_params["engagement"] = engagement
+            edge_params["engagement"] = engagement
+
         # Load nodes across all known labels — single query
         with self._driver.session(database=self._database) as session:
-            node_query = """
+            node_query = f"""
             MATCH (n)
-            WHERE any(l IN labels(n) WHERE l IN $labels)
+            {node_where}
             RETURN n.id AS id,
                    n.kind AS kind,
                    n.label AS label,
-                   coalesce(n.props, '{}') AS props,
+                   coalesce(n.props, '{{}}') AS props,
                    coalesce(n.created_at, 0.0) AS created_at,
                    coalesce(n.updated_at, 0.0) AS updated_at
             """
-            for row in session.run(node_query, labels=_ALL_NODE_LABELS):
+            for row in session.run(node_query, **node_params):
                 node_id = row.get("id")
                 kind_raw = row.get("kind")
                 if not isinstance(node_id, str) or not isinstance(kind_raw, str):
@@ -621,18 +676,18 @@ class Neo4jStore:
                 graph.nodes[node.id] = node
 
             # Load all edges (match any relationship type)
-            edge_query = """
+            edge_query = f"""
             MATCH (src)-[r]->(dst)
-            WHERE r.id IS NOT NULL
+            {edge_where}
             RETURN r.id AS id,
                    src.id AS src,
                    dst.id AS dst,
                    r.kind AS kind,
                    coalesce(r.weight, 1.0) AS weight,
-                   coalesce(r.props, '{}') AS props,
+                   coalesce(r.props, '{{}}') AS props,
                    coalesce(r.created_at, 0.0) AS created_at
             """
-            for row in session.run(edge_query):
+            for row in session.run(edge_query, **edge_params):
                 edge_id = row.get("id")
                 kind_raw = row.get("kind")
                 src = row.get("src")

--- a/packages/decepticon/tests/unit/research/test_engagement_scope.py
+++ b/packages/decepticon/tests/unit/research/test_engagement_scope.py
@@ -138,6 +138,22 @@ class TestWithEngagementProperty:
         assert "engagement" not in original
         assert out is not original
 
+    def test_existing_engagement_preserved_over_active(self) -> None:
+        token = set_active_engagement("engagement-b")
+        try:
+            out = with_engagement_property({"engagement": "engagement-a", "ip": "10.0.0.9"})
+            assert out["engagement"] == "engagement-a"
+        finally:
+            reset_active_engagement(token)
+
+    def test_existing_engagement_preserved_when_no_active(self) -> None:
+        out = with_engagement_property({"engagement": "engagement-a"})
+        assert out["engagement"] == "engagement-a"
+
+    def test_override_beats_existing_engagement(self) -> None:
+        out = with_engagement_property({"engagement": "engagement-a"}, override="engagement-c")
+        assert out["engagement"] == "engagement-c"
+
 
 class TestNeo4jUpsertCypherShape:
     def test_upsert_node_cypher_sets_engagement(self) -> None:

--- a/packages/decepticon/tests/unit/research/test_neo4j_store.py
+++ b/packages/decepticon/tests/unit/research/test_neo4j_store.py
@@ -895,3 +895,120 @@ class TestLoadGraph:
         store = _make_store(driver)
         graph = store.load_graph()
         assert isinstance(graph, KnowledgeGraph)
+
+
+class TestEngagementScopedReads:
+    def _load_session(self) -> _FakeSession:
+        return _FakeSession(results=[_FakeResult([]), _FakeResult([])])
+
+    def test_query_by_kind_unscoped_when_no_active_engagement(self) -> None:
+        session = _FakeSession(results=[_FakeResult([])])
+        store = _make_store(_FakeDriver(sessions=[session]))
+        store.query_by_kind("Host")
+        query, params = session.runs[0]
+        assert "engagement" not in query
+        assert "engagement" not in params
+
+    def test_query_by_kind_scoped_to_active_engagement(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = _FakeSession(results=[_FakeResult([])])
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.query_by_kind("Host")
+            query, params = session.runs[0]
+            assert "WHERE n.engagement = $engagement" in query
+            assert params["engagement"] == "acme"
+        finally:
+            reset_active_engagement(token)
+
+    def test_query_by_kind_all_engagements_opts_out(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = _FakeSession(results=[_FakeResult([])])
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.query_by_kind("Host", all_engagements=True)
+            query, params = session.runs[0]
+            assert "engagement" not in query
+            assert "engagement" not in params
+        finally:
+            reset_active_engagement(token)
+
+    # ── query_neighbors ──────────────────────────────────────────────────
+    def test_query_neighbors_scoped_filters_edge_and_neighbor(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = _FakeSession(results=[_FakeResult([])])
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.query_neighbors("n1")
+            query, params = session.runs[0]
+            assert "r.engagement = $engagement" in query
+            assert "nbr.engagement = $engagement" in query
+            assert params["engagement"] == "acme"
+        finally:
+            reset_active_engagement(token)
+
+    def test_query_neighbors_combines_engagement_with_edge_kind(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = _FakeSession(results=[_FakeResult([])])
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.query_neighbors("n1", edge_kind="has_vuln")
+            query, params = session.runs[0]
+            assert "type(r) = $edge_kind" in query
+            assert "r.engagement = $engagement" in query
+            assert " AND " in query
+            assert params["edge_kind"] == "HAS_VULN"
+            assert params["engagement"] == "acme"
+        finally:
+            reset_active_engagement(token)
+
+    def test_query_neighbors_all_engagements_opts_out(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = _FakeSession(results=[_FakeResult([])])
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.query_neighbors("n1", all_engagements=True)
+            query, params = session.runs[0]
+            assert "engagement" not in query
+            assert "engagement" not in params
+        finally:
+            reset_active_engagement(token)
+
+    # ── load_graph (the graph_transaction load path) ─────────────────────
+    def test_load_graph_unscoped_when_no_active_engagement(self) -> None:
+        session = self._load_session()
+        store = _make_store(_FakeDriver(sessions=[session]))
+        store.load_graph()
+        node_query, node_params = session.runs[0]
+        edge_query, edge_params = session.runs[1]
+        assert "n.engagement" not in node_query
+        assert "r.engagement" not in edge_query
+        assert "engagement" not in node_params
+        assert "engagement" not in edge_params
+
+    def test_load_graph_scoped_filters_nodes_and_edges(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = self._load_session()
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.load_graph()
+            node_query, node_params = session.runs[0]
+            edge_query, edge_params = session.runs[1]
+            assert "n.engagement = $engagement" in node_query
+            assert "r.engagement = $engagement" in edge_query
+            assert node_params["engagement"] == "acme"
+            assert edge_params["engagement"] == "acme"
+        finally:
+            reset_active_engagement(token)
+
+    def test_load_graph_all_engagements_opts_out(self) -> None:
+        token = set_active_engagement("acme")
+        try:
+            session = self._load_session()
+            store = _make_store(_FakeDriver(sessions=[session]))
+            store.load_graph(all_engagements=True)
+            node_query, node_params = session.runs[0]
+            assert "n.engagement" not in node_query
+            assert "engagement" not in node_params
+        finally:
+            reset_active_engagement(token)


### PR DESCRIPTION
## Summary

The Neo4j knowledge-graph store tags every write with the active engagement
(`n.engagement` / `r.engagement`) so a shared/SaaS instance can isolate tenants —
but the **read** side never used the property, and the transaction layer actively
**corrupted** it. This scopes the structured reads to the active engagement and
stops `graph_transaction` from relabelling other engagements' nodes.

This was deferred in `docs/security/neo4j-hardening.md`; the web dashboard's
`engagements/[id]/graph` route already ships the correct `WHERE n.engagement =
$engagement` filter, which this mirrors on the Python read path.

## The bug

- **Read leak.** `load_graph`, `query_by_kind`, and `query_neighbors` matched
  across *all* engagements. On a shared Neo4j, engagement A's graph leaked into
  engagement B's reads.
- **Write-amplified relabel (worse).** `graph_transaction()` loads via
  `load_graph()` (all engagements) and saves via batch upserts, which re-stamp
  `with_engagement_property` onto every loaded node. A transaction run under
  engagement B — or with no active engagement at all — silently relabelled every
  other engagement's nodes to `B` / `_legacy`, corrupting the very `engagement`
  property the dashboard filters on and contaminating chain planning.

## Changes

- Scope `load_graph`, `query_by_kind`, `query_neighbors` to the active engagement
  via a new `_read_engagement` helper. Each takes an explicit `all_engagements=True`
  opt-out for cross-engagement / admin / migration use.
- When no engagement is configured (single-tenant / local default), reads stay
  unscoped — current behaviour is preserved.
- `with_engagement_property` now **preserves** an `engagement` already present on
  the props instead of overwriting it, so a transaction save-back can never
  relabel a loaded node. New nodes (no engagement yet) still get the active label;
  `override` still wins.
- `query_neighbors` requires both the edge and the neighbour to be in-engagement,
  mirroring the dashboard route's two-in-engagement-nodes semantics.
- `query_custom` is left as the raw, intentionally-unscoped escape hatch with a
  docstring caveat. Scoping the chain-planner queries that run through it is a
  tracked follow-up (true per-path isolation through APOC dijkstra is a separate,
  larger change).
- Adds read-side isolation tests (counterpart to the existing write-tagging tests)
  and relabel-guard tests for `with_engagement_property`.

## Testing

- [x] `uv run ruff check .` + `ruff format --check` clean on changed files
- [x] `uv run pytest packages/decepticon/tests/unit/research/ -m "not slow"` — **561 passed**
  (includes 12 new tests; 0 regressions)
- [ ] `make quality` (full Python + CLI + Web) — run in CI

## Related Issues

<!-- Link the KG-hardening tracking issue if one exists. -->

## Notes

No CODEOWNERS-protected paths touched. Scope is intentionally one self-contained
fix per `docs/COWORK.md`. Two adjacent issues in the same subsystem are left for
their own PRs: scoping the chain-planner Cypher (above), and the dead
`compute_edge_cost` weight/cost mismatch (`chain.py` runs dijkstra on `cost` while
the store only writes `weight`).
