### PR TITLE
feat(web/http): allow per-request timeout override on HTTPSession

### DIFF
--- a/packages/decepticon/decepticon/tools/web/http.py
+++ b/packages/decepticon/decepticon/tools/web/http.py
@@ -212,6 +212,7 @@ class HTTPSession:
         body: bytes | str | None = None,
         json_body: Any = None,
         tag: str = "",
+        timeout_ms: int | None = None,
     ) -> HTTPResponse:
         full_url = url if url.startswith(("http://", "https://")) else f"{self.base_url}{url}"
         req_body: bytes = b""
@@ -232,6 +233,10 @@ class HTTPSession:
             tag=tag,
         )
 
+        extra: dict[str, Any] = {}
+        if timeout_ms is not None:
+            extra["timeout"] = timeout_ms / 1000.0
+
         start = time.monotonic()
         r = await self._client.request(
             method=method.upper(),
@@ -239,20 +244,24 @@ class HTTPSession:
             params=params,
             headers=headers,
             content=req_body if req_body else None,
+            **extra,
         )
-        elapsed = (time.monotonic() - start) * 1000.0
-
-        resp = HTTPResponse(
-            id=uuid.uuid4().hex[:12],
-            request_id=req.id,
-            status=r.status_code,
-            headers=dict(r.headers),
-            body=r.content,
-            elapsed_ms=elapsed,
-            timestamp=time.time(),
-        )
-        self.history.record(req, resp)
-        return resp
+        try:
+            elapsed = (time.monotonic() - start) * 1000.0
+            resp = HTTPResponse(
+                id=uuid.uuid4().hex[:12],
+                request_id=req.id,
+                status=r.status_code,
+                headers=dict(r.headers),
+                body=r.content,
+                elapsed_ms=elapsed,
+                timestamp=time.time(),
+            )
+            self.history.record(req, resp)
+            return resp
+        except BaseException:
+            await r.aclose()
+            raise
 
     async def get(self, url: str, **kwargs: Any) -> HTTPResponse:
         return await self.request("GET", url, **kwargs)

--- a/packages/decepticon/tests/unit/web/test_http_timeout.py
+++ b/packages/decepticon/tests/unit/web/test_http_timeout.py
@@ -1,0 +1,80 @@
+"""Per-request timeout override + exception safety on HTTPSession.request."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from decepticon.tools.web.http import HTTPSession
+
+
+class TestHTTPSessionPerRequestTimeout:
+    async def test_timeout_ms_is_forwarded_to_underlying_client_request(self) -> None:
+        session = HTTPSession()
+        try:
+            captured: dict[str, Any] = {}
+
+            async def fake_request(**kwargs: Any) -> httpx.Response:
+                captured.update(kwargs)
+                return httpx.Response(200, content=b"ok")
+
+            session._client.request = fake_request  # type: ignore[method-assign]
+            await session.request("GET", "https://x.test/ep", timeout_ms=2500)
+            assert "timeout" in captured
+            assert captured["timeout"] == pytest.approx(2.5)
+        finally:
+            await session.close()
+
+    async def test_timeout_unset_does_not_pass_timeout_kwarg(self) -> None:
+        session = HTTPSession()
+        try:
+            captured: dict[str, Any] = {}
+
+            async def fake_request(**kwargs: Any) -> httpx.Response:
+                captured.update(kwargs)
+                return httpx.Response(200, content=b"ok")
+
+            session._client.request = fake_request  # type: ignore[method-assign]
+            await session.request("GET", "https://x.test/ep")
+            assert "timeout" not in captured
+        finally:
+            await session.close()
+
+    async def test_timeout_zero_is_forwarded_not_treated_as_unset(self) -> None:
+        session = HTTPSession()
+        try:
+            captured: dict[str, Any] = {}
+
+            async def fake_request(**kwargs: Any) -> httpx.Response:
+                captured.update(kwargs)
+                return httpx.Response(200, content=b"ok")
+
+            session._client.request = fake_request  # type: ignore[method-assign]
+            await session.request("GET", "https://x.test/ep", timeout_ms=0)
+            assert "timeout" in captured
+            assert captured["timeout"] == pytest.approx(0.0)
+        finally:
+            await session.close()
+
+    async def test_response_is_closed_when_history_record_raises(self) -> None:
+        session = HTTPSession()
+        try:
+            fake_resp = MagicMock(spec=httpx.Response)
+            fake_resp.status_code = 200
+            fake_resp.headers = {}
+            fake_resp.content = b"ok"
+            fake_resp.aclose = AsyncMock()
+
+            async def fake_request(**_kwargs: Any) -> httpx.Response:
+                return fake_resp
+
+            session._client.request = fake_request  # type: ignore[method-assign]
+            with patch.object(session.history, "record", side_effect=RuntimeError("boom")):
+                with pytest.raises(RuntimeError, match="boom"):
+                    await session.request("GET", "https://x.test/ep")
+            fake_resp.aclose.assert_awaited_once()
+        finally:
+            await session.close()


### PR DESCRIPTION
## Summary

Add an optional `timeout_ms` parameter to `HTTPSession.request()` so callers can tune slow targets per call. The client-wide 30s default previously caused every call against a slow target to fail, with no way to override.

## Changes

- `HTTPSession.request()` now accepts `timeout_ms: int | None = None`. When set, the value (converted to seconds) is forwarded to `self._client.request(..., timeout=...)`. When unset, behavior is identical to today (client default 30s).
- Wrap the response-handling block in try/except so the underlying `httpx.Response` is `aclose()`d if an exception fires between dispatch and history record (avoids connection leak on partial failure).
- `timeout_ms=0` is honored as 0s (treated as set, not unset).

## Backward compatibility

Fully backward compatible. Existing callers (including `http_request` tool wrapper) do not pass `timeout_ms` and observe identical behavior.

## Tests

New file: `packages/decepticon/tests/unit/web/test_http_timeout.py`

- `test_timeout_ms_is_forwarded_to_underlying_client_request` — 2500ms → 2.5s passed as `timeout` kwarg
- `test_timeout_unset_does_not_pass_timeout_kwarg` — preserves default
- `test_timeout_zero_is_forwarded_not_treated_as_unset` — 0 is honored
- `test_response_is_closed_when_history_record_raises` — exception safety

### RED/GREEN evidence

RED (before implementation):
```
TypeError: HTTPSession.request() got an unexpected keyword argument 'timeout_ms'
FAILED test_http_timeout.py::TestHTTPSessionPerRequestTimeout::test_timeout_ms_is_forwarded_to_underlying_client_request
1 failed, 3 warnings in 3.27s
```

GREEN (after implementation, full web regression):
```
135 passed, 3 warnings in 2.16s
```

## Quality gates

- `ruff check` — All checks passed
- `ruff format --check` — clean
- `basedpyright` (errors-only on changed files) — 0 errors
- Regression: 135 passed across `tests/unit/tools/web/` + `tests/unit/web/`