### PR TITLE
fix(sandbox): distinguish interactive prompt from silently-hung process

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -34,9 +34,42 @@ PS1_PATTERN = re.compile(r"\[DCPTN:(\d+):(.+?)\]")
 
 POLL_INTERVAL: float = 0.5
 STALL_SECONDS: float = 3.0
+# Fallback after STALL_SECONDS when the tail is NOT a recognizable prompt:
+# treat as possibly-hung instead of mislabeling as interactive.
+HUNG_PROCESS_SECONDS: float = 30.0
 MAX_OUTPUT_CHARS: int = 30_000
 AUTO_BACKGROUND_SECONDS: float = 60.0
 SIZE_WATCHDOG_CHARS: int = 5_000_000
+
+# Common shell / REPL / offensive-tool prompt tails. Matched against the
+# last non-blank line of a stalled screen. The first alternative covers
+# generic shells ("$ ", "# ", "> ", ": ", "? "); the second covers
+# named tool prompts (msf6, meterpreter, sliver[, sliver (X)], Pdb,
+# Python REPL, mysql, ftp). Kept deliberately conservative — anything
+# that does not match is treated as a possibly-hung process, not as an
+# interactive prompt.
+_PROMPT_TAIL_RE = re.compile(
+    r"(?:[\$#>:?]\s*$)"
+    r"|(?:^(?:msf\d*|meterpreter|sliver(?:\s*\([^)]+\))?|mysql|ftp)\s*>\s*$)"
+    r"|(?:^\(Pdb\)\s*$)"
+    r"|(?:^>>>\s*$)"
+)
+
+
+def _looks_like_interactive_prompt(screen: str) -> bool:
+    """Return True if the screen's last non-blank line looks like a prompt.
+
+    Used by stall detection to distinguish a real interactive prompt
+    (msf6, meterpreter, ``$``, ``Password:`` …) from a silently hung
+    program that simply stopped producing output.
+    """
+    for line in reversed(screen.splitlines()):
+        stripped = line.rstrip()
+        if not stripped.strip():
+            continue
+        return _PROMPT_TAIL_RE.search(stripped) is not None
+    return False
+
 
 # ─── Sandbox env passthrough allowlist ──────────────────────────────────
 #
@@ -560,22 +593,41 @@ class TmuxSessionManager:
 
             # Stall detection: if screen changed from baseline (program produced
             # output) but hasn't changed for STALL_SECONDS, the program is likely
-            # waiting for input (interactive prompt like msf6>, sliver>).
+            # waiting for input (interactive prompt like msf6>, sliver>) — but
+            # only if the tail actually looks like a prompt. Otherwise keep
+            # polling until HUNG_PROCESS_SECONDS, then surface a distinct
+            # "may be hung" message instead of falsely claiming interactive.
             if screen != prev_screen:
                 last_change_time = time.monotonic()
                 prev_screen = screen
-            elif screen != baseline and time.monotonic() - last_change_time >= STALL_SECONDS:
-                log.info(
-                    "Stall detected after %.1fs — interactive program [%s]",
-                    time.monotonic() - start,
-                    _safe_log(command[:50]),
-                )
-                output = _extract_interactive_output(screen, baseline)
-                return (
-                    f"{_truncate(output).strip()}\n"
-                    f"[session: {self.session} — interactive, "
-                    f"send next command with is_input=True]"
-                )
+            elif screen != baseline:
+                stalled_for = time.monotonic() - last_change_time
+                if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
+                    log.info(
+                        "Stall detected after %.1fs — interactive program [%s]",
+                        time.monotonic() - start,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — interactive, "
+                        f"send next command with is_input=True]"
+                    )
+                if stalled_for >= HUNG_PROCESS_SECONDS:
+                    log.info(
+                        "Prompt-less stall after %.1fs — may be hung [%s]",
+                        stalled_for,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — no interactive prompt detected "
+                        f"after {int(stalled_for)}s of silence; the program may be hung. "
+                        f"Send input with is_input=True as an escape hatch, "
+                        f'or terminate with bash_kill(session="{self.session}").]'
+                    )
 
         # Full timeout — include screen capture
         try:
@@ -745,18 +797,34 @@ class TmuxSessionManager:
             if screen != prev_screen:
                 last_change_time = time.monotonic()
                 prev_screen = screen
