### PR TITLE
feat(roe): enforce authorized testing + blackout windows on gated tool calls

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/roe.py
+++ b/packages/decepticon-core/decepticon_core/types/roe.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import ipaddress
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from typing import Any, Iterable
 
@@ -100,6 +101,8 @@ class MachineEnforcement:
     allow_cloud_metadata: bool = False
     max_concurrent_connections: int | None = None
     min_inter_request_delay_ms: int = 0
+    authorized_windows: tuple[tuple[datetime, datetime], ...] = field(default_factory=tuple)
+    blackout_windows: tuple[tuple[datetime, datetime], ...] = field(default_factory=tuple)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> MachineEnforcement:
@@ -119,6 +122,8 @@ class MachineEnforcement:
             allow_cloud_metadata=bool(data.get("allow_cloud_metadata", False)),
             max_concurrent_connections=data.get("max_concurrent_connections"),
             min_inter_request_delay_ms=int(data.get("min_inter_request_delay_ms") or 0),
+            authorized_windows=tuple(_parse_windows(data.get("authorized_windows") or ())),
+            blackout_windows=tuple(_parse_windows(data.get("blackout_windows") or ())),
         )
 
     def effective_forbidden_destinations(self) -> tuple[str, ...]:
@@ -135,6 +140,33 @@ def _parse_rules(items: Iterable[Any]) -> list[ScopeRule]:
         elif isinstance(item, dict) and item.get("target"):
             rules.append(ScopeRule(pattern=str(item["target"]), kind=str(item.get("type", "auto"))))
     return rules
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_windows(items: Iterable[Any]) -> list[tuple[datetime, datetime]]:
+    windows: list[tuple[datetime, datetime]] = []
+    for item in items:
+        start_raw: Any = None
+        end_raw: Any = None
+        if isinstance(item, dict):
+            start_raw = item.get("start")
+            end_raw = item.get("end")
+        elif isinstance(item, (list, tuple)) and len(item) == 2:
+            start_raw, end_raw = item[0], item[1]
+        start = _parse_iso(start_raw)
+        end = _parse_iso(end_raw)
+        if start is None or end is None or end <= start:
+            continue
+        windows.append((start, end))
+    return windows
 
 
 @dataclass(frozen=True, slots=True)
@@ -253,4 +285,44 @@ def evaluate_command(
                 )
         except re.error:
             continue
+    return Decision.allow_default()
+
+
+def _within(now: datetime, window: tuple[datetime, datetime]) -> bool:
+    start, end = window
+    return start <= now < end
+
+
+def evaluate_time_window(
+    now: datetime,
+    rules: MachineEnforcement,
+) -> Decision:
+    for window in rules.blackout_windows:
+        if _within(now, window):
+            return Decision.refuse(
+                code="BLACKOUT_WINDOW",
+                detail=(
+                    f"{now.isoformat()} falls inside blackout window "
+                    f"{window[0].isoformat()}..{window[1].isoformat()}"
+                ),
+                matched=(f"{window[0].isoformat()}/{window[1].isoformat()}",),
+            )
+
+    if rules.authorized_windows:
+        for window in rules.authorized_windows:
+            if _within(now, window):
+                return Decision(
+                    allow=True,
+                    reason_code="IN_TESTING_WINDOW",
+                    reason_detail=(
+                        f"{now.isoformat()} is inside authorized window "
+                        f"{window[0].isoformat()}..{window[1].isoformat()}"
+                    ),
+                )
+        return Decision.refuse(
+            code="OUTSIDE_TESTING_WINDOW",
+            detail=f"{now.isoformat()} is outside all authorized testing windows",
+            risk="medium",
+        )
+
     return Decision.allow_default()

--- a/packages/decepticon/decepticon/middleware/roe.py
+++ b/packages/decepticon/decepticon/middleware/roe.py
@@ -31,8 +31,9 @@ import json
 import logging
 import os
 import time
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import ToolMessage
@@ -47,6 +48,7 @@ from decepticon_core.types.roe import (
     MachineEnforcement,
     evaluate_command,
     evaluate_target,
+    evaluate_time_window,
 )
 
 log = logging.getLogger(__name__)
@@ -148,10 +150,12 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         *,
         sink: RoEAuditSink | None = None,
         gated_tools: frozenset[str] | None = None,
