### PR TITLE
fix(agents): point mobile/wireless operators at their real skill source dirs

### DIFF
--- a/packages/decepticon/decepticon/agents/standard/mobile_operator.py
+++ b/packages/decepticon/decepticon/agents/standard/mobile_operator.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from langchain.agents import create_agent
 
+from decepticon.agents._benchmark_mode import benchmark_skill_sources
 from decepticon.agents.build import build_middleware, build_tools
 from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
@@ -62,6 +63,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 _ROLE = "mobile_operator"
 _RECURSION_LIMIT = 250
+_SKILL_SOURCES: list[str] = ["/skills/standard/mobile/", "/skills/shared/"]
 
 
 def create_mobile_operator_agent(
@@ -95,6 +97,7 @@ def create_mobile_operator_agent(
     if middleware is None:
         middleware = build_middleware(
             role=_ROLE,
+            skill_sources=[*_SKILL_SOURCES, *benchmark_skill_sources()],
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,

--- a/packages/decepticon/decepticon/agents/standard/wireless_operator.py
+++ b/packages/decepticon/decepticon/agents/standard/wireless_operator.py
@@ -43,6 +43,7 @@ from typing import Any
 
 from langchain.agents import create_agent
 
+from decepticon.agents._benchmark_mode import benchmark_skill_sources
 from decepticon.agents.build import build_middleware, build_tools
 from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
@@ -75,6 +76,7 @@ _STANDARD_TOOLS: dict[str, Any] = {
 
 _ROLE = "wireless_operator"
 _RECURSION_LIMIT = 200
+_SKILL_SOURCES: list[str] = ["/skills/standard/wireless/", "/skills/shared/"]
 
 
 def create_wireless_operator_agent(
@@ -108,6 +110,7 @@ def create_wireless_operator_agent(
     if middleware is None:
         middleware = build_middleware(
             role=_ROLE,
+            skill_sources=[*_SKILL_SOURCES, *benchmark_skill_sources()],
             backend=backend,
             llm=llm,
             fallback_models=fallback_models,

--- a/packages/decepticon/tests/unit/agents/standard/test_specialist_skill_sources.py
+++ b/packages/decepticon/tests/unit/agents/standard/test_specialist_skill_sources.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from decepticon.agents.standard import mobile_operator, wireless_operator
+from decepticon.backends import SKILLS_LOCAL_PATH
+
+_SKILLS_ROOT = Path(SKILLS_LOCAL_PATH)
+
+
+def _resolve(source: str) -> Path:
+    assert source.startswith("/skills/")
+    return _SKILLS_ROOT / source[len("/skills/") :].strip("/")
+
+
+@pytest.mark.parametrize(
+    ("module", "expected_standard_dir"),
+    [
+        (mobile_operator, "/skills/standard/mobile/"),
+        (wireless_operator, "/skills/standard/wireless/"),
+    ],
+)
+def test_specialist_skill_source_dir_exists_and_non_empty(module, expected_standard_dir):
+    assert expected_standard_dir in module._SKILL_SOURCES
+    resolved = _resolve(expected_standard_dir)
+    assert resolved.is_dir()
+    assert any(resolved.iterdir())
+
+
+@pytest.mark.parametrize("module", [mobile_operator, wireless_operator])
+def test_specialist_role_named_skill_dir_does_not_exist(module):
+    role_dir = _SKILLS_ROOT / "standard" / module._ROLE
+    assert not role_dir.exists()
+
+
+@pytest.mark.parametrize("module", [mobile_operator, wireless_operator])
+def test_specialist_skill_sources_all_resolve_on_disk(module):
+    for source in module._SKILL_SOURCES:
+        assert _resolve(source).is_dir()


### PR DESCRIPTION
## Summary
`MobileOperator` and `WirelessOperator` loaded **none of their domain skills**. Both factories built without an explicit `skill_sources=`, so the loader resolved to `/skills/standard/mobile_operator/` and `/skills/standard/wireless_operator/` — directories that **don't exist** (the real dirs are `skills/standard/mobile/` and `skills/standard/wireless/`). They silently fell back to `/skills/shared/` only.

## Fix
- Pass explicit `skill_sources` pointing at the real dirs (`/skills/standard/mobile/` + `/skills/shared/`, and `/skills/standard/wireless/` + `/skills/shared/`), mirroring the existing `benchmark_skill_sources()` convention used by other factories. No directory rename (lower blast radius).
- Add a regression test asserting both agents resolve to skill-source dirs that exist on disk and are non-empty.

## Testing
- ruff clean; `uv run basedpyright` 0 errors; **full fast suite 3559 passed**. (Phisher already mapped correctly — unchanged.)

No CODEOWNERS paths.
