### PR TITLE
fix(sandbox): reap orphaned tmux sessions on daemon startup

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/base.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/base.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import posixpath
 import re
 import subprocess
@@ -36,6 +37,80 @@ from decepticon.sandbox_kernel.jobs import BackgroundJob, BackgroundJobTracker
 from decepticon.sandbox_kernel.tmux import PS1_PATTERN, TmuxSessionManager, _safe_log
 
 log = logging.getLogger("decepticon.sandbox_kernel.base")
+
+# ── Startup orphan-reap ──────────────────────────────────────────────────
+#
+# When the daemon is SIGKILLed, the tmux sessions/sockets it spawned via
+# ``tmux -L <session> …`` (see TmuxSessionManager._tmux) survive the
+# parent's death. A fresh daemon then starts with an empty manager map
+# and `TmuxSessionManager._initialized` set, so it has no idea those
+# servers exist and they accumulate forever — file-descriptor + memory
+# leak, plus session-name collisions on the next engagement attempt.
+#
+# Reap discovers pre-existing sockets and kills the ones the new process
+# does NOT own. The decision is split from the I/O so the unit tests can
+# verify orphan classification without invoking real tmux (CI has none).
+#
+# Heuristic — we only reap sockets whose name carries the ``dcptn_``
+# prefix produced by SandboxBase._tmux_session_name for non-root
+# workspaces. Root-workspace sessions (bare names like ``main``) could
+# belong to anything on a shared host and are left alone deliberately.
+
+_DECEPTICON_TMUX_SOCKET_PREFIX = "dcptn_"
+
+
+def _compute_orphan_tmux_sessions(
+    discovered: set[str],
+    tracked: set[str],
+) -> set[str]:
+    """Pure decision function for the startup reap.
+
+    Returns the subset of ``discovered`` that are decepticon-owned
+    (``dcptn_`` prefix) AND not present in ``tracked``. Tracked sessions
+    are spared; non-decepticon-prefixed names are spared regardless.
+    """
+    return {
+        name
+        for name in discovered
+        if name.startswith(_DECEPTICON_TMUX_SOCKET_PREFIX) and name not in tracked
+    }
+
+
+def _list_decepticon_tmux_sockets() -> list[str]:
+    """List decepticon-owned tmux socket names on the host.
+
+    Each ``tmux -L <name>`` creates a socket at ``/tmp/tmux-<uid>/<name>``
+    (see ``man tmux``). We scan that directory and keep only the names
+    matching the decepticon prefix so we never touch an unrelated user's
+    tmux server on a shared host. Errors are logged + swallowed — a
+    missing socket dir simply means no sessions to reap.
+    """
+    socket_dir = f"/tmp/tmux-{os.getuid()}"
+    try:
+        return [n for n in os.listdir(socket_dir) if n.startswith(_DECEPTICON_TMUX_SOCKET_PREFIX)]
+    except FileNotFoundError:
+        return []
+    except OSError as e:
+        log.debug("tmux socket directory probe failed: %s", _safe_log(e))
+        return []
+
+
+def _kill_tmux_socket(session: str) -> None:
+    """Kill the tmux server backing a single decepticon socket.
+
+    ``tmux -L <session> kill-server`` terminates the server (and reaps
+    its bash children) for that named socket only — no other tmux server
+    on the host is affected.
+    """
+    subprocess.run(
+        ["tmux", "-L", session, "kill-server"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=True,
+        encoding="utf-8",
+        errors="replace",
+    )
 
 
 class SandboxBase(BaseSandbox):
@@ -366,6 +441,42 @@ class SandboxBase(BaseSandbox):
                     TmuxSessionManager._initialized.discard(mgr.session)
             self.reset_session_log_offset(session, effective_workspace)
             self._jobs.remove(session, key=manager_key)
+
+    def reap_orphaned_tmux_sessions(self) -> int:
+        """Kill decepticon-named tmux sockets this process does NOT own.
+
+        Wired into the daemon's startup lifespan: if the previous daemon
+        was SIGKILLed, its tmux sockets/sessions survive but no live
+        manager tracks them. Without this reap they leak forever.
+
+        Returns the count of sockets successfully killed. Discovery and
+        kill go through module-level seams (``_list_decepticon_tmux_sockets``,
+        ``_kill_tmux_socket``) so unit tests can drive the logic without
+        invoking real tmux.
+        """
+        discovered = set(_list_decepticon_tmux_sockets())
+        with self._managers_lock:
+            tracked = {mgr.session for mgr in self._managers.values()}
+        orphans = _compute_orphan_tmux_sessions(discovered, tracked)
+        killed = 0
+        for session in orphans:
+            try:
+                _kill_tmux_socket(session)
+                killed += 1
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+                OSError,
+                RuntimeError,
+            ) as e:
+                log.warning(
+                    "reap: failed to kill orphan tmux socket '%s': %s",
+                    _safe_log(session),
+                    _safe_log(e),
+                )
+        if killed:
+            log.info("reap: killed %d orphan tmux socket(s) on startup", killed)
+        return killed
 
     def kill_all_sessions(self) -> int:
         """Kill every tmux session this sandbox has handed out a manager for.

--- a/packages/decepticon/decepticon/sandbox_server/app.py
+++ b/packages/decepticon/decepticon/sandbox_server/app.py
@@ -227,7 +227,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Warm the backend so the first agent request doesn't pay the
     # init cost on its critical path.
-    _get_backend()
+    backend = _get_backend()
+    # Reap tmux sockets/sessions left by a previously-killed daemon
+    # process. A SIGKILL leaves them orphaned (their tmux servers
+    # survive but no live manager tracks them); without this reap they
+    # accumulate forever and can collide with new session names on the
+    # next engagement attempt. Scoped to decepticon-named sockets
+    # only — see SandboxBase.reap_orphaned_tmux_sessions docstring.
+    try:
+        reaped = backend.reap_orphaned_tmux_sessions()
+        if reaped:
+            log.info("startup: reaped %d orphan tmux session(s)", reaped)
+    except Exception:
+        log.exception("startup: reap_orphaned_tmux_sessions raised")
     yield
     # Shutdown: kill every tmux session we ever handed out so the tmux
     # servers don't outlive the daemon and leave bash zombies behind.

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_orphan_reap.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_orphan_reap.py
@@ -1,0 +1,116 @@
+"""Startup orphan-reap for tmux sessions left by a previously-killed daemon.
+
+If the daemon is SIGKILLed, its tmux sessions/sockets survive but the new
+process starts with an empty manager map — they would leak forever. The
+reap path discovers pre-existing decepticon-named sockets on the host and
+kills the ones not tracked by the live manager.
+
+These tests cover the pure decision function (no I/O) and the reap method
+with the discovery/kill seams mocked, so they pass in CI where tmux is not
+installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon.sandbox_kernel.base import _compute_orphan_tmux_sessions
+from decepticon.sandbox_kernel.daemon import DaemonSandbox
+
+# ── pure decision function ─────────────────────────────────────────────
+
+
+def test_compute_orphans_returns_discovered_minus_tracked() -> None:
+    discovered = {"dcptn_eng-abc_main", "dcptn_eng-abc_recon", "dcptn_eng-xyz_main"}
+    tracked = {"dcptn_eng-abc_main"}
+
+    assert _compute_orphan_tmux_sessions(discovered, tracked) == {
+        "dcptn_eng-abc_recon",
+        "dcptn_eng-xyz_main",
+    }
+
+
+def test_compute_orphans_spares_every_tracked_session() -> None:
+    discovered = {"dcptn_eng-abc_main", "dcptn_eng-abc_recon"}
+    tracked = {"dcptn_eng-abc_main", "dcptn_eng-abc_recon"}
+
+    assert _compute_orphan_tmux_sessions(discovered, tracked) == set()
+
+
+def test_compute_orphans_ignores_non_decepticon_sockets() -> None:
+    # The reap path must scope to decepticon-named sockets only — never
+    # touch a session that some other process (e.g. an operator's shell)
+    # might own on a shared host.
+    discovered = {"dcptn_eng-abc_main", "user-tmux", "main", "agent-session-1"}
+    tracked: set[str] = set()
+
+    assert _compute_orphan_tmux_sessions(discovered, tracked) == {"dcptn_eng-abc_main"}
+
+
+def test_compute_orphans_with_empty_discovered_is_empty() -> None:
+    assert _compute_orphan_tmux_sessions(set(), {"dcptn_eng-abc_main"}) == set()
+
+
+# ── reap method (seams mocked) ─────────────────────────────────────────
+
+
+def test_reap_kills_only_orphans(monkeypatch: pytest.MonkeyPatch) -> None:
+    sandbox = DaemonSandbox()
+    # The session name includes a workspace-slug digest (see
+    # SandboxBase._workspace_slug) — bind it to the actual live manager
+    # so the test is robust to slug-generation changes.
+    live_mgr = sandbox._get_manager("main", "/workspace/eng-abc")
+    live_session = live_mgr.session
+    assert live_session.startswith("dcptn_")
+
+    discovered = [live_session, "dcptn_eng-abc_recon", "dcptn_eng-xyz_main"]
+    killed: list[str] = []
+
+    monkeypatch.setattr(
+        "decepticon.sandbox_kernel.base._list_decepticon_tmux_sockets",
+        lambda: list(discovered),
+    )
+    monkeypatch.setattr(
+        "decepticon.sandbox_kernel.base._kill_tmux_socket",
+        lambda s: killed.append(s),
+    )
+
+    reaped = sandbox.reap_orphaned_tmux_sessions()
+
+    assert sorted(killed) == ["dcptn_eng-abc_recon", "dcptn_eng-xyz_main"]
+    assert reaped == 2
+
+
+def test_reap_is_a_noop_when_nothing_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
+    killed: list[str] = []
+
+    monkeypatch.setattr("decepticon.sandbox_kernel.base._list_decepticon_tmux_sockets", lambda: [])
+    monkeypatch.setattr(
+        "decepticon.sandbox_kernel.base._kill_tmux_socket",
+        lambda s: killed.append(s),
+    )
+
+    assert DaemonSandbox().reap_orphaned_tmux_sessions() == 0
+    assert killed == []
+
+
+def test_reap_swallows_kill_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    # One stuck socket must not block the rest from being reaped.
+    monkeypatch.setattr(
+        "decepticon.sandbox_kernel.base._list_decepticon_tmux_sockets",
+        lambda: ["dcptn_eng-abc_main", "dcptn_eng-abc_recon"],
+    )
+
+    killed: list[str] = []
+
+    def flaky_kill(session: str) -> None:
+        if session == "dcptn_eng-abc_main":
+            raise RuntimeError("simulated tmux failure")
+        killed.append(session)
+
+    monkeypatch.setattr("decepticon.sandbox_kernel.base._kill_tmux_socket", flaky_kill)
+
+    reaped = DaemonSandbox().reap_orphaned_tmux_sessions()
+    # The successful kill is counted; the failure is logged + swallowed.
+    assert killed == ["dcptn_eng-abc_recon"]
+    assert reaped == 1


