### PR TITLE
chore(ci): add non-blocking coverage-report job for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,10 +272,13 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
-    # Belt-and-braces: even if the runner choked, this job must never
-    # block a PR. Required-status enforcement lives in branch
-    # protection, but `continue-on-error` makes the non-blocking intent
-    # explicit in the workflow file itself.
+    # The real non-blocking guarantee is that this job is NOT in the
+    # required-status list in branch protection — that is what keeps a
+    # red result here from blocking merge. `continue-on-error: true` is
+    # a secondary safety net at the workflow level: if a step fails, the
+    # workflow run's overall conclusion stays `success` (so the commit
+    # status check posted by GitHub Actions never goes red), even though
+    # the job's own conclusion in the run UI will still read `failure`.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,76 @@ jobs:
           path: coverage.xml
           if-no-files-found: ignore
 
+  # ── PR coverage visibility (NON-BLOCKING) ───────────────────────────
+  # Informational coverage job that runs in PARALLEL with the blocking
+  # `python` job, so it does NOT add to merge latency. The blocking PR
+  # lane deliberately runs pytest WITHOUT coverage (see the comment in
+  # the `python` job above — coverage adds ~3x runtime and PR feedback
+  # latency is the priority). This job exists purely to surface a
+  # coverage delta to PR reviewers without contradicting that decision:
+  #   * uses `--cov-fail-under=0` (via `make ci-test-coverage-report`),
+  #     so a coverage drop NEVER fails the PR;
+  #   * is NOT in the repo's required-status set — keep it out of the
+  #     branch protection list so it remains advisory only;
+  #   * uploads coverage.xml as an artifact and writes a short summary
+  #     to $GITHUB_STEP_SUMMARY for at-a-glance review.
+  coverage-report:
+    name: Coverage report (PRs — informational, non-blocking)
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    # Belt-and-braces: even if the runner choked, this job must never
+    # block a PR. Required-status enforcement lives in branch
+    # protection, but `continue-on-error` makes the non-blocking intent
+    # explicit in the workflow file itself.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.8.15"
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      # Share the cached .venv with the blocking `python` job (same key
+      # shape) so the cold-cache cost of this job is mostly checkout +
+      # pytest, not a full uv resolve.
+      - name: Cache .venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+      - run: uv sync --dev --locked
+      - name: Pytest with coverage (no threshold — `make ci-test-coverage-report`)
+        run: make ci-test-coverage-report
+      - name: Write coverage summary to step summary
+        if: always()
+        run: |
+          {
+            echo "## Coverage report (informational)"
+            echo ""
+            echo "This is a NON-BLOCKING coverage visibility job. The blocking PR"
+            echo "pytest step runs without coverage by design — see the comment in"
+            echo "the \`python\` job. Coverage threshold gating happens on main pushes."
+            echo ""
+            if [ -f coverage.xml ]; then
+              # line-rate is a fraction in [0,1] on the root <coverage> tag
+              rate=$(python -c "import xml.etree.ElementTree as ET; print(ET.parse('coverage.xml').getroot().attrib.get('line-rate','0'))")
+              pct=$(python -c "print(f'{float(\"$rate\")*100:.2f}')")
+              echo "**Line coverage:** ${pct}%"
+            else
+              echo "_coverage.xml not produced — see the pytest step logs._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-pr
+          path: coverage.xml
+          if-no-files-found: ignore
+
   cli:
     # Matrix mirrors the python job — Linux + macOS. Windows runner is
     # deferred until the cli test suite is verified on Windows in a

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ help:
 	@echo "  make ci-lint        Lint + format + basedpyright errors-only (CI mirror)"
 	@echo "  make ci-test        pytest fast lane (-n auto -m \"not slow\", no coverage)"
 	@echo "  make ci-test-coverage  pytest with coverage gate (--cov-fail-under=60)"
+	@echo "  make ci-test-coverage-report  pytest fast lane with coverage report (no gate, PR-informational)"
 	@echo "  make test           pytest in container"
 	@echo "  make test-local     pytest locally (uv sync --dev; takes ARGS=)"
 	@echo "  make lint           Python lint + format check + basedpyright (all levels, local exploratory)"
@@ -252,12 +253,15 @@ check-skill-graph:
 ci-test-coverage:
 	uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=60
 
-## PR-informational lane: coverage without any threshold. Used by the
-## non-blocking ``coverage-report`` job in ci.yml so PR authors see a
-## coverage delta without blocking merge (the documented decision is to
-## keep the blocking PR pytest step coverage-free — see ci.yml comment).
+## PR-informational lane: coverage without any threshold, fast subset
+## (``-m "not slow"`` — matches the blocking PR ``ci-test`` lane so the
+## reported coverage % is for the same test set authors actually run on a
+## PR). Used by the non-blocking ``coverage-report`` job in ci.yml so PR
+## authors see a coverage delta without blocking merge (the documented
+## decision is to keep the blocking PR pytest step coverage-free — see
+## ci.yml comment).
 ci-test-coverage-report:
-	uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=0
+	uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=0 -m "not slow"
 
 quality-cli: node-install
 	# streaming workspace must be built first — its package.json main

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export CODEX_AUTH_VOLUME ?= $(shell test -f $(HOME)/.codex/auth.json && echo $(H
         dogfood launcher smoke \
         dev cli-dev web-dev infra \
         quality quality-strict quality-cli test test-local lint lint-fix \
-        ci-lint ci-test ci-test-coverage \
+        ci-lint ci-test ci-test-coverage ci-test-coverage-report \
         web-build web-hotswap web-lint web-migrate \
         status logs health clean \
         node-install web-db-ensure \
@@ -251,6 +251,13 @@ check-skill-graph:
 ## main-push lane: slow included, coverage 60% gate (ratcheted from 35% in #380).
 ci-test-coverage:
 	uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=60
+
+## PR-informational lane: coverage without any threshold. Used by the
+## non-blocking ``coverage-report`` job in ci.yml so PR authors see a
+## coverage delta without blocking merge (the documented decision is to
+## keep the blocking PR pytest step coverage-free — see ci.yml comment).
+ci-test-coverage-report:
+	uv run pytest -n auto --cov --cov-report=xml --cov-report=term --cov-fail-under=0
 
 quality-cli: node-install
 	# streaming workspace must be built first — its package.json main


### PR DESCRIPTION
## What

Adds a **parallel, informational** `coverage-report` job to `.github/workflows/ci.yml` that runs on `pull_request`. It runs pytest with coverage (`--cov-fail-under=0`), uploads `coverage.xml`, and writes a line-coverage summary to `$GITHUB_STEP_SUMMARY`.

Also adds a `ci-test-coverage-report` target to `Makefile` so the Makefile stays the single source of truth for CI commands (same pattern as `ci-test` / `ci-test-coverage`).

## What this is NOT

This **does not** change the existing fast blocking PR lane. The `python` job's `Pytest (PRs — fast, no coverage; mirrors make ci-test)` step is untouched and stays coverage-free, honoring the documented maintainer decision in `ci.yml`:

> PRs run tests without coverage instrumentation — coverage adds ~3x runtime and PR feedback latency matters more than coverage tracking on every change.

There is **no coverage gate** added to the PR blocking path. The new job:

- runs in parallel with the blocking `python` job → does **not** add to merge latency;
- uses `--cov-fail-under=0` → a coverage drop never fails the PR;
- has `continue-on-error: true` → belt-and-braces non-blocking;
- is **not** added to required-status checks (branch protection list unchanged) → it is purely advisory.

## CODEOWNERS gate

`.github/workflows/**` is owned by `@PurpleCHOIms` per `.github/CODEOWNERS`, so this PR awaits maintainer review before merge. No required-check list change is requested as part of this PR.

## Verification (local, no live Actions)

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → `YAML_OK`
- `actionlint v1.7.7 .github/workflows/ci.yml` → exit 0, no findings
- `uv run ruff check .` → All checks passed
- `uv run ruff format .` → 471 files left unchanged
- `uv run pytest -n auto --cov --cov-report=xml --cov-fail-under=0 -q -m "not slow"` → 3553 passed, 3 skipped, `coverage.xml` produced (719 KB)

## Files touched

- `.github/workflows/ci.yml` (+70): new `coverage-report` job
- `Makefile` (+7): new `ci-test-coverage-report` target

No changes to dependencies, `pyproject.toml`, or `uv.lock`.