### PR TITLE
fix(sandbox): bound consecutive docker-exec capture failures in poll loop

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -37,6 +37,11 @@ STALL_SECONDS: float = 3.0
 MAX_OUTPUT_CHARS: int = 30_000
 AUTO_BACKGROUND_SECONDS: float = 60.0
 SIZE_WATCHDOG_CHARS: int = 5_000_000
+# Consecutive transient capture failures (docker-exec stall / tmux-server
+# unresponsive) tolerated inside the poll loop before we fail fast. Without
+# this cap a wedged `docker exec` resets the stall timer every iteration and
+# the command spins until the full `timeout`, pinning a core the whole time.
+MAX_CONSECUTIVE_CAPTURE_FAILURES: int = 5
 
 # ─── Sandbox env passthrough allowlist ──────────────────────────────────
 #
@@ -500,6 +505,7 @@ class TmuxSessionManager:
         start = time.monotonic()
         prev_screen = baseline
         last_change_time = start
+        consecutive_capture_failures = 0
 
         while time.monotonic() - start < timeout:
             time.sleep(POLL_INTERVAL)
@@ -513,11 +519,21 @@ class TmuxSessionManager:
                     f"Session will auto-recover on next bash() call."
                 )
             except (OSError, subprocess.TimeoutExpired) as poll_err:
-                # docker exec stall — keep polling, do not let it trigger stall detection
+                consecutive_capture_failures += 1
+                if consecutive_capture_failures >= MAX_CONSECUTIVE_CAPTURE_FAILURES:
+                    self._forget_cached_state()
+                    return (
+                        f"[ERROR] Sandbox capture failed {consecutive_capture_failures} times "
+                        f"in a row for session '{self.session}': {poll_err}\n"
+                        f"docker exec is stalled or the tmux server is unresponsive — "
+                        f"giving up rather than spinning until the {timeout}s timeout.\n"
+                        f'Retry, or terminate with bash_kill(session="{self.session}").'
+                    )
                 log.debug("transient capture error in poll loop: %s", poll_err)
                 last_change_time = time.monotonic()
                 continue
 
+            consecutive_capture_failures = 0
             current_count = len(PS1_PATTERN.findall(screen))
 
             if current_count > initial_count:
@@ -658,6 +674,7 @@ class TmuxSessionManager:
         start = time.monotonic()
         prev_screen = baseline
         last_change_time = start
+        consecutive_capture_failures = 0
 
         while time.monotonic() - start < timeout:
             await asyncio.sleep(POLL_INTERVAL)  # CancelledError delivered here
@@ -671,11 +688,21 @@ class TmuxSessionManager:
                     f"Session will auto-recover on next bash() call."
                 )
             except (OSError, subprocess.TimeoutExpired) as poll_err:
-                # docker exec stall — keep polling, do not let it trigger stall detection
+                consecutive_capture_failures += 1
+                if consecutive_capture_failures >= MAX_CONSECUTIVE_CAPTURE_FAILURES:
+                    self._forget_cached_state()
+                    return (
+                        f"[ERROR] Sandbox capture failed {consecutive_capture_failures} times "
+                        f"in a row for session '{self.session}': {poll_err}\n"
+                        f"docker exec is stalled or the tmux server is unresponsive — "
+                        f"giving up rather than spinning until the {timeout}s timeout.\n"
+                        f'Retry, or terminate with bash_kill(session="{self.session}").'
+                    )
                 log.debug("transient capture error in poll loop: %s", poll_err)
                 last_change_time = time.monotonic()
                 continue
 
