### PR TITLE
chore(make): build @decepticon/streaming before the web targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,10 @@ cli-dev: infra
 	cd clients/cli && (npm run dev & DECEPTICON_API_URL=$${DECEPTICON_API_URL:-http://localhost:2024} node --watch dist/index.js & wait)
 
 ## Next.js dev server locally — infra stays in Docker with hot-reload.
-web-dev: infra web-db-ensure
+web-dev: infra web-db-ensure node-install
+	# Build streaming first: both the Next dev server and the PTY-spawned CLI
+	# import @decepticon/streaming, which resolves to its dist/ build.
+	npm run build --workspace=@decepticon/streaming
 	@$(COMPOSE_WATCH) watch --no-up --quiet langgraph &
 	@echo "[web-dev] Starting terminal server (ws://localhost:3003)..."
 	@cd $(WEB_DIR) && npx tsx server/terminal-server.ts &
@@ -255,6 +258,9 @@ quality-strict: ci-lint ci-test-coverage quality-cli web-lint web-build
 # into the root node_modules — no separate clients/web/node_modules tree.
 
 web-build: node-install
+	# streaming workspace first — the web resolves @decepticon/streaming to its
+	# dist/ via package exports (no src path alias), so next build needs it.
+	npm run build --workspace=@decepticon/streaming
 	cd $(WEB_DIR) && npx prisma generate && npm run build
 
 ## Hot-swap web dashboard into running container (~15s vs ~5min docker build).


### PR DESCRIPTION
`web-build` and `web-dev` ran `next build` / `next dev` **without first building the `@decepticon/streaming` workspace**. The web has no `src` path alias for it (checked `clients/web/tsconfig.json` + `next.config.ts` — no `transpilePackages`), so it resolves the package via package.json `exports` to `./dist/index.js`. On a clean checkout that `dist/` does not exist yet, so the build fails with `Cannot find module @decepticon/streaming`. The PTY-spawned CLI imports the same package and needs the same `dist/`.

`make quality` happened to work only because `quality-cli` builds streaming as a side effect *before* `web-build` runs — the standalone `web-*` targets did not.

### Fix
Build the streaming workspace first in `web-build` and `web-dev` (and thus `web-hotswap`, which depends on `web-build`), mirroring the existing pattern in `cli-dev` and `quality-cli`. Also added `node-install` to `web-dev`'s prerequisites so the build has its deps on a clean checkout. The rebuild is idempotent and fast when `dist/` already exists.

### Scope
`Makefile` only (not a CODEOWNERS-protected path).

### Testing
Verified the dependency by inspecting the streaming package `exports` (dist-only), the web tsconfig (no alias), and the existing `quality-cli` ordering. Recipe lines are tab-indented. _From a multi-lens audit; adversarially verified._