### PR TITLE
fix(bash): bound passive-read tracker with LRU + TTL

### DIFF
--- a/packages/decepticon/decepticon/tools/bash/bash.py
+++ b/packages/decepticon/decepticon/tools/bash/bash.py
@@ -30,6 +30,7 @@ import logging
 import os
 import re
 import time
+from collections import OrderedDict
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
@@ -96,20 +97,43 @@ _scratch_prune_state: dict[str, float] = {}
 # hint once the threshold is hit. Resets on any state-changing event:
 # non-empty command, output diff, kill, or new background job.
 _STALE_PASSIVE_READS = 3  # consecutive identical reads before [STALE] hint
-_passive_read_state: dict[tuple[str, str], list[str]] = {}
+# Bound the tracker: a long-lived server otherwise accumulates one entry per
+# (workspace, session) forever. Cap by both count (LRU) and age (TTL) so
+# idle/abandoned sessions are reaped on access; `_passive_clock` is module-
+# patchable so tests can drive time without sleeping.
+_PASSIVE_MAX_ENTRIES = 128
+_PASSIVE_TTL_SECONDS = 300.0
+_passive_clock = time.monotonic
+_passive_read_state: "OrderedDict[tuple[str, str], tuple[float, list[str]]]" = OrderedDict()
 
 
 def _passive_key(workspace_path: str, session: str) -> tuple[str, str]:
     return (workspace_path, session)
 
 
+def _prune_expired_passive(now: float) -> None:
+    expired = [k for k, (ts, _) in _passive_read_state.items() if now - ts > _PASSIVE_TTL_SECONDS]
+    for k in expired:
+        del _passive_read_state[k]
+
+
 def _track_passive_read(workspace_path: str, session: str, output: str) -> str | None:
     """Record a passive read; return [STALE] hint when threshold tripped."""
     key = _passive_key(workspace_path, session)
     digest = hashlib.sha256(output.encode("utf-8", errors="replace")).hexdigest()[:16]
-    hashes = _passive_read_state.setdefault(key, [])
+    now = _passive_clock()
+    _prune_expired_passive(now)
+
+    entry = _passive_read_state.get(key)
+    hashes = entry[1] if entry is not None else []
     hashes.append(digest)
     del hashes[: max(0, len(hashes) - _STALE_PASSIVE_READS)]
