### PR TITLE
feat(roe): enforce max_concurrent_connections as a concurrent gated-bash-call cap

### DIFF
--- a/packages/decepticon/decepticon/middleware/roe.py
+++ b/packages/decepticon/decepticon/middleware/roe.py
@@ -27,10 +27,13 @@ Reading the RoE:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
+import threading
 import time
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -152,6 +155,10 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         super().__init__()
         self._sink = sink
         self._gated = gated_tools or GATED_TOOL_NAMES
+        self._conc_lock = threading.Lock()
+        self._conc_limit: int | None = None
+        self._sync_sema: threading.Semaphore | None = None
+        self._async_sema: asyncio.Semaphore | None = None
 
     @override
     def wrap_tool_call(self, request, handler) -> ToolMessage | Command:
@@ -166,7 +173,9 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         self._record(request, tool_name, decision, rules.mode)
         if not decision.allow and rules.mode == EnforcementMode.ENFORCE:
             return _refused_message(decision, tool_name, _tcid(request))
-        result = handler(request)
+        gated = tool_name in self._gated
+        with self._sync_gate(rules, gated):
+            result = handler(request)
         if (
             not decision.allow
             and rules.mode == EnforcementMode.WARN
@@ -180,7 +189,9 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         self._record(request, tool_name, decision, rules.mode)
         if not decision.allow and rules.mode == EnforcementMode.ENFORCE:
             return _refused_message(decision, tool_name, _tcid(request))
-        result = await handler(request)
+        gated = tool_name in self._gated
+        async with self._async_gate(rules, gated):
+            result = await handler(request)
         if (
             not decision.allow
             and rules.mode == EnforcementMode.WARN
@@ -188,6 +199,44 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         ):
             return _warn_message(decision, result)
         return result
+
+    def _resolve_limit(self, rules: MachineEnforcement) -> int | None:
+        limit = rules.max_concurrent_connections
+        if limit is None or limit <= 0:
+            return None
+        with self._conc_lock:
+            if self._conc_limit is None:
+                self._conc_limit = limit
+            return self._conc_limit
+
+    @contextmanager
+    def _sync_gate(self, rules: MachineEnforcement, gated: bool):
+        limit = self._resolve_limit(rules) if gated else None
+        if limit is None:
+            yield
+            return
+        with self._conc_lock:
+            if self._sync_sema is None:
+                self._sync_sema = threading.Semaphore(limit)
+            sema = self._sync_sema
+        sema.acquire()
+        try:
+            yield
+        finally:
+            sema.release()
+
+    @asynccontextmanager
+    async def _async_gate(self, rules: MachineEnforcement, gated: bool):
+        limit = self._resolve_limit(rules) if gated else None
+        if limit is None:
+            yield
+            return
+        with self._conc_lock:
+            if self._async_sema is None:
+                self._async_sema = asyncio.Semaphore(limit)
+            sema = self._async_sema
+        async with sema:
+            yield
 
     def _evaluate(self, request) -> tuple[Decision, MachineEnforcement, str]:
         tool = getattr(request, "tool", None)

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -432,3 +435,184 @@ class TestFqdnTrailingDotNormalization:
         assert evaluate_target("single-host.example.", rules).allow is True
         # An unrelated FQDN-form host is still refused (not in scope).
         assert evaluate_target("other.example.", rules).allow is False
+
+
+class _ConcurrencyProbe:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.active = 0
+        self.peak = 0
+
+    def enter(self) -> None:
+        with self.lock:
+            self.active += 1
+            self.peak = max(self.peak, self.active)
+
+    def exit(self) -> None:
+        with self.lock:
+            self.active -= 1
+
+
+class TestConcurrencyGate:
+    def test_limit_none_means_unlimited(self) -> None:
+        mw = RoEEnforcementMiddleware()
+        rules = MachineEnforcement.from_dict({"mode": "audit"})
+        assert mw._resolve_limit(rules) is None
+        with mw._sync_gate(rules, gated=True):
+            pass
+        assert mw._sync_sema is None
+
+    def test_limit_zero_means_unlimited(self) -> None:
+        mw = RoEEnforcementMiddleware()
+        rules = MachineEnforcement.from_dict({"max_concurrent_connections": 0})
+        assert mw._resolve_limit(rules) is None
+        with mw._sync_gate(rules, gated=True):
+            pass
+        assert mw._sync_sema is None
+
+    def test_first_seen_limit_wins(self) -> None:
+        mw = RoEEnforcementMiddleware()
+        first = MachineEnforcement.from_dict({"max_concurrent_connections": 2})
+        second = MachineEnforcement.from_dict({"max_concurrent_connections": 9})
+        assert mw._resolve_limit(first) == 2
+        assert mw._resolve_limit(second) == 2
+
+    def test_ungated_call_is_not_gated(self) -> None:
+        mw = RoEEnforcementMiddleware()
+        rules = MachineEnforcement.from_dict({"max_concurrent_connections": 1})
+        with mw._sync_gate(rules, gated=False):
+            pass
+        assert mw._sync_sema is None
+
+    def test_sync_gate_admits_at_most_n(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {"mode": "audit", "max_concurrent_connections": 2},
+        )
+        mw = RoEEnforcementMiddleware()
+        probe = _ConcurrencyProbe()
+        release = threading.Event()
+
+        def handler(_request):
+            probe.enter()
+            release.wait(timeout=5)
+            probe.exit()
+            return ToolMessage(content="ok", tool_call_id="tc-test")
+
+        def run() -> None:
+            req = _make_request("bash", "nmap 10.0.0.1", state={"workspace_path": str(tmp_path)})
+            mw.wrap_tool_call(req, handler)
+
+        threads = [threading.Thread(target=run) for _ in range(5)]
+        for t in threads:
+            t.start()
+        deadline = time.time() + 5
+        while probe.active < 2 and time.time() < deadline:
+            time.sleep(0.01)
+        time.sleep(0.05)
+        peak_while_blocked = probe.peak
+        release.set()
+        for t in threads:
+            t.join(timeout=5)
+        assert peak_while_blocked == 2
+        assert probe.peak == 2
+
+    def test_sync_gate_unlimited_runs_all_concurrently(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "audit"})
+        mw = RoEEnforcementMiddleware()
+        probe = _ConcurrencyProbe()
+        release = threading.Event()
+        started = threading.Semaphore(0)
+
+        def handler(_request):
+            probe.enter()
+            started.release()
+            release.wait(timeout=5)
+            probe.exit()
+            return ToolMessage(content="ok", tool_call_id="tc-test")
+
+        def run() -> None:
+            req = _make_request("bash", "nmap 10.0.0.1", state={"workspace_path": str(tmp_path)})
+            mw.wrap_tool_call(req, handler)
+
+        threads = [threading.Thread(target=run) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for _ in range(4):
+            assert started.acquire(timeout=5)
+        assert probe.peak == 4
+        release.set()
+        for t in threads:
+            t.join(timeout=5)
+
+    async def test_async_gate_admits_at_most_n(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {"mode": "audit", "max_concurrent_connections": 2},
+        )
+        mw = RoEEnforcementMiddleware()
+        active = 0
+        peak = 0
+        gate = asyncio.Event()
+
+        async def handler(_request):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await gate.wait()
+            active -= 1
+            return ToolMessage(content="ok", tool_call_id="tc-test")
+
+        async def run():
+            req = _make_request("bash", "nmap 10.0.0.1", state={"workspace_path": str(tmp_path)})
+            return await mw.awrap_tool_call(req, handler)
+
+        tasks = [asyncio.create_task(run()) for _ in range(5)]
+        deadline = time.time() + 5
+        while active < 2 and time.time() < deadline:
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
+        assert peak == 2
+        gate.set()
+        await asyncio.gather(*tasks)
+        assert peak == 2
+
+    async def test_async_gate_unlimited_runs_all_concurrently(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "audit"})
+        mw = RoEEnforcementMiddleware()
+        active = 0
+        peak = 0
+        gate = asyncio.Event()
+
+        async def handler(_request):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await gate.wait()
+            active -= 1
+            return ToolMessage(content="ok", tool_call_id="tc-test")
+
+        async def run():
+            req = _make_request("bash", "nmap 10.0.0.1", state={"workspace_path": str(tmp_path)})
+            return await mw.awrap_tool_call(req, handler)
+
+        tasks = [asyncio.create_task(run()) for _ in range(4)]
+        deadline = time.time() + 5
+        while active < 4 and time.time() < deadline:
+            await asyncio.sleep(0.01)
+        assert peak == 4
+        gate.set()
+        await asyncio.gather(*tasks)
+
+    def test_refused_call_releases_no_slot(self, tmp_path: Path) -> None:
+        _write_roe(
+            tmp_path,
+            {"mode": "enforce", "in_scope": ["10.0.0.0/24"], "max_concurrent_connections": 1},
+        )
+        mw = RoEEnforcementMiddleware()
+        req = _make_request("bash", "nmap 8.8.8.8", state={"workspace_path": str(tmp_path)})
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "[ROE_REFUSED]" in result.content
+        assert mw._sync_sema is None


### PR DESCRIPTION
## Summary
`MachineEnforcement.max_concurrent_connections` is parsed from `roe.json` but enforced nowhere. This activates it.

## Design (honest semantics)
Implemented as a cap on **concurrently in-flight gated bash tool calls** per agent — a proxy for target-connection concurrency, **not** a network-/socket-layer cap. When set (>0), at most N allowed gated calls run at once; excess calls **wait** for a slot (not refused — preserves work).

## Changes
- `RoEEnforcementMiddleware`: lazy `threading.Semaphore` (sync path) + `asyncio.Semaphore` (async path), per-instance, first-seen limit wins for the instance lifetime (documented). Acquire before the handler for an allowed gated call, release in `finally`. Refused/ungated/limit-None calls bypass the gate.

## Testing
- ruff clean; `uv run basedpyright` 0 errors; **full fast suite 3562 passed** (2 `test_shutdown.py` subprocess flakes under `-n auto` confirmed pre-existing/green in isolation). 10 new concurrency tests.

⚠️ `roe.py` overlaps in-flight PRs #463/#466/#469/#470 — localized to `__init__` + `_dispatch_*` + 3 helpers; rebase after those merge.
