### PR TITLE
fix(web): align WORKSPACE_PATH default across API routes

### DIFF
--- a/clients/web/src/app/api/engagements/[id]/approvals/route.ts
+++ b/clients/web/src/app/api/engagements/[id]/approvals/route.ts
@@ -31,7 +31,7 @@ interface ApprovalRequest {
 const ACTIONS = new Set(["allow", "deny", "redirect"]);
 
 function workspaceFor(name: string) {
-  const WORKSPACE = process.env.WORKSPACE_PATH ?? "/workspace";
+  const WORKSPACE = process.env.WORKSPACE_PATH ?? path.join(process.env.HOME ?? "", ".decepticon", "workspace");
   const dir = path.join(WORKSPACE, name, "approvals");
   return {
     dir,

--- a/clients/web/src/app/api/engagements/[id]/timeline/route.ts
+++ b/clients/web/src/app/api/engagements/[id]/timeline/route.ts
@@ -33,7 +33,7 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const WORKSPACE = process.env.WORKSPACE_PATH ?? "/workspace";
+  const WORKSPACE = process.env.WORKSPACE_PATH ?? path.join(process.env.HOME ?? "", ".decepticon", "workspace");
   const events: TimelineEvent[] = [];
 
   // Engagement creation


### PR DESCRIPTION
Five engagement API routes (`engagements`, `export`, `findings`, `opplan`, `plan-docs`) default `WORKSPACE_PATH` to `~/.decepticon/workspace`, but **`timeline` and `approvals` defaulted to `/workspace`**.

### Impact
When the web runs locally without `WORKSPACE_PATH` set (e.g. `make web-dev`), `timeline` and `approvals` looked under `/workspace` while everything else — including the canonical `engagements` route that creates and imports workspace dirs — looked under `~/.decepticon/workspace`. So timeline events and HITL approval files were silently invisible in local runs.

### Fix
Align the two outliers to the same default the other five routes use (both already import `path`). In-container deployments set `WORKSPACE_PATH` explicitly, so this only affects the unset-env local path.

### Scope
2 lines across `timeline/route.ts` and `approvals/route.ts`.

### Testing
Web build/lint via CI. _From a multi-lens audit; the default drift was adversarially verified across all 7 routes._