+    _passive_read_state[key] = (now, hashes)
+    _passive_read_state.move_to_end(key)
+
+    while len(_passive_read_state) > _PASSIVE_MAX_ENTRIES:
+        _passive_read_state.popitem(last=False)
+
     if len(hashes) < _STALE_PASSIVE_READS or len(set(hashes)) != 1:
         return None
     return (

--- a/packages/decepticon/tests/unit/tools/bash/test_passive_read_bounds.py
+++ b/packages/decepticon/tests/unit/tools/bash/test_passive_read_bounds.py
@@ -1,0 +1,96 @@
+"""LRU + TTL bounds on the passive-read stale-poll tracker.
+
+The tracker dict was previously unbounded: one entry per (workspace, session)
+key, never pruned. In a long-lived server this grew without limit. These tests
+lock in the bounded behavior:
+
+* size cap: inserting more than ``_PASSIVE_MAX_ENTRIES`` keys evicts the
+  least-recently-used entry;
+* TTL: an entry untouched for longer than ``_PASSIVE_TTL_SECONDS`` is treated
+  as absent and gets pruned on the next access.
+"""
+
+import importlib
+
+from decepticon.tools.bash.bash import (
+    _PASSIVE_MAX_ENTRIES,
+    _PASSIVE_TTL_SECONDS,
+    _passive_read_state,
+    _track_passive_read,
+)
+
+# `from decepticon.tools.bash import bash` resolves to the @tool-decorated
+# StructuredTool because the submodule shadows the package attribute. Reach the
+# real module object explicitly so monkeypatch.setattr can target `_passive_clock`.
+bash_mod = importlib.import_module("decepticon.tools.bash.bash")
+
+
+def setup_function():
+    _passive_read_state.clear()
+
+
+def test_lru_evicts_oldest_when_over_capacity(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(bash_mod, "_passive_clock", lambda: clock["t"])
+
+    # Fill exactly to capacity.
+    for i in range(_PASSIVE_MAX_ENTRIES):
+        clock["t"] += 1.0
+        _track_passive_read("/w", f"s{i}", "x")
+    assert len(_passive_read_state) == _PASSIVE_MAX_ENTRIES
+    assert ("/w", "s0") in _passive_read_state
+
+    # One more key — oldest ("s0") must be evicted.
+    clock["t"] += 1.0
+    _track_passive_read("/w", "overflow", "x")
+    assert len(_passive_read_state) == _PASSIVE_MAX_ENTRIES
+    assert ("/w", "s0") not in _passive_read_state
+    assert ("/w", "overflow") in _passive_read_state
+
+
+def test_recent_access_protects_from_eviction(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(bash_mod, "_passive_clock", lambda: clock["t"])
+
+    for i in range(_PASSIVE_MAX_ENTRIES):
+        clock["t"] += 1.0
+        _track_passive_read("/w", f"s{i}", "x")
+
+    # Touch s0 so it becomes most-recently-used.
+    clock["t"] += 1.0
+    _track_passive_read("/w", "s0", "x")
+
+    # Add a new key — s0 must survive, the next-oldest (s1) is evicted.
+    clock["t"] += 1.0
+    _track_passive_read("/w", "overflow", "x")
+    assert ("/w", "s0") in _passive_read_state
+    assert ("/w", "s1") not in _passive_read_state
+
+
+def test_ttl_expired_entry_pruned_on_access(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(bash_mod, "_passive_clock", lambda: clock["t"])
+
+    # Seed an entry, then jump past the TTL.
+    _track_passive_read("/w", "main", "same")
+    _track_passive_read("/w", "main", "same")
+    assert len(_passive_read_state[("/w", "main")][1]) == 2
+
+    clock["t"] += _PASSIVE_TTL_SECONDS + 1.0
+    # After TTL the prior history is gone — the next identical read starts
+    # fresh, so it cannot trip the stale threshold on its own.
+    result = _track_passive_read("/w", "main", "same")
+    assert result is None
+    assert len(_passive_read_state[("/w", "main")][1]) == 1
+
+
+def test_ttl_prunes_idle_sibling_entries(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(bash_mod, "_passive_clock", lambda: clock["t"])
+
+    _track_passive_read("/w", "idle", "x")
+    clock["t"] += _PASSIVE_TTL_SECONDS + 1.0
+    _track_passive_read("/w", "active", "x")
+    # Idle sibling must be swept on the active access.
+    assert ("/w", "idle") not in _passive_read_state
+    assert ("/w", "active") in _passive_read_state


### PR DESCRIPTION
## Problem

`packages/decepticon/decepticon/tools/bash/bash.py` defined a module-level dict `_passive_read_state: dict[tuple[str, str], list[str]]` that accumulated one entry per `(workspace, session)` key and was **never pruned**. In a long-lived server this is a slow memory leak; stale-poll hints also degraded as the dict grew and historical sessions lingered.

## Fix

Replace the unbounded dict with an `OrderedDict`-backed LRU + TTL:

- **Size cap**: `_PASSIVE_MAX_ENTRIES = 128` — oldest entry evicted on overflow via `popitem(last=False)`.
- **TTL**: `_PASSIVE_TTL_SECONDS = 300.0` — idle entries swept on every access.
- **Testable clock**: `_passive_clock = time.monotonic` as a module-level indirection so tests drive time deterministically via `monkeypatch`.
- **API unchanged**: `_track_passive_read` / `_reset_passive_read` keep the same signature; `_passive_read_state.clear()` still works for existing tests.
- **stdlib only** — `collections.OrderedDict`. No new deps.

## Tests (TDD)

New `packages/decepticon/tests/unit/tools/bash/test_passive_read_bounds.py` locks in:

1. `test_lru_evicts_oldest_when_over_capacity` — `N+1`-th insert evicts `s0`.
2. `test_recent_access_protects_from_eviction` — touched key survives, next-oldest evicted.
3. `test_ttl_expired_entry_pruned_on_access` — entry past TTL is reset, cannot trip the stale-threshold alone.
4. `test_ttl_prunes_idle_sibling_entries` — TTL sweeps idle siblings on any access.

RED verified via `git stash push` of `bash.py` → `ImportError: cannot import name '_PASSIVE_MAX_ENTRIES'`. GREEN after `stash pop`: all 53 bash unit tests pass, full `packages/decepticon/tests/unit/tools/` regression: **461 passed**.

## Gates

- `uv run ruff check` ✓
- `uv run ruff format` ✓ (no changes)
- `uv run basedpyright` → **0 errors**, 345 warnings (pre-existing)

## Scope

Touches only `bash.py` + new test. No `pyproject`/`uv.lock` changes. No new dependencies.