### PR TITLE
fix(web): validate/normalize engagement name as a slug in the New Engagement form

### DIFF
--- a/clients/web/src/app/(dashboard)/engagements/new/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/new/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Globe, Server, Loader2 } from "lucide-react";
+import { isValidEngagementSlug } from "@/lib/engagement-slug";
 
 export default function NewEngagementPage() {
   const router = useRouter();
@@ -17,8 +18,14 @@ export default function NewEngagementPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const nameValid = isValidEngagementSlug(name);
+  const nameError =
+    name.length > 0 && !nameValid
+      ? "Name must be 3-64 chars, lowercase letters / digits with internal hyphens only"
+      : null;
+
   async function handleSubmit() {
-    if (!name.trim() || !targetValue.trim()) {
+    if (!nameValid || !targetValue.trim()) {
       setError("Please fill in all required fields");
       return;
     }
@@ -71,10 +78,19 @@ export default function NewEngagementPage() {
             <Label htmlFor="name">Engagement Name</Label>
             <Input
               id="name"
-              placeholder="e.g., Q2 Security Assessment"
+              placeholder="e.g., q2-security-assessment"
               value={name}
               onChange={(e) => setName(e.target.value)}
+              aria-invalid={nameError ? true : undefined}
             />
+            {nameError ? (
+              <p className="text-xs text-destructive">{nameError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Used as the workspace folder name — 3-64 chars, lowercase
+                letters / digits with internal hyphens
+              </p>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -140,7 +156,7 @@ export default function NewEngagementPage() {
         <Button variant="outline" onClick={() => router.back()}>
           Cancel
         </Button>
-        <Button onClick={handleSubmit} disabled={submitting}>
+        <Button onClick={handleSubmit} disabled={submitting || !nameValid}>
           {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Create Engagement
         </Button>


### PR DESCRIPTION
## Summary
The New Engagement form posted the name with only an empty-check while its placeholder (`e.g., Q2 Security Assessment`) fails the server slug regex — guaranteeing a confusing late 400.

## Changes
- Validate the name client-side with `isValidEngagementSlug` from `@/lib/engagement-slug` (byte-identical to the server's `SLUG_RE`), inline error + helper text, `aria-invalid`, disable Create until valid, fix the placeholder to a valid slug. Server 400 stays the authority (still surfaces e.g. duplicate-name 409).

## Testing
Mirrors the form's existing field/error patterns; **CI is the build gate**. No CODEOWNERS paths.
