### PR TITLE
feat(roe): enforce min_inter_request_delay throttle (+OPSEC jitter) on gated tool calls

### DIFF
--- a/packages/decepticon/decepticon/middleware/roe.py
+++ b/packages/decepticon/decepticon/middleware/roe.py
@@ -27,9 +27,12 @@ Reading the RoE:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
+import random
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -141,6 +144,9 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         gated_tools: Override the default tool-name set. Use this to
             extend enforcement to additional tools (e.g. an HTTP
             request tool).
+        jitter_frac: Fraction of ``min_inter_request_delay_ms`` added as
+            random OPSEC jitter on top of the floor when a gated call is
+            paced (0 disables jitter; the floor is still honoured).
     """
 
     def __init__(
@@ -148,10 +154,14 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         *,
         sink: RoEAuditSink | None = None,
         gated_tools: frozenset[str] | None = None,
+        jitter_frac: float = 0.25,
     ) -> None:
         super().__init__()
         self._sink = sink
         self._gated = gated_tools or GATED_TOOL_NAMES
+        self._jitter_frac = max(0.0, jitter_frac)
+        self._pace_lock = threading.Lock()
+        self._last_gated_monotonic = 0.0
 
     @override
     def wrap_tool_call(self, request, handler) -> ToolMessage | Command:
@@ -166,6 +176,10 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         self._record(request, tool_name, decision, rules.mode)
         if not decision.allow and rules.mode == EnforcementMode.ENFORCE:
             return _refused_message(decision, tool_name, _tcid(request))
+        wait = self._pace_wait_seconds(rules)
+        if wait > 0:
+            self._record_throttle(request, tool_name, wait)
+            time.sleep(wait)
         result = handler(request)
         if (
             not decision.allow
@@ -180,6 +194,10 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         self._record(request, tool_name, decision, rules.mode)
         if not decision.allow and rules.mode == EnforcementMode.ENFORCE:
             return _refused_message(decision, tool_name, _tcid(request))
+        wait = self._pace_wait_seconds(rules)
+        if wait > 0:
+            self._record_throttle(request, tool_name, wait)
+            await asyncio.sleep(wait)
         result = await handler(request)
         if (
             not decision.allow
@@ -239,6 +257,45 @@ class RoEEnforcementMiddleware(AgentMiddleware):
             self._sink.append(record)
         except Exception as exc:  # noqa: BLE001 - audit must never break tool execution
             log.error("roe: audit sink write failed: %s", exc)
+
+    def _pace_wait_seconds(self, rules: MachineEnforcement) -> float:
+        """Seconds to sleep before a gated call to honour ``min_inter_request_delay_ms``.
+
+        The first runtime request-cadence control (opplan only prints an OPSEC
+        label). Isolated calls never wait; bursts are spaced to the floor plus
+        up to ``jitter_frac`` of it, so the cadence is not a fixed-interval IOC.
+        Never goes below the configured minimum; returns 0 when unset.
+        """
+        floor = rules.min_inter_request_delay_ms / 1000.0
+        if floor <= 0:
+            return 0.0
+        now = time.monotonic()
+        with self._pace_lock:
+            start_at = max(now, self._last_gated_monotonic + floor)
+            self._last_gated_monotonic = start_at
+        wait = start_at - now
+        if wait > 0 and self._jitter_frac > 0:
+            wait += random.uniform(0.0, floor * self._jitter_frac)
+        return wait
+
+    def _record_throttle(self, request, tool_name: str, wait_seconds: float) -> None:
+        if self._sink is None:
+            return
+        state = getattr(request, "state", {}) or {}
+        get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+        record = {
+            "ts": time.time(),
+            "engagement": get("engagement_name") or "unknown-engagement",
+            "objective_id": get("active_objective_id") or get("current_objective") or "",
+            "tool": tool_name,
+            "event": "throttle",
+            "reason_code": "MIN_INTER_REQUEST_DELAY",
+            "delay_seconds": round(wait_seconds, 3),
+        }
+        try:
+            self._sink.append(record)
+        except Exception as exc:  # noqa: BLE001 - audit must never break tool execution
+            log.error("roe: throttle audit write failed: %s", exc)
 
 
 def _tcid(request) -> str | None:

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 from langchain_core.messages import ToolMessage
 
+from decepticon.middleware import roe as roe_mod
 from decepticon.middleware._audit_sink import RoEAuditSink, verify_ledger
 from decepticon.middleware._command_targets import extract_targets
 from decepticon.middleware.roe import (
@@ -432,3 +433,82 @@ class TestFqdnTrailingDotNormalization:
         assert evaluate_target("single-host.example.", rules).allow is True
         # An unrelated FQDN-form host is still refused (not in scope).
         assert evaluate_target("other.example.", rules).allow is False
+
+
+class TestRoEThrottle:
+    def test_zero_delay_never_waits(self) -> None:
+        mw = RoEEnforcementMiddleware(jitter_frac=0.0)
+        rules = MachineEnforcement.from_dict({"min_inter_request_delay_ms": 0})
+        assert mw._pace_wait_seconds(rules) == 0.0
+
+    def test_first_call_does_not_wait_then_burst_is_spaced(self, monkeypatch) -> None:
+        mw = RoEEnforcementMiddleware(jitter_frac=0.0)
+        rules = MachineEnforcement.from_dict({"min_inter_request_delay_ms": 200})
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(roe_mod.time, "monotonic", lambda: clock["t"])
+        assert mw._pace_wait_seconds(rules) == 0.0
+        assert abs(mw._pace_wait_seconds(rules) - 0.2) < 1e-9
+        assert abs(mw._pace_wait_seconds(rules) - 0.4) < 1e-9
+
+    def test_elapsed_gap_resets_wait(self, monkeypatch) -> None:
+        mw = RoEEnforcementMiddleware(jitter_frac=0.0)
+        rules = MachineEnforcement.from_dict({"min_inter_request_delay_ms": 100})
+        clock = {"t": 5000.0}
+        monkeypatch.setattr(roe_mod.time, "monotonic", lambda: clock["t"])
+        assert mw._pace_wait_seconds(rules) == 0.0
+        clock["t"] += 1.0
+        assert mw._pace_wait_seconds(rules) == 0.0
+
+    def test_jitter_added_above_floor_under_contention(self, monkeypatch) -> None:
+        mw = RoEEnforcementMiddleware(jitter_frac=0.5)
+        rules = MachineEnforcement.from_dict({"min_inter_request_delay_ms": 200})
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(roe_mod.time, "monotonic", lambda: clock["t"])
+        monkeypatch.setattr(roe_mod.random, "uniform", lambda _a, b: b)
+        assert mw._pace_wait_seconds(rules) == 0.0
+        assert abs(mw._pace_wait_seconds(rules) - 0.3) < 1e-9
+
+    def test_dispatch_sleeps_and_records_throttle(self, tmp_path: Path, monkeypatch) -> None:
+        _write_roe(tmp_path, {"mode": "audit", "min_inter_request_delay_ms": 150})
+        sink = RoEAuditSink(path=tmp_path / "audit.jsonl")
+        mw = RoEEnforcementMiddleware(sink=sink, jitter_frac=0.0)
+        slept: list[float] = []
+        monkeypatch.setattr(roe_mod.time, "monotonic", lambda: 1000.0)
+        monkeypatch.setattr(roe_mod.time, "sleep", lambda s: slept.append(s))
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        req = _make_request("bash", "id", state={"workspace_path": str(tmp_path)})
+        mw.wrap_tool_call(req, handler)
+        mw.wrap_tool_call(req, handler)
+        assert slept and abs(slept[0] - 0.15) < 1e-9
+        assert handler.call_count == 2
+        recs = [json.loads(line) for line in (tmp_path / "audit.jsonl").read_text().splitlines()]
+        assert any(
+            r.get("event") == "throttle" and r["reason_code"] == "MIN_INTER_REQUEST_DELAY"
+            for r in recs
+        )
+
+    def test_refused_call_is_not_paced(self, tmp_path: Path, monkeypatch) -> None:
+        _write_roe(
+            tmp_path,
+            {"mode": "enforce", "in_scope": ["10.0.0.0/24"], "min_inter_request_delay_ms": 500},
+        )
+        mw = RoEEnforcementMiddleware(jitter_frac=0.0)
+        slept: list[float] = []
+        monkeypatch.setattr(roe_mod.time, "sleep", lambda s: slept.append(s))
+        handler = MagicMock()
+        req = _make_request("bash", "nmap 8.8.8.8", state={"workspace_path": str(tmp_path)})
+        result = mw.wrap_tool_call(req, handler)
+        assert "[ROE_REFUSED]" in result.content
+        assert not handler.called
+        assert slept == []
+
+    def test_ungated_tool_not_paced(self, tmp_path: Path, monkeypatch) -> None:
+        _write_roe(tmp_path, {"mode": "audit", "min_inter_request_delay_ms": 500})
+        mw = RoEEnforcementMiddleware(jitter_frac=0.0)
+        slept: list[float] = []
+        monkeypatch.setattr(roe_mod.time, "sleep", lambda s: slept.append(s))
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        req = _make_request("opplan_add_objective", "", state={"workspace_path": str(tmp_path)})
+        mw.wrap_tool_call(req, handler)
+        mw.wrap_tool_call(req, handler)
+        assert slept == []


### PR DESCRIPTION
## Summary

`MachineEnforcement.min_inter_request_delay_ms` is parsed out of `roe.json`
(`types/roe.py`) but was **consumed by nothing** — there was no runtime
request-cadence control anywhere (`opplan.py` only prints an `OPSEC: careful`
label). This activates that dead knob: `RoEEnforcementMiddleware` now paces
gated tool calls to honour the configured minimum inter-request delay, with
OPSEC jitter on top.

## Changes

- Pace gated calls (`bash` / `bash_output` / `bash_kill`) to the configured
  `min_inter_request_delay_ms`. The gap is enforced between *consecutive*
  gated calls per agent (the middleware instance is per-agent), so isolated,
  well-spaced calls never wait and only bursts are throttled.
- Add up to `jitter_frac` (default 25%) of the floor as random jitter **only
  when a call is actually paced**, so the cadence isn't a fixed-interval IOC.
  The effective delay never drops below the configured minimum.
- Refused calls (ENFORCE mode) and ungated tools are never paced.
- Each pace is recorded to the RoE audit ledger as a `throttle` event
  (`reason_code=MIN_INTER_REQUEST_DELAY`) so the out-brief shows where cadence
  control fired.
- Both the sync (`time.sleep`) and async (`asyncio.sleep`) tool-call paths are
  paced.

## Scope / non-goals

Activates `min_inter_request_delay_ms` only. The companion
`max_concurrent_connections` cap is deferred to a follow-up: a correct
*dynamic* (hot-reloadable) concurrency limiter spanning the sync and async
paths is a larger change than this self-contained cadence throttle. Framed
honestly as agent-issued **call cadence + OPSEC jitter**, not a network-layer
DoS cap.

## Testing

- [x] `uv run ruff check` + `ruff format --check` clean
- [x] `uv run basedpyright packages/decepticon/decepticon/middleware/roe.py` — 0 errors
- [x] `uv run pytest packages/decepticon/tests/unit/middleware/` — **441 passed**
  (7 new throttle tests; 0 regressions)
- [ ] `make quality` (full Python + CLI + Web) — run in CI

## Notes

No CODEOWNERS-protected paths touched (`middleware/roe.py`, `tests/`). One
self-contained PR per `docs/COWORK.md`. Independent of the in-flight KG
engagement-scope PR.
