### PR TITLE
fix(kg): promote indexed scalar props to top-level Neo4j props on upsert

### DIFF
--- a/packages/decepticon/decepticon/tools/research/neo4j_store.py
+++ b/packages/decepticon/decepticon/tools/research/neo4j_store.py
@@ -159,6 +159,7 @@ def _read_engagement(all_engagements: bool) -> str | None:
         return None
     return get_active_engagement()
 
+
 class Neo4jStore:
     """Load/query/upsert knowledge graph nodes and edges in Neo4j.
 

--- a/packages/decepticon/decepticon/tools/research/neo4j_store.py
+++ b/packages/decepticon/decepticon/tools/research/neo4j_store.py
@@ -108,6 +108,43 @@ def _encode_props(props: dict[str, Any]) -> str:
         return "{}"
 
 
+_INDEXED_SCALAR_KEYS: frozenset[str] = frozenset(
+    {
+        "ip",
+        "fqdn",
+        "cidr",
+        "url",
+        "cve_id",
+        "cwe_id",
+        "technique_id",
+        "arn",
+        "address",
+        "explored",
+        "compromised",
+        "product",
+        "version",
+        "severity",
+        "validated",
+        "vuln_class",
+        "status",
+        "cracked",
+        "tactic",
+        "admin",
+    }
+)
+
+
+def _promoted_props(scoped_props: dict[str, Any]) -> dict[str, Any]:
+    promoted: dict[str, Any] = {}
+    for key in _INDEXED_SCALAR_KEYS:
+        if key not in scoped_props:
+            continue
+        value = scoped_props[key]
+        if isinstance(value, bool) or isinstance(value, (str, int, float)):
+            promoted[key] = value
+    return promoted
+
+
 class Neo4jStore:
     """Load/query/upsert knowledge graph nodes and edges in Neo4j.
 
@@ -247,6 +284,7 @@ class Neo4jStore:
             n.engagement = $engagement,
             n.created_at = coalesce(n.created_at, $created_at),
             n.updated_at = $updated_at
+        SET n += $promoted
         """
         params = {
             "id": node.id,
@@ -257,6 +295,7 @@ class Neo4jStore:
             "engagement": engagement,
             "created_at": node.created_at,
             "updated_at": now,
+            "promoted": _promoted_props(scoped_props),
         }
         with self._driver.session(database=self._database) as session:
             session.run(query, params)
@@ -320,6 +359,7 @@ class Neo4jStore:
                     "engagement": scoped_props["engagement"],
                     "created_at": node.created_at,
                     "updated_at": now,
+                    "promoted": _promoted_props(scoped_props),
                 }
             )
 
@@ -336,6 +376,7 @@ class Neo4jStore:
                     n.engagement = row.engagement,
                     n.created_at = coalesce(n.created_at, row.created_at),
                     n.updated_at = row.updated_at
+                SET n += row.promoted
                 """
                 session.run(query, batch=batch)
                 total += len(batch)

--- a/packages/decepticon/tests/unit/research/test_neo4j_store.py
+++ b/packages/decepticon/tests/unit/research/test_neo4j_store.py
@@ -21,6 +21,7 @@ from decepticon.tools.research.neo4j_store import (
     _decode_props,
     _encode_props,
     _label_for,
+    _promoted_props,
 )
 from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
 
@@ -179,6 +180,33 @@ class TestEncodeProps:
         monkeypatch.setattr(mod.json, "dumps", bad_dumps)
         assert mod._encode_props({"x": 1}) == "{}"
         monkeypatch.setattr(mod.json, "dumps", original_dumps)
