### PR TITLE
docs(security): add runtime security reference suite (RoE enforcement, audit ledger, controls, HITL)

### DIFF
--- a/docs/security/audit-ledger.md
+++ b/docs/security/audit-ledger.md
@@ -1,0 +1,115 @@
+# Audit Ledger
+
+> The HMAC-chained, append-only record of every RoE decision — the legal
+> artifact for paid and regulated engagement out-briefs.
+
+## TL;DR
+
+Every RoE evaluation (PASS as well as REFUSE) emits one record to an
+append-only JSON Lines ledger. Each record is hash-chained to its
+predecessor and optionally bound to an operator-held HMAC secret, so
+tampering with record N invalidates every record after N.
+
+The ledger lives at `<workspace>/audit/roe-decisions.jsonl`. It is the
+key artifact for "what the agent tried, what was approved, what was
+blocked."
+
+Source of record:
+[`middleware/_audit_sink.py`](../../packages/decepticon/decepticon/middleware/_audit_sink.py)
+(the sink + verifier) and
+[`middleware/roe.py`](../../packages/decepticon/decepticon/middleware/roe.py)
+(the writer).
+
+## Record shape
+
+The RoE middleware builds the per-decision fields; the sink stamps the
+chain fields on append.
+
+### Decision fields (written by the middleware)
+
+| Field | Meaning |
+|-------|---------|
+| `ts` | Wall-clock timestamp (`time.time()`). |
+| `engagement` | Engagement name from state, else `"unknown-engagement"`. |
+| `objective_id` | Active objective id from state, else `""`. |
+| `tool` | Gated tool name (`bash`, `bash_output`, `bash_kill`). |
+| `decision` | `"allow"` or `"refuse"`. |
+| `reason_code` | RoE outcome code (`OK`, `IN_SCOPE`, `OUT_OF_SCOPE`, `NOT_IN_SCOPE`, `FORBIDDEN_DESTINATION`, `FORBIDDEN_COMMAND`). |
+| `reason_detail` | Human-readable explanation of the decision. |
+| `risk` | `low` / `medium` / `high`. |
+| `matched_targets` | List of the rule patterns or destinations that matched. |
+| `mode` | The enforcement mode in effect (`audit` / `warn` / `enforce`). |
+| `command_excerpt` | The command text, truncated to 512 characters. |
+
+The audit write is wrapped so an audit-sink failure logs an error but
+never breaks tool execution.
+
+### Chain fields (stamped by the sink on append)
+
+| Field | Meaning |
+|-------|---------|
+| `seq` | Monotonic per-ledger counter, starting at 1. |
+| `prev_hash` | SHA-256 of the previous record's canonical encoding, or 64 zero hex digits (`"0" * 64`) for the first record. |
+| `hash` | SHA-256 over this record's canonical fields **plus** `prev_hash`. |
+| `hmac` | HMAC-SHA-256 of `hash` under the operator secret, or `""` when no key is set. |
+
+Canonical encoding is `json.dumps` with `sort_keys=True` and tight
+separators, so the hash is stable regardless of field insertion order.
+
+## The HMAC binder
+
+The `hmac` field binds the chain to an operator-held secret read from
+`DECEPTICON_AUDIT_HMAC_KEY` (UTF-8 encoded). When the key is set, a party
+that tampers with the file can recompute the hash chain but cannot forge
+a valid `hmac` without the secret. When the key is unset, the `hmac`
+field stays `""` and integrity rests only on the hash chain.
+
+## Verification
+
+`verify_ledger(path, hmac_key=None)` walks the file end-to-end and
+returns a `VerifyResult`:
+
+| Field | Meaning |
+|-------|---------|
+| `ok` | `True` if the whole ledger verifies. |
+| `records_checked` | Number of records walked. |
+| `first_bad_seq` | The sequence number of the first failing record, or `None`. |
+| `reason` | Explanation of the first failure. |
+
+It checks, per record: the `seq` is the expected next value (catches gaps
+and duplicates), `prev_hash` matches the running chain head, the
+recomputed `hash` matches the stored `hash`, and — when an `hmac_key` is
+supplied — the `hmac` matches under constant-time comparison. A missing
+file verifies as `ok` with zero records checked.
+
+`iter_records(path)` yields decoded records without verifying integrity —
+useful for reporting and analytics. It skips blank and malformed lines
+silently.
+
+## Configuration
+
+| Knob | Effect |
+|------|--------|
+| `DECEPTICON_ROE_AUDIT_PATH` | Pins the ledger to a deterministic path. When unset, the default sink writes to `<workspace>/audit/roe-decisions.jsonl`; with no workspace yet, the sink is `None` (no-op). |
+| `DECEPTICON_AUDIT_HMAC_KEY` | The HMAC secret. Set it to bind the chain to an operator-held key. |
+
+## Limitations
+
+- **Local file only** in this implementation. Remote shipping (S3,
+  syslog, Loki over mTLS) is a follow-up; the local file is the primary
+  integrity boundary.
+- **Single writer per file.** The runtime guarantees this because the
+  LangGraph orchestrator runs one event loop per engagement workspace;
+  the append-then-fsync is atomic per record on POSIX append-only files,
+  and on Windows for buffer sizes under 4096 bytes.
+- The **`decepticon audit verify` CLI hook is a TODO** — call
+  `verify_ledger` directly until it lands.
+
+## See also
+
+- [RoE Machine Enforcement](./roe-machine-enforcement.md) — what produces
+  these records and the decision codes they carry.
+- [Security Controls](./security-controls.md) — the runtime-guard
+  knob/default table, including the audit env vars.
+- [Threat Model](./decepticon-threat-model.md) — the ledger as the
+  repudiation control for the sandbox and orchestrator assets.

