### PR TITLE
feat(llm): classify provider errors as retryable vs fatal

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from langchain_core.language_models import BaseChatModel
@@ -1117,6 +1117,57 @@ def _redact_secrets(text: str) -> str:
     return text
 
 
+ProviderErrorClass = Literal["retryable", "fatal"]
+
+# HTTP status → class. 408/425/429 + 5xx are worth a retry / fallback hop;
+# 4xx auth/config (400/401/403/404) won't be fixed by another attempt.
+_RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+_FATAL_STATUS = frozenset({400, 401, 403, 404})
+
+# Last-resort message scrape when the exception lacks ``status_code`` —
+# LiteLLM/openai surface the upstream status only in the body text.
+_STATUS_IN_MSG = re.compile(r"(?:error\s*code|status(?:_code)?|http)\D{0,8}(\d{3})", re.I)
+
+
+def _classify_provider_error(exc: BaseException) -> ProviderErrorClass:
+    """Tag a provider exception as ``retryable`` or ``fatal``.
+
+    Inspection order (cheapest signal first):
+      1. Our own ``LLMTimeoutError`` and httpx transport errors → retryable.
+      2. ``status_code`` attribute (openai.APIStatusError shape).
+      3. ``response.status_code`` (httpx.HTTPStatusError shape).
+      4. Regex over ``str(exc)`` — LiteLLM nests upstream status in the body.
+
+    Default for unrecognised shapes is ``retryable`` so we preserve today's
+    behavior (LiteLLM ``num_retries`` keeps spinning). Only flip to ``fatal``
+    on a positive 4xx signal.
+    """
+    if isinstance(exc, LLMTimeoutError):
+        return "retryable"
+    if isinstance(exc, (httpx.TransportError, httpx.TimeoutException)):
+        return "retryable"
+
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        if status in _FATAL_STATUS:
+            return "fatal"
+        if status in _RETRYABLE_STATUS:
+            return "retryable"
+
+    match = _STATUS_IN_MSG.search(str(exc))
+    if match is not None:
+        code = int(match.group(1))
+        if code in _FATAL_STATUS:
+            return "fatal"
+        if code in _RETRYABLE_STATUS:
+            return "retryable"
+
+    return "retryable"
+
+
 def _reraise_if_connection_error(exc: Exception) -> None:
     err_type = type(exc).__name__
     if any(
@@ -1153,6 +1204,9 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
     err_type = type(exc).__name__
     msg = str(exc)
     msg_lower = msg.lower()
+    fatal_prefix = (
+        "non-retryable provider error: " if _classify_provider_error(exc) == "fatal" else ""
+    )
     # Match on the raw text (status codes / keywords are not secret-shaped),
     # but interpolate the scrubbed copy so an echoed credential never reaches
     # the user-facing message — see _redact_secrets.
@@ -1172,7 +1226,7 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
 
     if "badrequest" in err_type.lower() or "code: 400" in msg_lower:
         raise RuntimeError(
-            f"Model '{model_name}' rejected the request (400). "
+            f"{fatal_prefix}Model '{model_name}' rejected the request (400). "
             f"This usually means a parameter the model no longer supports "
             f"(e.g. temperature on Claude Opus 4.7). Underlying: {safe_msg}"
         ) from exc
@@ -1183,7 +1237,7 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
         or "invalid_api_key" in msg_lower
     ):
         raise RuntimeError(
-            f"Model '{model_name}' rejected your credentials (401). "
+            f"{fatal_prefix}Model '{model_name}' rejected your credentials (401). "
             f"Check the API key for that provider in ~/.decepticon/.env, "
             f"or run 'decepticon onboard --reset'.\nUnderlying: {safe_msg}"
         ) from exc
