### PR TITLE
feat(roe): extend the RoE scope gate to http/browser/proxy network tools

### DIFF
--- a/packages/decepticon/decepticon/middleware/roe.py
+++ b/packages/decepticon/decepticon/middleware/roe.py
@@ -31,8 +31,10 @@ import json
 import logging
 import os
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import ToolMessage
@@ -57,8 +59,45 @@ GATED_TOOL_NAMES: frozenset[str] = frozenset(
         "bash",
         "bash_output",
         "bash_kill",
+        "http_request",
+        "proxy_send_request",
+        "browser_action",
     }
 )
+
+
+def _host_from_url(url: Any) -> list[str]:
+    if not isinstance(url, str) or not url:
+        return []
+    try:
+        host = urlsplit(url).hostname
+    except ValueError:
+        return []
+    return [host] if host else []
+
+
+def _hosts_from_url_arg(args: dict[str, Any]) -> list[str]:
+    return _host_from_url(args.get("url"))
+
+
+def _hosts_from_browser_action(args: dict[str, Any]) -> list[str]:
+    raw = args.get("params_json")
+    if not isinstance(raw, str) or not raw:
+        return []
+    try:
+        params = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(params, dict):
+        return []
+    return _host_from_url(params.get("url"))
+
+
+NETWORK_TARGET_EXTRACTORS: dict[str, Callable[[dict[str, Any]], list[str]]] = {
+    "http_request": _hosts_from_url_arg,
+    "proxy_send_request": _hosts_from_url_arg,
+    "browser_action": _hosts_from_browser_action,
+}
 
 
 def _load_rules_for_workspace(workspace_path: str | None) -> MachineEnforcement:
@@ -120,13 +159,16 @@ def _to_text(content: Any) -> str:
     return str(content)
 
 
-def _command_from_tool_call(request) -> str:
+def _tool_call_args(request) -> dict[str, Any]:
     args = getattr(request, "tool_call_args", None)
     if not isinstance(args, dict):
         last = getattr(request, "tool_call", None)
         args = getattr(last, "args", None) if last else None
-    if not isinstance(args, dict):
-        return ""
+    return args if isinstance(args, dict) else {}
+
+
+def _command_from_tool_call(request) -> str:
+    args = _tool_call_args(request)
     cmd = args.get("command") or args.get("cmd") or ""
     return cmd if isinstance(cmd, str) else ""
 
@@ -198,6 +240,14 @@ class RoEEnforcementMiddleware(AgentMiddleware):
         get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
         workspace = get("workspace_path") or None
         rules = _load_rules_for_workspace(workspace)
+        extractor = NETWORK_TARGET_EXTRACTORS.get(tool_name)
+        if extractor is not None:
+            hosts = extractor(_tool_call_args(request))
+            for host in sorted(set(hosts)):
+                target_decision = evaluate_target(host, rules)
+                if not target_decision.allow:
+                    return target_decision, rules, tool_name
+            return Decision.allow_default(), rules, tool_name
         command = _command_from_tool_call(request)
         cmd_decision = evaluate_command(command, rules)
         if not cmd_decision.allow:

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -256,6 +256,19 @@ def _make_request(tool_name: str, command: str = "", state: dict | None = None):
     return request
 
 
