### PR TITLE
fix(web): dedupe orchestrator tool calls by position, not just name

### DIFF
--- a/clients/web/src/hooks/useRunObserver.ts
+++ b/clients/web/src/hooks/useRunObserver.ts
@@ -135,11 +135,14 @@ export function useRunObserver({ threadId }: UseRunObserverOptions): UseRunObser
             const lastMsg = data.messages[data.messages.length - 1];
 
             if (lastMsg?.type === "ai" && lastMsg.tool_calls?.length) {
-              for (const tc of lastMsg.tool_calls) {
+              for (let i = 0; i < lastMsg.tool_calls.length; i++) {
+                const tc = lastMsg.tool_calls[i];
                 if (tc.name === "task") continue; // Sub-agent delegation — handled by custom events
-                // Orchestrator's own tool call
-                if (!seenToolCalls.has(`decepticon-${tc.name}-${data.messages.length}`)) {
-                  seenToolCalls.add(`decepticon-${tc.name}-${data.messages.length}`);
+                // Key by position too, so parallel calls to the same tool in one
+                // message are not collapsed into a single event.
+                const key = `decepticon-${tc.name}-${i}-${data.messages.length}`;
+                if (!seenToolCalls.has(key)) {
+                  seenToolCalls.add(key);
                   newEvents.push({
                     type: "subagent_tool_call",
                     agent: "decepticon",


### PR DESCRIPTION
useRunObserver synthesizes the orchestrator's own tool calls from the `values` stream, deduping on `decepticon-<tool>-<messageCount>`. When the orchestrator emits **two calls to the same tool in one AI message** (parallel tool use), both share that key, so the second is silently dropped and the graph/feed under-counts the orchestrator's activity.

### Fix
Include the tool-call index in the dedup key so distinct calls to the same tool in one message are kept.

### Scope
Single hunk in `clients/web/src/hooks/useRunObserver.ts` (disjoint from #521's poll-effect change — rebases cleanly).

### Testing
Web build/lint via CI. _From a multi-lens audit; adversarially verified._