### PR TITLE
fix(runtime): bound Windows event-log lock with timeout + backoff

### DIFF
--- a/packages/decepticon/decepticon/runtime/event_log.py
+++ b/packages/decepticon/decepticon/runtime/event_log.py
@@ -28,13 +28,60 @@ import os
 import sys
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
 log = logging.getLogger("decepticon.runtime.event_log")
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        v = float(raw)
+    except ValueError:
+        return default
+    return v if v > 0 else default
+
+
+LOCK_ACQUIRE_TIMEOUT_S: float = _env_float("DECEPTICON_EVENT_LOG_LOCK_TIMEOUT_S", 10.0)
+_LOCK_RETRY_INITIAL_SLEEP_S: float = 0.01
+_LOCK_RETRY_MAX_SLEEP_S: float = 1.0
+
+
+def _retry_lock(
+    acquire: Callable[[], None],
+    *,
+    timeout: float,
+    sleep: Callable[[float], None],
+    clock: Callable[[], float],
+) -> None:
+    """Call ``acquire`` until it returns, with capped exponential backoff.
+
+    ``acquire`` must raise ``OSError`` on contention and return on
+    success. The retry stops once the elapsed time since the first
+    attempt exceeds ``timeout``; in that case the last ``OSError`` is
+    re-raised as :class:`TimeoutError` so callers fail fast instead of
+    spinning forever on a stale lock.
+    """
+    deadline = clock() + timeout
+    delay = _LOCK_RETRY_INITIAL_SLEEP_S
+    last_err: OSError | None = None
+    while True:
+        try:
+            acquire()
+            return
+        except OSError as e:
+            last_err = e
+        remaining = deadline - clock()
+        if remaining <= 0:
+            raise TimeoutError(f"event-log lock not acquired within {timeout:.3f}s") from last_err
+        sleep(min(delay, remaining))
+        delay = min(delay * 2, _LOCK_RETRY_MAX_SLEEP_S)
 
 
 class EventType(str, Enum):
@@ -113,12 +160,12 @@ def _acquire_lock(fd: int) -> None:
         import msvcrt
 
         os.lseek(fd, 0, os.SEEK_SET)
-        while True:
-            try:
-                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
-                return
-            except OSError:
-                time.sleep(0.01)
+        _retry_lock(
+            lambda: msvcrt.locking(fd, msvcrt.LK_LOCK, 1),
+            timeout=LOCK_ACQUIRE_TIMEOUT_S,
+            sleep=time.sleep,
+            clock=time.monotonic,
+        )
     else:
         import fcntl
 

