### PR TITLE
fix(kg): do not persist graph after a failed transaction body

### DIFF
--- a/packages/decepticon/decepticon/tools/research/_state.py
+++ b/packages/decepticon/decepticon/tools/research/_state.py
@@ -83,17 +83,7 @@ def _json(data: Any) -> str:
 
 @contextmanager
 def graph_transaction():
-    """Load the graph, yield it for mutation, save on exit.
-
-    Thread-safe: only one transaction runs at a time.
-    Crash-safe: saves even if the body raises (best-effort).
-    """
     with _GRAPH_LOCK:
         graph, path = _load()
-        try:
-            yield graph
-        finally:
-            try:
-                _save(graph, path)
-            except Exception:
-                log.exception("Failed to save graph after transaction")
+        yield graph
+        _save(graph, path)

--- a/packages/decepticon/tests/unit/research/test_state_backend.py
+++ b/packages/decepticon/tests/unit/research/test_state_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 
@@ -90,3 +91,32 @@ def test_save_compat_batch_upserts(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_json_helper() -> None:
     result = state._json({"key": "value"})
     assert '"key": "value"' in result
+
+
+def test_transaction_does_not_save_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    save_calls: list[KnowledgeGraph] = []
+
+    monkeypatch.setattr(state, "_load", lambda: (KnowledgeGraph(), Path("/dev/null")))
+    monkeypatch.setattr(state, "_save", lambda graph, path=None: save_calls.append(graph))
+
+    with pytest.raises(RuntimeError):
+        with state.graph_transaction():
+            raise RuntimeError("boom")
+
+    assert save_calls == []
+
+
+def test_transaction_saves_once_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    save_calls: list[KnowledgeGraph] = []
+
+    monkeypatch.setattr(state, "_load", lambda: (KnowledgeGraph(), Path("/dev/null")))
+    monkeypatch.setattr(state, "_save", lambda graph, path=None: save_calls.append(graph))
+
+    with state.graph_transaction() as g:
+        g.upsert_node(Node.make(NodeKind.HOST, "10.0.0.2", key="host::10.0.0.2"))
+
+    assert len(save_calls) == 1


### PR DESCRIPTION
## Summary
`graph_transaction()` saved the in-memory graph in a `finally` block, so if the with-body raised after partially mutating the graph, the half-applied state was committed to Neo4j (upsert-only, no rollback) across 27 call sites while the agent saw a failed tool call.

## Changes
- Save **only on the success path** (acquire `_GRAPH_LOCK` → `_load()` → `yield` → `_save()`); on exception, propagate without saving. Thread-safety preserved. Removed the misleading "crash-safe" docstring.

## Testing
- ruff/format clean; basedpyright 0 errors; `pytest test_state_backend.py` **7 passed** — new tests assert `_save` is NOT called when the body raises, and is called once on success.

No CODEOWNERS paths. Orthogonal to PR #462.
