### PR TITLE
feat(runtime): degrade summarization middleware to safe passthrough on failure

### DIFF
--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -22,7 +22,8 @@ needs an entry in ``SLOTS_PER_ROLE``.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 # Middleware classes & factory helpers — imported at module level so
@@ -32,7 +33,7 @@ from typing import Any
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.subagents import SubAgentMiddleware
 from deepagents.middleware.summarization import create_summarization_middleware
-from langchain.agents.middleware import ModelFallbackMiddleware
+from langchain.agents.middleware import AgentMiddleware, ModelFallbackMiddleware
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
 from decepticon.agents._benchmark_mode import benchmark_skill_sources
@@ -70,6 +71,8 @@ from decepticon_core.contracts.slots import (
     MiddlewareSlot,
 )
 from decepticon_core.plugin_loader import load_plugin_skill_sources
+
+logger = logging.getLogger(__name__)
 
 # ─────────────────────────────────────────────────────────────────────
 # Skills sources — role-specific
@@ -188,8 +191,58 @@ def _make_model_fallback(*, fallback_models: list | None = None, **_: Any):
     return ModelFallbackMiddleware(*fallback_models)
 
 
+class _SafeSummarizationProxy(AgentMiddleware):
+    """Defensive wrapper around the deepagents summarization middleware.
+
+    The inner middleware's ``wrap_model_call`` / ``awrap_model_call``
+    hooks issue a live LLM call to compute the summary; a provider
+    timeout or 5xx would otherwise propagate up and kill the whole
+    agent run for one transient backend failure. This proxy delegates
+    to the inner hook and, on exception, logs a warning and falls back
+    to invoking the downstream ``handler`` unchanged — effectively
+    skipping summarization for that turn rather than aborting the run.
+    Successful summarization is passed through untouched.
+    """
+
+    def __init__(self, inner: AgentMiddleware) -> None:
+        super().__init__()
+        self._inner = inner
+        # Forward the inner's state schema and tools so langchain's agent
+        # factory sees the same merged state shape and registered tools
+        # it would see for the unwrapped middleware. ``name`` is a
+        # property on AgentMiddleware so it's delegated below instead.
+        self.state_schema = inner.state_schema
+        self.tools = list(getattr(inner, "tools", []) or [])
+
+    @property
+    def name(self) -> str:
+        return self._inner.name
+
+    def wrap_model_call(self, request: Any, handler: Callable[[Any], Any]) -> Any:
+        try:
+            return self._inner.wrap_model_call(request, handler)
+        except Exception:
+            logger.warning(
+                "Summarization middleware failed; skipping summarization "
+                "this turn and forwarding the original request.",
+                exc_info=True,
+            )
+            return handler(request)
+
+    async def awrap_model_call(self, request: Any, handler: Callable[[Any], Awaitable[Any]]) -> Any:
+        try:
+            return await self._inner.awrap_model_call(request, handler)
+        except Exception:
+            logger.warning(
+                "Summarization middleware failed; skipping summarization "
+                "this turn and forwarding the original request.",
+                exc_info=True,
+            )
+            return await handler(request)
+
+
 def _make_summarization(*, backend: Any, llm: Any, **_: Any):
-    return create_summarization_middleware(llm, backend)
+    return _SafeSummarizationProxy(create_summarization_middleware(llm, backend))
 
 
 def _make_prompt_caching(**_: Any):

