### PR TITLE
fix(web): surface the HITL waiting state in the agent graph

### DIFF
--- a/clients/web/src/hooks/useAgentActivity.ts
+++ b/clients/web/src/hooks/useAgentActivity.ts
@@ -83,6 +83,12 @@ export function useAgentActivity({
           }
           break;
         }
+
+        case "ask_user_question": {
+          agentStates.set(event.agent, "waiting_for_user");
+          activeAgentIds.add(event.agent);
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
The agent graph never showed the human-in-the-loop "waiting" state that the CLI shows.

### Cause
`useAgentActivity`'s switch handled only `subagent_start/end/tool_call/tool_result`, with **no case for `ask_user_question`**. So no node ever entered `runtimeState: "waiting_for_user"`, `isWaitingState()` was always `false`, and the graph's prominent "Waiting: …" bars (`agent-graph-canvas`) plus the `agent-node` waiting pill were unreachable — even though the dashboard forwards the `ask_user_question` event and the CLI renders the prompt.

### Fix
Add an `ask_user_question` case that marks the agent `waiting_for_user` and active. Stickiness is automatic: `useAgentActivity` replays the full event array each render, so the agent stays waiting until a later event (`tool_call` / `message` / `subagent_end`) overwrites its state when the run resumes.

### Scope
Single file: `clients/web/src/hooks/useAgentActivity.ts`. Mapped to `waiting_for_user` only — there is no approval/permission event in the `SubagentEventType` union, so a `waiting_for_permission` branch would be unreachable.

### Testing
Web build/lint via CI. _From a multi-lens audit; adversarially verified._