@@ -1197,7 +1251,7 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
 
     if "notfound" in err_type.lower() or "code: 404" in msg_lower:
         raise RuntimeError(
-            f"Model '{model_name}' is not registered in the LiteLLM proxy "
+            f"{fatal_prefix}Model '{model_name}' is not registered in the LiteLLM proxy "
             f"(404). For local Ollama, set OLLAMA_MODEL to something you "
             f"actually pulled ('ollama list'). For cloud providers, check "
             f"that the model id matches config/litellm.yaml.\n"

--- a/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
+++ b/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``_classify_provider_error`` + fatal-vs-retryable labelling.
+
+Background: ``_reraise_with_actionable_message`` already handles 400/401/404/429,
+but a caller (or human reading CLI output) cannot tell *retryable* (worth a
+fallback hop) from *fatal* (no auth swap will fix it). The classifier returns
+a tiny tag so the surfaced message can drop the misleading
+"configure another auth method" hint on fatal cases while preserving today's
+behavior for transient ones (#107 follow-up).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from decepticon.llm.factory import (
+    LLMTimeoutError,
+    _classify_provider_error,
+    _reraise_with_actionable_message,
+)
+
+
+def _exc_with_status(name: str, status: int, msg: str = "") -> Exception:
+    """Build a synthetic provider-style exception that mirrors what LiteLLM /
+    openai surface in the wild — class name encodes the error kind and a
+    ``status_code`` attribute matches ``openai.APIStatusError``.
+    """
+    cls = type(name, (Exception,), {})
+    exc = cls(msg or f"Error code: {status}")
+    exc.status_code = status  # type: ignore[attr-defined]
+    return exc
+
+
+class TestClassifyProviderErrorRetryable:
+    """Transient failures the agent (or LiteLLM retry layer) can recover from."""
+
+    def test_429_rate_limit_is_retryable(self):
+        assert _classify_provider_error(_exc_with_status("RateLimitError", 429)) == "retryable"
+
+    def test_503_service_unavailable_is_retryable(self):
+        assert (
+            _classify_provider_error(_exc_with_status("ServiceUnavailableError", 503))
+            == "retryable"
+        )
+
+    def test_500_internal_server_error_is_retryable(self):
+        assert _classify_provider_error(_exc_with_status("InternalServerError", 500)) == "retryable"
+
+    def test_llm_timeout_error_is_retryable(self):
+        assert _classify_provider_error(LLMTimeoutError("timed out after 600s")) == "retryable"
+
+    def test_httpx_connect_error_is_retryable(self):
+        assert _classify_provider_error(httpx.ConnectError("connection refused")) == "retryable"
+
+    def test_httpx_read_timeout_is_retryable(self):
+        assert _classify_provider_error(httpx.ReadTimeout("read timed out")) == "retryable"
+
+    def test_message_only_5xx_is_retryable(self):
+        # No status_code attribute; classifier must fall back to message regex
+        # (LiteLLM surface for proxied errors).
+        exc = Exception("litellm.APIError: Error code: 502 - upstream bad gateway")
+        assert _classify_provider_error(exc) == "retryable"
+
+
+class TestClassifyProviderErrorFatal:
+    """4xx auth/config failures — no retry, no auth swap, will fix nothing."""
+
+    def test_400_bad_request_is_fatal(self):
+        assert _classify_provider_error(_exc_with_status("BadRequestError", 400)) == "fatal"
+
+    def test_401_authentication_is_fatal(self):
+        assert _classify_provider_error(_exc_with_status("AuthenticationError", 401)) == "fatal"
+
+    def test_403_forbidden_is_fatal(self):
+        assert _classify_provider_error(_exc_with_status("PermissionDeniedError", 403)) == "fatal"
+
+    def test_404_not_found_is_fatal(self):
+        assert _classify_provider_error(_exc_with_status("NotFoundError", 404)) == "fatal"
+
+    def test_message_only_400_is_fatal(self):
+        exc = Exception("Error code: 400 - parameter 'temperature' is deprecated")
+        assert _classify_provider_error(exc) == "fatal"
+
+
+class TestActionableMessageFatalLabel:
+    """Integration with ``_reraise_with_actionable_message``: fatal classes
+    must carry the ``non-retryable provider error`` marker so callers /
+    operators stop chasing transient explanations."""
+
+    def test_400_message_labelled_non_retryable(self):
+        exc = _exc_with_status(
+            "BadRequestError",
+            400,
+            "Error code: 400 - temperature is deprecated",
+        )
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "anthropic/claude-opus-4-7")
+        msg = str(info.value)
+        assert "non-retryable provider error" in msg
+        # Existing remediation text preserved (regression).
+        assert "rejected the request (400)" in msg
+
+    def test_401_message_labelled_non_retryable(self):
+        exc = _exc_with_status("AuthenticationError", 401, "Error code: 401 - invalid_api_key")
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "openai/gpt-5.5")
+        msg = str(info.value)
+        assert "non-retryable provider error" in msg
+        assert "credentials (401)" in msg
+
+    def test_404_message_labelled_non_retryable(self):
+        exc = _exc_with_status("NotFoundError", 404, "Error code: 404 - model not found")
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "ollama_chat/nope")
+        msg = str(info.value)
+        assert "non-retryable provider error" in msg
+        assert "404" in msg
+
+    def test_429_message_unchanged_retryable_path(self):
+        # Retryable branch must NOT acquire the fatal label — would mislead
+        # operators into thinking the rate-limit isn't recoverable.
+        exc = _exc_with_status("RateLimitError", 429, "Error code: 429")
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "anthropic/claude-opus-4-7")
+        msg = str(info.value)
+        assert "non-retryable provider error" not in msg
+        assert "rate limit (429)" in msg


