### PR TITLE
chore(pre-commit): correct stale header comment about a CI pre-commit job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 # Pre-commit hooks — install with: uvx pre-commit install
 # Run on demand: uvx pre-commit run --all-files
 #
-# CI runs a curated subset via the `pre-commit` job in
-# .github/workflows/ci.yml. The subset excludes hooks that need a
-# language toolchain (basedpyright, gofmt) — those run in their own CI
-# job already.
+# These hooks run locally; there is no `pre-commit` job in CI. The
+# linters that gate merges are enforced independently in the `python`
+# job of .github/workflows/ci.yml via `make ci-lint` (ci.yml:186) —
+# namely ruff (check + format) and basedpyright. The remaining hooks
+# (shellcheck, hadolint, typos, gitleaks) run only locally via pre-commit.
 #
 # Hooks that would auto-fix pre-existing files at large scale
 # (end-of-file-fixer, mixed-line-ending, trailing-whitespace) are


### PR DESCRIPTION
## Summary
The `.pre-commit-config.yaml` header comment (lines 4-7) claims a "pre-commit job in `ci.yml`" that doesn't exist (CI jobs are changes / compose-validate / python / cli / web / launcher / docker-build / security / actionlint).

## Changes
- Rewrite the header to state accurately: pre-commit runs locally; **ruff** is independently enforced in CI's python job via `make ci-lint` (`ci.yml:186`); shellcheck/hadolint/typos/gitleaks/basedpyright run locally via pre-commit.

YAML comment-only; verified the file still parses.
