### PR TITLE
chore(web): add an npm test script for the node:test slug suite

### DIFF
--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -12,6 +12,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
 
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",


### PR DESCRIPTION
## Summary
`clients/web/src/lib/engagement-slug.test.ts` is a real path-traversal slug-containment regression suite (`node:test`), but `package.json` had no `test` script, so it could only be run by hand.

## Changes
- Add `"test": "node --import tsx --test \"src/**/*.test.ts\""` (CI Node is v24 so the positional glob resolves; `tsx` is already a dependency).

## Follow-up (maintainer, needs `workflow` scope)
My token lacks `workflow` scope, so I couldn't include the CI wiring. To run it in CI, add this step to the web job in `.github/workflows/ci.yml` (mirrors the eslint step):
```yaml
      - name: Test
        if: needs.changes.outputs.web == 'true'
        run: cd clients/web && npm test
```

## Testing
JSON validated; couldn't run locally (no native Linux Node). `clients/web/package.json` is CODEOWNERS-protected → maintainer review expected.
