### PR TITLE
docs(agents): correct middleware stack, class names, per-role diagrams, and skill-load path

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -10,7 +10,7 @@ Decepticon ships **16 specialist agents** organized by kill chain phase. Each ag
 
 | Agent | Role |
 |-------|------|
-| **Decepticon** | Main red-team orchestrator. Reads the OPPLAN, dispatches objectives to specialist sub-agents, and tracks status transitions. Sub-agents: `recon`, `exploit`, `postexploit`, `analyst`, `reverser`, `contract_auditor`, `cloud_hunter`, `ad_operator`. |
+| **Decepticon** | Main red-team orchestrator. Reads the OPPLAN, dispatches objectives to specialist sub-agents, and tracks status transitions. Sub-agents: `recon`, `exploit`, `postexploit`, `analyst`, `reverser`, `contract_auditor`, `cloud_hunter`, `ad_operator`, `phisher`, `mobile_operator`, `wireless_operator`. |
 | **Vulnresearch** | Vulnerability research orchestrator — runs the five-stage pipeline (`scanner → detector → verifier → patcher → exploiter`) with state passed between stages exclusively through the knowledge graph. |
 | **Soundwave** | Engagement planner. Standalone graph (not a sub-agent of Decepticon). Interviews the operator and writes the eight-document engagement bundle — RoE, Threat Profile, CONOPS, Deconfliction, Contact, Data Handling, Abort, Cleanup. The orchestrator builds the OPPLAN. |
 
@@ -48,6 +48,9 @@ Sub-agents of the **Vulnresearch** orchestrator. State flows between stages via 
 | **Contract Auditor** | Solidity / EVM smart contract audits — reentrancy, oracle manipulation, flash loan abuse, access control. |
 | **Reverser** | Binary analysis and reverse engineering — ELF/PE/Mach-O triage, packer detection, ROP gadget inventories, Ghidra/radare2 recon. |
 | **Analyst** | Vulnerability research and reporting — source code review, static analysis (semgrep/bandit/gitleaks), dependency CVE sweeps, multi-hop exploit chain construction. |
+| **Phisher** | Initial-access via phishing / social engineering (MITRE T1566.\*) — email phishing, evilginx2 token capture, M365 OAuth device-code, lookalike domains. Coordinates lure deconfliction with the blue team before sending. |
+| **Mobile Operator** | Android / iOS application attacks — static analysis (apktool/jadx/class-dump), dynamic instrumentation (frida/objection), SSL pinning + root/jailbreak bypass, exported-component abuse, WebView JS bridge exploitation, MobSF. |
+| **Wireless Operator** | Wi-Fi / BLE / Zigbee / sub-GHz attacks — WPA2 handshake / PMKID capture, WPA3-SAE downgrade, WPA-Enterprise evil-twin, KARMA / Mana, deauth, WPS Pixie Dust, BLE GATT, Zigbee Touchlink, sub-GHz replay. Requires hardware passthrough or an SSH dropbox. |
 
 ---
 
@@ -66,48 +69,85 @@ This prevents context window bloat and token accumulation across a long engageme
 
 ## Middleware Stack
 
-Each agent runs with a configurable middleware stack. Middleware is applied in order before each LLM call.
+Each agent assembles its middleware stack from a fixed set of named **slots** (`MiddlewareSlot`). The enum declaration order is the canonical assembly order — every factory walks the enum top-to-bottom and instantiates only the slots its role opts into via `SLOTS_PER_ROLE`. Plugins replace or disable slots by name (`PluginBundle.replaced_middleware` / `disabled_middleware`); slot definitions and the per-role mapping live in `decepticon_core.contracts.slots`, the langchain-bound factories in `decepticon.agents.middleware_slots`.
 
