### PR TITLE
feat(kg): persist computed r.cost on attack edges so dijkstra honors exploitation difficulty

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/kg.py
+++ b/packages/decepticon-core/decepticon_core/types/kg.py
@@ -149,6 +149,15 @@ SEVERITY_SCORE: dict[Severity, float] = {
 }
 
 
+SEVERITY_COST_MULTIPLIER: dict[Severity, float] = {
+    Severity.CRITICAL: 0.4,
+    Severity.HIGH: 0.6,
+    Severity.MEDIUM: 1.0,
+    Severity.LOW: 1.6,
+    Severity.INFO: 2.5,
+}
+
+
 # ── Models ──────────────────────────────────────────────────────────────
 
 

--- a/packages/decepticon/decepticon/tools/research/chain.py
+++ b/packages/decepticon/decepticon/tools/research/chain.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from decepticon.tools.research._state import get_store
 from decepticon_core.types.kg import (
+    SEVERITY_COST_MULTIPLIER,
     SEVERITY_SCORE,
     EdgeKind,
     NodeKind,
@@ -51,15 +52,6 @@ _ATTACK_REL_TYPES = "|".join(
         EdgeKind.ADMIN_TO.value,
     ]
 )
-
-# Severity → multiplier. High severity shrinks cost (faster to reach).
-_SEVERITY_MULTIPLIER: dict[str, float] = {
-    Severity.CRITICAL.value: 0.4,
-    Severity.HIGH.value: 0.6,
-    Severity.MEDIUM.value: 1.0,
-    Severity.LOW.value: 1.6,
-    Severity.INFO.value: 2.5,
-}
 
 
 @dataclass(frozen=True)
@@ -123,7 +115,10 @@ def compute_edge_cost(
     This should be called at ingestion time and stored as the ``cost``
     property on relationships so Cypher path algorithms can use it.
     """
-    mult = _SEVERITY_MULTIPLIER.get(severity, 1.0)
+    try:
+        mult = SEVERITY_COST_MULTIPLIER[Severity(severity)]
+    except ValueError:
+        mult = 1.0
     if validated:
         mult *= 0.5
     return max(base_weight, 0.05) * mult

--- a/packages/decepticon/decepticon/tools/research/neo4j_store.py
+++ b/packages/decepticon/decepticon/tools/research/neo4j_store.py
@@ -32,8 +32,26 @@ from typing import Any
 from decepticon.tools.research._engagement_scope import (
     with_engagement_property,
 )
-from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
+from decepticon_core.types.kg import (
+    SEVERITY_COST_MULTIPLIER,
+    Edge,
+    EdgeKind,
+    KnowledgeGraph,
+    Node,
+    NodeKind,
+)
 from decepticon_core.utils.logging import get_logger
+
+
+def _edge_cost_expr(weight_ref: str) -> str:
+    severity_when = " ".join(
+        f"WHEN '{sev.value}' THEN {mult}" for sev, mult in SEVERITY_COST_MULTIPLIER.items()
+    )
+    severity_case = f"CASE coalesce(dst.severity, '') {severity_when} ELSE 1.0 END"
+    validated_case = "CASE WHEN coalesce(dst.validated, false) THEN 0.5 ELSE 1.0 END"
+    weight_case = f"CASE WHEN {weight_ref} > 0.05 THEN {weight_ref} ELSE 0.05 END"
+    return f"({severity_case}) * ({validated_case}) * ({weight_case})"
+
 
 log = get_logger("research.neo4j")
 
@@ -272,11 +290,13 @@ class Neo4jStore:
         rel_type = edge.kind.value.upper()
         scoped_props = with_engagement_property(edge.props)
         engagement = scoped_props["engagement"]
+        cost_expr = _edge_cost_expr("$weight")
         query = f"""
         MATCH (src {{id: $src_id}}), (dst {{id: $dst_id}})
         MERGE (src)-[r:{rel_type} {{id: $edge_id}}]->(dst)
         SET r.kind = $kind,
             r.weight = $weight,
+            r.cost = {cost_expr},
             r.props = $props,
             r.engagement = $engagement,
             r.created_at = coalesce(r.created_at, $created_at)
@@ -369,6 +389,7 @@ class Neo4jStore:
             )
 
         total = 0