--- a/packages/decepticon/tests/unit/runtime/test_event_log_retry_lock.py
+++ b/packages/decepticon/tests/unit/runtime/test_event_log_retry_lock.py
@@ -1,0 +1,86 @@
+"""Cross-platform unit tests for the bounded lock-retry helper.
+
+The Windows ``_acquire_lock`` branch previously spun forever on
+``msvcrt.locking`` ``OSError``. The retry policy is now extracted into
+``_retry_lock`` so it can be tested on Linux CI without ``msvcrt``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon.runtime.event_log import LOCK_ACQUIRE_TIMEOUT_S, _retry_lock
+
+
+class _FailNTimes:
+    """Acquire callable that raises ``OSError`` the first ``n`` calls."""
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+        if self.calls <= self.n:
+            raise OSError("locked")
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, dt: float) -> None:
+        self.sleeps.append(dt)
+        self.now += dt
+
+
+def test_retry_lock_returns_when_acquire_eventually_succeeds() -> None:
+    clock = _FakeClock()
+    acquire = _FailNTimes(2)
+    _retry_lock(acquire, timeout=10.0, sleep=clock.sleep, clock=clock.time)
+    assert acquire.calls == 3
+    assert len(clock.sleeps) == 2
+    assert all(0 < s <= 1.0 for s in clock.sleeps)
+
+
+def test_retry_lock_raises_timeout_when_deadline_exceeded() -> None:
+    clock = _FakeClock()
+
+    def always_fail() -> None:
+        raise OSError("locked")
+
+    with pytest.raises(TimeoutError):
+        _retry_lock(always_fail, timeout=0.5, sleep=clock.sleep, clock=clock.time)
+
+    assert len(clock.sleeps) >= 1
+    assert clock.now >= 0.5
+
+
+def test_retry_lock_bounded_sleeps_with_backoff() -> None:
+    clock = _FakeClock()
+
+    def always_fail() -> None:
+        raise OSError("locked")
+
+    with pytest.raises(TimeoutError):
+        _retry_lock(always_fail, timeout=2.0, sleep=clock.sleep, clock=clock.time)
+
+    assert len(clock.sleeps) < 1000
+    assert clock.sleeps == sorted(clock.sleeps)
+    assert max(clock.sleeps) <= 1.0
+
+
+def test_retry_lock_succeeds_on_first_try_without_sleeping() -> None:
+    clock = _FakeClock()
+    acquire = _FailNTimes(0)
+    _retry_lock(acquire, timeout=1.0, sleep=clock.sleep, clock=clock.time)
+    assert acquire.calls == 1
+    assert clock.sleeps == []
+
+
+def test_lock_acquire_timeout_default_is_sane() -> None:
+    assert 1.0 <= LOCK_ACQUIRE_TIMEOUT_S <= 120.0


### PR DESCRIPTION
## Problem

`packages/decepticon/decepticon/runtime/event_log.py` `_acquire_lock` on Windows runs:

```python
while True:
    try:
        msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
        return
    except OSError:
        time.sleep(0.01)
```

No timeout, no max retries, no backoff. If a peer holding the lock crashes/hangs, the writer spins forever at ~100 Hz pinning CPU, blocks every subsequent `EventLog.append`, and prevents graceful shutdown.

## Fix

Extract the retry policy into a pure helper:

```python
def _retry_lock(acquire, *, timeout, sleep, clock) -> None: ...
```

- Capped exponential backoff (10ms -> 1s cap), bounded by the remaining deadline so we never oversleep past it.
- On deadline exhaustion raises `TimeoutError` chaining the last `OSError` — callers fail fast instead of hanging.
- Win32 branch now calls `_retry_lock(lambda: msvcrt.locking(...), timeout=LOCK_ACQUIRE_TIMEOUT_S, sleep=time.sleep, clock=time.monotonic)`. POSIX `fcntl.flock` path is unchanged.
- Timeout default 10s, tunable via `DECEPTICON_EVENT_LOG_LOCK_TIMEOUT_S`.

## Testability

`msvcrt` is Windows-only, CI is Linux. The helper is pure (clock + sleep injected, `acquire` is any `Callable[[], None]` that raises `OSError` until success), so it's covered by cross-platform unit tests without any `msvcrt` shim:

- acquire fails twice then succeeds -> returns; sleeps bounded
- acquire always fails -> `TimeoutError` after deadline, bounded number of sleeps, sleeps monotonically grow up to 1s cap
- acquire succeeds on first try -> no sleep
- default `LOCK_ACQUIRE_TIMEOUT_S` sanity bound

Existing Windows-only `test_event_log_winlock.py` tests stay green (still skipped on Linux as before).

## RED / GREEN evidence

RED (test file lands first, import fails because helper doesn't exist):

```
ERROR packages/decepticon/tests/unit/runtime/test_event_log_retry_lock.py
1 error during collection
```

GREEN (after implementation):

```
106 passed, 3 skipped, 3 warnings in 23.18s
```

Gates:

```
ruff check . && ruff format .         # All checks passed
basedpyright: 0 errors
```

## Scope

Touched only `packages/decepticon/decepticon/runtime/event_log.py` and added `packages/decepticon/tests/unit/runtime/test_event_log_retry_lock.py`. No dependency, `pyproject`, or `uv.lock` changes.