### PR TITLE
fix(web): read the operator-set LiteLLM key in the health check

### DIFF
--- a/clients/web/src/app/api/health/route.ts
+++ b/clients/web/src/app/api/health/route.ts
@@ -2,12 +2,12 @@ import { NextResponse } from "next/server";
 
 const LANGGRAPH_URL = process.env.LANGGRAPH_API_URL ?? "http://langgraph:2024";
 const LITELLM_URL = process.env.LITELLM_URL ?? "http://litellm:4000";
-// LITELLM_API_KEY: no fallback to the documented public default. Health
-// endpoints that probe LiteLLM with the public key effectively bypass
-// any deployment-specific auth and report a false-positive "ok" against
-// a misconfigured stack. Require the env var to be set; otherwise the
-// LiteLLM check reports degraded.
-const LITELLM_KEY = process.env.LITELLM_API_KEY ?? "";
+// Read the operator-configured LiteLLM key. The stack sets LITELLM_MASTER_KEY
+// (compose + .env.example), so accept it as the source of truth while keeping
+// LITELLM_API_KEY supported for overrides. Still NO fallback to the public
+// default — probing with the public key would mask a misconfigured stack as
+// "ok"; an unset key correctly reports degraded.
+const LITELLM_KEY = process.env.LITELLM_API_KEY ?? process.env.LITELLM_MASTER_KEY ?? "";
 const NEO4J_HTTP_URL = process.env.NEO4J_HTTP_URL ?? "http://neo4j:7474";
 
 interface ServiceHealth {


### PR DESCRIPTION
The health route read `process.env.LITELLM_API_KEY` with no fallback, but **nothing in the stack sets that var** — `.env.example` and `docker-compose.yml` define `LITELLM_MASTER_KEY`. So the LiteLLM probe was always skipped and reported `status: "error"` (`"LITELLM_API_KEY not configured"`), forcing the whole `/api/health` response to `"degraded"` on **every default deployment**.

### Fix
Fall back to `LITELLM_MASTER_KEY` (the key the operator actually configures) while keeping `LITELLM_API_KEY` for overrides.

Deliberately **still no fallback to the public default key**: probing LiteLLM with the public key would mask a misconfigured stack as healthy, and hardcoding it would trip the repo's secret semgrep rule. This keeps the original security intent while fixing the false "degraded".

### Scope
Single file: `clients/web/src/app/api/health/route.ts`. No `docker-compose.yml` change needed (kept out of CODEOWNERS-protected paths).

### Testing
Web build/lint via CI. _From a multi-lens audit; adversarially verified, including the semgrep-rule interaction._