### PR TITLE
fix(web): handle terminal session replacement and guard hidden-mount resize

### DIFF
--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -155,9 +155,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
       session.orphanTimer = null;
     }
 
-    // Detach old WS if any
+    // Detach old WS if any. 4001 (app range) distinguishes "another connection
+    // took over" from the genuine PTY-exit 1000 the client treats as session end.
     if (session.ws && session.ws !== ws && session.ws.readyState === WebSocket.OPEN) {
-      session.ws.close(1000, "Replaced by new connection");
+      session.ws.close(4001, "Replaced by new connection");
     }
     session.ws = ws;
 

--- a/clients/web/src/components/terminal/web-terminal.tsx
+++ b/clients/web/src/components/terminal/web-terminal.tsx
@@ -129,7 +129,9 @@ export function WebTerminal({
       reconnectMsgShownRef.current = false;
       // Silent reconnect — no terminal output. If the server reattaches us
       // to an existing session, the scrollback replay handles visual continuity.
-      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+      if (term.cols > 0 && term.rows > 0) {
+        ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+      }
     };
 
     ws.onmessage = (event) => {
@@ -160,6 +162,14 @@ export function WebTerminal({
 
     ws.onclose = (ev) => {
       if (disposedRef.current) return;
+
+      if (ev.code === 4001) {
+        // Server handed this session to another connection (e.g. a second tab).
+        // Go quiet without the "session ended" banner and without reconnecting,
+        // which would only ping-pong the session back and forth.
+        setConnState("disconnected");
+        return;
+      }
 
       if (ev.code === 1000) {
         // Clean close — process exited normally
@@ -283,7 +293,7 @@ export function WebTerminal({
       const fit = new FitAddon();
       term.loadAddon(fit);
       term.open(container);
-      fit.fit();
+      if (container.clientWidth > 0 && container.clientHeight > 0) fit.fit();
 
       termRef.current = term;
       fitRef.current = fit;


### PR DESCRIPTION
Two transport-robustness defects in the embedded terminal (`web-terminal.tsx` + `terminal-server.ts`):

### 1. Replaced session shows a false "session ended"
When a second WebSocket attaches to a live session, the server detached the prior socket with close code **1000 — the same code it uses for a genuine PTY exit**. The old client's `onclose` only checks `ev.code === 1000`, so it printed `[Session ended. Press Enter to start a new session.]` and dropped into the manual-restart path even though the PTY was alive under the new connection (e.g. a second browser tab).

**Fix:** use a distinct application close code (`4001`) for the replaced case; the client goes quiet on it — no banner and **no** auto-reconnect (which would only ping-pong the session between tabs). `1000` stays reserved for a real PTY exit.

### 2. Degenerate resize when mounted hidden
The engagement layout always mounts the terminal but wraps it at `width: 0` on every route except `/live`. `init()` called `fit.fit()` unconditionally while `clientWidth` was 0, then `onopen` sent that ~1-column geometry with no guard (the ResizeObserver path already guards `cols/rows > 0`), resizing the live CLI to a single column.

**Fix:** guard the initial `fit()` on nonzero container size and the `onopen` resize on `cols/rows > 0`, so the PTY keeps its 120x30 spawn size until `/live` is opened and the ResizeObserver sends the first real resize.

### Testing
Web build/lint via CI. `4001` is in the valid application close-code range (3000–4999) for both the browser and the `ws` server.

_From a multi-lens audit of the web terminal; both findings were adversarially verified._