### PR TITLE
feat(tools/mcp): retry transient MCP server connect failures with bounded backoff

### DIFF
--- a/packages/decepticon/decepticon/tools/mcp/client.py
+++ b/packages/decepticon/decepticon/tools/mcp/client.py
@@ -31,6 +31,7 @@ convention used by ``DECEPTICON_BUDGET__*``, ``DECEPTICON_RUNTIME__*``,
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from collections.abc import Mapping
@@ -48,6 +49,16 @@ ENV_SERVERS = "DECEPTICON_MCP__SERVERS"
 Transport = Literal["streamable_http", "sse", "stdio"]
 
 _VALID_TRANSPORTS: frozenset[str] = frozenset({"streamable_http", "sse", "stdio"})
+
+#: Bounded retry policy for per-server MCP connect+get_tools. A transient
+#: network hiccup must not permanently drop a server's tools, but we still
+#: need a hard ceiling so a dead endpoint can't stall agent start-up.
+_MAX_ATTEMPTS = 3
+_BACKOFF_BASE_SECONDS = 1.0
+
+#: Module-level sleep indirection so tests can patch it to a no-op without
+#: monkey-patching ``asyncio.sleep`` globally.
+_sleep = asyncio.sleep
 
 
 @dataclass(frozen=True)
@@ -224,15 +235,33 @@ async def load_mcp_tools(
     collected: list[Any] = []
     for srv in servers:
         connections = {srv.name: srv.to_client_kwargs()}
-        try:
-            client = MultiServerMCPClient(connections)
-            tools = await client.get_tools()
-        except Exception as exc:  # noqa: BLE001 — third-party I/O
+        tools: list[Any] | None = None
+        last_exc: BaseException | None = None
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                client = MultiServerMCPClient(connections)
+                tools = await client.get_tools()
+                break
+            except Exception as exc:  # noqa: BLE001 — third-party I/O
+                last_exc = exc
+                if attempt < _MAX_ATTEMPTS:
+                    delay = _BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+                    log.info(
+                        "MCP server %r attempt %d/%d failed (%s: %s); retrying in %.1fs",
+                        srv.name,
+                        attempt,
+                        _MAX_ATTEMPTS,
+                        type(exc).__name__,
+                        exc,
+                        delay,
+                    )
+                    await _sleep(delay)
+        if tools is None:
             log.warning(
                 "MCP server %r unreachable, skipping (%s: %s)",
                 srv.name,
-                type(exc).__name__,
-                exc,
+                type(last_exc).__name__ if last_exc is not None else "Error",
+                last_exc,
             )
             continue
         log.info("loaded %d tool(s) from MCP server %r", len(tools), srv.name)

--- a/packages/decepticon/tests/unit/tools/test_mcp_client.py
+++ b/packages/decepticon/tests/unit/tools/test_mcp_client.py
@@ -229,6 +229,84 @@ async def test_load_mcp_tools_uses_mock_client_when_package_present(
     }
 
 
+async def test_load_mcp_tools_retries_transient_failures(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """A server whose get_tools() fails twice then succeeds is retried."""
+    from decepticon.tools.mcp import client as mcp_client
+
+    sentinel_tools = [object()]
+    attempts: list[int] = []
+
+    class FakeClient:
+        def __init__(self, connections: dict[str, Any]):
+            pass
+
+        async def get_tools(self) -> list[Any]:
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise ConnectionError("transient")
+            return sentinel_tools
+
+    fake_pkg = types.ModuleType("langchain_mcp_adapters")
+    fake_client_mod = types.ModuleType("langchain_mcp_adapters.client")
+    fake_client_mod.MultiServerMCPClient = FakeClient  # type: ignore[attr-defined]
+    fake_pkg.client = fake_client_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters", fake_pkg)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters.client", fake_client_mod)
+
+    sleeps: list[float] = []
+
+    async def _no_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(mcp_client, "_sleep", _no_sleep)
+
+    servers = (MCPServerConfig(name="kali", transport="streamable_http", url="http://x/mcp"),)
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = await load_mcp_tools(servers)
+    assert result == sentinel_tools
+    assert len(attempts) == 3
+    assert len(sleeps) == 2
+    assert all(s > 0 for s in sleeps)
+
+
+async def test_load_mcp_tools_skips_after_all_attempts_exhausted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """A server that fails every retry is logged+skipped (current end-state)."""
+    from decepticon.tools.mcp import client as mcp_client
+
+    attempts: list[int] = []
+
+    class FakeClient:
+        def __init__(self, connections: dict[str, Any]):
+            pass
+
+        async def get_tools(self) -> list[Any]:
+            attempts.append(1)
+            raise ConnectionError("down")
+
+    fake_pkg = types.ModuleType("langchain_mcp_adapters")
+    fake_client_mod = types.ModuleType("langchain_mcp_adapters.client")
+    fake_client_mod.MultiServerMCPClient = FakeClient  # type: ignore[attr-defined]
+    fake_pkg.client = fake_client_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters", fake_pkg)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters.client", fake_client_mod)
+
+    async def _no_sleep(seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(mcp_client, "_sleep", _no_sleep)
+
+    servers = (MCPServerConfig(name="bad", transport="streamable_http", url="http://x/mcp"),)
+    with caplog.at_level(logging.WARNING, logger="decepticon.tools.mcp"):
+        result = await load_mcp_tools(servers)
+    assert result == []
+    assert len(attempts) >= 2
+    assert any("unreachable" in rec.message for rec in caplog.records)
+
+
 async def test_load_mcp_tools_one_bad_server_does_not_kill_others(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ):


### PR DESCRIPTION
## Problem

`load_mcp_tools` (`packages/decepticon/decepticon/tools/mcp/client.py`) wrapped per-server `connect + get_tools()` in a single `try/except Exception` that **logged and skipped on any failure**. A single transient hiccup (DNS blip, server cold-start, brief 5xx, momentary socket reset) at agent start-up permanently dropped that server's tools for the agent's entire lifetime — no retry, no recovery.

## Fix (scoped: retry-with-backoff only)

Wrap the per-server probe in a bounded retry loop:

- **3 attempts** with exponential backoff (1s → 2s between tries)
- Sleep indirected through module-level `_sleep` so tests can patch it to a no-op (instant test runs)
- **End-state behavior preserved**: only after all attempts fail do we log+skip; a permanently-down server still doesn't kill other servers' tools
- Only `tools/mcp/client.py` is touched (plus its test file). No deps, no `pyproject.toml`, no `uv.lock` changes.

## Tests

Added two TDD-first tests next to existing MCP coverage (`tests/unit/tools/test_mcp_client.py`):

1. `test_load_mcp_tools_retries_transient_failures` — server fails twice then succeeds; asserts 3 `get_tools()` calls, 2 backoff sleeps with positive delays, tools loaded.
2. `test_load_mcp_tools_skips_after_all_attempts_exhausted` — server fails every retry; asserts `>= 2` attempts, `[]` result, "unreachable" warning logged (existing skip-on-failure contract preserved).

### RED → GREEN evidence

RED (before implementation, on the new test):
```
E       AttributeError: <module 'decepticon.tools.mcp.client' ...> has no attribute '_sleep'
FAILED packages/decepticon/tests/unit/tools/test_mcp_client.py::test_load_mcp_tools_retries_transient_failures
```

GREEN (after implementation, full MCP test file):
```
======================== 19 passed, 3 warnings in 5.07s ========================
```

Full `packages/decepticon/tests/unit/tools/` regression (single-process, no `-n auto`):
```
======================= 459 passed, 3 warnings in 5.76s ========================
```

## Gates

- `ruff check` → `All checks passed!`
- `ruff format` → applied
- `basedpyright` on touched files → **0 errors**

## Follow-up (intentionally out of scope)

Mid-engagement **lazy reconnect** — recovering a server that drops *after* successful start-up — is a larger change (connection-state cache, per-call retry semantics on tool invocation, possibly an MCP-tool wrapper). Left for a dedicated PR so this one stays a small, reviewable surface.