### PR TITLE
fix(llm): redact credentials from proxy URL in info logs

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -1103,6 +1103,26 @@ _SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 
+def _redact_url_credentials(url: str) -> str:
+    """Strip ``user:pass@`` userinfo from a URL before logging.
+
+    Operators may configure the proxy URL with embedded credentials
+    (``http://user:pass@litellm:4000``); those must not reach INFO logs.
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.scheme or "@" not in parts.netloc:
+        return url
+    host = parts.hostname or ""
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, f"***@{host}", parts.path, parts.query, parts.fragment))
+
+
 def _redact_secrets(text: str) -> str:
     """Scrub credential-shaped substrings from upstream error text.
 
@@ -1305,7 +1325,7 @@ class LLMFactory:
             "Creating LLM for role '%s' → model '%s' via %s",
             role,
             assignment.primary,
-            self._proxy.url,
+            _redact_url_credentials(self._proxy.url),
         )
 
         model = self._create_chat_model(assignment.primary, assignment.temperature)

--- a/packages/decepticon/tests/unit/llm/test_factory_url_redaction.py
+++ b/packages/decepticon/tests/unit/llm/test_factory_url_redaction.py
@@ -1,0 +1,35 @@
+"""Unit tests for `_redact_url_credentials` proxy URL scrubbing."""
+
+from __future__ import annotations
+
+from decepticon.llm.factory import _redact_url_credentials
+
+
+def test_redacts_user_and_password() -> None:
+    assert _redact_url_credentials("http://user:secret@litellm:4000") == "http://***@litellm:4000"
+
+
+def test_redacts_user_only() -> None:
+    assert _redact_url_credentials("http://user@litellm:4000") == "http://***@litellm:4000"
+
+
+def test_plain_url_unchanged() -> None:
+    assert _redact_url_credentials("http://litellm:4000") == "http://litellm:4000"
+
+
+def test_https_with_path_preserved() -> None:
+    assert (
+        _redact_url_credentials("https://u:p@host.example.com:443/v1/chat")
+        == "https://***@host.example.com:443/v1/chat"
+    )
+
+
+def test_no_secret_substring_in_output() -> None:
+    out = _redact_url_credentials("http://admin:hunter2@proxy:4000")
+    assert "hunter2" not in out
+    assert "admin" not in out
+
+
+def test_non_url_input_returned_as_is() -> None:
+    assert _redact_url_credentials("not a url") == "not a url"
+    assert _redact_url_credentials("") == ""


### PR DESCRIPTION
## Problem

`LLMFactory.get_model` logs the configured proxy URL at INFO level:

```
log.info("Creating LLM for role '%s' → model '%s' via %s", role, ..., self._proxy.url)
```

If an operator configures the LiteLLM proxy with embedded credentials (e.g. `http://user:pass@litellm:4000` — common when fronting LiteLLM with HTTP basic auth), those credentials leak into INFO logs and anywhere those logs ship (files, journald, log aggregators). The existing `_redact_secrets` helper only scrubs error-message text, not this log site.

## Fix

Add a small `_redact_url_credentials(url) -> str` helper that uses `urllib.parse` to replace the `user:pass@` userinfo component with `***`, and apply it at the proxy-URL INFO log site in `get_model`. Plain URLs (no userinfo) pass through unchanged. Other `self._proxy.url` uses (`base_url` kwarg to `ChatOpenAI`, `/health` GET) are not log sinks and stay untouched.

## TDD evidence

- **RED** (helper absent): `uv run pytest -p no:xdist -q packages/decepticon/tests/unit/llm/test_factory_url_redaction.py` → collection ERROR (ImportError on `_redact_url_credentials`).
- **GREEN** (helper + log-site call): `6 passed`.
- **Regression**: `packages/decepticon/tests/unit/llm/` → `285 passed`.
- **Gates**: `ruff check` clean; `ruff format` clean; `basedpyright` → `0 errors, 345 warnings, 0 info`.

## Scope

Touches only `packages/decepticon/decepticon/llm/factory.py` and adds `packages/decepticon/tests/unit/llm/test_factory_url_redaction.py`. No dep/lockfile changes.