### PR TITLE
fix(browser): replace silent close() excepts with logged, timeout-bounded cleanup

### DIFF
--- a/packages/decepticon/decepticon/tools/browser/tools.py
+++ b/packages/decepticon/decepticon/tools/browser/tools.py
@@ -21,12 +21,48 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import threading
 from collections import deque
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
 from langchain_core.tools import tool
+
+log = logging.getLogger(__name__)
+
+# Per-handle close timeout: one hung Playwright handle must not wedge cleanup.
+_CLOSE_TIMEOUT_S = 5.0
+
+
+async def _safe_close(
+    obj: Any,
+    name: str,
+    *,
+    timeout: float = _CLOSE_TIMEOUT_S,
+    method: str = "close",
+) -> None:
+    """Await ``obj.<method>()`` with a bounded timeout, logging any failure.
+
+    Replaces silent ``except Exception: pass`` blocks: a hung handle is
+    cancelled after ``timeout`` seconds and every failure is recorded so
+    operators can diagnose leaks instead of seeing the resource vanish.
+    """
+    if obj is None:
+        return
+    close_fn: Callable[[], Awaitable[Any]] = getattr(obj, method)
+    try:
+        await asyncio.wait_for(close_fn(), timeout=timeout)
+    except asyncio.TimeoutError:
+        log.warning(
+            "browser cleanup: %s.%s() timed out after %.2fs; abandoning handle",
+            name,
+            method,
+            timeout,
+        )
+    except Exception as exc:  # noqa: BLE001 — close paths must never re-raise
+        log.warning("browser cleanup: %s.%s() failed: %s", name, method, exc)
 
 
 class BrowserActionError(RuntimeError):
@@ -212,31 +248,16 @@ class BrowserSessionManager:
 
     async def close(self) -> dict[str, Any]:
         async with self._lock:
-            for tab in self._tabs.values():
-                try:
-                    await tab.page.close()
-                except Exception:
-                    pass
+            for tab_id, tab in self._tabs.items():
+                await _safe_close(tab.page, f"page[{tab_id}]")
             self._tabs.clear()
             self._active = None
-            if self._context is not None:
-                try:
-                    await self._context.close()
-                except Exception:
-                    pass
-                self._context = None
-            if self._browser is not None:
-                try:
-                    await self._browser.close()
-                except Exception:
-                    pass
-                self._browser = None
-            if self._playwright is not None:
-                try:
-                    await self._playwright.stop()
-                except Exception:
-                    pass
-                self._playwright = None
+            await _safe_close(self._context, "context")
+            self._context = None
+            await _safe_close(self._browser, "browser")
+            self._browser = None
+            await _safe_close(self._playwright, "playwright", method="stop")
+            self._playwright = None
             return {"closed": True}
 
 