### PR DESCRIPTION
## Problem

When the sandbox daemon is SIGKILLed (OOM, k8s eviction, manual `kill -9`,
crash loop), the tmux sockets/sessions it spawned via `tmux -L <name>` survive
the parent's death — each `TmuxSessionManager` runs its own socket
(see `tmux.py::TmuxSessionManager._tmux`) which is independent of the daemon
process tree.

A fresh daemon then starts with an empty `SandboxBase._managers` map and an
empty `TmuxSessionManager._initialized` class-level set, so it has no way to
discover those orphaned servers. They accumulate forever — FD + memory leak,
plus session-name collisions when the next engagement tries to allocate a
session with a slug that already exists.

## Fix

Add a startup reap split into three pieces for testability (tmux is not
guaranteed in CI):

- **`_compute_orphan_tmux_sessions(discovered, tracked)`** — pure decision
  function: returns `discovered − tracked`, scoped to the `dcptn_` prefix
  produced by `SandboxBase._tmux_session_name` for non-root workspaces. We
  never touch an unrelated user's tmux server on a shared host. Root-workspace
  sessions (bare names like `main`) cannot be safely distinguished from
  non-decepticon tmux instances and are left alone deliberately — see comment
  block in `base.py`.
- **`_list_decepticon_tmux_sockets` / `_kill_tmux_socket`** — thin I/O seams
  the unit tests monkeypatch. Discovery scans `/tmp/tmux-<uid>/` and filters
  by the `dcptn_` prefix; kill is `tmux -L <name> kill-server`.