+def _make_network_request(tool_name: str, args: dict, state: dict | None = None):
+    request = MagicMock()
+    request.tool = MagicMock()
+    request.tool.name = tool_name
+    request.state = state or {}
+    request.tool_call = MagicMock()
+    request.tool_call.args = args
+    request.tool_call.id = "tc-test"
+    request.tool_call_args = args
+    request.tool_call_id = "tc-test"
+    return request
+
+
 def _write_roe(workspace: Path, machine_enforcement: dict) -> None:
     (workspace / "plan").mkdir(parents=True, exist_ok=True)
     (workspace / "plan" / "roe.json").write_text(
@@ -363,6 +376,127 @@ class TestRoEMiddleware:
         assert len(recs) == 1
         assert recs[0]["decision"] == "refuse"
         assert recs[0]["reason_code"] == "NOT_IN_SCOPE"
+
+
+class TestNetworkToolGating:
+    def test_http_request_out_of_scope_refused_in_enforce(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "http_request",
+            {"method": "GET", "url": "https://evilcorp.com/x"},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "[ROE_REFUSED]" in result.content
+        assert result.status == "error"
+
+    def test_http_request_in_scope_allowed(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "http_request",
+            {"method": "GET", "url": "https://api.acme.com/v1"},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_proxy_send_request_out_of_scope_refused(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "proxy_send_request",
+            {"method": "POST", "url": "https://evilcorp.com/login"},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "[ROE_REFUSED]" in result.content
+
+    def test_browser_action_goto_url_respected(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "browser_action",
+            {"action": "goto", "params_json": json.dumps({"url": "https://evilcorp.com/"})},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "[ROE_REFUSED]" in result.content
+
+    def test_browser_action_in_scope_url_allowed(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "browser_action",
+            {"action": "goto", "params_json": json.dumps({"url": "https://app.acme.com/"})},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_browser_action_malformed_params_degrades_to_allow(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "browser_action",
+            {"action": "goto", "params_json": "{not valid json"},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_browser_action_without_url_allowed(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["*.acme.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "browser_action",
+            {"action": "screenshot", "params_json": json.dumps({"full_page": True})},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert result.content == "ok"
+
+    def test_http_request_imds_blocked_by_default(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "enforce", "in_scope": ["10.0.0.0/8"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "http_request",
+            {"method": "GET", "url": "http://169.254.169.254/latest/meta-data/"},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock()
+        result = mw.wrap_tool_call(req, handler)
+        assert not handler.called
+        assert "FORBIDDEN_DESTINATION" in result.content
+
+    def test_http_request_warn_mode_appends_warning(self, tmp_path: Path) -> None:
+        _write_roe(tmp_path, {"mode": "warn", "out_of_scope": ["evilcorp.com"]})
+        mw = RoEEnforcementMiddleware()
+        req = _make_network_request(
+            "http_request",
+            {"method": "GET", "url": "https://evilcorp.com/x"},
+            state={"workspace_path": str(tmp_path)},
+        )
+        handler = MagicMock(return_value=ToolMessage(content="resp body", tool_call_id="tc-test"))
+        result = mw.wrap_tool_call(req, handler)
+        assert handler.called
+        assert "[ROE_WARN]" in result.content
+        assert "resp body" in result.content
 
 
 class TestSlotRegistration:


### PR DESCRIPTION
## Summary
`GATED_TOOL_NAMES` was bash-only, so the genuine network-egress tools (`http_request`, `proxy_send_request`, `browser_action`) routed **around** the RoE scope / forbidden-destination check — out-of-scope egress was silently allowed.

## Changes
- Extend the RoE gate to those tools via a per-tool target-extractor registry: `http_request`/`proxy_send_request` → host from the `url` arg (`urllib.parse`); `browser_action` → `url` parsed from `params_json`. In `_evaluate`, network tools derive targets via their extractor and run the existing `evaluate_target`, refusing/warning per `EnforcementMode` exactly like bash. Extraction failures degrade to allow (no crash). Bash behavior unchanged.

## Testing
- ruff clean; `uv run basedpyright` 0 errors; full fast suite green (the 8 failures observed were verified pre-existing flakes — `test_shutdown.py` subprocess timeouts under `-n auto` + one clock-timing test — confirmed by re-running on the base commit). New tests: out-of-scope http refused in ENFORCE, in-scope allowed, browser goto url respected, malformed `params_json` degrades to allow.

⚠️ `roe.py` overlaps in-flight PRs #463/#466/#469/#470 + the max-concurrent PR — localized to the gated set + `_evaluate` + an extractor block; rebase after those merge.
