### PR TITLE
feat(llm): fail fast when a tier resolves to an empty model chain

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -38,11 +38,14 @@ from pydantic import SecretStr
 from decepticon.llm.router import ModelRouter
 from decepticon_core.registry import RoleRegistry
 from decepticon_core.types.llm import (
+    AGENT_TIERS,
     AuthMethod,
     Credentials,
     LLMModelMapping,
     ModelProfile,
     ProxyConfig,
+    Tier,
+    resolve_chain,
 )
 from decepticon_core.utils.logging import get_logger
 
@@ -1205,6 +1208,51 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
         ) from exc
 
 
+def _tiers_required(profile: ModelProfile) -> dict[Tier, list[str]]:
+    if profile == ModelProfile.MAX:
+        return {Tier.HIGH: list(AGENT_TIERS)}
+    if profile == ModelProfile.TEST:
+        return {Tier.LOW: list(AGENT_TIERS)}
+    grouped: dict[Tier, list[str]] = {}
+    for role, tier in AGENT_TIERS.items():
+        grouped.setdefault(tier, []).append(role)
+    return grouped
+
+
+def _validate_chain_coverage(credentials: Credentials, profile: ModelProfile) -> None:
+    """Fail fast when ``credentials`` resolve to an EMPTY chain for any
+    tier the factory must serve under ``profile``.
+
+    ``LLMModelMapping.from_credentials_and_profile`` silently skips a role
+    whose resolved chain is empty (no configured AuthMethod has a
+    ``(method, tier)`` entry in ``METHOD_MODELS``). Downstream this surfaces
+    as a confusing ``KeyError`` at ``get_model`` time or a primary-less
+    ``ModelFallbackMiddleware([])``. Surface it once, here, with the
+    offending tier(s) + the configured inventory so the operator can fix
+    config immediately rather than chase a runtime failure.
+    """
+    empty: list[tuple[Tier, list[str]]] = [
+        (tier, roles)
+        for tier, roles in _tiers_required(profile).items()
+        if not resolve_chain(tier, credentials)
+    ]
+    if not empty:
+        return
+    details = "; ".join(
+        f"{tier.value} (roles: {', '.join(sorted(roles))})" for tier, roles in empty
+    )
+    inventory = ", ".join(m.value for m in credentials.methods) or "<none>"
+    tier_list = ", ".join(tier.value for tier, _ in empty)
+    raise ValueError(
+        f"LLMFactory: no model available for tier(s) [{tier_list}] under "
+        f"profile {profile.value!r}. Empty chains: {details}. Configured "
+        f"credentials: [{inventory}]. Add a credential whose AuthMethod "
+        f"has an entry for the listed tier(s) in METHOD_MODELS "
+        f"(packages/decepticon-core/decepticon_core/types/llm.py), or "
+        f"adjust DECEPTICON_AUTH_PRIORITY / DECEPTICON_MODEL_PROFILE."
+    )
+
+
 class LLMFactory:
     """Creates and caches LangChain ChatModel instances per agent role.
 
@@ -1228,7 +1276,9 @@ class LLMFactory:
             self._mapping = mapping
         else:
             creds = credentials if credentials is not None else _resolve_credentials()
-            resolved_profile = profile if profile is not None else self._resolve_profile()
+            raw_profile = profile if profile is not None else self._resolve_profile()
+            resolved_profile = ModelProfile(raw_profile)
+            _validate_chain_coverage(creds, resolved_profile)
             self._mapping = LLMModelMapping.from_credentials_and_profile(creds, resolved_profile)
         self._router = ModelRouter(self._mapping)
         self._cache: dict[str, BaseChatModel] = {}

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -236,6 +236,56 @@ class TestLLMFactory:
         assert factory.get_model("decepticon").model_name == "openai/gpt-5.5"
 
 
+class TestLLMFactoryEmptyChainValidation:
+    """A credentials inventory whose AuthMethods lack a (method, tier) entry
+    for some required tier resolves to an EMPTY model chain at that tier.
+    ``LLMModelMapping.from_credentials_and_profile`` silently skips such
+    roles, so the failure surfaces much later — either as a confusing
+    ``KeyError: No model assignment for role: ...`` at ``get_model`` time
+    or, when a caller routes through middleware, as a primary-less
+    ``ModelFallbackMiddleware([])``. Validate at construction so the
+    operator gets one actionable error naming the empty tier(s) and the
+    configured credentials inventory."""
+
+    def setup_method(self) -> None:
+        self.proxy = ProxyConfig(url="http://localhost:4000", api_key="test-key")
+
+    def test_empty_tier_raises_at_init_with_inventory_listed(self) -> None:
+        # MINIMAX_API has only HIGH+MID entries in METHOD_MODELS — no LOW.
+        # ECO routes ``recon`` (and other LOW roles) to Tier.LOW, so the
+        # LOW chain resolves to []. The factory must refuse to construct.
+        creds = Credentials(methods=[AuthMethod.MINIMAX_API])
+        with pytest.raises(ValueError) as exc_info:
+            LLMFactory(self.proxy, credentials=creds, profile=ModelProfile.ECO)
+        msg = str(exc_info.value)
+        # Names the empty tier so the operator knows what to fix.
+        assert "low" in msg.lower()
+        # Echoes the configured credentials so the operator can audit
+        # what was actually detected (vs. what they think they set).
+        assert AuthMethod.MINIMAX_API.value in msg
+
+    def test_test_profile_empty_high_chain_raises(self) -> None:
+        # MINIMAX_API covers HIGH+MID but not LOW; TEST profile forces every
+        # role to LOW → empty chain across the board.
+        creds = Credentials(methods=[AuthMethod.MINIMAX_API])
+        with pytest.raises(ValueError, match="(?i)low"):
+            LLMFactory(self.proxy, credentials=creds, profile=ModelProfile.TEST)
+
+    def test_valid_inventory_still_constructs(self) -> None:
+        # OPENAI_API covers all three tiers — no empty chain, no regression.
+        creds = Credentials(methods=[AuthMethod.OPENAI_API])
+        factory = LLMFactory(self.proxy, credentials=creds, profile=ModelProfile.ECO)
+        assert factory.get_model("recon").model_name == "openai/gpt-5-nano"
+        assert factory.get_model("decepticon").model_name == "openai/gpt-5.5"
+
+    def test_explicit_mapping_bypasses_validation(self) -> None:
+        # When the caller supplies a mapping directly, they own its shape —
+        # the credentials-based validation does not apply (existing tests
+        # build empty/partial mappings explicitly).
+        factory = LLMFactory(self.proxy, mapping=LLMModelMapping())
+        assert factory.proxy_url == "http://localhost:4000"
+
+
 class TestLLMFactoryHealthCheck:
     def test_health_check_returns_false_when_no_proxy(self):
         proxy = ProxyConfig(url="http://localhost:19999")


### PR DESCRIPTION
## Problem

`LLMModelMapping.from_credentials_and_profile` silently skips a role whose resolved chain is empty (no configured AuthMethod has a `(method, tier)` entry in `METHOD_MODELS` for the required tier — see the "(method, tier) entry missing … skips" note in `packages/decepticon-core/decepticon_core/types/llm.py` around L170). Downstream this surfaces as either:

- a confusing `KeyError: No model assignment for role: ...` at `get_model` time, or
- a primary-less `ModelFallbackMiddleware([])` that only fails on the first request.

Either way the operator chases a runtime symptom instead of fixing the obvious config gap.

### Example

Credentials inventory `[minimax_api]` under `ECO`: MiniMax has only HIGH+MID in `METHOD_MODELS`, so the LOW chain resolves to `[]`. `recon`, `scanner`, `soundwave`, `wireless_operator` all silently lose their model.

## Fix

Validate at `LLMFactory` construction (only when the factory builds the mapping from credentials — explicit `mapping=` callers own their mapping shape). For each tier the factory must serve under the active profile, re-run `resolve_chain`; if any tier is empty, raise `ValueError` naming the offending tier(s), affected roles, and the configured credentials inventory.

## RED / GREEN

- **RED** (test added, validation absent): 2 fail with `DID NOT RAISE`, 2 pass (valid-inventory + explicit-mapping-bypass guards).
- **GREEN** (after fix): all 283 tests in `packages/decepticon/tests/unit/llm/` pass.

## Scope

Touches `packages/decepticon/decepticon/llm/factory.py` + its unit tests only. No changes to `decepticon-core` (CODEOWNERS-gated). No dependency / lockfile changes.