+        now: Callable[[], datetime] | None = None,
     ) -> None:
         super().__init__()
         self._sink = sink
         self._gated = gated_tools or GATED_TOOL_NAMES
+        self._now = now or (lambda: datetime.now(timezone.utc))
 
     @override
     def wrap_tool_call(self, request, handler) -> ToolMessage | Command:
@@ -198,6 +202,9 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
         workspace = get("workspace_path") or None
         rules = _load_rules_for_workspace(workspace)
+        time_decision = evaluate_time_window(self._now(), rules)
+        if not time_decision.allow:
+            return time_decision, rules, tool_name
         command = _command_from_tool_call(request)
         cmd_decision = evaluate_command(command, rules)
         if not cmd_decision.allow:

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -18,6 +19,7 @@ from decepticon_core.types.roe import (
     MachineEnforcement,
     evaluate_command,
     evaluate_target,
+    evaluate_time_window,
 )
 
 
@@ -118,6 +120,90 @@ class TestEvaluateCommand:
     def test_invalid_regex_skipped(self) -> None:
         rules = MachineEnforcement.from_dict({"forbidden_command_patterns": ["[unclosed"]})
         assert evaluate_command("rm -rf /etc", rules).allow
+
+
+class TestTimeWindowSchema:
+    def test_no_windows_by_default(self) -> None:
+        rules = MachineEnforcement.from_dict({})
+        assert rules.authorized_windows == ()
+        assert rules.blackout_windows == ()
+
+    def test_authorized_windows_parsed_from_pairs(self) -> None:
+        rules = MachineEnforcement.from_dict(
+            {"authorized_windows": [["2026-06-01T09:00:00+00:00", "2026-06-01T18:00:00+00:00"]]}
+        )
+        assert len(rules.authorized_windows) == 1
+        start, end = rules.authorized_windows[0]
+        assert start == datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
+        assert end == datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc)
+
+    def test_dict_windows_parsed(self) -> None:
+        rules = MachineEnforcement.from_dict(
+            {
+                "blackout_windows": [
+                    {"start": "2026-06-01T22:00:00+00:00", "end": "2026-06-02T06:00:00+00:00"}
+                ]
+            }
+        )
+        assert len(rules.blackout_windows) == 1
+
+    def test_bad_values_skipped(self) -> None:
+        rules = MachineEnforcement.from_dict(
+            {
+                "authorized_windows": [
+                    ["not-a-date", "2026-06-01T18:00:00+00:00"],
+                    ["2026-06-01T18:00:00+00:00", "2026-06-01T09:00:00+00:00"],
+                    "Mon-Fri 09:00-18:00 KST",
+                    ["2026-06-01T09:00:00+00:00", "2026-06-01T18:00:00+00:00"],
+                ]
+            }
+        )
+        assert len(rules.authorized_windows) == 1
+
+
+class TestEvaluateTimeWindow:
+    AUTH = {"authorized_windows": [["2026-06-01T09:00:00+00:00", "2026-06-01T18:00:00+00:00"]]}
+    BLACKOUT = {"blackout_windows": [["2026-06-01T12:00:00+00:00", "2026-06-01T13:00:00+00:00"]]}
+
+    def test_no_windows_allow(self) -> None:
+        now = datetime(2026, 6, 1, 3, 0, tzinfo=timezone.utc)
+        assert evaluate_time_window(now, MachineEnforcement()).allow
+
+    def test_in_window_allow(self) -> None:
+        rules = MachineEnforcement.from_dict(self.AUTH)
+        now = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+        d = evaluate_time_window(now, rules)
+        assert d.allow
+        assert d.reason_code == "IN_TESTING_WINDOW"
+
+    def test_out_of_window_refuse(self) -> None:
+        rules = MachineEnforcement.from_dict(self.AUTH)
+        now = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        d = evaluate_time_window(now, rules)
+        assert not d.allow
+        assert d.reason_code == "OUTSIDE_TESTING_WINDOW"
+
+    def test_window_end_is_exclusive(self) -> None:
+        rules = MachineEnforcement.from_dict(self.AUTH)
+        now = datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc)
+        assert not evaluate_time_window(now, rules).allow
+
+    def test_blackout_refuse(self) -> None:
+        rules = MachineEnforcement.from_dict({**self.AUTH, **self.BLACKOUT})
+        now = datetime(2026, 6, 1, 12, 30, tzinfo=timezone.utc)
+        d = evaluate_time_window(now, rules)
+        assert not d.allow
+        assert d.reason_code == "BLACKOUT_WINDOW"
+
+    def test_blackout_takes_precedence_over_authorized(self) -> None:
+        rules = MachineEnforcement.from_dict({**self.AUTH, **self.BLACKOUT})
+        now = datetime(2026, 6, 1, 12, 30, tzinfo=timezone.utc)
+        assert evaluate_time_window(now, rules).reason_code == "BLACKOUT_WINDOW"
+
+    def test_blackout_only_allows_outside_blackout(self) -> None:
+        rules = MachineEnforcement.from_dict(self.BLACKOUT)
+        now = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
+        assert evaluate_time_window(now, rules).allow
 
 
 class TestExtractTargets:
