### PR TITLE
fix(cli): stop double-rendering completed sub-agent sessions

### DIFF
--- a/clients/cli/src/components/agents/CoordinatorPanel.tsx
+++ b/clients/cli/src/components/agents/CoordinatorPanel.tsx
@@ -1,17 +1,14 @@
 /**
  * CoordinatorPanel — dynamic region sub-agent display.
  *
- * Shows currently running + recently completed sub-agent sessions
- * using Claude Code's inline format via AgentSessionGroup.
+ * Shows currently running sub-agent sessions using Claude Code's inline
+ * format via AgentSessionGroup.
  */
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { Box } from "ink";
 import { AgentSessionGroup } from "./AgentSessionGroup.js";
 import type { AgentEvent, SubAgentSession } from "../../types.js";
-
-/** How long completed sessions remain visible (ms). */
-const LINGER_MS = 10_000;
 
 interface Props {
   sessions: SubAgentSession[];
@@ -22,23 +19,9 @@ export const CoordinatorPanel = React.memo(function CoordinatorPanel({
   sessions,
   events,
 }: Props) {
-  // Tick every second to refresh linger expiry
-  const [now, setNow] = useState(Date.now());
-  useEffect(() => {
-    if (sessions.length === 0) return;
-    const interval = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(interval);
-  }, [sessions.length]);
-
-  // Visible sessions: running OR completed within LINGER_MS
   const visible = useMemo(
-    () =>
-      sessions.filter(
-        (s) =>
-          s.status === "running" ||
-          (s.endTime != null && now - s.endTime < LINGER_MS),
-      ),
-    [sessions, now],
+    () => sessions.filter((s) => s.status === "running"),
+    [sessions],
   );
 
   if (visible.length === 0) return null;


### PR DESCRIPTION
## Summary
REPL puts non-running sessions into the append-only Static region, but `CoordinatorPanel` ALSO rendered the same session for `LINGER_MS=10000` after it ended — a finished session showed twice for ~10s.

## Changes
- Filter `CoordinatorPanel` to `status==='running'` only (the completed card already lives permanently in Static) and delete the now-dead `LINGER_MS` const + now-tick `useEffect`. SessionFooter self-ticks, so the running footer is unaffected.

## Testing
Single-component change. **CI `CLI` lane is the gate**. No CODEOWNERS paths.
