### PR TITLE
feat(engagement): surface DeconflictionPlan identifiers to operating agents

### DIFF
--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -24,7 +24,10 @@ state-backed context injection via wrap_model_call.
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+from pathlib import Path
 from typing import Annotated, Any, NotRequired, cast
 
 from langchain.agents import AgentState
@@ -67,6 +70,9 @@ class EngagementContextState(AgentState):
     ]
     flag_format: NotRequired[Annotated[str, "Expected flag format string."]]
     mission_brief: NotRequired[Annotated[str, "Challenge name + description."]]
+
+
+log = logging.getLogger(__name__)
 
 
 _FALSY_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
@@ -170,6 +176,45 @@ def _build_engagement_injection(slug: str, workspace: str) -> str:
         "engagement directory name; the launcher already chose them. The "
         "human-friendly engagement title belongs in roe.json:engagement_name "
         "and may differ from this slug."
+    )
+
+
+def _load_deconfliction(workspace: str) -> dict[str, Any] | None:
+    root = workspace.rstrip("/") or workspace
+    path = Path(root) / "plan" / "deconfliction.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("engagement: failed to read %s: %s; skipping block", path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _build_deconfliction_injection(data: dict[str, Any]) -> str:
+    code = data.get("deconfliction_code")
+    raw_identifiers = data.get("identifiers")
+    identifiers = raw_identifiers if isinstance(raw_identifiers, list) else []
+
+    lines: list[str] = []
+    if isinstance(code, str) and code:
+        lines.append(f"Deconfliction code: {code}")
+    for entry in identifiers:
+        if not isinstance(entry, dict):
+            continue
+        kind = entry.get("type")
+        value = entry.get("value")
+        if isinstance(kind, str) and kind and isinstance(value, str) and value:
+            lines.append(f"- {kind}: {value}")
+
+    if not lines:
+        return ""
+
+    return (
+        "\n\n[Deconfliction — set by Soundwave for blue-team coordination]\n"
+        "Stamp your activity with these identifiers so defenders can separate "
+        "this engagement from real threats:\n" + "\n".join(lines)
     )
 
 
@@ -287,6 +332,11 @@ class EngagementContextMiddleware(AgentMiddleware):
         sections: list[str] = []
         if slug:
             sections.append(_build_engagement_injection(slug, workspace))
+            deconfliction = _load_deconfliction(workspace)
+            if deconfliction is not None:
+                block = _build_deconfliction_injection(deconfliction)
+                if block:
+                    sections.append(block)
         if _benchmark_mode_active():
             sections.append(
                 _build_benchmark_injection(

--- a/packages/decepticon/tests/unit/middleware/test_engagement.py
+++ b/packages/decepticon/tests/unit/middleware/test_engagement.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -330,6 +332,105 @@ def test_appended_to_existing_system_message(
     assert "Workspace slug: demo" in text
     assert "## CTF Benchmark Challenge" in text
     assert text.index("ORIGINAL_PROMPT_BODY") < text.index("Workspace slug")
+
+
+def _write_deconfliction(workspace: Path, payload: dict[str, Any]) -> None:
+    plan_dir = workspace / "plan"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / "deconfliction.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def test_deconfliction_identifiers_appear_in_injection(
+    tmp_path: Path,
+    middleware: EngagementContextMiddleware,
+) -> None:
+    _write_deconfliction(
+        tmp_path,
+        {
+            "engagement_name": "blue-falcon",
+            "deconfliction_code": "ECHO-9",
+            "identifiers": [
+                {"type": "source-ip", "value": "10.4.4.4", "description": "jump host"},
+                {"type": "user-agent", "value": "decepticon/1.0"},
+            ],
+        },
+    )
+    req = _FakeRequest(
+        state={"engagement_name": "blue-falcon", "workspace_path": str(tmp_path)},
+    )
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "Deconfliction code: ECHO-9" in text
+    assert "source-ip: 10.4.4.4" in text
+    assert "user-agent: decepticon/1.0" in text
+    assert text.index("Workspace slug:") < text.index("Deconfliction code: ECHO-9")
+
+
+def test_deconfliction_absent_degrades_cleanly(
+    tmp_path: Path,
+    middleware: EngagementContextMiddleware,
+) -> None:
+    req = _FakeRequest(
+        state={"engagement_name": "blue-falcon", "workspace_path": str(tmp_path)},
+    )
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "Workspace slug: blue-falcon" in text
+    assert "Deconfliction" not in text
+
+
+def test_deconfliction_malformed_json_degrades_cleanly(
+    tmp_path: Path,
+    middleware: EngagementContextMiddleware,
+) -> None:
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / "deconfliction.json").write_text("{not valid json", encoding="utf-8")
+
+    req = _FakeRequest(
+        state={"engagement_name": "blue-falcon", "workspace_path": str(tmp_path)},
+    )
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "Workspace slug: blue-falcon" in text
+    assert "Deconfliction" not in text
+
+
+def test_deconfliction_empty_identifiers_emit_no_block(
+    tmp_path: Path,
+    middleware: EngagementContextMiddleware,
+) -> None:
+    _write_deconfliction(
+        tmp_path,
+        {"engagement_name": "blue-falcon", "deconfliction_code": "", "identifiers": []},
+    )
+    req = _FakeRequest(
+        state={"engagement_name": "blue-falcon", "workspace_path": str(tmp_path)},
+    )
+    result = middleware._inject(req)
+    text = _flatten(result.system_message)
+
+    assert "Workspace slug: blue-falcon" in text
+    assert "Deconfliction" not in text
+
+
+def test_deconfliction_skipped_without_engagement_slug(
+    tmp_path: Path,
+    middleware: EngagementContextMiddleware,
+) -> None:
+    _write_deconfliction(
+        tmp_path,
+        {"engagement_name": "blue-falcon", "deconfliction_code": "ECHO-9"},
+    )
+    req = _FakeRequest(state={"workspace_path": str(tmp_path)})
+    result = middleware._inject(req)
+
+    assert result is req
 
 
 # ── runnable-config hydration ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
`DeconflictionPlan` identifiers (`deconfliction_code` + `identifiers[]`) are written by Soundwave to `plan/deconfliction.json` but no runtime path surfaced them to the operating agents, so the agent couldn't stamp its activity for blue-team deconfliction.

## Changes
- `EngagementContextMiddleware` now reads `<workspace>/plan/deconfliction.json` and appends a concise deconfliction block (code + `type: value` identifiers) to the engagement-context system-message it already injects. Degrades cleanly when the file is absent/malformed (mirrors `roe.py`'s `_load_rules_for_workspace`). Gated on an engagement slug being present.

## Testing
- ruff clean; `uv run basedpyright` 0 errors; **full fast suite 3558 passed**; engagement middleware module 49 passed (5 new tests: present / absent-degrades / malformed-degrades / empty-identifiers / no-slug-skip).

Does **not** touch `roe.py`. No CODEOWNERS paths.
