### PR TITLE
fix(web): validate engagement status/targetType against the Prisma enums

### DIFF
--- a/clients/web/src/app/api/engagements/[id]/route.ts
+++ b/clients/web/src/app/api/engagements/[id]/route.ts
@@ -1,6 +1,6 @@
 import { requireAuth, AuthError } from "@/lib/auth-bridge";
 import { prisma } from "@/lib/prisma";
-import { SLUG_RE } from "@/lib/workspace";
+import { SLUG_RE, VALID_TARGET_TYPES, VALID_STATUSES } from "@/lib/workspace";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(
@@ -66,6 +66,23 @@ export async function PATCH(
           error:
             "Invalid engagement name — must be 3-64 chars, lowercase letters / digits / internal hyphens",
         },
+        { status: 400 }
+      );
+    }
+
+    if ("status" in data && !VALID_STATUSES.includes(data.status as (typeof VALID_STATUSES)[number])) {
+      return NextResponse.json(
+        { error: `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    if (
+      "targetType" in data &&
+      !VALID_TARGET_TYPES.includes(data.targetType as (typeof VALID_TARGET_TYPES)[number])
+    ) {
+      return NextResponse.json(
+        { error: `Invalid targetType. Must be one of: ${VALID_TARGET_TYPES.join(", ")}` },
         { status: 400 }
       );
     }

--- a/clients/web/src/app/api/engagements/route.ts
+++ b/clients/web/src/app/api/engagements/route.ts
@@ -1,6 +1,6 @@
 import { requireAuth, AuthError } from "@/lib/auth-bridge";
 import { prisma } from "@/lib/prisma";
-import { SLUG_RE } from "@/lib/workspace";
+import { SLUG_RE, VALID_TARGET_TYPES } from "@/lib/workspace";
 import { NextRequest, NextResponse } from "next/server";
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -77,12 +77,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const validTypes = [
-      "local_path", "git_url", "file_upload", "web_url", "ip_range",
-    ];
-    if (!validTypes.includes(targetType)) {
+    if (!VALID_TARGET_TYPES.includes(targetType)) {
       return NextResponse.json(
-        { error: `Invalid targetType. Must be one of: ${validTypes.join(", ")}` },
+        { error: `Invalid targetType. Must be one of: ${VALID_TARGET_TYPES.join(", ")}` },
         { status: 400 }
       );
     }

--- a/clients/web/src/lib/workspace.ts
+++ b/clients/web/src/lib/workspace.ts
@@ -5,6 +5,9 @@ import * as path from "path";
 // doubles as an on-disk workspace directory shared by both sides.
 export const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/;
 
+export const VALID_TARGET_TYPES = ["web_url", "ip_range"] as const;
+export const VALID_STATUSES = ["draft", "planning", "running", "completed", "failed"] as const;
+
 // Path-traversal containment: refuse any `name` whose resolved directory escapes
 // `workspace`, so a poisoned DB row (e.g. "../../etc" from the CLI auto-import
 // path) cannot be read. Checked on the resolved absolute path, not the raw input.


### PR DESCRIPTION
## Summary
Engagement `targetType`/`status` weren't validated against the Prisma enums: POST's `validTypes` allowlist had stale values (`local_path`/`git_url`/`file_upload`) that pass the route check then make `prisma.create` throw a **500**; PATCH copied `status`/`targetType` straight through (500 + leaked Prisma message on a bad value).

## Changes
- Hoist shared allowlists (`VALID_TARGET_TYPES` = {web_url, ip_range}, `VALID_STATUSES` = EngagementStatus) to `lib/workspace.ts` so the two routes can't drift from `schema.prisma`.
- POST: validate `targetType` against the real enum. PATCH: validate `status` + `targetType` (when present) → clean **400** instead of 500.

## Testing
Read `schema.prisma` for the authoritative enum values; mirrors the routes' existing 400 style. **CI is the build gate**. No CODEOWNERS paths.
