### PR TITLE
feat: bugclaw P1-A — contracts + types

### DIFF
--- a/packages/decepticon-core/decepticon_core/protocols/__init__.py
+++ b/packages/decepticon-core/decepticon_core/protocols/__init__.py
@@ -25,17 +25,25 @@ from __future__ import annotations
 from decepticon_core.protocols.agent import AgentProtocol
 from decepticon_core.protocols.backend import BackendProtocol
 from decepticon_core.protocols.callback import CallbackProtocol
+from decepticon_core.protocols.identity_provider import IdentityProvider
 from decepticon_core.protocols.llm import LLMProtocol
 from decepticon_core.protocols.middleware import MiddlewareProtocol
+from decepticon_core.protocols.platform_adapter import PlatformAdapter
+from decepticon_core.protocols.report_template import ReportTemplate
 from decepticon_core.protocols.sandbox import SandboxProtocol
+from decepticon_core.protocols.scope_provider import ScopeProvider
 from decepticon_core.protocols.tool import ToolProtocol
 
 __all__ = [
     "AgentProtocol",
     "BackendProtocol",
     "CallbackProtocol",
+    "IdentityProvider",
     "LLMProtocol",
     "MiddlewareProtocol",
+    "PlatformAdapter",
+    "ReportTemplate",
     "SandboxProtocol",
+    "ScopeProvider",
     "ToolProtocol",
 ]

