### PR TITLE
fix(untrusted-output): quarantine HTTP/browser/proxy tool output as untrusted

### DIFF
--- a/packages/decepticon/decepticon/middleware/untrusted_output.py
+++ b/packages/decepticon/decepticon/middleware/untrusted_output.py
@@ -76,6 +76,15 @@ UNTRUSTED_TOOL_NAMES: frozenset[str] = frozenset(
         # file reaches the model wrapped + risk-scored, not as trusted text.
         "scan_shard",
         "rank_candidates",
+        "http_request",
+        "http_history",
+        "browser_action",
+        "proxy_list_requests",
+        "proxy_view_request",
+        "proxy_send_request",
+        "proxy_repeat_request",
+        "proxy_list_sitemap",
+        "proxy_view_sitemap_entry",
     }
 )
 

--- a/packages/decepticon/tests/unit/middleware/test_prompt_injection_shield.py
+++ b/packages/decepticon/tests/unit/middleware/test_prompt_injection_shield.py
@@ -209,15 +209,24 @@ def test_skill_loader_rename_is_picked_up_dynamically(monkeypatch):
 
 def test_external_tools_are_wrapped():
     mw = PromptInjectionShieldMiddleware(append_policy_to_system=False)
-    # ``bash``/``read_file``/``kg_*`` are intentionally excluded: the
+    # ``bash``/``read_file``/``kg_*`` and the network tools (``http_request``,
+    # ``browser_action``, ``proxy_*``) are intentionally excluded: the
     # UNTRUSTED_OUTPUT slot envelopes them, so the shield skips them to avoid
-    # double-wrapping (covered by test_shield_skips_untrusted_output_tools_no_double_wrap).
-    for name in ("http_fetch", "http_request", "totally_unknown_tool"):
+    # double-wrapping (covered by test_untrusted_network_tools_are_skipped_by_shield).
+    for name in ("http_fetch", "totally_unknown_tool"):
         assert _is_trusted_internal_tool(name) is False
         msg = ToolMessage(content="attacker controlled bytes", tool_call_id="t1", name=name)
         result = mw._maybe_wrap(_DummyRequest(name), msg)
         assert "<untrusted_tool_output>" in result.content
         assert "attacker controlled bytes" in result.content
+
+
+def test_untrusted_network_tools_are_skipped_by_shield():
+    mw = PromptInjectionShieldMiddleware(append_policy_to_system=False)
+    for name in ("http_request", "browser_action", "proxy_send_request"):
+        msg = ToolMessage(content="attacker controlled bytes", tool_call_id="t1", name=name)
+        result = mw._maybe_wrap(_DummyRequest(name), msg)
+        assert result.content == "attacker controlled bytes"
 
 
 def test_fallback_when_registry_unavailable(monkeypatch):

--- a/packages/decepticon/tests/unit/middleware/test_untrusted_output.py
+++ b/packages/decepticon/tests/unit/middleware/test_untrusted_output.py
@@ -139,6 +139,29 @@ class TestEnvelopeWrapping:
             assert f'origin="{tool_name}"' in result.content, tool_name
             assert "candidate hit from target file" in result.content, tool_name
 
+    def test_network_tools_output_is_quarantined(self) -> None:
+        mw = UntrustedOutputMiddleware()
+        network_tools = (
+            "http_request",
+            "http_history",
+            "browser_action",
+            "proxy_list_requests",
+            "proxy_view_request",
+            "proxy_send_request",
+            "proxy_repeat_request",
+            "proxy_list_sitemap",
+            "proxy_view_sitemap_entry",
+        )
+        for tool_name in network_tools:
+            assert tool_name in UNTRUSTED_TOOL_NAMES, tool_name
+            request = _make_request(tool_name)
+            handler = MagicMock(return_value=_tool_message("response bytes from target"))
+            result = mw.wrap_tool_call(request, handler)
+            assert isinstance(result, ToolMessage)
+            assert "<UNTRUSTED_TOOL_OUTPUT" in result.content, tool_name
+            assert f'origin="{tool_name}"' in result.content, tool_name
+            assert "response bytes from target" in result.content, tool_name
+
     def test_embedded_marker_cannot_break_out_of_envelope(self) -> None:
         # Regression: attacker-controlled tool output containing the closing
         # envelope marker must not forge/close the quarantine and smuggle text


### PR DESCRIPTION
## Summary
Defense-in-depth: `UNTRUSTED_TOOL_NAMES` omitted the tools returning the most attacker-controlled bytes, so the strong quarantine envelope (provenance + risk=high + quarantine ledger) never wrapped web/DOM/proxy output.

## Changes
- Add the real registered tool names: `http_request`, `http_history`, `browser_action`, and proxy capture/replay tools (`proxy_list_requests`, `proxy_view_request`, `proxy_send_request`, `proxy_repeat_request`, `proxy_list_sitemap`, `proxy_view_sitemap_entry`). Excludes operator-config tools (`proxy_scope_rules`) and input-operating tools (jwt/oauth/cookie/graphql).

## Testing
- ruff/format clean; basedpyright 0 errors; `pytest test_untrusted_output.py` **52 passed**.

No CODEOWNERS paths. These tools aren't in default agent loadouts yet — framed as defense-in-depth (latent until a plugin/custom agent attaches them).