-            elif screen != baseline and time.monotonic() - last_change_time >= STALL_SECONDS:
-                log.info(
-                    "Stall detected after %.1fs — interactive program [%s]",
-                    time.monotonic() - start,
-                    _safe_log(command[:50]),
-                )
-                output = _extract_interactive_output(screen, baseline)
-                return (
-                    f"{_truncate(output).strip()}\n"
-                    f"[session: {self.session} — interactive, "
-                    f"send next command with is_input=True]"
-                )
+            elif screen != baseline:
+                stalled_for = time.monotonic() - last_change_time
+                if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
+                    log.info(
+                        "Stall detected after %.1fs — interactive program [%s]",
+                        time.monotonic() - start,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — interactive, "
+                        f"send next command with is_input=True]"
+                    )
+                if stalled_for >= HUNG_PROCESS_SECONDS:
+                    log.info(
+                        "Prompt-less stall after %.1fs — may be hung [%s]",
+                        stalled_for,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — no interactive prompt detected "
+                        f"after {int(stalled_for)}s of silence; the program may be hung. "
+                        f"Send input with is_input=True as an escape hatch, "
+                        f'or terminate with bash_kill(session="{self.session}").]'
+                    )
 
         # Full timeout — include screen capture
         try:

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_interactive_prompt_detection.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_interactive_prompt_detection.py
@@ -1,0 +1,57 @@
+"""Tests for ``_looks_like_interactive_prompt``.
+
+Stall detection in :mod:`decepticon.sandbox_kernel.tmux` used to label any
+3 s no-output window as ``[interactive]``. That confused a silently hung
+process (network deadlock, infinite wait) with a real prompt waiting for
+input. ``_looks_like_interactive_prompt`` inspects the last non-blank
+line of the screen and returns ``True`` only when that tail looks like a
+shell or offensive-tool prompt — so the stall path can fall through to a
+distinct "may be hung" message for prompt-less stalls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon.sandbox_kernel.tmux import _looks_like_interactive_prompt
+
+
+@pytest.mark.parametrize(
+    "screen",
+    [
+        # Shell-style prompts (trailing whitespace is normal in tmux capture)
+        "doing stuff\n$ ",
+        "root@box:/# ",
+        "user@host:~$",
+        "Continue? ",
+        "Password: ",
+        "Press any key > ",
+        # Offensive-tool / REPL prompts
+        "[*] Started reverse handler\nmsf6 > ",
+        "meterpreter > ",
+        "sliver > ",
+        "sliver (BLUE_PHANTOM) > ",
+        "(Pdb) ",
+        ">>> ",
+        "mysql> ",
+        "ftp> ",
+    ],
+)
+def test_prompt_tails_detected(screen: str) -> None:
+    assert _looks_like_interactive_prompt(screen) is True
+
+
+@pytest.mark.parametrize(
+    "screen",
+    [
+        # Plain log / spinner tails — NOT prompts
+        "downloading...\n  42% [=====>     ]",
+        "fetching metadata\nresolving deps",
+        "INFO  connecting to 10.0.0.5",
+        "Scanning 1000 ports",
+        "",  # nothing on screen at all
+        "   \n   ",  # only blank lines
+    ],
+)
+def test_non_prompt_tails_rejected(screen: str) -> None:
+    assert _looks_like_interactive_prompt(screen) is False


### PR DESCRIPTION
## Problem

`tmux.py` stall detection (sync loop ~L561-578, async ~L744-759) treated **any** 3 s no-change window as "interactive":

```python
elif screen != baseline and (now - last_change_time) >= STALL_SECONDS:
    return "[session: ... interactive, send next command with is_input=True]"
```

A silently hung process (network deadlock, infinite wait with no output) was mislabeled `interactive`, and the agent waited for input that never came.

## Fix

New helper `_looks_like_interactive_prompt(screen)` inspects the **last non-blank line** and returns True for:

- Generic shell tails: `$ `, `# `, `> `, `: `, `? ` (e.g. `Password: `, `Continue? `)
- Named tool prompts: `msf6 >`, `meterpreter >`, `sliver >`, `sliver (NAME) >`, `(Pdb)`, `>>>`, `mysql>`, `ftp>`

Wired into **both sync and async** stall branches:

- **Tail looks like a prompt at `STALL_SECONDS`** → return the existing interactive result **exactly as today** (no behaviour change for genuine prompts).
- **Tail does NOT look like a prompt** → keep polling until `HUNG_PROCESS_SECONDS` (30 s), then return a **distinct** `no interactive prompt detected ... may be hung` message, still allowing `is_input=True` as an escape hatch.

## Non-regression

The existing stall regression (`test_poll_loop_capture_errors_dont_falsely_trigger_stall_detection` in `tests/unit/backends/test_session_log.py`) stays green — it only asserts that transient capture errors **don't** falsely trigger `[interactive]`; it never asserts a non-prompt screen *should* reach the interactive branch. All 163 `sandbox_kernel/` + `backends/` unit tests pass.

## TDD evidence

- **RED**: new test `tests/unit/sandbox_kernel/test_interactive_prompt_detection.py` failed at import (`_looks_like_interactive_prompt` did not exist).
- **GREEN**: after implementing helper + wiring, full suite `packages/decepticon/tests/unit/sandbox_kernel/ + backends/` → **163 passed**.

## Gates

- `ruff check` + `ruff format` clean.
- `basedpyright` errors-only on changed files → **0 errors**.

## Files

- `packages/decepticon/decepticon/sandbox_kernel/tmux.py`
- `packages/decepticon/tests/unit/sandbox_kernel/test_interactive_prompt_detection.py` (new)