### PR TITLE
fix(web): add missing /api/workspace/[name]/files routes so the Documents tab works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ demo.tape
 .decepticon/
 .dogfood/
 workspace/
+!clients/web/src/app/api/workspace/
 .bg-shell/
 
 # Local reference corpus — dev-only, ~34 MB (PayloadsAllTheThings + OWASP WSTG).

--- a/clients/web/src/app/api/workspace/[name]/files/[...path]/route.ts
+++ b/clients/web/src/app/api/workspace/[name]/files/[...path]/route.ts
@@ -1,0 +1,68 @@
+import { requireAuth, AuthError } from "@/lib/auth-bridge";
+import { prisma } from "@/lib/prisma";
+import { resolveEngagementDir } from "@/lib/workspace";
+import { NextRequest, NextResponse } from "next/server";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+const WORKSPACE = process.env.WORKSPACE_PATH ?? path.join(process.env.HOME ?? "", ".decepticon", "workspace");
+
+const FOLDERS = ["recon", "exploit", "post-exploit", "findings", "report"];
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ name: string; path: string[] }> }
+) {
+  let userId: string;
+  try {
+    ({ userId } = await requireAuth());
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    throw e;
+  }
+
+  const { name, path: segments } = await params;
+  const engagement = await prisma.engagement.findFirst({
+    where: { name, userId },
+  });
+
+  if (!engagement) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!segments || segments.length === 0) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let engagementDir: string;
+  try {
+    engagementDir = resolveEngagementDir(engagement.name, WORKSPACE);
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!FOLDERS.includes(segments[0])) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const target = path.resolve(engagementDir, ...segments);
+  if (target !== engagementDir && !target.startsWith(engagementDir + path.sep)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let content: string;
+  try {
+    const stat = await fs.stat(target);
+    if (!stat.isFile()) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    content = await fs.readFile(target, "utf-8");
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const isJson = target.endsWith(".json");
+  return new NextResponse(content, {
+    headers: { "Content-Type": isJson ? "application/json" : "text/plain; charset=utf-8" },
+  });
+}

--- a/clients/web/src/app/api/workspace/[name]/files/route.ts
+++ b/clients/web/src/app/api/workspace/[name]/files/route.ts
@@ -1,0 +1,82 @@
+import { requireAuth, AuthError } from "@/lib/auth-bridge";
+import { prisma } from "@/lib/prisma";
+import { resolveEngagementDir } from "@/lib/workspace";
+import { NextRequest, NextResponse } from "next/server";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+const WORKSPACE = process.env.WORKSPACE_PATH ?? path.join(process.env.HOME ?? "", ".decepticon", "workspace");
+
+const FOLDERS = ["recon", "exploit", "post-exploit", "findings", "report"] as const;
+
+interface FileEntry {
+  name: string;
+  folder: string;
+  path: string;
+  size: number;
+}
+
+interface FolderGroup {
+  folder: string;
+  files: FileEntry[];
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  let userId: string;
+  try {
+    ({ userId } = await requireAuth());
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    throw e;
+  }
+
+  const { name } = await params;
+  const engagement = await prisma.engagement.findFirst({
+    where: { name, userId },
+  });
+
+  if (!engagement) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let engagementDir: string;
+  try {
+    engagementDir = resolveEngagementDir(engagement.name, WORKSPACE);
+  } catch {
+    return NextResponse.json({ folders: [] });
+  }
+
+  const folders: FolderGroup[] = [];
+
+  for (const folder of FOLDERS) {
+    const folderDir = path.join(engagementDir, folder);
+    let entries;
+    try {
+      entries = await fs.readdir(folderDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    const files: FileEntry[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      let size = 0;
+      try {
+        const stat = await fs.stat(path.join(folderDir, entry.name));
+        size = stat.size;
+      } catch {
+        continue;
+      }
+      files.push({ name: entry.name, folder, path: `${folder}/${entry.name}`, size });
+    }
+
+    if (files.length > 0) {
+      folders.push({ folder, files });
+    }
+  }
+
+  return NextResponse.json({ folders });
+}


### PR DESCRIPTION
## Summary
The Documents tab and idle activity feed fetch `/api/workspace/{name}/files` and `/files/{path}`, but no such route existed — the tab was permanently stuck on "No workspace files found".

## Changes
- Add `GET /api/workspace/[name]/files` (lists files under the known folders: recon, exploit, post-exploit, findings, report) and `GET /api/workspace/[name]/files/[...path]` (reads one file). Both mirror the sibling `engagements/[id]/plan-docs` route: `requireAuth`, `prisma.engagement.findFirst({name,userId})` (name isn't unique), `resolveEngagementDir`.
- Path-traversal guard: the `[...path]` route resolves the joined path and verifies it stays inside the engagement dir, restricted to the five known folders, regular files only.
- Response shape (`{folders:[{folder,files:[{name,folder,path,size}]}]}`) matches the callers.
- `.gitignore`: add a scoped negation so the new `api/workspace` source dir isn't caught by the broad runtime `workspace/` ignore.

## Testing
Mirrors sibling routes for type-correctness; **CI `Web (lint + build)` is the build gate** (local Node toolchain unavailable in this env). No CODEOWNERS paths.