-| Middleware | Purpose |
-|------------|---------|
-| `EngagementContextMiddleware` | Injects engagement metadata (slug, target, RoE summary) into the system prompt for the orchestrator. |
-| `DecepticonSkillsMiddleware` | Loads SKILL.md frontmatter at startup, filters by agent role, and injects matching skill descriptions into the system prompt. Full skill content is fetched on demand via `read_file`. |
-| `FilesystemMiddlewareNoExecute` | Provides `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep` tools backed by the sandbox filesystem. Execute is intentionally disabled — agents use the dedicated `bash` tool for command execution. |
-| `SubAgentMiddleware` | Allows orchestrators (Decepticon, Vulnresearch) to delegate objectives to specialist sub-agents via the `task()` tool. |
-| `OPPLANMiddleware` | Injects the current OPPLAN progress table into every LLM call and provides 5 CRUD tools for objective management (Claude Code V2 Task pattern). |
-| `ModelFallbackMiddleware` | Switches to a fallback model on provider outage, rate limit, or context overflow. Walks the fallback chain built from the user's credentials inventory. |
-| `SummarizationMiddleware` | Auto-compacts conversation history when the context window approaches capacity. |
-| `AnthropicPromptCachingMiddleware` | Caches static system prompt content for Anthropic models to reduce token costs. Silently no-ops on non-Anthropic providers. |
-| `PatchToolCallsMiddleware` | Sanitizes and normalizes tool call formats for compatibility across model providers (e.g. repairs dangling tool calls). |
+### Safety stack (every agent)
+
+These slots are part of the base set every role receives — they are the engagement guard rails:
+
+| Middleware | Slot | Purpose |
+|------------|------|---------|
+| `RoEEnforcementMiddleware` | `roe-enforcement` | Legal/safety gate on tool calls — extracts the target, evaluates it against the Rules of Engagement, and appends to a chained audit log (`<workspace>/audit/roe-decisions.jsonl`, or `DECEPTICON_ROE_AUDIT_PATH`). |
+| `UntrustedOutputMiddleware` | `untrusted-output` | Quarantines attacker-influenceable tool output (bash stdout, file reads, KG queries) inside a `<UNTRUSTED_TOOL_OUTPUT>` envelope so hostile content can't re-author the agent's instructions. |
+| `PromptInjectionShieldMiddleware` | `prompt-injection-shield` | Deny-list wrap of attacker-controlled tool output (HTTP bodies, banners, file reads); dedups against `UNTRUSTED_OUTPUT` and does not re-inject the system policy. |
+| `EventLogMiddleware` | `event-log` | Structured event logging for every model and tool call. |
+| `BudgetEnforcementMiddleware` | `budget` | Enforces per-engagement spend caps (no-op when caps ≤ 0). |
+
+Bash-executing agents and the orchestrator additionally get:
+
+| Middleware | Slot | Purpose |
+|------------|------|---------|
+| `EngagementContextMiddleware` | `engagement-context` | Injects engagement metadata (slug, workspace) and per-challenge state (target URL, tags, flag format, mission brief) into every model call. Carries RoE scope into tool calls — it is **safety-critical**. |
+| `SandboxNotificationMiddleware` | `sandbox-notification` | Tracks background-job completion and emits the CLI's `Background command` event. Bash agents only. |
+| `HITLApprovalMiddleware` | `hitl-approval` | Operator-approval gate for high-impact actions (credential dumping, destructive ops). **Opt-in** — skipped unless `DECEPTICON_HITL__ENABLED` is set to a truthy value (off by default so engagements don't freeze waiting on a human). |
+
+### Framework middleware
+
+| Middleware | Slot | Purpose |
+|------------|------|---------|
+| `SkillsMiddleware` | `skills` | Loads `SKILL.md` frontmatter, filters by agent role, and injects matching skill descriptions into the system prompt. Full skill content is fetched on demand via the `load_skill` tool — `read_file` / `bash cat` **do not** resolve `/skills/*` (that tree is served in-process by a local `FilesystemBackend`, not the sandbox). |
+| `FilesystemMiddleware` | `filesystem` | Provides `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep` tools backed by the sandbox filesystem. Execute is intentionally stripped — agents use the dedicated `bash` tool for command execution. |
+| `SubAgentMiddleware` | `subagent` | Allows orchestrators (Decepticon, Vulnresearch) to delegate objectives to specialist sub-agents via the `task()` tool. |
+| `OPPLANMiddleware` | `opplan` | Injects the current OPPLAN progress table into every LLM call and provides CRUD tools for objective management. |
+| `ModelOverrideMiddleware` | `model-override` | Per-objective model selection. Orchestrator only. |
+| `ModelFallbackMiddleware` | `model-fallback` | Switches to a fallback model on provider outage, rate limit, or context overflow. Conditional — skipped when no fallback chain is configured. |
+| `SummarizationMiddleware` | `summarization` | Auto-compacts conversation history when the context window approaches capacity. |
+| `AnthropicPromptCachingMiddleware` | `prompt-caching` | Caches static system prompt content for Anthropic models to reduce token costs. Silently no-ops on non-Anthropic providers. |
+| `PatchToolCallsMiddleware` | `patch-tool-calls` | Sanitizes and normalizes tool call formats for compatibility across model providers (e.g. repairs dangling tool calls). |
+
+### Safety-critical slots
+
+`SAFETY_CRITICAL_SLOTS` — `engagement-context`, `roe-enforcement`, `untrusted-output`, `prompt-injection-shield`, `sandbox-notification`, `hitl-approval` — can only be replaced or disabled by a plugin when `DECEPTICON_ALLOW_SAFETY_OVERRIDES=1` is set in the environment. The gate is enforced by `build_middleware` in `decepticon.agents.build`; without it, an override raises `SafetyOverrideViolation`. Replacement is fine if the new middleware honours the same contract — the gate exists so an accidentally-installed plugin can't silently subvert the safety story.
 
 ### Stack per Agent Role
 
-**Decepticon (Orchestrator)** — full stack with engagement context and sub-agent dispatch.
+Each diagram lists the slots a role instantiates, in `MiddlewareSlot` enum order (the order they wrap each call). `HITLApproval` appears in the bash-agent and orchestrator stacks but is opt-in — skipped at runtime unless `DECEPTICON_HITL__ENABLED` is truthy.
+
+**Decepticon (Orchestrator)** — full stack with engagement context, sub-agent dispatch, and per-objective model override. No `SandboxNotification`.
 
 ```
-EngagementContext → Skills → FilesystemNoExecute → SubAgent → OPPLAN
+EngagementContext → RoEEnforcement → HITLApproval → UntrustedOutput → PromptInjectionShield
+                  → Skills → Filesystem → SubAgent → OPPLAN → EventLog → Budget → ModelOverride
                   → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```
 
-**Vulnresearch (Orchestrator)** — same as Decepticon but without `EngagementContextMiddleware`.
+**Vulnresearch (Orchestrator)** — base + sub-agent dispatch. No `EngagementContext` (it consumes its parent's context), no `ModelOverride`, no `HITLApproval`, no `SandboxNotification`.
 
 ```
-Skills → FilesystemNoExecute → SubAgent → OPPLAN
-       → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
+RoEEnforcement → UntrustedOutput → PromptInjectionShield → Skills → Filesystem → SubAgent → OPPLAN
+              → EventLog → Budget → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```
 
-**Specialist sub-agents (Recon, Exploit, Post-Exploit, Scanner, Detector, etc.)**
+**Bash-executing specialists** (Recon, Exploit, Post-Exploit, Analyst, Reverser, Contract Auditor, Cloud Hunter, AD Operator, Phisher, Mobile Operator, Wireless Operator — and the plugin specialists Verifier, Patcher, Scanner, Exploiter) — the full bash-agent stack including `EngagementContext` and `SandboxNotification`.
 
 ```
-Skills → FilesystemNoExecute
-       → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
+EngagementContext → RoEEnforcement → HITLApproval → UntrustedOutput → PromptInjectionShield
+                  → Skills → Filesystem → EventLog → SandboxNotification → Budget
+                  → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```
 
-Specialists also have the `bash` tool for command execution inside the sandbox; `FilesystemMiddlewareNoExecute` covers all file I/O.
+These specialists also have the `bash` tool for command execution inside the sandbox; `FilesystemMiddleware` covers all file I/O.
 
-**Soundwave (Planner)** — no `bash`, no sub-agents (document generation only).
+**Detector (read-only plugin specialist)** — base set only. No `bash`, no `EngagementContext`, no `SandboxNotification`, no `HITLApproval`.
 
 ```
-Skills → FilesystemNoExecute
-       → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
+RoEEnforcement → UntrustedOutput → PromptInjectionShield → Skills → Filesystem → EventLog → Budget
+              → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
+```
+
+**Soundwave (Planner)** — base set + `EngagementContext`. No `bash`, no sub-agents, no `SandboxNotification`, no `HITLApproval` (document generation only).
+
+```
+EngagementContext → RoEEnforcement → UntrustedOutput → PromptInjectionShield → Skills → Filesystem
+                  → EventLog → Budget → ModelFallback → Summarization → AnthropicPromptCaching → PatchToolCalls
 ```


### PR DESCRIPTION
## Summary
`docs/agents.md`'s middleware section was materially inaccurate vs the code. This rewrites it from the authoritative `contracts/slots.py` + `agents/middleware_slots.py`.

## Fixes (code is authoritative; verified against it)
- **Fabricated class names** → real ones: `DecepticonSkillsMiddleware` → `SkillsMiddleware` (`skills.py:136`), `FilesystemMiddlewareNoExecute` → `FilesystemMiddleware` (`filesystem.py:270`).
- **Entire base safety stack was omitted** — now documented: RoEEnforcement, UntrustedOutput, PromptInjectionShield, EventLog, Budget (+ SandboxNotification & HITL for bash/orchestrator, ModelOverride for the orchestrator), with `SAFETY_CRITICAL_SLOTS` + the `DECEPTICON_ALLOW_SAFETY_OVERRIDES` gate.
- **Per-role diagrams regenerated** in `MiddlewareSlot` enum order from `SLOTS_PER_ROLE` (fixes vulnresearch lacking ModelOverride/HITL/SandboxNotification; soundwave = base + EngagementContext).
- **HITL** documented as **opt-in, off by default** (`DECEPTICON_HITL__ENABLED`).
- **Skill loading**: corrected the claim that skill content is read via `read_file` — `load_skill()` is required; `read_file`/`bash cat` do not resolve `/skills/*` (`skills.py:104-113`).
- **Roster**: added the 3 missing Domain Specialists (Phisher, MobileOperator, WirelessOperator) and corrected the Decepticon sub-agent list 8 → 11. Kept the **"16 specialist agents"** count (verified correct: 16 SUBAGENT_SPECs + 3 orchestrators = 19 factories).

Docs-only; no CODEOWNERS paths.
