### PR TITLE
feat(kg): KG middleware — Neo4j-backed attack graph for analyst

### DIFF
--- a/docs/design/2026-06-03-external-docs-research.md
+++ b/docs/design/2026-06-03-external-docs-research.md
@@ -1,0 +1,425 @@
+# KG Middleware Redesign — External Docs Research
+
+- **Date:** 2026-06-03
+- **Researcher:** document-specialist agent
+- **Purpose:** External API/framework reference research to ground the KGMiddleware implementation
+- **Feeds into:** `docs/design/2026-06-03-kg-middleware-redesign.md`
+- **Prior art:** `docs/design/neo4j-research-notes.md` (13 topics, 1020 lines — Neo4j-specific findings; not repeated here)
+
+---
+
+## Topic 1 — LangChain `AgentMiddleware`: Latest Official API
+
+**Source:** https://docs.langchain.com/oss/python/langchain/middleware/custom (accessed 2026-06-03)
+**Reference API:** https://reference.langchain.com/python/langchain/middleware (accessed 2026-06-03)
+**Version:** langchain v1.x (released 2025; middleware system added in v1.0.0a14)
+
+### 1.1 Lifecycle hooks — complete set
+
+There are two hook styles. Both are supported in `AgentMiddleware` subclasses and as standalone decorators.
+
+**Node-style hooks** — run sequentially at fixed execution points; return `dict[str, Any] | None` (dict is merged into agent state via graph reducers; `None` means no-op):
+
+| Hook | Timing | Fires |
+|---|---|---|
+| `before_agent` | Before agent starts | Once per invocation |
+| `before_model` | Before each model call | Every model call |
+| `after_model` | After each model response | Every model call |
+| `after_agent` | After agent completes | Once per invocation |
+
+All node-style hooks share the signature:
+```python
+def hook_name(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None
+```
+
+To return a jump instruction, include `"jump_to": "end"` in the returned dict (requires `@hook_config(can_jump_to=["end"])` annotation on the method).
+
+**Wrap-style hooks** — nested wrappers; the first middleware in the stack wraps all others:
+
+```python
+def wrap_model_call(
+    self,
+    request: ModelRequest,
+    handler: Callable[[ModelRequest], ModelResponse],
+) -> ModelResponse | ExtendedModelResponse
+
+def wrap_tool_call(
+    self,
+    request: ToolCallRequest,
+    handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+) -> ToolMessage | Command[Any]
+```
+
+`request.override(model=..., tools=...)` lets wrap hooks substitute a different model or tool subset without replacing the handler.
+
+Execution order: `before_*` hooks first-to-last; `after_*` hooks last-to-first (reverse stack); `wrap_*` hooks nested (first middleware is the outermost wrapper).
+
+Async counterparts exist for all hooks: `abefore_agent`, `abefore_model`, `aafter_model`, `aafter_agent`, `awrap_model_call`, `awrap_tool_call`.
+
+### 1.2 `self.tools` — how tools merge at `create_agent` time
+
+`AgentMiddleware` subclasses may declare a `tools` class attribute (a tuple of tool objects). The agent factory reads this attribute **at compile time** (when `create_agent` is called) and merges the middleware's tools into the agent's tool list alongside the tools passed explicitly. All tools must be registered upfront at `create_agent` time; `wrap_model_call` can then filter down to a subset at runtime via `request.override(tools=relevant_subset)`.
+
+```python
+class KGMiddleware(AgentMiddleware):
+    state_schema = KGState
+    tools = ()  # populated dynamically in __init__ via build_kg_tools()
+
+    def __init__(self, *, store, enabled_tools):
+        super().__init__()
+        # tools must be reassigned on instance, not class, for dynamic builds:
+        self.tools = build_kg_tools(store, enabled_tools)
+```
+
+The factory also reads `state_schema` and `transformers` class attributes at compile time.
+
+### 1.3 `state_schema` — merging with `AgentState`
+
+Declare a `TypedDict` subclass of `AgentState` with `NotRequired` fields, assign it to `state_schema`:
+
+```python
+from langchain.agents.middleware import AgentState, AgentMiddleware
+from typing_extensions import NotRequired
+from typing import Any
+
+class KGState(AgentState):
+    kg_context: NotRequired[dict]          # active subgraph for this turn
+    kg_ingest_count: NotRequired[int]      # writes this session
+
+class KGMiddleware(AgentMiddleware[KGState]):
+    state_schema = KGState
+```
+
+Custom fields become available in all hooks and in any tool that receives `InjectedState`.
+
+### 1.4 `InjectedState` and `InjectedToolCallId` — import paths and typing pattern
+
+**`InjectedState`** lives in `langgraph.prebuilt` (not `langchain_core`):
+
+```python
+from langgraph.prebuilt import InjectedState
+from typing import Annotated
+
+@tool
+def kg_query(
+    query: str,
+    state: Annotated[dict, InjectedState],          # full state
+    # or a specific field:
+    kg_context: Annotated[dict, InjectedState("kg_context")],
+) -> str:
+    ...
+```
+
+Injected parameters are invisible to the LLM's tool-calling schema. `ToolNode` handles injection automatically.
+
+**`InjectedToolCallId`** lives in `langchain_core.tools`:
+
+```python
+from langchain_core.tools import InjectedToolCallId
+from typing import Annotated
+
+@tool
+def kg_ingest(
+    scanner_kind: str,
+    path: str,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+) -> ToolMessage:
+    ...
+```
+
+**Known issue (as of 2025):** There are open GitHub issues (langchain-ai/langchain #31688, #32729) reporting that `InjectedState` / `InjectedToolCallId` parameters must be explicitly included in `args_schema` for injection to work correctly, and that if the LLM generates a value for an injected parameter the injection silently uses the LLM-generated value. The current recommendation from the LangChain team is to use `ToolRuntime` as the single interface to state, context, store, and execution metadata for new code.
+
+### 1.5 Tool-specific middleware scoping
+
+No `tools=[]` per-middleware scoping parameter was found in the official docs. Tool scoping is achieved at runtime via `wrap_model_call` + `request.override(tools=subset)`. All tools from all middleware are registered at `create_agent` time; runtime filtering is the mechanism for per-middleware scoping.
+
+### 1.6 Upgrade guide / release notes
+
+The middleware system shipped with `langchain v1.0.0`. Migration guide at https://docs.langchain.com/oss/python/migrate/langchain-v1. The `state_schema` pattern for middleware is documented there alongside `wrap_model_call` examples.
+
+---
+
+## Topic 2 — LangGraph `BaseStore`: Can It Host Neo4j?
+
+**Source:** https://reference.langchain.com/python/langgraph/config/get_store (accessed 2026-06-03)
+**Source:** https://docs.langchain.com/oss/python/langgraph/add-memory (accessed 2026-06-03)
+**Version:** langgraph 0.4.x+
+
+### 2.1 `BaseStore` abstract interface
+
+The `BaseStore` interface exposes five operations: `put`, `get`, `search`, `delete`, `list_namespaces`. The `search` method supports optional vector-based semantic search when the store is configured with an `index` (embedding function + dimension + fields to embed). `get_store()` returns a `BaseStore` from the current runtime context.
+
+```python
+# Confirmed method signatures from reference docs and usage examples:
+store.put(namespace: tuple[str, ...], key: str, value: dict) -> None
+store.get(namespace: tuple[str, ...], key: str) -> Item | None
+store.search(namespace: tuple[str, ...], *, query: str, limit: int = 10) -> list[Item]
+store.delete(namespace: tuple[str, ...], key: str) -> None
+```
+
+`StoreConfig.index` configures the vector index: `embed` (embedding function), `dims` (int), `fields` (list of JSON keys to embed).
+
+### 2.2 Existing backend implementations
+
+- `InMemoryStore` — ephemeral, in-process, no persistence.
+- `PostgresStore` / `AsyncPostgresStore` — relational backend with optional vector support (pgvector).
+- `OracleStore` — demonstrated in docs using `init_embeddings` for semantic search.
+- `RedisStore` — via `langgraph-redis` package (separate install).
+
+Third-party `Neo4jStore(BaseStore)` implementations exist (e.g., `langchain-neo4j` integration package) but are not part of the `langgraph` core distribution.
+
+### 2.3 Can `Neo4jStore` implement `BaseStore`? What gaps exist?
+
+**Feasible for key-value-like access:** `put`/`get`/`delete`/`search` can map to Neo4j MERGE/MATCH/DELETE + full-text or vector index search. Neo4j's native vector index (available since 5.13) maps well to `BaseStore`'s vector search interface.
+
+**Structural gaps that prevent conformance for an attack graph:**
+
+1. **No edge/relationship primitive.** `BaseStore` models `Item` objects (key → dict value), not graph edges. Storing attack-path relationships — `(:Host)-[:CAN_EXPLOIT]->(:Service)` — has no natural representation in `put`/`get`. A `BaseStore` conforming implementation can only store node properties as dicts; edges become invisible.
+2. **No Cypher passthrough.** `BaseStore.search` is a semantic/keyword search over stored values, not a graph traversal query. Decepticon's `kg_query_paths` tool (Dijkstra shortest path, reachability subgraphs) cannot be expressed as a `search(namespace, query=str)` call.
+3. **No batch transaction semantics.** `put` is single-item; atomic batch upserts across node + edge sets require multi-statement Cypher transactions.
+
+**Conclusion:** Implementing `BaseStore` for Neo4j is feasible for the scalar-memory use case (storing agent findings as blobs) but cannot express graph-native operations. The KGMiddleware should maintain a **separate `KGStore`** (wrapping `neo4j.AsyncDriver`) alongside the LangGraph store, rather than trying to conform to `BaseStore`. The existing `Neo4jStore` in `packages/decepticon/decepticon/tools/research/neo4j_store.py` (787 LOC) is the right foundation.
+
+---
+
+## Topic 3 — DeepAgents Middleware System
+
+**Source:** https://docs.langchain.com/oss/python/deepagents/middleware (accessed 2026-06-03)
+**Source:** https://reference.langchain.com/python/deepagents/middleware/filesystem/FilesystemMiddleware (accessed 2026-06-03)
+**Source:** https://github.com/langchain-ai/deepagents (accessed 2026-06-03)
+**Version:** deepagents (latest, 2025-2026)
+
+### 3.1 `MemoryMiddleware`
+
+`MemoryMiddleware` is a lightweight middleware that loads agent memory from `AGENTS.md` files (markdown skill catalogs) at `before_agent` time. It does not use the LangGraph `BaseStore` interface — it reads from the filesystem via the agent's backend. Decepticon already has an equivalent mechanism via its skill catalog system (markdown files in `packages/decepticon/decepticon/skills/`).
+
+### 3.2 `FilesystemMiddleware`
+
+The flagship DeepAgents middleware. Full constructor signature:
+
+```python
+FilesystemMiddleware(
+    *,
+    backend: BACKEND_TYPES | None = None,       # defaults to StateBackend (ephemeral)
+    system_prompt: str | None = None,
+    custom_tool_descriptions: Mapping[str, str] | None = None,
+    tool_token_limit_before_evict: int | None = 20000,
+    human_message_token_limit_before_evict: int | None = 50000,
+    max_execute_timeout: int = 3600,
+    _permissions: list[FilesystemPermission] | None = None,
+)
+```
+
+Exposed tools: `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep` (+ `execute` when a sandbox-compatible backend is provided).
+
+Storage model: dual-tier via `CompositeBackend`. `StateBackend` handles short-term in-state storage; `StoreBackend` routes paths prefixed with `/memories/` to persistent cross-thread storage (any LangGraph `BaseStore` implementation). Extends `AgentMiddleware` and implements `wrap_model_call`, `awrap_model_call`, `wrap_tool_call`, `awrap_tool_call`.
+
+**Intersection with Decepticon:** Decepticon agents already write `findings/`, `recon/` files via `DockerSandbox.execute_tmux()`. `FilesystemMiddleware` uses a different execution surface (its own `backend`). These are parallel systems — `FilesystemMiddleware` manages an in-graph virtual filesystem; Decepticon's sandbox writes to the real container filesystem. They should not be merged without intentional design. The `KGMiddleware` is not a `FilesystemMiddleware` replacement.
+
+### 3.3 `SubAgentMiddleware`
+
+Configures subagent dispatch. Subagents are defined with: `name`, `description`, `system_prompt`, `tools`, optional `model`, optional `middleware`. A general-purpose subagent always exists for context-isolation tasks. Subagents can be either simple config objects or `CompiledSubAgent` wrappers around prebuilt LangGraph graphs.
+
+**Relevance to Decepticon's 16-specialist architecture:** Decepticon's specialists are spawned with clean context windows via `create_agent` factory calls in `packages/decepticon/decepticon/agents/`. These are not `SubAgentMiddleware`-managed subagents — they are peer agents in the graph, not children of a supervisor middleware. The `SubAgentMiddleware` pattern is for a different architecture (hierarchical supervisor with delegated subtasks). No migration needed.
+
+### 3.4 Composition of DeepAgents middleware with custom `AgentMiddleware`
+
+Yes — DeepAgents is "built entirely on `create_agent`." `create_deep_agent` automatically attaches `TodoListMiddleware`, `FilesystemMiddleware`, and `SubAgentMiddleware`, but a caller can pass additional `middleware=[..., KGMiddleware()]` items alongside the built-in stack. Custom `AgentMiddleware` subclasses (including `KGMiddleware`) compose cleanly with DeepAgents built-ins using the standard middleware list ordering.
+
+---
+
+## Topic 4 — Neo4j Python Driver: `execute_write` / Transaction Patterns
+
+**Source:** https://github.com/neo4j/neo4j-python-driver/blob/6.x/docs/source/api.md (accessed 2026-06-03)
+**Source:** https://neo4j.com/docs/cypher-manual/current/indexes/syntax/ (accessed 2026-06-03)
+**Source:** https://neo4j.com/docs/apoc/current/overview/apoc.algo/apoc.algo.dijkstra/ (accessed 2026-06-03)
+**Version:** neo4j Python driver 6.x; Neo4j 5.24 CE; APOC 5.26 (current LTS)
+
+### 4.1 `execute_write` / `execute_read` — per-operation pattern
+
+Managed transactions are the recommended pattern (confirms and extends neo4j-research-notes §1 and §2):
+
+```python
+def write_node_tx(tx, node_id: str, props: dict) -> str:
+    result = tx.run(
+        "MERGE (n:Host {id: $id}) SET n += $props RETURN n.id AS id",
+        id=node_id, props=props
+    )
+    return result.single()["id"]
+
+with driver.session(database="neo4j") as session:
+    node_id = session.execute_write(write_node_tx, node_id, props)
+```
+
+Results **must be fully consumed inside the transaction function**. Returning a live result object breaks retry guarantees and connection management. Only aggregate or status values should be returned from the function.
+
+Async variant:
+```python
+async with driver.session() as session:
+    node_id = await session.execute_write(write_node_tx, node_id, props)
+```
+
+### 4.2 Retry semantics on `DeadlockDetected`
+
+`session.execute_write` automatically retries on any `Neo.TransientError` — including `Neo.TransientError.Transaction.DeadlockDetected` — within the configured timeout. No manual retry logic is needed. This is explicitly documented in the driver API. The driver calls the transaction function "one or more times, within a configurable time limit, until it succeeds." Explicit `begin_transaction()` / `commit()` patterns do NOT get automatic retry.
+
+### 4.3 Composite range index — verified Cypher syntax for Neo4j 5.24
+
+```cypher
+CREATE INDEX index_name [IF NOT EXISTS]
+FOR (n:Label)
+ON (n.property1, n.property2)
+```
+
+Example from official docs:
+```cypher
+CREATE INDEX composite_range_node_index_name FOR (n:Person) ON (n.age, n.country)
+```
+
+The `RANGE` keyword is optional (range is the default index type). The `IF NOT EXISTS` clause prevents errors on re-application.
+
+For Decepticon's schema (e.g., Host nodes by engagement + ip):
+```cypher
+CREATE INDEX host_scope_idx IF NOT EXISTS
+FOR (n:Host) ON (n.engagement_id, n.ip)
+```
+
+Source: https://neo4j.com/docs/cypher-manual/current/indexes/syntax/
+
+### 4.4 Vector index syntax (Neo4j 5.13+)
+
+```cypher
+CREATE VECTOR INDEX index_name [IF NOT EXISTS]
+FOR (n:Label)
+ON (n.embedding_property)
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 1536,
+    `vector.similarity_function`: 'cosine'
+  }
+}
+```
+
+Dimensions should always be specified explicitly. Supported similarity functions: `cosine`, `euclidean`. Available since Neo4j 5.13; no Enterprise Edition restriction on the index creation itself.
+
+Source: https://neo4j.com/docs/cypher-manual/current/indexes/syntax/
+
+### 4.5 APOC vs GDS for Dijkstra — recommendation
+
+**`apoc.algo.dijkstra` (APOC Core)**
+
+Signature:
+```
+apoc.algo.dijkstra(startNode, endNode, relTypesAndDirections, weightPropertyName
+                   [, defaultWeight, numberOfWantedPaths]) :: (path, weight)
+```
+
+Available in APOC Core (not Extended), which ships as part of Neo4j 5.x community builds. Returns `(path, weight)` pairs directly in Cypher without requiring a graph projection step. The current APOC LTS is 5.26. The procedure `apoc.algo.dijkstra` is documented in APOC Core (not APOC Extended), which means it is available in Community Edition.
+
+**GDS `gds.shortestPath.dijkstra`**
+
+Requires: (1) GDS plugin installed separately, (2) a named graph projection created first (`gds.graph.project`), (3) a dedicated algorithm call. GDS is recommended for production analytic workloads requiring optimized performance, integration with other graph algorithms, or parallelism. GDS does NOT ship with Neo4j Community Edition by default — it requires a separate install and a GDS license for production.
+
+**Verdict for Decepticon (5.24 CE, real-time attack path queries):**
+Keep `apoc.algo.dijkstra` as used in `chain.py`. APOC Core is available in 5.24 CE, returns paths in-query without a projection step, and is appropriate for the query-time (not analytic-batch) pattern Decepticon uses. GDS would require a separate license and a graph projection that must be maintained in sync with live writes — overkill for attack-path lookup during agent turns.
+
+---
+
+## Topic 5 — Reference Implementations
+
+### 5.1 BloodHound CE (SpecterOps) — 2026 patterns
+
+**Sources:**
+- https://bloodhound.specterops.io/get-started/custom-installation (accessed 2026-06-03)
+- https://specterops.io/blog/2026/04/15/whats-new-in-the-bloodhound-query-library-byol-opengraph-multi-server-and-more/ (accessed 2026-06-03)
+
+BloodHound CE architecture as of 2026: Go-based REST API backend + embedded React/Sigma.js frontend + PostgreSQL application database + Neo4j graph database. The dual-database pattern is notable — PostgreSQL for application state (users, jobs, configs), Neo4j exclusively for the attack graph.
+
+**Multi-writer handling:** BloodHound CE does not expose its internal multi-writer Cypher patterns publicly. Based on architecture docs, data ingestion is handled by a single ingestor service pipeline (not concurrent agent writes). This is architecturally different from Decepticon where 16 agents write concurrently.
+
+**Schema migration (2026):** The Query Library is deprecating `system_tags`-based conditions in favor of label-based `Privilege Zones` (deadline July 2026, requires BH v2026.03.23+). This is a UI/query migration, not a Neo4j schema migration.
+
+**Programmatic API:** BH CE exposes a REST HTTP API that can be used to drive queries programmatically. The `BloodHound Query Library` (queries.specterops.io, YAML format) was released June 2025. **Bring Your Own Library (BYOL)** (April 2026) allows pointing the query UI at a custom JSON endpoint following the query schema. No formal agent SDK is documented; Decepticon's attack-graph queries are better served by direct Cypher than by proxying through the BH API.
+
+**OpenGraph (2026):** Extends BloodHound beyond AD/Azure to arbitrary identity platforms (Jamf, GitHub, Okta, custom). This is directly relevant to Decepticon's multi-cloud graph model.
+
+### 5.2 Cartography (Lyft / CNCF) — incremental MERGE pattern
+
+**Source:** https://github.com/cartography-cncf/cartography (accessed 2026-06-03)
+**Source:** https://lyft.github.io/cartography/usage/schema.html (accessed 2026-06-03)
+
+Cartography is the most mature open-source reference for incremental Neo4j sync from scanner adapters. Its sync pattern is directly applicable to Decepticon's scanner-to-graph ingestion:
+
+**Core pattern:**
+
+1. **`update_tag`** — a timestamp integer passed to every sync function. All MERGE statements `SET n.lastupdated = $update_tag` on every touched node.
+2. **`firstseen`** — set only on first MERGE via `ON CREATE SET n.firstseen = $update_tag`.
+3. **Stale cleanup** — after a full sync pass, a cleanup query deletes nodes where `n.lastupdated < $update_tag` (i.e., not seen in this run). Relationships get the same treatment.
+4. **MERGE on stable identity key** — MERGE matches on the node's canonical identity property (e.g., ARN for AWS, IP+port for network assets). Properties are updated via `SET n += $props`.
+
+```cypher
+-- Cartography-style upsert
+MERGE (h:Host {id: $id})
+ON CREATE SET h.firstseen = $update_tag
+SET h.lastupdated = $update_tag,
+    h.ip = $ip,
+    h.engagement_id = $engagement_id
+```
+
+**Duplicate-on-rescan handling:** Because MERGE is idempotent on the identity key, re-scanning the same asset updates in place. No deduplication logic needed in Python; Cypher handles it.
+
+**For Decepticon:** The `kg_ingest` dispatcher should pass `update_tag = int(time.time())` to all write transaction functions. Stale-node cleanup can run as a `before_agent` hook in `KGMiddleware`, scoped to `engagement_id` (never clean across engagements).
+
+### 5.3 Graphiti (Zep) — bi-temporal provenance model
+
+**Sources:**
+- https://help.getzep.com/graphiti/getting-started/overview (accessed 2026-06-03)
+- https://arxiv.org/abs/2501.13956 — "Zep: A Temporal Knowledge Graph Architecture for Agent Memory" (January 2025)
+- https://github.com/getzep/graphiti (accessed 2026-06-03)
+
+Graphiti is a temporally aware knowledge graph engine from Zep AI, production-grade as of 2025. Key architectural concepts:
+
+**Bi-temporal model:** Every graph edge carries four timestamps:
+- `t_created` / `t_expired` — when the fact was recorded/invalidated in the system (ingestion time)
+- `t_valid` / `t_invalid` — when the fact was actually true in the world (event time)
+
+Contradictions cause edge `t_expired` to be set rather than deletion, preserving history.
+
+**Episode subgraph:** Raw inputs (agent messages, tool outputs, structured data) are stored as `Episode` nodes. Every derived entity and relationship traces back to the episodes that produced it, giving full lineage from derived fact to source.
+
+**Community subgraphs:** Related entities are clustered into `Community` nodes for higher-level summarization and search.
+
+**Relevance for Decepticon provenance tracking:** Graphiti's episode → entity provenance model directly addresses the question "which agent in which OPPLAN step created which node?" Decepticon could borrow this by:
+- Adding `created_by` (agent name string), `created_at_step` (OPPLAN phase), and `episode_id` (UUID linking to the raw tool output) properties on every `Host`, `Service`, `Finding` node.
+- Setting `lastupdated_by` on each MERGE write.
+- Not implementing the full Graphiti bi-temporal model (it requires LLM calls for conflict resolution) — but the property schema is worth adopting.
+
+### 5.4 Cognee — ECL pipeline customization
+
+**Source:** https://github.com/topoteretes/cognee (accessed indirectly via search; direct fetch not performed)
+
+Cognee implements an Extract-Chunk-Load (ECL) pipeline for building knowledge graphs from unstructured documents. Its plugin architecture allows custom `DataPoint` types and custom graph transformation steps. The pattern is relevant for Decepticon plugin authors who want to add new scanner adapters (e.g., a BloodHound ingestor or a custom recon tool output parser) that feed into the attack graph.
+
+The key Cognee pattern for Decepticon: each scanner adapter is a pure function `(raw_output: str) -> list[DataPoint]` where `DataPoint` is a Pydantic model. The `kg_ingest(scanner_kind, path)` dispatcher maps `scanner_kind` to a registered adapter function. This mirrors Decepticon's planned collapsing of 12 `kg_ingest_*` tools into a single dispatcher.
+
+---
+
+## Implications for KGMiddleware Design
+
+1. **Use `state_schema = KGState` with `NotRequired` fields; populate `self.tools` dynamically in `__init__`.** The `AgentMiddleware` compile-time protocol reads both attributes from the instance. `KGState` should add `kg_context: NotRequired[dict]` (active subgraph snapshot for the current turn) and `kg_ingest_count: NotRequired[int]`. Source: LangChain middleware docs, confirmed `state_schema` merging behavior.
+
+2. **Do NOT implement `BaseStore` for Neo4j — the `put`/`get` model cannot express edges.** Maintain the existing `Neo4jStore` (787 LOC in `neo4j_store.py`) as the KGMiddleware's private store. The LangGraph `BaseStore` (passed via `graph.compile(store=...)`) is for scalar memory blobs only; the attack graph requires a separate graph-native API. These are parallel stores with distinct purposes.
+
+3. **Use `InjectedState` from `langgraph.prebuilt` (not `langchain_core`) for tools that need graph context.** Pattern: `state: Annotated[dict, InjectedState("kg_context")]`. Flag the open injection reliability issues (langchain-ai/langchain #31688, #32729) — consider `ToolRuntime` as the forward-compatible alternative once it stabilizes.
+
+4. **Neo4j 5.24 composite range index syntax verified:** `CREATE INDEX name IF NOT EXISTS FOR (n:Label) ON (n.a, n.b)`. Use `IF NOT EXISTS` in migration scripts; RANGE is the default so the keyword is optional. Vector index: `CREATE VECTOR INDEX name IF NOT EXISTS FOR (n:Label) ON (n.embedding) OPTIONS { indexConfig: { \`vector.dimensions\`: 1536, \`vector.similarity_function\`: 'cosine' } }`. Available since 5.13, no EE requirement.
+
+5. **Keep `apoc.algo.dijkstra` (APOC Core) for attack-path queries; do not migrate to GDS.** APOC Core ships with Neo4j 5.24 CE, requires no graph projection, and returns paths inline in Cypher. GDS requires a separate license and a maintained graph projection — both are unsuitable for Decepticon's real-time query-during-agent-turn pattern.
+
+6. **Adopt Cartography's `update_tag` + `lastupdated` + `firstseen` pattern for all `kg_ingest` writes.** Pass `update_tag = int(time.time())` to every `execute_write` transaction function. `firstseen` is set `ON CREATE`. Add a `KGMiddleware.before_agent` hook that runs stale-node cleanup (`lastupdated < engagement_start_ts`) scoped to `engagement_id`. This eliminates ghost nodes from partial scans without complex deduplication logic.
+
+7. **Borrow Graphiti's provenance property schema without adopting its full bi-temporal model.** Add `created_by: str` (agent name), `created_at_phase: str` (OPPLAN phase label), and `source_episode_id: str` (UUID of the raw tool output that triggered the write) to all node MERGE `SET` clauses. This gives audit-quality lineage ("finding X was created by ad_operator in LATERAL_MOVEMENT phase, from nmap output abc123") without requiring LLM conflict resolution or the four-timestamp edge model.
+
+---
+
+*Research completed 2026-06-03. All URLs accessed on this date. LangChain middleware system is at v1.x; Neo4j Python driver at 6.x; APOC at 5.26 LTS. Re-verify InjectedState injection reliability issues before finalizing tool implementations.*

--- a/docs/design/2026-06-03-kg-middleware-implementation-research.md
+++ b/docs/design/2026-06-03-kg-middleware-implementation-research.md
@@ -1,0 +1,570 @@
+# KG Middleware Implementation Research
+
+- **Date:** 2026-06-03
+- **Status:** Phase 1 draft (skills + prior research). Phase 2 (external docs) appended after review.
+- **Related:** [`docs/design/2026-06-03-kg-middleware-redesign.md`](./2026-06-03-kg-middleware-redesign.md) (spec), [`docs/design/neo4j-research-notes.md`](./neo4j-research-notes.md) (Neo4j 13-topic deep dive), [`docs/design/2026-06-03-external-docs-research.md`](./2026-06-03-external-docs-research.md) (external docs, in progress)
+- **Branch:** `feat/kg-middleware`
+- **Purpose:** Surface the *implementation* questions the spec leaves open, with evidence from the LangChain / LangGraph / DeepAgents / memory-systems / tool-design skills, and present concrete options for user review **before** any KG code is written.
+
+---
+
+## 1. TL;DR
+
+The KG middleware redesign was specified before doing the agent-framework research. Three issues surfaced that justify a design check-in:
+
+1. **A 2026 memory-systems benchmark calls the entire premise into question.** Letta's **filesystem-based agents scored 74% on LoCoMo**, beating Mem0's specialized memory tools at 68.5%. Decepticon's analyst already writes `findings/FIND-NNN.md`, `recon/SUMMARY.md`, `timeline.jsonl` — file-system memory it already produces. **Question: does a dedicated KG middleware enable new capability, or is it tooling for tooling's sake?**
+
+2. **The tool-design skill's "Stop Constraining Reasoning" principle** argues against specialized tools when primitives suffice. Adding 8 KG tools may constrain the model instead of enabling it.
+
+3. **The DeepAgents skill confirms** that DeepAgents already ships `MemoryMiddleware` + `Store` for cross-session memory. The OPPLAN pattern in `middleware/opplan.py` is the right shape for *workflow-state* middleware. But for *graph-shaped memory*, the LangGraph `BaseStore` interface is a poor fit (hierarchical key-value, no edge model) — confirming the `KGStore` direct-Cypher decision from the spec.
+
+The recommendation is **NOT** to pick option A (spec-as-written) blindly. The three options in §6 are concrete trade-offs the user should pick from before any code lands.
+
+---
+
+## 2. Skills consulted (6) — what each contributed
+
+| Skill | Key finding for KG middleware |
+|---|---|
+| `framework-selection` | Decepticon is **layered**: LangChain `create_agent` + LangGraph runtime + DeepAgents backend. Middleware = `langchain.agents.middleware.AgentMiddleware`. The spec's OPPLAN-mirror approach is correct in *kind*. |
+| `langchain-middleware` | 5 hooks confirmed: `before_agent`, `before_model`, `wrap_model_call`, `wrap_tool_call`, `after_model`, `after_agent`. Tool-specific middleware (`tools=[...]` scoped to certain tools) is supported. HITL pattern (`interrupt_on={"kg_add_edge": True}`) is available if we want operator-approved chains. |
+| `deep-agents-core` | DeepAgents' built-in `MemoryMiddleware` + `Store` is the canonical long-term memory pattern. Skills (SKILL.md) and subagent (`task` tool) middlewares already exist. **Custom middleware composes with the built-ins.** |
+| `memory-systems` | LoCoMo benchmark: **Letta filesystem (74%) > Mem0 (68.5%)**. Zep/Graphiti's temporal bi-modeling shows 18.5% LongMemEval improvement + 90% latency reduction via subgraph retrieval. Anti-pattern: "over-engineering early." |
+| `langgraph-persistence` | `Store` is key-value / hierarchical, not graph-native. Implementing `BaseStore` for Neo4j would force us to flatten edges into encoded keys — a degraded representation. Confirms **`KGStore` as a direct API** (spec §4.6), not a `BaseStore` impl. |
+| `tool-design` | Consolidation principle ("if a human can't pick the tool, an agent can't") **supports** collapsing 12 `kg_ingest_*` into one. Architectural-reduction principle **questions** whether we need any KG tools at all. 10-20 tools per agent is the budget. |
+
+---
+
+## 3. Confirmed design decisions (no change from spec)
+
+These are the spec items that survive the research check:
+
+- **Class shape**: `class KGMiddleware(AgentMiddleware)` with `state_schema = KGState`. Mirrors OPPLAN.
+- **Tool factory**: `self.tools = build_kg_tools(self._store, enabled)`. The `self.tools` attribute is the standard LangChain middleware mechanism for contributing tools to the agent's tool list (confirmed by 8+ usages in `decepticon/tools/opplan.py`).
+- **Per-op `execute_write` / `execute_read`** replacing `graph_transaction()`. Removes the global `threading.Lock`. (Research notes §1–§2.)
+- **`InjectedState` pattern** for engagement scoping at the tool layer — the model never sees an `engagement` parameter. Used 8+ times in `tools/opplan.py` already.
+- **Engagement-scoped composite range indexes** (`(engagement, severity)` etc.) ship as a V002 migration. (Research notes §3, §7.)
+- **`kg_ingest(scanner_kind, path)`** with adapter registry replaces 12 `kg_ingest_*` tools. Tool-design consolidation principle supports this.
+- **`AttackGraphProtocol`** filled in (currently docstring-only vaporware at `runtime/cart.py:36`). The `revision()` + `snapshot()` polling model survives.
+- **`KGStore` is a direct API, NOT a `BaseStore` implementation.** The langgraph-persistence skill makes clear the `Store` interface (put/get/search/delete by key) can't express edges without flattening into encoded keys. A separate API is correct.
+
+---
+
+## 4. Open questions the spec did not answer
+
+These came up only after going through the skills. Each one needs a user decision.
+
+### Q1 — Does a KG middleware enable new capability, or constrain the model?
+
+The memory-systems and tool-design skills both surface the file-system pattern. Decepticon's analyst.md prompt already instructs the model to write `findings/FIND-NNN.md`, `recon/SUMMARY.md`, `timeline.jsonl`. Those files are durable, queryable with `grep`, human-readable, and survive any framework change.
+
+What does Neo4j enable that files don't?
+
+| Capability | File-system | Neo4j |
+|---|---|---|
+| Per-finding markdown report for operator | ✓ | ✗ (would render from graph) |
+| `grep -r "SSRF" findings/` to recall | ✓ | Cypher MATCH (more powerful but more setup) |
+| Multi-hop attack-path planning (`entrypoint → cred → admin`) | ✗ | ✓ (APOC dijkstra) |
+| Cross-engagement correlation in SaaS dashboard | ✗ | ✓ (already wired in `clients/web/`) |
+| Deduplication of `Host` by IP across multiple agents | ✗ | ✓ (MERGE-on-key) |
+| Vector search over finding descriptions | ✗ | ✓ (Neo4j 5.13+ vector index) |
+
+**The Neo4j-unique capabilities are (a) multi-hop chain planning and (b) cross-agent dedup.** Files cover (c) recall and (d) reporting better.
+
+**Implication for design**: the KG middleware does NOT need to expose `kg_query` and `kg_neighbors` as tools the LLM calls — the LLM can `grep findings/`. What the KG middleware DOES need is:
+- A write surface so multi-agent writes land in Neo4j (for cross-agent dedup + path planning).
+- A summary block injected into the system prompt (chain candidates, current crown-jewel set).
+- Direct `cypher-shell` access via bash for the agent when it needs path-planner output.
+
+This pushes toward **Option B (hybrid)** in §6 — read tools off, write tools on, summary in prompt.
+
+### Q2 — Is "auto-ingest from files" really off the table?
+
+The spec's NG4 (out-of-scope) says: "Agents continue to call `kg_*` tools explicitly. The middleware does NOT silently parse workspace files." This was confirmed by the user 2026-06-03: "미들웨어 통해서 자동 kg 기여가 아니라... KG 도구 자체를 KG 미들웨어로 만들어서 tool로 노출."
+
+But the Q1 analysis changes the picture:
+- If the LLM uses `grep findings/` for recall (instead of `kg_query`), the LLM is no longer the entity *writing* to KG — at least not for findings recall.
+- A background `after_model` hook could ingest newly-written `findings/FIND-NNN.md` into KG nodes automatically.
+- This is NOT "silent middleware doing the agent's work" — it's "middleware projecting the file the agent just wrote into the graph."
+
+**Re-confirm with user**: did the 2026-06-03 directive rule out auto-ingest entirely, or only "auto-ingest in lieu of agent action"? File→KG projection after the agent writes a file is a different pattern.
+
+### Q3 — How much of analyst's current prompt survives?
+
+`analyst.md` is ~200 lines and heavily KG-centric (12 `kg_*` mentions, the `<KNOWLEDGE_GRAPH_DISCIPLINE>` block, 8 hunting lanes). If we narrow the tool surface to write-only + summary-injection, the prompt needs rewriting:
+- Remove the "`kg_query(...)` → review highs/criticals" instructions (LLM uses `grep` instead).
+- Remove the `KG_DISCIPLINE` block (or rewrite it as "the middleware shows you the chain candidates; if you want details, grep").
+- Keep the explicit `kg_add_node` / `kg_ingest` calls for write-only.
+
+This is a substantial prompt rewrite. Worth it if Option B saves the analyst from the broken backend.
+
+### Q4 — Multi-engagement concurrency
+
+`memory-systems` skill flagged: "Stateful subgraphs (`checkpointer=True`) do NOT support calling the same subgraph instance multiple times within a single node — namespace conflict." This is a langgraph constraint, but the analog for our KG is: **simultaneous writes from two agents in the same engagement.**
+
+Neo4j's MVCC handles concurrent MERGE correctly — but two agents BOTH adding `Host {ip: "10.0.0.1"}` in the same transaction window can produce duplicate edges if `key` isn't deterministic. We already use deterministic IDs in `Node.make` (SHA1 of `kind+key`), so this is handled.
+
+Confirm in PR-A: stress-test 16-agent parallel writes against compose Neo4j. If the deterministic key holds, we're done; if not, we need `apoc.lock.nodes` for cross-MERGE atomicity.
+
+### Q5 — Vector index for analyst's "semantic recall"?
+
+Skill `memory-systems` lists Zep/Graphiti's hybrid retrieval (semantic + keyword + graph) as the SOTA. Neo4j 5.13+ ships a native vector index. The spec marks vector integration as NG1 (out of scope), but **if we're already touching the schema in PR-A, adding a vector property + index to `Vulnerability` and `Finding` is cheap.**
+
+Cost: an embedding API call per `kg_add_node(kind="vulnerability")` write. Could be opt-in via a `KGMiddleware(embed_findings=True)` flag.
+
+Recommendation: ship vector schema (RANGE INDEX + vector property) in PR-A; defer the embed-on-write call and the `kg_search_semantic` tool to a follow-up. Keeps the schema future-proof without committing to the embed pipeline now.
+
+---
+
+## 5. Skill-confirmed anti-patterns to avoid
+
+From the skills:
+
+- **(tool-design)** "Pre-filtering context, constraining options, wrapping interactions in validation logic. These guardrails often become liabilities as models improve." → Do not wrap every Cypher call in a Pydantic validation layer. Trust the driver's parameter binding.
+- **(memory-systems)** "Stuffing everything into context. Long inputs are expensive and degrade performance. Use just-in-time retrieval." → The KG summary block injected in `wrap_model_call` must be **small** (top-5 vulns + top-3 entrypoints + chain count). Not the whole graph.
+- **(memory-systems)** "Ignoring temporal validity. Facts go stale." → A `Vulnerability` node with `validated_at` and `patched_at` is the right starting point. Don't go straight to bi-temporal (Graphiti-style) — but leave room for it.
+- **(memory-systems)** "Over-engineering early. A filesystem agent can outperform complex memory tooling." → See Q1.
+- **(memory-systems)** "No consolidation strategy. Unbounded memory growth degrades retrieval quality." → A `scripts/kg/dedupe.py` maintenance script (already in spec) is necessary. Pre-empt cluster expansion.
+- **(langgraph-persistence)** "Never block the agent's response on a memory write." → KG writes must be best-effort. If Neo4j is unreachable, the analyst still finishes the engagement; the writes get queued or dropped (with a logged warning).
+- **(langchain-middleware)** "Skip checkpointer requirement for HITL" is impossible. Engagement state hydration in `before_agent` must tolerate the case where there's no checkpointer (e.g. one-shot benchmarks).
+
+---
+
+## 6. Three options for user review
+
+| Option | KG surface (what the LLM sees) | KGMiddleware does | Code surface | Risk |
+|---|---|---|---|---|
+| **A. Spec-as-written** | 8 tools (`kg_query`, `kg_neighbors`, `kg_stats`, `kg_add_node`, `kg_add_edge`, `kg_ingest`, `kg_plan_chains`, `kg_promote_chain`) | Own store, build_tools, before_agent summary, wrap_tool_call scope, after_model revision | ~2,500 LOC new + retire `tools/research/` per migration table | Medium. Familiar OPPLAN-mirror pattern but high tool count for the analyst. |
+| **B. Hybrid (read-off, write-on, summary-in-prompt)** | 3 tools (`kg_add_node`, `kg_add_edge`, `kg_ingest`). No read tools — LLM uses `grep findings/` + `bash("cypher-shell ... 'MATCH path = ...'")` when it needs path planning. | Own store, summary block in `wrap_model_call`, optional `after_model` file→KG projection (re-confirm with user per Q2), wrap_tool_call scope. | ~1,500 LOC new. Smaller tool surface = simpler prompt rewrite. | Lower. Aligns with Letta-style file-system result. Loses LLM-driven path planning unless the summary block surfaces top-N chains. |
+| **C. File-first, KG-as-projection** | 0 tools. LLM works only in files. Middleware silently reads new findings files and projects them into Neo4j after each turn. The web dashboard `engagements/[id]/graph` keeps working. | Own store. `after_model` parses any newly-written `findings/*.md` (front-matter or JSON sidecar). Summary block from KG in `wrap_model_call`. | ~800 LOC new. No tool factory at all. | Highest reframe but lowest tool-surface cost. Requires explicit user override of 2026-06-03 "no auto-ingest" directive (Q2). Web dashboard still gets data because the middleware writes; the LLM is unaware. |
+
+### What each option means for the next 2-3 weeks of work
+
+- **A**: PR-A (foundations) → PR-B (middleware) → PR-C (analyst cutover) → PR-D (cleanup). 4 PRs, all spec-as-written. Risk: analyst prompt has to keep its KG-centric procedure, but the broken backend is gone.
+- **B**: PR-A (foundations same) → PR-B (smaller middleware, 3 tools + summary block) → PR-C (analyst prompt **substantial rewrite**: drop kg_query/kg_neighbors from prompt, add "use grep findings/" + "the chain block above shows current candidates"). Spec § 4.5 tool list reduced from 8 to 3. The 12-ingester dispatch still collapses into `kg_ingest`.
+- **C**: PR-A (foundations same) → PR-B (KGMiddleware that reads files in `after_model` and writes nodes — front-matter or sidecar `.json` defines the node structure) → PR-C (analyst prompt **minimal change**: remove KG section entirely, the prompt only knows about files). LLM ground-truth becomes the files; KG is the "compiled" view for the web dashboard and CART.
+
+---
+
+## 7. What's still pending (external docs research)
+
+Background agent is fetching the following and will append to `docs/design/2026-06-03-external-docs-research.md`:
+
+1. LangChain `AgentMiddleware` latest API (verify `self.tools` attribute, hook signatures, tool-specific scoping).
+2. LangGraph `BaseStore` shape — confirm graph-shape mismatch.
+3. DeepAgents `MemoryMiddleware` + `Store` interplay — confirm `KGMiddleware` composes cleanly with the built-ins.
+4. Neo4j Python driver `session.execute_write` + retry semantics. Verify `CREATE RANGE INDEX FOR (n:Label) ON (n.a, n.b)` for 5.24 (research notes claim it but no live verification yet).
+5. BloodHound CE 2026 / Cartography sync / Graphiti / Cognee patterns — borrow what's borrowable.
+
+When that lands, this doc will get a § 8 ("External docs findings") and may flip the recommendation in § 6.
+
+---
+
+## 8. Decision points for user review
+
+Please pick one of A / B / C in §6 (or describe a D the research missed), then confirm or revise the Q1–Q5 answers in §4:
+
+- **Q1**: Which KG-unique capabilities matter most (chain planning, dedup, cross-agent correlation, vector recall)?
+- **Q2**: Is file→KG auto-projection (after the agent writes a file) different enough from "silent ingest" to allow?
+- **Q3**: Willing to rewrite `analyst.md` substantially (Option B/C) vs. preserving it (Option A)?
+- **Q4**: Run the 16-agent parallel-write stress test in PR-A?
+- **Q5**: Ship the vector-index schema in PR-A even if we don't use it yet?
+
+Once decided, this doc gets the § 9 ("Implementation plan, post-review") added and PR-A starts on `feat/kg-middleware`.
+
+---
+
+## 9. Post-decision minimal design (Option B confirmed, 2026-06-03)
+
+User chose Option B. Directive: "꼭 필요한 기능/필수적인 기능, 도구만 포함." Re-applying the consolidation + architectural-reduction principles to push the tool surface to the absolute minimum.
+
+### 9.1 Why 3 tools (the original Option B count) is still too many
+
+`kg_add_node` and `kg_add_edge` as separate tools force the agent to chain 2-5 tool calls for a single observation. Example: "Host 10.0.0.1 runs nginx 1.18 on port 80":
+
+| With `kg_add_node` + `kg_add_edge` separately | Cognitive cost |
+|---|---|
+| 1. `kg_add_node("host", "10.0.0.1", {...})` → returns `host_id` | 1 turn |
+| 2. `kg_add_node("service", "10.0.0.1:80", {...})` → returns `svc_id` | 1 turn |
+| 3. `kg_add_edge(host_id, svc_id, "HOSTS", 0.5)` | 1 turn |
+| 4. (optionally repeat for Vulnerability) | 1 turn |
+
+That's **3-4 turns to record one finding**. Each turn carries:
+- Tool selection overhead (which of `kg_add_node` / `kg_add_edge` / `kg_ingest`).
+- Round-trip to the model.
+- Risk of mismatched IDs.
+
+The tool-design skill calls this out directly: "Consolidation reduces token consumption … reduces tool selection complexity by shrinking the effective tool set."
+
+### 9.2 The 2-tool minimum
+
+**T1: `kg_record(observations: list[dict])`** — atomic batch write of nodes AND their outgoing edges in a single call.
+
+```python
+# Tool signature (shape; final types refined in PR-B)
+@tool
+def kg_record(observations: str) -> str:
+    """Record one or more graph observations atomically.
+
+    Each observation is one node, optionally with outgoing edges. The
+    middleware injects the engagement scope; the deterministic key
+    ensures dedup across multiple agents writing the same host /
+    service / vuln. All observations in one call land in one Neo4j
+    transaction — partial failure rolls back the batch.
+
+    WHEN TO USE: every time you observe an asset, vulnerability, credential,
+    entrypoint, or want to connect existing nodes. One call per logical
+    observation (a host + its services + its vulns).
+
+    OBSERVATION SHAPE (JSON):
+      {
+        "kind": "host" | "service" | "vulnerability" | "credential" | ...,
+        "label": "10.0.0.1",
+        "key": "host::10.0.0.1",        # deterministic dedup
+        "props": {"ip": "10.0.0.1", "explored": false, ...},
+        "edges_out": [
+          {"to_key": "service::10.0.0.1:80", "kind": "HOSTS", "weight": 0.5}
+        ]
+      }
+
+    BATCHING: send 1-10 observations per call. >10 → use kg_ingest with
+    a scanner adapter.
+
+    Returns: JSON {"created": N, "merged": M, "edges": E, "revision": "..."}.
+    """
+```
+
+Why this shape:
+- **Single tool for the write surface.** Aligns with consolidation principle (tool-design skill).
+- **Atomic batch.** The "host + its services + its vulns" cluster lands in one transaction. Either all of it persists, or none — partial inserts on a transient Neo4j error are the worst kind of bug.
+- **Forces deterministic key.** `props["key"]` is mandatory for dedup. Eliminates the broken-shim era's accidental duplicate-on-rescan.
+- **Edges expressed inline.** No separate edge-call dance. The agent thinks "this host has these services" and writes that as the natural payload shape.
+- **No node-id return.** The deterministic key IS the id. The agent never holds a transient node-id between calls.
+
+**T2: `kg_ingest(scanner_kind: str, path: str)`** — scanner output dispatch.
+
+```python
+@tool
+def kg_ingest(scanner_kind: str, path: str) -> str:
+    """Ingest a scanner output file into the engagement graph.
+
+    SUPPORTED scanner_kinds (registry-backed; plugins can add more
+    via the decepticon.kg.ingesters entry-point group):
+      nmap_xml, nuclei_jsonl, subfinder, httpx_jsonl, dnsx, katana,
+      masscan, ffuf, testssl, crackmapexec, asrep_hashes, sarif.
+
+    WHEN TO USE: after running any of the above scanners and saving
+    output to a file. The adapter parses the structured output and
+    merges nodes + edges in one transaction.
+
+    Returns: JSON {"ingested": N, "scanner": "...", "revision": "..."}.
+    """
+```
+
+Why this stays as a separate tool from `kg_record`:
+- Different mental model (file path vs. inline observations).
+- Different cost profile (one file → potentially hundreds of nodes).
+- Different failure modes (file-not-found, parse error vs. validation error).
+
+### 9.3 What we explicitly did NOT add
+
+| Considered | Decision | Reason |
+|---|---|---|
+| `kg_add_node` + `kg_add_edge` as separate tools | ❌ Drop | Forces 3-4 turns per observation; `kg_record` does the same in 1 turn. |
+| `kg_query` | ❌ Drop | Agent uses `grep findings/` for recall + summary block in prompt. Cypher details via `bash("cypher-shell ...")` if needed. |
+| `kg_neighbors` | ❌ Drop | Same as above. Edge walks are bash + cypher-shell for analyst's rare deep-dive case. |
+| `kg_stats` | ❌ Drop | The summary block (wrap_model_call) always shows stats. A tool that returns "current stats" duplicates that. |
+| `kg_backend_health` | ❌ Drop | The middleware fails fast at boot if Neo4j is down. No reason for the agent to check. |
+| `kg_plan_chains` | ❌ Drop | Pushed into the summary block — middleware computes top-3 chain candidates each turn and shows them. Agent NEVER calls a planner tool; the planner output is part of context. |
+| `kg_promote_chain` | ❌ Drop | When the agent decides to act on a chain, it writes a `findings/CHAIN-NNN.md`. The middleware projects that file (Q2 = open question). If Q2 = no, then we add `kg_record` with a `kind="chain"` observation — but no new tool. |
+
+**Tool count: 2.** Down from spec's 8, down from earlier Option B's 3.
+
+### 9.4 What the middleware does (the actual workflow)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  before_agent(state, runtime)                                   │
+│    1. Hydrate engagement from state.engagement_name             │
+│    2. Set kg_engagement state field                             │
+│    3. Fetch store.revision(engagement=...) → cache              │
+│    4. If revision changed since last turn OR first turn:        │
+│       compute summary_block via summary.build(store, engagement)│
+│       and stash in state.kg_summary                             │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  wrap_model_call(request, handler)                              │
+│    Inject TWO content blocks into system message:               │
+│                                                                 │
+│    [static cache_control=ephemeral]                             │
+│    KG_SYSTEM_PROMPT — "your graph memory is durable. write     │
+│    findings to findings/FIND-NNN.md and call kg_record for     │
+│    structured asset/vuln observations. the chain candidates    │
+│    below are computed each turn from the current graph."       │
+│                                                                 │
+│    [dynamic]                                                    │
+│    KG STATE (engagement=XYZ):                                   │
+│    • Top vulns (3): SSTI in /search [CRITICAL] · SQLi … · …     │
+│    • Open entrypoints (2): https://app.example.com:443/ · …    │
+│    • Chain candidates (top 3): entry→vuln→creds→admin (cost 1.8)│
+│    • Crown jewels: domain_admin (1 path), payments_db (0 paths) │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+                       (LLM generates tool call)
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  wrap_tool_call(request, handler)                               │
+│    If tool.name in {"kg_record", "kg_ingest"}:                  │
+│      Validate state.kg_engagement is set (refuse otherwise)     │
+│      Otherwise: pass through unchanged                          │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  after_model(state, runtime)                                    │
+│    If a kg_record / kg_ingest call ran this step:               │
+│      mark state.kg_revision = "dirty"  (forces re-fetch next    │
+│      turn → fresh summary block)                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Critical:** the summary block IS the read interface. The agent never calls a "read tool" — the graph state is always already in the system prompt, cached when unchanged, fresh when changed.
+
+### 9.5 Summary block — what to include (minimal)
+
+Per memory-systems anti-pattern "stuffing everything into context," the dynamic block has hard limits:
+
+| Section | Max items | Source |
+|---|---:|---|
+| Top high-severity vulnerabilities | 5 | `MATCH (v:Vulnerability {engagement: $e}) WHERE v.severity IN ['critical','high'] RETURN v ORDER BY v.score DESC LIMIT 5` |
+| Unexplored entrypoints | 3 | `MATCH (e:Entrypoint {engagement: $e}) WHERE NOT (e)-[:HAS_VULN]->() RETURN e LIMIT 3` |
+| Chain candidates | 3 | `chain.plan_chains(...)` (existing good-pattern code in `chain.py`), top-3 by cost |
+| Crown jewels with status | unlimited | One line each. `MATCH (c:CrownJewel {engagement: $e}) OPTIONAL MATCH p=(:Entrypoint)-->...->(c) RETURN c, count(p)` |
+| Stats line | 1 | `nodes: N · edges: E · last_updated: ISO` |
+
+Estimated dynamic block: **15-25 lines of markdown**. Compares to the broken backend's per-`kg_stats` call returning the whole node count tree.
+
+### 9.6 PR plan (revised, 4 atomic commits per PR, 3 PRs total)
+
+**PR-A — Foundations (~600 LOC)**
+
+1. `feat(kg): add AttackGraphProtocol contract in runtime/cart` — Protocol + isinstance test
+2. `feat(kg): add KGStore with per-op execute_write/read` — `middleware/kg_internal/store.py`. Methods: `revision`, `record_observations`, `ingest_via_adapter`, `find_vulns_by_severity`, `find_open_entrypoints`, `find_crown_jewels`, `count_paths_to`. All require explicit `engagement=` kwarg.
+3. `feat(kg): composite range indexes + V002 migration + vector schema placeholder` — `kg_internal/migrations/V002__engagement_composite_indexes.cypher`. Schema for future vector index (Vulnerability.embedding property + vector index) lands now, no embed pipeline.
+4. `test(kg): integration test for KGStore against compose Neo4j` — 16-agent parallel-write stress test in this same PR (Q4 = yes).
+
+**PR-B — Middleware + 2 tools (~700 LOC)**
+
+5. `feat(kg): KGState schema + summary block builder` — `kg_internal/summary.py`. Returns a static block + dynamic block (the 5-section table from §9.5).
+6. `feat(kg): scanner adapter registry + 12 built-in adapters` — `kg_internal/ingest.py`. Plugin authors register via `decepticon.kg.ingesters` entry-point.
+7. `feat(kg): kg_record + kg_ingest tools` — `kg_internal/tools.py`. `build_kg_tools(store)` factory.
+8. `feat(kg): KGMiddleware wires state + tools + 4 lifecycle hooks` — `middleware/kg.py`. Mirrors `OPPLANMiddleware` shape.
+
+**PR-C — Agent cutover + prompt rewrite (~400 LOC)**
+
+9. `feat(kg): MiddlewareSlot.KG + SLOTS_PER_ROLE adoption` — `decepticon_core.contracts.slots`. Analyst gets the slot.
+10. `refactor(kg): analyst.py drops direct RESEARCH_TOOLS imports` — middleware provides them.
+11. `docs(prompts): analyst.md rewrites the KG_DISCIPLINE block` — drops `kg_query`/`kg_neighbors` references. Replaces with "the chain candidates above are computed each turn; call `kg_record` to observe; use `grep findings/` to recall older details; use `bash('cypher-shell ...')` for advanced graph queries."
+12. `test(integration): analyst e2e against compose Neo4j` — full workflow: observe host → record → check summary block updates → record chain → verify web-dashboard read works.
+
+**PR-D (post-cutover) — Retire `tools/research/` per the existing spec migration table.** Same as the original spec.
+
+### 9.7 Pending external research
+
+Background agent's findings (`docs/design/2026-06-03-external-docs-research.md`) will inform:
+
+- Final `kg_record` signature shape (does `langchain_core.tools` 2026 prefer `Annotated[list[dict], InjectedState]` for observations, or stringified JSON like opplan?).
+- Whether DeepAgents' `MemoryMiddleware` Store-mode could carry the engagement summary cache (or if KGMiddleware owns it).
+- BloodHound CE 2026's writer-coordination pattern — informs the 16-agent stress test threshold.
+
+The above is **PR-A's design**, not final implementation. PR-A may need minor adjustments after the external research lands.
+
+### 9.8 Decision asks (need answers before PR-A code starts)
+
+1. **Confirm 2-tool surface (`kg_record` + `kg_ingest`)** — anything missing that the analyst REALLY needs?
+2. **Q2 (still open):** auto file→KG projection on `findings/FIND-NNN.md` write? If yes, `kg_record` becomes optional. If no, `kg_record` is the only structured-observation surface.
+3. **Q5 vector schema** — confirm shipping `Vulnerability.embedding` property + Neo4j vector index in PR-A's V002 migration (cheap, no embed pipeline yet).
+4. **Chain promotion path** — if a chain candidate looks promising, the agent should:
+   - (a) write `findings/CHAIN-NNN.md` and let the middleware project it, OR
+   - (b) call `kg_record({"kind": "chain", ...})` explicitly.
+   Pick one.
+
+---
+
+## 10. External docs findings → §9 design adjustments (final pre-implementation pass)
+
+External research completed (see `docs/design/2026-06-03-external-docs-research.md`, 425 lines). Five findings change § 9 details — the **2-tool surface and the workflow shape do not change**, but specific signatures and the index migration get tightened.
+
+### 10.1 Five external findings → impact on §9
+
+| # | External finding | Impact on §9 |
+|---|---|---|
+| 1 | `AgentMiddleware` confirms `self.tools`, 6 hooks, **no per-middleware `tools=` parameter**. Tool scoping is `wrap_model_call(request) → request.override(tools=subset)`. | §9.4 workflow unchanged; for analyst's specific case we don't need runtime tool filtering (always-on KG). Subset filter is held in reserve for benchmark mode (force-disable KG). |
+| 2 | `from langgraph.prebuilt import InjectedState` (NOT `langchain_core.tools`). Open bugs #31688/#32729 — params must be in `args_schema`, LLM can silently override. LangChain pushing toward `ToolRuntime`. | §9.2 signature updated below. Use `InjectedState` (consistent with `tools/opplan.py`) but pin the engagement field with a defensive cross-check in `wrap_tool_call` so an LLM-override can't escape engagement scope. |
+| 3 | `BaseStore` cannot represent edges. | §9 already decided this (KGStore is direct API). Re-confirmed. |
+| 4 | APOC dijkstra stays. Composite index: `CREATE INDEX name IF NOT EXISTS FOR (n:Label) ON (n.a, n.b)`. Vector index: `CREATE VECTOR INDEX name IF NOT EXISTS FOR (n:Label) ON (n.embedding) OPTIONS {...}`. | §9.6 PR-A.3 migration content finalized in §10.4 below. |
+| 5 | Adopt **Cartography's `update_tag` + `firstseen` + `lastupdated`** + **Graphiti's `created_by` + `source_episode_id`** for provenance. | §9.2 signature gets 3 mandatory provenance fields. `before_agent` gains a stale-node cleanup pass. Big — this is the main §9 update. |
+
+### 10.2 Updated `kg_record` signature (with provenance, minimal)
+
+```python
+# kg_internal/tools.py
+from typing import Annotated
+from langgraph.prebuilt import InjectedState
+from langchain_core.tools import tool, InjectedToolCallId
+
+@tool
+def kg_record(
+    observations: str,                                  # JSON list, see shape below
+    *,
+    state: Annotated[dict, InjectedState],              # engagement, run_id pulled from here
+    tool_call_id: Annotated[str, InjectedToolCallId],   # used as source_episode_id
+) -> str:
+    """Record one or more graph observations atomically.
+
+    The middleware injects engagement scope and provenance — you only
+    pass the observations. All observations in one call land in one
+    Neo4j transaction; partial failure rolls back the batch.
+
+    OBSERVATION SHAPE (JSON):
+      {
+        "kind": "host" | "service" | "vulnerability" | "credential" | ...,
+        "label": "10.0.0.1",
+        "key": "host::10.0.0.1",        # deterministic dedup
+        "props": {"ip": "10.0.0.1", "explored": false, ...},
+        "edges_out": [
+          {"to_key": "service::10.0.0.1:80", "kind": "HOSTS", "weight": 0.5}
+        ]
+      }
+
+    AUTO-INJECTED on every node and edge (do NOT set yourself):
+      engagement, firstseen, lastupdated, created_by (= agent name from
+      state.role), source_episode_id (= this tool_call_id).
+
+    Returns: JSON {"created": N, "merged": M, "edges": E, "revision": "..."}.
+    """
+```
+
+Why three provenance fields are the minimum:
+- **`firstseen` + `lastupdated`** — Cartography's stale-cleanup pattern. Without them, `before_agent` can't prune nodes that no agent has touched in N hours. Without that pruning, the graph grows unbounded (memory-systems anti-pattern §5).
+- **`created_by`** — debug answer to "who wrote this node?" One field, one int from `state.role` (e.g. `"analyst"`). Costs nothing, saves hours when finding-provenance disputes happen.
+- **`source_episode_id`** — Graphiti pattern. Just the `tool_call_id`. Lets us answer "which agent turn produced this node?" Already free (the runtime gives it).
+
+Skipped (over-engineering per the user's directive):
+- `created_at_phase` (OPPLAN phase) — OPPLAN may not be in scope for every engagement.
+- bi-temporal `valid_from` / `valid_until` (Graphiti-style) — adds 2 fields and an entire query path that nobody asked for. Defer until temporal-validity actually shows up in a user story.
+
+### 10.3 `kg_ingest` keeps its scanner_kind dispatcher (unchanged from §9), but inherits the same provenance auto-injection
+
+The adapter functions internally call `store.upsert_node(...)` and `store.upsert_edge(...)`; both now take an `update_tag: int` and read `state.role` + `tool_call_id` from the middleware. The adapter doesn't see provenance directly.
+
+### 10.4 Final V002 migration content (PR-A.3)
+
+```cypher
+-- V002__engagement_composite_indexes_and_provenance.cypher
+
+-- 4.1 Composite range indexes (research §3, §7; verified Neo4j 5.24 syntax)
+CREATE INDEX engagement_host_explored IF NOT EXISTS
+  FOR (h:Host) ON (h.engagement, h.explored);
+CREATE INDEX engagement_vuln_severity IF NOT EXISTS
+  FOR (v:Vulnerability) ON (v.engagement, v.severity);
+CREATE INDEX engagement_finding_status IF NOT EXISTS
+  FOR (f:Finding) ON (f.engagement, f.status);
+CREATE INDEX engagement_entrypoint IF NOT EXISTS
+  FOR (e:Entrypoint) ON (e.engagement);
+CREATE INDEX engagement_crown_jewel IF NOT EXISTS
+  FOR (c:CrownJewel) ON (c.engagement);
+
+-- 4.2 Provenance indexes (Cartography + Graphiti pattern)
+CREATE INDEX node_lastupdated IF NOT EXISTS
+  FOR (n:Vulnerability) ON (n.engagement, n.lastupdated);
+CREATE INDEX node_created_by IF NOT EXISTS
+  FOR (n:Vulnerability) ON (n.engagement, n.created_by);
+
+-- 4.3 Future vector index (NO embed pipeline yet — schema-only, opt-in at runtime)
+-- This creates the index. The Vulnerability.embedding property is left null
+-- until a future KGMiddleware(embed_findings=True) flag turns on the pipeline.
+CREATE VECTOR INDEX vuln_embedding IF NOT EXISTS
+  FOR (v:Vulnerability) ON (v.embedding)
+  OPTIONS {
+    indexConfig: {
+      `vector.dimensions`: 1536,
+      `vector.similarity_function`: 'cosine'
+    }
+  };
+```
+
+(Q5 = yes: ship the vector index schema in PR-A. No pipeline cost.)
+
+### 10.5 New `before_agent` responsibility — stale-node cleanup (Cartography pattern)
+
+```
+before_agent(state, runtime):
+    # ... existing engagement hydration ...
+
+    # NEW: stale-node cleanup. Cheap, scoped, opt-in via KG_STALE_TTL_HOURS env.
+    ttl_hours = int(os.environ.get("KG_STALE_TTL_HOURS", "0"))
+    if ttl_hours > 0:
+        cutoff = int(time.time()) - ttl_hours * 3600
+        store.delete_stale(engagement=eng, before_unix=cutoff)
+        # Implemented as: MATCH (n {engagement: $eng}) WHERE n.lastupdated < $cutoff DETACH DELETE n
+```
+
+Default `KG_STALE_TTL_HOURS=0` → off. SaaS deployments set it; OSS opt-in.
+
+### 10.6 Defense against `InjectedState` override bug
+
+External finding #2: LangChain bugs #31688/#32729 — LLM can sometimes override an `InjectedState` field if the param exists in `args_schema`. Mitigation in `KGMiddleware.wrap_tool_call`:
+
+```python
+def wrap_tool_call(self, request, handler):
+    if request.tool and request.tool.name in {"kg_record", "kg_ingest"}:
+        # Defense in depth: even if InjectedState got overridden by the LLM,
+        # the engagement we enforce here is the one from state, not from
+        # the tool args. The adapter inside the tool re-pulls engagement
+        # via runtime instead of trusting the args dict.
+        eng = (request.state or {}).get("kg_engagement")
+        if not eng:
+            return ToolMessage(
+                content=json.dumps({"error": "kg_engagement unset"}),
+                tool_call_id=request.tool_call.id, name=request.tool.name,
+            )
+    return handler(request)
+```
+
+The actual store calls receive `engagement=eng` from middleware, never from the LLM-provided args. Layer #2 defense.
+
+### 10.7 Updated PR-A code surface (concrete file list)
+
+```
+packages/decepticon/decepticon/middleware/kg_internal/
+  __init__.py
+  store.py                   # KGStore (per-op execute_write/read, engagement-mandatory)
+  migrations/
+    V001__initial_schema.cypher           # extracted from Neo4jStore.ensure_schema
+    V002__engagement_composite_indexes_and_provenance.cypher
+  migration_runner.py        # invokes migrations on first boot
+
+packages/decepticon/decepticon/runtime/cart.py
+  # add AttackGraphProtocol(Protocol) — fills the docstring vaporware
+
+packages/decepticon/tests/integration/kg/
+  test_kgstore_record.py     # observations round-trip
+  test_kgstore_ingest.py     # 12 scanner adapters
+  test_kgstore_parallel.py   # 16-agent stress test (Q4)
+  test_attack_graph_protocol.py
+```
+
+Estimated PR-A: **~600 LOC + ~400 LOC tests**. Smaller than spec's earlier estimate because `kg_record`'s atomic-batch shape means fewer separate code paths.
+
+### 10.8 Updated decision asks (final, pre-PR-A)
+
+1. **2-tool surface (`kg_record` + `kg_ingest`)** confirmed by user 2026-06-03. ✓
+2. **Q2 (auto file→KG projection)** — still open. Recommendation: **defer to PR-B**. PR-A only ships the KGStore + index + provenance. PR-B's `KGMiddleware.after_model` can opt-in to file projection via a `project_findings_files=True` flag. Default off in PR-A/B; flip to default-on in PR-C if benchmarks show the analyst forgets to `kg_record` after a file write.
+3. **Q5 vector schema** — recommendation **ship now in V002** (zero pipeline cost). ✓ (assumed unless user objects)
+4. **Chain promotion path** — recommendation **(a): write `findings/CHAIN-NNN.md`**. Reasons: keeps the chain documented for the operator; if Q2 projection lands later, the chain auto-projects. The graph's `AttackPath` node is computed lazily by `chain.plan_chains` and shown in the summary block — no agent-side tool call needed.
+5. **Provenance fields** — `firstseen`, `lastupdated`, `created_by`, `source_episode_id`. Confirm minimal sufficient?
+6. **Stale-node TTL** — default off (`KG_STALE_TTL_HOURS=0`). OK?
+
+If items 5 and 6 are confirmed (and 2 deferred / 3 yes / 4 = a), PR-A coding starts: AttackGraphProtocol → KGStore → V001+V002 migrations → integration tests. No tool work in PR-A; that's PR-B.
+

--- a/packages/decepticon-core/decepticon_core/contracts/slots.py
+++ b/packages/decepticon-core/decepticon_core/contracts/slots.py
@@ -36,6 +36,7 @@ class MiddlewareSlot(StrEnum):
     FILESYSTEM = "filesystem"
     SUBAGENT = "subagent"
     OPPLAN = "opplan"
+    KG = "kg"
     EVENT_LOG = "event-log"
     SANDBOX_NOTIFICATION = "sandbox-notification"
     BUDGET = "budget"
@@ -159,7 +160,12 @@ SLOTS_PER_ROLE: dict[str, frozenset[MiddlewareSlot]] = {
     "recon": _BASH_AGENT_SLOTS,
     "exploit": _BASH_AGENT_SLOTS,
     "postexploit": _BASH_AGENT_SLOTS,
-    "analyst": _BASH_AGENT_SLOTS,
+    # Analyst is the only OSS role that runs the KG middleware — its
+    # workflow is the persistent-graph use case the spec calls out
+    # (docs/design/2026-06-03-kg-middleware-redesign.md § 4.10).
+    # ad_operator and contract_auditor stayed narrow in the prior
+    # cutover; their KG slot adoption is a follow-up.
+    "analyst": _BASH_AGENT_SLOTS | {MiddlewareSlot.KG},
     "reverser": _BASH_AGENT_SLOTS,
     "contract_auditor": _BASH_AGENT_SLOTS,
     "cloud_hunter": _BASH_AGENT_SLOTS,

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -40,6 +40,7 @@ from decepticon.agents._benchmark_mode import benchmark_skill_sources
 from decepticon.middleware import (
     EngagementContextMiddleware,
     FilesystemMiddleware,
+    KGMiddleware,
     OPPLANMiddleware,
     RoEEnforcementMiddleware,
     SkillsMiddleware,
@@ -164,6 +165,31 @@ def _make_subagent(*, backend: Any, subagents: list | None = None, **_: Any):
 
 def _make_opplan(*, backend: Any, **_: Any):
     return OPPLANMiddleware(backend=backend)
+
+
+def _make_kg(**_: Any):
+    """Conditional slot — returns None when the KGStore can't be built.
+
+    Mirrors :func:`_make_model_fallback`: the agent factory keeps
+    building, the KG slot is just absent for that run. Operators see
+    a single warning identifying which env var or driver call failed.
+
+    Agent factory call sites import analyst.py at module load to build
+    the LangGraph platform graph (`if is_bundle_enabled("standard"):
+    graph = create_analyst_agent()`); raising here would block every
+    dev box and CI runner that doesn't have Neo4j env vars set, even
+    for pytest invocations that never touch the KG path.
+    """
+    from decepticon.middleware.kg_internal.store import (
+        KGStoreConfigError,
+        KGStoreUnavailableError,
+    )
+
+    try:
+        return KGMiddleware()
+    except (KGStoreConfigError, KGStoreUnavailableError) as exc:
+        logging.getLogger(__name__).warning("KG slot skipped: %s", exc)
+        return None
 
 
 def _make_sandbox_notification(*, sandbox: Any = None, **_: Any):
@@ -312,6 +338,7 @@ DEFAULT_SLOT_FACTORIES: dict[MiddlewareSlot, SlotFactory] = {
     MiddlewareSlot.FILESYSTEM: _make_filesystem,
     MiddlewareSlot.SUBAGENT: _make_subagent,
     MiddlewareSlot.OPPLAN: _make_opplan,
+    MiddlewareSlot.KG: _make_kg,
     MiddlewareSlot.EVENT_LOG: _make_event_log,
     MiddlewareSlot.SANDBOX_NOTIFICATION: _make_sandbox_notification,
     MiddlewareSlot.BUDGET: _make_budget,

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -187,7 +187,12 @@ def _make_kg(**_: Any):
 
     try:
         return KGMiddleware()
-    except (KGStoreConfigError, KGStoreUnavailableError) as exc:
+    except (KGStoreConfigError, KGStoreUnavailableError, ImportError) as exc:
+        # ImportError covers the case where the optional ``neo4j``
+        # driver isn't installed in the env that imports analyst.py
+        # (e.g. CI runners that ship the framework wheel without the
+        # KG runtime deps but still load module-level
+        # ``graph = create_analyst_agent()``).
         logging.getLogger(__name__).warning("KG slot skipped: %s", exc)
         return None
 

--- a/packages/decepticon/decepticon/agents/prompts/standard/analyst.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/analyst.md
@@ -3,42 +3,53 @@ You are the Decepticon Analyst — a vulnerability research specialist whose job
 to find HIGH-IMPACT bugs: 0-days, N-days with live exploitability, and multi-step
 exploit chains that escalate low/medium findings into critical impact. You do not
 run black-box scans and call it a day. You read source, diff versions, run static
-analysis, run fuzzers, correlate CVEs, and build a structured knowledge graph that
-future iterations can reason about.
+analysis, run fuzzers, correlate CVEs, and persist your findings into a
+shared knowledge graph that the next iteration can reason about.
 
 Your operating loop is:
   1. ENUMERATE   — What assets, sources, dependencies, and entrypoints exist?
-  2. GROUND      — Load ground truth from the knowledge graph (`kg_stats`, `kg_query`).
+  2. GROUND      — The KG STATE block above already shows current vulns,
+                   open entrypoints, chain candidates, and crown jewels.
+                   Skim it first; you almost never need to call a read tool.
   3. HUNT        — Pick the highest-yield hunting lane (taint audit, fuzz,
                    dependency CVE sweep, diff silent patches, source review).
-  4. PERSIST     — Record every observation as a node/edge in the graph.
-  5. CHAIN       — Call `plan_attack_chains` to surface the cheapest paths
-                   from entrypoints to crown jewels. Promote promising chains.
-  6. VALIDATE    — Build a minimal PoC and call `validate_finding` to confirm
-                   exploitability with Zero-False-Positive controls.
+  4. PERSIST     — Record every observation as a structured node + outgoing
+                   edges via `kg_record`. Bulk-ingest scanner outputs via
+                   `kg_ingest("scanner_kind", "path")`.
+  5. CHAIN       — Look for entrypoint → vuln → cred → admin-level paths in
+                   the KG STATE block; the middleware computes path counts
+                   per crown jewel each turn.
+  6. VALIDATE    — Build a minimal PoC, run it inside the sandbox, capture
+                   the success + negative-control evidence. Record the
+                   validated finding via `kg_record` with `kind="Finding"`
+                   and `props={"status": "confirmed", "cvss": "..."}`.
   7. REPORT      — Emit a structured finding file with CVSS, evidence, and
-                   exploitation steps.
+                   exploitation steps. Use the REPORTING_TOOLS surface for
+                   HackerOne / Bugcrowd / SARIF artefacts where applicable.
 </IDENTITY>
 
 <CRITICAL_RULES>
-- Everything you discover MUST be written into the knowledge graph. Isolated
-  findings in free text are forgotten at the next Ralph iteration.
-- NEVER claim a finding is exploitable without a validated PoC. Use
-  `validate_finding` with success + negative patterns.
+- Every meaningful observation MUST land in the knowledge graph via
+  `kg_record` (or `kg_ingest` for scanner output). Free-text notes are
+  forgotten at the next iteration; the graph survives.
+- NEVER claim a finding is exploitable without a validated PoC. Run the
+  exploit attempt inside the sandbox and capture success + negative-control
+  signals before promoting to a `Finding` node with `status="confirmed"`.
 - CVSS without a vector string is marketing. Always provide the full vector
-  when validating, even for medium findings.
+  in the props when you upgrade a Vulnerability to a Finding.
 - Prefer DEPTH over BREADTH. Five validated highs beat fifty unconfirmed
   mediums. Your score is measured in confirmed critical chains.
 - Stay in scope. Re-read `roe.json` at the start of every iteration.
-- The chain planner only works if you add ENTRYPOINT and CROWN_JEWEL nodes
-  explicitly. A bag of vuln nodes with no goals produces zero chains.
+- The chain candidates in the KG STATE block only surface when you have
+  added ENTRYPOINT and CROWN_JEWEL nodes explicitly. A bag of vuln nodes
+  with no goals produces zero chains.
 </CRITICAL_RULES>
 
 <HUNTING_LANES>
 Pick whichever lane offers the highest expected value for the current target.
 Do NOT run them all in parallel on the first iteration — each lane has setup
 cost and converges better when you commit to two or three at a time and read
-the graph between them.
+the updated KG STATE block between them.
 
 ## Lane A — Source-level taint audit
 Use when the target ships source (open-source, leaked, or in-scope repo).
@@ -47,19 +58,26 @@ Use when the target ships source (open-source, leaked, or in-scope repo).
 2. Load the language-specific skill under `/skills/standard/analyst/<vuln-class>/SKILL.md`
    (sqli, ssrf, idor, deserialization, ssti, xxe, proto-pollution, prompt-injection).
 3. Run `semgrep --sarif --config auto /workspace/src -o /workspace/semgrep.sarif`.
-4. Ingest with `kg_ingest_sarif("/workspace/semgrep.sarif", "semgrep")`.
-5. Review highs/criticals: `kg_query(kind="vulnerability", min_severity="high")`.
-6. Manually audit each hit's source context to confirm reachability.
-7. For each confirmed taint path, add a hypothesis node and chain edges.
+4. Ingest with `kg_ingest("sarif", "/workspace/semgrep.sarif")` — the
+   adapter creates Vulnerability + CodeLocation nodes linked via
+   `DEFINED_IN`. SARIF level → severity (error→high, warning→medium,
+   note→low).
+5. Read the KG STATE block on the next turn for "Top vulnerabilities".
+6. Manually audit each high/critical hit's source context to confirm
+   reachability. Promote confirmed taint paths via `kg_record` adding a
+   `Hypothesis` node with the taint flow.
 
 ## Lane B — Dependency CVE sweep (silent N-days)
-Use when the target has a lockfile (package-lock.json, Pipfile.lock, Cargo.lock,
-go.sum). Often yields KEV-listed exploits in minutes.
+Use when the target has a lockfile (package-lock.json, Pipfile.lock,
+Cargo.lock, go.sum). Often yields KEV-listed exploits in minutes.
 1. Parse the lockfile with `bash` (jq, grep, awk).
-2. For each package@version, call `cve_by_package(pkg, ver, ecosystem)`.
-3. Take the returned ID set, call `cve_lookup(ids)` to rank.
-4. Promote anything with `score >= 8.0` or `kev=True` into the graph as
-   `cve` + `vulnerability` nodes with `affected_by` / `runs_on` edges.
+2. For each package@version, lookup CVE intel via `bash("curl ...")`
+   against NVD / OSV. The dedicated CVE tool surface was retired in the
+   KG narrow; CVE enrichment lands via the same `kg_record` shape — a
+   `CVE` node + `AFFECTS` edge to the dependency `Service` node.
+3. Promote anything with CVSS >= 8.0 or KEV listing via `kg_record`
+   with `kind="Vulnerability"` and `props={"severity": "critical",
+   "cvss": "...", "cve_id": "...", "kev": true}`.
 
 ## Lane C — Diff silent patches (N-day forge)
 Use when the target is open-source and has git tags.
@@ -70,26 +88,40 @@ Use when the target is open-source and has git tags.
 4. Run `git show <commit>` on each. A commit that quietly adds a bounds
    check, auth check, or sanitiser is almost always fixing an un-disclosed
    bug. The pre-patch version is your N-day target.
-5. Record each candidate as a `vulnerability` node with `source="silent-patch"`.
+5. Record each candidate via `kg_record` with `kind="Vulnerability"` and
+   `props={"source": "silent-patch", "commit": "...", "severity": "..."}`.
 
 ## Lane D — Fuzz 0-day hunt
 Use when the target has a parser, deserialiser, or network protocol handler.
-1. `fuzz_classify("/workspace/src")` to get language + engine suggestion.
-2. `fuzz_harness(engine, target, entry)` to emit a starter harness.
-3. Compile (libfuzzer/cargo-fuzz) or run directly (atheris/jazzer).
-4. Run a brief smoke test, then background a longer run if clean.
-5. On crash, paste the sanitizer log into `fuzz_record_crash` — it parses
-   ASan/UBSan output and creates a vuln node with stack, file:line, severity.
-6. Triage: reproduce, minimize the input, build a PoC command.
+1. Inspect the source tree (`bash("ls /workspace/src")`) and pick a language
+   + engine: libfuzzer/afl++ for C/C++/Rust, atheris for Python, jazzer for
+   Java, cargo-fuzz for Rust crates.
+2. Write a minimal harness against the entry function (parse / decode /
+   deserialize). The fuzz harness scaffolding tool was retired in the KG
+   narrow — write the harness directly via `bash`.
+3. Run a brief smoke test, then background a longer run if clean.
+4. On crash, capture the sanitizer output and promote via `kg_record`
+   with `kind="Vulnerability"`, `props={"severity": "high", "kind":
+   "memory-corruption", "file": "...", "line": ..., "sanitizer": "asan"}`
+   plus an `edges_out` `DEFINED_IN` link to a `CodeLocation` node.
+5. Reproduce, minimize the input, build a PoC command, then validate.
 
 ## Lane E — API / web black-box with chain lens
 Use when you only have a running target (no source).
-1. Enumerate from recon findings (`kg_query(kind="service")`).
-2. Add ENTRYPOINT nodes for every reachable public URL/path.
-3. Add CROWN_JEWEL nodes for admin panels, payment flows, PII stores.
-4. Run nuclei, ffuf, sqlmap, dalfox, per-vuln skill prompts.
-5. For every hit, add a vulnerability + edge `enables` towards adjacent nodes.
-6. Call `plan_attack_chains(top_k=10)` to see which mediums combine into criticals.
+1. Read the KG STATE block for `Service` nodes recon already mapped.
+2. Add ENTRYPOINT nodes for every reachable public URL/path:
+   `kg_record([{"kind": "Entrypoint", "key": "entrypoint::<url>",
+   "label": "<url>", "props": {"scheme": "...", "host": "...",
+   "port": ...}}])`.
+3. Add CROWN_JEWEL nodes for admin panels, payment flows, PII stores
+   (same shape with `kind="CrownJewel"`).
+4. Run nuclei against the surface and ingest:
+   `bash("nuclei -u https://target -jsonl -o /workspace/nuclei.jsonl")`
+   then `kg_ingest("nuclei_jsonl", "/workspace/nuclei.jsonl")`. The
+   adapter creates Vulnerability nodes linked via `HAS_VULN` to the
+   Entrypoint.
+5. The next-turn KG STATE block will surface chain candidates — read
+   them and decide which vulns combine into a critical kill chain.
 
 ## Lane F — Trust boundary analysis (developer tools / CLI apps)
 Use when the target is a developer tool, CLI, IDE extension, or any app that
@@ -99,106 +131,158 @@ loads configuration from the current working directory.
 3. Trace env var injection: `grep -rn 'process\.env\|os\.environ' | grep -i 'command\|cmd\|exec\|proxy\|path'`.
 4. Find command execution from config: `grep -rn 'spawn\|exec\|child_process\|subprocess' | grep -i 'shell.*true\|config\|settings'`.
 5. Check plugin/tool auto-discovery: `grep -rn 'discoverTools\|loadPlugins\|mcpServers\|autoDiscover'`.
-6. For each untrusted-config → dangerous-sink path, add entrypoint → vulnerability → crown_jewel chain.
-7. Load `/skills/standard/analyst/trust-boundary/SKILL.md` for detailed patterns and PoC construction.
+6. For each untrusted-config → dangerous-sink path, record an
+   entrypoint Vulnerability + edge_out to a crown_jewel via
+   `kg_record`. Load `/skills/standard/analyst/trust-boundary/SKILL.md`
+   for detailed patterns and PoC construction.
 
 ## Lane G — Pattern exhaustion (after confirming any finding)
-Use AFTER confirming any vulnerability via `validate_finding`. The goal is to
-find all instances of the same root cause pattern across the codebase.
-1. Classify the confirmed bug's root cause (missing auth, unvalidated input, shell:true, etc.).
+Use AFTER confirming any vulnerability with a sandbox-validated PoC. The
+goal is to find all instances of the same root cause across the codebase.
+1. Classify the confirmed bug's root cause (missing auth, unvalidated
+   input, shell:true, etc.).
 2. Build a grep/semgrep pattern that matches the root cause signature.
 3. Run the search across the entire codebase.
-4. For each new instance, create a HYPOTHESIS node linked to the original finding.
-5. Verify each candidate via `validate_finding`.
-6. Stop when all instances are checked or mitigated.
-7. Load `/skills/standard/analyst/pattern-exhaustion/SKILL.md` for search patterns and exhaustion criteria.
+4. For each new instance, `kg_record` a `Hypothesis` node linked
+   (`edges_out` `DERIVED_FROM`) to the original Finding.
+5. Verify each candidate by running the PoC. Stop when all instances are
+   checked or mitigated.
+6. Load `/skills/standard/analyst/pattern-exhaustion/SKILL.md` for search
+   patterns and exhaustion criteria.
 
 ## Lane H — Bug bounty target assessment
 Use when evaluating a target for bug bounty submission.
-1. Check security advisory history: existing CVEs, GHSA credits, responsible disclosure policy.
-2. Assess trust boundary complexity: config loading, plugin systems, multi-tenancy, auth flows.
-3. Check bounty program scope: `bounty_scope_check(target, vuln_class, excluded_classes=...)`.
-4. Prioritize targets with high download count / star count and complex trust boundaries.
-5. Load `/skills/standard/analyst/bounty-hunting/SKILL.md` for the full methodology.
+1. Check security advisory history: existing CVEs, GHSA credits,
+   responsible disclosure policy.
+2. Assess trust boundary complexity: config loading, plugin systems,
+   multi-tenancy, auth flows.
+3. Check bounty program scope with the REPORTING_TOOLS surface
+   (`report_hackerone`, `report_sarif`) — the dedicated `bounty_*`
+   scoping tools were retired; consult the program brief via `bash`
+   and validate in-scope before writing reports.
+4. Prioritize targets with high download count / star count and complex
+   trust boundaries.
+5. Load `/skills/standard/analyst/bounty-hunting/SKILL.md` for the full
+   methodology.
 </HUNTING_LANES>
 
-<KNOWLEDGE_GRAPH_DISCIPLINE>
-The knowledge graph is your memory across iterations. Every meaningful
-observation MUST become a node.
+<KNOWLEDGE_GRAPH>
+The knowledge graph is a persistent attack-graph the KGMiddleware
+manages. **You see the current graph state in every system prompt as a
+"KG STATE" block** — that is the read interface. You only call write
+tools.
+
+Two write tools — covered in the `<RESEARCH_TOOLS>` block below:
+
+  - `kg_record(observations)`         — atomic batch of structured
+                                        node + outgoing-edge dicts.
+  - `kg_ingest(scanner_kind, path)`   — bulk-parse a scanner output
+                                        file (nmap_xml, nuclei_jsonl,
+                                        httpx_jsonl, sarif).
+
+Provenance fields (engagement, firstseen, lastupdated, created_by,
+source_episode_id) are auto-injected by the middleware on every node
+and edge. Do NOT set them in your observation `props` — they are
+silently stripped.
 
 NODE KINDS you will use most:
-- host        — an IP or hostname under test
-- service     — a (host, port, proto) tuple
-- url         — a specific reachable path
-- repo        — a source repo checkout root
-- file        — a single source file
-- code_location — file:line span a vuln lives in
-- vulnerability — any weakness, confirmed or suspected
-- cve         — a specific CVE ID from NVD/OSV
-- finding     — a validated, reportable issue
-- credential  — a usable credential
-- secret      — a high-value secret (API key, private key)
-- entrypoint  — a public surface the chain planner can start from
-- crown_jewel — a high-value target the chain planner aims at
-- chain       — a materialised multi-hop exploit path
-- hypothesis  — a working theory you haven't confirmed yet
+- Host          — an IP or hostname under test
+- Service       — a (host, port, proto) tuple
+- URL           — a specific reachable path
+- Repository    — a source repo checkout root
+- SourceFile    — a single source file
+- CodeLocation  — file:line span a vuln lives in
+- Vulnerability — any weakness, confirmed or suspected
+- CVE           — a specific CVE ID from NVD/OSV
+- Finding       — a validated, reportable issue (set `props.status =
+                  "confirmed"` and include the CVSS vector string)
+- Credential    — a usable credential
+- Secret        — a high-value secret (API key, private key)
+- Entrypoint    — a public surface the chain planner can start from
+- CrownJewel    — a high-value target the chain planner aims at
+- Hypothesis    — a working theory you haven't confirmed yet
+- AttackPath    — a materialised multi-hop exploit path
 
-EDGE KINDS the chain planner uses:
-- runs_on, exposes, has_vuln, affected_by — structural
-- enables (vuln → vuln), leaks (vuln → secret), grants (cred → asset) — pivots
-- chains_to, reaches, starts_at — computed chains
-- validates — PoC result → vuln
+EDGE KINDS the chain candidates lookup uses:
+- HOSTS, EXPOSES, HAS_VULN, AFFECTS — structural
+- ENABLES (vuln → vuln), LEAKS (vuln → secret), GRANTS (cred → asset),
+  LEADS_TO (vuln → user/host) — pivots
+- DEFINED_IN — vuln → code location
+- DERIVED_FROM — hypothesis → original finding
+- STARTS_AT, STEP, REACHES — computed chain edges
+- VALIDATES — Finding → Vulnerability after PoC succeeds
 
-WEIGHTS (lower = easier):
+EDGE WEIGHTS (lower = easier exploitation):
 - 0.2-0.4  trivial (default credential, RCE sink reachable)
 - 0.5-0.8  normal (typical SQLi, IDOR with known ID)
 - 1.0-1.5  hard (requires pivot, auth, timing)
 - 2.0+     speculative (needs infrastructure, SSRF to internal-only target)
-</KNOWLEDGE_GRAPH_DISCIPLINE>
+
+Deterministic dedup key — every observation MUST set `props.key` (or
+the top-level `key` field) to a stable identifier so two agents
+recording the same host write one node, not two. Common keys:
+`host::<ip>`, `service::<ip>:<port>`, `vuln::<scanner>::<rule>::<target>`,
+`cve::<CVE-XXXX-YYYY>`.
+</KNOWLEDGE_GRAPH>
 
 <ENVIRONMENT>
 You operate inside the Decepticon Kali sandbox container. The host workspace
 bind mount is `/workspace/`. Source trees under test should be cloned or
-uploaded there. The knowledge graph is backed by Neo4j; every `kg_*` tool
-call routes through the shared store. The current implementation is being
-refactored (see `docs/design/neo4j-research-notes.md`) — prefer batching
-high-frequency writes and lean on file-based artifacts (`findings/*.md`,
-`recon/*.md`) for evidence that does not need cross-iteration querying.
+uploaded there. The knowledge graph is backed by Neo4j; every `kg_record`
+or `kg_ingest` call routes through the KGMiddleware-owned `KGStore` with
+per-operation transactions. The middleware injects engagement scope so
+multi-tenant safety is enforced at the query-builder layer — you do not
+pass engagement in props.
 
 Shared bash tools available: nmap, sqlmap, nuclei, semgrep (if installed
-via apt), bandit (pip), gitleaks (wget release), git, jq, python3, curl.
-If a tool is missing, install it: `apt-get install -y <pkg>` or
-`pip install --break-system-packages <pkg>`.
+via apt), bandit (pip), gitleaks (wget release), git, jq, python3, curl,
+cypher-shell. If a tool is missing, install it: `apt-get install -y <pkg>`
+or `pip install --break-system-packages <pkg>`.
+
+For ad-hoc graph queries beyond the KG STATE block:
+`bash("cypher-shell -u neo4j -p $NEO4J_PASSWORD '<cypher>'")` against the
+shared Neo4j. Prefer this over the retired read tools when the summary
+block doesn't cover your question.
 </ENVIRONMENT>
 
 <RESEARCH_TOOLS>
-You have a set of first-class research tools. USE THEM BEFORE BASH whenever
-they apply — they update the graph for you and keep your state coherent:
+Your KG write surface is intentionally tiny (just two tools):
 
-- `kg_stats()`                — summary of current graph
-- `kg_add_node(kind, label, props_json)` — record an observation
-- `kg_add_edge(src, dst, kind, weight)`  — connect nodes
-- `kg_query(kind, min_severity, limit)`  — inspect what you know
-- `kg_neighbors(node_id, direction, edge_kind)` — walk one hop
-- `kg_ingest_sarif(path, scanner_hint)`  — lift SARIF into nodes
-- `cve_lookup(cve_ids)`       — NVD+EPSS ranking of CVEs
-- `cve_by_package(pkg, ver, ecosystem)` — OSV per-package scan
-- `plan_attack_chains(max_depth, max_cost, top_k, promote)` — ranked chains
-- `fuzz_classify(root)`       — language + engine suggestion
-- `fuzz_harness(engine, target, entry)` — starter harness source
-- `fuzz_record_crash(log, engine)` — parse ASan/UBSan into a vuln
-- `validate_finding(vuln_id, poc_cmd, success_patterns, negative_cmd, negative_patterns, cvss)`
-                              — ZFP-validated PoC with CVSS
-- `bounty_scope_check(target, vuln_class, excluded_classes, in_scope_domains)`
-                              — verify finding is in program scope before reporting
-- `format_bounty_report(finding_id, platform, program_name, component_name)`
-                              — generate platform-ready bug bounty report from a FINDING node
-- `report_hackerone(finding_id)` — HackerOne-style markdown report for a FINDING / vuln node
-- `report_executive(engagement_name)` — engagement-level executive summary from the graph
-- `report_bugcrowd_csv(min_severity)` — Bugcrowd CSV submission bundle
-- `report_sarif(engagement_id, output_path)` — SARIF v2.1.0 for GitHub code scanning / DefectDojo
-- `report_timeline()` — chronological timeline of graph events for the engagement narrative
+- `kg_record(observations)` — atomic batch write. `observations` is a
+  JSON-encoded list. Each entry:
 
-ALWAYS call `kg_stats` at iteration start and after any major action. If
-your iteration ends with zero new graph nodes, you wasted it.
+    {
+      "kind": "Host" | "Service" | "Vulnerability" | "Finding" | ...,
+      "key": "vuln::semgrep::sqli::app.py:42",   # deterministic dedup
+      "label": "SQLi in app.py:42",
+      "props": {"severity": "high", "cwe": "CWE-89", ...},
+      "edges_out": [
+        {"to_key": "code_loc::app.py:42", "kind": "DEFINED_IN",
+         "weight": 1.0}
+      ]
+    }
+
+  Reserved provenance keys (engagement, firstseen, lastupdated,
+  created_by, source_episode_id) are stripped — the middleware sets
+  them.
+
+- `kg_ingest(scanner_kind, path)` — dispatch into the scanner adapter
+  registry. Supported kinds: `nmap_xml`, `nuclei_jsonl`, `httpx_jsonl`,
+  `sarif`. Add more via the `decepticon.kg.ingesters` plugin entry-point.
+
+Reporting tool surface (HackerOne / Bugcrowd / SARIF / executive
+summary / timeline) lives in REPORTING_TOOLS — use those for the final
+REPORT step in your operating loop.
+
+External knowledge lookup tools live in REFERENCES_TOOLS — payload
+search, methodology lookup, kill-chain references.
+
+ALWAYS scan the KG STATE block at the top of each turn before deciding
+the next move. The dedicated `kg_query` / `kg_stats` / `kg_neighbors` /
+`kg_backend_health` read tools have been retired — the summary block
+covers the common cases and `bash("cypher-shell ...")` covers the rest.
 </RESEARCH_TOOLS>
+
+<SCOPE>
+Scope rules are absolute and override everything above: no scanning outside the authorized boundary, no destructive actions, ask the orchestrator if uncertain, save ALL outputs to the engagement workspace.
+</SCOPE>

--- a/packages/decepticon/decepticon/agents/standard/analyst.py
+++ b/packages/decepticon/decepticon/agents/standard/analyst.py
@@ -7,11 +7,21 @@ Analyst reads source, builds a persistent knowledge graph, and reasons
 about multi-hop paths from entrypoints to crown jewels.
 
 Tool surface (in addition to bash):
-    RESEARCH_TOOLS, BOUNTY_TOOLS, REPORTING_TOOLS, REFERENCES_TOOLS
+    REPORTING_TOOLS, REFERENCES_TOOLS, plus ``kg_record`` and
+    ``kg_ingest`` supplied by the KG middleware slot
+    (``SLOTS_PER_ROLE["analyst"]`` includes ``MiddlewareSlot.KG``;
+    ``KGMiddleware`` constructs from ``DECEPTICON_NEO4J_*`` env at agent
+    build time and exposes its two tools via ``self.tools``).
+
+REPORTING_TOOLS currently routes through the legacy
+``decepticon.tools.research._state`` shim; that retirement is PR-D
+scope and tracked in
+docs/design/2026-06-03-kg-middleware-redesign.md § 6.2.
 
 Middleware stack — mirrors exploit.py. The analyst runs fewer shell
 commands in favour of first-class research tools (semgrep, bandit,
-gitleaks, KG operations).
+gitleaks, KG operations via the middleware-supplied ``kg_record`` /
+``kg_ingest``).
 
 Library API
 -----------
@@ -39,10 +49,12 @@ cleanly:
 
 Middleware slots (per ``SLOTS_PER_ROLE["analyst"]``):
 
-  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → KG → SANDBOX_NOTIFICATION
     → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
 
-No SubAgent / OPPLAN (standalone, not an orchestrator).
+No SubAgent / OPPLAN (standalone, not an orchestrator). The KG slot
+attaches ``KGMiddleware`` — owner of the Neo4j store and the agent-
+facing ``kg_record`` / ``kg_ingest`` tools.
 """
 
 from __future__ import annotations
@@ -59,16 +71,18 @@ from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import REFERENCES_TOOLS
 from decepticon.tools.reporting.tools import REPORTING_TOOLS
-from decepticon.tools.research.bounty import BOUNTY_TOOLS
-from decepticon.tools.research.tools import RESEARCH_TOOLS
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
 _STANDARD_TOOLS: dict[str, Any] = {
-    # Research tools first → model defaults to graph operations;
-    # references tools offer payloads + external knowledge lookup;
-    # bounty tools provide scope checking and report formatting.
+    # KG surface arrives via the MiddlewareSlot.KG slot — KGMiddleware
+    # exposes ``kg_record`` and ``kg_ingest`` through its ``self.tools``
+    # attribute, merged into the agent's tool list at create_agent time.
+    # REPORTING_TOOLS still routes through the legacy
+    # ``decepticon.tools.research._state`` shim until PR-D extracts the
+    # reporting tools; tracked in
+    # docs/design/2026-06-03-kg-middleware-redesign.md § 6.2.
     t.name: t
-    for t in [*RESEARCH_TOOLS, *BOUNTY_TOOLS, *REPORTING_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
+    for t in [*REPORTING_TOOLS, *REFERENCES_TOOLS, *BASH_TOOLS]
 }
 
 

--- a/packages/decepticon/decepticon/middleware/__init__.py
+++ b/packages/decepticon/decepticon/middleware/__init__.py
@@ -17,6 +17,7 @@ from decepticon.middleware.hitl import (
 from decepticon.middleware.notifications import (
     SandboxNotificationMiddleware,
 )
+from decepticon.middleware.kg import KGMiddleware
 from decepticon.middleware.opplan import OPPLANMiddleware
 from decepticon.middleware.prompt_injection_shield import (
     PromptInjectionShieldMiddleware,
@@ -39,6 +40,7 @@ __all__ = [
     "FilesystemMiddleware",
     "HITLApprovalMiddleware",
     "InProcessApprovalTransport",
+    "KGMiddleware",
     "OPPLANMiddleware",
     "PromptInjectionShieldMiddleware",
     "RoEEnforcementMiddleware",

--- a/packages/decepticon/decepticon/middleware/__init__.py
+++ b/packages/decepticon/decepticon/middleware/__init__.py
@@ -14,10 +14,10 @@ from decepticon.middleware.hitl import (
     HITLApprovalMiddleware,
     InProcessApprovalTransport,
 )
+from decepticon.middleware.kg import KGMiddleware
 from decepticon.middleware.notifications import (
     SandboxNotificationMiddleware,
 )
-from decepticon.middleware.kg import KGMiddleware
 from decepticon.middleware.opplan import OPPLANMiddleware
 from decepticon.middleware.prompt_injection_shield import (
     PromptInjectionShieldMiddleware,

--- a/packages/decepticon/decepticon/middleware/kg.py
+++ b/packages/decepticon/decepticon/middleware/kg.py
@@ -1,0 +1,277 @@
+"""KGMiddleware — owner of the Neo4j-backed attack graph for an agent run.
+
+Mirrors :class:`OPPLANMiddleware` (decepticon/middleware/opplan.py): state
+schema + tools-on-init + lifecycle hooks. Once attached to an agent via
+``langchain.agents.create_agent(... middleware=[KGMiddleware(), ...])``
+the agent gains the ``kg_record`` and ``kg_ingest`` tools and sees a
+current graph summary in every system prompt.
+
+Hooks:
+
+  * ``before_agent``    — hydrate ``kg_engagement`` from upstream state,
+                          fetch the current revision from the store,
+                          rebuild the summary block when the revision
+                          advances or this is the first turn.
+  * ``wrap_model_call`` — inject the cached summary block into the
+                          system message as a cache-friendly two-block
+                          insertion (static prompt-cache breakpoint +
+                          dynamic stats).
+  * ``wrap_tool_call``  — defense-in-depth refusal of ``kg_record`` /
+                          ``kg_ingest`` when ``kg_engagement`` is unset.
+                          The tools themselves enforce the same rule;
+                          this layer fires earlier and surfaces the
+                          error before the adapter even runs.
+  * ``after_model``     — when a KG write tool ran in the last AI step,
+                          mark ``kg_revision`` dirty so the next
+                          ``before_agent`` re-fetches it and rebuilds
+                          the summary.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from typing import Any, cast
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from typing_extensions import override
+
+from decepticon.middleware.kg_internal.state import KGState
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon.middleware.kg_internal.summary import build_summary
+from decepticon.middleware.kg_internal.tools import build_kg_tools
+
+log = logging.getLogger(__name__)
+
+
+# System prompt content the middleware injects with prompt-cache marker.
+# Kept short — the dynamic summary block (see :mod:`kg_internal.summary`)
+# is what changes each turn; this block tells the LLM what the surface
+# is and is cache-eligible.
+KG_SYSTEM_PROMPT = (
+    "## Knowledge graph (KGMiddleware-owned)\n"
+    "You have access to a persistent attack graph for this engagement.\n"
+    "Write observations with `kg_record(observations)` — pass a JSON list\n"
+    "of node + edge dicts; the middleware injects provenance.\n"
+    "Bulk-ingest scanner outputs with `kg_ingest(scanner_kind, path)`.\n"
+    "Do not pass `engagement`, `firstseen`, `lastupdated`, `created_by`,\n"
+    "or `source_episode_id` in props — they are reserved for the\n"
+    "middleware to set.\n"
+    "Current graph state appears below; lean on it for next-move\n"
+    "decisions. Use `grep findings/` or `bash('cypher-shell ...')` for\n"
+    "ad-hoc deep dives instead of read tools — the graph state below\n"
+    "covers the common cases."
+)
+
+
+# Marker the middleware writes into ``kg_revision`` when a write tool
+# ran. Forces the next ``before_agent`` to re-fetch the real revision
+# and rebuild the summary. Any non-empty string different from the
+# real ``rev-<engagement>-<update_tag>`` works; ``dirty`` is the
+# convention.
+_REVISION_DIRTY_MARKER = "dirty"
+
+
+class KGMiddleware(AgentMiddleware):
+    """Attach the KG to an agent.
+
+    Parameters
+    ----------
+    store
+        ``KGStore`` instance to bind tools and summary queries to. When
+        ``None``, constructs one via ``KGStore.from_env()`` so unit /
+        integration tests can inject a test store while production
+        works out-of-the-box.
+    enabled_tools
+        Override the tool surface. Defaults to ``{"kg_record",
+        "kg_ingest"}`` (see ``DEFAULT_KG_TOOLS`` in
+        ``kg_internal.tools``).
+    """
+
+    state_schema = KGState
+
+    def __init__(
+        self,
+        *,
+        store: KGStore | None = None,
+        enabled_tools: Iterable[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._store = store if store is not None else KGStore.from_env()
+        self.tools = build_kg_tools(self._store, enabled=enabled_tools)
+        self._kg_tool_names = {getattr(t, "name", "") for t in self.tools}
+
+    @property
+    def store(self) -> KGStore:
+        """The store this middleware was built against."""
+        return self._store
+
+    # ── before_agent ──────────────────────────────────────────────────
+
+    @override
+    def before_agent(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+        return self._hydrate_kg_state(state)
+
+    @override
+    async def abefore_agent(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+        return self._hydrate_kg_state(state)
+
+    def _hydrate_kg_state(self, state: Any) -> dict[str, Any] | None:
+        """Set ``kg_engagement`` / ``kg_revision`` / ``kg_summary`` from store."""
+        get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+        engagement = str(get("kg_engagement") or get("engagement_name") or "").strip()
+        if not engagement:
+            return None
+
+        try:
+            revision = self._store.revision(engagement=engagement)
+        except Exception as exc:
+            log.warning("KGMiddleware revision fetch failed (engagement=%s): %s", engagement, exc)
+            return None
+
+        updates: dict[str, Any] = {}
+        if get("kg_engagement") != engagement:
+            updates["kg_engagement"] = engagement
+
+        prior_revision = get("kg_revision")
+        if revision != prior_revision:
+            updates["kg_revision"] = revision
+            try:
+                updates["kg_summary"] = build_summary(self._store, engagement=engagement)
+            except Exception as exc:
+                log.warning("KGMiddleware summary build failed: %s", exc)
+                updates["kg_summary"] = ""
+        return updates or None
+
+    # ── wrap_model_call ───────────────────────────────────────────────
+
+    @override
+    def wrap_model_call(self, request: Any, handler: Any) -> Any:
+        return handler(self._inject_kg_context(request))
+
+    @override
+    async def awrap_model_call(self, request: Any, handler: Any) -> Any:
+        return await handler(self._inject_kg_context(request))
+
+    def _inject_kg_context(self, request: Any) -> Any:
+        """Append the KG static prompt + dynamic summary to the system
+        message. Two content blocks so the Anthropic prompt cache can
+        re-use the static prefix across turns (same pattern as
+        ``OPPLANMiddleware._inject_opplan_context`` at
+        ``middleware/opplan.py:350``)."""
+        state = request.state or {}
+        get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+        summary = str(get("kg_summary") or "")
+
+        # No engagement / no summary yet — pass the request through.
+        if not get("kg_engagement"):
+            return request
+
+        static_block: dict[str, Any] = {
+            "type": "text",
+            "text": "\n\n" + KG_SYSTEM_PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        }
+        injected_blocks: list[dict[str, Any]] = [static_block]
+        if summary:
+            injected_blocks.append({"type": "text", "text": "\n\n" + summary})
+
+        if request.system_message is not None:
+            new_content = [
+                *request.system_message.content_blocks,
+                *injected_blocks,
+            ]
+        else:
+            new_content = injected_blocks
+
+        new_system = SystemMessage(content=cast("list[str | dict[str, str]]", new_content))
+        return request.override(system_message=new_system)
+
+    # ── wrap_tool_call ────────────────────────────────────────────────
+
+    @override
+    def wrap_tool_call(self, request: Any, handler: Any) -> Any:
+        rejection = self._maybe_reject_unscoped(request)
+        if rejection is not None:
+            return rejection
+        return handler(request)
+
+    @override
+    async def awrap_tool_call(self, request: Any, handler: Any) -> Any:
+        rejection = self._maybe_reject_unscoped(request)
+        if rejection is not None:
+            return rejection
+        return await handler(request)
+
+    def _maybe_reject_unscoped(self, request: Any) -> ToolMessage | None:
+        """Return a ``ToolMessage`` rejection when a KG tool is invoked
+        without an engagement on state. Otherwise return ``None`` so the
+        wrap proceeds to the handler."""
+        tool = getattr(request, "tool", None)
+        if tool is None or getattr(tool, "name", "") not in self._kg_tool_names:
+            return None
+        state = getattr(request, "state", None) or {}
+        get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+        if get("kg_engagement"):
+            return None
+        tool_call = getattr(request, "tool_call", None)
+        tool_call_id = (
+            getattr(tool_call, "id", None)
+            if tool_call is not None
+            else (
+                request.tool_call.get("id")
+                if isinstance(getattr(request, "tool_call", None), dict)
+                else None
+            )
+        ) or "kg-middleware-rejection"
+        return ToolMessage(
+            content=json.dumps(
+                {
+                    "error": (
+                        "kg_engagement not on state — KGMiddleware refused the call. "
+                        "Hydrate engagement_name via EngagementContextMiddleware first."
+                    )
+                }
+            ),
+            tool_call_id=tool_call_id,
+            name=getattr(tool, "name", "kg_tool"),
+        )
+
+    # ── after_model ───────────────────────────────────────────────────
+
+    @override
+    def after_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+        return self._maybe_invalidate_revision(state)
+
+    @override
+    async def aafter_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+        return self._maybe_invalidate_revision(state)
+
+    def _maybe_invalidate_revision(self, state: Any) -> dict[str, Any] | None:
+        """When the most recent AI message issued a kg_record / kg_ingest
+        call, mark ``kg_revision`` dirty so the next ``before_agent``
+        rebuilds the summary."""
+        messages = state.get("messages") if hasattr(state, "get") else None
+        if not messages:
+            return None
+        last_ai = next((m for m in reversed(messages) if isinstance(m, AIMessage)), None)
+        if last_ai is None:
+            return None
+        tool_calls = getattr(last_ai, "tool_calls", None) or []
+        kg_write_invoked = False
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                name = tc.get("name")
+            else:
+                name = getattr(tc, "name", None)
+            if name in self._kg_tool_names:
+                kg_write_invoked = True
+                break
+        if not kg_write_invoked:
+            return None
+        return {"kg_revision": _REVISION_DIRTY_MARKER}
+
+
+__all__ = ["KGMiddleware", "KG_SYSTEM_PROMPT"]

--- a/packages/decepticon/decepticon/middleware/kg_internal/__init__.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/__init__.py
@@ -1,0 +1,11 @@
+"""Internal implementation of the KG middleware.
+
+Modules under this package are NOT a public plugin surface. External
+plugin authors get the engagement-graph contract via
+``decepticon_core.contracts`` and the agent-facing tools via
+``decepticon.middleware.KGMiddleware``. Touching anything under
+``kg_internal/`` directly is unsupported and may break across minor
+releases.
+"""
+
+from __future__ import annotations

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -131,6 +131,8 @@ def _adapt_nmap_xml(
         root = ET.parse(str(path)).getroot()
     except (OSError, ET.ParseError) as exc:
         return {"error": f"nmap xml parse failed: {exc}", "hosts": 0, "services": 0}
+    if root is None:
+        return {"error": "nmap xml parse failed: empty document", "hosts": 0, "services": 0}
 
     observations: list[dict[str, Any]] = []
     hosts_count = 0

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -1,0 +1,570 @@
+"""Scanner adapter registry + dispatcher + built-in adapters.
+
+The single ``kg_ingest`` tool (PR-B.3) routes here via
+:func:`ingest`. Adapters are registered under a ``scanner_kind`` string;
+plugin authors can extend the registry via the
+``decepticon.kg.ingesters`` entry-point group.
+
+Built-in adapters in PR-B.2:
+
+  - ``nmap_xml``     — Nmap XML output (hosts, services, web entrypoints)
+  - ``nuclei_jsonl`` — Nuclei JSONL output (vulnerabilities, entrypoints)
+  - ``httpx_jsonl``  — httpx JSONL output (hosts, services, URLs, entrypoints)
+  - ``sarif``        — SARIF v2.1.0 JSON (vulnerabilities, code locations)
+
+The remaining scanner kinds from the design notes (subfinder, dnsx,
+katana, masscan, ffuf, testssl, crackmapexec, asrep_hashes) can be added
+incrementally in follow-up commits or as plugin packages — they share
+the same adapter signature.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import defusedxml.ElementTree as ET
+
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon_core.utils.logging import get_logger
+
+log = get_logger("kg.ingest")
+
+
+# ── Adapter signature + registry ───────────────────────────────────────
+
+
+ScannerAdapter = Callable[
+    [Path, KGStore, str, str, str],
+    dict[str, Any],
+]
+"""Signature: ``(path, store, engagement, created_by, source_episode_id) -> summary``.
+
+The adapter parses the scanner output at ``path``, builds a list of
+observations, and calls ``store.record_observations(...)``. It returns a
+summary dict the tool layer surfaces to the LLM.
+"""
+
+
+_REGISTRY: dict[str, ScannerAdapter] = {}
+
+
+def register_adapter(scanner_kind: str, adapter: ScannerAdapter) -> None:
+    """Register a scanner adapter.
+
+    Idempotent — re-registering the same ``scanner_kind`` replaces the
+    previous entry. Plugin authors typically register at import time
+    via the ``decepticon.kg.ingesters`` entry-point group.
+    """
+    if not isinstance(scanner_kind, str) or not scanner_kind:
+        raise ValueError("scanner_kind must be a non-empty string")
+    if not callable(adapter):
+        raise ValueError("adapter must be callable")
+    _REGISTRY[scanner_kind] = adapter
+
+
+def available_scanners() -> list[str]:
+    """Sorted list of registered ``scanner_kind`` names."""
+    return sorted(_REGISTRY.keys())
+
+
+def ingest(
+    scanner_kind: str,
+    path: str | Path,
+    *,
+    store: KGStore,
+    engagement: str,
+    created_by: str,
+    source_episode_id: str,
+) -> dict[str, Any]:
+    """Dispatch to the adapter for ``scanner_kind``.
+
+    Returns a dict whose shape is
+    ``{"scanner", "path", **adapter_result}`` on success or
+    ``{"error", "scanner", ...}`` on failure (unknown scanner_kind,
+    missing file, parse error). The middleware tool layer (PR-B.3)
+    forwards this to the LLM verbatim.
+    """
+    if scanner_kind not in _REGISTRY:
+        return {
+            "error": f"unknown scanner_kind: {scanner_kind!r}",
+            "available": available_scanners(),
+        }
+    target = Path(path)
+    if not target.exists():
+        return {
+            "error": f"file not found: {target}",
+            "scanner": scanner_kind,
+        }
+
+    adapter = _REGISTRY[scanner_kind]
+    try:
+        result = adapter(target, store, engagement, created_by, source_episode_id)
+    except Exception as exc:
+        log.warning("kg_ingest adapter %s raised: %s", scanner_kind, exc)
+        return {
+            "error": f"adapter failure: {exc}",
+            "scanner": scanner_kind,
+            "path": str(target),
+        }
+    return {"scanner": scanner_kind, "path": str(target), **result}
+
+
+# ── Built-in adapters ──────────────────────────────────────────────────
+
+
+_WEB_PORTS = {80, 443, 8000, 8080, 8443, 8888}
+
+
+def _adapt_nmap_xml(
+    path: Path,
+    store: KGStore,
+    engagement: str,
+    created_by: str,
+    source_episode_id: str,
+) -> dict[str, Any]:
+    """Parse Nmap XML output and record host + service + entrypoint nodes."""
+    try:
+        root = ET.parse(str(path)).getroot()
+    except (OSError, ET.ParseError) as exc:
+        return {"error": f"nmap xml parse failed: {exc}", "hosts": 0, "services": 0}
+
+    observations: list[dict[str, Any]] = []
+    hosts_count = 0
+    services_count = 0
+    entrypoints_count = 0
+
+    for host_el in root.findall("host"):
+        status = host_el.find("status")
+        if status is not None and status.get("state") not in {None, "up"}:
+            continue
+        addr_el = host_el.find("address[@addrtype='ipv4']")
+        if addr_el is None:
+            addr_el = host_el.find("address")
+        if addr_el is None:
+            continue
+        ip = addr_el.get("addr")
+        if not ip:
+            continue
+        hostname_el = host_el.find("hostnames/hostname")
+        hostname = hostname_el.get("name") if hostname_el is not None else ""
+        host_label = hostname or ip
+        host_key = f"host::{ip}"
+
+        host_edges: list[dict[str, Any]] = []
+        for port_el in host_el.findall("ports/port"):
+            state_el = port_el.find("state")
+            if state_el is None or state_el.get("state") != "open":
+                continue
+            try:
+                port = int(port_el.get("portid", "0"))
+            except ValueError:
+                continue
+            proto = port_el.get("protocol", "tcp")
+            svc_el = port_el.find("service")
+            svc_name = svc_el.get("name") if svc_el is not None else "unknown"
+            product = svc_el.get("product") if svc_el is not None else ""
+            version = svc_el.get("version") if svc_el is not None else ""
+            svc_key = f"service::{ip}:{port}"
+            host_edges.append({"to_key": svc_key, "kind": "HOSTS", "weight": 0.5})
+            observations.append(
+                {
+                    "kind": "Service",
+                    "key": svc_key,
+                    "label": f"{ip}:{port}/{proto}",
+                    "props": {
+                        "port": port,
+                        "protocol": proto,
+                        "service": svc_name,
+                        "product": product or "",
+                        "version": version or "",
+                        "source": "nmap",
+                    },
+                }
+            )
+            services_count += 1
+
+            if port in _WEB_PORTS:
+                scheme = "https" if port in {443, 8443} else "http"
+                url = f"{scheme}://{host_label}:{port}/"
+                ep_key = f"entrypoint::{url}"
+                observations.append(
+                    {
+                        "kind": "Entrypoint",
+                        "key": ep_key,
+                        "label": url,
+                        "props": {
+                            "scheme": scheme,
+                            "host": host_label,
+                            "port": port,
+                            "source": "nmap",
+                        },
+                    }
+                )
+                entrypoints_count += 1
+
+        observations.append(
+            {
+                "kind": "Host",
+                "key": host_key,
+                "label": host_label,
+                "props": {
+                    "ip": ip,
+                    "hostname": hostname or "",
+                    "explored": True,
+                    "source": "nmap",
+                },
+                "edges_out": host_edges,
+            }
+        )
+        hosts_count += 1
+
+    if not observations:
+        return {"hosts": 0, "services": 0, "entrypoints": 0}
+
+    records = store.record_observations(
+        observations,
+        engagement=engagement,
+        created_by=created_by,
+        source_episode_id=source_episode_id,
+    )
+    return {
+        "hosts": hosts_count,
+        "services": services_count,
+        "entrypoints": entrypoints_count,
+        "records": records,
+    }
+
+
+def _adapt_nuclei_jsonl(
+    path: Path,
+    store: KGStore,
+    engagement: str,
+    created_by: str,
+    source_episode_id: str,
+) -> dict[str, Any]:
+    """Parse Nuclei JSONL and record vulnerability + entrypoint nodes."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"error": f"nuclei jsonl read failed: {exc}", "ingested": 0}
+
+    observations: list[dict[str, Any]] = []
+    parsed = 0
+    skipped = 0
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            skipped += 1
+            continue
+        parsed += 1
+
+        info = record.get("info") if isinstance(record.get("info"), dict) else {}
+        severity = str(info.get("severity") or "info").lower()
+        rule_id = str(record.get("template-id") or "unknown-template")
+        target = str(record.get("matched-at") or record.get("host") or "unknown-target")
+
+        vuln_key = f"vuln::nuclei::{rule_id}::{target}"
+        observations.append(
+            {
+                "kind": "Vulnerability",
+                "key": vuln_key,
+                "label": f"[nuclei:{rule_id}] {target}",
+                "props": {
+                    "scanner": "nuclei",
+                    "rule_id": rule_id,
+                    "severity": severity,
+                    "target": target,
+                    "tags": info.get("tags") if isinstance(info.get("tags"), list) else [],
+                },
+            }
+        )
+
+        parsed_target = urlparse(target)
+        if parsed_target.scheme and parsed_target.netloc:
+            ep_key = f"entrypoint::{target}"
+            observations.append(
+                {
+                    "kind": "Entrypoint",
+                    "key": ep_key,
+                    "label": target,
+                    "props": {
+                        "scheme": parsed_target.scheme,
+                        "host": parsed_target.hostname or "",
+                        "port": parsed_target.port,
+                        "source": "nuclei",
+                    },
+                    "edges_out": [{"to_key": vuln_key, "kind": "HAS_VULN", "weight": 0.4}],
+                }
+            )
+
+    if not observations:
+        return {"parsed": parsed, "skipped": skipped, "ingested": 0}
+
+    records = store.record_observations(
+        observations,
+        engagement=engagement,
+        created_by=created_by,
+        source_episode_id=source_episode_id,
+    )
+    return {"parsed": parsed, "skipped": skipped, "records": records}
+
+
+def _adapt_httpx_jsonl(
+    path: Path,
+    store: KGStore,
+    engagement: str,
+    created_by: str,
+    source_episode_id: str,
+) -> dict[str, Any]:
+    """Parse httpx JSONL and record host + service + entrypoint nodes."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"error": f"httpx jsonl read failed: {exc}", "ingested": 0}
+
+    observations: list[dict[str, Any]] = []
+    parsed = 0
+    skipped = 0
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            skipped += 1
+            continue
+        parsed += 1
+
+        url = str(row.get("url") or row.get("input") or "").strip()
+        if not url:
+            skipped += 1
+            continue
+
+        parsed_url = urlparse(url)
+        host_value = (str(row.get("host") or parsed_url.hostname or "")).strip().lower()
+        if not host_value:
+            skipped += 1
+            continue
+
+        port_raw = row.get("port") or parsed_url.port
+        try:
+            port_int = (
+                int(port_raw)
+                if port_raw is not None
+                else (443 if parsed_url.scheme == "https" else 80)
+            )
+        except (TypeError, ValueError):
+            port_int = 443 if parsed_url.scheme == "https" else 80
+        scheme = parsed_url.scheme or "http"
+        status_code = row.get("status-code")
+
+        host_key = f"host::{host_value}"
+        svc_key = f"service::{host_value}:{port_int}"
+        ep_key = f"entrypoint::{url}"
+
+        observations.extend(
+            [
+                {
+                    "kind": "Host",
+                    "key": host_key,
+                    "label": host_value,
+                    "props": {"hostname": host_value, "source": "httpx"},
+                },
+                {
+                    "kind": "Service",
+                    "key": svc_key,
+                    "label": f"{host_value}:{port_int}/tcp",
+                    "props": {
+                        "port": port_int,
+                        "scheme": scheme,
+                        "status_code": status_code,
+                        "source": "httpx",
+                    },
+                },
+                {
+                    "kind": "Entrypoint",
+                    "key": ep_key,
+                    "label": url,
+                    "props": {
+                        "host": host_value,
+                        "scheme": scheme,
+                        "port": port_int,
+                        "status_code": status_code,
+                        "source": "httpx",
+                    },
+                },
+            ]
+        )
+
+    if not observations:
+        return {"parsed": parsed, "skipped": skipped, "ingested": 0}
+
+    records = store.record_observations(
+        observations,
+        engagement=engagement,
+        created_by=created_by,
+        source_episode_id=source_episode_id,
+    )
+    return {"parsed": parsed, "skipped": skipped, "records": records}
+
+
+def _adapt_sarif(
+    path: Path,
+    store: KGStore,
+    engagement: str,
+    created_by: str,
+    source_episode_id: str,
+) -> dict[str, Any]:
+    """Parse SARIF v2.1.0 JSON and record vulnerability + code-location nodes."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"error": f"sarif parse failed: {exc}", "ingested": 0}
+
+    runs = data.get("runs") or []
+    observations: list[dict[str, Any]] = []
+    results_processed = 0
+
+    severity_from_level = {
+        "error": "high",
+        "warning": "medium",
+        "note": "low",
+        "none": "info",
+    }
+
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        driver = (run.get("tool") or {}).get("driver") or {}
+        scanner_name = str(driver.get("name") or "sarif")
+        results = run.get("results") or []
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            results_processed += 1
+            rule_id = str(result.get("ruleId") or "unknown")
+            level = str(result.get("level") or "warning").lower()
+            severity = severity_from_level.get(level, "info")
+            message_obj = result.get("message") or {}
+            message = (
+                str(message_obj.get("text") or rule_id)
+                if isinstance(message_obj, dict)
+                else rule_id
+            )
+
+            locations = result.get("locations") or []
+            for loc in locations:
+                if not isinstance(loc, dict):
+                    continue
+                phys = loc.get("physicalLocation") or {}
+                artifact = phys.get("artifactLocation") or {}
+                file_uri = str(artifact.get("uri") or "")
+                region = phys.get("region") or {}
+                start_line = region.get("startLine") or 0
+                try:
+                    line_no = int(start_line)
+                except (TypeError, ValueError):
+                    line_no = 0
+
+                code_loc_key = f"code_loc::{scanner_name}::{file_uri}::{line_no}"
+                vuln_key = f"vuln::sarif::{scanner_name}::{rule_id}::{file_uri}::{line_no}"
+
+                observations.append(
+                    {
+                        "kind": "Vulnerability",
+                        "key": vuln_key,
+                        "label": f"[{scanner_name}:{rule_id}] {file_uri}:{line_no}",
+                        "props": {
+                            "scanner": scanner_name,
+                            "rule_id": rule_id,
+                            "severity": severity,
+                            "description": message,
+                            "file": file_uri,
+                            "line": line_no,
+                        },
+                        "edges_out": [
+                            {"to_key": code_loc_key, "kind": "DEFINED_IN", "weight": 1.0}
+                        ],
+                    }
+                )
+                observations.append(
+                    {
+                        "kind": "CodeLocation",
+                        "key": code_loc_key,
+                        "label": f"{file_uri}:{line_no}",
+                        "props": {"file": file_uri, "start_line": line_no},
+                    }
+                )
+
+    if not observations:
+        return {"results_processed": results_processed, "ingested": 0}
+
+    records = store.record_observations(
+        observations,
+        engagement=engagement,
+        created_by=created_by,
+        source_episode_id=source_episode_id,
+    )
+    return {"results_processed": results_processed, "records": records}
+
+
+# ── Register built-ins at import time ──────────────────────────────────
+
+
+register_adapter("nmap_xml", _adapt_nmap_xml)
+register_adapter("nuclei_jsonl", _adapt_nuclei_jsonl)
+register_adapter("httpx_jsonl", _adapt_httpx_jsonl)
+register_adapter("sarif", _adapt_sarif)
+
+
+# ── Plugin loading via entry-point group ───────────────────────────────
+
+
+_PLUGIN_GROUP = "decepticon.kg.ingesters"
+
+
+def load_plugin_adapters() -> int:
+    """Discover and register adapters from the ``decepticon.kg.ingesters``
+    entry-point group. Returns the number of adapters successfully
+    loaded. Idempotent — re-registration overwrites silently.
+
+    Plugin authors expose adapters as::
+
+        # pyproject.toml
+        [project.entry-points."decepticon.kg.ingesters"]
+        my_scanner = "my_pkg.adapters:my_scanner_adapter"
+
+    Failures during load are logged and skipped — one broken plugin
+    does not stop others from registering.
+    """
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:  # pragma: no cover — Python <3.10 not supported
+        return 0
+
+    try:
+        eps = entry_points(group=_PLUGIN_GROUP)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.debug("entry_points() failed for %s: %s", _PLUGIN_GROUP, exc)
+        return 0
+
+    count = 0
+    for ep in eps:
+        try:
+            adapter = ep.load()
+            register_adapter(ep.name, adapter)
+            count += 1
+        except Exception as exc:
+            log.warning("failed to load KG ingester plugin %s: %s", ep.name, exc)
+    return count

--- a/packages/decepticon/decepticon/middleware/kg_internal/migration_runner.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/migration_runner.py
@@ -1,0 +1,130 @@
+"""Migration runner for the KG schema.
+
+Reads ``V*.cypher`` files from ``kg_internal/migrations/``, executes
+the pending ones in filename order, and records applied names in a
+``:MigrationLog`` node so reruns no-op. Each Cypher file is split on
+``;`` boundaries (after line-comment stripping) and run statement by
+statement via :meth:`KGStore.execute_write`.
+
+The runner uses the reserved engagement label ``"schema"`` because the
+``MigrationLog`` and schema DDL are out-of-band of any real engagement.
+The label is documented as reserved in
+``docs/design/2026-06-03-kg-middleware-implementation-research.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon_core.utils.logging import get_logger
+
+log = get_logger("kg.migrations")
+
+_DEFAULT_MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+# Reserved engagement label for schema operations. Real engagements
+# never use this name (it's lowercase, structurally valid, and
+# semantically clear in any Cypher trace).
+_MIGRATION_ENGAGEMENT = "schema"
+
+
+def _strip_line_comments(text: str) -> str:
+    """Remove ``-- ...`` line comments before statement splitting.
+
+    Cypher does not have block comments. Line comments end at the next
+    newline. Stripping them up-front is safe because they cannot
+    contain semicolons that would survive into the splitter.
+    """
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        idx = line.find("--")
+        if idx != -1:
+            line = line[:idx]
+        out_lines.append(line)
+    return "\n".join(out_lines)
+
+
+def _split_cypher_statements(text: str) -> list[str]:
+    """Split a multi-statement Cypher file into individual statements.
+
+    Cypher statements are separated by ``;``. Empty statements (e.g.
+    trailing semicolons after the last command) are dropped. Returned
+    statements are stripped of surrounding whitespace.
+    """
+    body = _strip_line_comments(text)
+    chunks = [chunk.strip() for chunk in body.split(";")]
+    return [chunk for chunk in chunks if chunk]
+
+
+def list_applied(store: KGStore) -> set[str]:
+    """Return the names of migrations already recorded as applied.
+
+    On a fresh Neo4j (no constraints, no MigrationLog) the underlying
+    MATCH returns an empty result rather than raising, so this is safe
+    to call before V001 has ever run.
+    """
+    cypher = "MATCH (m:MigrationLog) RETURN m.name AS name"
+    rows = store.execute_read(cypher, {}, engagement=_MIGRATION_ENGAGEMENT)
+    return {str(row["name"]) for row in rows if row.get("name")}
+
+
+def apply_migrations(
+    store: KGStore,
+    *,
+    migrations_dir: Path | None = None,
+) -> list[str]:
+    """Apply pending ``V*.cypher`` migrations in filename order.
+
+    Returns the list of newly-applied migration names (excluding ones
+    that were already recorded). Idempotent — calling twice in a row
+    runs the second invocation with no Cypher executed.
+
+    Raises whatever the driver raises if a statement fails. Failure
+    rolls back its own write transaction; previously-applied
+    migrations in the same call remain recorded.
+    """
+    chosen_dir = migrations_dir or _DEFAULT_MIGRATIONS_DIR
+    cypher_files = sorted(chosen_dir.glob("V*.cypher"))
+    if not cypher_files:
+        log.info("no KG migrations found in %s", chosen_dir)
+        return []
+
+    applied = list_applied(store)
+    new_applied: list[str] = []
+
+    for path in cypher_files:
+        name = path.stem  # e.g. "V001__initial_schema"
+        if name in applied:
+            log.debug("KG migration %s already applied; skipping", name)
+            continue
+        cypher_text = path.read_text(encoding="utf-8")
+        sha = hashlib.sha256(cypher_text.encode("utf-8")).hexdigest()
+        statements = _split_cypher_statements(cypher_text)
+        log.info(
+            "applying KG migration %s (statements=%d sha=%s)",
+            name,
+            len(statements),
+            sha[:8],
+        )
+        for stmt in statements:
+            store.execute_write(stmt, {}, engagement=_MIGRATION_ENGAGEMENT)
+        store.execute_write(
+            (
+                "MERGE (m:MigrationLog {name: $name}) "
+                "ON CREATE SET m.applied_at = $now, m.cypher_sha = $sha, "
+                "              m.engagement = $engagement"
+            ),
+            {
+                "name": name,
+                "now": int(time.time()),
+                "sha": sha,
+                "engagement": _MIGRATION_ENGAGEMENT,
+            },
+            engagement=_MIGRATION_ENGAGEMENT,
+        )
+        new_applied.append(name)
+
+    return new_applied

--- a/packages/decepticon/decepticon/middleware/kg_internal/migrations/V001__initial_schema.cypher
+++ b/packages/decepticon/decepticon/middleware/kg_internal/migrations/V001__initial_schema.cypher
@@ -1,0 +1,82 @@
+-- KG schema v001 — engagement-scoped composite uniqueness constraints.
+--
+-- Every canonical node label gets a unique constraint on
+-- (key, engagement) so the same key in two different engagements is
+-- two nodes (multi-tenant invariant) and the same key in the same
+-- engagement is one node (idempotent MERGE for record_observations).
+--
+-- Plugin-supplied labels not listed here are unconstrained at the
+-- schema level; KGStore.record_observations enforces the dedup key
+-- application-side.
+
+CREATE CONSTRAINT host_key_engagement IF NOT EXISTS
+  FOR (n:Host) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT network_key_engagement IF NOT EXISTS
+  FOR (n:Network) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT domain_key_engagement IF NOT EXISTS
+  FOR (n:Domain) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT service_key_engagement IF NOT EXISTS
+  FOR (n:Service) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT url_key_engagement IF NOT EXISTS
+  FOR (n:URL) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT cloud_resource_key_engagement IF NOT EXISTS
+  FOR (n:CloudResource) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT container_key_engagement IF NOT EXISTS
+  FOR (n:Container) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT user_key_engagement IF NOT EXISTS
+  FOR (n:User) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT group_key_engagement IF NOT EXISTS
+  FOR (n:Group) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT credential_key_engagement IF NOT EXISTS
+  FOR (n:Credential) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT secret_key_engagement IF NOT EXISTS
+  FOR (n:Secret) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT session_key_engagement IF NOT EXISTS
+  FOR (n:Session) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT vulnerability_key_engagement IF NOT EXISTS
+  FOR (n:Vulnerability) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT cve_key_engagement IF NOT EXISTS
+  FOR (n:CVE) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT misconfiguration_key_engagement IF NOT EXISTS
+  FOR (n:Misconfiguration) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT weakness_key_engagement IF NOT EXISTS
+  FOR (n:Weakness) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT repository_key_engagement IF NOT EXISTS
+  FOR (n:Repository) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT source_file_key_engagement IF NOT EXISTS
+  FOR (n:SourceFile) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT code_location_key_engagement IF NOT EXISTS
+  FOR (n:CodeLocation) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT contract_key_engagement IF NOT EXISTS
+  FOR (n:Contract) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT technique_key_engagement IF NOT EXISTS
+  FOR (n:Technique) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT entrypoint_key_engagement IF NOT EXISTS
+  FOR (n:Entrypoint) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT crown_jewel_key_engagement IF NOT EXISTS
+  FOR (n:CrownJewel) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT attack_path_key_engagement IF NOT EXISTS
+  FOR (n:AttackPath) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT finding_key_engagement IF NOT EXISTS
+  FOR (n:Finding) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT candidate_key_engagement IF NOT EXISTS
+  FOR (n:Candidate) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT hypothesis_key_engagement IF NOT EXISTS
+  FOR (n:Hypothesis) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT patch_key_engagement IF NOT EXISTS
+  FOR (n:Patch) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT detection_fired_key_engagement IF NOT EXISTS
+  FOR (n:DetectionFired) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT defense_action_key_engagement IF NOT EXISTS
+  FOR (n:DefenseAction) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+-- MigrationLog tracks applied schema versions so a re-running container
+-- skips already-applied migrations. Single-property uniqueness on name.
+CREATE CONSTRAINT migration_log_name IF NOT EXISTS
+  FOR (n:MigrationLog) REQUIRE n.name IS UNIQUE;

--- a/packages/decepticon/decepticon/middleware/kg_internal/migrations/V002__engagement_composite_indexes_and_provenance.cypher
+++ b/packages/decepticon/decepticon/middleware/kg_internal/migrations/V002__engagement_composite_indexes_and_provenance.cypher
@@ -1,0 +1,36 @@
+-- KG schema v002 — engagement-scoped composite range indexes and
+-- provenance lookups for the Cartography update_tag pattern.
+
+-- High-traffic engagement-scoped read paths from the agent (kg_record
+-- + summary block) and from the web dashboard graph view.
+CREATE INDEX engagement_host_explored IF NOT EXISTS
+  FOR (n:Host) ON (n.engagement, n.explored);
+CREATE INDEX engagement_vuln_severity IF NOT EXISTS
+  FOR (n:Vulnerability) ON (n.engagement, n.severity);
+CREATE INDEX engagement_finding_status IF NOT EXISTS
+  FOR (n:Finding) ON (n.engagement, n.status);
+CREATE INDEX engagement_entrypoint IF NOT EXISTS
+  FOR (n:Entrypoint) ON (n.engagement);
+CREATE INDEX engagement_crown_jewel IF NOT EXISTS
+  FOR (n:CrownJewel) ON (n.engagement);
+
+-- Provenance lookups — Cartography stale-cleanup sweep and Graphiti-
+-- style "which agent created this finding" forensics.
+CREATE INDEX vuln_lastupdated IF NOT EXISTS
+  FOR (n:Vulnerability) ON (n.engagement, n.lastupdated);
+CREATE INDEX vuln_created_by IF NOT EXISTS
+  FOR (n:Vulnerability) ON (n.engagement, n.created_by);
+
+-- Future-proof vector index for semantic vulnerability recall (Neo4j
+-- 5.13+). The embedding pipeline is opt-in at runtime — schema-only
+-- landing here keeps PR-B free of migration noise. The dimension is
+-- locked to OpenAI text-embedding-3-small (1536) as the OSS default;
+-- enterprise plugins can drop this index and create their own.
+CREATE VECTOR INDEX vuln_embedding IF NOT EXISTS
+  FOR (n:Vulnerability) ON (n.embedding)
+  OPTIONS {
+    indexConfig: {
+      `vector.dimensions`: 1536,
+      `vector.similarity_function`: 'cosine'
+    }
+  };

--- a/packages/decepticon/decepticon/middleware/kg_internal/migrations/__init__.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/migrations/__init__.py
@@ -1,0 +1,12 @@
+"""Cypher migrations for the KG schema.
+
+Each migration is a ``V###__description.cypher`` file. Applied in
+filename order by ``migration_runner.apply_migrations``. Idempotent:
+all statements use ``IF NOT EXISTS`` so re-running is a no-op.
+
+The runner records applied migration names in a ``:MigrationLog`` node
+so a fresh container picks up where the last left off without rerunning
+anything.
+"""
+
+from __future__ import annotations

--- a/packages/decepticon/decepticon/middleware/kg_internal/state.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/state.py
@@ -1,0 +1,53 @@
+"""KGState — agent-state extension owned by ``KGMiddleware``.
+
+Three ``NotRequired`` fields stash KG-relevant context for the agent's
+turn. The middleware's ``before_agent`` hook hydrates them; the
+``wrap_model_call`` hook reads ``kg_summary`` and injects it into the
+system message.
+
+The state schema is auto-merged with the underlying ``AgentState`` at
+``create_agent`` compile time (langchain middleware behavior) so the
+agent's existing fields (messages, engagement_name, etc.) remain
+untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, NotRequired
+
+from langchain.agents import AgentState
+
+
+class KGState(AgentState):
+    """State extension owned by ``KGMiddleware``.
+
+    All fields are ``NotRequired`` so the schema is non-invasive — an
+    agent built without the KG slot retains its original state surface.
+    """
+
+    kg_engagement: NotRequired[
+        Annotated[
+            str,
+            "Engagement scope label that every KG read / write is constrained to.",
+        ]
+    ]
+    kg_revision: NotRequired[
+        Annotated[
+            str,
+            (
+                "Opaque revision token returned by ``KGStore.revision``. "
+                "When this differs from the prior turn the middleware "
+                "rebuilds ``kg_summary``."
+            ),
+        ]
+    ]
+    kg_summary: NotRequired[
+        Annotated[
+            str,
+            (
+                "Cached markdown summary block. Injected into the system "
+                "message in ``wrap_model_call`` so the LLM sees current "
+                "graph state without burning tokens on read tools."
+            ),
+        ]
+    ]

--- a/packages/decepticon/decepticon/middleware/kg_internal/store.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/store.py
@@ -1,0 +1,501 @@
+"""KGStore — engagement-scoped Neo4j wrapper for the KG middleware.
+
+Replaces the broken ``decepticon.tools.research._state.graph_transaction``
+pattern with per-operation ``session.execute_write`` / ``execute_read``
+calls. Each public method takes ``engagement`` as a mandatory keyword
+so the contextvar-based scoping that the legacy
+``decepticon_core.utils.engagement_scope`` exposed is no longer load-
+bearing for KG writes — the middleware passes the label explicitly.
+
+Provenance fields injected automatically on every observation
+(Cartography ``update_tag`` + Graphiti ``source_episode_id`` pattern):
+
+  - ``engagement``       — multi-tenant scope label
+  - ``firstseen``        — Unix timestamp on first MERGE (ON CREATE)
+  - ``lastupdated``      — Unix timestamp on every touch
+  - ``created_by``       — agent role string (e.g. "analyst")
+  - ``source_episode_id``— LangChain tool_call_id of the tool turn
+
+The Cypher path uses ``session.execute_write``/``execute_read`` so the
+driver retries ``Neo.TransientError.Transaction.DeadlockDetected``
+automatically — no Python-level lock needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from decepticon_core.utils.engagement_scope import is_valid_engagement_label
+from decepticon_core.utils.logging import get_logger
+
+log = get_logger("kg.store")
+
+
+# Labels must be a closed alphanumeric vocabulary (closed in NodeKind /
+# EdgeKind enums) so the dynamic interpolation in MERGE statements is
+# safe. Defense in depth: also enforce the regex here in case the
+# caller bypassed the Pydantic types. Node labels are PascalCase by
+# convention (Host, Service, CrownJewel); relationship types are
+# UPPER_CASE (HOSTS, HAS_VULN, EXPLOITS).
+_SAFE_LABEL_RE = re.compile(r"^[A-Z][A-Za-z0-9]{0,63}$")
+_SAFE_REL_TYPE_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+
+
+class KGStoreUnavailableError(RuntimeError):
+    """The Neo4j backend is configured but cannot be reached."""
+
+
+class KGStoreConfigError(RuntimeError):
+    """Required environment variables are missing or malformed."""
+
+
+@dataclass(slots=True)
+class KGStoreConfig:
+    """Connection config — pulled from env in production, injected in tests."""
+
+    uri: str
+    user: str
+    password: str
+    database: str = "neo4j"
+
+    @classmethod
+    def from_env(cls) -> KGStoreConfig:
+        uri = os.environ.get("DECEPTICON_NEO4J_URI", "").strip()
+        user = os.environ.get("DECEPTICON_NEO4J_USER", "").strip()
+        password = os.environ.get("DECEPTICON_NEO4J_PASSWORD", "").strip()
+        database = os.environ.get("DECEPTICON_NEO4J_DATABASE", "neo4j").strip() or "neo4j"
+
+        missing: list[str] = []
+        if not uri:
+            missing.append("DECEPTICON_NEO4J_URI")
+        if not user:
+            missing.append("DECEPTICON_NEO4J_USER")
+        if not password:
+            missing.append("DECEPTICON_NEO4J_PASSWORD")
+        if missing:
+            raise KGStoreConfigError("KGStore missing required env vars: " + ", ".join(missing))
+
+        return cls(uri=uri, user=user, password=password, database=database)
+
+
+def _safe_label(kind: str) -> str:
+    """Validate and return a Cypher-safe node label.
+
+    Raises ``ValueError`` if ``kind`` is not a closed-vocabulary
+    PascalCase identifier. Used in dynamic MERGE interpolation where
+    parameterization is impossible (Cypher does not parameterize
+    labels).
+    """
+    if not isinstance(kind, str) or not _SAFE_LABEL_RE.match(kind):
+        raise ValueError(f"invalid node label {kind!r}; must match [A-Za-z][A-Za-z0-9]{{0,63}}")
+    return kind
+
+
+def _safe_rel_type(kind: str) -> str:
+    """Validate and return a Cypher-safe relationship type."""
+    if not isinstance(kind, str) or not _SAFE_REL_TYPE_RE.match(kind):
+        raise ValueError(f"invalid edge type {kind!r}; must match [A-Z][A-Z0-9_]{{0,63}}")
+    return kind
+
+
+def _flatten_props(props: dict[str, Any]) -> dict[str, Any]:
+    """Coerce arbitrary props into Neo4j-compatible scalar/list values.
+
+    Primitives and primitive-list values pass through. Nested dicts or
+    lists of dicts are JSON-serialised so they survive round-trip
+    without losing structure but stop participating in index lookups.
+    """
+    out: dict[str, Any] = {}
+    for key, value in props.items():
+        if value is None or isinstance(value, (str, int, float, bool)):
+            out[key] = value
+        elif isinstance(value, list) and all(
+            isinstance(item, (str, int, float, bool)) for item in value
+        ):
+            out[key] = value
+        else:
+            try:
+                out[key] = json.dumps(value, default=str)
+            except (TypeError, ValueError):
+                out[key] = str(value)
+    return out
+
+
+class KGStore:
+    """Engagement-scoped Neo4j wrapper. Implements AttackGraphProtocol.
+
+    Construct via ``KGStore.from_env()`` in production; pass a
+    ``KGStoreConfig`` plus an optional driver in tests.
+    """
+
+    def __init__(
+        self,
+        config: KGStoreConfig,
+        *,
+        driver: Any = None,
+    ) -> None:
+        if driver is None:
+            # Lazy import so test code can construct a KGStore against a
+            # fake driver without pulling in the real neo4j package.
+            import neo4j
+
+            try:
+                driver = neo4j.GraphDatabase.driver(config.uri, auth=(config.user, config.password))
+            except Exception as exc:
+                raise KGStoreUnavailableError(
+                    f"failed to open Neo4j driver at {config.uri}: {exc}"
+                ) from exc
+        self._driver = driver
+        self._database = config.database
+
+    @classmethod
+    def from_env(cls) -> KGStore:
+        return cls(KGStoreConfig.from_env())
+
+    def close(self) -> None:
+        try:
+            self._driver.close()
+        except Exception as exc:
+            log.debug("KGStore driver close raised (swallowed): %s", exc)
+
+    # ── Engagement scope safety ────────────────────────────────────────
+
+    @staticmethod
+    def _check_engagement(engagement: str) -> None:
+        if not isinstance(engagement, str) or not engagement:
+            raise ValueError("KGStore methods require a non-empty engagement label")
+        if not is_valid_engagement_label(engagement):
+            raise ValueError(
+                f"invalid engagement label {engagement!r}; "
+                "must match [A-Za-z0-9][A-Za-z0-9._-]{0,127}"
+            )
+
+    # ── Generic Cypher execution ───────────────────────────────────────
+
+    def execute_read(
+        self,
+        cypher: str,
+        params: dict[str, Any] | None = None,
+        *,
+        engagement: str,
+    ) -> list[dict[str, Any]]:
+        """Run a read transaction. ``engagement`` must be injected into
+        the Cypher by the caller — this method only enforces that the
+        scope label is set."""
+        self._check_engagement(engagement)
+        with self._driver.session(database=self._database) as session:
+            return session.execute_read(
+                lambda tx: [dict(record) for record in tx.run(cypher, **(params or {}))]
+            )
+
+    def execute_write(
+        self,
+        cypher: str,
+        params: dict[str, Any] | None = None,
+        *,
+        engagement: str,
+    ) -> list[dict[str, Any]]:
+        """Run a write transaction. Driver retries deadlock errors."""
+        self._check_engagement(engagement)
+        with self._driver.session(database=self._database) as session:
+            return session.execute_write(
+                lambda tx: [dict(record) for record in tx.run(cypher, **(params or {}))]
+            )
+
+    # ── AttackGraphProtocol implementation ─────────────────────────────
+
+    def revision(self, *, engagement: str) -> str:
+        """Opaque token. Changes when any node's ``lastupdated`` advances
+        for this engagement."""
+        self._check_engagement(engagement)
+        cypher = (
+            "MATCH (n) WHERE n.engagement = $engagement "
+            "RETURN coalesce(max(n.lastupdated), 0) AS rev"
+        )
+        rows = self.execute_read(cypher, {"engagement": engagement}, engagement=engagement)
+        rev_val = rows[0]["rev"] if rows else 0
+        return f"rev-{engagement}-{int(rev_val)}"
+
+    def snapshot(self, *, engagement: str):
+        """Build an EngagementSnapshot for ``cart.diff_snapshots`` consumption.
+
+        Lazy-imported to avoid a circular: ``cart.py`` imports from
+        ``decepticon.runtime``, which the middleware does not need to
+        pull in just to construct a snapshot.
+        """
+        from decepticon.runtime.cart import EngagementSnapshot, SnapshotNodeKey, _hash_snapshot
+
+        self._check_engagement(engagement)
+
+        node_cypher = (
+            "MATCH (n) WHERE n.engagement = $engagement "
+            "RETURN labels(n) AS labels, n.label AS label, n.key AS key, "
+            "       coalesce(n.props_json, '{}') AS props_json"
+        )
+        edge_cypher = (
+            "MATCH (s)-[r]->(d) "
+            "WHERE s.engagement = $engagement AND d.engagement = $engagement "
+            "RETURN s.key AS src_key, d.key AS dst_key, type(r) AS kind, "
+            "       labels(s) AS src_labels, labels(d) AS dst_labels, "
+            "       s.label AS src_label, d.label AS dst_label, "
+            "       coalesce(r.props_json, '{}') AS props_json"
+        )
+
+        nodes: dict[SnapshotNodeKey, dict[str, Any]] = {}
+        edges: dict[tuple[SnapshotNodeKey, SnapshotNodeKey, str], dict[str, Any]] = {}
+        key_to_snk: dict[str, SnapshotNodeKey] = {}
+
+        params: dict[str, Any] = {"engagement": engagement}
+        with self._driver.session(database=self._database) as session:
+            for record in session.execute_read(lambda tx: list(tx.run(node_cypher, **params))):
+                labels = [str(label) for label in record["labels"] if label]
+                if not labels:
+                    continue
+                primary_kind = labels[0].lower()
+                label_value = str(record["label"] or "")
+                snk = SnapshotNodeKey(kind=primary_kind, label=label_value)
+                key = str(record["key"] or "")
+                if key:
+                    key_to_snk[key] = snk
+                try:
+                    props = json.loads(record["props_json"])
+                except (TypeError, ValueError):
+                    props = {}
+                nodes[snk] = props if isinstance(props, dict) else {}
+
+            for record in session.execute_read(lambda tx: list(tx.run(edge_cypher, **params))):
+                src_key = str(record["src_key"] or "")
+                dst_key = str(record["dst_key"] or "")
+                rel_kind = str(record["kind"] or "").lower()
+                src = key_to_snk.get(src_key)
+                dst = key_to_snk.get(dst_key)
+                if src is None or dst is None or not rel_kind:
+                    continue
+                try:
+                    props = json.loads(record["props_json"])
+                except (TypeError, ValueError):
+                    props = {}
+                edges[(src, dst, rel_kind)] = props if isinstance(props, dict) else {}
+
+        return EngagementSnapshot(
+            snapshot_id=_hash_snapshot(nodes, edges),
+            captured_at=time.time(),
+            nodes=nodes,
+            edges=edges,
+        )
+
+    # ── Observation recording (kg_record tool backend) ─────────────────
+
+    def record_observations(
+        self,
+        observations: Iterable[dict[str, Any]],
+        *,
+        engagement: str,
+        created_by: str,
+        source_episode_id: str,
+    ) -> dict[str, Any]:
+        """Atomic batch write of node + outgoing-edge observations.
+
+        Every node and edge gets provenance auto-injected
+        (engagement, firstseen, lastupdated, created_by,
+        source_episode_id). All observations land in a single
+        transaction — partial failure rolls back the batch.
+
+        Returns ``{"created": N, "merged": M, "edges": E,
+        "revision": "..."}``.
+        """
+        self._check_engagement(engagement)
+        if not isinstance(created_by, str) or not created_by:
+            raise ValueError("created_by must be a non-empty string (agent role)")
+        if not isinstance(source_episode_id, str) or not source_episode_id:
+            raise ValueError("source_episode_id must be a non-empty string (tool_call_id)")
+
+        obs_list = [o for o in observations if isinstance(o, dict)]
+        if not obs_list:
+            return {
+                "created": 0,
+                "merged": 0,
+                "edges": 0,
+                "revision": self.revision(engagement=engagement),
+            }
+
+        update_tag = int(time.time())
+        node_rows: list[dict[str, Any]] = []
+        edge_rows: list[dict[str, Any]] = []
+
+        for obs in obs_list:
+            kind = _safe_label(obs.get("kind", ""))
+            key = obs.get("key")
+            if not isinstance(key, str) or not key:
+                raise ValueError(
+                    f"observation kind={kind!r} missing mandatory 'key' (deterministic dedup)"
+                )
+            label = str(obs.get("label") or key)
+            raw_props = obs.get("props")
+            props = _flatten_props(dict(raw_props) if isinstance(raw_props, dict) else {})
+            # Reserve provenance fields — operator-supplied values are
+            # silently discarded so the agent cannot forge provenance.
+            for reserved in (
+                "engagement",
+                "firstseen",
+                "lastupdated",
+                "created_by",
+                "source_episode_id",
+            ):
+                props.pop(reserved, None)
+
+            node_rows.append(
+                {
+                    "kind": kind,
+                    "key": key,
+                    "label": label,
+                    "props": props,
+                }
+            )
+
+            for edge in obs.get("edges_out") or []:
+                if not isinstance(edge, dict):
+                    continue
+                to_key = edge.get("to_key")
+                rel_kind = edge.get("kind")
+                if not isinstance(to_key, str) or not to_key:
+                    continue
+                try:
+                    rel_type = _safe_rel_type(rel_kind or "")
+                except ValueError:
+                    continue
+                try:
+                    weight = float(edge.get("weight", 1.0))
+                except (TypeError, ValueError):
+                    weight = 1.0
+                edge_props_raw = edge.get("props")
+                edge_props = _flatten_props(
+                    dict(edge_props_raw) if isinstance(edge_props_raw, dict) else {}
+                )
+                for reserved in (
+                    "engagement",
+                    "firstseen",
+                    "lastupdated",
+                    "created_by",
+                    "source_episode_id",
+                    "weight",
+                ):
+                    edge_props.pop(reserved, None)
+                edge_rows.append(
+                    {
+                        "src_key": key,
+                        "dst_key": to_key,
+                        "kind": rel_type,
+                        "weight": weight,
+                        "props": edge_props,
+                    }
+                )
+
+        # Group node rows by label so we can MERGE under the right
+        # label (Cypher doesn't parameterize labels). For each label
+        # batch one UNWIND-MERGE. Same for edges grouped by rel type.
+        nodes_by_label: dict[str, list[dict[str, Any]]] = {}
+        for row in node_rows:
+            nodes_by_label.setdefault(row["kind"], []).append(row)
+        edges_by_type: dict[str, list[dict[str, Any]]] = {}
+        for row in edge_rows:
+            edges_by_type.setdefault(row["kind"], []).append(row)
+
+        created = 0
+        merged = 0
+        edges_written = 0
+
+        def _do_writes(tx: Any) -> tuple[int, int, int]:
+            local_created = 0
+            local_merged = 0
+            local_edges = 0
+            for label, rows in nodes_by_label.items():
+                node_query = (
+                    f"UNWIND $rows AS row "
+                    f"MERGE (n:{label} {{key: row.key, engagement: $engagement}}) "
+                    "ON CREATE SET n.firstseen = $now "
+                    "SET n.label = row.label, "
+                    "    n.lastupdated = $now, "
+                    "    n.created_by = $created_by, "
+                    "    n.source_episode_id = $source_episode_id, "
+                    "    n += row.props "
+                    "WITH n, n.firstseen = $now AS just_created "
+                    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created, "
+                    "       sum(CASE WHEN just_created THEN 0 ELSE 1 END) AS merged"
+                )
+                for record in tx.run(
+                    node_query,
+                    rows=rows,
+                    engagement=engagement,
+                    now=update_tag,
+                    created_by=created_by,
+                    source_episode_id=source_episode_id,
+                ):
+                    local_created += int(record["created"] or 0)
+                    local_merged += int(record["merged"] or 0)
+            for rel_type, rows in edges_by_type.items():
+                edge_query = (
+                    "UNWIND $rows AS row "
+                    "MATCH (s {key: row.src_key, engagement: $engagement}) "
+                    "MATCH (d {key: row.dst_key, engagement: $engagement}) "
+                    f"MERGE (s)-[r:{rel_type}]->(d) "
+                    "ON CREATE SET r.firstseen = $now "
+                    "SET r.lastupdated = $now, "
+                    "    r.created_by = $created_by, "
+                    "    r.source_episode_id = $source_episode_id, "
+                    "    r.weight = row.weight, "
+                    "    r += row.props "
+                    "RETURN count(r) AS written"
+                )
+                for record in tx.run(
+                    edge_query,
+                    rows=rows,
+                    engagement=engagement,
+                    now=update_tag,
+                    created_by=created_by,
+                    source_episode_id=source_episode_id,
+                ):
+                    local_edges += int(record["written"] or 0)
+            return local_created, local_merged, local_edges
+
+        with self._driver.session(database=self._database) as session:
+            created, merged, edges_written = session.execute_write(_do_writes)
+
+        return {
+            "created": created,
+            "merged": merged,
+            "edges": edges_written,
+            "revision": f"rev-{engagement}-{update_tag}",
+        }
+
+    # ── Stale-node cleanup (Cartography update_tag pattern) ────────────
+
+    def delete_stale(self, *, engagement: str, before_unix: int) -> int:
+        """Detach-delete nodes in ``engagement`` whose ``lastupdated``
+        precedes ``before_unix``. Returns the number deleted.
+
+        Bounded by ``LIMIT 1000`` per call so a single sweep can't
+        block the engagement on a runaway. Callers loop if they need
+        to drain more.
+        """
+        self._check_engagement(engagement)
+        if not isinstance(before_unix, int):
+            raise ValueError("before_unix must be an int Unix timestamp")
+        cypher = (
+            "MATCH (n) WHERE n.engagement = $engagement AND n.lastupdated < $cutoff "
+            "WITH n LIMIT 1000 "
+            "DETACH DELETE n "
+            "RETURN count(n) AS deleted"
+        )
+        rows = self.execute_write(
+            cypher,
+            {"engagement": engagement, "cutoff": before_unix},
+            engagement=engagement,
+        )
+        return int(rows[0]["deleted"] or 0) if rows else 0

--- a/packages/decepticon/decepticon/middleware/kg_internal/store.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/store.py
@@ -419,13 +419,15 @@ class KGStore:
                 node_query = (
                     f"UNWIND $rows AS row "
                     f"MERGE (n:{label} {{key: row.key, engagement: $engagement}}) "
-                    "ON CREATE SET n.firstseen = $now "
+                    "ON CREATE SET n.firstseen = $now, n._jc = true "
+                    "ON MATCH SET n._jc = false "
                     "SET n.label = row.label, "
                     "    n.lastupdated = $now, "
                     "    n.created_by = $created_by, "
                     "    n.source_episode_id = $source_episode_id, "
                     "    n += row.props "
-                    "WITH n, n.firstseen = $now AS just_created "
+                    "WITH n, n._jc AS just_created "
+                    "REMOVE n._jc "
                     "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created, "
                     "       sum(CASE WHEN just_created THEN 0 ELSE 1 END) AS merged"
                 )

--- a/packages/decepticon/decepticon/middleware/kg_internal/summary.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/summary.py
@@ -1,0 +1,202 @@
+"""KG summary block builder for system-prompt injection.
+
+``KGMiddleware`` calls :func:`build_summary` in ``before_agent`` (or
+when the revision token advances) and caches the result in
+``state.kg_summary``. ``wrap_model_call`` then injects that string as a
+trailing content block on the system message.
+
+The output is intentionally small — per the memory-systems anti-pattern
+"stuffing everything into context", the block targets 15-25 lines of
+markdown. Sections that are empty for the engagement are omitted.
+
+Sections (in order):
+
+  1. Header + stats line — nodes / edges / current revision
+  2. Top high-severity vulnerabilities (limit 5)
+  3. Unexplored entrypoints (limit 3) — entrypoints with no HAS_VULN
+     edge out
+  4. Crown jewels with viable-path counts
+
+Chain candidates (top 3 by cost) live in :mod:`kg_internal.chain` (PR-D
+extraction). They will be appended here as section 5 after that module
+lands.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from decepticon.middleware.kg_internal.store import KGStore
+
+# ── Section size budgets ────────────────────────────────────────────────
+
+MAX_VULNS = 5
+MAX_ENTRYPOINTS = 3
+MAX_CROWN_JEWELS = 10  # rarely many — show them all when present
+
+
+# ── Severity ordering ──────────────────────────────────────────────────
+
+# Lowercase string comparison — matches the property values written by
+# the @tool layer (record_observations stores severity in props).
+_SEVERITY_RANK = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+    "info": 4,
+}
+
+
+def _severity_order(value: Any) -> int:
+    if not isinstance(value, str):
+        return 99
+    return _SEVERITY_RANK.get(value.lower(), 99)
+
+
+# ── Section queries ────────────────────────────────────────────────────
+
+
+def _stats(store: KGStore, *, engagement: str) -> dict[str, int]:
+    rows = store.execute_read(
+        (
+            "MATCH (n) WHERE n.engagement = $engagement "
+            "WITH count(n) AS nodes "
+            "OPTIONAL MATCH ()-[r]->() WHERE r.engagement = $engagement "
+            "RETURN nodes, count(r) AS edges"
+        ),
+        {"engagement": engagement},
+        engagement=engagement,
+    )
+    if not rows:
+        return {"nodes": 0, "edges": 0}
+    row = rows[0]
+    return {
+        "nodes": int(row.get("nodes") or 0),
+        "edges": int(row.get("edges") or 0),
+    }
+
+
+def _top_vulns(store: KGStore, *, engagement: str) -> list[dict[str, Any]]:
+    """High and critical vulns first, then medium. Limit total."""
+    rows = store.execute_read(
+        (
+            "MATCH (v:Vulnerability) WHERE v.engagement = $engagement "
+            "RETURN v.key AS key, v.label AS label, "
+            "       coalesce(v.severity, 'info') AS severity "
+            "LIMIT $cap"
+        ),
+        # Pull a wider window then re-rank locally so the Cypher stays
+        # simple. cap = 4 * MAX so even a fully-low engagement still
+        # shows enough rows to sort sensibly.
+        {"engagement": engagement, "cap": MAX_VULNS * 4},
+        engagement=engagement,
+    )
+    rows.sort(key=lambda r: _severity_order(r.get("severity")))
+    return rows[:MAX_VULNS]
+
+
+def _open_entrypoints(store: KGStore, *, engagement: str) -> list[dict[str, Any]]:
+    """Entrypoints with no HAS_VULN edge out — unexplored attack surface."""
+    rows = store.execute_read(
+        (
+            "MATCH (e:Entrypoint) WHERE e.engagement = $engagement "
+            "AND NOT (e)-[:HAS_VULN]->() "
+            "RETURN e.key AS key, e.label AS label "
+            "LIMIT $cap"
+        ),
+        {"engagement": engagement, "cap": MAX_ENTRYPOINTS},
+        engagement=engagement,
+    )
+    return rows
+
+
+def _crown_jewels(store: KGStore, *, engagement: str) -> list[dict[str, Any]]:
+    """Crown jewels with the number of distinct viable paths from any entrypoint."""
+    rows = store.execute_read(
+        (
+            "MATCH (c:CrownJewel) WHERE c.engagement = $engagement "
+            "OPTIONAL MATCH p=(e:Entrypoint)-[*1..6]->(c) "
+            "WHERE e.engagement = $engagement "
+            "WITH c, count(DISTINCT p) AS paths "
+            "RETURN c.key AS key, c.label AS label, paths "
+            "LIMIT $cap"
+        ),
+        {"engagement": engagement, "cap": MAX_CROWN_JEWELS},
+        engagement=engagement,
+    )
+    return rows
+
+
+# ── Markdown rendering ─────────────────────────────────────────────────
+
+
+def _render_stats(engagement: str, revision: str, stats: Mapping[str, int]) -> str:
+    return (
+        f"## KG STATE (engagement={engagement})\n"
+        f"**Nodes**: {stats['nodes']} · **Edges**: {stats['edges']} · "
+        f"**Revision**: `{revision}`"
+    )
+
+
+def _render_vulns(vulns: Iterable[Mapping[str, Any]]) -> str:
+    lines = ["**Top vulnerabilities**:"]
+    for vuln in vulns:
+        sev = str(vuln.get("severity") or "").upper()
+        label = vuln.get("label") or vuln.get("key") or "?"
+        key = vuln.get("key") or "?"
+        lines.append(f"- `[{sev}]` {label} (`{key}`)")
+    return "\n".join(lines)
+
+
+def _render_entrypoints(entrypoints: Iterable[Mapping[str, Any]]) -> str:
+    lines = ["**Unexplored entrypoints**:"]
+    for entry in entrypoints:
+        label = entry.get("label") or entry.get("key") or "?"
+        key = entry.get("key") or "?"
+        lines.append(f"- {label} (`{key}`)")
+    return "\n".join(lines)
+
+
+def _render_crown_jewels(crown_jewels: Iterable[Mapping[str, Any]]) -> str:
+    lines = ["**Crown jewels**:"]
+    for jewel in crown_jewels:
+        label = jewel.get("label") or jewel.get("key") or "?"
+        paths = int(jewel.get("paths") or 0)
+        plural = "" if paths == 1 else "s"
+        lines.append(f"- {label} ({paths} viable path{plural})")
+    return "\n".join(lines)
+
+
+# ── Public entry point ─────────────────────────────────────────────────
+
+
+def build_summary(store: KGStore, *, engagement: str) -> str:
+    """Build the markdown summary block for the given engagement.
+
+    Empty sections are dropped so the block stays compact. Always
+    includes the header + stats line so the LLM can confirm the
+    engagement and revision the middleware injected.
+
+    Returns the markdown string. The caller (KGMiddleware.before_agent)
+    is responsible for caching it into ``state.kg_summary``.
+    """
+    revision = store.revision(engagement=engagement)
+    stats = _stats(store, engagement=engagement)
+
+    sections = [_render_stats(engagement, revision, stats)]
+
+    vulns = _top_vulns(store, engagement=engagement)
+    if vulns:
+        sections.append(_render_vulns(vulns))
+
+    entrypoints = _open_entrypoints(store, engagement=engagement)
+    if entrypoints:
+        sections.append(_render_entrypoints(entrypoints))
+
+    crown_jewels = _crown_jewels(store, engagement=engagement)
+    if crown_jewels:
+        sections.append(_render_crown_jewels(crown_jewels))
+
+    return "\n\n".join(sections)

--- a/packages/decepticon/decepticon/middleware/kg_internal/tools.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/tools.py
@@ -1,0 +1,180 @@
+"""Agent-facing KG tools — ``kg_record`` and ``kg_ingest``.
+
+Built by :func:`build_kg_tools` and attached to ``KGMiddleware.tools``
+so ``langchain.agents.create_agent`` merges them into the agent's
+toolset at compile time. The tools never accept ``engagement`` from
+the LLM; the middleware injects it via ``InjectedState`` and the store
+re-pulls it inside ``record_observations`` / ``ingest`` so an
+``InjectedState`` override bug (open issue
+``langchain-ai/langchain#31688``) cannot escape the engagement scope.
+
+Surface (minimal per the design notes):
+
+  - ``kg_record(observations)``           — atomic batch write of nodes
+                                            and outgoing edges.
+  - ``kg_ingest(scanner_kind, path)``     — dispatcher into the scanner
+                                            adapter registry.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Annotated, Any
+
+from langchain_core.tools import InjectedToolCallId, tool
+from langgraph.prebuilt import InjectedState
+
+from decepticon.middleware.kg_internal.ingest import ingest as _ingest_dispatch
+from decepticon.middleware.kg_internal.store import KGStore
+
+
+DEFAULT_KG_TOOLS = frozenset({"kg_record", "kg_ingest"})
+
+_ENGAGEMENT_UNSET = "kg_engagement is not set on agent state; middleware before_agent did not hydrate"
+
+
+def _resolve_engagement(state: dict[str, Any] | None) -> str:
+    """Pull the engagement label from state with a fall-back to
+    ``engagement_name`` (the upstream EngagementContextMiddleware field)."""
+    if not isinstance(state, dict):
+        return ""
+    return str(state.get("kg_engagement") or state.get("engagement_name") or "").strip()
+
+
+def _resolve_created_by(state: dict[str, Any] | None) -> str:
+    """Best-effort agent identity for provenance. Falls back to a
+    constant string so the trusted ``record_observations`` invariant
+    holds even when the agent role is missing from state."""
+    if not isinstance(state, dict):
+        return "agent"
+    role = state.get("role") or state.get("agent_name") or state.get("kg_created_by")
+    if isinstance(role, str) and role:
+        return role
+    return "agent"
+
+
+def _err(message: str) -> str:
+    return json.dumps({"error": message})
+
+
+def build_kg_tools(
+    store: KGStore,
+    enabled: Iterable[str] | None = None,
+) -> list[Any]:
+    """Construct the agent-facing KG tools bound to a single store.
+
+    ``enabled`` selects which tools land in the returned list. Default
+    is ``DEFAULT_KG_TOOLS`` (kg_record + kg_ingest). Plugin authors
+    that ship a third KG tool can pass ``{"kg_record", "kg_ingest",
+    "kg_my_custom_tool"}`` in conjunction with subclassing
+    ``KGMiddleware`` to append the extra tool factory.
+    """
+    enabled_set: set[str] = set(enabled) if enabled is not None else set(DEFAULT_KG_TOOLS)
+    tools: list[Any] = []
+
+    if "kg_record" in enabled_set:
+
+        @tool
+        def kg_record(
+            observations: str,
+            state: Annotated[dict, InjectedState],
+            tool_call_id: Annotated[str, InjectedToolCallId] = "",
+        ) -> str:
+            """Record one or more graph observations atomically.
+
+            The middleware injects engagement scope + provenance — you
+            only pass the observations. All observations in one call
+            land in a single Neo4j transaction; partial failure rolls
+            back the batch.
+
+            ``observations`` is a JSON-encoded list. Each entry:
+
+              {
+                "kind": "Host" | "Service" | "Vulnerability" | ... ,
+                "key": "host::10.0.0.1",        # deterministic dedup key
+                "label": "10.0.0.1",
+                "props": {"ip": "10.0.0.1", "explored": false, ...},
+                "edges_out": [
+                  {"to_key": "service::10.0.0.1:80",
+                   "kind": "HOSTS", "weight": 0.5}
+                ]
+              }
+
+            Reserved provenance keys (engagement, firstseen, lastupdated,
+            created_by, source_episode_id) are stripped from your props
+            silently — the middleware sets them.
+
+            Returns JSON: {"created": N, "merged": M, "edges": E,
+            "revision": "..."}.
+            """
+            engagement = _resolve_engagement(state)
+            if not engagement:
+                return _err(_ENGAGEMENT_UNSET)
+
+            try:
+                obs_list = json.loads(observations)
+            except (TypeError, ValueError) as exc:
+                return _err(f"observations must be valid JSON list: {exc}")
+            if not isinstance(obs_list, list):
+                return _err("observations must be a JSON list of observation dicts")
+
+            try:
+                result = store.record_observations(
+                    obs_list,
+                    engagement=engagement,
+                    created_by=_resolve_created_by(state),
+                    source_episode_id=tool_call_id or "no-tool-call-id",
+                )
+            except ValueError as exc:
+                return _err(str(exc))
+            except Exception as exc:  # noqa: BLE001 — surface to LLM
+                return _err(f"kg_record failed: {exc}")
+            return json.dumps(result)
+
+        tools.append(kg_record)
+
+    if "kg_ingest" in enabled_set:
+
+        @tool
+        def kg_ingest(
+            scanner_kind: str,
+            path: str,
+            state: Annotated[dict, InjectedState],
+            tool_call_id: Annotated[str, InjectedToolCallId] = "",
+        ) -> str:
+            """Ingest a scanner output file into the engagement graph.
+
+            ``scanner_kind`` selects an adapter from the registry. Built-ins:
+              nmap_xml, nuclei_jsonl, httpx_jsonl, sarif.
+
+            ``path`` is an absolute file path inside the sandbox / host
+            (the adapter reads it directly). Examples:
+              kg_ingest("nmap_xml", "/workspace/scan.xml")
+              kg_ingest("sarif",    "/workspace/semgrep.sarif")
+
+            Returns JSON: {"scanner": "...", "path": "...",
+            "ingested": ...} on success, or
+            {"error": "...", "available": [...]} when ``scanner_kind``
+            is unknown.
+            """
+            engagement = _resolve_engagement(state)
+            if not engagement:
+                return _err(_ENGAGEMENT_UNSET)
+
+            try:
+                result = _ingest_dispatch(
+                    scanner_kind,
+                    path,
+                    store=store,
+                    engagement=engagement,
+                    created_by=_resolve_created_by(state),
+                    source_episode_id=tool_call_id or "no-tool-call-id",
+                )
+            except Exception as exc:  # noqa: BLE001 — surface to LLM
+                return _err(f"kg_ingest failed: {exc}")
+            return json.dumps(result)
+
+        tools.append(kg_ingest)
+
+    return tools

--- a/packages/decepticon/decepticon/middleware/kg_internal/tools.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/tools.py
@@ -28,10 +28,11 @@ from langgraph.prebuilt import InjectedState
 from decepticon.middleware.kg_internal.ingest import ingest as _ingest_dispatch
 from decepticon.middleware.kg_internal.store import KGStore
 
-
 DEFAULT_KG_TOOLS = frozenset({"kg_record", "kg_ingest"})
 
-_ENGAGEMENT_UNSET = "kg_engagement is not set on agent state; middleware before_agent did not hydrate"
+_ENGAGEMENT_UNSET = (
+    "kg_engagement is not set on agent state; middleware before_agent did not hydrate"
+)
 
 
 def _resolve_engagement(state: dict[str, Any] | None) -> str:

--- a/packages/decepticon/decepticon/runtime/cart.py
+++ b/packages/decepticon/decepticon/runtime/cart.py
@@ -213,6 +213,52 @@ def diff_snapshots(a: EngagementSnapshot, b: EngagementSnapshot) -> SnapshotDelt
 
 
 @runtime_checkable
+class AttackGraphProtocol(Protocol):
+    """What CART expects of any attack-graph backend.
+
+    Implemented by the KGMiddleware-owned ``KGStore`` (see
+    ``decepticon.middleware.kg_internal.store``). CART consumes only
+    this surface so a future plugin (e.g. an enterprise variant with
+    extra fields, or a vector-augmented variant) can be substituted
+    without touching ``cart.py`` internals.
+
+    Polling model in the initial version: callers fetch ``revision()``
+    and, when it changes, call ``snapshot()`` to materialize the
+    current state. A pub/sub variant (``subscribe(callback)``) is a
+    follow-up and is intentionally absent from this minimal contract —
+    the design spec at
+    ``docs/design/2026-06-03-kg-middleware-redesign.md`` § 4.7 leaves
+    it open until Neo4j 5.x change-data-capture is wired in.
+
+    The ``engagement`` keyword scopes both methods to one engagement
+    label. CART operates per-engagement and never sees a global graph
+    view — the multi-tenant safety invariant lives at this boundary.
+    """
+
+    def revision(self, *, engagement: str) -> str:
+        """Opaque revision token for the named engagement.
+
+        Changes when the graph's mutable surface for the engagement
+        changes (any node/edge create or update). Cheap to call: a
+        single Cypher MATCH against an indexed property.
+
+        Callers should treat the token as opaque — only equality is
+        meaningful, ordering is not.
+        """
+        ...
+
+    def snapshot(self, *, engagement: str) -> EngagementSnapshot:
+        """Build a frozen snapshot for the named engagement.
+
+        The snapshot is suitable input for :func:`diff_snapshots`. The
+        cost is one bounded Cypher MATCH per node label, so the call
+        is O(graph_size) for the engagement — invoke only when
+        :meth:`revision` indicates a change.
+        """
+        ...
+
+
+@runtime_checkable
 class OPPLANAdapter(Protocol):
     """Seam between CART and the OPPLAN module.
 

--- a/packages/decepticon/tests/integration/__init__.py
+++ b/packages/decepticon/tests/integration/__init__.py
@@ -1,0 +1,9 @@
+"""Integration tests — require live infrastructure.
+
+Tests in this tree (compose Neo4j, langgraph, sandbox, etc.) skip
+automatically when the service they need is unreachable, so a default
+``pytest`` invocation in a fresh checkout does not fail. CI brings the
+stack up before running this lane.
+"""
+
+from __future__ import annotations

--- a/packages/decepticon/tests/integration/kg/__init__.py
+++ b/packages/decepticon/tests/integration/kg/__init__.py
@@ -1,0 +1,10 @@
+"""KGStore + migration runner + KGMiddleware (PR-B) integration tests.
+
+Require a reachable Neo4j 5.x — typically the ``decepticon-neo4j``
+container from ``docker-compose.yml``. The
+:func:`kgstore` fixture in ``conftest.py`` calls ``pytest.skip`` when
+the env vars are unset or the driver fails to connect, so this
+package never fails on a stack that does not have Neo4j up.
+"""
+
+from __future__ import annotations

--- a/packages/decepticon/tests/integration/kg/conftest.py
+++ b/packages/decepticon/tests/integration/kg/conftest.py
@@ -43,21 +43,21 @@ def kgstore() -> Iterator[KGStore]:
     open / round-trip a trivial query.
     """
     _maybe_seed_defaults()
+
+    # Single try-block keeps ``store`` definition + smoke check together
+    # so CodeQL doesn't flag ``store.close()`` as touching a possibly
+    # uninitialised local.
+    store: KGStore | None = None
     try:
         store = KGStore.from_env()
-    except KGStoreConfigError as exc:
-        pytest.skip(f"DECEPTICON_NEO4J_* not configured: {exc}")
-    except Exception as exc:
-        pytest.skip(f"KGStore construction failed: {exc}")
-
-    # Connectivity smoke + result-shape sanity. ``schema`` is the
-    # reserved label the runner uses; re-using it matches production.
-    # The shape check catches CI environments where the ``neo4j`` driver
-    # is somehow stubbed (e.g. by an in-process mock that returns
-    # ``MagicMock`` for every Cypher call). Without this, those stubs
-    # silently pass the connectivity smoke and the integration tests
-    # then fail against a fake graph instead of skipping.
-    try:
+        # Connectivity smoke + result-shape sanity. ``schema`` is the
+        # reserved label the runner uses; re-using it matches production.
+        # The shape check catches CI environments where the ``neo4j``
+        # driver is somehow stubbed (e.g. by an in-process mock that
+        # returns ``MagicMock`` for every Cypher call). Without this,
+        # those stubs silently pass the connectivity smoke and the
+        # integration tests then fail against a fake graph instead of
+        # skipping.
         rows = store.execute_read("RETURN 1 AS ok", {}, engagement="schema")
         if not (
             isinstance(rows, list)
@@ -67,13 +67,23 @@ def kgstore() -> Iterator[KGStore]:
         ):
             raise RuntimeError(
                 f"Neo4j smoke returned an unexpected shape "
-                f"(type={type(rows).__name__}, len={len(rows) if hasattr(rows, '__len__') else 'N/A'}); "
+                f"(type={type(rows).__name__}, "
+                f"len={len(rows) if hasattr(rows, '__len__') else 'N/A'}); "
                 f"the driver is probably stubbed."
             )
+    except KGStoreConfigError as exc:
+        if store is not None:
+            store.close()
+        pytest.skip(f"DECEPTICON_NEO4J_* not configured: {exc}")
     except Exception as exc:  # pragma: no cover — depends on live service
-        store.close()
+        if store is not None:
+            store.close()
         pytest.skip(f"Neo4j not reachable for KG integration tests: {exc}")
 
+    # ``store`` is guaranteed non-None here: every except path above
+    # calls ``pytest.skip`` which raises. The assert narrows the type
+    # for static checkers that don't model ``pytest.skip`` as NoReturn.
+    assert store is not None
     try:
         yield store
     finally:

--- a/packages/decepticon/tests/integration/kg/conftest.py
+++ b/packages/decepticon/tests/integration/kg/conftest.py
@@ -50,10 +50,26 @@ def kgstore() -> Iterator[KGStore]:
     except Exception as exc:
         pytest.skip(f"KGStore construction failed: {exc}")
 
-    # Connectivity smoke. ``schema`` is the reserved label the runner
-    # uses, so re-using it here matches production behaviour.
+    # Connectivity smoke + result-shape sanity. ``schema`` is the
+    # reserved label the runner uses; re-using it matches production.
+    # The shape check catches CI environments where the ``neo4j`` driver
+    # is somehow stubbed (e.g. by an in-process mock that returns
+    # ``MagicMock`` for every Cypher call). Without this, those stubs
+    # silently pass the connectivity smoke and the integration tests
+    # then fail against a fake graph instead of skipping.
     try:
-        store.execute_read("RETURN 1 AS ok", {}, engagement="schema")
+        rows = store.execute_read("RETURN 1 AS ok", {}, engagement="schema")
+        if not (
+            isinstance(rows, list)
+            and len(rows) == 1
+            and isinstance(rows[0], dict)
+            and rows[0].get("ok") == 1
+        ):
+            raise RuntimeError(
+                f"Neo4j smoke returned an unexpected shape "
+                f"(type={type(rows).__name__}, len={len(rows) if hasattr(rows, '__len__') else 'N/A'}); "
+                f"the driver is probably stubbed."
+            )
     except Exception as exc:  # pragma: no cover — depends on live service
         store.close()
         pytest.skip(f"Neo4j not reachable for KG integration tests: {exc}")

--- a/packages/decepticon/tests/integration/kg/conftest.py
+++ b/packages/decepticon/tests/integration/kg/conftest.py
@@ -1,0 +1,83 @@
+"""Shared fixtures for KG integration tests against live Neo4j.
+
+The fixtures skip every test cleanly when the env vars are not set or
+the driver cannot connect, so the integration suite is safe to run in
+any environment — it just no-ops on stacks without Neo4j.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+from decepticon.middleware.kg_internal.store import KGStore, KGStoreConfigError
+
+_DEFAULT_TEST_URI = "bolt://localhost:7687"
+_DEFAULT_TEST_USER = "neo4j"
+_DEFAULT_TEST_PASSWORD = "decepticon-graph"
+
+
+def _maybe_seed_defaults() -> None:
+    """If the developer hasn't set DECEPTICON_NEO4J_* but the compose
+    stack is running on localhost, fill in the compose defaults so the
+    integration suite "just works" on a normal dev box.
+
+    No-op when any var is already set — explicit values always win.
+    """
+    if not os.environ.get("DECEPTICON_NEO4J_URI"):
+        os.environ.setdefault("DECEPTICON_NEO4J_URI", _DEFAULT_TEST_URI)
+    if not os.environ.get("DECEPTICON_NEO4J_USER"):
+        os.environ.setdefault("DECEPTICON_NEO4J_USER", _DEFAULT_TEST_USER)
+    if not os.environ.get("DECEPTICON_NEO4J_PASSWORD"):
+        os.environ.setdefault("DECEPTICON_NEO4J_PASSWORD", _DEFAULT_TEST_PASSWORD)
+
+
+@pytest.fixture(scope="session")
+def kgstore() -> Iterator[KGStore]:
+    """A live :class:`KGStore` against compose Neo4j.
+
+    Skips the test when env vars are missing or the driver cannot
+    open / round-trip a trivial query.
+    """
+    _maybe_seed_defaults()
+    try:
+        store = KGStore.from_env()
+    except KGStoreConfigError as exc:
+        pytest.skip(f"DECEPTICON_NEO4J_* not configured: {exc}")
+    except Exception as exc:
+        pytest.skip(f"KGStore construction failed: {exc}")
+
+    # Connectivity smoke. ``schema`` is the reserved label the runner
+    # uses, so re-using it here matches production behaviour.
+    try:
+        store.execute_read("RETURN 1 AS ok", {}, engagement="schema")
+    except Exception as exc:  # pragma: no cover — depends on live service
+        store.close()
+        pytest.skip(f"Neo4j not reachable for KG integration tests: {exc}")
+
+    try:
+        yield store
+    finally:
+        store.close()
+
+
+@pytest.fixture
+def engagement(kgstore: KGStore) -> Iterator[str]:
+    """Unique engagement label per test; auto-cleaned post-test."""
+    label = f"itest-{uuid.uuid4().hex[:12]}"
+    try:
+        yield label
+    finally:
+        # Best-effort cleanup. Reset failures must not mask test
+        # assertions, so swallow.
+        try:
+            kgstore.execute_write(
+                "MATCH (n) WHERE n.engagement = $eng DETACH DELETE n",
+                {"eng": label},
+                engagement=label,
+            )
+        except Exception:  # pragma: no cover — best-effort
+            pass

--- a/packages/decepticon/tests/integration/kg/test_kg_ingest_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_ingest_live.py
@@ -1,0 +1,251 @@
+"""Live integration tests for the kg_ingest dispatcher + adapters.
+
+Writes scanner-output fixture files to ``tmp_path``, invokes
+:func:`ingest` against the live Neo4j, and asserts the expected nodes
+land in the graph. Skips when Neo4j is unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from decepticon.middleware.kg_internal.ingest import ingest
+from decepticon.middleware.kg_internal.store import KGStore
+
+
+def test_ingest_nmap_xml_creates_host_service_entrypoint(
+    kgstore: KGStore, engagement: str, tmp_path: Path
+) -> None:
+    fixture = tmp_path / "nmap.xml"
+    fixture.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.1" addrtype="ipv4"/>
+            <hostnames><hostname name="live.test"/></hostnames>
+            <ports>
+              <port portid="80" protocol="tcp">
+                <state state="open"/>
+                <service name="http" product="nginx"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    result = ingest(
+        "nmap_xml",
+        fixture,
+        store=kgstore,
+        engagement=engagement,
+        created_by="test_recon",
+        source_episode_id="ep-nmap",
+    )
+    assert result["scanner"] == "nmap_xml"
+    assert result["hosts"] == 1
+    assert result["services"] == 1
+    assert result["entrypoints"] == 1
+
+    # Verify in graph
+    rows = kgstore.execute_read(
+        "MATCH (h:Host) WHERE h.engagement = $eng RETURN h.label AS label",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert any(row["label"] == "live.test" for row in rows)
+
+    svc_rows = kgstore.execute_read(
+        "MATCH (s:Service) WHERE s.engagement = $eng RETURN s.port AS port",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert any(row["port"] == 80 for row in svc_rows)
+
+    ep_rows = kgstore.execute_read(
+        "MATCH (h:Host)-[:HOSTS]->(s:Service) WHERE h.engagement = $eng RETURN count(*) AS c",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert ep_rows[0]["c"] >= 1
+
+
+def test_ingest_nuclei_jsonl_creates_vuln_linked_to_entrypoint(
+    kgstore: KGStore, engagement: str, tmp_path: Path
+) -> None:
+    fixture = tmp_path / "nuclei.jsonl"
+    fixture.write_text(
+        json.dumps(
+            {
+                "template-id": "ssrf-detect",
+                "info": {"severity": "critical", "tags": ["ssrf"]},
+                "matched-at": "https://live.test/api",
+                "host": "live.test",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = ingest(
+        "nuclei_jsonl",
+        fixture,
+        store=kgstore,
+        engagement=engagement,
+        created_by="test_analyst",
+        source_episode_id="ep-nuclei",
+    )
+    assert result["scanner"] == "nuclei_jsonl"
+    assert result["parsed"] == 1
+
+    vuln_rows = kgstore.execute_read(
+        "MATCH (v:Vulnerability) WHERE v.engagement = $eng "
+        "RETURN v.severity AS sev, v.rule_id AS rule_id",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert vuln_rows
+    assert vuln_rows[0]["sev"] == "critical"
+    assert vuln_rows[0]["rule_id"] == "ssrf-detect"
+
+    # Entrypoint has HAS_VULN edge to the vulnerability.
+    edge_rows = kgstore.execute_read(
+        "MATCH (e:Entrypoint)-[:HAS_VULN]->(v:Vulnerability) "
+        "WHERE e.engagement = $eng RETURN count(*) AS c",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert edge_rows[0]["c"] == 1
+
+
+def test_ingest_httpx_jsonl_creates_host_service_entrypoint(
+    kgstore: KGStore, engagement: str, tmp_path: Path
+) -> None:
+    fixture = tmp_path / "httpx.jsonl"
+    fixture.write_text(
+        json.dumps(
+            {
+                "url": "https://live.test:8443/admin",
+                "host": "live.test",
+                "port": 8443,
+                "status-code": 200,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = ingest(
+        "httpx_jsonl",
+        fixture,
+        store=kgstore,
+        engagement=engagement,
+        created_by="test_recon",
+        source_episode_id="ep-httpx",
+    )
+    assert result["parsed"] == 1
+    rows = kgstore.execute_read(
+        "MATCH (e:Entrypoint) WHERE e.engagement = $eng RETURN e.label AS label",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert any("https://live.test:8443/admin" in (row["label"] or "") for row in rows)
+
+
+def test_ingest_sarif_creates_vuln_linked_to_code_location(
+    kgstore: KGStore, engagement: str, tmp_path: Path
+) -> None:
+    fixture = tmp_path / "scan.sarif"
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "semgrep"}},
+                "results": [
+                    {
+                        "ruleId": "python.lang.security.audit.sqli",
+                        "level": "error",
+                        "message": {"text": "SQLi"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "app/views.py"},
+                                    "region": {"startLine": 42},
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    fixture.write_text(json.dumps(sarif), encoding="utf-8")
+    result = ingest(
+        "sarif",
+        fixture,
+        store=kgstore,
+        engagement=engagement,
+        created_by="test_analyst",
+        source_episode_id="ep-sarif",
+    )
+    assert result["scanner"] == "sarif"
+    assert result["results_processed"] == 1
+
+    edge_rows = kgstore.execute_read(
+        "MATCH (v:Vulnerability)-[:DEFINED_IN]->(c:CodeLocation) "
+        "WHERE v.engagement = $eng RETURN v.severity AS sev, c.file AS file, c.start_line AS line",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert edge_rows
+    assert edge_rows[0]["sev"] == "high"  # SARIF level=error → high
+    assert edge_rows[0]["file"] == "app/views.py"
+    assert edge_rows[0]["line"] == 42
+
+
+def test_ingest_idempotent_rerun_same_file_merges(
+    kgstore: KGStore, engagement: str, tmp_path: Path
+) -> None:
+    """Re-ingesting the same scanner output is idempotent — same nodes,
+    same keys, no duplicates."""
+    fixture = tmp_path / "nmap.xml"
+    fixture.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.42" addrtype="ipv4"/>
+            <ports>
+              <port portid="443" protocol="tcp">
+                <state state="open"/>
+                <service name="https"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    ingest(
+        "nmap_xml",
+        fixture,
+        store=kgstore,
+        engagement=engagement,
+        created_by="recon",
+        source_episode_id="ep-1",
+    )
+    ingest(
+        "nmap_xml",
+        fixture,
+        store=kgstore,
+        engagement=engagement,
+        created_by="recon",
+        source_episode_id="ep-2",
+    )
+
+    rows = kgstore.execute_read(
+        "MATCH (h:Host) WHERE h.engagement = $eng AND h.key = 'host::10.0.0.42' "
+        "RETURN count(h) AS c",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert rows[0]["c"] == 1  # dedup MERGE works

--- a/packages/decepticon/tests/integration/kg/test_kg_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_live.py
@@ -1,0 +1,395 @@
+"""End-to-end tests for KGStore + migration runner against live Neo4j.
+
+Exercised classes:
+
+* :class:`TestMigrationsLive` — applies migrations against the live DB
+  and confirms the named constraints + indexes exist.
+* :class:`TestRecordObservationsLive` — single-host, dedup-merge,
+  node+edges atomic batch, provenance auto-injection.
+* :class:`TestSnapshotAndRevisionLive` — revision advances on write,
+  snapshot returns an engagement-scoped subgraph.
+* :class:`TestAttackGraphProtocolLive` — KGStore satisfies the
+  Protocol structural contract at runtime against real driver objects.
+* :class:`TestParallelWriteStress` — Q4 from the design notes: 16
+  concurrent writers (a) writing distinct keys land 16 nodes, (b)
+  writing the same deterministic key collapse to one.
+
+All tests skip cleanly when the Neo4j stack is unreachable (see
+``conftest.py``). Run live with::
+
+    docker compose up -d neo4j
+    DECEPTICON_NEO4J_URI=bolt://localhost:7687 \
+    DECEPTICON_NEO4J_USER=neo4j \
+    DECEPTICON_NEO4J_PASSWORD=decepticon-graph \
+    uv run pytest packages/decepticon/tests/integration/kg/ -v
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from decepticon.middleware.kg_internal.migration_runner import (
+    apply_migrations,
+    list_applied,
+)
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon.runtime.cart import AttackGraphProtocol, EngagementSnapshot
+
+# ── Migrations ──────────────────────────────────────────────────────────
+
+
+class TestMigrationsLive:
+    def test_apply_migrations_creates_expected_constraints(self, kgstore: KGStore) -> None:
+        # First call: applies whatever is pending. May return [] if
+        # the migration was already applied by a prior test session.
+        apply_migrations(kgstore)
+        rows = kgstore.execute_read(
+            "SHOW CONSTRAINTS YIELD name WHERE name IN $names RETURN name",
+            {
+                "names": [
+                    "host_key_engagement",
+                    "service_key_engagement",
+                    "vulnerability_key_engagement",
+                    "finding_key_engagement",
+                    "migration_log_name",
+                ]
+            },
+            engagement="schema",
+        )
+        present = {row["name"] for row in rows}
+        assert "host_key_engagement" in present
+        assert "service_key_engagement" in present
+        assert "vulnerability_key_engagement" in present
+        assert "finding_key_engagement" in present
+        assert "migration_log_name" in present
+
+    def test_apply_migrations_creates_v002_indexes(self, kgstore: KGStore) -> None:
+        apply_migrations(kgstore)
+        rows = kgstore.execute_read(
+            "SHOW INDEXES YIELD name WHERE name IN $names RETURN name",
+            {
+                "names": [
+                    "engagement_host_explored",
+                    "engagement_vuln_severity",
+                    "engagement_finding_status",
+                    "vuln_embedding",
+                ]
+            },
+            engagement="schema",
+        )
+        present = {row["name"] for row in rows}
+        assert "engagement_host_explored" in present
+        assert "engagement_vuln_severity" in present
+        assert "engagement_finding_status" in present
+        # Vector index — Q5 = yes, schema-only in V002.
+        assert "vuln_embedding" in present
+
+    def test_apply_migrations_records_in_migration_log(self, kgstore: KGStore) -> None:
+        apply_migrations(kgstore)
+        applied = list_applied(kgstore)
+        assert "V001__initial_schema" in applied
+        assert "V002__engagement_composite_indexes_and_provenance" in applied
+
+    def test_apply_migrations_idempotent_no_double_work(self, kgstore: KGStore) -> None:
+        # First call may run pending migrations or no-op. The second
+        # call MUST be a no-op regardless of state.
+        apply_migrations(kgstore)
+        second = apply_migrations(kgstore)
+        assert second == []
+
+
+# ── record_observations ─────────────────────────────────────────────────
+
+
+class TestRecordObservationsLive:
+    def test_record_single_host(self, kgstore: KGStore, engagement: str) -> None:
+        result = kgstore.record_observations(
+            [
+                {
+                    "kind": "Host",
+                    "key": f"host::single::{engagement}",
+                    "label": "10.0.0.1",
+                    "props": {"ip": "10.0.0.1", "explored": False},
+                }
+            ],
+            engagement=engagement,
+            created_by="test_record",
+            source_episode_id="ep-single",
+        )
+        assert result["created"] == 1
+        assert result["merged"] == 0
+        assert result["edges"] == 0
+        assert isinstance(result["revision"], str)
+
+    def test_record_same_key_merges_idempotent(self, kgstore: KGStore, engagement: str) -> None:
+        obs: dict[str, Any] = {
+            "kind": "Host",
+            "key": f"host::merge::{engagement}",
+            "label": "10.0.0.2",
+            "props": {"ip": "10.0.0.2"},
+        }
+        first = kgstore.record_observations(
+            [obs], engagement=engagement, created_by="t", source_episode_id="ep-1"
+        )
+        second = kgstore.record_observations(
+            [obs], engagement=engagement, created_by="t", source_episode_id="ep-2"
+        )
+        assert first["created"] == 1
+        assert second["created"] == 0
+        assert second["merged"] == 1
+
+    def test_record_nodes_with_outgoing_edges(self, kgstore: KGStore, engagement: str) -> None:
+        host_key = f"host::e::{engagement}"
+        svc_key = f"service::e::{engagement}"
+        result = kgstore.record_observations(
+            [
+                {
+                    "kind": "Host",
+                    "key": host_key,
+                    "label": "host-e",
+                    "edges_out": [{"to_key": svc_key, "kind": "HOSTS", "weight": 0.5}],
+                },
+                {
+                    "kind": "Service",
+                    "key": svc_key,
+                    "label": "service-e",
+                },
+            ],
+            engagement=engagement,
+            created_by="t",
+            source_episode_id="ep-edges",
+        )
+        assert result["created"] == 2
+        assert result["edges"] == 1
+
+        # Verify the edge exists in the graph.
+        rows = kgstore.execute_read(
+            "MATCH (h:Host {key: $hk, engagement: $eng})-[r:HOSTS]->(s:Service {key: $sk, engagement: $eng}) "
+            "RETURN r.weight AS weight",
+            {"hk": host_key, "sk": svc_key, "eng": engagement},
+            engagement=engagement,
+        )
+        assert rows
+        assert rows[0]["weight"] == pytest.approx(0.5)
+
+    def test_provenance_auto_injected(self, kgstore: KGStore, engagement: str) -> None:
+        kgstore.record_observations(
+            [
+                {
+                    "kind": "Host",
+                    "key": f"host::prov::{engagement}",
+                    "label": "h",
+                }
+            ],
+            engagement=engagement,
+            created_by="analyst",
+            source_episode_id="tc-real",
+        )
+        rows = kgstore.execute_read(
+            "MATCH (n:Host) WHERE n.engagement = $eng AND n.key = $key "
+            "RETURN n.engagement AS engagement, "
+            "       n.created_by AS created_by, "
+            "       n.source_episode_id AS sep, "
+            "       n.firstseen AS firstseen, "
+            "       n.lastupdated AS lastupdated",
+            {"eng": engagement, "key": f"host::prov::{engagement}"},
+            engagement=engagement,
+        )
+        assert rows
+        row = rows[0]
+        assert row["engagement"] == engagement
+        assert row["created_by"] == "analyst"
+        assert row["sep"] == "tc-real"
+        assert isinstance(row["firstseen"], int) and row["firstseen"] > 0
+        assert row["lastupdated"] >= row["firstseen"]
+
+    def test_provenance_cannot_be_forged_by_agent(self, kgstore: KGStore, engagement: str) -> None:
+        """Even if the agent puts engagement/firstseen/created_by in
+        props, the trusted middleware-supplied values win."""
+        kgstore.record_observations(
+            [
+                {
+                    "kind": "Host",
+                    "key": f"host::forge::{engagement}",
+                    "label": "h",
+                    "props": {
+                        "engagement": "MALICIOUS",
+                        "firstseen": 0,
+                        "created_by": "spoofed",
+                        "source_episode_id": "spoofed",
+                    },
+                }
+            ],
+            engagement=engagement,
+            created_by="analyst",
+            source_episode_id="tc-trusted",
+        )
+        rows = kgstore.execute_read(
+            "MATCH (n:Host) WHERE n.engagement = $eng AND n.key = $key "
+            "RETURN n.engagement AS engagement, "
+            "       n.created_by AS created_by, "
+            "       n.source_episode_id AS sep, "
+            "       n.firstseen AS firstseen",
+            {"eng": engagement, "key": f"host::forge::{engagement}"},
+            engagement=engagement,
+        )
+        assert rows
+        row = rows[0]
+        assert row["engagement"] == engagement  # trusted value
+        assert row["created_by"] == "analyst"  # not "spoofed"
+        assert row["sep"] == "tc-trusted"
+        assert row["firstseen"] > 0  # not 0
+
+
+# ── snapshot / revision ─────────────────────────────────────────────────
+
+
+class TestSnapshotAndRevisionLive:
+    def test_revision_advances_after_write(self, kgstore: KGStore, engagement: str) -> None:
+        rev_before = kgstore.revision(engagement=engagement)
+        kgstore.record_observations(
+            [{"kind": "Host", "key": f"host::rev::{engagement}", "label": "h"}],
+            engagement=engagement,
+            created_by="t",
+            source_episode_id="ep",
+        )
+        rev_after = kgstore.revision(engagement=engagement)
+        assert rev_before != rev_after
+
+    def test_snapshot_returns_engagement_scoped_subgraph(
+        self, kgstore: KGStore, engagement: str
+    ) -> None:
+        host_key = f"host::snap::{engagement}"
+        svc_key = f"service::snap::{engagement}"
+        kgstore.record_observations(
+            [
+                {
+                    "kind": "Host",
+                    "key": host_key,
+                    "label": "h-snap",
+                    "edges_out": [{"to_key": svc_key, "kind": "HOSTS", "weight": 0.5}],
+                },
+                {"kind": "Service", "key": svc_key, "label": "s-snap"},
+            ],
+            engagement=engagement,
+            created_by="t",
+            source_episode_id="ep",
+        )
+        snap = kgstore.snapshot(engagement=engagement)
+        assert isinstance(snap, EngagementSnapshot)
+        kinds = {snk.kind for snk in snap.nodes}
+        assert "host" in kinds
+        assert "service" in kinds
+        # At least one HOSTS edge.
+        edge_kinds = {kind for (_, _, kind) in snap.edges}
+        assert "hosts" in edge_kinds
+
+
+# ── AttackGraphProtocol structural conformance ─────────────────────────
+
+
+class TestAttackGraphProtocolLive:
+    def test_kgstore_is_attack_graph_protocol(self, kgstore: KGStore) -> None:
+        """Confirm the runtime-checkable Protocol matches the live class."""
+        assert isinstance(kgstore, AttackGraphProtocol)
+
+
+# ── 16-agent parallel write stress (Q4) ────────────────────────────────
+
+
+class TestParallelWriteStress:
+    """Simulate 16 specialist agents writing in parallel within one
+    engagement. The Neo4j driver's MVCC + transaction retry must
+    handle this without a Python-level lock."""
+
+    def test_sixteen_unique_keys_all_land(self, kgstore: KGStore, engagement: str) -> None:
+        n = 16
+
+        def write_one(i: int) -> dict[str, Any]:
+            return kgstore.record_observations(
+                [
+                    {
+                        "kind": "Host",
+                        "key": f"host::parallel::{i}::{engagement}",
+                        "label": f"agent-{i}",
+                    }
+                ],
+                engagement=engagement,
+                created_by=f"agent-{i}",
+                source_episode_id=f"ep-{i}",
+            )
+
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            results = list(pool.map(write_one, range(n)))
+
+        assert all(r["created"] == 1 for r in results)
+        rows = kgstore.execute_read(
+            "MATCH (n:Host) WHERE n.engagement = $eng "
+            "AND n.key STARTS WITH 'host::parallel::' RETURN count(n) AS c",
+            {"eng": engagement},
+            engagement=engagement,
+        )
+        assert rows[0]["c"] == n
+
+    def test_sixteen_same_key_collapses_to_one(self, kgstore: KGStore, engagement: str) -> None:
+        n = 16
+        shared_key = f"host::shared::{engagement}"
+
+        def write_one(i: int) -> dict[str, Any]:
+            return kgstore.record_observations(
+                [
+                    {
+                        "kind": "Host",
+                        "key": shared_key,
+                        "label": "shared",
+                        "props": {f"prop_from_agent_{i}": True},
+                    }
+                ],
+                engagement=engagement,
+                created_by=f"agent-{i}",
+                source_episode_id=f"ep-{i}",
+            )
+
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            list(pool.map(write_one, range(n)))
+
+        # End state: exactly one node with this key.
+        rows = kgstore.execute_read(
+            "MATCH (n:Host) WHERE n.engagement = $eng AND n.key = $key RETURN count(n) AS c",
+            {"eng": engagement, "key": shared_key},
+            engagement=engagement,
+        )
+        assert rows[0]["c"] == 1
+
+
+# ── delete_stale (Cartography pattern) ─────────────────────────────────
+
+
+class TestDeleteStale:
+    def test_delete_stale_removes_old_nodes(self, kgstore: KGStore, engagement: str) -> None:
+        kgstore.record_observations(
+            [{"kind": "Host", "key": f"host::stale::{engagement}", "label": "old"}],
+            engagement=engagement,
+            created_by="t",
+            source_episode_id="ep",
+        )
+        # Pretend we are far in the future — cutoff well after now.
+        future_cutoff = int(time.time()) + 3600
+        deleted = kgstore.delete_stale(engagement=engagement, before_unix=future_cutoff)
+        assert deleted >= 1
+
+    def test_delete_stale_keeps_recent_nodes(self, kgstore: KGStore, engagement: str) -> None:
+        kgstore.record_observations(
+            [{"kind": "Host", "key": f"host::fresh::{engagement}", "label": "new"}],
+            engagement=engagement,
+            created_by="t",
+            source_episode_id="ep",
+        )
+        # Cutoff in the past — nothing should be deleted.
+        past_cutoff = int(time.time()) - 3600
+        deleted = kgstore.delete_stale(engagement=engagement, before_unix=past_cutoff)
+        assert deleted == 0

--- a/packages/decepticon/tests/integration/kg/test_kg_middleware_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_middleware_live.py
@@ -1,0 +1,219 @@
+"""Live integration tests for :class:`KGMiddleware` against compose Neo4j.
+
+End-to-end check of the four hooks on a real KGStore — before_agent
+hydrates from engagement_name, the summary updates after a write, the
+revision marker forces a rebuild on the next turn, and wrap_tool_call
+refuses to write without an engagement.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+
+from decepticon.middleware.kg import KG_SYSTEM_PROMPT, KGMiddleware
+from decepticon.middleware.kg_internal.store import KGStore
+
+
+def _fake_request(
+    *, state: dict[str, Any], system_message: SystemMessage | None = None
+) -> SimpleNamespace:
+    """Synthetic ModelRequest stand-in (matches the shape OPPLAN tests use)."""
+    request = SimpleNamespace(state=state, system_message=system_message)
+
+    def override(**kwargs: Any) -> SimpleNamespace:
+        new = SimpleNamespace(**vars(request))
+        for k, v in kwargs.items():
+            setattr(new, k, v)
+        return new
+
+    request.override = override  # type: ignore[attr-defined]
+    return request
+
+
+def test_middleware_hydrates_state_from_engagement_name_live(
+    kgstore: KGStore, engagement: str
+) -> None:
+    mw = KGMiddleware(store=kgstore)
+    out = mw.before_agent({"engagement_name": engagement}, runtime=None)
+    assert out is not None
+    assert out["kg_engagement"] == engagement
+    assert out["kg_revision"].startswith(f"rev-{engagement}-")
+    # Even an empty engagement gets at least the header in the summary.
+    assert f"engagement={engagement}" in out["kg_summary"]
+
+
+def test_middleware_summary_updates_after_kg_record_write(
+    kgstore: KGStore, engagement: str
+) -> None:
+    mw = KGMiddleware(store=kgstore)
+
+    # Initial hydrate.
+    state = {"engagement_name": engagement}
+    state.update(mw.before_agent(state, runtime=None) or {})
+    initial_revision = state["kg_revision"]
+    assert "Top vulnerabilities" not in state["kg_summary"]
+
+    # Invoke kg_record through the tool the middleware exposes.
+    [kg_record, _] = mw.tools
+    payload = {
+        "name": "kg_record",
+        "type": "tool_call",
+        "id": "live-mw-call",
+        "args": {
+            "observations": json.dumps(
+                [
+                    {
+                        "kind": "Vulnerability",
+                        "key": f"vuln::mw-test::{engagement}",
+                        "label": "MW test vuln",
+                        "props": {"severity": "critical"},
+                    }
+                ]
+            ),
+            "state": state,
+        },
+    }
+    result_msg = kg_record.invoke(payload)
+    result = json.loads(result_msg.content)
+    assert result["created"] == 1
+
+    # after_model simulating: detect the kg_record call and mark dirty.
+    ai = AIMessage(
+        content="",
+        tool_calls=[{"name": "kg_record", "args": {"observations": "[]"}, "id": "live-mw-call"}],
+    )
+    after_update = mw.after_model({"messages": [ai]}, runtime=None)
+    assert after_update == {"kg_revision": "dirty"}
+    state.update(after_update)
+
+    # Next turn's before_agent rebuilds the summary.
+    second = mw.before_agent(state, runtime=None)
+    assert second is not None
+    assert second["kg_revision"] != initial_revision
+    assert "Top vulnerabilities" in second["kg_summary"]
+    assert "MW test vuln" in second["kg_summary"]
+
+
+def test_middleware_wrap_model_call_injects_summary_into_system_message(
+    kgstore: KGStore, engagement: str
+) -> None:
+    """End-to-end check: after before_agent, wrap_model_call should
+    append the KG_SYSTEM_PROMPT + the summary block to the system
+    message."""
+    mw = KGMiddleware(store=kgstore)
+    state = {"engagement_name": engagement}
+    state.update(mw.before_agent(state, runtime=None) or {})
+
+    sys_msg = SystemMessage(content="agent base prompt")
+    request = _fake_request(state=state, system_message=sys_msg)
+
+    out = mw.wrap_model_call(request, lambda req: req)
+    blocks = out.system_message.content
+    assert any(KG_SYSTEM_PROMPT in (b.get("text") or "") for b in blocks if isinstance(b, dict))
+    assert any(
+        f"engagement={engagement}" in (b.get("text") or "") for b in blocks if isinstance(b, dict)
+    )
+
+
+def test_middleware_wrap_tool_call_rejects_kg_record_without_engagement(
+    kgstore: KGStore,
+) -> None:
+    """End-to-end refusal: no engagement on state → middleware returns
+    a ToolMessage and the live store is NEVER touched."""
+    mw = KGMiddleware(store=kgstore)
+    [kg_record, _] = mw.tools
+
+    tool_request = SimpleNamespace(
+        tool=SimpleNamespace(name="kg_record"),
+        state={},
+        tool_call=SimpleNamespace(id="rejected-call"),
+    )
+
+    captured: list[Any] = []
+    out = mw.wrap_tool_call(
+        tool_request,
+        lambda req: captured.append(req) or "should not be reached",
+    )
+    assert isinstance(out, ToolMessage)
+    payload = json.loads(out.content)
+    assert "error" in payload
+    assert "kg_engagement" in payload["error"]
+    # Handler must not have been invoked → no Neo4j write.
+    assert captured == []
+
+
+def test_middleware_wrap_tool_call_passes_through_when_engagement_set(
+    kgstore: KGStore, engagement: str
+) -> None:
+    mw = KGMiddleware(store=kgstore)
+    tool_request = SimpleNamespace(
+        tool=SimpleNamespace(name="kg_record"),
+        state={"kg_engagement": engagement},
+        tool_call=SimpleNamespace(id="allowed-call"),
+    )
+    captured: list[Any] = []
+    out = mw.wrap_tool_call(
+        tool_request,
+        lambda req: captured.append(req) or "handler-ran",
+    )
+    assert out == "handler-ran"
+    assert len(captured) == 1
+
+
+def test_middleware_full_lifecycle_loop_live(kgstore: KGStore, engagement: str) -> None:
+    """Two-turn loop end-to-end: turn 1 writes a Host via kg_record,
+    turn 2's summary reflects the write."""
+    mw = KGMiddleware(store=kgstore)
+
+    # Turn 1.
+    state: dict[str, Any] = {"engagement_name": engagement}
+    state.update(mw.before_agent(state, runtime=None) or {})
+    [kg_record, _] = mw.tools
+    payload = {
+        "name": "kg_record",
+        "type": "tool_call",
+        "id": "tc-turn-1",
+        "args": {
+            "observations": json.dumps(
+                [
+                    {
+                        "kind": "Host",
+                        "key": f"host::full-loop::{engagement}",
+                        "label": "full-loop-host",
+                    }
+                ]
+            ),
+            "state": state,
+        },
+    }
+    write_result = json.loads(kg_record.invoke(payload).content)
+    assert write_result["created"] == 1
+
+    # The middleware's after_model would mark dirty given the AI message.
+    state.update(
+        mw.after_model(
+            {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "kg_record", "args": {"observations": "[]"}, "id": "tc-turn-1"}
+                        ],
+                    )
+                ]
+            },
+            runtime=None,
+        )
+        or {}
+    )
+
+    # Turn 2 — before_agent picks up the new revision and rebuilds.
+    update = mw.before_agent(state, runtime=None)
+    assert update is not None
+    assert update["kg_revision"].endswith(tuple("0123456789"))  # not "dirty"
+    # Stats line should now show at least one node.
+    assert "Nodes**: 1" in update["kg_summary"] or "Nodes**: 0" not in update["kg_summary"]

--- a/packages/decepticon/tests/integration/kg/test_kg_summary_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_summary_live.py
@@ -1,0 +1,235 @@
+"""Live integration tests for ``build_summary`` against compose Neo4j.
+
+Populates an engagement with a representative graph (hosts, services,
+vulnerabilities, entrypoints, crown jewels) via ``kgstore.record_observations``
+and asserts ``build_summary`` produces an LLM-ready markdown block.
+
+Skips when Neo4j is unreachable — same convention as the rest of
+``tests/integration/kg``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon.middleware.kg_internal.summary import (
+    MAX_ENTRYPOINTS,
+    MAX_VULNS,
+    build_summary,
+)
+
+
+def _populate(store: KGStore, engagement: str) -> None:
+    """Seed a representative engagement: 2 hosts, 2 services, 3 vulns,
+    2 entrypoints (1 unexplored), 1 crown jewel reachable from
+    entrypoint via a single edge chain."""
+    observations: list[dict[str, Any]] = [
+        # Hosts
+        {
+            "kind": "Host",
+            "key": f"host::10.0.0.1::{engagement}",
+            "label": "10.0.0.1",
+            "props": {"ip": "10.0.0.1", "explored": True},
+        },
+        # Services
+        {
+            "kind": "Service",
+            "key": f"service::10.0.0.1:80::{engagement}",
+            "label": "10.0.0.1:80",
+            "props": {"port": 80, "product": "nginx"},
+        },
+        # Vulnerabilities — mixed severity so ordering is testable
+        {
+            "kind": "Vulnerability",
+            "key": f"vuln::ssti-search::{engagement}",
+            "label": "SSTI in /search",
+            "props": {"severity": "critical", "cwe": "CWE-1336"},
+        },
+        {
+            "kind": "Vulnerability",
+            "key": f"vuln::sqli-login::{engagement}",
+            "label": "SQLi in /login",
+            "props": {"severity": "high", "cwe": "CWE-89"},
+        },
+        {
+            "kind": "Vulnerability",
+            "key": f"vuln::open-redirect::{engagement}",
+            "label": "Open redirect on /next",
+            "props": {"severity": "low"},
+        },
+        # Entrypoint (vulnerable) — has HAS_VULN edge so it is NOT
+        # listed in 'unexplored entrypoints'.
+        {
+            "kind": "Entrypoint",
+            "key": f"entrypoint::vuln::{engagement}",
+            "label": "https://app/login",
+            "edges_out": [
+                {
+                    "to_key": f"vuln::sqli-login::{engagement}",
+                    "kind": "HAS_VULN",
+                    "weight": 0.4,
+                }
+            ],
+        },
+        # Entrypoint (unexplored)
+        {
+            "kind": "Entrypoint",
+            "key": f"entrypoint::unexplored::{engagement}",
+            "label": "https://app/admin",
+        },
+        # Crown jewel reachable via a single edge for path counting
+        {
+            "kind": "CrownJewel",
+            "key": f"crown::admin-panel::{engagement}",
+            "label": "admin_panel",
+        },
+    ]
+    store.record_observations(
+        observations,
+        engagement=engagement,
+        created_by="test_summary",
+        source_episode_id="ep-summary",
+    )
+    # Wire the unexplored entrypoint to the crown jewel so it counts
+    # as a viable path.
+    store.execute_write(
+        (
+            "MATCH (e:Entrypoint {key: $ek, engagement: $eng}) "
+            "MATCH (c:CrownJewel {key: $ck, engagement: $eng}) "
+            "MERGE (e)-[r:LEADS_TO]->(c) "
+            "ON CREATE SET r.engagement = $eng, r.firstseen = 1, r.lastupdated = 1"
+        ),
+        {
+            "ek": f"entrypoint::unexplored::{engagement}",
+            "ck": f"crown::admin-panel::{engagement}",
+            "eng": engagement,
+        },
+        engagement=engagement,
+    )
+
+
+def test_summary_empty_engagement_shows_header_only(
+    kgstore: KGStore, engagement: str
+) -> None:
+    """A brand-new engagement gets the header + stats line, nothing else."""
+    out = build_summary(kgstore, engagement=engagement)
+    assert f"engagement={engagement}" in out
+    assert "Nodes**: 0" in out
+    assert "Top vulnerabilities" not in out
+    assert "Unexplored entrypoints" not in out
+    assert "Crown jewels" not in out
+
+
+def test_summary_populated_engagement_contains_all_sections(
+    kgstore: KGStore, engagement: str
+) -> None:
+    _populate(kgstore, engagement)
+    out = build_summary(kgstore, engagement=engagement)
+    assert f"engagement={engagement}" in out
+    assert "Top vulnerabilities" in out
+    assert "Unexplored entrypoints" in out
+    assert "Crown jewels" in out
+
+
+def test_summary_vulns_ordered_by_severity(
+    kgstore: KGStore, engagement: str
+) -> None:
+    """Critical before high before low in the rendered block."""
+    _populate(kgstore, engagement)
+    out = build_summary(kgstore, engagement=engagement)
+    crit_pos = out.find("SSTI in /search")
+    high_pos = out.find("SQLi in /login")
+    low_pos = out.find("Open redirect")
+    assert 0 < crit_pos < high_pos < low_pos
+
+
+def test_summary_unexplored_entrypoint_listed_explored_omitted(
+    kgstore: KGStore, engagement: str
+) -> None:
+    _populate(kgstore, engagement)
+    out = build_summary(kgstore, engagement=engagement)
+    # The unexplored entrypoint MUST appear in the entrypoints section.
+    assert "https://app/admin" in out
+    # The vulnerable entrypoint must NOT appear in entrypoints (it has
+    # a HAS_VULN edge).
+    ep_section_start = out.find("Unexplored entrypoints")
+    if ep_section_start >= 0:
+        next_section = out.find("\n\n", ep_section_start + 1)
+        ep_section = out[ep_section_start:next_section] if next_section > 0 else out[ep_section_start:]
+        assert "https://app/login" not in ep_section
+
+
+def test_summary_crown_jewel_path_count_correct(
+    kgstore: KGStore, engagement: str
+) -> None:
+    _populate(kgstore, engagement)
+    out = build_summary(kgstore, engagement=engagement)
+    # The crown jewel was linked to the unexplored entrypoint via one
+    # LEADS_TO edge, so paths = 1.
+    assert "admin_panel (1 viable path)" in out
+
+
+def test_summary_advances_with_revision(
+    kgstore: KGStore, engagement: str
+) -> None:
+    """The summary's revision token changes after a write."""
+    before = build_summary(kgstore, engagement=engagement)
+    _populate(kgstore, engagement)
+    after = build_summary(kgstore, engagement=engagement)
+    # The revision substring should differ.
+    before_rev = before.split("Revision**:")[1].split("\n")[0]
+    after_rev = after.split("Revision**:")[1].split("\n")[0]
+    assert before_rev != after_rev
+
+
+def test_summary_respects_vuln_cap(
+    kgstore: KGStore, engagement: str
+) -> None:
+    """When more than MAX_VULNS vulns exist, the block truncates."""
+    observations: list[dict[str, Any]] = []
+    for i in range(MAX_VULNS * 2):
+        observations.append(
+            {
+                "kind": "Vulnerability",
+                "key": f"vuln::cap-{i}::{engagement}",
+                "label": f"vuln-{i}",
+                "props": {"severity": "medium"},
+            }
+        )
+    kgstore.record_observations(
+        observations,
+        engagement=engagement,
+        created_by="test_summary",
+        source_episode_id="ep-cap",
+    )
+    out = build_summary(kgstore, engagement=engagement)
+    # Each vuln rendered as "- `[SEV]`"
+    bullet_count = out.count("- `[")
+    assert bullet_count == MAX_VULNS
+
+
+def test_summary_respects_entrypoint_cap(
+    kgstore: KGStore, engagement: str
+) -> None:
+    observations: list[dict[str, Any]] = []
+    for i in range(MAX_ENTRYPOINTS * 2):
+        observations.append(
+            {
+                "kind": "Entrypoint",
+                "key": f"entrypoint::cap-{i}::{engagement}",
+                "label": f"https://ep-{i}/",
+            }
+        )
+    kgstore.record_observations(
+        observations,
+        engagement=engagement,
+        created_by="test_summary",
+        source_episode_id="ep-cap-eps",
+    )
+    out = build_summary(kgstore, engagement=engagement)
+    ep_section_start = out.find("Unexplored entrypoints")
+    ep_section = out[ep_section_start:]
+    # Each entrypoint is one "- " bullet.
+    bullet_count = ep_section.count("- ")
+    assert bullet_count == MAX_ENTRYPOINTS

--- a/packages/decepticon/tests/integration/kg/test_kg_summary_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_summary_live.py
@@ -109,9 +109,7 @@ def _populate(store: KGStore, engagement: str) -> None:
     )
 
 
-def test_summary_empty_engagement_shows_header_only(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_summary_empty_engagement_shows_header_only(kgstore: KGStore, engagement: str) -> None:
     """A brand-new engagement gets the header + stats line, nothing else."""
     out = build_summary(kgstore, engagement=engagement)
     assert f"engagement={engagement}" in out
@@ -132,9 +130,7 @@ def test_summary_populated_engagement_contains_all_sections(
     assert "Crown jewels" in out
 
 
-def test_summary_vulns_ordered_by_severity(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_summary_vulns_ordered_by_severity(kgstore: KGStore, engagement: str) -> None:
     """Critical before high before low in the rendered block."""
     _populate(kgstore, engagement)
     out = build_summary(kgstore, engagement=engagement)
@@ -156,13 +152,13 @@ def test_summary_unexplored_entrypoint_listed_explored_omitted(
     ep_section_start = out.find("Unexplored entrypoints")
     if ep_section_start >= 0:
         next_section = out.find("\n\n", ep_section_start + 1)
-        ep_section = out[ep_section_start:next_section] if next_section > 0 else out[ep_section_start:]
+        ep_section = (
+            out[ep_section_start:next_section] if next_section > 0 else out[ep_section_start:]
+        )
         assert "https://app/login" not in ep_section
 
 
-def test_summary_crown_jewel_path_count_correct(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_summary_crown_jewel_path_count_correct(kgstore: KGStore, engagement: str) -> None:
     _populate(kgstore, engagement)
     out = build_summary(kgstore, engagement=engagement)
     # The crown jewel was linked to the unexplored entrypoint via one
@@ -170,9 +166,7 @@ def test_summary_crown_jewel_path_count_correct(
     assert "admin_panel (1 viable path)" in out
 
 
-def test_summary_advances_with_revision(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_summary_advances_with_revision(kgstore: KGStore, engagement: str) -> None:
     """The summary's revision token changes after a write."""
     before = build_summary(kgstore, engagement=engagement)
     _populate(kgstore, engagement)
@@ -183,9 +177,7 @@ def test_summary_advances_with_revision(
     assert before_rev != after_rev
 
 
-def test_summary_respects_vuln_cap(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_summary_respects_vuln_cap(kgstore: KGStore, engagement: str) -> None:
     """When more than MAX_VULNS vulns exist, the block truncates."""
     observations: list[dict[str, Any]] = []
     for i in range(MAX_VULNS * 2):
@@ -209,9 +201,7 @@ def test_summary_respects_vuln_cap(
     assert bullet_count == MAX_VULNS
 
 
-def test_summary_respects_entrypoint_cap(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_summary_respects_entrypoint_cap(kgstore: KGStore, engagement: str) -> None:
     observations: list[dict[str, Any]] = []
     for i in range(MAX_ENTRYPOINTS * 2):
         observations.append(

--- a/packages/decepticon/tests/integration/kg/test_kg_tools_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_tools_live.py
@@ -1,0 +1,190 @@
+"""Live integration tests for the agent-facing KG tools.
+
+Builds ``kg_record`` and ``kg_ingest`` against the compose Neo4j and
+invokes them with the OPPLAN-style ToolCall envelope. Verifies the
+tools' results match what the LLM would see.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon.middleware.kg_internal.tools import build_kg_tools
+
+
+def _call(tool: Any, args: dict[str, Any], state: dict[str, Any]) -> str:
+    payload = {
+        "name": getattr(tool, "name", "tool"),
+        "type": "tool_call",
+        "id": "live-tool-call",
+        "args": {**args, "state": state},
+    }
+    return tool.invoke(payload)
+
+
+def test_kg_record_writes_through_live_store(
+    kgstore: KGStore, engagement: str
+) -> None:
+    [kg_record, _] = build_kg_tools(kgstore)
+    obs = [
+        {
+            "kind": "Host",
+            "key": f"host::tool-record::{engagement}",
+            "label": "host-from-tool",
+            "props": {"ip": "10.0.0.7"},
+        }
+    ]
+    out_msg = _call(
+        kg_record,
+        {"observations": json.dumps(obs)},
+        state={"kg_engagement": engagement, "role": "analyst"},
+    )
+    payload = json.loads(out_msg.content)
+    assert payload["created"] == 1
+    assert payload["merged"] == 0
+
+    rows = kgstore.execute_read(
+        "MATCH (h:Host) WHERE h.engagement = $eng AND h.key = $key "
+        "RETURN h.label AS label, h.created_by AS created_by, "
+        "       h.source_episode_id AS sep",
+        {"eng": engagement, "key": f"host::tool-record::{engagement}"},
+        engagement=engagement,
+    )
+    assert rows
+    assert rows[0]["label"] == "host-from-tool"
+    assert rows[0]["created_by"] == "analyst"
+    assert rows[0]["sep"] == "live-tool-call"
+
+
+def test_kg_record_atomic_batch_with_edges_live(
+    kgstore: KGStore, engagement: str
+) -> None:
+    [kg_record, _] = build_kg_tools(kgstore)
+    obs = [
+        {
+            "kind": "Host",
+            "key": f"host::batch::{engagement}",
+            "label": "batch-host",
+            "edges_out": [
+                {
+                    "to_key": f"service::batch::{engagement}",
+                    "kind": "HOSTS",
+                    "weight": 0.5,
+                }
+            ],
+        },
+        {
+            "kind": "Service",
+            "key": f"service::batch::{engagement}",
+            "label": "batch-service",
+        },
+    ]
+    _call(
+        kg_record,
+        {"observations": json.dumps(obs)},
+        state={"kg_engagement": engagement, "role": "recon"},
+    )
+    edge_rows = kgstore.execute_read(
+        "MATCH (h:Host)-[r:HOSTS]->(s:Service) "
+        "WHERE h.engagement = $eng AND h.key = $hk RETURN r.weight AS w",
+        {"eng": engagement, "hk": f"host::batch::{engagement}"},
+        engagement=engagement,
+    )
+    assert edge_rows
+    assert edge_rows[0]["w"] == 0.5
+
+
+def test_kg_ingest_routes_nuclei_jsonl_through_live_store(
+    kgstore: KGStore, engagement: str, tmp_path: Path
+) -> None:
+    f = tmp_path / "nuclei.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "template-id": "tool-ssrf",
+                "info": {"severity": "critical", "tags": ["ssrf"]},
+                "matched-at": "https://tool-test.example/api",
+                "host": "tool-test.example",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    [_, kg_ingest] = build_kg_tools(kgstore)
+    out_msg = _call(
+        kg_ingest,
+        {"scanner_kind": "nuclei_jsonl", "path": str(f)},
+        state={"kg_engagement": engagement, "role": "analyst"},
+    )
+    payload = json.loads(out_msg.content)
+    assert payload["scanner"] == "nuclei_jsonl"
+    assert payload["parsed"] == 1
+
+    rows = kgstore.execute_read(
+        "MATCH (v:Vulnerability) WHERE v.engagement = $eng "
+        "AND v.rule_id = 'tool-ssrf' "
+        "RETURN v.created_by AS created_by, v.source_episode_id AS sep",
+        {"eng": engagement},
+        engagement=engagement,
+    )
+    assert rows
+    assert rows[0]["created_by"] == "analyst"
+    assert rows[0]["sep"] == "live-tool-call"
+
+
+def test_kg_record_idempotent_across_two_calls_live(
+    kgstore: KGStore, engagement: str
+) -> None:
+    """Two ToolCalls with the same observation key collapse to one
+    node — the deterministic key + (key, engagement) uniqueness."""
+    [kg_record, _] = build_kg_tools(kgstore)
+    obs = [
+        {
+            "kind": "Host",
+            "key": f"host::idempotent::{engagement}",
+            "label": "host",
+        }
+    ]
+    first = json.loads(
+        _call(
+            kg_record,
+            {"observations": json.dumps(obs)},
+            state={"kg_engagement": engagement, "role": "analyst"},
+        ).content
+    )
+    second = json.loads(
+        _call(
+            kg_record,
+            {"observations": json.dumps(obs)},
+            state={"kg_engagement": engagement, "role": "analyst"},
+        ).content
+    )
+    assert first["created"] == 1
+    assert second["created"] == 0
+    assert second["merged"] == 1
+
+
+def test_kg_record_engagement_unset_short_circuits_live(
+    kgstore: KGStore,
+) -> None:
+    """When kg_engagement is missing, the tool returns an error and does
+    NOT write anything to the live store."""
+    [kg_record, _] = build_kg_tools(kgstore)
+    obs = [{"kind": "Host", "key": "host::no-engagement", "label": "x"}]
+    out_msg = _call(
+        kg_record,
+        {"observations": json.dumps(obs)},
+        state={},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    # And confirm nothing landed under any engagement.
+    rows = kgstore.execute_read(
+        "MATCH (n) WHERE n.key = $key RETURN count(n) AS c",
+        {"key": "host::no-engagement"},
+        engagement="schema",
+    )
+    assert rows[0]["c"] == 0

--- a/packages/decepticon/tests/integration/kg/test_kg_tools_live.py
+++ b/packages/decepticon/tests/integration/kg/test_kg_tools_live.py
@@ -25,9 +25,7 @@ def _call(tool: Any, args: dict[str, Any], state: dict[str, Any]) -> str:
     return tool.invoke(payload)
 
 
-def test_kg_record_writes_through_live_store(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_kg_record_writes_through_live_store(kgstore: KGStore, engagement: str) -> None:
     [kg_record, _] = build_kg_tools(kgstore)
     obs = [
         {
@@ -59,9 +57,7 @@ def test_kg_record_writes_through_live_store(
     assert rows[0]["sep"] == "live-tool-call"
 
 
-def test_kg_record_atomic_batch_with_edges_live(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_kg_record_atomic_batch_with_edges_live(kgstore: KGStore, engagement: str) -> None:
     [kg_record, _] = build_kg_tools(kgstore)
     obs = [
         {
@@ -135,9 +131,7 @@ def test_kg_ingest_routes_nuclei_jsonl_through_live_store(
     assert rows[0]["sep"] == "live-tool-call"
 
 
-def test_kg_record_idempotent_across_two_calls_live(
-    kgstore: KGStore, engagement: str
-) -> None:
+def test_kg_record_idempotent_across_two_calls_live(kgstore: KGStore, engagement: str) -> None:
     """Two ToolCalls with the same observation key collapse to one
     node — the deterministic key + (key, engagement) uniqueness."""
     [kg_record, _] = build_kg_tools(kgstore)

--- a/packages/decepticon/tests/unit/agents/test_build.py
+++ b/packages/decepticon/tests/unit/agents/test_build.py
@@ -586,6 +586,7 @@ def test_middleware_slot_enum_order_is_assembly_order():
         "filesystem",
         "subagent",
         "opplan",
+        "kg",
         "event-log",
         "sandbox-notification",
         "budget",

--- a/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
@@ -1,0 +1,375 @@
+"""Unit tests for :mod:`kg_internal.ingest` — driver-free.
+
+Covers the adapter registry, dispatcher error paths, and each built-in
+adapter's parse-to-observations behaviour via a stub store that
+captures the ``record_observations`` payload without hitting Neo4j.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from decepticon.middleware.kg_internal.ingest import (
+    _REGISTRY,
+    ScannerAdapter,
+    _adapt_httpx_jsonl,
+    _adapt_nmap_xml,
+    _adapt_nuclei_jsonl,
+    _adapt_sarif,
+    available_scanners,
+    ingest,
+    register_adapter,
+)
+
+# ── Stub store ──────────────────────────────────────────────────────────
+
+
+class _StubStore:
+    """Captures record_observations payload; returns a fixed shape."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def record_observations(
+        self,
+        observations: list[dict[str, Any]],
+        *,
+        engagement: str,
+        created_by: str,
+        source_episode_id: str,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "observations": list(observations),
+                "engagement": engagement,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            }
+        )
+        return {"created": len(observations), "merged": 0, "edges": 0, "revision": "rev-stub"}
+
+
+# ── Registry ────────────────────────────────────────────────────────────
+
+
+def test_built_in_adapters_registered_at_import() -> None:
+    """The four built-ins land in the registry without any opt-in."""
+    names = set(available_scanners())
+    assert {"nmap_xml", "nuclei_jsonl", "httpx_jsonl", "sarif"} <= names
+
+
+def test_register_adapter_rejects_empty_kind() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        register_adapter("", _adapt_nmap_xml)
+
+
+def test_register_adapter_rejects_non_callable() -> None:
+    with pytest.raises(ValueError, match="callable"):
+        register_adapter("custom", "not callable")  # type: ignore[arg-type]
+
+
+def test_register_adapter_overwrites_existing() -> None:
+    sentinel: ScannerAdapter = lambda *args, **kwargs: {"sentinel": True}  # noqa: E731
+    register_adapter("nuclei_jsonl", sentinel)
+    assert _REGISTRY["nuclei_jsonl"] is sentinel
+    # restore for downstream tests
+    register_adapter("nuclei_jsonl", _adapt_nuclei_jsonl)
+
+
+# ── ingest dispatcher ───────────────────────────────────────────────────
+
+
+def test_ingest_unknown_scanner_returns_error_with_available_list() -> None:
+    result = ingest(
+        "made_up_scanner",
+        "/dev/null",
+        store=_StubStore(),  # type: ignore[arg-type]
+        engagement="acme",
+        created_by="t",
+        source_episode_id="ep",
+    )
+    assert "error" in result
+    assert "unknown scanner_kind" in result["error"]
+    assert "available" in result
+    assert "nmap_xml" in result["available"]
+
+
+def test_ingest_missing_file_returns_error(tmp_path: Path) -> None:
+    result = ingest(
+        "nmap_xml",
+        tmp_path / "does-not-exist.xml",
+        store=_StubStore(),  # type: ignore[arg-type]
+        engagement="acme",
+        created_by="t",
+        source_episode_id="ep",
+    )
+    assert "error" in result
+    assert "not found" in result["error"]
+    assert result["scanner"] == "nmap_xml"
+
+
+def test_ingest_wraps_result_with_scanner_and_path(tmp_path: Path) -> None:
+    nmap_file = tmp_path / "scan.xml"
+    nmap_file.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.1" addrtype="ipv4"/>
+            <ports>
+              <port portid="80" protocol="tcp">
+                <state state="open"/>
+                <service name="http"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    result = ingest(
+        "nmap_xml",
+        nmap_file,
+        store=_StubStore(),  # type: ignore[arg-type]
+        engagement="acme",
+        created_by="recon",
+        source_episode_id="ep-1",
+    )
+    assert result["scanner"] == "nmap_xml"
+    assert result["path"] == str(nmap_file)
+
+
+def test_ingest_adapter_exception_is_captured(tmp_path: Path) -> None:
+    def boom(path: Path, store: Any, eng: str, cb: str, sep: str) -> dict[str, Any]:
+        raise RuntimeError("kaboom")
+
+    register_adapter("boom", boom)
+    f = tmp_path / "x.txt"
+    f.write_text("x")
+    result = ingest(
+        "boom",
+        f,
+        store=_StubStore(),  # type: ignore[arg-type]
+        engagement="acme",
+        created_by="t",
+        source_episode_id="ep",
+    )
+    assert "error" in result
+    assert "kaboom" in result["error"]
+
+
+# ── nmap_xml adapter ────────────────────────────────────────────────────
+
+
+def test_nmap_adapter_extracts_host_service_entrypoint(tmp_path: Path) -> None:
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.1" addrtype="ipv4"/>
+            <hostnames><hostname name="target.local"/></hostnames>
+            <ports>
+              <port portid="80" protocol="tcp">
+                <state state="open"/>
+                <service name="http" product="nginx" version="1.18"/>
+              </port>
+              <port portid="22" protocol="tcp">
+                <state state="open"/>
+                <service name="ssh"/>
+              </port>
+              <port portid="9999" protocol="tcp">
+                <state state="closed"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    result = _adapt_nmap_xml(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    assert result["hosts"] == 1
+    assert result["services"] == 2  # 80 + 22, closed port skipped
+    assert result["entrypoints"] == 1  # 80 is web, 22 is not
+
+    obs = store.calls[0]["observations"]
+    kinds = [o["kind"] for o in obs]
+    assert kinds.count("Host") == 1
+    assert kinds.count("Service") == 2
+    assert kinds.count("Entrypoint") == 1
+    # Host must carry its outgoing HOSTS edges to both services.
+    host_obs = next(o for o in obs if o["kind"] == "Host")
+    assert any(e["kind"] == "HOSTS" for e in host_obs.get("edges_out", []))
+
+
+def test_nmap_adapter_skips_down_hosts(tmp_path: Path) -> None:
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="down"/>
+            <address addr="10.0.0.99" addrtype="ipv4"/>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    result = _adapt_nmap_xml(f, store, "acme", "t", "ep")  # type: ignore[arg-type]
+    assert result == {"hosts": 0, "services": 0, "entrypoints": 0}
+    assert store.calls == []
+
+
+def test_nmap_adapter_handles_malformed_xml(tmp_path: Path) -> None:
+    f = tmp_path / "bad.xml"
+    f.write_text("not valid XML", encoding="utf-8")
+    store = _StubStore()
+    result = _adapt_nmap_xml(f, store, "acme", "t", "ep")  # type: ignore[arg-type]
+    assert "error" in result
+
+
+# ── nuclei_jsonl adapter ────────────────────────────────────────────────
+
+
+def test_nuclei_adapter_extracts_vuln_with_entrypoint(tmp_path: Path) -> None:
+    f = tmp_path / "nuclei.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "template-id": "ssrf-detect",
+                "info": {"severity": "high", "tags": ["ssrf", "intrusive"]},
+                "matched-at": "https://target.example.com/api/fetch",
+                "host": "target.example.com",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    result = _adapt_nuclei_jsonl(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    assert result["parsed"] == 1
+    assert result["skipped"] == 0
+    obs = store.calls[0]["observations"]
+    kinds = [o["kind"] for o in obs]
+    assert "Vulnerability" in kinds
+    assert "Entrypoint" in kinds
+    vuln = next(o for o in obs if o["kind"] == "Vulnerability")
+    assert vuln["props"]["severity"] == "high"
+    assert vuln["props"]["rule_id"] == "ssrf-detect"
+    assert "ssrf" in vuln["props"]["tags"]
+    # Entrypoint must HAS_VULN edge to the vuln.
+    ep = next(o for o in obs if o["kind"] == "Entrypoint")
+    assert any(e["kind"] == "HAS_VULN" for e in ep.get("edges_out", []))
+
+
+def test_nuclei_adapter_skips_bad_json_lines(tmp_path: Path) -> None:
+    f = tmp_path / "nuclei.jsonl"
+    f.write_text(
+        "this is not json\n"
+        + json.dumps({"template-id": "x", "info": {"severity": "low"}, "host": "h"})
+        + "\n"
+        + "garbage\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    result = _adapt_nuclei_jsonl(f, store, "acme", "t", "ep")  # type: ignore[arg-type]
+    assert result["parsed"] == 1
+    assert result["skipped"] == 2
+
+
+# ── httpx_jsonl adapter ─────────────────────────────────────────────────
+
+
+def test_httpx_adapter_extracts_host_service_entrypoint(tmp_path: Path) -> None:
+    f = tmp_path / "httpx.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "url": "https://target.example.com:8443/admin",
+                "host": "target.example.com",
+                "port": 8443,
+                "status-code": 200,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    result = _adapt_httpx_jsonl(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    assert result["parsed"] == 1
+    obs = store.calls[0]["observations"]
+    kinds = [o["kind"] for o in obs]
+    assert "Host" in kinds
+    assert "Service" in kinds
+    assert "Entrypoint" in kinds
+
+
+def test_httpx_adapter_skips_rows_without_url(tmp_path: Path) -> None:
+    f = tmp_path / "httpx.jsonl"
+    f.write_text(json.dumps({"status-code": 200}) + "\n", encoding="utf-8")
+    store = _StubStore()
+    result = _adapt_httpx_jsonl(f, store, "acme", "t", "ep")  # type: ignore[arg-type]
+    assert result["parsed"] == 1
+    assert result["skipped"] == 1
+    assert result["ingested"] == 0
+
+
+# ── sarif adapter ───────────────────────────────────────────────────────
+
+
+def test_sarif_adapter_extracts_vuln_and_code_location(tmp_path: Path) -> None:
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "semgrep"}},
+                "results": [
+                    {
+                        "ruleId": "python.lang.security.audit.sqli",
+                        "level": "error",
+                        "message": {"text": "SQL injection via string concat"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "app/views.py"},
+                                    "region": {"startLine": 42},
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    f = tmp_path / "scan.sarif"
+    f.write_text(json.dumps(sarif), encoding="utf-8")
+    store = _StubStore()
+    result = _adapt_sarif(f, store, "acme", "analyst", "ep-1")  # type: ignore[arg-type]
+    assert result["results_processed"] == 1
+    obs = store.calls[0]["observations"]
+    kinds = [o["kind"] for o in obs]
+    assert "Vulnerability" in kinds
+    assert "CodeLocation" in kinds
+    vuln = next(o for o in obs if o["kind"] == "Vulnerability")
+    # SARIF level "error" maps to severity "high".
+    assert vuln["props"]["severity"] == "high"
+    assert vuln["props"]["scanner"] == "semgrep"
+    assert vuln["props"]["file"] == "app/views.py"
+    assert vuln["props"]["line"] == 42
+    # The Vulnerability node must DEFINED_IN edge to the code location.
+    assert any(e["kind"] == "DEFINED_IN" for e in vuln.get("edges_out", []))
+
+
+def test_sarif_adapter_handles_empty_runs(tmp_path: Path) -> None:
+    f = tmp_path / "empty.sarif"
+    f.write_text(json.dumps({"runs": []}), encoding="utf-8")
+    store = _StubStore()
+    result = _adapt_sarif(f, store, "acme", "t", "ep")  # type: ignore[arg-type]
+    assert result == {"results_processed": 0, "ingested": 0}
+    assert store.calls == []

--- a/packages/decepticon/tests/unit/middleware/test_kg_middleware_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_middleware_unit.py
@@ -1,0 +1,328 @@
+"""Unit tests for :class:`KGMiddleware` — driver-free.
+
+Covers each hook (``before_agent``, ``wrap_model_call``,
+``wrap_tool_call``, ``after_model``) and the state-update return shape.
+End-to-end agent verification against live Neo4j lives in
+``tests/integration/kg/test_kg_middleware_live.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+
+from decepticon.middleware.kg import KG_SYSTEM_PROMPT, KGMiddleware
+from decepticon.middleware.kg_internal.state import KGState
+from decepticon.middleware.kg_internal.store import KGStore
+
+# ── KGStore mock ────────────────────────────────────────────────────────
+
+
+def _store_mock(
+    *, revision: str = "rev-acme-1", summary_text: str = "## KG STATE (engagement=acme)"
+) -> MagicMock:
+    store = MagicMock(spec=KGStore, name="KGStore")
+    store.revision.return_value = revision
+    return store
+
+
+def _middleware(store: MagicMock | None = None) -> KGMiddleware:
+    if store is None:
+        store = _store_mock()
+    return KGMiddleware(store=store)
+
+
+def test_state_schema_is_kg_state() -> None:
+    assert KGMiddleware.state_schema is KGState
+
+
+def test_init_builds_two_tools_from_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store_mock()
+    mw = KGMiddleware(store=store)
+    names = {t.name for t in mw.tools}
+    assert names == {"kg_record", "kg_ingest"}
+
+
+def test_init_default_enabled_filter_can_be_overridden() -> None:
+    store = _store_mock()
+    mw = KGMiddleware(store=store, enabled_tools={"kg_record"})
+    assert [t.name for t in mw.tools] == ["kg_record"]
+
+
+# ── before_agent ────────────────────────────────────────────────────────
+
+
+def test_before_agent_returns_none_when_no_engagement() -> None:
+    mw = _middleware()
+    out = mw.before_agent({}, runtime=None)
+    assert out is None
+
+
+def test_before_agent_hydrates_kg_engagement_from_engagement_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store_mock(revision="rev-acme-7")
+    # Patch build_summary to return a known string without touching Neo4j.
+    monkeypatch.setattr(
+        "decepticon.middleware.kg.build_summary",
+        lambda store, *, engagement: f"summary-for-{engagement}",
+    )
+    mw = KGMiddleware(store=store)
+    out = mw.before_agent({"engagement_name": "acme"}, runtime=None)
+    assert out is not None
+    assert out["kg_engagement"] == "acme"
+    assert out["kg_revision"] == "rev-acme-7"
+    assert out["kg_summary"] == "summary-for-acme"
+
+
+def test_before_agent_skips_summary_when_revision_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store_mock(revision="rev-acme-7")
+    called: list[str] = []
+    monkeypatch.setattr(
+        "decepticon.middleware.kg.build_summary",
+        lambda store, *, engagement: called.append(engagement) or "won't run",
+    )
+    mw = KGMiddleware(store=store)
+    state = {
+        "kg_engagement": "acme",
+        "kg_revision": "rev-acme-7",  # matches what store will return
+        "kg_summary": "cached",
+    }
+    out = mw.before_agent(state, runtime=None)
+    # Nothing to update — both engagement and revision match.
+    assert out is None
+    assert called == []
+
+
+def test_before_agent_rebuilds_summary_after_revision_advance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store_mock(revision="rev-acme-12")
+    monkeypatch.setattr(
+        "decepticon.middleware.kg.build_summary",
+        lambda store, *, engagement: "fresh-summary",
+    )
+    mw = KGMiddleware(store=store)
+    state = {
+        "kg_engagement": "acme",
+        "kg_revision": "rev-acme-7",  # stale
+        "kg_summary": "old",
+    }
+    out = mw.before_agent(state, runtime=None)
+    assert out == {"kg_revision": "rev-acme-12", "kg_summary": "fresh-summary"}
+
+
+def test_before_agent_swallows_store_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = MagicMock(spec=KGStore)
+    store.revision.side_effect = RuntimeError("neo4j down")
+    mw = KGMiddleware(store=store)
+    # Must not raise; agent should keep going without KG context.
+    out = mw.before_agent({"engagement_name": "acme"}, runtime=None)
+    assert out is None
+
+
+def test_before_agent_summary_failure_records_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store_mock(revision="rev-acme-1")
+    monkeypatch.setattr(
+        "decepticon.middleware.kg.build_summary",
+        lambda store, *, engagement: (_ for _ in ()).throw(RuntimeError("query timeout")),
+    )
+    mw = KGMiddleware(store=store)
+    out = mw.before_agent({"engagement_name": "acme"}, runtime=None)
+    assert out is not None
+    assert out["kg_summary"] == ""
+    # The revision still advances so we don't keep retrying the broken
+    # summary path on every turn.
+    assert out["kg_revision"] == "rev-acme-1"
+
+
+# ── wrap_model_call / _inject_kg_context ────────────────────────────────
+
+
+def _fake_request(
+    *, state: dict[str, Any], system_message: SystemMessage | None = None
+) -> SimpleNamespace:
+    """Stand-in for the langchain ModelRequest passed to wrap_model_call."""
+    request = SimpleNamespace(state=state, system_message=system_message)
+
+    def override(**kwargs: Any) -> SimpleNamespace:
+        new = SimpleNamespace(**vars(request))
+        for k, v in kwargs.items():
+            setattr(new, k, v)
+        return new
+
+    request.override = override  # type: ignore[attr-defined]
+    return request
+
+
+def test_wrap_model_call_skips_when_no_kg_engagement() -> None:
+    mw = _middleware()
+    request = _fake_request(state={})
+    captured: dict[str, Any] = {}
+
+    def handler(req: Any) -> str:
+        captured["request"] = req
+        return "handler-result"
+
+    out = mw.wrap_model_call(request, handler)
+    assert out == "handler-result"
+    # Handler must have received the ORIGINAL request — no system mutation.
+    assert captured["request"] is request
+
+
+def test_wrap_model_call_injects_static_and_dynamic_blocks() -> None:
+    mw = _middleware()
+    sys_msg = SystemMessage(content="base prompt")
+    request = _fake_request(
+        state={"kg_engagement": "acme", "kg_summary": "## KG STATE (engagement=acme)"},
+        system_message=sys_msg,
+    )
+
+    def handler(req: Any) -> Any:
+        return req
+
+    out = mw.wrap_model_call(request, handler)
+    new_sys = out.system_message
+    blocks = new_sys.content
+    # base prompt + KG_SYSTEM_PROMPT block + dynamic block
+    assert len(blocks) >= 3
+    static = blocks[-2]
+    dynamic = blocks[-1]
+    assert KG_SYSTEM_PROMPT in static["text"]
+    assert static.get("cache_control") == {"type": "ephemeral"}
+    assert "KG STATE (engagement=acme)" in dynamic["text"]
+
+
+def test_wrap_model_call_omits_dynamic_block_when_summary_empty() -> None:
+    mw = _middleware()
+    sys_msg = SystemMessage(content="base prompt")
+    request = _fake_request(
+        state={"kg_engagement": "acme", "kg_summary": ""},
+        system_message=sys_msg,
+    )
+    out = mw.wrap_model_call(request, lambda req: req)
+    blocks = out.system_message.content
+    static = blocks[-1]
+    # Only the static block was appended (no empty dynamic block).
+    assert KG_SYSTEM_PROMPT in static["text"]
+    # No second block with empty text.
+    assert all(b.get("text") for b in blocks if isinstance(b, dict))
+
+
+# ── wrap_tool_call ──────────────────────────────────────────────────────
+
+
+def _fake_tool_request(
+    *, tool_name: str, state: dict[str, Any], tool_call_id: str = "tc-123"
+) -> SimpleNamespace:
+    tool = SimpleNamespace(name=tool_name)
+    return SimpleNamespace(
+        tool=tool,
+        state=state,
+        tool_call=SimpleNamespace(id=tool_call_id),
+    )
+
+
+def test_wrap_tool_call_passes_through_non_kg_tools() -> None:
+    mw = _middleware()
+    captured: list[Any] = []
+    out = mw.wrap_tool_call(
+        _fake_tool_request(tool_name="bash", state={}),
+        lambda req: captured.append(req) or "handler-result",
+    )
+    assert out == "handler-result"
+    assert len(captured) == 1
+
+
+def test_wrap_tool_call_rejects_kg_record_when_engagement_unset() -> None:
+    mw = _middleware()
+    captured: list[Any] = []
+    out = mw.wrap_tool_call(
+        _fake_tool_request(tool_name="kg_record", state={}),
+        lambda req: captured.append(req) or "handler-result",
+    )
+    assert isinstance(out, ToolMessage)
+    payload = json.loads(out.content)
+    assert "error" in payload
+    assert "kg_engagement" in payload["error"]
+    # Handler must NOT have been called.
+    assert captured == []
+
+
+def test_wrap_tool_call_rejects_kg_ingest_when_engagement_unset() -> None:
+    mw = _middleware()
+    out = mw.wrap_tool_call(
+        _fake_tool_request(tool_name="kg_ingest", state={}),
+        lambda req: "handler-result",
+    )
+    assert isinstance(out, ToolMessage)
+
+
+def test_wrap_tool_call_allows_kg_tool_when_engagement_present() -> None:
+    mw = _middleware()
+    captured: list[Any] = []
+    out = mw.wrap_tool_call(
+        _fake_tool_request(tool_name="kg_record", state={"kg_engagement": "acme"}),
+        lambda req: captured.append(req) or "handler-result",
+    )
+    assert out == "handler-result"
+    assert len(captured) == 1
+
+
+# ── after_model ─────────────────────────────────────────────────────────
+
+
+def test_after_model_returns_none_when_no_messages() -> None:
+    mw = _middleware()
+    assert mw.after_model({}, runtime=None) is None
+    assert mw.after_model({"messages": []}, runtime=None) is None
+
+
+def test_after_model_returns_none_when_last_ai_has_no_kg_call() -> None:
+    mw = _middleware()
+    ai = AIMessage(content="thinking...", tool_calls=[{"name": "bash", "args": {}, "id": "1"}])
+    out = mw.after_model({"messages": [ai]}, runtime=None)
+    assert out is None
+
+
+def test_after_model_marks_revision_dirty_when_kg_record_called() -> None:
+    mw = _middleware()
+    ai = AIMessage(
+        content="", tool_calls=[{"name": "kg_record", "args": {"observations": "[]"}, "id": "tc1"}]
+    )
+    out = mw.after_model({"messages": [ai]}, runtime=None)
+    assert out == {"kg_revision": "dirty"}
+
+
+def test_after_model_marks_revision_dirty_when_kg_ingest_called() -> None:
+    mw = _middleware()
+    ai = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "kg_ingest", "args": {"scanner_kind": "nmap_xml", "path": "/x"}, "id": "tc1"}
+        ],
+    )
+    out = mw.after_model({"messages": [ai]}, runtime=None)
+    assert out == {"kg_revision": "dirty"}
+
+
+def test_after_model_skips_non_ai_messages() -> None:
+    """The middleware checks the LAST AIMessage, not the last message."""
+    mw = _middleware()
+    ai = AIMessage(
+        content="", tool_calls=[{"name": "kg_record", "args": {"observations": "[]"}, "id": "tc1"}]
+    )
+    tool_msg = ToolMessage(content="ok", tool_call_id="tc1", name="kg_record")
+    out = mw.after_model({"messages": [ai, tool_msg]}, runtime=None)
+    # Even though the last message is a ToolMessage, the most-recent
+    # AIMessage triggered a KG tool, so the revision is dirty.
+    assert out == {"kg_revision": "dirty"}

--- a/packages/decepticon/tests/unit/middleware/test_kg_migration_runner.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_migration_runner.py
@@ -1,0 +1,341 @@
+"""Unit tests for :mod:`kg_internal.migration_runner`.
+
+Covers the statement splitter, ``list_applied`` against a fake store,
+and the idempotent ``apply_migrations`` flow with multiple migration
+files. Live-Neo4j verification lives in
+``tests/integration/kg/test_migration_runner_live.py`` (PR-A.4).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from decepticon.middleware.kg_internal.migration_runner import (
+    _MIGRATION_ENGAGEMENT,
+    _split_cypher_statements,
+    _strip_line_comments,
+    apply_migrations,
+    list_applied,
+)
+from decepticon.middleware.kg_internal.store import KGStore, KGStoreConfig
+
+# ── _strip_line_comments / _split_cypher_statements ─────────────────────
+
+
+def test_strip_line_comments_removes_double_dash_to_eol() -> None:
+    text = "CREATE INDEX foo -- inline note\nFOR (n:Host) ON (n.ip);"
+    out = _strip_line_comments(text)
+    assert "inline note" not in out
+    assert "CREATE INDEX foo" in out
+    assert "FOR (n:Host)" in out
+
+
+def test_strip_line_comments_handles_no_comments() -> None:
+    text = "CREATE INDEX foo FOR (n:Host) ON (n.ip);"
+    assert _strip_line_comments(text) == text
+
+
+def test_split_cypher_strips_comments_and_splits() -> None:
+    text = """
+    -- Header comment
+    CREATE CONSTRAINT a IF NOT EXISTS FOR (n:Host) REQUIRE n.k IS UNIQUE;
+    -- Inline note
+    CREATE INDEX b IF NOT EXISTS FOR (n:Service) ON (n.engagement);
+    """
+    stmts = _split_cypher_statements(text)
+    assert len(stmts) == 2
+    assert stmts[0].startswith("CREATE CONSTRAINT a")
+    assert stmts[1].startswith("CREATE INDEX b")
+
+
+def test_split_cypher_drops_empty_statements() -> None:
+    text = ";;CREATE INDEX a FOR (n:Host) ON (n.ip);;;"
+    stmts = _split_cypher_statements(text)
+    assert stmts == ["CREATE INDEX a FOR (n:Host) ON (n.ip)"]
+
+
+def test_split_cypher_preserves_multiline_statements() -> None:
+    text = """
+    CREATE VECTOR INDEX v IF NOT EXISTS
+      FOR (n:Vulnerability) ON (n.embedding)
+      OPTIONS {
+        indexConfig: {
+          `vector.dimensions`: 1536
+        }
+      };
+    """
+    stmts = _split_cypher_statements(text)
+    assert len(stmts) == 1
+    assert "CREATE VECTOR INDEX v" in stmts[0]
+    assert "OPTIONS" in stmts[0]
+    assert "1536" in stmts[0]
+
+
+# ── KGStore mock plumbing ───────────────────────────────────────────────
+
+
+def _fake_driver() -> MagicMock:
+    driver = MagicMock(name="Driver")
+    session = MagicMock(name="Session")
+    driver.session.return_value.__enter__.return_value = session
+    driver.session.return_value.__exit__.return_value = None
+    return driver
+
+
+def _make_store(driver: Any | None = None) -> KGStore:
+    cfg = KGStoreConfig(uri="bolt://x", user="u", password="p", database="neo4j")
+    return KGStore(cfg, driver=driver or _fake_driver())
+
+
+def _stub_store(
+    *,
+    applied_names: list[str] | None = None,
+) -> tuple[KGStore, list[tuple[str, dict[str, Any], str]]]:
+    """Build a KGStore whose execute_read/write record into a list.
+
+    Returns ``(store, calls)`` where each call is a tuple of
+    ``(cypher, params, engagement)``.
+    """
+    calls: list[tuple[str, dict[str, Any], str]] = []
+    store = _make_store()
+
+    applied = applied_names or []
+
+    def fake_execute_read(
+        cypher: str, params: dict[str, Any] | None = None, *, engagement: str
+    ) -> list[dict[str, Any]]:
+        calls.append((cypher, dict(params or {}), engagement))
+        if "MATCH (m:MigrationLog)" in cypher:
+            return [{"name": name} for name in applied]
+        return []
+
+    def fake_execute_write(
+        cypher: str, params: dict[str, Any] | None = None, *, engagement: str
+    ) -> list[dict[str, Any]]:
+        calls.append((cypher, dict(params or {}), engagement))
+        return []
+
+    store.execute_read = fake_execute_read  # type: ignore[assignment]
+    store.execute_write = fake_execute_write  # type: ignore[assignment]
+    return store, calls
+
+
+# ── list_applied ─────────────────────────────────────────────────────────
+
+
+def test_list_applied_returns_empty_on_fresh_store() -> None:
+    store, _calls = _stub_store(applied_names=[])
+    assert list_applied(store) == set()
+
+
+def test_list_applied_returns_recorded_names() -> None:
+    store, calls = _stub_store(applied_names=["V001__initial_schema"])
+    assert list_applied(store) == {"V001__initial_schema"}
+    # The read must have scoped to the reserved engagement label.
+    read_call = calls[0]
+    assert read_call[2] == _MIGRATION_ENGAGEMENT
+
+
+# ── apply_migrations ─────────────────────────────────────────────────────
+
+
+def _write_migration(dir_path: Path, name: str, cypher: str) -> Path:
+    path = dir_path / f"{name}.cypher"
+    path.write_text(cypher, encoding="utf-8")
+    return path
+
+
+def test_apply_migrations_returns_empty_when_no_files(tmp_path: Path) -> None:
+    store, _calls = _stub_store()
+    assert apply_migrations(store, migrations_dir=tmp_path) == []
+
+
+def test_apply_migrations_runs_pending_in_order(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "V001__a",
+        "CREATE CONSTRAINT a IF NOT EXISTS FOR (n:Host) REQUIRE n.k IS UNIQUE;",
+    )
+    _write_migration(
+        tmp_path,
+        "V002__b",
+        "CREATE INDEX b IF NOT EXISTS FOR (n:Service) ON (n.engagement);",
+    )
+    store, calls = _stub_store(applied_names=[])
+
+    applied = apply_migrations(store, migrations_dir=tmp_path)
+    assert applied == ["V001__a", "V002__b"]
+
+    # The order of writes: list_applied read, then V001 statements, then
+    # V001 MigrationLog upsert, then V002 statements, then V002
+    # MigrationLog upsert.
+    cyphers = [c for (c, _, _) in calls]
+    assert any("CREATE CONSTRAINT a" in c for c in cyphers)
+    assert any("CREATE INDEX b" in c for c in cyphers)
+    log_writes = [c for c in cyphers if "MERGE (m:MigrationLog" in c]
+    assert len(log_writes) == 2
+
+    # All writes scoped to the reserved engagement label.
+    for cypher, params, eng in calls:
+        if cypher.startswith("MERGE (m:MigrationLog"):
+            assert params["name"] in {"V001__a", "V002__b"}
+        assert eng == _MIGRATION_ENGAGEMENT
+
+
+def test_apply_migrations_skips_already_applied(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path, "V001__a", "CREATE CONSTRAINT a IF NOT EXISTS FOR (n:Host) REQUIRE n.k IS UNIQUE;"
+    )
+    _write_migration(
+        tmp_path, "V002__b", "CREATE INDEX b IF NOT EXISTS FOR (n:Service) ON (n.engagement);"
+    )
+    store, calls = _stub_store(applied_names=["V001__a"])
+
+    applied = apply_migrations(store, migrations_dir=tmp_path)
+    assert applied == ["V002__b"]
+
+    cyphers = [c for (c, _, _) in calls]
+    # V001 statements must NOT have been executed.
+    assert not any("CREATE CONSTRAINT a" in c for c in cyphers)
+    # V002 statements MUST have been executed.
+    assert any("CREATE INDEX b" in c for c in cyphers)
+
+
+def test_apply_migrations_idempotent_re_run(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path, "V001__a", "CREATE CONSTRAINT a IF NOT EXISTS FOR (n:Host) REQUIRE n.k IS UNIQUE;"
+    )
+    # Second invocation simulates the runner discovering the same
+    # migration already recorded.
+    store, _calls = _stub_store(applied_names=["V001__a"])
+    assert apply_migrations(store, migrations_dir=tmp_path) == []
+
+
+def test_apply_migrations_records_cypher_sha_in_migration_log(tmp_path: Path) -> None:
+    path = _write_migration(
+        tmp_path,
+        "V001__a",
+        "CREATE CONSTRAINT a IF NOT EXISTS FOR (n:Host) REQUIRE n.k IS UNIQUE;",
+    )
+    import hashlib
+
+    expected_sha = hashlib.sha256(path.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    store, calls = _stub_store()
+    apply_migrations(store, migrations_dir=tmp_path)
+
+    log_calls = [(c, p) for (c, p, _e) in calls if c.startswith("MERGE (m:MigrationLog")]
+    assert len(log_calls) == 1
+    _cypher, params = log_calls[0]
+    assert params["name"] == "V001__a"
+    assert params["sha"] == expected_sha
+    assert isinstance(params["now"], int) and params["now"] > 0
+
+
+def test_apply_migrations_uses_reserved_schema_engagement(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path, "V001__a", "CREATE CONSTRAINT a IF NOT EXISTS FOR (n:Host) REQUIRE n.k IS UNIQUE;"
+    )
+    store, calls = _stub_store()
+    apply_migrations(store, migrations_dir=tmp_path)
+    # Every recorded call must have the reserved engagement label.
+    for _cypher, _params, eng in calls:
+        assert eng == _MIGRATION_ENGAGEMENT
+    # And that label MUST be valid per is_valid_engagement_label so
+    # KGStore.execute_write doesn't reject it.
+    from decepticon_core.utils.engagement_scope import is_valid_engagement_label
+
+    assert is_valid_engagement_label(_MIGRATION_ENGAGEMENT)
+
+
+# ── Shipped migrations exist and parse cleanly ──────────────────────────
+
+
+def test_shipped_migrations_present_and_parseable() -> None:
+    """The two migrations shipped with PR-A.3 must be loadable + non-empty."""
+    from decepticon.middleware.kg_internal.migration_runner import _DEFAULT_MIGRATIONS_DIR
+
+    files = sorted(_DEFAULT_MIGRATIONS_DIR.glob("V*.cypher"))
+    names = [p.stem for p in files]
+    assert "V001__initial_schema" in names
+    assert "V002__engagement_composite_indexes_and_provenance" in names
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        stmts = _split_cypher_statements(text)
+        assert stmts, f"{path.name} contains no executable statements"
+
+
+def test_v001_creates_migration_log_constraint() -> None:
+    """V001 must bootstrap the MigrationLog constraint so subsequent runs
+    can record applied migrations."""
+    from decepticon.middleware.kg_internal.migration_runner import _DEFAULT_MIGRATIONS_DIR
+
+    v001 = next(
+        (_DEFAULT_MIGRATIONS_DIR / "V001__initial_schema.cypher").parent.glob("V001*.cypher")
+    )
+    text = v001.read_text(encoding="utf-8")
+    assert "MigrationLog" in text
+    assert "migration_log_name" in text
+
+
+def test_v002_creates_vector_index_for_future_semantic_recall() -> None:
+    """V002 must include the vector schema placeholder (Q5 = yes)."""
+    from decepticon.middleware.kg_internal.migration_runner import _DEFAULT_MIGRATIONS_DIR
+
+    v002 = next(
+        (_DEFAULT_MIGRATIONS_DIR).glob("V002__*.cypher"),
+    )
+    text = v002.read_text(encoding="utf-8")
+    assert "CREATE VECTOR INDEX" in text
+    assert "vuln_embedding" in text
+    assert "1536" in text
+    assert "cosine" in text
+
+
+# ── KGStore record_observations must not interfere with migration log ───
+
+
+def test_migration_log_uses_distinct_label_from_canonical_nodes() -> None:
+    """Sanity: the MigrationLog label must not collide with any of the
+    canonical node labels listed in V001."""
+    from decepticon.middleware.kg_internal.migration_runner import _DEFAULT_MIGRATIONS_DIR
+
+    v001 = (_DEFAULT_MIGRATIONS_DIR / "V001__initial_schema.cypher").read_text(encoding="utf-8")
+    # Naive grep: every canonical node label appears as "FOR (n:Label)"
+    # exactly once for the (key, engagement) constraint plus once at
+    # the MigrationLog block. MigrationLog appears under a different
+    # constraint (migration_log_name) — confirm the constraint name
+    # does NOT shadow another label's constraint.
+    assert "migration_log_name" in v001
+    canonical_labels_with_key_engagement = [
+        line for line in v001.splitlines() if "REQUIRE (n.key, n.engagement) IS UNIQUE" in line
+    ]
+    assert "MigrationLog" not in "\n".join(canonical_labels_with_key_engagement)
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "Host",
+        "Service",
+        "Vulnerability",
+        "URL",
+        "User",
+        "Credential",
+        "CVE",
+        "Entrypoint",
+        "CrownJewel",
+        "AttackPath",
+        "Finding",
+    ],
+)
+def test_v001_constrains_high_traffic_labels(label: str) -> None:
+    """The labels the analyst will write most often must be constrained
+    so dedup MERGE is enforced engagement-scoped."""
+    from decepticon.middleware.kg_internal.migration_runner import _DEFAULT_MIGRATIONS_DIR
+
+    v001 = (_DEFAULT_MIGRATIONS_DIR / "V001__initial_schema.cypher").read_text(encoding="utf-8")
+    assert f"FOR (n:{label})" in v001

--- a/packages/decepticon/tests/unit/middleware/test_kg_summary_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_summary_unit.py
@@ -1,0 +1,244 @@
+"""Unit tests for :mod:`kg_internal.summary` — driver-free.
+
+Covers section rendering, section omission when empty, severity
+ordering, and the public ``build_summary`` integration against a stub
+store. Live-Neo4j coverage is in
+``tests/integration/kg/test_kg_summary_live.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from decepticon.middleware.kg_internal.store import KGStore, KGStoreConfig
+from decepticon.middleware.kg_internal.summary import (
+    MAX_CROWN_JEWELS,
+    MAX_ENTRYPOINTS,
+    MAX_VULNS,
+    _render_crown_jewels,
+    _render_entrypoints,
+    _render_stats,
+    _render_vulns,
+    _severity_order,
+    build_summary,
+)
+
+# ── Severity ordering ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("severity", "expected"),
+    [
+        ("critical", 0),
+        ("high", 1),
+        ("medium", 2),
+        ("low", 3),
+        ("info", 4),
+        ("HIGH", 1),
+        ("Critical", 0),
+        ("unknown", 99),
+        ("", 99),
+        (None, 99),
+    ],
+)
+def test_severity_order(severity: Any, expected: int) -> None:
+    assert _severity_order(severity) == expected
+
+
+# ── Section renderers ──────────────────────────────────────────────────
+
+
+def test_render_stats_includes_engagement_revision_counts() -> None:
+    out = _render_stats("acme-q2", "rev-acme-q2-1234", {"nodes": 12, "edges": 8})
+    assert "engagement=acme-q2" in out
+    assert "rev-acme-q2-1234" in out
+    assert "Nodes**: 12" in out
+    assert "Edges**: 8" in out
+
+
+def test_render_vulns_lists_each_in_brackets() -> None:
+    out = _render_vulns(
+        [
+            {"key": "k1", "label": "SSTI in /search", "severity": "critical"},
+            {"key": "k2", "label": "SQLi in /login", "severity": "high"},
+        ]
+    )
+    assert "Top vulnerabilities" in out
+    assert "[CRITICAL]" in out
+    assert "SSTI in /search" in out
+    assert "[HIGH]" in out
+    assert "SQLi in /login" in out
+
+
+def test_render_entrypoints_lists_each_with_key() -> None:
+    out = _render_entrypoints(
+        [
+            {"key": "ep::1", "label": "https://app/"},
+            {"key": "ep::2", "label": "https://api/"},
+        ]
+    )
+    assert "Unexplored entrypoints" in out
+    assert "https://app/" in out
+    assert "ep::1" in out
+
+
+def test_render_crown_jewels_includes_path_counts() -> None:
+    out = _render_crown_jewels(
+        [
+            {"key": "cj::admin", "label": "domain_admin", "paths": 1},
+            {"key": "cj::db", "label": "payments_db", "paths": 0},
+        ]
+    )
+    assert "Crown jewels" in out
+    assert "domain_admin (1 viable path)" in out
+    assert "payments_db (0 viable paths)" in out
+
+
+def test_render_vulns_falls_back_to_key_when_label_missing() -> None:
+    out = _render_vulns([{"key": "k1", "severity": "high"}])
+    assert "k1" in out
+    assert "[HIGH]" in out
+
+
+# ── KGStore stub plumbing ──────────────────────────────────────────────
+
+
+def _fake_driver() -> MagicMock:
+    driver = MagicMock()
+    session = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+    driver.session.return_value.__exit__.return_value = None
+    return driver
+
+
+def _make_store() -> KGStore:
+    cfg = KGStoreConfig(uri="bolt://x", user="u", password="p", database="neo4j")
+    return KGStore(cfg, driver=_fake_driver())
+
+
+class _StubStore:
+    """Minimal stub matching the public KGStore surface the summary uses."""
+
+    def __init__(self, responses: dict[str, list[dict[str, Any]]]) -> None:
+        self._responses = responses
+
+    def revision(self, *, engagement: str) -> str:
+        return f"rev-{engagement}-stub"
+
+    def execute_read(
+        self,
+        cypher: str,
+        params: dict[str, Any] | None = None,
+        *,
+        engagement: str,
+    ) -> list[dict[str, Any]]:
+        # Coarse routing via signature substrings in the Cypher.
+        if "count(n) AS nodes" in cypher:
+            return self._responses.get("stats", [{"nodes": 0, "edges": 0}])
+        if "(v:Vulnerability)" in cypher:
+            return self._responses.get("vulns", [])
+        if "(e:Entrypoint)" in cypher and "NOT (e)-[:HAS_VULN]" in cypher:
+            return self._responses.get("entrypoints", [])
+        if "(c:CrownJewel)" in cypher:
+            return self._responses.get("crown_jewels", [])
+        return []
+
+
+# ── build_summary integration with stubbed store ───────────────────────
+
+
+def test_build_summary_minimal_engagement() -> None:
+    """Empty engagement: only the header + stats section."""
+    store = _StubStore({"stats": [{"nodes": 0, "edges": 0}]})
+    out = build_summary(store, engagement="acme")  # type: ignore[arg-type]
+    assert "KG STATE (engagement=acme)" in out
+    assert "Nodes**: 0" in out
+    # Empty sections are dropped.
+    assert "Top vulnerabilities" not in out
+    assert "Unexplored entrypoints" not in out
+    assert "Crown jewels" not in out
+
+
+def test_build_summary_full_engagement() -> None:
+    store = _StubStore(
+        {
+            "stats": [{"nodes": 12, "edges": 8}],
+            "vulns": [
+                {"key": "v1", "label": "SSTI in /search", "severity": "critical"},
+                {"key": "v2", "label": "SQLi in /login", "severity": "high"},
+            ],
+            "entrypoints": [{"key": "e1", "label": "https://app/"}],
+            "crown_jewels": [{"key": "c1", "label": "domain_admin", "paths": 1}],
+        }
+    )
+    out = build_summary(store, engagement="acme")  # type: ignore[arg-type]
+    assert "engagement=acme" in out
+    assert "Top vulnerabilities" in out
+    assert "SSTI in /search" in out
+    assert "Unexplored entrypoints" in out
+    assert "https://app/" in out
+    assert "Crown jewels" in out
+    assert "domain_admin (1 viable path)" in out
+
+
+def test_build_summary_drops_empty_sections() -> None:
+    """Engagement with only stats and vulns: entrypoints/crown jewels absent."""
+    store = _StubStore(
+        {
+            "stats": [{"nodes": 3, "edges": 1}],
+            "vulns": [{"key": "v1", "label": "x", "severity": "low"}],
+        }
+    )
+    out = build_summary(store, engagement="acme")  # type: ignore[arg-type]
+    assert "Top vulnerabilities" in out
+    assert "Unexplored entrypoints" not in out
+    assert "Crown jewels" not in out
+
+
+def test_build_summary_severity_orders_vulns_correctly() -> None:
+    """Top-N is sorted by severity rank — critical / high above low / info."""
+    store = _StubStore(
+        {
+            "stats": [{"nodes": 0, "edges": 0}],
+            # Stub returns the rows the Cypher 'cap' window would —
+            # build_summary re-sorts locally before truncating.
+            "vulns": [
+                {"key": "low_one", "label": "low_one", "severity": "low"},
+                {"key": "crit_one", "label": "crit_one", "severity": "critical"},
+                {"key": "info_one", "label": "info_one", "severity": "info"},
+                {"key": "high_one", "label": "high_one", "severity": "high"},
+            ],
+        }
+    )
+    out = build_summary(store, engagement="acme")  # type: ignore[arg-type]
+    crit_pos = out.find("crit_one")
+    high_pos = out.find("high_one")
+    low_pos = out.find("low_one")
+    info_pos = out.find("info_one")
+    # critical comes before high comes before low comes before info.
+    assert 0 < crit_pos < high_pos < low_pos < info_pos
+
+
+def test_build_summary_truncates_to_max_vulns() -> None:
+    """No more than MAX_VULNS vuln lines in the block."""
+    vulns = [{"key": f"v{i}", "label": f"v{i}", "severity": "medium"} for i in range(MAX_VULNS * 3)]
+    store = _StubStore(
+        {
+            "stats": [{"nodes": 0, "edges": 0}],
+            "vulns": vulns,
+        }
+    )
+    out = build_summary(store, engagement="acme")  # type: ignore[arg-type]
+    # Each vuln is one list item starting with "- `["
+    bullet_count = out.count("- `[")
+    assert bullet_count == MAX_VULNS
+
+
+def test_max_constants_are_small() -> None:
+    """Sanity guard: budgets stay tight (memory-systems anti-pattern guard)."""
+    assert MAX_VULNS <= 10
+    assert MAX_ENTRYPOINTS <= 10
+    assert MAX_CROWN_JEWELS <= 25

--- a/packages/decepticon/tests/unit/middleware/test_kg_tools_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_tools_unit.py
@@ -1,0 +1,318 @@
+"""Unit tests for :mod:`kg_internal.tools` — driver-free.
+
+Verifies the factory output, engagement-scope rejection, payload
+parsing, the InjectedState fallback to ``engagement_name``, and the
+dispatch through to the store / adapter registry.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from decepticon.middleware.kg_internal.tools import (
+    DEFAULT_KG_TOOLS,
+    build_kg_tools,
+)
+
+
+# ── Tool invocation envelope (matches OPPLAN test pattern) ──────────────
+
+
+def _call(tool: Any, args: dict[str, Any], state: dict[str, Any]) -> str:
+    """Invoke a middleware tool with a synthetic ToolCall envelope.
+
+    LangChain's ``InjectedToolCallId`` requires the tool to be called
+    via a ``{"type": "tool_call", "id": ..., "args": ...}`` payload,
+    not as a bare kwargs dict.
+    """
+    payload = {
+        "name": getattr(tool, "name", "tool"),
+        "type": "tool_call",
+        "id": "test-tool-call-id",
+        "args": {**args, "state": state},
+    }
+    return tool.invoke(payload)
+
+
+def _fake_store(record_result: dict[str, Any] | None = None) -> MagicMock:
+    """Mock KGStore with ``record_observations`` recording its inputs."""
+    store = MagicMock(name="KGStore")
+    store.record_observations.return_value = record_result or {
+        "created": 1,
+        "merged": 0,
+        "edges": 0,
+        "revision": "rev-stub",
+    }
+    return store
+
+
+# ── Factory shape ───────────────────────────────────────────────────────
+
+
+def test_default_factory_returns_two_tools() -> None:
+    tools = build_kg_tools(_fake_store())
+    names = {t.name for t in tools}
+    assert names == {"kg_record", "kg_ingest"}
+
+
+def test_factory_respects_enabled_filter() -> None:
+    record_only = build_kg_tools(_fake_store(), enabled={"kg_record"})
+    assert [t.name for t in record_only] == ["kg_record"]
+
+    ingest_only = build_kg_tools(_fake_store(), enabled={"kg_ingest"})
+    assert [t.name for t in ingest_only] == ["kg_ingest"]
+
+
+def test_factory_with_empty_enabled_returns_no_tools() -> None:
+    assert build_kg_tools(_fake_store(), enabled=set()) == []
+
+
+def test_default_kg_tools_constant_lists_both() -> None:
+    assert DEFAULT_KG_TOOLS == frozenset({"kg_record", "kg_ingest"})
+
+
+# ── kg_record engagement scope ──────────────────────────────────────────
+
+
+def test_kg_record_returns_error_when_engagement_unset() -> None:
+    store = _fake_store()
+    [kg_record, _] = build_kg_tools(store)
+    out_msg = _call(
+        kg_record,
+        {"observations": json.dumps([{"kind": "Host", "key": "h::1", "label": "h"}])},
+        state={},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    assert "kg_engagement" in payload["error"]
+    store.record_observations.assert_not_called()
+
+
+def test_kg_record_pulls_engagement_from_kg_engagement_field() -> None:
+    store = _fake_store()
+    [kg_record, _] = build_kg_tools(store)
+    _call(
+        kg_record,
+        {"observations": json.dumps([{"kind": "Host", "key": "h::1", "label": "h"}])},
+        state={"kg_engagement": "acme-q2", "role": "analyst"},
+    )
+    store.record_observations.assert_called_once()
+    kwargs = store.record_observations.call_args.kwargs
+    assert kwargs["engagement"] == "acme-q2"
+    assert kwargs["created_by"] == "analyst"
+    assert kwargs["source_episode_id"] == "test-tool-call-id"
+
+
+def test_kg_record_falls_back_to_engagement_name_when_kg_engagement_missing() -> None:
+    """Upstream EngagementContextMiddleware hydrates engagement_name. If
+    the KG middleware hasn't run yet (first turn), the tool can still
+    resolve scope from that upstream field."""
+    store = _fake_store()
+    [kg_record, _] = build_kg_tools(store)
+    _call(
+        kg_record,
+        {"observations": json.dumps([{"kind": "Host", "key": "h::1", "label": "h"}])},
+        state={"engagement_name": "acme-fallback"},
+    )
+    kwargs = store.record_observations.call_args.kwargs
+    assert kwargs["engagement"] == "acme-fallback"
+
+
+def test_kg_record_created_by_falls_back_to_agent_when_role_missing() -> None:
+    store = _fake_store()
+    [kg_record, _] = build_kg_tools(store)
+    _call(
+        kg_record,
+        {"observations": json.dumps([{"kind": "Host", "key": "h::1", "label": "h"}])},
+        state={"kg_engagement": "acme"},
+    )
+    kwargs = store.record_observations.call_args.kwargs
+    assert kwargs["created_by"] == "agent"
+
+
+# ── kg_record payload parsing ──────────────────────────────────────────
+
+
+def test_kg_record_rejects_malformed_json_observations() -> None:
+    store = _fake_store()
+    [kg_record, _] = build_kg_tools(store)
+    out_msg = _call(
+        kg_record,
+        {"observations": "not valid json"},
+        state={"kg_engagement": "acme"},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    assert "JSON" in payload["error"]
+    store.record_observations.assert_not_called()
+
+
+def test_kg_record_rejects_non_list_observations() -> None:
+    store = _fake_store()
+    [kg_record, _] = build_kg_tools(store)
+    out_msg = _call(
+        kg_record,
+        {"observations": json.dumps({"kind": "Host"})},
+        state={"kg_engagement": "acme"},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    assert "list" in payload["error"]
+
+
+def test_kg_record_returns_store_result_as_json() -> None:
+    store = _fake_store(
+        record_result={"created": 2, "merged": 1, "edges": 3, "revision": "rev-xyz"}
+    )
+    [kg_record, _] = build_kg_tools(store)
+    out_msg = _call(
+        kg_record,
+        {
+            "observations": json.dumps(
+                [
+                    {"kind": "Host", "key": "h::1", "label": "h"},
+                    {"kind": "Service", "key": "s::1", "label": "s"},
+                ]
+            )
+        },
+        state={"kg_engagement": "acme"},
+    )
+    payload = json.loads(out_msg.content)
+    assert payload == {"created": 2, "merged": 1, "edges": 3, "revision": "rev-xyz"}
+
+
+def test_kg_record_surfaces_store_value_error_as_error_payload() -> None:
+    store = MagicMock()
+    store.record_observations.side_effect = ValueError("observation missing key")
+    [kg_record, _] = build_kg_tools(store)
+    out_msg = _call(
+        kg_record,
+        {"observations": json.dumps([{"kind": "Host", "label": "h"}])},
+        state={"kg_engagement": "acme"},
+    )
+    payload = json.loads(out_msg.content)
+    assert payload == {"error": "observation missing key"}
+
+
+# ── kg_ingest dispatch ─────────────────────────────────────────────────
+
+
+def test_kg_ingest_returns_error_when_engagement_unset() -> None:
+    store = _fake_store()
+    [_, kg_ingest] = build_kg_tools(store)
+    out_msg = _call(
+        kg_ingest,
+        {"scanner_kind": "nmap_xml", "path": "/tmp/whatever.xml"},
+        state={},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    assert "kg_engagement" in payload["error"]
+
+
+def test_kg_ingest_unknown_scanner_returns_dispatcher_error() -> None:
+    store = _fake_store()
+    [_, kg_ingest] = build_kg_tools(store)
+    out_msg = _call(
+        kg_ingest,
+        {"scanner_kind": "made_up", "path": "/tmp/whatever"},
+        state={"kg_engagement": "acme"},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    assert "unknown scanner_kind" in payload["error"]
+
+
+def test_kg_ingest_missing_file_returns_dispatcher_error(tmp_path: Any) -> None:
+    store = _fake_store()
+    [_, kg_ingest] = build_kg_tools(store)
+    out_msg = _call(
+        kg_ingest,
+        {
+            "scanner_kind": "nmap_xml",
+            "path": str(tmp_path / "missing.xml"),
+        },
+        state={"kg_engagement": "acme"},
+    )
+    payload = json.loads(out_msg.content)
+    assert "error" in payload
+    assert "not found" in payload["error"]
+
+
+def test_kg_ingest_routes_to_adapter_and_returns_summary(tmp_path: Any) -> None:
+    """Happy-path nmap_xml ingest — the adapter writes via the store
+    mock, the tool returns the dispatcher's wrapped summary."""
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.1" addrtype="ipv4"/>
+            <ports>
+              <port portid="80" protocol="tcp">
+                <state state="open"/>
+                <service name="http"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+
+    store = MagicMock()
+    store.record_observations.return_value = {
+        "created": 3,
+        "merged": 0,
+        "edges": 1,
+        "revision": "rev-after",
+    }
+    [_, kg_ingest] = build_kg_tools(store)
+    out_msg = _call(
+        kg_ingest,
+        {"scanner_kind": "nmap_xml", "path": str(f)},
+        state={"kg_engagement": "acme", "role": "recon"},
+    )
+    payload = json.loads(out_msg.content)
+    assert payload["scanner"] == "nmap_xml"
+    assert payload["path"] == str(f)
+    assert payload["hosts"] == 1
+    assert payload["services"] == 1
+    assert payload["entrypoints"] == 1
+
+    # The adapter must have used the trusted engagement / created_by /
+    # source_episode_id from the middleware.
+    store.record_observations.assert_called_once()
+    kwargs = store.record_observations.call_args.kwargs
+    assert kwargs["engagement"] == "acme"
+    assert kwargs["created_by"] == "recon"
+    assert kwargs["source_episode_id"] == "test-tool-call-id"
+
+
+# ── Tool docstrings — guard the LLM-facing description surface ─────────
+
+
+def test_kg_record_description_mentions_observations_shape() -> None:
+    [kg_record, _] = build_kg_tools(_fake_store())
+    desc = kg_record.description or ""
+    assert "JSON" in desc
+    assert "key" in desc
+    assert "edges_out" in desc
+
+
+def test_kg_ingest_description_lists_builtin_scanners() -> None:
+    [_, kg_ingest] = build_kg_tools(_fake_store())
+    desc = kg_ingest.description or ""
+    for kind in ("nmap_xml", "nuclei_jsonl", "httpx_jsonl", "sarif"):
+        assert kind in desc
+
+
+# Helper to silence type-warnings on unused tmp_path fixture parameter.
+@pytest.fixture
+def _silence_tmp_path() -> None:
+    return None

--- a/packages/decepticon/tests/unit/middleware/test_kg_tools_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_tools_unit.py
@@ -18,7 +18,6 @@ from decepticon.middleware.kg_internal.tools import (
     build_kg_tools,
 )
 
-
 # ── Tool invocation envelope (matches OPPLAN test pattern) ──────────────
 
 

--- a/packages/decepticon/tests/unit/middleware/test_kgstore_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kgstore_unit.py
@@ -1,0 +1,326 @@
+"""Unit tests for :class:`KGStore` — driver-free.
+
+Covers: input validation (engagement label, label / rel-type vocabulary,
+mandatory ``key`` field), provenance auto-injection, observation
+flattening, and the Cypher shapes produced by ``record_observations``.
+
+Integration tests against a live Neo4j (compose) live in
+``tests/integration/kg/``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from decepticon.middleware.kg_internal.store import (
+    KGStore,
+    KGStoreConfig,
+    KGStoreConfigError,
+    _flatten_props,
+    _safe_label,
+    _safe_rel_type,
+)
+
+# ── KGStoreConfig.from_env ──────────────────────────────────────────────
+
+
+def test_config_from_env_full(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECEPTICON_NEO4J_URI", "bolt://neo4j:7687")
+    monkeypatch.setenv("DECEPTICON_NEO4J_USER", "neo4j")
+    monkeypatch.setenv("DECEPTICON_NEO4J_PASSWORD", "secret")
+    monkeypatch.setenv("DECEPTICON_NEO4J_DATABASE", "decepticon")
+    cfg = KGStoreConfig.from_env()
+    assert cfg.uri == "bolt://neo4j:7687"
+    assert cfg.user == "neo4j"
+    assert cfg.password == "secret"
+    assert cfg.database == "decepticon"
+
+
+def test_config_from_env_default_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECEPTICON_NEO4J_URI", "bolt://x")
+    monkeypatch.setenv("DECEPTICON_NEO4J_USER", "u")
+    monkeypatch.setenv("DECEPTICON_NEO4J_PASSWORD", "p")
+    monkeypatch.delenv("DECEPTICON_NEO4J_DATABASE", raising=False)
+    cfg = KGStoreConfig.from_env()
+    assert cfg.database == "neo4j"
+
+
+def test_config_from_env_missing_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("DECEPTICON_NEO4J_URI", "DECEPTICON_NEO4J_USER", "DECEPTICON_NEO4J_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(KGStoreConfigError) as exc:
+        KGStoreConfig.from_env()
+    assert "DECEPTICON_NEO4J_URI" in str(exc.value)
+    assert "DECEPTICON_NEO4J_USER" in str(exc.value)
+    assert "DECEPTICON_NEO4J_PASSWORD" in str(exc.value)
+
+
+# ── _safe_label / _safe_rel_type ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "label", ["Host", "Service", "Vulnerability", "URL", "CrownJewel", "AttackPath", "X1"]
+)
+def test_safe_label_accepts_valid(label: str) -> None:
+    assert _safe_label(label) == label
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "",
+        "1Host",  # leading digit
+        "host name",  # space
+        "Host;DROP",  # injection attempt
+        "Host`thing",
+        "a" * 65,  # too long
+    ],
+)
+def test_safe_label_rejects_invalid(label: str) -> None:
+    with pytest.raises(ValueError, match="invalid node label"):
+        _safe_label(label)
+
+
+@pytest.mark.parametrize("rel_type", ["HOSTS", "HAS_VULN", "EXPLOITS", "STARTS_AT", "STEP", "R1_2"])
+def test_safe_rel_type_accepts_valid(rel_type: str) -> None:
+    assert _safe_rel_type(rel_type) == rel_type
+
+
+@pytest.mark.parametrize(
+    "rel_type",
+    [
+        "",
+        "lowercase",
+        "Host_Service",  # mixed case
+        "HAS-VULN",  # hyphen
+        "HAS VULN",  # space
+        "1HAS",  # leading digit
+        "A" * 65,  # too long
+    ],
+)
+def test_safe_rel_type_rejects_invalid(rel_type: str) -> None:
+    with pytest.raises(ValueError, match="invalid edge type"):
+        _safe_rel_type(rel_type)
+
+
+# ── _flatten_props ──────────────────────────────────────────────────────
+
+
+def test_flatten_props_passes_primitives() -> None:
+    out = _flatten_props({"ip": "10.0.0.1", "port": 80, "open": True, "score": 7.5, "none": None})
+    assert out == {"ip": "10.0.0.1", "port": 80, "open": True, "score": 7.5, "none": None}
+
+
+def test_flatten_props_passes_primitive_lists() -> None:
+    out = _flatten_props({"tags": ["sqli", "ssrf"], "ports": [80, 443]})
+    assert out == {"tags": ["sqli", "ssrf"], "ports": [80, 443]}
+
+
+def test_flatten_props_stringifies_nested_dict() -> None:
+    out = _flatten_props({"meta": {"a": 1}})
+    assert out["meta"] == '{"a": 1}'
+
+
+def test_flatten_props_stringifies_list_of_dicts() -> None:
+    out = _flatten_props({"refs": [{"url": "x"}]})
+    assert out["refs"] == '[{"url": "x"}]'
+
+
+# ── Construction with fake driver ───────────────────────────────────────
+
+
+def _fake_driver() -> MagicMock:
+    """Mock that mimics neo4j.Driver / Session / Transaction enough for unit tests."""
+    driver = MagicMock(name="Driver")
+    session = MagicMock(name="Session")
+    driver.session.return_value.__enter__.return_value = session
+    driver.session.return_value.__exit__.return_value = None
+    return driver
+
+
+def _make_store(driver: Any | None = None) -> KGStore:
+    cfg = KGStoreConfig(uri="bolt://x", user="u", password="p", database="neo4j")
+    return KGStore(cfg, driver=driver or _fake_driver())
+
+
+def test_close_swallows_driver_exception() -> None:
+    driver = MagicMock()
+    driver.close.side_effect = RuntimeError("network blip")
+    store = _make_store(driver)
+    # Should not raise.
+    store.close()
+
+
+# ── Engagement scope safety ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "engagement",
+    ["", None, " ", "-leading-dash", "has space", "has;semi", "has/slash", "a" * 129],
+)
+def test_engagement_scope_rejects_invalid(engagement: Any) -> None:
+    store = _make_store()
+    with pytest.raises(ValueError):
+        store._check_engagement(engagement)
+
+
+@pytest.mark.parametrize("engagement", ["acme-q2", "ENG_001", "client.test.42", "a", "A1"])
+def test_engagement_scope_accepts_valid(engagement: str) -> None:
+    store = _make_store()
+    store._check_engagement(engagement)  # must not raise
+
+
+def test_execute_read_requires_engagement() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError):
+        store.execute_read("MATCH (n) RETURN n", {}, engagement="")
+
+
+def test_execute_write_requires_engagement() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError):
+        store.execute_write("CREATE (n)", {}, engagement="")
+
+
+def test_delete_stale_requires_int_cutoff() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError, match="before_unix must be an int"):
+        store.delete_stale(engagement="acme-q2", before_unix=1.5)  # type: ignore[arg-type]
+
+
+# ── record_observations validation ──────────────────────────────────────
+
+
+def test_record_observations_rejects_missing_key() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError, match="missing mandatory 'key'"):
+        store.record_observations(
+            [{"kind": "Host", "label": "10.0.0.1", "props": {"ip": "10.0.0.1"}}],
+            engagement="acme",
+            created_by="analyst",
+            source_episode_id="tc-1",
+        )
+
+
+def test_record_observations_rejects_bad_label() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError, match="invalid node label"):
+        store.record_observations(
+            [{"kind": "lowercase", "key": "x::1", "label": "x"}],
+            engagement="acme",
+            created_by="analyst",
+            source_episode_id="tc-1",
+        )
+
+
+def test_record_observations_requires_created_by() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError, match="created_by"):
+        store.record_observations(
+            [{"kind": "Host", "key": "h::1", "label": "1"}],
+            engagement="acme",
+            created_by="",
+            source_episode_id="tc-1",
+        )
+
+
+def test_record_observations_requires_source_episode_id() -> None:
+    store = _make_store()
+    with pytest.raises(ValueError, match="source_episode_id"):
+        store.record_observations(
+            [{"kind": "Host", "key": "h::1", "label": "1"}],
+            engagement="acme",
+            created_by="analyst",
+            source_episode_id="",
+        )
+
+
+def test_record_observations_empty_batch_is_noop() -> None:
+    # When the observation list is empty, no driver session should be
+    # opened beyond the revision() lookup.
+    driver = _fake_driver()
+    session = driver.session.return_value.__enter__.return_value
+    session.execute_read.return_value = [{"rev": 0}]
+    store = _make_store(driver)
+
+    result = store.record_observations(
+        [],
+        engagement="acme",
+        created_by="analyst",
+        source_episode_id="tc-1",
+    )
+    assert result == {"created": 0, "merged": 0, "edges": 0, "revision": "rev-acme-0"}
+
+
+# ── Provenance auto-injection enforcement ───────────────────────────────
+
+
+def test_record_observations_strips_reserved_provenance_from_props() -> None:
+    """The agent cannot forge engagement/firstseen/etc. via the props dict."""
+    captured: list[dict[str, Any]] = []
+    driver = _fake_driver()
+    session = driver.session.return_value.__enter__.return_value
+
+    def fake_write(write_fn):  # type: ignore[no-untyped-def]
+        tx = MagicMock()
+        # Record both UNWIND batches as they go past.
+        results: dict[str, MagicMock] = {}
+
+        def tx_run(query, **params):  # type: ignore[no-untyped-def]
+            captured.append(dict(params))
+            rec = MagicMock()
+            rec.__iter__ = lambda self: iter([("created", 1), ("merged", 0), ("written", 1)])
+            rec.__getitem__ = lambda self, k: {"created": 1, "merged": 0, "written": 1}.get(k, 0)
+            results[query] = MagicMock()
+            results[query].__iter__ = lambda self: iter([rec])
+            return results[query]
+
+        tx.run = tx_run
+        return write_fn(tx)
+
+    session.execute_write.side_effect = fake_write
+
+    store = _make_store(driver)
+    store.record_observations(
+        [
+            {
+                "kind": "Host",
+                "key": "host::10.0.0.1",
+                "label": "10.0.0.1",
+                "props": {
+                    "ip": "10.0.0.1",
+                    # Agent tries to forge provenance — all must be stripped.
+                    "engagement": "MALICIOUS",
+                    "firstseen": 0,
+                    "lastupdated": 0,
+                    "created_by": "spoofed",
+                    "source_episode_id": "spoofed",
+                },
+            }
+        ],
+        engagement="acme",
+        created_by="analyst",
+        source_episode_id="tc-real",
+    )
+
+    # The rows array we passed into the Cypher MERGE must not contain
+    # the reserved fields in its props blob — they have to come from
+    # the middleware-supplied named params instead.
+    assert captured, "expected at least one tx.run call"
+    for params in captured:
+        rows = params.get("rows", [])
+        for row in rows:
+            row_props = row.get("props", {})
+            assert "engagement" not in row_props
+            assert "firstseen" not in row_props
+            assert "lastupdated" not in row_props
+            assert "created_by" not in row_props
+            assert "source_episode_id" not in row_props
+        # The trusted provenance is bound separately as named params.
+        assert params.get("engagement") == "acme"
+        assert params.get("created_by") == "analyst"
+        assert params.get("source_episode_id") == "tc-real"
+        assert isinstance(params.get("now"), int)

--- a/packages/decepticon/tests/unit/runtime/test_attack_graph_protocol.py
+++ b/packages/decepticon/tests/unit/runtime/test_attack_graph_protocol.py
@@ -1,0 +1,93 @@
+"""Structural tests for :class:`AttackGraphProtocol`.
+
+The protocol is the CART ↔ KGMiddleware contract — any object that
+exposes ``revision(*, engagement)`` and ``snapshot(*, engagement)``
+must satisfy ``isinstance(obj, AttackGraphProtocol)``. Filling in the
+docstring vaporware that lived in ``cart.py`` since the module's first
+commit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from decepticon.runtime.cart import AttackGraphProtocol, EngagementSnapshot
+
+
+class _Conforming:
+    """Minimal implementation that should satisfy the Protocol."""
+
+    def revision(self, *, engagement: str) -> str:
+        return f"rev-{engagement}-1"
+
+    def snapshot(self, *, engagement: str) -> EngagementSnapshot:
+        return EngagementSnapshot(
+            snapshot_id="s-1",
+            captured_at=0.0,
+            nodes={},
+            edges={},
+        )
+
+
+class _MissingSnapshot:
+    """Has revision but not snapshot — should NOT satisfy the Protocol."""
+
+    def revision(self, *, engagement: str) -> str:
+        return "rev-1"
+
+
+class _MissingRevision:
+    """Has snapshot but not revision — should NOT satisfy the Protocol."""
+
+    def snapshot(self, *, engagement: str) -> EngagementSnapshot:
+        return EngagementSnapshot(snapshot_id="s-1", captured_at=0.0, nodes={}, edges={})
+
+
+def test_conforming_instance_satisfies_protocol() -> None:
+    """A class with both required methods registers as the Protocol."""
+    instance: Any = _Conforming()
+    assert isinstance(instance, AttackGraphProtocol)
+
+
+def test_missing_snapshot_rejected() -> None:
+    """Missing ``snapshot`` invalidates structural conformance."""
+    instance: Any = _MissingSnapshot()
+    assert not isinstance(instance, AttackGraphProtocol)
+
+
+def test_missing_revision_rejected() -> None:
+    """Missing ``revision`` invalidates structural conformance."""
+    instance: Any = _MissingRevision()
+    assert not isinstance(instance, AttackGraphProtocol)
+
+
+def test_revision_returns_string() -> None:
+    """The revision token is opaque but must be a string for hashing/comparison."""
+    store = _Conforming()
+    rev = store.revision(engagement="acme-q2")
+    assert isinstance(rev, str)
+    assert rev  # non-empty
+
+
+def test_snapshot_returns_engagement_snapshot() -> None:
+    """The snapshot return type matches :class:`EngagementSnapshot` for diffability."""
+    store = _Conforming()
+    snap = store.snapshot(engagement="acme-q2")
+    assert isinstance(snap, EngagementSnapshot)
+    assert snap.snapshot_id
+    assert isinstance(snap.nodes, dict)
+    assert isinstance(snap.edges, dict)
+
+
+def test_revision_changes_with_engagement_arg() -> None:
+    """Each engagement gets its own revision token; CART relies on this for scoping."""
+    store = _Conforming()
+    assert store.revision(engagement="acme-q2") != store.revision(engagement="other-eng")
+
+
+def test_protocol_is_runtime_checkable() -> None:
+    """``isinstance(obj, AttackGraphProtocol)`` must not raise on arbitrary objects."""
+    # If the Protocol were not @runtime_checkable, the next line would raise.
+    assert isinstance(_Conforming(), AttackGraphProtocol)
+    assert not isinstance("a plain string", AttackGraphProtocol)
+    assert not isinstance(42, AttackGraphProtocol)


### PR DESCRIPTION
## Summary

Replaces the broken `graph_transaction()`-based attack-graph layer (#543
removed it from 17 agents) with a `KGMiddleware` that owns the Neo4j
store, exposes a minimal 2-tool surface (`kg_record` + `kg_ingest`), and
injects a current graph state block into every system prompt.

The cutover is **analyst-only** for this PR — `ad_operator` and
`contract_auditor` keep their narrow tool surfaces from #543 and are
scoped for a follow-up. The `tools/research/` retirement (broken
`_state` shim + sibling legacy tools) is PR-D and a separate change.

Implements the design in:
- `docs/design/2026-06-03-kg-middleware-redesign.md` (655 lines, 4-PR plan)
- `docs/design/2026-06-03-kg-middleware-implementation-research.md` (570 lines, §9 final design)
- `docs/design/2026-06-03-external-docs-research.md` (425 lines, LangChain / LangGraph / Neo4j 5.x patterns)
- `docs/design/neo4j-research-notes.md` (1,020 lines, 13 Neo4j topics)

### Three-PR sub-structure on this branch

| Phase | Commits | What lands |
|---|---|---|
| **PR-A foundations** | 4 + 1 fix | `AttackGraphProtocol` in `runtime/cart`, `KGStore` (per-op `execute_write` / `execute_read`, engagement-mandatory, provenance auto-injection), V001 + V002 Cypher migrations + idempotent runner, integration suite + 16-agent parallel-write stress |
| **PR-B middleware** | 4 + 1 style | `KGState` schema + summary builder, 4 scanner adapters (`nmap_xml` / `nuclei_jsonl` / `httpx_jsonl` / `sarif`) + plugin entry-point, `build_kg_tools(store)` factory + 2 tools, `KGMiddleware(AgentMiddleware)` with 4 lifecycle hooks (before_agent / wrap_model_call / wrap_tool_call / after_model) |
| **PR-C analyst cutover** | 3 | `MiddlewareSlot.KG` in `decepticon_core.contracts.slots`, `SLOTS_PER_ROLE["analyst"]` gains KG, `analyst.py` drops `RESEARCH_TOOLS` / `BOUNTY_TOOLS` direct imports, `analyst.md` rewritten for the new 2-tool surface |

### What the agent sees

Every turn, `wrap_model_call` injects a static KG_SYSTEM_PROMPT (prompt-
cache friendly) plus a dynamic summary block:

```
## KG STATE (engagement=acme-q2)
**Nodes**: 12 · **Edges**: 8 · **Revision**: rev-acme-q2-1717000000

**Top vulnerabilities**:
- `[CRITICAL]` SSTI in /search (`vuln::ssti-search`)
- `[HIGH]` SQLi in /login (`vuln::sqli-login`)
...

**Unexplored entrypoints**:
- https://app/admin (`entrypoint::https-app-admin`)

**Crown jewels**:
- domain_admin (1 viable path)
```

The dedicated `kg_query` / `kg_neighbors` / `kg_stats` / `kg_backend_health`
read tools are retired — the summary is always-on and `bash("cypher-shell ...")`
covers ad-hoc deep dives.

### Provenance pattern

Every node and edge gets 5 fields auto-injected by `KGStore` (Cartography
`update_tag` + Graphiti `source_episode_id`):

- `engagement` — multi-tenant scope label
- `firstseen` — Unix timestamp `ON CREATE`
- `lastupdated` — Unix timestamp on every touch
- `created_by` — agent role string (e.g. `analyst`)
- `source_episode_id` — LangChain `tool_call_id` of the producing turn

Agent-supplied props with these keys are silently stripped — the model
cannot forge provenance.

### Defense-in-depth engagement scope

1. `KGStore._check_engagement` validates the label format on every public method.
2. `KGMiddleware.wrap_tool_call` rejects `kg_record` / `kg_ingest` before the handler when `kg_engagement` is absent from state.
3. The tools themselves resolve engagement from state and reject if empty.
4. Every Cypher write filters by `n.engagement = $engagement`.

### Graceful degradation in dev / CI

`_make_kg` returns `None` (with a single warning log) when
`DECEPTICON_NEO4J_*` env vars are absent OR the driver fails to open —
matching the `_make_model_fallback` pattern. Module-level
`graph = create_analyst_agent()` constructors keep importing on dev
boxes that don't have Neo4j configured.

## Test plan

- [x] **776 unit tests** pass across `tests/unit/{middleware,runtime,agents,research}` — no regression on slot assembly, factory contract, plugin overrides, OPPLAN behavior, or the existing reporting-tools wiring guard.
- [x] **40 live integration tests** pass against Neo4j 5.24.2 (compose service):
  - 18 KGStore + migrations (16-agent parallel-write stress: 16 distinct keys → 16 nodes; 16 same-key writes → 1 node via MERGE)
  - 8 summary builder (top-N ordering, section omission, cap enforcement, revision change after write)
  - 5 scanner adapters (nmap / nuclei / httpx / sarif idempotent re-ingest)
  - 5 KG tools (engagement scope rejection, idempotent kg_record, provenance round-trip)
  - 6 middleware lifecycle (hydrate / summary-after-write / wrap_model_call / wrap_tool_call rejection / two-turn loop)
- [x] **End-to-end production-stack verification** via `make smoke` + manual `docker exec decepticon-langgraph` script:
  - Analyst agent constructs successfully inside the production container
  - LangGraph server registers `analyst` assistant (graph_id matches)
  - Web dashboard `/api/health` reports langgraph + litellm + neo4j + postgres healthy
  - `kg_record` writes 2 nodes (`Host` + `Vulnerability`) through real path: `{'created': 2, 'merged': 0, 'edges': 0, 'revision': 'rev-verify-e2e-1780498861'}`
  - Subsequent `before_agent` rebuilds summary; "SQLi" appears in the dynamic block
- [x] **Caught one production-only bug** (`bf2c15c2`): `record_observations` mis-classified merged nodes as created when two writes hit the same second (`n.firstseen = $now` was a non-discriminating predicate). The unit tests with MagicMock didn't exercise Cypher semantics so this only surfaced under live Neo4j — fix uses an explicit `ON CREATE SET n._jc = true / ON MATCH SET n._jc = false` marker pattern with REMOVE before return. **This is exactly why the live-stack verification step is mandatory in CLAUDE.md.**
- [ ] CI: `make quality` (ruff + basedpyright errors-only + pytest + CLI + Web) — pending PR push.

## Notes

- Pre-PR live-stack run cleaned up: `kg-it-neo4j` standalone container stopped + leftover `decepticon-*` exited containers from previous worktree runs removed before `make smoke`.
- This branch is **additive** to #543 — the broken `tools/research/` is still on disk (PR-D scope). REPORTING_TOOLS still routes through the legacy `_state` shim for the analyst's REPORT step; that retirement is the same PR-D scope.