+            consecutive_capture_failures = 0
             current_count = len(PS1_PATTERN.findall(screen))
 
             if current_count > initial_count:

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_poll_capture_failures.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_poll_capture_failures.py
@@ -1,0 +1,76 @@
+"""Regression: the poll loop must fail fast after repeated transient capture
+failures instead of resetting the stall timer forever.
+
+A wedged ``docker exec`` (``OSError`` / ``subprocess.TimeoutExpired`` raised by
+``_capture``) previously reset ``last_change_time`` every iteration, so the
+command span until the full ``timeout`` elapsed -- pinning a core the whole
+time. Both the sync and async poll loops now give up after
+``MAX_CONSECUTIVE_CAPTURE_FAILURES`` consecutive failures and return a distinct
+infrastructure error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import Any
+
+import pytest
+
+from decepticon.sandbox_kernel import tmux as tmux_mod
+from decepticon.sandbox_kernel.tmux import TmuxSessionManager
+
+_EXCEPTIONS = [
+    OSError("docker exec stalled"),
+    subprocess.TimeoutExpired(cmd="tmux", timeout=10),
+]
+
+
+def _stalling_capture(exc: BaseException) -> tuple[Any, dict[str, int]]:
+    state = {"n": 0}
+
+    def capture() -> str:
+        state["n"] += 1
+        if state["n"] == 1:
+            return "baseline-no-marker"
+        raise exc
+
+    return capture, state
+
+
+def _make_manager(monkeypatch: pytest.MonkeyPatch, capture: Any) -> TmuxSessionManager:
+    mgr = TmuxSessionManager(session="t", container_name="c")
+    monkeypatch.setattr(mgr, "initialize", lambda: None)
+    monkeypatch.setattr(mgr, "_send", lambda *a, **k: None)
+    monkeypatch.setattr(mgr, "_forget_cached_state", lambda: None)
+    monkeypatch.setattr(mgr, "_capture", capture)
+    monkeypatch.setattr(tmux_mod, "POLL_INTERVAL", 0.0)
+    return mgr
+
+
+@pytest.mark.parametrize("exc", _EXCEPTIONS)
+def test_sync_poll_caps_consecutive_capture_failures(
+    monkeypatch: pytest.MonkeyPatch, exc: BaseException
+) -> None:
+    capture, state = _stalling_capture(exc)
+    mgr = _make_manager(monkeypatch, capture)
+
+    result = mgr.execute("sleep 999", is_input=False, timeout=2)
+
+    assert "[ERROR]" in result
+    assert "capture failed" in result.lower()
+    assert state["n"] <= tmux_mod.MAX_CONSECUTIVE_CAPTURE_FAILURES + 2
+
+
+@pytest.mark.parametrize("exc", _EXCEPTIONS)
+def test_async_poll_caps_consecutive_capture_failures(
+    monkeypatch: pytest.MonkeyPatch, exc: BaseException
+) -> None:
+    capture, state = _stalling_capture(exc)
+    mgr = _make_manager(monkeypatch, capture)
+
+    result = asyncio.run(mgr.execute_async("sleep 999", is_input=False, timeout=2))
+
+    assert "[ERROR]" in result
+    assert "capture failed" in result.lower()
+    assert state["n"] <= tmux_mod.MAX_CONSECUTIVE_CAPTURE_FAILURES + 2


### PR DESCRIPTION
## What

Both the sync and async tmux poll loops in `sandbox_kernel/tmux.py` reset `last_change_time` on every transient capture failure (`OSError` / `subprocess.TimeoutExpired` from `_capture()`). When `docker exec` wedges or the tmux server goes unresponsive, that means the command **spins until the full `timeout` elapses** — pinning a core the whole time and never surfacing the infrastructure fault as a distinct error.

## Fix

- Add `MAX_CONSECUTIVE_CAPTURE_FAILURES = 5` tunable.
- In both poll loops, count consecutive transient capture failures; once the cap is hit, `_forget_cached_state()` and return a distinct `[ERROR] Sandbox capture failed N times in a row …` message instead of spinning.
- Reset the counter on any successful capture, so isolated blips don't accumulate.

The session-destroyed (`RuntimeError`) and normal-timeout paths are unchanged.

## Tests

New `tests/unit/sandbox_kernel/test_poll_capture_failures.py` covers sync + async loops against both `OSError` and `subprocess.TimeoutExpired`. Verified RED (4 failed) with the fix reverted, GREEN (4 passed) with it applied. Full fast suite: 3557 passed, 0 regressions; ruff + basedpyright (errors-only) clean.