+
+
+class TestPromotedProps:
+    def test_whitelisted_scalars_promoted(self) -> None:
+        result = _promoted_props({"severity": "high", "validated": True, "engagement": "acme"})
+        assert result == {"severity": "high", "validated": True}
+
+    def test_absent_keys_omitted_not_nulled(self) -> None:
+        result = _promoted_props({"severity": "low"})
+        assert result == {"severity": "low"}
+        assert "validated" not in result
+
+    def test_none_values_skipped(self) -> None:
+        result = _promoted_props({"severity": None, "validated": False})
+        assert result == {"validated": False}
+
+    def test_dict_and_list_values_skipped(self) -> None:
+        result = _promoted_props({"status": ["open"], "severity": {"x": 1}, "cracked": True})
+        assert result == {"cracked": True}
+
+    def test_non_whitelisted_keys_skipped(self) -> None:
+        result = _promoted_props({"notes": "free text", "ip": "10.0.0.1"})
+        assert result == {"ip": "10.0.0.1"}
+
+    def test_numeric_scalars_promoted(self) -> None:
+        result = _promoted_props({"version": 1, "product": "nginx"})
+        assert result == {"version": 1, "product": "nginx"}
 
 
 class TestLabelFor:
@@ -398,6 +426,25 @@ class TestUpsertNode:
         _query, params = session.runs[0]
         assert params["key"] == node.id
 
+    def test_upsert_node_promotes_indexed_scalar_props(self) -> None:
+        session = _FakeSession()
+        driver = _FakeDriver(sessions=[session])
+        store = _make_store(driver)
+        node = Node.make(NodeKind.VULNERABILITY, "v1", severity="high", validated=True)
+        store.upsert_node(node)
+        query, params = session.runs[0]
+        assert "n += $promoted" in query
+        assert params["promoted"] == {"severity": "high", "validated": True}
+
+    def test_upsert_node_promoted_excludes_non_whitelisted(self) -> None:
+        session = _FakeSession()
+        driver = _FakeDriver(sessions=[session])
+        store = _make_store(driver)
+        node = Node.make(NodeKind.VULNERABILITY, "v2", severity="medium", notes="ignore me")
+        store.upsert_node(node)
+        _query, params = session.runs[0]
+        assert params["promoted"] == {"severity": "medium"}
+
 
 class TestUpsertEdge:
     def test_upsert_edge_runs_merge_query_with_correct_params(self) -> None:
@@ -465,6 +512,18 @@ class TestBatchUpsertNodes:
             assert batch[0]["engagement"] == "test-eng"
         finally:
             reset_active_engagement(token)
+
+    def test_batch_rows_include_promoted_map_and_query(self) -> None:
+        session = _FakeSession()
+        driver = _FakeDriver(sessions=[session])
+        store = _make_store(driver)
+        node = Node.make(NodeKind.VULNERABILITY, "v1", severity="high", validated=True)
+        store.batch_upsert_nodes([node])
+        query, params = session.runs[0]
+        assert "n += row.promoted" in query
+        batch = params.get("batch", [])
+        assert len(batch) == 1
+        assert batch[0]["promoted"] == {"severity": "high", "validated": True}
 
 
 class TestBatchUpsertEdges:


### PR DESCRIPTION
## Summary
`upsert_node`/`batch_upsert_nodes` stored scalar props (severity, validated, explored, …) **only inside the `n.props` JSON blob**, never as top-level Neo4j properties. So every declared index (`vuln_severity`, `vuln_validated`, `host_explored`, …) is dead and Cypher reads of top-level props return null — `chain.py:336` `coalesce(v.severity,'info')` always returns `info` (critical chains mis-scored as info) and `chain.py:394` `h.explored=false` never matches (unexplored_surface permanently empty).

## Changes
- Add `_INDEXED_SCALAR_KEYS` (exactly the keys backing the declared constraints/indexes) + `_promoted_props()` (present scalar str/int/float/bool only).
- `upsert_node`: `SET n += $promoted`; `batch_upsert_nodes`: per-row `promoted` map + `SET n += row.promoted` (map-merge — never null-wipes absent keys). JSON blob retained for fidelity. `ensure_schema` untouched.

## Testing
- ruff + ruff format clean; basedpyright 0 errors; `pytest test_neo4j_store.py` **73 passed** (new helper + single/batch promotion tests).

No CODEOWNERS paths. Overlaps PR #462 (read-side of same file) — trivial rebase.