--- a/docs/security/decepticon-threat-model.md
+++ b/docs/security/decepticon-threat-model.md
@@ -85,7 +85,7 @@ Per-asset analysis.
 | **Tampering** | LiteLLM admin UI mutates routing | Master key never exposed to sandbox network | Done |
 | **Information disclosure** | OAuth credential files bind-mounted (Claude/Codex) | Bind RO; LiteLLM container itself is on `decepticon-net` only | Done |
 | **Information disclosure** | Health endpoint hardcoded master key as fallback | Removed; health refuses without explicit `LITELLM_API_KEY` | Done |
-| **Denial of service** | Per-engagement model-tier spend not capped | Per-engagement budget cap (planned) | Open |
+| **Denial of service** | Per-engagement model-tier spend not capped | `BudgetEnforcementMiddleware` (in `_BASE_SLOTS`) hard-pauses at the per-engagement / per-agent USD cap | Done — opt-in via `DECEPTICON_BUDGET__*` ([security-controls](./security-controls.md)) |
 | **Elevation of privilege** | Compromised LiteLLM → upstream provider impersonation | Provider keys held server-side; client can't extract | Done (LiteLLM design) |
 
 ### Asset: Sandbox container
@@ -154,7 +154,7 @@ Tracked in this PR's roadmap, in order of priority:
 
 1. **Per-engagement Cypher user** (`decepticon-sandbox-<engagement>`, rotating Bolt token). Caps the impact of a single sandbox compromise to that engagement's portion of the graph.
 2. **Per-engagement sandbox container** (Docker SDK based lifecycle, one container per engagement open). Eliminates the "Engagement A's `.scratch/` is visible to Engagement B" leak. Tier 3 of this PR ships the design + compose hardening; full lifecycle ships in a follow-up.
-3. **Per-engagement budget cap** (token / dollar threshold per LiteLLM virtual key, downgrades to lower tier at threshold, hard-stops at 2x).
+3. ~~**Per-engagement budget cap**~~ — **shipped.** `BudgetEnforcementMiddleware` (in `_BASE_SLOTS`) soft-warns at a configurable fraction of the cap and hard-pauses the run at 100%, scoped per-engagement and per-agent. Enable via `DECEPTICON_BUDGET__ENGAGEMENT_USD` / `DECEPTICON_BUDGET__PER_AGENT_USD`; see [security-controls](./security-controls.md). Automatic model-tier downgrade at threshold is not implemented.
 4. **Plugin bundle signature** (PluginBundle ships an Ed25519 signature; operator pins trust set; `pip install` of an unpinned bundle is rejected at boot).
 5. **Firecracker microVM sandbox** (one ~125ms-boot microVM per objective). Kernel boundary instead of namespace boundary. SaaS-only; OSS keeps Docker.
 6. **Sigstore-style transparent log** for the RoE audit ledger. Today the ledger lives next to the engagement workspace; the HMAC key is operator-held. For paid engagements, ship the chain hash to a third-party transparency log (Rekor) so even the operator can't rewrite history.
