### PR TITLE
fix(web): correct agent-graph node radius, seed layout, and selection

### DIFF
--- a/clients/web/src/components/agents/agent-graph-canvas.tsx
+++ b/clients/web/src/components/agents/agent-graph-canvas.tsx
@@ -37,7 +37,6 @@ interface AgentGraphCanvasProps {
 export function AgentGraphCanvas({
   agents,
   events,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   selectedAgent,
   onAgentClick,
 }: AgentGraphCanvasProps) {
@@ -285,8 +284,8 @@ export function AgentGraphCanvas({
                 targetY={targetPos.y}
                 active={edge.active}
                 color={targetNode?.color ?? "#6b7280"}
-                sourceRadius={sourceNode?.radius ?? 48}
-                targetRadius={targetNode?.radius ?? 32}
+                sourceRadius={sourceNode?.radius ?? 36}
+                targetRadius={targetNode?.radius ?? 24}
               />
             );
           })}
@@ -312,6 +311,7 @@ export function AgentGraphCanvas({
                 node={node}
                 x={pos.x}
                 y={pos.y}
+                selected={selectedAgent?.id === node.agentId}
                 onDragStart={handleNodeDragStart}
               />
             );

--- a/clients/web/src/components/agents/agent-node.tsx
+++ b/clients/web/src/components/agents/agent-node.tsx
@@ -18,10 +18,11 @@ interface AgentNodeProps {
   node: GraphNode;
   x: number;
   y: number;
+  selected?: boolean;
   onDragStart?: (node: GraphNode, e: React.MouseEvent) => void;
 }
 
-export function AgentNode({ node, x, y, onDragStart }: AgentNodeProps) {
+export function AgentNode({ node, x, y, selected, onDragStart }: AgentNodeProps) {
   const isOrchestrator = node.type === "orchestrator";
   const { runtimeState } = node;
 
@@ -62,6 +63,17 @@ export function AgentNode({ node, x, y, onDragStart }: AgentNodeProps) {
     >
       {/* Invisible hit area for reliable drag */}
       <circle r={r + 8} fill="transparent" />
+
+      {selected && (
+        <circle
+          r={r + 5}
+          fill="none"
+          stroke={color}
+          strokeWidth={2}
+          opacity={0.9}
+          style={{ pointerEvents: "none" }}
+        />
+      )}
 
       {isOrchestrator ? (
         <>

--- a/clients/web/src/components/agents/graph-edge.tsx
+++ b/clients/web/src/components/agents/graph-edge.tsx
@@ -34,8 +34,8 @@ export function GraphEdgeComponent({
   active,
   color,
   edgeId,
-  sourceRadius = 48,
-  targetRadius = 32,
+  sourceRadius = 36,
+  targetRadius = 24,
 }: GraphEdgeProps) {
   const dx = targetX - sourceX;
   const dy = targetY - sourceY;

--- a/clients/web/src/hooks/useAgentActivity.ts
+++ b/clients/web/src/hooks/useAgentActivity.ts
@@ -13,8 +13,8 @@ import type { SubagentCustomEvent } from "@decepticon/streaming";
 import type { GraphNode, GraphEdge, AgentRuntimeState } from "@/lib/graph/types";
 import { isWaitingState } from "@/lib/graph/types";
 
-const ORCHESTRATOR_RADIUS = 48;
-const AGENT_RADIUS = 32;
+const ORCHESTRATOR_RADIUS = 36;
+const AGENT_RADIUS = 24;
 const TOOL_SESSION_RADIUS = 10;
 
 interface ToolSession {
@@ -91,7 +91,8 @@ export function useAgentActivity({
 
     const nodes: GraphNode[] = [];
     const agentPositions = new Map<string, { x: number; y: number }>();
-    const angleStep = (2 * Math.PI) / Math.max(visibleAgents.length - 1, 1); // -1 for orchestrator at center
+    const ringCount = visibleAgents.filter((a) => a.id !== "decepticon").length;
+    const angleStep = (2 * Math.PI) / Math.max(ringCount, 1);
 
     let angleIdx = 0;
     for (const agent of visibleAgents) {


### PR DESCRIPTION
Three rendering defects in the agent execution graph (cohesive subsystem — bundled to avoid a same-file rebase cascade):

### 1. Radius mismatch
`useAgentActivity` wrote `node.radius = 48/32` (orchestrator/agent), feeding `forceCollide` padding and the edge-endpoint trimming, but `AgentNode` draws the circle at a hardcoded **36/24**. So the physics and edges treated every node as larger than it renders — extra spacing and edges that stop short of the circle. Set the constants (and the stale `?? 48`/`?? 32` fallbacks in the canvas + `graph-edge` defaults) to 36/24 to match the drawn SVG, which already flows through `node.radius`.

### 2. Seed-ring overlap
The initial angle step divided by `visibleAgents.length - 1`, assuming the orchestrator sits at index 0. When `decepticon` is not first (or absent), a ring agent landed at angle 0 **on top of** the centered orchestrator. Divide by the count of actual ring (non-orchestrator) agents instead.

### 3. Selected node had no highlight
`selectedAgent` was accepted but ignored (unused-var suppressed). Clicking a node opened the detail panel with no feedback on the graph. Pass `selected` to `AgentNode` (matched on `agentId`) and draw a selection halo ring.

### Scope
`useAgentActivity.ts`, `agent-graph-canvas.tsx`, `agent-node.tsx`, `graph-edge.tsx`. Deferred (delicate force-sim internals, lower value): fit-to-view timing and drag-pin-across-topology-change.

### Testing
Web build/lint via CI. _From a multi-lens audit; all three adversarially verified._