### PR TITLE
fix(budget): close psycopg2 connection in LiteLLM spend provider

### DIFF
--- a/packages/decepticon/decepticon/middleware/budget.py
+++ b/packages/decepticon/decepticon/middleware/budget.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from contextlib import closing
 from typing import Any, ClassVar
 
 from langchain.agents.middleware import AgentMiddleware
@@ -274,17 +275,18 @@ def _default_litellm_spend_provider(scope_key: str) -> float:
         log.warning("psycopg2 unavailable — install psycopg2-binary to enable budget enforcement")
         return 0.0
     try:
-        with psycopg2.connect(db_url) as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT COALESCE(SUM(spend), 0)::float
-                FROM "LiteLLM_SpendLogs"
-                WHERE metadata->>'scope_key' = %s
-                """,
-                (scope_key,),
-            )
-            row = cur.fetchone()
-            return float(row[0]) if row else 0.0
+        with closing(psycopg2.connect(db_url)) as conn:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT COALESCE(SUM(spend), 0)::float
+                    FROM "LiteLLM_SpendLogs"
+                    WHERE metadata->>'scope_key' = %s
+                    """,
+                    (scope_key,),
+                )
+                row = cur.fetchone()
+                return float(row[0]) if row else 0.0
     except Exception as exc:  # noqa: BLE001
         log.warning("LiteLLM spend query failed for scope=%s: %s", scope_key, exc)
         return 0.0

--- a/packages/decepticon/tests/unit/middleware/test_budget_internals.py
+++ b/packages/decepticon/tests/unit/middleware/test_budget_internals.py
@@ -19,12 +19,16 @@ The spend source is injected, so there is no LiteLLM / Postgres dependency.
 
 from __future__ import annotations
 
+import sys
+import types
+
 import pytest
 
 from decepticon.middleware import budget as budget_mod
 from decepticon.middleware.budget import (
     BudgetEnforcementMiddleware,
     BudgetExceeded,
+    _default_litellm_spend_provider,
     _emit_warning_event,
     _env_float,
     _SpendCache,
@@ -208,3 +212,89 @@ def test_emit_warning_event_swallows_writer_errors(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(lgconfig, "get_stream_writer", lambda: _boom)
     _emit_warning_event("agent", 1.0, 2.0, 0.5)  # logged, not raised
+
+
+class _StubCursor:
+    def __init__(self, row: tuple[object, ...]) -> None:
+        self._row = row
+
+    def __enter__(self) -> _StubCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def execute(self, _sql: str, _params: object) -> None:
+        return None
+
+    def fetchone(self) -> tuple[object, ...]:
+        return self._row
+
+
+class _StubConnection:
+    def __init__(self, row: tuple[object, ...], closed: list[int]) -> None:
+        self._row = row
+        self._closed = closed
+
+    def __enter__(self) -> _StubConnection:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def cursor(self) -> _StubCursor:
+        return _StubCursor(self._row)
+
+    def close(self) -> None:
+        self._closed.append(1)
+
+
+def _install_stub_psycopg2(
+    monkeypatch: pytest.MonkeyPatch,
+    row: tuple[object, ...],
+    closed: list[int],
+) -> None:
+    module = types.ModuleType("psycopg2")
+    module.connect = lambda _dsn: _StubConnection(row, closed)
+    monkeypatch.setitem(sys.modules, "psycopg2", module)
+
+
+def test_default_provider_closes_connection_once(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub/db")
+    closed: list[int] = []
+    _install_stub_psycopg2(monkeypatch, (12.5,), closed)
+
+    result = _default_litellm_spend_provider("engagement:test")
+
+    assert result == 12.5
+    assert closed == [1]
+
+
+def test_default_provider_closes_connection_on_query_error(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub/db")
+    closed: list[int] = []
+
+    class _BoomCursor(_StubCursor):
+        def execute(self, _sql: str, _params: object) -> None:
+            raise RuntimeError("boom")
+
+    module = types.ModuleType("psycopg2")
+
+    class _Conn(_StubConnection):
+        def cursor(self) -> _BoomCursor:
+            return _BoomCursor((0.0,))
+
+    module.connect = lambda _dsn: _Conn((0.0,), closed)
+    monkeypatch.setitem(sys.modules, "psycopg2", module)
+
+    assert _default_litellm_spend_provider("engagement:test") == 0.0
+    assert closed == [1]
+
+
+def test_default_provider_no_database_url(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    closed: list[int] = []
+    _install_stub_psycopg2(monkeypatch, (5.0,), closed)
+
+    assert _default_litellm_spend_provider("engagement:test") == 0.0
+    assert closed == []


### PR DESCRIPTION
## Summary
`_default_litellm_spend_provider` used `with psycopg2.connect(...) as conn` — psycopg2's connection CM manages the **transaction, not close()** — so every spend check leaked a Postgres connection. On a long run this climbs toward `max_connections`; once exhausted, `connect()` throws, the broad except returns `0.0`, and the budget cap is silently disabled.

## Changes
- Wrap with `contextlib.closing(psycopg2.connect(...))`; keep the inner `with conn, conn.cursor()` transaction and the `except → 0.0` fallback.

## Testing
- ruff/format clean; basedpyright 0 errors; `pytest test_budget_internals.py`+`test_budget.py` **28 passed** — stub-psycopg2 tests assert `close()` is called exactly once per invocation (success and error paths).

No CODEOWNERS paths.