@@ -363,6 +449,84 @@ class TestRoEMiddleware:
         assert len(recs) == 1
         assert recs[0]["decision"] == "refuse"
         assert recs[0]["reason_code"] == "NOT_IN_SCOPE"
+
+    def test_enforce_refuses_outside_testing_window(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {
+                "mode": "enforce",
+                "in_scope": ["10.0.0.0/24"],
+                "authorized_windows": [["2026-06-01T09:00:00+00:00", "2026-06-01T18:00:00+00:00"]],
+            },
+        )
+        now = datetime(2026, 6, 1, 22, 0, tzinfo=timezone.utc)
+        mw = RoEEnforcementMiddleware(now=lambda: now)
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "OUTSIDE_TESTING_WINDOW" in result.content
+
+    def test_enforce_allows_inside_testing_window(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {
+                "mode": "enforce",
+                "in_scope": ["10.0.0.0/24"],
+                "authorized_windows": [["2026-06-01T09:00:00+00:00", "2026-06-01T18:00:00+00:00"]],
+            },
+        )
+        now = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+        mw = RoEEnforcementMiddleware(now=lambda: now)
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_enforce_refuses_during_blackout(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {
+                "mode": "enforce",
+                "in_scope": ["10.0.0.0/24"],
+                "blackout_windows": [["2026-06-01T12:00:00+00:00", "2026-06-01T13:00:00+00:00"]],
+            },
+        )
+        now = datetime(2026, 6, 1, 12, 30, tzinfo=timezone.utc)
+        mw = RoEEnforcementMiddleware(now=lambda: now)
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "BLACKOUT_WINDOW" in result.content
+
+    def test_enforce_allows_when_no_windows_configured(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["10.0.0.0/24"]})
+        now = datetime(2026, 6, 1, 3, 0, tzinfo=timezone.utc)
+        mw = RoEEnforcementMiddleware(now=lambda: now)
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_warn_mode_runs_outside_window_with_warning(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {
+                "mode": "warn",
+                "authorized_windows": [["2026-06-01T09:00:00+00:00", "2026-06-01T18:00:00+00:00"]],
+            },
+        )
+        now = datetime(2026, 6, 1, 22, 0, tzinfo=timezone.utc)
+        mw = RoEEnforcementMiddleware(now=lambda: now)
+        req = _make_request("bash", "nmap 10.0.0.10", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock(return_value=ToolMessage(content="scan output", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert "[ROE_WARN]" in result.content
+        assert "OUTSIDE_TESTING_WINDOW" in result.content
 
 
 class TestSlotRegistration:


### PR DESCRIPTION
## Summary
`RoE.testing_window` / `ContactPlan.blackout_windows` are designed but **unenforced** — an autonomous agent will run active scans outside the contractually authorized window.

## Changes
- `MachineEnforcement` gains optional `authorized_windows` + `blackout_windows` (ISO-8601 pairs, parsed with `datetime.fromisoformat`; bad/free-form values skipped).
- New `evaluate_time_window(now, rules)`: allow when unset (backward compatible); refuse `BLACKOUT_WINDOW` (precedence) inside a blackout; refuse `OUTSIDE_TESTING_WINDOW` when authorized windows are set and `now` is outside all. Wired as the first gated check in `_evaluate`; `now` injectable for tests.

## Testing
- ruff/format clean; basedpyright 0 errors; `pytest test_roe.py` **64 passed** (+16); public-API/schema stability **92 passed**.

No CODEOWNERS paths (`types/` not protected; additive). Overlaps PR #463 in roe.py — localized to import/`__init__`/`_evaluate`.
