### PR TITLE
fix(web): harden terminal-server PTY lifecycle and scrollback replay

### DIFF
--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -72,7 +72,11 @@ function sessionKey(slug: string, agentId: string): string {
 function appendScrollback(session: Session, data: string): void {
   session.scrollback += data;
   if (session.scrollback.length > SCROLLBACK_LIMIT) {
-    session.scrollback = session.scrollback.slice(-SCROLLBACK_LIMIT);
+    const trimmed = session.scrollback.slice(-SCROLLBACK_LIMIT);
+    // Resume at a line boundary so replay never starts mid escape sequence,
+    // which would mis-color or swallow output on the client after term.reset().
+    const nl = trimmed.indexOf("\n");
+    session.scrollback = nl >= 0 && nl < trimmed.length - 1 ? trimmed.slice(nl + 1) : trimmed;
   }
 }
 
@@ -261,8 +265,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
       }
       newSession.ws.close(1000, "PTY exited");
     }
-    // Don't destroy immediately — let reattach see the exit message
-    setTimeout(() => destroySession(key), 5000);
+    // Don't destroy immediately — let reattach see the exit message. Guard on
+    // session identity so a reconnect that respawns a fresh PTY under the same
+    // key within the window isn't killed by this stale timer.
+    setTimeout(() => {
+      if (sessions.get(key) === newSession) destroySession(key);
+    }, 5000);
   });
 
   wireWsToSession(ws, newSession);
@@ -271,8 +279,6 @@ wss.on("connection", async (ws: WebSocket, req) => {
 // ── Wire a WebSocket to a Session ────────────────────────────────
 
 function wireWsToSession(ws: WebSocket, session: Session): void {
-  // Send initial resize
-
   ws.on("message", (raw: Buffer | string) => {
     const msg = raw.toString();
     try {


### PR DESCRIPTION
Three server-side robustness fixes in the terminal WebSocket server (`clients/web/server/terminal-server.ts`):

### 1. PTY-exit destroy race (HIGH)
On PTY exit the server scheduled `setTimeout(() => destroySession(key), 5000)` keyed by the stable `slug:agentId` string. If a client reconnected **inside that 5s window**, the connection handler destroyed the dead session and spawned a **fresh PTY under the same key** — then the original anonymous timer fired and killed the just-spawned PTY. Fast reconnects are common here (the "press Enter to restart" path and any abnormal-close auto-reconnect).

**Fix:** guard the timer on session identity (`sessions.get(key) === newSession`) so it only ever destroys the exact dead session it was scheduled for.

### 2. Scrollback truncation cut ANSI sequences
The 50 KB scrollback ring buffer was truncated by raw string `slice`, which can land inside a CSI/OSC escape. On reattach the client `term.reset()`s and writes the raw buffer, so a chopped leading sequence mis-colored or swallowed output.

**Fix:** snap the retained buffer to the next line boundary so replay starts in a clean parser state.

### 3. Dead comment
Removed a `// Send initial resize` no-op comment that described behavior `wireWsToSession` never had.

### Note
Touches the same file as #524 in disjoint regions — trivial sequential rebase if both land.

### Testing
Web build/lint via CI. _From a multi-lens audit of the web terminal; the destroy race and scrollback cut were adversarially verified._