@@ -167,6 +167,20 @@ This document does NOT cover:
 - **OpenAI/Anthropic/Google provider trust**: Decepticon trusts the upstream LLM providers' published security posture.
 - **Operator workstation hardening**: standard endpoint hygiene applies.
 - **Network ingress filtering** above what compose provides: deployers responsible for firewalling beyond `127.0.0.1:*` exposed ports.
+
+## Runtime security reference
+
+The controls referenced throughout this STRIDE walk are documented in
+detail in the runtime security reference suite:
+
+- [Security Controls](./security-controls.md) — knob/default/verify table
+  for every runtime guard, plus the budget, audit, and HITL env vars.
+- [RoE Machine Enforcement](./roe-machine-enforcement.md) — the scope and
+  forbidden-command gate for bash tool calls.
+- [Audit Ledger](./audit-ledger.md) — the HMAC-chained record of RoE
+  decisions and how to verify it.
+- [HITL Approval](./hitl-approval.md) — the opt-in operator-approval gate
+  for high-impact actions.
 
 ## Reporting
 

--- a/docs/security/hitl-approval.md
+++ b/docs/security/hitl-approval.md
@@ -1,0 +1,126 @@
+# HITL Approval
+
+> The human-in-the-loop checkpoint that pauses high-impact tool calls
+> until the operator approves, denies, or redirects them.
+
+## TL;DR
+
+Autonomous execution on real client infrastructure cannot be
+all-or-nothing. Some actions — credential dumping, C2 implant
+deployment, pushing detection rules to a production SIEM, destructive
+operations — need a human stop-the-line gate. `HITLApprovalMiddleware`
+intercepts tool calls that match a declarative policy, pauses the run,
+and applies the operator's decision.
+
+It is **opt-in and off by default**: the slot factory returns nothing
+unless `DECEPTICON_HITL__ENABLED` is truthy, so default engagements never
+freeze waiting on a human.
+
+Source of record:
+[`middleware/hitl.py`](../../packages/decepticon/decepticon/middleware/hitl.py)
+(middleware, policy, transports) and
+[`agents/middleware_slots.py`](../../packages/decepticon/decepticon/agents/middleware_slots.py)
+(the opt-in slot factory).
+
+## Enabling it
+
+`DECEPTICON_HITL__ENABLED` controls the slot. Any value other than the
+falsy set — `""`, `0`, `false`, `no`, `off` (case-insensitive) — enables
+the gate. When enabled, the factory builds the middleware with
+`DEFAULT_HIGH_IMPACT_POLICY`, `transport=None`, the engagement id from
+`DECEPTICON_ENGAGEMENT_ID` (default `default-engagement`), and the
+agent's role as `agent_name`.
+
+With `transport=None`, the middleware resolves a transport **per
+request** from `state["workspace_path"]` (falling back to
+`DECEPTICON_WORKSPACE_PATH`, then `/workspace`). The resolved transport is
+a [`FileBackedApprovalTransport`](#transports) writing
+`<workspace>/approvals/requests.jsonl` and
+`<workspace>/approvals/decisions.jsonl` — a contract shared with the web
+bridge. Per-request resolution matters because the standard graphs are
+built once at import, but a long-lived server serves many engagements.
+
+## Policy rules
+
+A policy is a list of `ApprovalPolicyRule`. Each rule MUST set
+`technique_tag` and/or `tool_pattern` (at least one):
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `technique_tag` | `None` | ATT&CK technique id (e.g. `T1003`); matched against the active objective's `technique_id`/`mitre`. |
+| `tool_pattern` | `None` | Regex matched against the tool name with `re.search`. |
+| `timeout_seconds` | `300.0` | How long to wait for an operator decision. |
+| `default_on_timeout` | `"deny"` | Action applied when no decision arrives in time. |
+| `reason` | `""` | Human-readable justification surfaced in the request. |
+
+Resolution checks each rule in order: a technique-tag match (when the
+objective carries a tag) wins, otherwise a tool-pattern regex match. The
+first matching rule applies; a tool call matching no rule passes straight
+through.
+
+## The default policy
+
+`DEFAULT_HIGH_IMPACT_POLICY` ships these rules:
+
+| Match | Timeout | On timeout | Why |
+|-------|---------|-----------|-----|
+| `T1003` (OS Credential Dumping) | 300 s | deny | Credential dumping needs operator approval. |
+| `T1486` (Data Encrypted for Impact) | 600 s | deny | Destructive operation. |
+| `T1485` (Data Destruction) | 600 s | deny | Destructive operation. |
+| tool `^(sliver_implant\|sliver_generate\|c2_deploy)` | 300 s | deny | C2 implant deployment needs explicit approval. |
+| tool `^(sigma_to\|yara_to)_` | 180 s | deny | Pushing detection rules to production SIEM/EDR needs approval. |
+| tool `^bash$` | 120 s | **allow** | Informational — bash invocation logged for audit only. |
+
+Note the `bash` rule defaults to **allow** on timeout: it exists so bash
+calls surface to the operator UI, not to block them.
+
+## Approval flow
+
+On a matching tool call the middleware:
+
+1. **Builds** an `ApprovalRequest` — `request_id` (UUID), engagement and
+   agent names, tool name, the tool args with secret keys redacted to
+   `***REDACTED***`, the matched rule, and a reason.
+2. **Submits** it via `transport.submit(request)`.
+3. **Waits** with `transport.wait_for_decision(request_id, timeout)` up to
+   the rule's `timeout_seconds`.
+4. **Applies** the decision:
+   - `allow` → pass through to the inner handler.
+   - `deny` → return an error `ToolMessage` explaining the denial.
+   - `redirect` → run the operator-supplied `redirect_args` instead.
+   - no response within the timeout → fall back to the rule's
+     `default_on_timeout` (deny for safety, except the informational bash
+     rule).
+
+Secret redaction covers keys such as `password`, `token`, `api_key`,
+`private_key`, `authorization`, `credentials`, `session`, and `cookie`.
+
+### Stack ordering
+
+HITL sits **above** the RoE gate so RoE refusals still fire after
+operator approval — operator approval cannot override RoE. This is
+defense in depth: see [RoE Machine Enforcement](./roe-machine-enforcement.md).
+
+## Transports
+
+The middleware does not hardcode any event-log format; it talks to an
+`ApprovalTransport` (a `submit` + `wait_for_decision` protocol).
+
+- **`InProcessApprovalTransport`** — in-memory queue for tests and
+  single-process UIs. Operator code calls `provide_decision` to unblock a
+  pending request.
+- **`FileBackedApprovalTransport`** — append-only JSONL queue. Writes
+  `approval_request` records to `requests.jsonl`; tails `decisions.jsonl`
+  for matching `approval_decision` records keyed by `request_id`. This is
+  the transport the default factory resolves per workspace.
+
+## See also
+
+- [Security Controls](./security-controls.md) — the runtime-guard
+  knob/default table, including `DECEPTICON_HITL__ENABLED`.
+- [RoE Machine Enforcement](./roe-machine-enforcement.md) — the gate
+  below HITL; operator approval cannot override an RoE refusal.
+- [Audit Ledger](./audit-ledger.md) — the append-only record of RoE
+  decisions.
+- [Threat Model](./decepticon-threat-model.md) — HITL as the
+  operator-approval control.

--- a/docs/security/roe-machine-enforcement.md
+++ b/docs/security/roe-machine-enforcement.md
@@ -1,0 +1,198 @@
+# RoE Machine Enforcement
+
+> How the machine-readable Rules of Engagement block out-of-scope and
+> forbidden tool calls at the moment the agent tries to run them.
+
+## TL;DR
+
+The human-readable RoE (`in_scope`, `out_of_scope`, `prohibited_actions`)
+that Soundwave authors during planning is for the operator's review. A
+separate, OPTIONAL `machine_enforcement` block inside the same
+`roe.json` drives the **RoE-enforcement middleware**, which evaluates
+every gated tool call against allowlist + denylist + forbidden-command
+rules at tool-call time.
+
+The block lives at `<workspace>/plan/roe.json`. When it is **absent**,
+the middleware runs in audit-only mode: every gated tool call is logged
+to the [audit ledger](./audit-ledger.md) but nothing is ever refused.
+
+Source of record:
+[`types/roe.py`](../../packages/decepticon-core/decepticon_core/types/roe.py)
+(schema + evaluator) and
+[`middleware/roe.py`](../../packages/decepticon/decepticon/middleware/roe.py)
+(the gate).
+
+## Enforcement modes
+
+`mode` is one of three values; the default is `audit` for backward
+compatibility (an engagement that never opts in keeps running).
+
+| Mode | Behavior on a refused call |
+|------|----------------------------|
+| `audit` | Logged, allowed to proceed. **Default.** |
+| `warn` | Logged; a `[ROE_WARN]` `ToolMessage` is prepended to the tool's output so the model sees it failed RoE, but the call still executes. |
+| `enforce` | Logged; the call short-circuits with a `[ROE_REFUSED]` `ToolMessage`. No bytes leave the sandbox. |
+
+The mode parses case-insensitively; an unrecognized string falls back to
+`audit` rather than erroring.
+
+## The `machine_enforcement` block
+
+Fields and defaults (`MachineEnforcement`):
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `mode` | `audit` \| `warn` \| `enforce` | `audit` | Enforcement mode (above). |
+| `in_scope` | list of scope rules | empty | Allowlist. When non-empty, a target must match one entry. |
+| `out_of_scope` | list of scope rules | empty | Denylist. Takes precedence over `in_scope`. |
+| `forbidden_destinations` | list of strings | empty | Extra denied hosts/IPs/CIDRs, merged with the default IMDS list. |
+| `forbidden_command_patterns` | list of regex strings | empty | Commands matching any pattern are refused. |
+| `allow_cloud_metadata` | bool | `false` | When `false`, the default cloud-metadata denylist is appended. |
+| `max_concurrent_connections` | int or null | `null` | Carried in the schema; advisory. |
+| `min_inter_request_delay_ms` | int | `0` | Carried in the schema; advisory. |
+
+`from_dict` reads the block; each scope list is parsed by `_parse_rules`,
+which accepts **either** a bare string (`"*.acme.com"`) **or** an object
+(`{"target": "10.0.0.0/24", "type": "cidr"}`). Any other shape is
+skipped.
+
+### Scope rules and `resolved_kind`
+
+A `ScopeRule` has a `pattern` and a `kind` (default `"auto"`). When the
+kind is `"auto"`, `resolved_kind()` infers it from the pattern shape:
+
+- parses as an IP network → `cidr`
+- contains `*` or `?` → `domain-glob` (`*` matches one label, `?` matches
+  one character)
+- a bare IP literal → `ip`
+- otherwise → `host` (literal, case-insensitive match)
+
+### Cloud-metadata defaults
+
+When `allow_cloud_metadata` is `false` (the default), five IMDS endpoints
+are appended to the forbidden-destinations list:
+
+```
+169.254.169.254
+fd00:ec2::254
+metadata.google.internal
+metadata.azure.com
+100.100.100.200
+```
+
+Setting `allow_cloud_metadata: true` drops these defaults and leaves only
+the operator's explicit `forbidden_destinations`.
+
+## How a target is evaluated
+
+`evaluate_target` runs in this precedence order (denylist wins):
+
+1. **Forbidden destinations** (operator list + IMDS defaults) → refuse
+   with `FORBIDDEN_DESTINATION`.
+2. **Out-of-scope** entries → refuse with `OUT_OF_SCOPE`.
+3. **In-scope** entries (only checked when `in_scope` is non-empty):
+   - a match → allow with `IN_SCOPE`;
+   - no match → refuse with `NOT_IN_SCOPE` (risk `medium`).
+4. When `in_scope` is empty, an unmatched target is allowed by default.
+
+### Trailing-dot normalization
+
+A trailing dot is DNS-equivalent (`host.` resolves identically to
+`host`). The matcher strips a trailing dot from **both** the rule pattern
+and the target before comparing. Without this, the FQDN form
+(`metadata.google.internal.`) or the IMDS IP written as
+`169.254.169.254.` slipped past the forbidden-destination and
+out-of-scope checks — a verified scope bypass that enabled
+cloud-credential exfil in enforce mode.
+
+## How a command is evaluated
+
+`evaluate_command` runs each `forbidden_command_patterns` regex against
+the literal command string with `re.search`. A match refuses with
+`FORBIDDEN_COMMAND`. Patterns that fail to compile are skipped (the
+evaluator never raises on a bad regex). Patterns are matched against the
+command string, not the full tool-arguments dict.
+
+## What gets gated
+
+The middleware only evaluates tool calls whose name is in
+`GATED_TOOL_NAMES`:
+
+```
+bash
+bash_output
+bash_kill
+```
+
+Any other tool call passes through as an allow-default and is not
+recorded. For a gated call, the middleware reads the engagement RoE from
+`state["workspace_path"]/plan/roe.json` **per iteration**, so an
+operator can hot-edit the RoE without restarting the run. It extracts the
+intended targets from the command text (best-effort regex extraction over
+~30 kill-chain tools), evaluates the command regexes first, then each
+target, and records the decision regardless of mode.
+
+If `workspace_path` is unset, the RoE fails open to a default
+`MachineEnforcement()` — i.e. audit-only, no rules — and a malformed or
+unreadable `roe.json` logs a warning and degrades the same way.
+
+## Worked example — enforce mode
+
+`<workspace>/plan/roe.json`:
+
+```json
+{
+  "in_scope": ["*.acme.com", "10.10.0.0/24"],
+  "out_of_scope": ["billing.acme.com"],
+  "machine_enforcement": {
+    "mode": "enforce",
+    "in_scope": ["*.acme.com", "10.10.0.0/24"],
+    "out_of_scope": ["billing.acme.com"],
+    "forbidden_command_patterns": ["\\bhydra\\s.*-t\\s*[5-9]\\d+"]
+  }
+}
+```
+
+With this in place:
+
+- `curl https://app.acme.com/` → **allow** (`IN_SCOPE`, matches
+  `*.acme.com`).
+- `curl https://billing.acme.com/` → **refuse** (`OUT_OF_SCOPE`); the
+  out-of-scope denylist wins over the in-scope glob.
+- `curl http://169.254.169.254/latest/meta-data/` → **refuse**
+  (`FORBIDDEN_DESTINATION`); the IMDS IP is on the default denylist
+  because `allow_cloud_metadata` defaults to `false`.
+- `nmap 192.0.2.10` → **refuse** (`NOT_IN_SCOPE`); a target outside the
+  allowlist, while `in_scope` is non-empty.
+- `hydra -t 64 ssh://app.acme.com` → **refuse** (`FORBIDDEN_COMMAND`);
+  the command matches the >50-thread Hydra pattern before any target is
+  evaluated.
+
+In each refusal the agent receives a `[ROE_REFUSED]` `ToolMessage`
+explaining the block and is told to change target/technique rather than
+re-issue the command. The PASS for `app.acme.com` and every refusal above
+are written to the audit ledger.
+
+## Limitations
+
+- Target extraction is regex-based and best-effort; it errs toward more
+  targets than the command would actually reach (false-positive-safe),
+  not fewer.
+- `max_concurrent_connections` and `min_inter_request_delay_ms` are
+  carried in the schema but are advisory — they are not throttled by this
+  middleware.
+- Enforcement covers the gated bash tools only; HTTP-style tools must be
+  added to `gated_tools` explicitly.
+
+## See also
+
+- [Audit Ledger](./audit-ledger.md) — where every RoE decision is
+  recorded and how to verify the chain.
+- [Security Controls](./security-controls.md) — the full runtime-guard
+  knob/default table.
+- [HITL Approval](./hitl-approval.md) — the operator-approval gate that
+  sits above RoE; operator approval cannot override an RoE refusal.
+- [Threat Model](./decepticon-threat-model.md) — Decepticon's own attack
+  surface.
+- [Engagement Workflow](../engagement-workflow.md) — where `plan/roe.json`
+  comes from.

--- a/docs/security/roe-machine-enforcement.md
+++ b/docs/security/roe-machine-enforcement.md
@@ -116,12 +116,15 @@ command string, not the full tool-arguments dict.
 ## What gets gated
 
 The middleware only evaluates tool calls whose name is in
-`GATED_TOOL_NAMES`:
+`GATED_TOOL_NAMES` (`decepticon/middleware/roe.py`):
 
 ```
 bash
 bash_output
 bash_kill
+http_request
+proxy_send_request
+browser_action
 ```
 
 Any other tool call passes through as an allow-default and is not
@@ -181,8 +184,11 @@ are written to the audit ledger.
 - `max_concurrent_connections` and `min_inter_request_delay_ms` are
   carried in the schema but are advisory — they are not throttled by this
   middleware.
-- Enforcement covers the gated bash tools only; HTTP-style tools must be
-  added to `gated_tools` explicitly.
+- Enforcement covers the six `GATED_TOOL_NAMES` tools by default — the three
+  bash tools plus `http_request`, `proxy_send_request`, and `browser_action`.
+  A caller may pass a custom `gated_tools` set to the middleware to narrow or
+  extend that list; any tool name outside the active set passes through as an
+  allow-default and is not recorded.
 
 ## See also
 

--- a/docs/security/security-controls.md
+++ b/docs/security/security-controls.md
@@ -1,0 +1,88 @@
+# Security Controls
+
+> One-page reference for the runtime guards in the agent middleware
+> stack: what each control does, its default posture, the knob that
+> changes it, and how to verify it is active.
+
+## TL;DR
+
+Every agent assembles its middleware stack by walking `MiddlewareSlot` in
+declaration order; a role only instantiates the slots in its
+`SLOTS_PER_ROLE` set. Five of those slots are the runtime security
+guards. Two are always-on and `SAFETY_CRITICAL` (cannot be silently
+disabled by a plugin); the rest opt in.
+
+Source of record:
+[`contracts/slots.py`](../../packages/decepticon-core/decepticon_core/contracts/slots.py)
+(slot enum, `SAFETY_CRITICAL_SLOTS`, `_BASE_SLOTS`),
+[`middleware/hitl.py`](../../packages/decepticon/decepticon/middleware/hitl.py),
+and
+[`middleware/budget.py`](../../packages/decepticon/decepticon/middleware/budget.py).
+
+## Controls overview
+
+| Control (slot) | Default posture | Knob | How to verify |
+|----------------|-----------------|------|---------------|
+| **RoE enforcement** (`roe-enforcement`) | Audit-only; logs but never blocks. Safety-critical. | `mode` in `<workspace>/plan/roe.json:machine_enforcement` (`audit`/`warn`/`enforce`) | Add an out-of-scope target under `enforce`; expect a `[ROE_REFUSED]` `ToolMessage` and an `OUT_OF_SCOPE` row in the [audit ledger](./audit-ledger.md). |
+| **Untrusted-output quarantine** (`untrusted-output`) | Always on, every role. Safety-critical. | None — in `_BASE_SLOTS`; only a plugin with `DECEPTICON_ALLOW_SAFETY_OVERRIDES=1` can replace it. | Read a hostile banner; tool output is wrapped in the `<UNTRUSTED_TOOL_OUTPUT>` envelope. See [prompt-injection-defense](./prompt-injection-defense.md). |
+| **Prompt-injection shield** (`prompt-injection-shield`) | Always on, every role. Safety-critical. | None — in `_BASE_SLOTS`; same override gate as above. | Deny-listed payloads in tool output are wrapped before reaching the next model call. |
+| **HITL approval** (`hitl-approval`) | Off by default — opt-in. Safety-critical when enabled. | `DECEPTICON_HITL__ENABLED` (truthy enables) | Enable it, trigger a `T1003` objective or a `sliver_*` tool; the run pauses for an approval written to `<workspace>/approvals/requests.jsonl`. See [hitl-approval](./hitl-approval.md). |
+| **Budget enforcement** (`budget`) | No-op unless a cap is set. In `_BASE_SLOTS`. | `DECEPTICON_BUDGET__ENGAGEMENT_USD` / `DECEPTICON_BUDGET__PER_AGENT_USD` (a positive cap enables it) | Set a low cap; expect a `budget_warning` stream event at the soft threshold and `BudgetExceeded` (run terminates) at 100%. |
+
+### What "safety-critical" means
+
+`SAFETY_CRITICAL_SLOTS` lists the slots a plugin can only replace or
+disable when `DECEPTICON_ALLOW_SAFETY_OVERRIDES=1` is set: engagement
+context, RoE enforcement, untrusted-output, prompt-injection shield,
+sandbox notification, and HITL approval. The gate exists so an
+accidentally-installed plugin cannot silently subvert the safety story.
+`DECEPTICON_ALLOW_SAFETY_OVERRIDES` is documented in the
+[library-usage](../library-usage.md) and
+[plugin-author-guide](../plugin-author-guide.md) docs.
+
+## Environment variables
+
+These runtime-guard knobs are otherwise undocumented; their defaults are
+read in `budget.py` and the audit sink.
+
+### Budget
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `DECEPTICON_BUDGET__ENGAGEMENT_USD` | `0.0` | Hard USD cap for the whole engagement. Non-positive = disabled. |
+| `DECEPTICON_BUDGET__PER_AGENT_USD` | `0.0` | Hard USD cap per specialist agent. Non-positive = disabled. |
+| `DECEPTICON_BUDGET__SOFT_WARN_AT_PCT` | `0.7` | Fraction of a cap at which a `budget_warning` stream event fires (the agent proceeds). |
+| `DECEPTICON_BUDGET__POLL_SECONDS` | `5.0` | How often LiteLLM spend is re-queried; spend is cached for this interval. |
+
+The middleware is a no-op unless `ENGAGEMENT_USD` or `PER_AGENT_USD` is
+positive. It blocks LLM calls only, never tool calls — an in-flight tool
+round-trip and a final synthesis message can still complete before the
+next inference fails. Spend comes from LiteLLM's `spend_logs` table
+(requires `DATABASE_URL`); a provider error is treated as "no data this
+turn, don't enforce" rather than a hard stop.
+
+### Audit ledger
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `DECEPTICON_AUDIT_HMAC_KEY` | unset (`hmac` field empty) | Operator secret that binds the audit chain via HMAC-SHA-256. |
+| `DECEPTICON_ROE_AUDIT_PATH` | `<workspace>/audit/roe-decisions.jsonl` | Pins the ledger to a deterministic path. |
+
+See [audit-ledger](./audit-ledger.md) for the chain format and
+verification.
+
+### HITL
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `DECEPTICON_HITL__ENABLED` | unset (disabled) | Truthy enables the approval gate. Falsy spellings (`""`, `0`, `false`, `no`, `off`) keep it off. |
+
+See [hitl-approval](./hitl-approval.md) for the policy and approval flow.
+
+## See also
+
+- [RoE Machine Enforcement](./roe-machine-enforcement.md)
+- [Audit Ledger](./audit-ledger.md)
+- [HITL Approval](./hitl-approval.md)
+- [Threat Model](./decepticon-threat-model.md)
+- [Prompt-Injection Defense](./prompt-injection-defense.md)


### PR DESCRIPTION
## Summary
There was no reference documentation for Decepticon's runtime security guards, and `decepticon-threat-model.md` cited an audit ledger and a RoE enforcer that had no reference page. This adds a grounded **runtime security reference suite** (every claim read off the code).

## New docs (`docs/security/`)
- **`roe-machine-enforcement.md`** — the `machine_enforcement` schema field-by-field (`types/roe.py`): modes (default AUDIT), scope rules, IMDS defaults, `evaluate_target`/`evaluate_command` precedence, gated tools, a worked enforce example.
- **`audit-ledger.md`** — the HMAC-chained RoE audit ledger (`_audit_sink.py`): record + chain fields, genesis hash, `verify_ledger`, paths/env, limitations (local-file, single-writer, `decepticon audit verify` TODO).
- **`security-controls.md`** — knob/default/how-to-verify overview of the runtime guards; surfaces 6 previously **undocumented** env vars (`DECEPTICON_BUDGET__*`, `DECEPTICON_AUDIT_HMAC_KEY`, `DECEPTICON_ROE_AUDIT_PATH`).
- **`hitl-approval.md`** — the HITL approval middleware (opt-in, policy rules, `DEFAULT_HIGH_IMPACT_POLICY`, transports, timeout→deny flow).

## Also
- Fixed two **stale rows** in `decepticon-threat-model.md` that implied budget enforcement was planned/absent — `BudgetEnforcementMiddleware` ships in `_BASE_SLOTS` (soft-warns at `SOFT_WARN_AT_PCT`, hard-pauses at 100%). Added a cross-link section to the four new docs.

Docs-only. All internal links verified to resolve.