--- a/packages/decepticon/tests/unit/middleware/test_summarization_fallback.py
+++ b/packages/decepticon/tests/unit/middleware/test_summarization_fallback.py
@@ -1,0 +1,146 @@
+"""Defensive-wrap behavior for the SUMMARIZATION slot.
+
+The summarization middleware issues a live LLM call inside the agent
+loop; when its provider fails (timeout / 5xx / context-overflow retry
+also failing) we must keep the surrounding agent run alive by skipping
+that turn's summarization instead of bubbling the exception up. These
+tests pin that contract via a fake inner middleware whose hook can be
+flipped between "raises" and "returns normally".
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from decepticon.agents.middleware_slots import _SafeSummarizationProxy
+
+# The ``decepticon`` parent logger is configured with ``propagate=False``
+# (see decepticon_core.utils.logging), so caplog's root-attached handler
+# never sees records emitted under it. We attach a dedicated handler
+# directly to the proxy's logger to assert the warning is fired.
+_PROXY_LOGGER = "decepticon.agents.middleware_slots"
+
+
+@pytest.fixture
+def warn_records() -> Iterator[list[logging.LogRecord]]:
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler(level=logging.WARNING)
+    handler.emit = records.append  # type: ignore[method-assign]
+    logger = logging.getLogger(_PROXY_LOGGER)
+    prior = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prior)
+
+
+class _FakeInner:
+    """Stand-in for the deepagents summarization middleware.
+
+    Mirrors the public surface ``_SafeSummarizationProxy`` reads from
+    the real inner (``state_schema``, ``tools``, ``name`` plus the two
+    wrap-model-call hooks) without dragging the real LLM-bound class
+    into the test.
+    """
+
+    state_schema = dict
+    tools: list[Any] = []
+    name = "FakeSummarizationInner"
+
+    def __init__(self, *, fail: bool) -> None:
+        self._fail = fail
+        self.sync_calls = 0
+        self.async_calls = 0
+
+    def wrap_model_call(self, request: Any, handler: Any) -> Any:
+        self.sync_calls += 1
+        if self._fail:
+            raise RuntimeError("summarization LLM exploded")
+        return ("inner-sync", request)
+
+    async def awrap_model_call(self, request: Any, handler: Any) -> Any:
+        self.async_calls += 1
+        if self._fail:
+            raise RuntimeError("summarization LLM exploded (async)")
+        return ("inner-async", request)
+
+
+def _handler(request: Any) -> Any:
+    return ("handler", request)
+
+
+async def _ahandler(request: Any) -> Any:
+    return ("ahandler", request)
+
+
+def test_sync_failure_falls_back_to_handler_and_logs(
+    warn_records: list[logging.LogRecord],
+) -> None:
+    inner = _FakeInner(fail=True)
+    proxy = _SafeSummarizationProxy(inner)
+
+    result = proxy.wrap_model_call("REQ", _handler)
+
+    assert result == ("handler", "REQ")
+    assert inner.sync_calls == 1
+    assert any(
+        "summarization" in rec.getMessage().lower() and rec.levelno == logging.WARNING
+        for rec in warn_records
+    ), warn_records
+
+
+def test_sync_success_passes_inner_result_through() -> None:
+    inner = _FakeInner(fail=False)
+    proxy = _SafeSummarizationProxy(inner)
+
+    result = proxy.wrap_model_call("REQ", _handler)
+
+    assert result == ("inner-sync", "REQ")
+    assert inner.sync_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_failure_falls_back_to_handler_and_logs(
+    warn_records: list[logging.LogRecord],
+) -> None:
+    inner = _FakeInner(fail=True)
+    proxy = _SafeSummarizationProxy(inner)
+
+    result = await proxy.awrap_model_call("REQ", _ahandler)
+
+    assert result == ("ahandler", "REQ")
+    assert inner.async_calls == 1
+    assert any(
+        "summarization" in rec.getMessage().lower() and rec.levelno == logging.WARNING
+        for rec in warn_records
+    ), warn_records
+
+
+@pytest.mark.asyncio
+async def test_async_success_passes_inner_result_through() -> None:
+    inner = _FakeInner(fail=False)
+    proxy = _SafeSummarizationProxy(inner)
+
+    result = await proxy.awrap_model_call("REQ", _ahandler)
+
+    assert result == ("inner-async", "REQ")
+    assert inner.async_calls == 1
+
+
+def test_proxy_forwards_inner_state_schema_and_name() -> None:
+    inner = _FakeInner(fail=False)
+    proxy = _SafeSummarizationProxy(inner)
+
+    # The factory inspects ``state_schema`` per-instance (langchain
+    # collects ``m.state_schema for m in middleware``) and ``name`` for
+    # tracing. Both must reflect the wrapped middleware so the inner's
+    # state extensions and observability survive the wrap.
+    assert proxy.state_schema is inner.state_schema
+    assert proxy.name == inner.name


### PR DESCRIPTION
## Problem

`_make_summarization` in `packages/decepticon/decepticon/agents/middleware_slots.py` returns `create_summarization_middleware(llm, backend)` (deepagents) with **no error handling**. The middleware issues a live LLM call inside its `wrap_model_call` / `awrap_model_call` hooks to compute the running summary. A provider timeout / 5xx / context-overflow-retry-also-fails during that call **propagates up and kills the entire agent run** — one transient backend hiccup terminates the engagement.

## Fix

Introduce `_SafeSummarizationProxy`, a tiny `AgentMiddleware` subclass that wraps the inner summarization middleware and overrides **only** the two hooks the inner overrides (`wrap_model_call` + `awrap_model_call`). On exception inside the inner hook it:

1. Logs a warning (with traceback) on the module logger.
2. Falls back to invoking the downstream `handler` with the original request — i.e. skips summarization for that turn rather than aborting.

Success path is **unchanged** — the inner's return value is passed straight through. `state_schema` / `tools` / `name` are forwarded so langchain's agent factory sees the same merged state shape and trace identity it would for the unwrapped middleware.

## Surface

- `packages/decepticon/decepticon/agents/middleware_slots.py` — add `_SafeSummarizationProxy` + wrap in `_make_summarization`.
- `packages/decepticon/tests/unit/middleware/test_summarization_fallback.py` — new test module (5 tests).

No deps / pyproject / uv.lock changes.

## Verification

### RED (pre-implementation)
```
ImportError: cannot import name '_SafeSummarizationProxy' from 'decepticon.agents.middleware_slots'
```

### GREEN (post-implementation)
```
$ uv run pytest packages/decepticon/tests/unit/middleware/test_summarization_fallback.py
======================== 5 passed, 3 warnings in 1.82s =========================
```

### Regression (middleware + agents)
```
$ uv run pytest packages/decepticon/tests/unit/middleware/ packages/decepticon/tests/unit/agents/
======================= 492 passed, 17 warnings in 4.50s =======================
```

### Quality gates
- `ruff check` — All checks passed
- `ruff format` — clean
- `basedpyright --outputjson` on changed files → **0 errors**

## Test coverage

- Sync failure → handler invoked, warning logged, no exception escapes.
- Sync success → inner's return passed through unchanged.
- Async failure → async handler invoked, warning logged, no exception escapes.
- Async success → inner's async return passed through unchanged.
- `state_schema` + `name` forwarded from inner (langchain factory contract).