### PR TITLE
feat(runtime): terminal guard for consecutive sub-agent failures

### DIFF
--- a/packages/decepticon/decepticon/core/subagent_streaming.py
+++ b/packages/decepticon/decepticon/core/subagent_streaming.py
@@ -41,6 +41,16 @@ from langchain_core.runnables import Runnable, RunnableBinding
 
 log = logging.getLogger("decepticon.subagent_streaming")
 
+# Terminal guard: cap on consecutive sub-agent failures before we surface a
+# distinct marker the orchestrator can stop on. We can't re-raise from the
+# except branches (it strands tool calls and PatchToolCallsMiddleware turns
+# them into "cancelled" → retry loop), so the only stop signal we own is
+# the *content* of the returned state. After this many back-to-back
+# failures on the same runnable instance, emit a TERMINAL message instead
+# of yet another generic per-failure one.
+MAX_SUBAGENT_CONSECUTIVE_FAILURES = 3
+_TERMINAL_MARKER = "[TERMINAL]"
+
 # Context variable for the active renderer — set by StreamingEngine.run()
 _active_renderer: contextvars.ContextVar[Any] = contextvars.ContextVar(
     "subagent_renderer", default=None
@@ -103,6 +113,26 @@ class StreamingRunnable(RunnableBinding):
         if name is not None and "name" not in data:
             data["name"] = name
         super().__init__(**data)
+        # Pydantic BaseModel: use object.__setattr__ to attach mutable
+        # per-instance state outside the declared field schema.
+        object.__setattr__(self, "_consecutive_failures", 0)
+
+    def _bump_failure_and_format(self, exc: BaseException) -> str:
+        """Increment the failure counter; return the message body for the
+        returned state. Switches to a distinct TERMINAL marker once the cap
+        is reached so the orchestrator can stop re-delegating."""
+        n = int(getattr(self, "_consecutive_failures", 0)) + 1
+        object.__setattr__(self, "_consecutive_failures", n)
+        if n >= MAX_SUBAGENT_CONSECUTIVE_FAILURES:
+            return (
+                f"{_TERMINAL_MARKER} subagent '{self._name}' failed {n} "
+                f"consecutive times; aborting this objective. "
+                f"Last error: {type(exc).__name__}: {exc}"
+            )
+        return f"Subagent '{self._name}' failed: {type(exc).__name__}: {exc}"
+
+    def _reset_failures(self) -> None:
+        object.__setattr__(self, "_consecutive_failures", 0)
 
     # ── Back-compat aliases for OSS callers / tests ────────────────────
     # Internal code (and unit tests) refer to ``self._runnable`` / ``self._name``;
@@ -328,13 +358,14 @@ class StreamingRunnable(RunnableBinding):
             # thread state. On the next run, PatchToolCallsMiddleware finds the
             # dangling tool calls and injects "cancelled" messages, causing the
             # orchestrator to retry in an infinite loop.
-            error_msg = f"Subagent '{self._name}' failed: {type(exc).__name__}: {exc}"
+            error_msg = self._bump_failure_and_format(exc)
             if last_state is not None:
                 last_state.setdefault("messages", []).append(AIMessage(content=error_msg))
                 return last_state
             return {"messages": [AIMessage(content=error_msg)]}
 
         self._emit_end(renderer, has_renderer, writer, time.monotonic() - start)
+        self._reset_failures()
 
         if last_state is None:
             # stream() yielded zero states. Re-invoking the sub-agent here
@@ -417,13 +448,14 @@ class StreamingRunnable(RunnableBinding):
             # thread state. On the next run, PatchToolCallsMiddleware finds the
             # dangling tool calls and injects "cancelled" messages, causing the
             # orchestrator to retry in an infinite loop.
-            error_msg = f"Subagent '{self._name}' failed: {type(exc).__name__}: {exc}"
+            error_msg = self._bump_failure_and_format(exc)
             if last_state is not None:
                 last_state.setdefault("messages", []).append(AIMessage(content=error_msg))
                 return last_state
             return {"messages": [AIMessage(content=error_msg)]}
 
         self._emit_end(renderer, has_renderer, writer, time.monotonic() - start)
+        self._reset_failures()
 
         if last_state is None:
             # See the sync invoke() branch above: re-invoking here would

--- a/packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py
+++ b/packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py
@@ -1,0 +1,149 @@
+"""Consecutive-failure terminal guard for ``StreamingRunnable``.
+
+Returning a generic per-failure error state (instead of re-raising) is
+required to avoid PatchToolCallsMiddleware's "cancelled" loop. But the
+orchestrator has no way to distinguish a transient subagent error from
+one that will never succeed, so it just keeps re-delegating. This test
+suite locks in a terminal signal: after
+``MAX_SUBAGENT_CONSECUTIVE_FAILURES`` back-to-back failures, the wrapper
+must surface a *distinct* terminal marker on the returned state, and a
+successful run in between must reset the counter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import Runnable
+
+from decepticon.core.subagent_streaming import (
+    MAX_SUBAGENT_CONSECUTIVE_FAILURES,
+    StreamingRunnable,
+    clear_subagent_renderer,
+    set_subagent_renderer,
+)
+
+TERMINAL_MARKER = "[TERMINAL]"
+
+
+class _ToggleRunnable(Runnable):
+    """Inner runnable whose stream/astream raises or yields a final state
+    based on the mutable ``should_fail`` flag — used to drive the
+    failure counter across success transitions without swapping the
+    pydantic-bound inner runnable on the wrapper."""
+
+    _FINAL: dict[str, Any] = {"messages": [AIMessage(content="ok")]}
+
+    def __init__(self, should_fail: bool = True) -> None:
+        self.should_fail = should_fail
+        self._exc = RuntimeError("boom")
+
+    def stream(self, input: Any, config: Any = None, stream_mode: str = "values", **kwargs: Any):
+        if self.should_fail:
+            raise self._exc
+        yield self._FINAL
+
+    async def astream(
+        self, input: Any, config: Any = None, stream_mode: str = "values", **kwargs: Any
+    ):
+        if self.should_fail:
+            raise self._exc
+        yield self._FINAL
+
+    def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:  # pragma: no cover
+        if self.should_fail:
+            raise self._exc
+        return self._FINAL
+
+    async def ainvoke(
+        self, input: Any, config: Any = None, **kwargs: Any
+    ) -> Any:  # pragma: no cover
+        if self.should_fail:
+            raise self._exc
+        return self._FINAL
+
+
+class _Renderer:
+    def on_subagent_start(self, *a: Any, **kw: Any) -> None: ...
+    def on_subagent_end(self, *a: Any, **kw: Any) -> None: ...
+    def on_subagent_message(self, *a: Any, **kw: Any) -> None: ...
+    def on_subagent_tool_call(self, *a: Any, **kw: Any) -> None: ...  # pragma: no cover
+    def on_subagent_tool_result(self, *a: Any, **kw: Any) -> None: ...  # pragma: no cover
+
+
+@pytest.fixture
+def renderer():
+    token = set_subagent_renderer(_Renderer())
+    try:
+        yield
+    finally:
+        clear_subagent_renderer(token)
+
+
+def _last_text(state: Any) -> str:
+    return str(state["messages"][-1].content)
+
+
+def _hm() -> dict[str, Any]:
+    return {"messages": [HumanMessage(content="go")]}
+
+
+class TestSyncTerminalGuard:
+    def test_constant_is_positive(self) -> None:
+        assert MAX_SUBAGENT_CONSECUTIVE_FAILURES >= 1
+
+    def test_each_failure_before_cap_is_generic(self, renderer: None) -> None:
+        wrapper = StreamingRunnable(_ToggleRunnable(), "scanner")
+        for _ in range(MAX_SUBAGENT_CONSECUTIVE_FAILURES - 1):
+            out = wrapper.invoke(_hm())
+            text = _last_text(out)
+            assert "failed" in text
+            assert TERMINAL_MARKER not in text
+
+    def test_failure_at_cap_emits_terminal_marker(self, renderer: None) -> None:
+        wrapper = StreamingRunnable(_ToggleRunnable(), "scanner")
+        out: Any = None
+        for _ in range(MAX_SUBAGENT_CONSECUTIVE_FAILURES):
+            out = wrapper.invoke(_hm())
+        text = _last_text(out)
+        assert TERMINAL_MARKER in text
+        assert "scanner" in text
+        assert str(MAX_SUBAGENT_CONSECUTIVE_FAILURES) in text
+
+    def test_success_resets_counter(self, renderer: None) -> None:
+        toggle = _ToggleRunnable(should_fail=True)
+        wrapper = StreamingRunnable(toggle, "scanner")
+        for _ in range(MAX_SUBAGENT_CONSECUTIVE_FAILURES - 1):
+            wrapper.invoke(_hm())
+        toggle.should_fail = False
+        ok = wrapper.invoke(_hm())
+        assert TERMINAL_MARKER not in _last_text(ok)
+        toggle.should_fail = True
+        out = wrapper.invoke(_hm())
+        assert TERMINAL_MARKER not in _last_text(out)
+
+
+@pytest.mark.asyncio
+class TestAsyncTerminalGuard:
+    async def test_failure_at_cap_emits_terminal_marker(self, renderer: None) -> None:
+        wrapper = StreamingRunnable(_ToggleRunnable(), "verifier")
+        out: Any = None
+        for _ in range(MAX_SUBAGENT_CONSECUTIVE_FAILURES):
+            out = await wrapper.ainvoke(_hm())
+        text = _last_text(out)
+        assert TERMINAL_MARKER in text
+        assert "verifier" in text
+
+    async def test_async_success_resets_counter(self, renderer: None) -> None:
+        toggle = _ToggleRunnable(should_fail=True)
+        wrapper = StreamingRunnable(toggle, "verifier")
+        for _ in range(MAX_SUBAGENT_CONSECUTIVE_FAILURES - 1):
+            await wrapper.ainvoke(_hm())
+        toggle.should_fail = False
+        ok = await wrapper.ainvoke(_hm())
+        assert TERMINAL_MARKER not in _last_text(ok)
+        toggle.should_fail = True
+        out = await wrapper.ainvoke(_hm())
+        assert TERMINAL_MARKER not in _last_text(out)


### PR DESCRIPTION
## Problem

`StreamingRunnable` (packages/decepticon/decepticon/core/subagent_streaming.py) intentionally swallows sub-agent stream errors in both `invoke()` and `ainvoke()` and returns a generic `Subagent '<name>' failed: ...` AIMessage on the last state, instead of re-raising. Re-raising is not an option: it strands tool calls, and on the next run `PatchToolCallsMiddleware` turns them into `cancelled` messages — the orchestrator then retries forever.

But there was **no terminal signal**: if the sub-agent kept failing, the orchestrator kept re-delegating with no way to tell a transient error from a permanent one.

## Fix

Track consecutive failures on the runnable instance:

- `__init__` seeds `_consecutive_failures = 0` (via `object.__setattr__` because RunnableBinding is a pydantic model).
- Both `except` branches (sync + async) call `_bump_failure_and_format(exc)`:
  - Increment the counter.
  - Below the cap → return the original generic per-failure message.
  - At/above the cap (`MAX_SUBAGENT_CONSECUTIVE_FAILURES = 3`) → return a **distinct** `[TERMINAL] subagent '<name>' failed N consecutive times; aborting this objective. Last error: ...` message that the orchestrator can detect and stop on.
- A successful stream completion calls `_reset_failures()`.

State is still returned (never re-raised), so the anti-dangling-tool-call behavior the existing comments document is preserved.

## TDD

Added `packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py`:

- RED (before implementing): collection failed on the missing `MAX_SUBAGENT_CONSECUTIVE_FAILURES` import.
- GREEN: 5 new tests (sync + async) covering generic-before-cap, terminal-at-cap, and success-resets-counter — plus 8 existing `test_subagent_streaming.py` regression tests, all pass.

## Gates

- `uv run --package decepticon pytest packages/decepticon/tests/unit/core` → 44 passed
- `uv run ruff check` + `ruff format` → clean
- `uv run basedpyright` (errors-only on /tmp/bp_pr4.json) → **0 errors**

## Scope

Only touches the two files in question — no deps, no pyproject, no uv.lock.