+        cost_expr = _edge_cost_expr("row.weight")
         with self._driver.session(database=self._database) as session:
             for rel_type, batch in grouped.items():
                 query = f"""
@@ -377,6 +398,7 @@ class Neo4jStore:
                 MERGE (src)-[r:{rel_type} {{id: row.id}}]->(dst)
                 SET r.kind = row.kind,
                     r.weight = row.weight,
+                    r.cost = {cost_expr},
                     r.props = row.props,
                     r.engagement = row.engagement,
                     r.created_at = coalesce(r.created_at, row.created_at)

--- a/packages/decepticon/tests/unit/research/test_chain.py
+++ b/packages/decepticon/tests/unit/research/test_chain.py
@@ -11,7 +11,6 @@ import pytest
 
 from decepticon.tools.research.chain import (
     _ATTACK_REL_TYPES,
-    _SEVERITY_MULTIPLIER,
     Chain,
     ChainStep,
     compute_edge_cost,
@@ -22,7 +21,7 @@ from decepticon.tools.research.chain import (
     promote_chain,
     unexplored_surface,
 )
-from decepticon_core.types.kg import EdgeKind, NodeKind, Severity
+from decepticon_core.types.kg import SEVERITY_COST_MULTIPLIER, EdgeKind, NodeKind, Severity
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -95,25 +94,19 @@ class TestAttackRelTypes:
         assert not _ATTACK_REL_TYPES.endswith("|")
 
 
-# ── _SEVERITY_MULTIPLIER ─────────────────────────────────────────────────
-
-
 class TestSeverityMultiplier:
     def test_critical_cheapest(self) -> None:
-        assert (
-            _SEVERITY_MULTIPLIER[Severity.CRITICAL.value]
-            < _SEVERITY_MULTIPLIER[Severity.HIGH.value]
-        )
+        assert SEVERITY_COST_MULTIPLIER[Severity.CRITICAL] < SEVERITY_COST_MULTIPLIER[Severity.HIGH]
 
     def test_info_most_expensive(self) -> None:
-        assert _SEVERITY_MULTIPLIER[Severity.INFO.value] > _SEVERITY_MULTIPLIER[Severity.LOW.value]
+        assert SEVERITY_COST_MULTIPLIER[Severity.INFO] > SEVERITY_COST_MULTIPLIER[Severity.LOW]
 
     def test_medium_is_neutral(self) -> None:
-        assert _SEVERITY_MULTIPLIER[Severity.MEDIUM.value] == 1.0
+        assert SEVERITY_COST_MULTIPLIER[Severity.MEDIUM] == 1.0
 
     def test_all_severities_covered(self) -> None:
         for sev in Severity:
-            assert sev.value in _SEVERITY_MULTIPLIER
+            assert sev in SEVERITY_COST_MULTIPLIER
 
 
 # ── compute_edge_cost ────────────────────────────────────────────────────

--- a/packages/decepticon/tests/unit/research/test_neo4j_store.py
+++ b/packages/decepticon/tests/unit/research/test_neo4j_store.py
@@ -19,10 +19,18 @@ from decepticon.tools.research.neo4j_store import (
     Neo4jStore,
     Neo4jUnavailableError,
     _decode_props,
+    _edge_cost_expr,
     _encode_props,
     _label_for,
 )
-from decepticon_core.types.kg import Edge, EdgeKind, KnowledgeGraph, Node, NodeKind
+from decepticon_core.types.kg import (
+    SEVERITY_COST_MULTIPLIER,
+    Edge,
+    EdgeKind,
+    KnowledgeGraph,
+    Node,
+    NodeKind,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -895,3 +903,34 @@ class TestLoadGraph:
         store = _make_store(driver)
         graph = store.load_graph()
         assert isinstance(graph, KnowledgeGraph)
+
+
+class TestEdgeCost:
+    def test_upsert_edge_writes_computed_cost(self) -> None:
+        session = _FakeSession()
+        store = _make_store(_FakeDriver(sessions=[session]))
+        edge = Edge.make("h1", "v1", EdgeKind.HAS_VULN)
+        store.upsert_edge(edge)
+        query, _params = session.runs[0]
+        assert "r.cost =" in query
+        assert "coalesce(dst.severity, '')" in query
+        assert "coalesce(dst.validated, false)" in query
+        assert "WHEN 'critical' THEN 0.4" in query
+        assert "$weight > 0.05" in query
+
+    def test_batch_upsert_edges_writes_computed_cost(self) -> None:
+        session = _FakeSession()
+        store = _make_store(_FakeDriver(sessions=[session]))
+        e1 = Edge.make("h1", "v1", EdgeKind.HAS_VULN)
+        store.batch_upsert_edges([e1])
+        query, _params = session.runs[0]
+        assert "r.cost =" in query
+        assert "row.weight > 0.05" in query
+        assert "coalesce(dst.severity, '')" in query
+
+    def test_edge_cost_expr_covers_every_multiplier(self) -> None:
+        expr = _edge_cost_expr("$weight")
+        for sev, mult in SEVERITY_COST_MULTIPLIER.items():
+            assert f"WHEN '{sev.value}' THEN {mult}" in expr
+        assert "ELSE 1.0 END" in expr
+        assert "$weight" in expr


### PR DESCRIPTION
## Summary
The chain planner runs `apoc.algo.dijkstra(..., 'cost')` (fallback sums `coalesce(r.cost, 1.0)`), but the store only ever wrote `r.weight` — never `r.cost` — and `compute_edge_cost` (the documented cost model) had **zero callers**. So `r.cost` was always null → coalesced to `1.0` → the weighted shortest-path **silently degenerated to hop-count**, ignoring severity, validation state, and the analyst-assigned weight. This is the follow-up to #464 noted in that PR.

## Changes
- Add `SEVERITY_COST_MULTIPLIER` to `decepticon_core.types.kg` as the **single source of truth**; `compute_edge_cost` now reads it (behavior unchanged — its value-tests still pass).
- Compute `r.cost` **Cypher-side** in `upsert_edge` + `batch_upsert_edges` from the matched destination node's `severity`/`validated` and the edge `weight`, via a `_edge_cost_expr` generated from the same multiplier map (no drift — covered by a parity test).

## Dependency / sequencing
- Honors the **analyst weight immediately**. The **severity/validated** multipliers take full effect once **#464** (top-level prop promotion) merges — until then `dst.severity`/`dst.validated` read null and default to a `1.0` multiplier, still strictly better than the prior hop-count degeneration.
- No separate backfill: existing edges pick up `r.cost` on their next upsert (`graph_transaction` re-saves loaded edges).

## Testing
- ruff clean; `uv run basedpyright` 0 errors; **full fast suite 3556 passed**; targeted chain + store tests 125 passed.
- New tests: edge-cost present in both upsert queries (`r.cost =`, `dst.severity`/`dst.validated` CASEs, `$weight`/`row.weight`); `_edge_cost_expr` covers every multiplier; existing `compute_edge_cost` value-tests preserved.

No CODEOWNERS paths (`types/` is unprotected). ⚠️ `neo4j_store.py` / `test_neo4j_store.py` overlap #462 (reads) and #464 (node upserts) — my edits are the edge upserts + a new helper + additive tests; rebase after those merge.
