### PR TITLE
fix(research/poc): bound sandbox runner with timeout + typed error

### DIFF
--- a/packages/decepticon/decepticon/tools/research/poc.py
+++ b/packages/decepticon/decepticon/tools/research/poc.py
@@ -321,31 +321,52 @@ def _persist_result(graph: KnowledgeGraph, result: PoCResult) -> None:
 
 # ── Convenience: build a runner from an HTTPSandbox ─────────────────────
 
+# Typed-error sentinels: callers distinguish a hung runner from a crash by
+# inspecting the stderr prefix (return shape stays (stdout, stderr, code)).
+POC_ERR_TIMEOUT = "[POC_TIMEOUT]"
+POC_ERR_SANDBOX = "[SANDBOX_ERROR]"
 
-def sandbox_runner(sandbox: Any) -> PoCRunner:
+# Outer-bound on a single PoC invocation. The inner tmux call has its own
+# 60s budget but can wedge — this guards against indefinite hangs.
+POC_RUNNER_TIMEOUT_SECONDS: float = 120.0
+
+
+def sandbox_runner(sandbox: Any, *, timeout: float | None = None) -> PoCRunner:
     """Adapt an ``HTTPSandbox`` into a :data:`PoCRunner` callable.
 
     The sandbox must expose ``execute_tmux_async`` (or ``execute_tmux``) that
     returns a str output. We split the returned blob on ``[Exit code:`` to
     recover an exit code when present.
+
+    The invocation is bounded by ``timeout`` seconds (defaults to module
+    constant :data:`POC_RUNNER_TIMEOUT_SECONDS`). On timeout the stderr
+    field is prefixed with :data:`POC_ERR_TIMEOUT`; other sandbox failures
+    use :data:`POC_ERR_SANDBOX`. Return arity is unchanged so existing
+    callers continue to destructure ``(stdout, stderr, exit_code)``.
     """
 
     async def _run(command: str) -> tuple[str, str, int]:
+        eff_timeout = timeout if timeout is not None else POC_RUNNER_TIMEOUT_SECONDS
         try:
             if hasattr(sandbox, "execute_tmux_async"):
