### PR TITLE
feat(runtime): bound each shutdown-flush component with its own timeout

### DIFF
--- a/packages/decepticon/decepticon/runtime/shutdown.py
+++ b/packages/decepticon/decepticon/runtime/shutdown.py
@@ -37,6 +37,10 @@ MAX_FLUSH_SECONDS: float = 5.0
 The handler joins the worker thread with this deadline and exits even
 if writes are still in flight when the deadline expires."""
 
+PER_COMPONENT_FLUSH_SECONDS: float = 2.0
+"""Per-component upper bound: one hung checkpoint writer cannot consume
+the whole ``MAX_FLUSH_SECONDS`` budget and starve the remaining steps."""
+
 DUPLICATE_SIGNAL_WINDOW_SECONDS: float = 2.0
 """Second signal within this window of the first forces immediate exit."""
 
@@ -231,37 +235,71 @@ def _run_flush(signal_name: str, deadline: float) -> _FlushResult:
     if workspace is None:
         return result
 
-    if _time_left(deadline) <= 0:
-        return result
-    try:
-        result.findings_written = _write_inflight_findings(state, workspace)
-    except Exception as exc:  # noqa: BLE001
-        result.errors.append(f"findings: {exc!r}")
+    ok, val = _run_step(
+        "findings", lambda: _write_inflight_findings(state, workspace), deadline, result
+    )
+    if ok and isinstance(val, int):
+        result.findings_written = val
 
-    if _time_left(deadline) <= 0:
-        return result
-    try:
-        result.opplan_written = _write_opplan_checkpoint(state, workspace)
-    except Exception as exc:  # noqa: BLE001
-        result.errors.append(f"opplan: {exc!r}")
+    ok, val = _run_step(
+        "opplan", lambda: _write_opplan_checkpoint(state, workspace), deadline, result
+    )
+    if ok:
+        result.opplan_written = bool(val)
 
-    if _time_left(deadline) <= 0:
-        return result
-    try:
-        result.partial_executive_written = _write_partial_executive(state, workspace)
-    except Exception as exc:  # noqa: BLE001
-        result.errors.append(f"executive: {exc!r}")
+    ok, val = _run_step(
+        "executive", lambda: _write_partial_executive(state, workspace), deadline, result
+    )
+    if ok:
+        result.partial_executive_written = bool(val)
 
-    if _time_left(deadline) <= 0:
-        return result
-    try:
-        result.event_written = _write_checkpoint_event_if_available(
-            state, workspace, result, signal_name
-        )
-    except Exception as exc:  # noqa: BLE001
-        result.errors.append(f"event: {exc!r}")
+    ok, val = _run_step(
+        "event",
+        lambda: _write_checkpoint_event_if_available(state, workspace, result, signal_name),
+        deadline,
+        result,
+    )
+    if ok:
+        result.event_written = bool(val)
 
     return result
+
+
+def _run_step(
+    label: str,
+    func: Callable[[], Any],
+    deadline: float,
+    result: _FlushResult,
+) -> tuple[bool, Any]:
+    """Run ``func`` bounded by ``min(PER_COMPONENT_FLUSH_SECONDS, time_left)``.
+
+    The ``_write_*`` helpers are synchronous filesystem calls, so we cannot
+    cancel them cooperatively; instead each runs in its own short-lived
+    daemon thread and we ``join`` with a per-component timeout. On timeout
+    we record a structured error and return ``(False, None)`` so the next
+    checkpoint step can still execute within the remaining total budget.
+    """
+    cap = min(PER_COMPONENT_FLUSH_SECONDS, _time_left(deadline))
+    if cap <= 0:
+        return False, None
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            box["v"] = func()
+        except Exception as exc:  # noqa: BLE001 - reported via result.errors
+            box["e"] = exc
+
+    t = threading.Thread(target=_runner, name=f"decepticon-shutdown-{label}", daemon=True)
+    t.start()
+    t.join(timeout=cap)
+    if t.is_alive():
+        result.errors.append(f"{label}: timed out after {cap:.2f}s")
+        return False, None
+    if "e" in box:
+        result.errors.append(f"{label}: {box['e']!r}")
+        return False, None
+    return True, box.get("v")
 
 
 def _time_left(deadline: float) -> float:

--- a/packages/decepticon/tests/unit/runtime/test_shutdown.py
+++ b/packages/decepticon/tests/unit/runtime/test_shutdown.py
@@ -449,3 +449,47 @@ def time_monotonic_plus(seconds: float) -> float:
     import time
 
     return time.monotonic() + seconds
+
+
+class TestPerComponentTimeout:
+    """Each ``_write_*`` step must be bounded so one hung writer cannot
+    consume the whole flush deadline and starve the remaining steps."""
+
+    def test_hung_component_is_bounded_and_others_still_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import time as _time
+
+        from decepticon.runtime import shutdown as mod
+
+        monkeypatch.setattr(mod, "PER_COMPONENT_FLUSH_SECONDS", 0.2, raising=False)
+
+        state = {
+            "workspace_path": str(tmp_path),
+            "engagement_name": "hang-test",
+            "objectives": [{"id": "OBJ-001"}],
+            "objective_counter": 1,
+            "pending_findings": [{"title": "x", "severity": "low"}],
+        }
+        mod._state_provider = lambda: state
+
+        def _hang(*_args: object, **_kwargs: object) -> int:
+            _time.sleep(5.0)
+            return 0
+
+        monkeypatch.setattr(mod, "_write_inflight_findings", _hang)
+
+        start = _time.monotonic()
+        result = mod._run_flush("SIGINT", deadline=_time.monotonic() + 4.0)
+        elapsed = _time.monotonic() - start
+
+        # Hung step must be bounded — well under the total 4 s deadline.
+        assert elapsed < 2.0, f"flush stalled for {elapsed:.2f}s"
+        # Hung step is recorded as errored, with zero side effects.
+        assert result.findings_written == 0
+        assert any("findings" in e for e in result.errors), result.errors
+        # Subsequent steps must still execute and persist their output.
+        assert result.opplan_written is True
+        assert result.partial_executive_written is True
+        assert (tmp_path / "plan" / "opplan.json").exists()
+        assert (tmp_path / "report" / "report_partial_executive.md").exists()


### PR DESCRIPTION
## Problem

`packages/decepticon/decepticon/runtime/shutdown.py::_run_flush` runs four checkpoint writers (`_write_inflight_findings`, `_write_opplan_checkpoint`, `_write_partial_executive`, `_write_checkpoint_event_if_available`). Each is preceded only by a `_time_left(deadline) <= 0` short-circuit, so the *total* flush is bounded by `MAX_FLUSH_SECONDS = 5.0` — but there was no **per-component** bound. A single hung writer (slow disk, stuck `fsync`, NFS hiccup, …) would consume the entire remaining deadline and every subsequent checkpoint would be silently skipped.

## Fix

Each `_write_*` step now runs in its own short-lived daemon thread, joined with `min(PER_COMPONENT_FLUSH_SECONDS, time_left)` (default `PER_COMPONENT_FLUSH_SECONDS = 2.0`). On timeout we append a structured `"<label>: timed out after Xs"` entry to `_FlushResult.errors` and move on to the next step. The total `MAX_FLUSH_SECONDS` bound and the existing `_FlushResult` schema are preserved.

The threading shim is required because the writers are synchronous filesystem calls that cannot be cancelled cooperatively — `join(timeout=...)` is the only way to bound them without a SIGALRM-style escape that is not portable to Windows.

## Tests

New `TestPerComponentTimeout::test_hung_component_is_bounded_and_others_still_run` monkeypatches `_write_inflight_findings` to sleep well past the per-component cap and asserts:

- the flush returns in well under the total deadline,
- the hung step is recorded as errored with zero side-effects,
- `opplan` and `executive` still run and persist their artifacts.

### RED → GREEN

```
# RED (before implementation):
FAILED test_shutdown.py::TestPerComponentTimeout::test_hung_component_is_bounded_and_others_still_run

# GREEN (after):
packages/decepticon/tests/unit/runtime/  ->  102 passed, 3 skipped
```

## Gates

- `ruff check` + `ruff format` clean on touched files
- `basedpyright` errors: **0**

## Scope

Touches only `shutdown.py` and its test file. No dep / pyproject / lockfile changes.