--- a/packages/decepticon/tests/unit/tools/test_browser_cleanup.py
+++ b/packages/decepticon/tests/unit/tools/test_browser_cleanup.py
@@ -1,0 +1,159 @@
+"""Tests for bounded, logged cleanup in ``decepticon.tools.browser.tools``."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from decepticon.tools.browser.tools import (
+    BrowserSessionManager,
+    _reset_session_manager_for_tests,
+    _safe_close,
+)
+
+_LOGGER_NAME = "decepticon.tools.browser.tools"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> Iterator[None]:
+    _reset_session_manager_for_tests()
+    yield
+    _reset_session_manager_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _propagate_decepticon_logger() -> Iterator[None]:
+    # decepticon_core.utils.logging sets propagate=False on the "decepticon"
+    # root, which blocks pytest's caplog. Restore propagation per test.
+    parent = logging.getLogger("decepticon")
+    prior = parent.propagate
+    parent.propagate = True
+    try:
+        yield
+    finally:
+        parent.propagate = prior
+
+
+@pytest.mark.asyncio
+async def test_safe_close_logs_raised_exception(caplog: pytest.LogCaptureFixture) -> None:
+    obj = MagicMock()
+
+    async def boom() -> None:
+        raise RuntimeError("close kaboom")
+
+    obj.close = boom
+
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger(_LOGGER_NAME).propagate = True
+    await _safe_close(obj, "page", timeout=1.0)
+
+    assert "page" in caplog.text and "close kaboom" in caplog.text, caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safe_close_bounded_by_timeout(caplog: pytest.LogCaptureFixture) -> None:
+    obj = MagicMock()
+
+    async def hang() -> None:
+        await asyncio.sleep(60)
+
+    obj.close = hang
+
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger(_LOGGER_NAME).propagate = True
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    await _safe_close(obj, "browser", timeout=0.05)
+    elapsed = loop.time() - start
+
+    assert elapsed < 5.0, f"hang was not bounded by timeout: {elapsed}s"
+    assert "browser" in caplog.text and "timed out" in caplog.text.lower(), caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_continues_when_page_close_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mgr = BrowserSessionManager()
+
+    bad_page = MagicMock()
+
+    async def page_boom() -> None:
+        raise RuntimeError("page broke")
+
+    bad_page.close = page_boom
+
+    context_closed = False
+    browser_closed = False
+    playwright_stopped = False
+
+    async def ctx_close() -> None:
+        nonlocal context_closed
+        context_closed = True
+
+    async def br_close() -> None:
+        nonlocal browser_closed
+        browser_closed = True
+
+    async def pw_stop() -> None:
+        nonlocal playwright_stopped
+        playwright_stopped = True
+
+    ctx = MagicMock()
+    ctx.close = ctx_close
+    br = MagicMock()
+    br.close = br_close
+    pw = MagicMock()
+    pw.stop = pw_stop
+
+    from decepticon.tools.browser.tools import _Tab
+
+    mgr._tabs["main"] = _Tab(page=bad_page)
+    mgr._active = "main"
+    mgr._context = ctx
+    mgr._browser = br
+    mgr._playwright = pw
+
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger(_LOGGER_NAME).propagate = True
+    result = await mgr.close()
+
+    assert result == {"closed": True}
+    assert context_closed and browser_closed and playwright_stopped
+    assert mgr._tabs == {}
+    assert mgr._context is None
+    assert mgr._browser is None
+    assert mgr._playwright is None
+    assert "page broke" in caplog.text, caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_bounded_when_browser_close_hangs() -> None:
+    mgr = BrowserSessionManager()
+
+    async def hang() -> None:
+        await asyncio.sleep(60)
+
+    br = MagicMock()
+    br.close = hang
+    pw = MagicMock()
+
+    async def pw_stop() -> None:
+        return None
+
+    pw.stop = pw_stop
+    mgr._browser = br
+    mgr._playwright = pw
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    # Wrap in our own outer timeout so a regression cannot wedge the test run.
+    await asyncio.wait_for(mgr.close(), timeout=10.0)
+    elapsed = loop.time() - start
+    assert elapsed < 8.0, f"close did not bound hung browser.close(): {elapsed}s"
+    assert mgr._browser is None
+    assert mgr._playwright is None


### PR DESCRIPTION
## Problem

`BrowserSessionManager.close()` in `packages/decepticon/decepticon/tools/browser/tools.py` wrapped each Playwright shutdown (`page.close`, `context.close`, `browser.close`, `playwright.stop`) in:

```python
try:
    await tab.page.close()
except Exception:
    pass
```

Two failure modes:

1. **Silent swallowing** — any close failure (zombie context, websocket reset, asyncio cancellation mid-close) disappeared. Operators saw the resource "vanish" with no diagnostic.
2. **Unbounded close** — Playwright's `close()` can hang (lost CDP socket, stuck renderer). A single hung handle blocked the rest of the cleanup sequence indefinitely.

## Fix

Extract a private helper:

```python
async def _safe_close(obj, name, *, timeout=5.0, method="close") -> None
```

- Awaits `obj.<method>()` under `asyncio.wait_for(..., timeout)`.
- Catches `asyncio.TimeoutError` → `log.warning("... timed out after %.2fs; abandoning handle")`.
- Catches arbitrary `Exception` → `log.warning("... failed: %s")`.
- Module logger `log = logging.getLogger(__name__)` (`decepticon.tools.browser.tools`).

`close()` now calls `_safe_close` for every page, the context, the browser, and `playwright.stop`. One bad handle can no longer strand the rest.

## Tests

New file `packages/decepticon/tests/unit/tools/test_browser_cleanup.py`:

- `test_safe_close_logs_raised_exception` — `close()` raises → cleanup returns, message logged via `caplog`.
- `test_safe_close_bounded_by_timeout` — `close()` sleeps 60s → `_safe_close` returns within `timeout=0.05s`, "timed out" logged.
- `test_close_continues_when_page_close_raises` — full `close()` flow: bad page does not prevent context/browser/playwright teardown; error logged.
- `test_close_bounded_when_browser_close_hangs` — wraps `mgr.close()` itself in an outer 10s timeout to guarantee a regression cannot wedge CI.

Includes an autouse fixture that flips `propagate=True` on the `decepticon` parent logger so pytest's `caplog` can observe records (`decepticon_core.utils.logging.configure_logging` sets `propagate=False` globally).

## RED → GREEN evidence

```
# RED (no impl yet)
$ git stash push -- packages/decepticon/decepticon/tools/browser/tools.py
$ uv run pytest -q packages/decepticon/tests/unit/tools/test_browser_cleanup.py
ERROR ... ImportError: cannot import name '_safe_close'

# GREEN (after fix)
$ uv run pytest -q packages/decepticon/tests/unit/tools/test_browser_cleanup.py
4 passed in 6.76s

# Regression
$ uv run pytest -q packages/decepticon/tests/unit/tools/
461 passed in 7.49s
```

## Gates

- `ruff check` — clean (one import-sort autofix applied to the new test file).
- `ruff format` — clean.
- `basedpyright` errors-only — `0 errors, 1 warning, 0 info`.

## Constraints honored

- Touched only `browser/tools.py` + the new test file.
- No new dependencies, no `pyproject` / `uv.lock` changes.
- No `-n auto`.
- Conventional-Commit title, no AI co-author trailer, existing identity.
- Comments minimal: one rationale line on `_CLOSE_TIMEOUT_S`, `_safe_close` docstring documenting the new contract, one test fixture comment explaining the `propagate=False` workaround.