-                out = await sandbox.execute_tmux_async(
+                coro: Awaitable[str] = sandbox.execute_tmux_async(
                     command=command, session="poc", timeout=60, is_input=False
                 )
             else:
-                out = await asyncio.to_thread(
+                coro = asyncio.to_thread(
                     sandbox.execute_tmux,
                     command=command,
                     session="poc",
                     timeout=60,
                     is_input=False,
                 )
-        except Exception as e:  # pragma: no cover — defensive
-            err_msg = f"[SANDBOX_ERROR] {type(e).__name__}: {e}"
+            out = await asyncio.wait_for(coro, timeout=eff_timeout)
+        except asyncio.TimeoutError:
+            err_msg = f"{POC_ERR_TIMEOUT} runner exceeded {eff_timeout}s"
+            log.error("sandbox_runner timeout: %s", err_msg)
+            return "", err_msg, -1
+        except Exception as e:
+            err_msg = f"{POC_ERR_SANDBOX} {type(e).__name__}: {e}"
             log.error("sandbox_runner failed: %s", err_msg)
             return "", err_msg, -1
         code = 0

--- a/packages/decepticon/tests/unit/research/test_poc_runner_timeout.py
+++ b/packages/decepticon/tests/unit/research/test_poc_runner_timeout.py
@@ -1,0 +1,73 @@
+"""Tests for sandbox_runner timeout + typed-error classification."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from decepticon.tools.research import poc as poc_mod
+from decepticon.tools.research.poc import (
+    POC_ERR_SANDBOX,
+    POC_ERR_TIMEOUT,
+    sandbox_runner,
+)
+
+
+class _HangingSandbox:
+    async def execute_tmux_async(
+        self, command: str, session: str, timeout: int, is_input: bool
+    ) -> str:
+        await asyncio.sleep(5.0)  # exceeds patched runner timeout
+        return "should not reach"
+
+
+class _RaisingSandbox:
+    async def execute_tmux_async(
+        self, command: str, session: str, timeout: int, is_input: bool
+    ) -> str:
+        raise RuntimeError("boom")
+
+
+class _OkSandbox:
+    async def execute_tmux_async(
+        self, command: str, session: str, timeout: int, is_input: bool
+    ) -> str:
+        return "ok\n[Exit code: 0]"
+
+
+@pytest.mark.asyncio
+async def test_runner_times_out_with_typed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(poc_mod, "POC_RUNNER_TIMEOUT_SECONDS", 0.05)
+    runner = sandbox_runner(_HangingSandbox())
+    out, err, code = await runner("noop")
+    assert out == ""
+    assert err.startswith(POC_ERR_TIMEOUT)
+    assert code == -1
+
+
+@pytest.mark.asyncio
+async def test_runner_crash_classified_as_sandbox_error() -> None:
+    runner = sandbox_runner(_RaisingSandbox())
+    out, err, code = await runner("noop")
+    assert out == ""
+    assert err.startswith(POC_ERR_SANDBOX)
+    assert "RuntimeError" in err
+    assert code == -1
+
+
+@pytest.mark.asyncio
+async def test_runner_happy_path_preserves_shape() -> None:
+    runner = sandbox_runner(_OkSandbox())
+    out, err, code = await runner("id")
+    assert "ok" in out
+    assert err == ""
+    assert code == 0
+
+
+@pytest.mark.asyncio
+async def test_runner_timeout_override_kwarg() -> None:
+    runner = sandbox_runner(_HangingSandbox(), timeout=0.05)
+    out, err, code = await runner("noop")
+    assert err.startswith(POC_ERR_TIMEOUT)
+    assert code == -1


### PR DESCRIPTION
## Problem

`sandbox_runner` in `packages/decepticon/decepticon/tools/research/poc.py` wrapped sandbox execution in a bare `except Exception` that returned a single generic `("", err, -1)` tuple. Two consequences:

1. **No outer timeout.** The inner `execute_tmux*` call has its own 60s budget but can still wedge (network stalls, sandbox bugs, leaked tmux sessions). A hung runner therefore hangs PoC validation indefinitely.
2. **No typed error.** Callers (`validate_poc`, `patch.verify_patch`, `tools.py`) had no way to tell a timeout apart from a crash apart from a sandbox-side failure — all three collapsed into the same `[SANDBOX_ERROR]` blob.

## Fix

Wrap the runner invocation in `asyncio.wait_for(..., timeout=eff_timeout)` with:

- New module constant `POC_RUNNER_TIMEOUT_SECONDS: float = 120.0` (configurable / monkeypatchable).
- New optional `sandbox_runner(sandbox, *, timeout: float | None = None)` kwarg for per-call override.
- New sentinels `POC_ERR_TIMEOUT = "[POC_TIMEOUT]"` and `POC_ERR_SANDBOX = "[SANDBOX_ERROR]"` (latter preserved verbatim for backward compatibility with any caller that greps stderr).
- `asyncio.TimeoutError` -> stderr prefixed with `POC_ERR_TIMEOUT`.
- Any other exception -> stderr prefixed with `POC_ERR_SANDBOX` (existing behavior).

**Return contract unchanged**: still `(stdout: str, stderr: str, exit_code: int)`. The typed-error discriminant is additive via the stderr sentinel prefix, so existing `validate_poc` / `patch.verify_patch` / `tools.py` callers continue to destructure the tuple without modification.

## TDD evidence

- **RED**: `test_poc_runner_timeout.py` initially failed at collection with `ImportError: cannot import name 'POC_ERR_SANDBOX'` (constants/kwarg did not exist).
- **GREEN**: `4 passed` after implementation.
- **Regression**: `test_poc.py` + `test_patch.py` + new file = `26 passed` (single-process).

Tests cover: hanging sandbox bounded by patched timeout produces `POC_ERR_TIMEOUT`; raising sandbox produces `POC_ERR_SANDBOX` with exception class name; happy path preserves `(stdout, '', 0)` shape; `timeout=` kwarg override path.

## Gates

- `ruff check` + `ruff format`: clean.
- `basedpyright` (errors-only on touched files): **0 errors, 0 warnings**.

## Scope

Touches only `poc.py` + the new test file. No deps, no pyproject/uv.lock changes.