### PR TITLE
feat(llm): log provider/model that actually served each call

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -801,14 +801,16 @@ class _ProxiedChatOpenAI(ChatOpenAI):
 
     def invoke(self, *args, **kwargs):
         try:
-            return super().invoke(*args, **kwargs)
+            result = super().invoke(*args, **kwargs)
         except Exception as exc:
             _reraise_with_actionable_message(exc, self.model_name)
             raise
+        _log_served_model(self.model_name, result)
+        return result
 
     async def ainvoke(self, *args, **kwargs):
         try:
-            return await call_with_timeout(
+            result = await call_with_timeout(
                 super().ainvoke(*args, **kwargs),
                 _resolve_llm_timeout_seconds(),
             )
@@ -817,6 +819,32 @@ class _ProxiedChatOpenAI(ChatOpenAI):
         except Exception as exc:
             _reraise_with_actionable_message(exc, self.model_name)
             raise
+        _log_served_model(self.model_name, result)
+        return result
+
+
+def _log_served_model(requested: str, result: object) -> None:
+    """Best-effort attribution log: which provider/model the LiteLLM proxy
+    actually routed to. When fallback fires (primary -> fallback) the
+    requested model id and the served model id diverge — surfacing the
+    delta lets operators trace cost/perf/debug back to the real upstream.
+
+    Never raise from this path: attribution is observability, not control
+    flow. Any extraction failure is swallowed silently.
+    """
+    try:
+        metadata = getattr(result, "response_metadata", None) or {}
+        served = (
+            metadata.get("model_name")
+            or metadata.get("model")
+            or getattr(result, "model_name", None)
+        )
+        if served and served != requested:
+            log.info("llm.attribution requested=%s served=%s", requested, served)
+        elif served:
+            log.debug("llm.attribution requested=%s served=%s", requested, served)
+    except Exception:
+        pass
 
 
 def _model_drops_temperature(model: str) -> bool:

--- a/packages/decepticon/tests/unit/llm/test_factory_attribution.py
+++ b/packages/decepticon/tests/unit/llm/test_factory_attribution.py
@@ -1,0 +1,121 @@
+"""Provider/model attribution logging on the proxied ChatOpenAI wrapper.
+
+When fallback fires through the LiteLLM proxy, operators need to know
+which provider actually served each call. The proxied wrapper logs the
+served model id extracted from the response metadata after every
+successful invoke/ainvoke. Attribution is best-effort: a result lacking
+metadata must not raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_openai import ChatOpenAI
+from pydantic import SecretStr
+
+from decepticon.llm.factory import _ProxiedChatOpenAI
+
+
+def _make_proxy() -> _ProxiedChatOpenAI:
+    return _ProxiedChatOpenAI(
+        model="anthropic/claude-haiku-4-5",
+        base_url="http://localhost:4000",
+        api_key=SecretStr("sk-test"),
+        timeout=5,
+        max_retries=0,
+    )
+
+
+@pytest.fixture
+def propagate_decepticon_logs(monkeypatch: pytest.MonkeyPatch):
+    # ``decepticon_core.utils.logging`` defaults the parent ``decepticon``
+    # logger to ``propagate=False`` so library output doesn't double up
+    # in apps that own the root handler. caplog hooks the root logger,
+    # so without re-enabling propagation our attribution record never
+    # reaches the capture buffer.
+    decepticon_log = logging.getLogger("decepticon")
+    monkeypatch.setattr(decepticon_log, "propagate", True)
+
+
+class TestProviderAttributionLogging:
+    def test_invoke_logs_served_model_from_response_metadata(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        propagate_decepticon_logs,
+    ) -> None:
+        served = "anthropic/claude-haiku-4-5-20251022"
+        fake = AIMessage(content="ok", response_metadata={"model_name": served})
+
+        def fake_invoke(self, *args, **kwargs):
+            return fake
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+
+        model = _make_proxy()
+        with caplog.at_level(logging.DEBUG, logger="decepticon"):
+            result = model.invoke("hi")
+
+        assert result is fake
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(served in m and "anthropic/claude-haiku-4-5" in m for m in messages), (
+            f"No attribution log mentioning served={served}. Got: {messages}"
+        )
+
+    def test_ainvoke_logs_served_model_from_response_metadata(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        propagate_decepticon_logs,
+    ) -> None:
+        served = "openai/gpt-5-nano-2025-10-01"
+        fake = AIMessage(content="ok", response_metadata={"model_name": served})
+
+        async def fake_ainvoke(self, *args, **kwargs):
+            return fake
+
+        monkeypatch.setattr(ChatOpenAI, "ainvoke", fake_ainvoke)
+
+        model = _make_proxy()
+        with caplog.at_level(logging.DEBUG, logger="decepticon"):
+            result = asyncio.run(model.ainvoke("hi"))
+
+        assert result is fake
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(served in m for m in messages), (
+            f"No attribution log mentioning served={served}. Got: {messages}"
+        )
+
+    def test_invoke_missing_metadata_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch, propagate_decepticon_logs
+    ) -> None:
+        # Result with no response_metadata must still flow through cleanly.
+        fake = AIMessage(content="ok")
+
+        def fake_invoke(self, *args, **kwargs):
+            return fake
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+
+        model = _make_proxy()
+        # Must not raise even though metadata is absent.
+        assert model.invoke("hi") is fake
+
+    def test_invoke_broken_metadata_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch, propagate_decepticon_logs
+    ) -> None:
+        # Pathological return value (non-AIMessage) — attribution is
+        # best-effort and must never propagate exceptions to callers.
+        sentinel = object()
+
+        def fake_invoke(self, *args, **kwargs):
+            return sentinel
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+
+        model = _make_proxy()
+        assert model.invoke("hi") is sentinel


### PR DESCRIPTION
## Why

When the LiteLLM proxy falls back from a primary route to a secondary one, operators currently have **no way to tell which provider actually served a given request**. The proxied `ChatOpenAI` wrapper in `packages/decepticon/decepticon/llm/factory.py` only wraps `invoke`/`ainvoke` to re-raise errors with actionable messages — successful calls are silent. This breaks cost attribution, perf debugging, and incident triage.

## What

After every successful `super().invoke(...)` / `await super().ainvoke(...)`, extract the served model id from the result's `response_metadata` (LiteLLM/OpenAI surface `model_name` / `model`; we also probe `result.model_name` as a last resort) and emit a log line:

```
llm.attribution requested=<self.model_name> served=<served>
```

- **INFO** when `requested != served` (fallback actually fired — the interesting case).
- **DEBUG** when they match (chatty but useful at verbose log levels).
- **Best-effort**: the entire extraction path is wrapped in a bare `except Exception: pass`. Attribution is observability, never control flow — a pathological return value or missing metadata must not break the call.

Both `invoke` (sync) and `ainvoke` (async) get the new tail call. Error paths are untouched.

## RED → GREEN

New test file: `packages/decepticon/tests/unit/llm/test_factory_attribution.py` (4 tests).

**RED** (stash factory.py, run test, pop):
```
FAILED ::test_invoke_logs_served_model_from_response_metadata
FAILED ::test_ainvoke_logs_served_model_from_response_metadata
2 failed, 2 passed
```
The two robustness tests (missing metadata, non-AIMessage return) already pass on `main` because the existing code happens not to raise — they lock that behaviour for the future.

**GREEN** (after fix):
```
4 passed
```

**Regression** (full `tests/unit/llm/`): `283 passed`.

## Gates

- `uv run ruff check . && uv run ruff format .` — clean
- `uv run basedpyright --outputjson | scripts/check_basedpyright_errors.py` — **0 errors**

## Scope

Touched only:
- `packages/decepticon/decepticon/llm/factory.py` (+30/-2)
- `packages/decepticon/tests/unit/llm/test_factory_attribution.py` (new)

No dependency changes.