### PR TITLE
feat(evidence): add SHA-256 chain-of-custody sealing tool for engagement artifacts

### DIFF
--- a/packages/decepticon/decepticon/tools/evidence/tools.py
+++ b/packages/decepticon/decepticon/tools/evidence/tools.py
@@ -2,18 +2,29 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from langchain_core.tools import tool
 
+from decepticon.middleware._audit_sink import (
+    _GENESIS_PREV_HASH,
+    _record_hash,
+    _record_hmac,
+)
 from decepticon.tools.evidence.asciicast import (
     AsciicastExportError,
     export_asciicast,
     list_recordings,
 )
+
+_MANIFEST_NAME = "chain-of-custody.jsonl"
+_SEAL_FIELDS = ("path", "sha256", "size", "sealed_at")
 
 
 def _json(data: Any) -> str:
@@ -26,6 +37,38 @@ def _workspace() -> Path:
 
 def _evidence_dir() -> Path:
     return _workspace() / "evidence" / "recordings"
+
+
+def _evidence_root(workspace_path: str) -> Path:
+    base = Path(workspace_path) if workspace_path else _workspace()
+    return base / "evidence"
+
+
+def _hmac_key() -> bytes | None:
+    env_key = os.environ.get("DECEPTICON_AUDIT_HMAC_KEY")
+    return env_key.encode("utf-8") if env_key else None
+
+
+def _hmac_equal(expected: str, stored: Any) -> bool:
+    return hmac.compare_digest(expected, str(stored or ""))
+
+
+def _hash_file(file_path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with file_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _evidence_files(evidence_root: Path, manifest_path: Path) -> list[Path]:
+    found: list[Path] = []
+    for candidate in sorted(evidence_root.rglob("*")):
+        if candidate.is_file() and candidate != manifest_path:
+            found.append(candidate)
+    return found
 
 
 @tool
@@ -79,4 +122,135 @@ def list_session_recordings() -> str:
     return _json({"count": len(manifests), "recordings": manifests})
 
 
-EVIDENCE_TOOLS = [export_session_asciicast, list_session_recordings]
+@tool(
+    description=(
+        "Seal every file under <workspace>/evidence/ into an append-only "
+        "chain-of-custody manifest. Computes SHA-256 + byte size for each "
+        "artifact and appends one HMAC-chained record per file to "
+        "evidence/chain-of-custody.jsonl so later tampering is detectable. "
+        "Pass workspace_path to override the engagement workspace root; "
+        "leave it empty to use the active engagement. Run before out-brief "
+        "to lock evidence integrity."
+    )
+)
+def seal_evidence(workspace_path: str = "") -> str:
+    evidence_root = _evidence_root(workspace_path)
+    if not evidence_root.is_dir():
+        return _json({"error": f"evidence directory not found: {evidence_root}"})
+    manifest_path = evidence_root / _MANIFEST_NAME
+    files = _evidence_files(evidence_root, manifest_path)
+    key = _hmac_key()
+    sealed_at = datetime.now(timezone.utc).isoformat()
+    prev_hash = _GENESIS_PREV_HASH
+    if manifest_path.exists():
+        with manifest_path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    prev_hash = str(json.loads(line).get("hash", prev_hash))
+                except json.JSONDecodeError:
+                    continue
+    records: list[dict[str, Any]] = []
+    with manifest_path.open("a", encoding="utf-8") as fh:
+        for file_path in files:
+            sha256, size = _hash_file(file_path)
+            rel = file_path.relative_to(evidence_root).as_posix()
+            record: dict[str, Any] = {
+                "path": rel,
+                "sha256": sha256,
+                "size": size,
+                "sealed_at": sealed_at,
+            }
+            this_hash = _record_hash(record, prev_hash)
+            record["prev_hash"] = prev_hash
+            record["hash"] = this_hash
+            record["hmac"] = _record_hmac(this_hash, key)
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+            records.append(record)
+            prev_hash = this_hash
+    return _json(
+        {
+            "status": "sealed",
+            "manifest": str(manifest_path),
+            "sealed": len(records),
+            "files": [r["path"] for r in records],
+        }
+    )
+
+
+@tool(
+    description=(
+        "Verify the evidence chain-of-custody manifest. Re-hashes every file "
+        "recorded in evidence/chain-of-custody.jsonl, recomputes the HMAC "
+        "chain, and reports drift (changed SHA-256/size), missing files, and "
+        "any broken chain links. Pass workspace_path to override the "
+        "engagement workspace root. Returns ok=true only when every record "
+        "still matches the file on disk."
+    )
+)
+def verify_evidence(workspace_path: str = "") -> str:
+    evidence_root = _evidence_root(workspace_path)
+    manifest_path = evidence_root / _MANIFEST_NAME
+    if not manifest_path.exists():
+        return _json({"error": f"manifest not found: {manifest_path}"})
+    key = _hmac_key()
+    prev_hash = _GENESIS_PREV_HASH
+    checked = 0
+    drift: list[dict[str, Any]] = []
+    missing: list[str] = []
+    chain_errors: list[dict[str, Any]] = []
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                chain_errors.append({"reason": "undecodable record", "line": checked + 1})
+                continue
+            checked += 1
+            core = {k: rec.get(k) for k in _SEAL_FIELDS}
+            recomputed = _record_hash(core, prev_hash)
+            if rec.get("prev_hash") != prev_hash or rec.get("hash") != recomputed:
+                chain_errors.append({"path": rec.get("path"), "reason": "broken chain link"})
+            elif key is not None and not _hmac_equal(
+                _record_hmac(recomputed, key), rec.get("hmac")
+            ):
+                chain_errors.append({"path": rec.get("path"), "reason": "hmac mismatch"})
+            prev_hash = str(rec.get("hash", prev_hash))
+            file_path = evidence_root / str(rec.get("path", ""))
+            if not file_path.is_file():
+                missing.append(str(rec.get("path")))
+                continue
+            sha256, size = _hash_file(file_path)
+            if sha256 != rec.get("sha256") or size != rec.get("size"):
+                drift.append(
+                    {
+                        "path": rec.get("path"),
+                        "expected_sha256": rec.get("sha256"),
+                        "actual_sha256": sha256,
+                        "expected_size": rec.get("size"),
+                        "actual_size": size,
+                    }
+                )
+    ok = not drift and not missing and not chain_errors
+    return _json(
+        {
+            "ok": ok,
+            "records_checked": checked,
+            "drift": drift,
+            "missing": missing,
+            "chain_errors": chain_errors,
+        }
+    )
+
+
+EVIDENCE_TOOLS = [
+    export_session_asciicast,
+    list_session_recordings,
+    seal_evidence,
+    verify_evidence,
+]

--- a/packages/decepticon/tests/unit/tools/test_evidence_tools.py
+++ b/packages/decepticon/tests/unit/tools/test_evidence_tools.py
@@ -6,7 +6,22 @@ from pathlib import Path
 import pytest
 
 from decepticon.tools.evidence import tools as evtools
-from decepticon.tools.evidence.tools import export_session_asciicast, list_session_recordings
+from decepticon.tools.evidence.tools import (
+    export_session_asciicast,
+    list_session_recordings,
+    seal_evidence,
+    verify_evidence,
+)
+
+
+def _seed_evidence(workspace: Path) -> Path:
+    evidence = workspace / "evidence"
+    evidence.mkdir(parents=True, exist_ok=True)
+    (evidence / "a.txt").write_text("alpha", encoding="utf-8")
+    sub = evidence / "captures"
+    sub.mkdir()
+    (sub / "b.bin").write_bytes(b"\x00\x01\x02beta")
+    return evidence
 
 
 def test_workspace_default_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -110,3 +125,79 @@ def test_list_session_recordings_returns_manifests(
     result = json.loads(list_session_recordings.invoke({}))
     assert result["count"] == 2
     assert sorted(r["session_name"] for r in result["recordings"]) == ["a", "b"]
+
+
+def test_seal_evidence_error_when_dir_missing(tmp_path: Path) -> None:
+    result = json.loads(seal_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert "error" in result
+    assert "status" not in result
+
+
+def test_seal_evidence_writes_manifest_for_each_file(tmp_path: Path) -> None:
+    _seed_evidence(tmp_path)
+    result = json.loads(seal_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert result["status"] == "sealed"
+    assert result["sealed"] == 2
+    assert sorted(result["files"]) == ["a.txt", "captures/b.bin"]
+    manifest = tmp_path / "evidence" / "chain-of-custody.jsonl"
+    assert manifest.exists()
+    records = [json.loads(line) for line in manifest.read_text().splitlines() if line.strip()]
+    assert len(records) == 2
+    assert records[0]["prev_hash"] == "0" * 64
+    assert records[1]["prev_hash"] == records[0]["hash"]
+    for rec in records:
+        assert len(rec["sha256"]) == 64
+        assert rec["size"] >= 0
+
+
+def test_verify_evidence_ok_after_seal(tmp_path: Path) -> None:
+    _seed_evidence(tmp_path)
+    seal_evidence.invoke({"workspace_path": str(tmp_path)})
+    result = json.loads(verify_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert result["ok"] is True
+    assert result["records_checked"] == 2
+    assert result["drift"] == []
+    assert result["missing"] == []
+    assert result["chain_errors"] == []
+
+
+def test_verify_evidence_flags_drift_when_file_tampered(tmp_path: Path) -> None:
+    evidence = _seed_evidence(tmp_path)
+    seal_evidence.invoke({"workspace_path": str(tmp_path)})
+    (evidence / "a.txt").write_text("TAMPERED", encoding="utf-8")
+    result = json.loads(verify_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert result["ok"] is False
+    drift_paths = [d["path"] for d in result["drift"]]
+    assert "a.txt" in drift_paths
+
+
+def test_verify_evidence_flags_missing_file(tmp_path: Path) -> None:
+    evidence = _seed_evidence(tmp_path)
+    seal_evidence.invoke({"workspace_path": str(tmp_path)})
+    (evidence / "a.txt").unlink()
+    result = json.loads(verify_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert result["ok"] is False
+    assert "a.txt" in result["missing"]
+
+
+def test_verify_evidence_error_when_manifest_absent(tmp_path: Path) -> None:
+    (tmp_path / "evidence").mkdir()
+    result = json.loads(verify_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert "error" in result
+
+
+def test_verify_evidence_flags_hmac_chain_break(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DECEPTICON_AUDIT_HMAC_KEY", "secret-key")
+    _seed_evidence(tmp_path)
+    seal_evidence.invoke({"workspace_path": str(tmp_path)})
+    manifest = tmp_path / "evidence" / "chain-of-custody.jsonl"
+    lines = manifest.read_text().splitlines()
+    first = json.loads(lines[0])
+    first["sha256"] = "0" * 64
+    lines[0] = json.dumps(first)
+    manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    result = json.loads(verify_evidence.invoke({"workspace_path": str(tmp_path)}))
+    assert result["ok"] is False
+    assert result["chain_errors"]

--- a/packages/decepticon/tests/unit/tools/test_misc_tool_wrappers.py
+++ b/packages/decepticon/tests/unit/tools/test_misc_tool_wrappers.py
@@ -309,10 +309,10 @@ class TestListSessionRecordingsTool:
         names = sorted(m["session_name"] for m in data["recordings"])
         assert names == ["a", "b"]
 
-    def test_evidence_tools_list_has_two_items(self) -> None:
+    def test_evidence_tools_list_has_four_items(self) -> None:
         from decepticon.tools.evidence.tools import EVIDENCE_TOOLS
 
-        assert len(EVIDENCE_TOOLS) == 2
+        assert len(EVIDENCE_TOOLS) == 4
 
 
 # ── cloud/tools.py wrappers ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`Evidence.sha256` / `DataHandlingPlan.chain_of_custody` are designed contracts but nothing hashes evidence files — the integrity guarantee advertised for paid/regulated engagements doesn't exist.

## Changes
- Add `seal_evidence` / `verify_evidence` tools: walk `<workspace>/evidence/`, compute streaming SHA-256 + size per file, write an append-only HMAC-chained manifest `evidence/chain-of-custody.jsonl` (reusing the `_audit_sink` chaining helpers); `verify_evidence` re-hashes and flags drift / missing / chain breaks. Exported in `EVIDENCE_TOOLS`.

## Testing
- ruff/format clean; basedpyright 0 errors; `pytest test_evidence_tools.py`+`test_misc_tool_wrappers.py` **53 passed** (8 new: genesis+chained manifest, verify-OK, tamper-drift, missing-file, HMAC chain-break).

No CODEOWNERS paths. Tool + manifest only — not wired into any agent (avoids colliding with PR #455).
