### PR TITLE
fix(web): key terminal PTY sessions by engagement slug so handoff survives

### DIFF
--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -3,10 +3,12 @@
  * Terminal WebSocket Server — spawns Decepticon CLI in a PTY.
  *
  * Session-persistent architecture:
- *   PTY processes are keyed by engagement slug + agent ID and survive
- *   WebSocket disconnects. When the browser reconnects (tab refresh,
- *   network blip, hotswap), it reattaches to the SAME PTY — no new
- *   CLI banner, no lost state, no [Reconnecting...] spam.
+ *   PTY processes are keyed by engagement slug and survive WebSocket
+ *   disconnects. When the browser reconnects (tab refresh, network blip,
+ *   hotswap), it reattaches to the SAME PTY — no new CLI banner, no lost
+ *   state, no [Reconnecting...] spam. The key omits the agent id on purpose:
+ *   the CLI flips soundwave -> decepticon in-process on engagement_ready, so
+ *   a later connect computing a different agent must still find the live PTY.
  *
  *   PTYs are only destroyed when:
  *     1. The CLI process itself exits (user typed Ctrl+C, engagement finished)
@@ -65,8 +67,8 @@ interface Session {
 
 const sessions = new Map<string, Session>();
 
-function sessionKey(slug: string, agentId: string): string {
-  return `${slug}:${agentId}`;
+function sessionKey(slug: string): string {
+  return slug;
 }
 
 function appendScrollback(session: Session, data: string): void {
@@ -142,7 +144,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
     return;
   }
 
-  const key = sessionKey(engagementSlug, agentId);
+  const key = sessionKey(engagementSlug);
   let session = sessions.get(key);
 
   // ── Reattach to existing session ──


### PR DESCRIPTION
When soundwave finishes its interview it hands off to decepticon **in-process** (the CLI flips assistant on `engagement_ready` without changing the PTY). The terminal-server, however, keyed PTY sessions by `${slug}:${agentId}`, and the web recomputes `agentId` from plan-docs on every load (`pickAssistant`).

### Symptom
After the handoff, a page reload computed `agentId="decepticon"`, connected under key `${slug}:decepticon`, found **no** session there, and spawned a **brand-new empty CLI/PTY** — orphaning the live `${slug}:soundwave` session the operator was mid-engagement on.

### Fix
Key PTY sessions by **engagement slug alone**. The web mounts exactly one terminal per engagement, so there is never more than one live PTY per slug; dropping the agent id from the key lets any later connect reattach to the live PTY across the in-process handoff. The agent id is still used to seed the spawned CLI's assistant (`DECEPTICON_ASSISTANT_ID`) and the thread metadata.

### Why not "flip agentId + reconnect"?
That was the tempting approach, but the terminal **is** the CLI — reconnecting to a `decepticon`-keyed session would fork a *second* process and tear down the running one. Keeping the key stable is what preserves continuity. (`agentId` has no other consumer: nothing reads it from the engagement context for display.)

### Scope
Single file: `clients/web/server/terminal-server.ts`. Touches the same file as #524/#525 in a disjoint region.

### Known follow-up (separate, deeper)
The CLI's handoff creates a new LangGraph thread it does not report back to the web, so the *graph observer* can still trail the pre-handoff thread. Tracked in the audit backlog; the terminal itself now stays correct.

### Testing
Web build/lint via CI. _From a multi-lens audit; the harmful reconnect variant was rejected after verification._