### PR TITLE
fix(cli): Ctrl+C in the session/question picker dismisses it instead of exiting the app

### DIFF
--- a/clients/cli/src/hooks/useGlobalKeybindings.ts
+++ b/clients/cli/src/hooks/useGlobalKeybindings.ts
@@ -32,6 +32,7 @@ interface Props {
   runState: RunState;
   /** Whether a message is queued. */
   hasQueuedMessage?: boolean;
+  modalActive?: boolean;
 }
 
 const DOUBLE_PRESS_MS = 500;
@@ -44,6 +45,7 @@ export function useGlobalKeybindings({
   addSystemEvent,
   runState,
   hasQueuedMessage = false,
+  modalActive = false,
 }: Props): void {
   const screen = useAppState((s) => s.screen);
   const setAppState = useSetAppState();
@@ -113,6 +115,8 @@ export function useGlobalKeybindings({
           onClearQueue?.();
         } else if (screen === "transcript") {
           exitTranscript();
+        } else if (modalActive) {
+          return;
         } else {
           // Truly idle, no queue → exit app
           onExit();

--- a/clients/cli/src/screens/REPL.tsx
+++ b/clients/cli/src/screens/REPL.tsx
@@ -79,6 +79,7 @@ export function REPL({ initialMessage, resumeThread }: REPLProps) {
     addSystemEvent: agent.addSystemEvent,
     runState: agent.runState,
     hasQueuedMessage: agent.queuedMessage != null,
+    modalActive: showSessionPicker || agent.activeQuestion != null,
   });
 
   // ── Command handling ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`exitOnCtrlC` is false, so the only Ctrl+C exit path is `useGlobalKeybindings`' idle-exit branch — mounted unconditionally. Ink fires every active handler per keypress, so Ctrl+C while the session picker or a question modal is open killed the whole CLI (data-loss footgun).

## Changes
- Add a `modalActive` prop to `useGlobalKeybindings`, computed in REPL as `(showSessionPicker || agent.activeQuestion != null)`, and early-return on **only** the Ctrl+C idle-exit branch when a modal is active (streaming pause/cancel and other keys unaffected; per-picker Esc still dismisses).

## Testing
Mirrors the hook's existing props/typing. **CI `CLI` lane is the gate**. No CODEOWNERS paths.