### PR DESCRIPTION
## What

Add `_classify_provider_error(exc) -> Literal["retryable","fatal"]` in `packages/decepticon/decepticon/llm/factory.py` so transient provider failures (429 / 5xx / timeout / connection) are no longer conflated with fatal 4xx auth/config errors (400 / 401 / 403 / 404).

Integrate minimally at the existing `_reraise_with_actionable_message` catch site: fatal classes now carry a `non-retryable provider error` marker so CLI/log readers stop chasing "add another auth method" guidance on errors that won't be fixed by another attempt. The retryable 429 branch is unchanged.

## Why

`factory.py` already translates 400 / 401 / 404 / 429 / no-fallback into actionable RuntimeErrors, but a caller (or human reading CLI output) cannot tell which class is worth a fallback hop. Today fatal errors get surfaced with the same generic shape as transient ones, including misleading hints. This PR adds the missing classification without restructuring litellm's `num_retries` or the fallback middleware.

## How

`_classify_provider_error` inspection order (cheapest signal first):

1. `LLMTimeoutError` → retryable.
2. `httpx.TransportError` / `httpx.TimeoutException` → retryable.
3. `exc.status_code` (openai.APIStatusError shape) mapped against `_RETRYABLE_STATUS = {408, 425, 429, 500, 502, 503, 504}` / `_FATAL_STATUS = {400, 401, 403, 404}`.
4. `exc.response.status_code` (httpx.HTTPStatusError shape).
5. Regex over `str(exc)` — LiteLLM nests the upstream status in the body text.

Default for unrecognised shapes is `retryable` to preserve today's behavior (LiteLLM `num_retries` keeps spinning). Only flip to `fatal` on a positive 4xx signal.

## RED → GREEN

RED (collection error proves the symbol didn't exist before the implementation commit):

```
ERROR packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
!!! Interrupted: 1 error during collection !!!
```

GREEN (after implementation + minimal integration):

```
$ uv run pytest -p no:xdist -q packages/decepticon/tests/unit/llm/
295 passed, 3 warnings in 2.22s
```

New `tests/unit/llm/test_factory_classify_errors.py` covers:
- retryable: 429, 503, 500, `LLMTimeoutError`, `httpx.ConnectError`, `httpx.ReadTimeout`, message-only 5xx.
- fatal: 400, 401, 403, 404, message-only 400.
- integration: `_reraise_with_actionable_message` emits `non-retryable provider error` on 400 / 401 / 404 and does NOT emit it on 429.

## Gates

- `uv run ruff check` / `ruff format` — clean.
- `uv run basedpyright` (errors-only, JSON) — 0 errors.

## Scope

Touches only:

- `packages/decepticon/decepticon/llm/factory.py`
- `packages/decepticon/tests/unit/llm/test_factory_classify_errors.py` (new)

No deps / pyproject / uv.lock changes.