### PR TITLE
fix(web): keep live-observer events across runs within a thread

### DIFF
--- a/clients/web/src/hooks/useRunObserver.ts
+++ b/clients/web/src/hooks/useRunObserver.ts
@@ -55,7 +55,13 @@ export function useRunObserver({ threadId }: UseRunObserverOptions): UseRunObser
 
     let active = true;
     const client = clientRef.current;
-    console.log("[useRunObserver] Starting poll for thread:", threadId);
+
+    // New thread = new session: start from an empty event log. Within a thread
+    // events accumulate across runs so the feed/graph mirror the CLI's full
+    // session history instead of resetting on every operator message.
+    eventsRef.current = [];
+    setEvents([]);
+    observingRunRef.current = null;
 
     const poll = async () => {
       if (!active) return;
@@ -73,9 +79,6 @@ export function useRunObserver({ threadId }: UseRunObserverOptions): UseRunObser
           setIsRunning(true);
           setActiveRunId(runningRun.run_id);
           observingRunRef.current = runningRun.run_id;
-          // Reset events for new run
-          eventsRef.current = [];
-          setEvents([]);
           joinRunStream(threadId, runningRun.run_id);
         } else if (!runningRun && observingRunRef.current) {
           observingRunRef.current = null;


### PR DESCRIPTION
The dashboard graph/panels are driven by `useRunObserver`, which **wiped its entire event log every time it detected a new running run** on the thread. Since each operator message starts a fresh LangGraph run, the live Activity Feed and agent graph cleared on every turn and only ever showed the most recent run.

### Impact
Loss of realtime parity with the CLI, which accumulates the whole session as scrollback. On a multi-turn engagement the web view kept "forgetting" everything before the latest message.

### Fix
Move the reset to the **thread boundary**: clear the log once when the observed `threadId` changes (a genuinely new session) and accumulate events across runs within the same thread.

Re-joining a run cannot duplicate history — the `values` handler only processes the last message of each snapshot, and custom events are streamed live per run.

### Scope
Single file: `clients/web/src/hooks/useRunObserver.ts`. (The incidental debug `console.log` that sat at the top of the effect was replaced by the reset block.)

### Testing
Web build/lint via CI. Logic traced through the poll → new-run → join path for the single-run, multi-run, and thread-handoff cases.