--- a/packages/decepticon-core/decepticon_core/protocols/identity_provider.py
+++ b/packages/decepticon-core/decepticon_core/protocols/identity_provider.py
@@ -1,0 +1,34 @@
+"""IdentityProvider — source of attribution metadata for outbound traffic.
+
+Used by the bugclaw orchestrator (and any future identity-attribution
+middleware). Every outbound HTTP call gets a User-Agent + engagement
+header derived from the active provider's outputs.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["IdentityProvider"]
+
+
+@runtime_checkable
+class IdentityProvider(Protocol):
+    """Returns attribution strings for outbound traffic."""
+
+    def outbound_user_agent(self, engagement_id: str) -> str:
+        """RFC 7231-shaped User-Agent value.
+
+        Examples:
+            ``bugclaw/0.1 (+https://hackerone.com/purpleailab; eng=42)``
+            ``decepticon/pentest (+contract=ACME-2026; eng=42)``
+        """
+        ...
+
+    def callback_domain_prefix(self) -> str:
+        """Hostname/suffix where blind-callback subdomains live.
+
+        Lets triagers attribute callback traffic back to us.
+        Example: ``callbacks.bugclaw.purpleailab.com``.
+        """
+        ...

--- a/packages/decepticon-core/decepticon_core/protocols/platform_adapter.py
+++ b/packages/decepticon-core/decepticon_core/protocols/platform_adapter.py
@@ -1,0 +1,104 @@
+"""PlatformAdapter — one bug-bounty platform's worth of integration.
+
+The bugclaw orchestrator interacts with bug-bounty platforms only
+through this Protocol. Concrete implementations (HackerOneAdapter,
+NaverAdapter, etc.) live in bug-bounty plugin packages (e.g.
+``bugclaw.adapters.*``) and register via the
+``decepticon.platform_adapters`` entry-point group (see
+registry/platform_adapters.py).
+
+Inheritance: extends ``ScopeProvider`` and ``IdentityProvider`` so a
+single adapter object is the source of truth for scope rules, identity,
+and submission.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from decepticon_core.protocols.identity_provider import IdentityProvider
+from decepticon_core.protocols.scope_provider import ScopeProvider
+from decepticon_core.types.bounty import (
+    FindingSignature,
+    Program,
+    ReportDraft,
+    ReportStatus,
+    SubmittedReport,
+)
+
+__all__ = ["PlatformAdapter"]
+
+
+@runtime_checkable
+class PlatformAdapter(ScopeProvider, IdentityProvider, Protocol):
+    """Full surface bugclaw orchestrator needs from a bounty platform."""
+
+    platform_id: str
+    """Registry key, e.g. ``"hackerone"``, ``"naver"``."""
+
+    identity_handle: str
+    """External account handle, e.g. ``"purpleailab"``."""
+
+    report_template_id: str
+    """Registry key of the default ReportTemplate to use, e.g.
+    ``"hackerone-v1"``. Orchestrator may override per-finding."""
+
+    # ─────────────── Discovery ───────────────
+
+    async def list_programs(
+        self,
+        *,
+        only_in_scope_for_handle: bool = True,
+        min_payout_usd: int = 0,
+    ) -> list[Program]:
+        """Programs the current handle can hunt.
+
+        Default filter: only programs whose policy allows
+        ``identity_handle`` to participate (excludes private/invite-only
+        we haven't been invited to).
+        """
+        ...
+
+    # ─────────────── Dedupe ───────────────
+
+    async def search_prior_reports(
+        self,
+        program: Program,
+        signature: FindingSignature,
+    ) -> list[dict]:
+        """Search the platform for reports matching this signature.
+
+        Includes our own historic reports and (where the platform
+        exposes them) public hacktivity disclosures. Return shape is
+        platform-specific; the orchestrator only checks emptiness.
+        Empty list ⇒ no dupe ⇒ safe to draft.
+        """
+        ...
+
+    # ─────────────── Submission ───────────────
+
+    async def submit_report(
+        self,
+        program: Program,
+        draft: ReportDraft,
+        body_markdown: str,
+        idempotency_key: str,
+    ) -> SubmittedReport:
+        """POST the report to the platform.
+
+        ``idempotency_key`` is the orchestrator-supplied dedupe key the
+        adapter MUST honor: a second call with the same key against a
+        program where we've already submitted must return the original
+        ``SubmittedReport`` (no double-submit). For platforms without
+        native idempotency, the adapter maintains a local mapping.
+        """
+        ...
+
+    # ─────────────── Status polling ───────────────
+
+    async def fetch_report_status(
+        self,
+        report: SubmittedReport,
+    ) -> ReportStatus:
+        """Current state of a submitted report."""
+        ...

--- a/packages/decepticon-core/decepticon_core/protocols/report_template.py
+++ b/packages/decepticon-core/decepticon_core/protocols/report_template.py
@@ -1,0 +1,33 @@
+"""ReportTemplate — converts ReportDraft into platform-native markdown.
+
+Decoupled from PlatformAdapter so multiple platforms with similar
+conventions can share a template (e.g. ``bounty-classic-v1`` for both
+HackerOne and Bugcrowd). Templates register via the
+``decepticon.report_templates`` entry-point group.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from decepticon_core.types.bounty import ReportDraft
+
+__all__ = ["ReportTemplate"]
+
+
+@runtime_checkable
+class ReportTemplate(Protocol):
+    """Renderer from ReportDraft → platform-ready markdown body."""
+
+    template_id: str
+    """Registry key, e.g. ``"hackerone-v1"``."""
+
+    def render(self, draft: ReportDraft, *, locale: str = "en") -> str:
+        """Return the markdown body the adapter will submit.
+
+        ``locale`` is a 2-letter ISO 639-1 code. Templates that don't
+        support a locale fall back to ``"en"`` silently rather than
+        raising — that's the orchestrator's contract with multilingual
+        programs.
+        """
+        ...

--- a/packages/decepticon-core/decepticon_core/protocols/scope_provider.py
+++ b/packages/decepticon-core/decepticon_core/protocols/scope_provider.py
@@ -1,0 +1,49 @@
+"""ScopeProvider — source of the active RoE MachineEnforcement.
+
+Bug-bounty platform adapters, red-team RoE document loaders, and lab
+manifest loaders all implement this Protocol so the orchestrator can
+treat scope as a uniform input — the RoE middleware
+(``decepticon.middleware.roe``) consumes the produced
+``MachineEnforcement`` regardless of origin.
+
+We deliberately reuse ``MachineEnforcement`` from
+``decepticon_core.types.roe`` rather than introduce a new scope type.
+Same enforcement primitive, same audit ledger, same forbidden-IMDS
+defaults across pentest and bugbounty modes.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from decepticon_core.types.roe import MachineEnforcement
+
+__all__ = ["ScopeProvider"]
+
+
+@runtime_checkable
+class ScopeProvider(Protocol):
+    """Source of RoE rules for the existing roe middleware."""
+
+    scope_id: str
+    """Stable identifier for audit logs (e.g. 'hackerone:snapchat')."""
+
+    async def fetch_machine_enforcement(self) -> MachineEnforcement:
+        """Return the RoE block to write into <workspace>/plan/roe.json.
+
+        Empty in_scope or wide-open patterns are caught by the
+        orchestrator's pre-flight (not by this method). Audit-mode is
+        the default — providers should opt into ``enforce`` explicitly.
+        """
+        ...
+
+    def rate_limit_hint(self) -> dict[str, float]:
+        """Operational throttle hints (NOT enforced by RoE middleware).
+
+        Keys (all optional, all float):
+            ``requests_per_second`` — token-bucket fill rate
+            ``reports_per_day`` — submission cap (bug-bounty only)
+            ``status_poll_interval_seconds`` — polling cadence
+            ``status_poll_jitter_seconds`` — uniform jitter to apply
+        """
+        ...

--- a/packages/decepticon-core/decepticon_core/types/__init__.py
+++ b/packages/decepticon-core/decepticon_core/types/__init__.py
@@ -1,6 +1,6 @@
 """Pure-pydantic types for the Decepticon contract layer.
 
-Four submodules:
+Five submodules:
 
   * ``engagement`` — red-team planning documents (RoE, ConOps, OPPLAN,
     Finding, Objective, OpsecLevel, C2Tier, MITREPhase, ...). Was
@@ -16,6 +16,12 @@ Four submodules:
     evaluation layer that decides allow/deny for a target or command;
     consumed by the framework's RoE-enforcement middleware. Distinct from
     ``engagement.RoE`` (the planning document).
+  * ``bounty`` — bug-bounty platform integration types (``Program``,
+    ``FindingSignature``, ``ReportDraft``, ``SubmittedReport``,
+    ``ReportStatus``, ``ReportState``). Consumed by ``PlatformAdapter``
+    implementations and the bugclaw orchestrator. Scope rules are NOT
+    redefined here — bug-bounty adapters produce ``MachineEnforcement``
+    instances that the existing RoE middleware consumes.
 
 These modules import only ``pydantic`` + stdlib + ``typing_extensions`` —
 no ``langchain`` / ``langgraph`` / ``deepagents`` / ``httpx`` /
@@ -24,6 +30,6 @@ no ``langchain`` / ``langgraph`` / ``deepagents`` / ``httpx`` /
 
 from __future__ import annotations
 
-from decepticon_core.types import engagement, kg, llm, roe
+from decepticon_core.types import bounty, engagement, kg, llm, roe
 
-__all__ = ["engagement", "llm", "kg", "roe"]
+__all__ = ["bounty", "engagement", "llm", "kg", "roe"]

--- a/packages/decepticon-core/decepticon_core/types/bounty.py
+++ b/packages/decepticon-core/decepticon_core/types/bounty.py
@@ -1,0 +1,98 @@
+"""Bug-bounty data types — shared between platform adapters,
+the bugclaw orchestrator, and the saas web HITL UI.
+
+These are pure dataclasses (frozen, slots). No behavior — adapters
+and the orchestrator construct and read these; protocols/* defines
+the methods that operate on them.
+
+Note on ScopeRule: scope enforcement uses the existing
+``decepticon_core.types.roe.MachineEnforcement`` + ``ScopeRule``
+schema (see decepticon.middleware.roe). Bug-bounty platform adapters
+produce a ``MachineEnforcement`` instance that the existing RoE
+middleware consumes — no new scope types are defined here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+__all__ = [
+    "FindingSignature",
+    "Program",
+    "ReportDraft",
+    "ReportState",
+    "ReportStatus",
+    "SubmittedReport",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Program:
+    """One bug-bounty program (e.g. HackerOne's 'snapchat')."""
+
+    platform: str
+    handle: str
+    name: str
+    payout_range: tuple[int, int]      # (min_usd, max_usd) typical P3
+    avg_triage_days: float | None
+    bounty_table_url: str | None
+    scope_url: str
+    submission_endpoint: str           # URL or "email:..."
+    requires_managed_account: bool     # True for invitation-only programs
+
+
+@dataclass(frozen=True, slots=True)
+class FindingSignature:
+    """Stable hash-like view of a finding for dedupe."""
+
+    cwe: str
+    endpoint_canonical: str
+    poc_minimal_hash: str              # sha256 hex of normalized PoC
+    notes: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ReportDraft:
+    """Pre-render finding payload. ReportTemplate.render → markdown body."""
+
+    title: str
+    severity_cvss: str
+    summary: str
+    repro_steps: list[str]
+    poc_command: str
+    affected_assets: list[str]
+    suggested_fix: str
+    attachments: dict[str, bytes] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class SubmittedReport:
+    """Returned by PlatformAdapter.submit_report."""
+
+    platform_report_id: str
+    submitted_at: datetime
+    submission_url: str
+
+
+ReportState = Literal[
+    "new",
+    "triaged",
+    "needs_more_info",
+    "duplicate",
+    "informative",
+    "resolved",
+    "paid",
+    "rejected",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportStatus:
+    """Snapshot of a submitted report's current state."""
+
+    state: ReportState
+    payout_usd: int | None
+    triager_message: str | None
+    last_updated: datetime

--- a/packages/decepticon-core/tests/test_bounty_protocols.py
+++ b/packages/decepticon-core/tests/test_bounty_protocols.py
@@ -1,0 +1,209 @@
+"""Structural conformance tests for the 4 bounty-platform Protocols.
+
+Each Protocol is ``@runtime_checkable`` so isinstance() works on
+concrete stand-ins.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from decepticon_core.protocols.identity_provider import IdentityProvider
+from decepticon_core.protocols.platform_adapter import PlatformAdapter
+from decepticon_core.protocols.report_template import ReportTemplate
+from decepticon_core.protocols.scope_provider import ScopeProvider
+from decepticon_core.types.bounty import (
+    FindingSignature,
+    Program,
+    ReportDraft,
+    ReportStatus,
+    SubmittedReport,
+)
+from decepticon_core.types.roe import EnforcementMode, MachineEnforcement, ScopeRule
+
+
+# ─────────────── ScopeProvider ───────────────
+
+
+class _GoodScope:
+    scope_id = "test:program"
+
+    async def fetch_machine_enforcement(self) -> MachineEnforcement:
+        return MachineEnforcement(
+            mode=EnforcementMode.ENFORCE,
+            in_scope=(ScopeRule(pattern="example.com"),),
+        )
+
+    def rate_limit_hint(self) -> dict[str, float]:
+        return {"requests_per_second": 1.0}
+
+
+class _BadScope:
+    scope_id = "test:bad"
+
+    async def fetch_machine_enforcement(self) -> MachineEnforcement:
+        return MachineEnforcement()
+    # missing rate_limit_hint
+
+
+def test_scope_provider_satisfied() -> None:
+    p: ScopeProvider = _GoodScope()
+    assert isinstance(p, ScopeProvider)
+
+
+def test_scope_provider_missing_method_rejected() -> None:
+    assert not isinstance(_BadScope(), ScopeProvider)
+
+
+@pytest.mark.asyncio
+async def test_scope_provider_returns_enforcement() -> None:
+    p = _GoodScope()
+    me = await p.fetch_machine_enforcement()
+    assert me.mode == EnforcementMode.ENFORCE
+    assert me.in_scope[0].pattern == "example.com"
+
+
+# ─────────────── IdentityProvider ───────────────
+
+
+class _GoodIdentity:
+    def outbound_user_agent(self, engagement_id: str) -> str:
+        return f"test/0.1 (+local; eng={engagement_id})"
+
+    def callback_domain_prefix(self) -> str:
+        return "cb.test.local"
+
+
+class _BadIdentity:
+    def outbound_user_agent(self, engagement_id: str) -> str:
+        return "x"
+    # missing callback_domain_prefix
+
+
+def test_identity_provider_satisfied() -> None:
+    i: IdentityProvider = _GoodIdentity()
+    assert isinstance(i, IdentityProvider)
+
+
+def test_identity_provider_missing_method_rejected() -> None:
+    assert not isinstance(_BadIdentity(), IdentityProvider)
+
+
+def test_identity_ua_carries_eng_id() -> None:
+    ua = _GoodIdentity().outbound_user_agent("eng-123")
+    assert "eng=eng-123" in ua
+
+
+# ─────────────── ReportTemplate ───────────────
+
+
+class _GoodTemplate:
+    template_id = "test-v1"
+
+    def render(self, draft: ReportDraft, *, locale: str = "en") -> str:
+        return f"# {draft.title}\n\n{draft.summary}\n"
+
+
+def test_report_template_satisfied() -> None:
+    t: ReportTemplate = _GoodTemplate()
+    assert isinstance(t, ReportTemplate)
+
+
+def test_report_template_render_uses_draft_fields() -> None:
+    draft = ReportDraft(
+        title="IDOR in /users",
+        severity_cvss="CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+        summary="Reading other users' messages",
+        repro_steps=[],
+        poc_command="",
+        affected_assets=[],
+        suggested_fix="",
+        attachments={},
+    )
+    out = _GoodTemplate().render(draft)
+    assert "IDOR in /users" in out
+    assert "other users' messages" in out
+
+
+# ─────────────── PlatformAdapter ───────────────
+
+
+class _FakeAdapter:
+    platform_id = "fake"
+    identity_handle = "tester"
+    report_template_id = "fake-v1"
+
+    # ScopeProvider surface
+    scope_id = "fake:active"
+
+    async def fetch_machine_enforcement(self) -> MachineEnforcement:
+        return MachineEnforcement(
+            mode=EnforcementMode.ENFORCE,
+            in_scope=(ScopeRule(pattern="example.test"),),
+        )
+
+    def rate_limit_hint(self) -> dict[str, float]:
+        return {"requests_per_second": 2.0}
+
+    # IdentityProvider surface
+    def outbound_user_agent(self, engagement_id: str) -> str:
+        return f"fake/0.1 (eng={engagement_id})"
+
+    def callback_domain_prefix(self) -> str:
+        return "callbacks.fake.test"
+
+    # PlatformAdapter-specific
+    async def list_programs(
+        self, *, only_in_scope_for_handle: bool = True, min_payout_usd: int = 0,
+    ) -> list[Program]:
+        return []
+
+    async def search_prior_reports(
+        self, program: Program, signature: FindingSignature,
+    ) -> list[dict]:
+        return []
+
+    async def submit_report(
+        self,
+        program: Program,
+        draft: ReportDraft,
+        body_markdown: str,
+        idempotency_key: str,
+    ) -> SubmittedReport:
+        return SubmittedReport(
+            platform_report_id="X",
+            submitted_at=datetime.now(timezone.utc),
+            submission_url="https://example.test/r/X",
+        )
+
+    async def fetch_report_status(
+        self, report: SubmittedReport,
+    ) -> ReportStatus:
+        return ReportStatus(
+            state="new",
+            payout_usd=None,
+            triager_message=None,
+            last_updated=datetime.now(timezone.utc),
+        )
+
+
+def test_platform_adapter_satisfied() -> None:
+    a: PlatformAdapter = _FakeAdapter()
+    assert isinstance(a, PlatformAdapter)
+
+
+def test_platform_adapter_also_satisfies_parent_protocols() -> None:
+    a = _FakeAdapter()
+    assert isinstance(a, ScopeProvider)
+    assert isinstance(a, IdentityProvider)
+
+
+@pytest.mark.asyncio
+async def test_platform_adapter_smoke_flow() -> None:
+    a = _FakeAdapter()
+    assert await a.list_programs() == []
+    me = await a.fetch_machine_enforcement()
+    assert me.in_scope[0].pattern == "example.test"
+    assert a.outbound_user_agent("e1") == "fake/0.1 (eng=e1)"

--- a/packages/decepticon-core/tests/test_bounty_protocols.py
+++ b/packages/decepticon-core/tests/test_bounty_protocols.py
@@ -23,7 +23,6 @@ from decepticon_core.types.bounty import (
 )
 from decepticon_core.types.roe import EnforcementMode, MachineEnforcement, ScopeRule
 
-
 # ─────────────── ScopeProvider ───────────────
 
 

--- a/packages/decepticon-core/tests/test_bounty_types.py
+++ b/packages/decepticon-core/tests/test_bounty_types.py
@@ -1,0 +1,103 @@
+"""Dataclass shape + immutability tests for bug-bounty types."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from decepticon_core.types.bounty import (
+    FindingSignature,
+    Program,
+    ReportDraft,
+    ReportState,
+    ReportStatus,
+    SubmittedReport,
+)
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+class TestProgram:
+    def test_required_fields(self) -> None:
+        p = Program(
+            platform="hackerone",
+            handle="snapchat",
+            name="Snap",
+            payout_range=(100, 5000),
+            avg_triage_days=7.0,
+            bounty_table_url=None,
+            scope_url="https://hackerone.com/snapchat",
+            submission_endpoint="https://api.hackerone.com/v1/hackers/reports",
+            requires_managed_account=False,
+        )
+        assert p.platform == "hackerone"
+        assert p.payout_range == (100, 5000)
+
+    def test_frozen(self) -> None:
+        p = Program(
+            platform="hackerone",
+            handle="snapchat",
+            name="Snap",
+            payout_range=(100, 5000),
+            avg_triage_days=None,
+            bounty_table_url=None,
+            scope_url="https://hackerone.com/snapchat",
+            submission_endpoint="email:security@example.com",
+            requires_managed_account=False,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            p.handle = "evil"  # type: ignore[misc]
+
+
+class TestFindingSignature:
+    def test_basic(self) -> None:
+        sig = FindingSignature(
+            cwe="CWE-918",
+            endpoint_canonical="GET https://api.snap.com/v1/users/{id}",
+            poc_minimal_hash="a" * 64,
+        )
+        assert sig.cwe == "CWE-918"
+
+
+class TestReportDraft:
+    def test_attachments_default_empty(self) -> None:
+        d = ReportDraft(
+            title="t",
+            severity_cvss="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            summary="s",
+            repro_steps=["one", "two"],
+            poc_command="curl ...",
+            affected_assets=["api.snap.com"],
+            suggested_fix="patch",
+            attachments={},
+        )
+        assert d.attachments == {}
+
+
+class TestSubmittedReport:
+    def test_basic(self) -> None:
+        s = SubmittedReport(
+            platform_report_id="1234",
+            submitted_at=_utc(2026, 6, 3),
+            submission_url="https://hackerone.com/reports/1234",
+        )
+        assert s.platform_report_id == "1234"
+
+
+class TestReportStatus:
+    def test_states_enum_literal(self) -> None:
+        valid: set[ReportState] = {
+            "new", "triaged", "needs_more_info", "duplicate",
+            "informative", "resolved", "paid", "rejected",
+        }
+        for s in valid:
+            rs = ReportStatus(
+                state=s,
+                payout_usd=None,
+                triager_message=None,
+                last_updated=_utc(2026, 6, 3),
+            )
+            assert rs.state == s


### PR DESCRIPTION
## Summary

Foundation PR for the bugclaw bug-bounty hunter — adds 5 bug-bounty data types and 4 Protocols to `decepticon-core` so platform adapters (HackerOne, Naver, etc.) can register against a uniform contract.

### What's new

**`decepticon_core.types.bounty`** (new module)
- `Program` — one bug-bounty program (platform, handle, payout range, scope URL, submission endpoint)
- `FindingSignature` — dedupe key (CWE + canonical endpoint + PoC hash)
- `ReportDraft` — pre-render finding payload
- `SubmittedReport` — adapter return value
- `ReportStatus` + `ReportState` literal — submission tracking

**`decepticon_core.protocols`** (4 new Protocols, all `@runtime_checkable`)
- `ScopeProvider` — produces `MachineEnforcement` for the existing roe middleware
- `IdentityProvider` — outbound `User-Agent` + callback domain prefix
- `PlatformAdapter` — extends both above; adds `list_programs`, `search_prior_reports`, `submit_report`, `fetch_report_status`
- `ReportTemplate` — `ReportDraft` → platform-native markdown

### Key design choices

- **No new ScopeRule**: `ScopeProvider.fetch_machine_enforcement()` returns the existing `decepticon_core.types.roe.MachineEnforcement`. Same enforcement schema, same `roe.py` middleware, same audit ledger across pentest and bugbounty modes.
- **Default IMDS protection comes for free** via `MachineEnforcement.effective_forbidden_destinations()`.
- **Templates decoupled from adapters** so multiple platforms with similar conventions can share (e.g. HackerOne + Bugcrowd can both use `bounty-classic-v1`).

### Test plan

- [x] `uv run pytest packages/decepticon-core/tests/` → 109 passed (baseline 92 + 17 new)
- [x] Full `uv run pytest` → 3950 passed, 4 skipped (0 regressions) in 15m03s
- [x] `uv run basedpyright` on new files → 0 errors, 0 warnings
- [x] `uv run ruff check` → clean (1 import-order autofix applied)
- [x] Agent factory smoke: `create_soundwave_agent()` + `create_vulnresearch_agent()` construct cleanly; new Protocols/types import without side effects

### Follow-ups

- PR-C: `IdentityAttribution` middleware (consumes `IdentityProvider`)
- PR-E: registry tables for `decepticon.platform_adapters` and `decepticon.report_templates` entry-point groups
- Originally planned PR-B (`ScopeGuard` middleware) and PR-D (`RoEScopeProvider`) **dropped** — `roe.py` already enforces `MachineEnforcement` at the tool-call layer

See decepticon-saas spec: `docs/superpowers/specs/2026-06-03-bugclaw-design.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)