### PR TITLE
fix(web): stop the terminal heartbeat from force-closing a healthy socket

### DIFF
--- a/clients/web/src/components/terminal/web-terminal.tsx
+++ b/clients/web/src/components/terminal/web-terminal.tsx
@@ -76,6 +76,9 @@ export function WebTerminal({
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track whether we've shown the reconnecting message (to avoid spam)
   const reconnectMsgShownRef = useRef(false);
+  // True between sending a ping and receiving the next inbound frame; the
+  // pong-timeout only force-closes the socket while this is still set.
+  const awaitingPongRef = useRef(false);
   // Track the onData listener for manual retry so we can dispose it
   const retryListenerRef = useRef<{ dispose: () => void } | null>(null);
   // Track the main onData listener so we can dispose it on reconnect
@@ -133,6 +136,7 @@ export function WebTerminal({
     };
 
     ws.onmessage = (event) => {
+      awaitingPongRef.current = false;
       const data = typeof event.data === "string" ? event.data : "";
       if (data.startsWith("{")) {
         try {
@@ -324,9 +328,10 @@ export function WebTerminal({
   }, [init, cleanup]);
 
   // ── Heartbeat: detect silently-dead sockets ──────────────────────
-  // Ping every 15s; if no data received from server within 20s of a
-  // ping, the socket is half-open — force-close and let reconnect handle it.
-  // Pong responses are filtered by onmessage above (never reach terminal).
+  // Ping every 15s. A live socket answers with a pong (or is already
+  // streaming PTY output); both clear awaitingPongRef via onmessage. Only when
+  // nothing came back within PONG_TIMEOUT is the socket half-open — close it
+  // and let reconnect take over. Pongs are filtered in onmessage.
   useEffect(() => {
     const PING_INTERVAL = 15000;
     const PONG_TIMEOUT = 5000;
@@ -336,11 +341,11 @@ export function WebTerminal({
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
       try {
+        awaitingPongRef.current = true;
         ws.send(JSON.stringify({ type: "ping" }));
         clearTimeout(pongTimer);
         pongTimer = setTimeout(() => {
-          // If WS is still the same instance and still "open", it's half-open — kill it
-          if (wsRef.current === ws && ws.readyState === WebSocket.OPEN) {
+          if (awaitingPongRef.current && wsRef.current === ws && ws.readyState === WebSocket.OPEN) {
             ws.close();
           }
         }, PONG_TIMEOUT);


### PR DESCRIPTION
The WebTerminal heartbeat pinged every 15s and armed a 5s pong timeout that closed the socket, but **nothing ever cleared that timeout when a pong (or any PTY output) arrived**. `onmessage` filtered pong frames without recording liveness, so ~5s after every ping the socket was force-closed unconditionally.

### Impact
A reconnect roughly every ~20s on a perfectly healthy connection. Each cycle ran `term.reset()` + scrollback replay → periodic flicker, lost scroll position, and constant churn in the embedded terminal. (The comment also claimed a 20s window while the constant was 5s.)

### Fix
Track an `awaitingPongRef`, set when a ping is sent and cleared by **any** inbound frame (pong or PTY data). The pong timeout now closes the socket **only while the flag is still set** — i.e. genuinely no traffic came back — preserving real half-open detection without the false positives.

### Scope
Single file: `clients/web/src/components/terminal/web-terminal.tsx`. No behavior change to reconnect/backoff, resize, or scrollback paths.

### Testing
Web build/lint via CI (no local Node on this box). Logic verified by tracing the ping→pong→onmessage→timeout interaction.