### PR TITLE
fix(web): guard non-array API response in the global Graph page fetch

### DIFF
--- a/clients/web/src/app/(dashboard)/graph/page.tsx
+++ b/clients/web/src/app/(dashboard)/graph/page.tsx
@@ -17,16 +17,33 @@ export default function GraphPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let active = true;
     fetch("/api/engagements")
-      .then((res) => res.json())
-      .then((data: Engagement[]) => {
-        setEngagements(data);
-        // Auto-select first running or completed engagement
-        const active = data.find((e) => e.status === "running") ?? data.find((e) => e.status === "completed") ?? data[0];
-        if (active) setSelectedId(active.id);
+      .then((res) => {
+        if (!res.ok) throw new Error("fetch failed");
+        return res.json();
       })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+      .then((data: Engagement[]) => {
+        if (!active) return;
+        const engagements = Array.isArray(data) ? data : [];
+        setEngagements(engagements);
+        const selected =
+          engagements.find((e) => e.status === "running") ??
+          engagements.find((e) => e.status === "completed") ??
+          engagements[0];
+        if (selected) setSelectedId(selected.id);
+      })
+      .catch(() => {
+        if (!active) return;
+        setEngagements([]);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
   }, []);
 
   if (loading) {


### PR DESCRIPTION
## Summary
The global Graph page did `fetch('/api/engagements').then(res=>res.json())` with no `res.ok` check, so on 401/500 an error object landed in `setEngagements(data)` (typed `Engagement[]`) before `.find` threw into a swallowing catch.

## Changes
- Add `res.ok` throw + `Array.isArray` guard + `setEngagements([])` on catch, mirroring the `engagements`/`findings` sibling pages. (Also renamed an inner local to avoid shadowing the mounted-flag.)

## Testing
Mirrors two sibling pages exactly. **CI is the build gate**. No CODEOWNERS paths.
