### PR TITLE
fix(cli): render ask_user_question / ask_user_answer events in the log

### DIFF
--- a/clients/cli/src/components/EventItem.tsx
+++ b/clients/cli/src/components/EventItem.tsx
@@ -7,6 +7,7 @@ import { AIMessage } from "./messages/AIMessage.js";
 import { ToolCallMessage } from "./messages/ToolCallMessage.js";
 import { DelegateMessage } from "./messages/DelegateMessage.js";
 import { SystemMessage } from "./messages/SystemMessage.js";
+import { QAQuestionMessage, QAAnswerMessage } from "./messages/QAMessage.js";
 import { BackgroundCompleteMessage } from "./messages/BackgroundCompleteMessage.js";
 
 interface EventItemProps {
@@ -48,6 +49,17 @@ export const EventItem = React.memo(function EventItem({
 
     case "system":
       return <SystemMessage content={event.content} />;
+
+    case "ask_user_question":
+      return (
+        <QAQuestionMessage
+          header={event.header ?? ""}
+          question={event.question ?? event.content}
+        />
+      );
+
+    case "ask_user_answer":
+      return <QAAnswerMessage answer={event.content} />;
 
     case "background_complete":
       return (

--- a/clients/cli/src/components/messages/QAMessage.tsx
+++ b/clients/cli/src/components/messages/QAMessage.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Box, Text } from "ink";
+
+interface QuestionProps {
+  header: string;
+  question: string;
+}
+
+export const QAQuestionMessage = React.memo(function QAQuestionMessage({
+  header,
+  question,
+}: QuestionProps) {
+  return (
+    <Box flexDirection="row" marginTop={1}>
+      {header ? <Text color="cyan" bold>{`[${header}] `}</Text> : null}
+      <Text wrap="wrap">{question}</Text>
+    </Box>
+  );
+});
+
+interface AnswerProps {
+  answer: string;
+}
+
+export const QAAnswerMessage = React.memo(function QAAnswerMessage({
+  answer,
+}: AnswerProps) {
+  return (
+    <Box marginTop={1}>
+      <Text color="green" wrap="wrap">{`› ${answer}`}</Text>
+    </Box>
+  );
+});


### PR DESCRIPTION
## Summary
`useAgent` emits `ask_user_question`/`ask_user_answer` events, but `EventItem.tsx`'s switch had no case for either (both hit `default: return null`), so the live picker unmounts on submit and the entire Q&A exchange vanished from scrollback/transcript.

## Changes
- Add two switch cases rendering the question (header + question text) and the answer (`> answer` line) via a small `QAMessage` component (`QAQuestionMessage`/`QAAnswerMessage`), mirroring existing event-render style.

## Testing
Read the event payload shapes in `useAgent.ts`. **CI `CLI` lane is the gate**. No CODEOWNERS paths.