- **`SandboxBase.reap_orphaned_tmux_sessions`** — wires the seams + decision
  together, swallows per-socket failures (one stuck socket must not block the
  rest).

## Wiring

Hooked into `sandbox_server.app.lifespan` immediately after the backend is
warmed and before `yield` — the first agent request sees a clean slate.
Exceptions are caught + logged (reap failure must never block startup).

The startup wiring site was chosen because:
1. The HTTP daemon is the only production caller of `SandboxBase` /
   `TmuxSessionManager` (per `tmux.py` module docstring).
2. `lifespan` already owns the symmetric teardown (`kill_all_sessions` on
   shutdown), so startup-reap belongs in the same place.
3. `_get_backend()` is the warm-up seam — reap runs against an already-built
   backend so it can read `_managers` for the live-tracked set.

## TDD evidence

**RED** (before implementing `_compute_orphan_tmux_sessions` /
`reap_orphaned_tmux_sessions`):

```
ERROR packages/decepticon/tests/unit/sandbox_kernel/test_orphan_reap.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
3 warnings, 1 error in 3.30s
```

(ImportError: cannot import name `_compute_orphan_tmux_sessions`.)

**GREEN** after implementation:

```
$ uv run pytest -p no:xdist -q packages/decepticon/tests/unit/sandbox_kernel/
39 passed, 3 warnings in 2.21s
```

7 new tests cover:
- pure decision: orphans = discovered − tracked, scoped to `dcptn_`
- tracked sessions are always spared
- non-decepticon socket names are spared
- empty discovered → no-op
- reap kills only orphans (live manager session spared)
- reap is a no-op when nothing is discovered
- one stuck kill does not block the rest

## Gates

- `ruff check` + `ruff format`: clean
- `basedpyright` on touched files: **0 errors**

## Files touched

- `packages/decepticon/decepticon/sandbox_kernel/base.py` — pure fn + seams + method
- `packages/decepticon/decepticon/sandbox_server/app.py` — startup wiring
- `packages/decepticon/tests/unit/sandbox_kernel/test_orphan_reap.py` — new