### PR TITLE
feat(roe): wire an out-of-band emergency abort kill-switch into the RoE gate

### DIFF
--- a/packages/decepticon/decepticon/middleware/roe.py
+++ b/packages/decepticon/decepticon/middleware/roe.py
@@ -76,6 +76,26 @@ def _load_rules_for_workspace(workspace_path: str | None) -> MachineEnforcement:
     return MachineEnforcement.from_dict(block)
 
 
+def _abort_marker_present(workspace_path: str | None) -> bool:
+    if not workspace_path:
+        return False
+    try:
+        return (Path(workspace_path) / ".abort").exists()
+    except OSError:
+        return False
+
+
+def _halted_message(tool_name: str, tool_call_id: str | None) -> ToolMessage:
+    body = (
+        f"[AGENT_HALTED] code=EMERGENCY_ABORT tool={tool_name}\n"
+        "An out-of-band emergency abort was signalled by the operator "
+        "(.abort marker in the workspace). This gated call was NOT executed.\n"
+        "Stop work immediately and await operator instructions - do NOT "
+        "retry or attempt alternative commands this turn."
+    )
+    return ToolMessage(content=body, tool_call_id=tool_call_id or "", status="error")
+
+
 def _refused_message(decision: Decision, tool_name: str, tool_call_id: str | None) -> ToolMessage:
     body = (
         f"[ROE_REFUSED] code={decision.reason_code} tool={tool_name}\n"
@@ -162,6 +182,9 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         return await self._dispatch_async(request, handler)
 
     def _dispatch_sync(self, request, handler):
+        halt = self._check_abort(request)
+        if halt is not None:
+            return halt
         decision, rules, tool_name = self._evaluate(request)
         self._record(request, tool_name, decision, rules.mode)
         if not decision.allow and rules.mode == EnforcementMode.ENFORCE:
@@ -176,6 +199,9 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         return result
 
     async def _dispatch_async(self, request, handler):
+        halt = self._check_abort(request)
+        if halt is not None:
+            return halt
         decision, rules, tool_name = self._evaluate(request)
         self._record(request, tool_name, decision, rules.mode)
         if not decision.allow and rules.mode == EnforcementMode.ENFORCE:
@@ -188,6 +214,41 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         ):
             return _warn_message(decision, result)
         return result
+
+    def _check_abort(self, request) -> ToolMessage | None:
+        tool = getattr(request, "tool", None)
+        tool_name = getattr(tool, "name", "unknown") if tool else "unknown"
+        if tool_name not in self._gated:
+            return None
+        state = getattr(request, "state", {}) or {}
+        get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+        workspace = get("workspace_path") or None
+        if not _abort_marker_present(workspace):
+            return None
+        self._record_abort(request, tool_name)
+        return _halted_message(tool_name, _tcid(request))
+
+    def _record_abort(self, request, tool_name: str) -> None:
+        if self._sink is None:
+            return
+        state = getattr(request, "state", {}) or {}
+        get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+        engagement = get("engagement_name") or "unknown-engagement"
+        objective = get("active_objective_id") or get("current_objective") or ""
+        record = {
+            "ts": time.time(),
+            "event": "abort",
+            "engagement": engagement,
+            "objective_id": objective,
+            "tool": tool_name,
+            "decision": "refuse",
+            "reason_code": "EMERGENCY_ABORT",
+            "command_excerpt": _command_from_tool_call(request)[:512],
+        }
+        try:
+            self._sink.append(record)
+        except Exception as exc:  # noqa: BLE001 - audit must never break tool execution
+            log.error("roe: audit sink write failed: %s", exc)
 
     def _evaluate(self, request) -> tuple[Decision, MachineEnforcement, str]:
         tool = getattr(request, "tool", None)

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -365,6 +365,51 @@ class TestRoEMiddleware:
         assert recs[0]["reason_code"] == "NOT_IN_SCOPE"
 
 
+class TestEmergencyAbort:
+    def test_abort_marker_halts_gated_call(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["10.0.0.0/24"]})
+        (tmp_path / ".abort").write_text("", encoding="utf-8")
+        sink = RoEAuditSink(path=tmp_path / "audit.jsonl")
+        mw = RoEEnforcementMiddleware(sink=sink)
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert isinstance(result, ToolMessage)
+        assert result.content.startswith("[AGENT_HALTED]")
+        assert result.status == "error"
+        recs = [json.loads(line) for line in (tmp_path / "audit.jsonl").read_text().splitlines()]
+        assert len(recs) == 1
+        assert recs[0]["event"] == "abort"
+        assert recs[0]["reason_code"] == "EMERGENCY_ABORT"
+
+    def test_no_marker_allows_gated_call(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["10.0.0.0/24"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_abort_marker_ignored_for_ungated_tool(self, tmp_path: Path) -> None:
+        (tmp_path / ".abort").write_text("", encoding="utf-8")
+        mw = RoEEnforcementMiddleware()
+        req = _make_request("opplan_add_objective", "", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_no_workspace_does_not_halt(self) -> None:
+        mw = RoEEnforcementMiddleware()
+        req = _make_request("bash", "nmap 10.0.0.10", state={})
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+
 class TestSlotRegistration:
     def test_slot_is_in_enum_and_safety_critical(self) -> None:
         from decepticon_core.contracts.slots import (


### PR DESCRIPTION
## Summary
There is no in-band emergency halt for an autonomous run (only CLI Ctrl+C). `AbortPlan` is designed but unconsumed. This adds an out-of-band kill-switch into the RoE gate.

## Changes
- On every **gated** tool call, check for an out-of-band sentinel `<workspace>/.abort`. When present, short-circuit the call (handler not run) with an `[AGENT_HALTED]` `ToolMessage` and record an `event:abort` / `EMERGENCY_ABORT` audit record. Degrades cleanly when absent. Applied to both sync and async dispatch. No middleware slot added.

## Testing
- ruff/format clean; basedpyright 0 errors; `pytest test_roe.py` **52 passed** (halt-on-marker, proceed-without, ungated-ignored, no-workspace).

No CODEOWNERS paths. Kill-switch half only (authorized-window gate is a separate PR). Overlaps PR #463/#redact in roe.py — additive, mergeable.
