### PR TITLE
feat(kg): expose KG middleware to ad_operator and contract_auditor

### DIFF
--- a/packages/decepticon-core/decepticon_core/contracts/slots.py
+++ b/packages/decepticon-core/decepticon_core/contracts/slots.py
@@ -160,16 +160,21 @@ SLOTS_PER_ROLE: dict[str, frozenset[MiddlewareSlot]] = {
     "recon": _BASH_AGENT_SLOTS,
     "exploit": _BASH_AGENT_SLOTS,
     "postexploit": _BASH_AGENT_SLOTS,
-    # Analyst is the only OSS role that runs the KG middleware — its
-    # workflow is the persistent-graph use case the spec calls out
+    # Three OSS roles run the KG middleware — the persistent-graph use
+    # cases the spec calls out
     # (docs/design/2026-06-03-kg-middleware-redesign.md § 4.10).
-    # ad_operator and contract_auditor stayed narrow in the prior
-    # cutover; their KG slot adoption is a follow-up.
+    # ad_operator records BloodHound-derived principals / paths and
+    # confirmed AD findings; contract_auditor records Foundry-confirmed
+    # smart-contract vulnerabilities and chain candidates. The opt-in
+    # ``kg_record`` / ``kg_ingest`` tools complement (do not replace)
+    # the legacy AD_TOOLS / CONTRACT_TOOLS surfaces — the legacy
+    # ingest paths still route through the ``graph_transaction`` shim
+    # and migrate to KGStore in a separate RFC.
     "analyst": _BASH_AGENT_SLOTS | {MiddlewareSlot.KG},
     "reverser": _BASH_AGENT_SLOTS,
-    "contract_auditor": _BASH_AGENT_SLOTS,
+    "contract_auditor": _BASH_AGENT_SLOTS | {MiddlewareSlot.KG},
     "cloud_hunter": _BASH_AGENT_SLOTS,
-    "ad_operator": _BASH_AGENT_SLOTS,
+    "ad_operator": _BASH_AGENT_SLOTS | {MiddlewareSlot.KG},
     "phisher": _BASH_AGENT_SLOTS,
     "mobile_operator": _BASH_AGENT_SLOTS,
     "wireless_operator": _BASH_AGENT_SLOTS,

--- a/packages/decepticon/decepticon/agents/prompts/standard/ad_operator.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/ad_operator.md
@@ -2,15 +2,28 @@
 You are the Decepticon AD Operator — Active Directory and Windows
 attack specialist. You operate on BloodHound JSON / ZIP exports,
 Kerberos ticket dumps, Certipy output, and LDAP queries to build
-domain-wide attack chains.
+domain-wide attack chains, and you persist confirmed findings into
+the engagement knowledge graph so the next iteration (and other
+specialists) can reason about them.
 
 Your operating loop is:
-  1. INGEST   — bh_ingest_zip on collector output
+  1. INGEST   — bh_ingest_zip on collector output (legacy AD_TOOLS;
+                writes BloodHound nodes into the back-end Neo4j the
+                bh_ingest path uses — separate from the engagement KG)
   2. TRIAGE   — `bash("cypher-shell -u neo4j -p $NEO4J_PASSWORD 'MATCH (u:User) WHERE u.admin = true OR (u)-[:MEMBER_OF]->(:Group {admin: true}) RETURN u.username LIMIT 25'")` to surface admin-adjacent principals
   3. DCSYNC   — dcsync_check — if any principal has it, that's instant win
   4. ROAST    — kerberoast / asrep roast users with SPN / dontreqpreauth
   5. ADCS     — run certipy find, then adcs_audit on the JSON
-  6. CHAIN    — manually trace the cheapest BloodHound path to Domain Admins via cypher-shell (generic `plan_attack_chains` is parked pending the Neo4j middleware redesign — see docs/design/neo4j-research-notes.md)
+  6. CHAIN    — manually trace the cheapest BloodHound path to Domain
+                Admins via cypher-shell (generic `plan_attack_chains`
+                is parked pending the BloodHound-schema RFC — see
+                docs/design/neo4j-research-notes.md)
+  7. PERSIST  — every confirmed credential, takeover-capable principal,
+                viable attack path, and validated finding goes into
+                the engagement KG via `kg_record`. Use kind="Credential"
+                / "Principal" / "Vulnerability" / "Finding" so analyst
+                and reporting agents see your work. The KG STATE block
+                at the top of every turn shows what's already there.
 </IDENTITY>
 
 <CRITICAL_RULES>
@@ -21,6 +34,10 @@ Your operating loop is:
   the operator know the alert risk
 - ADCS ESC1/ESC6 chains are critical — escalate to operator even if
   the engagement wanted a slow approach
+- Every confirmed credential, viable path, and validated finding MUST
+  land in the engagement KG via `kg_record`. The bh_ingest_zip path
+  is for raw BloodHound topology and lives in a separate back-end —
+  it does NOT replace `kg_record` for your manually-confirmed work.
 </CRITICAL_RULES>
 
 <HUNTING_LANES>

--- a/packages/decepticon/decepticon/agents/prompts/standard/contract_auditor.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/contract_auditor.md
@@ -4,15 +4,26 @@ specialist. Your job is to find high-impact DeFi / smart contract
 bugs: reentrancy, oracle manipulation, flash loan abuse, access
 control gaps, upgradeable-proxy mistakes, signature replay, math
 rounding. You operate on source trees, Slither output, and Foundry
-test harnesses.
+test harnesses, and you persist Foundry-confirmed findings into the
+engagement knowledge graph so the next iteration (and reporting
+agents) can reason about chains and impact.
 
 Your operating loop is:
   1. MAP     — find contracts under /workspace/src or clone via bash
   2. SCAN    — solidity_scan on each .sol file
-  3. INGEST  — run slither via bash, then slither_ingest
+  3. INGEST  — run slither via bash, then slither_ingest (legacy
+               CONTRACT_TOOLS path; writes raw Slither hits to the
+               back-end Neo4j the slither_ingest path uses — separate
+               from the engagement KG)
   4. CHAIN   — group findings by function, model cross-function chains
   5. PROVE   — generate a Foundry test harness per finding, run forge test
-  6. REPORT  — validated findings → `findings/FIND-NNN.md` written as a
+  6. PERSIST — every Foundry-confirmed finding goes into the engagement
+               KG via `kg_record` with kind="Finding" and
+               props={"status": "confirmed", "cvss": "...", "poc": "..."}.
+               Record related Contract / Function / Oracle nodes and
+               link with edges (HAS_VULN, READS_FROM, CALLS) so chain
+               candidates surface in the KG STATE block.
+  7. REPORT  — validated findings → `findings/FIND-NNN.md` written as a
               HackerOne-style markdown report (impact, repro steps, CVSS
               vector, PoC link) for the operator to submit
 </IDENTITY>
@@ -25,6 +36,10 @@ Your operating loop is:
   link to the pool or feed as a node.
 - CVSS is ESTIMATED for smart contracts — use impact-based scoring
   (loss-of-funds = 9.8+, DoS only = 7.5, view-only = 4.0).
+- Every Foundry-confirmed finding MUST land in the engagement KG via
+  `kg_record`. The slither_ingest path is for raw Slither hits and
+  lives in a separate back-end — it does NOT replace `kg_record` for
+  your manually-confirmed work.
 </CRITICAL_RULES>
 
 <HUNTING_LANES>

--- a/packages/decepticon/decepticon/agents/standard/ad_operator.py
+++ b/packages/decepticon/decepticon/agents/standard/ad_operator.py
@@ -26,10 +26,14 @@ cleanly:
 
 Middleware slots (per ``SLOTS_PER_ROLE["ad_operator"]``):
 
-  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → KG → SANDBOX_NOTIFICATION
     → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
 
-No SubAgent / OPPLAN (standalone, not an orchestrator).
+No SubAgent / OPPLAN (standalone, not an orchestrator). The KG slot
+exposes ``kg_record`` / ``kg_ingest`` so the operator can persist
+BloodHound-derived principals, paths, and confirmed AD findings into
+the engagement graph alongside (not in place of) the legacy AD_TOOLS
+ingest path.
 """
 
 from __future__ import annotations
@@ -54,7 +58,12 @@ from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_
 # GPO / shadow-creds audits, Kerberos hash classification) is kept
 # because BloodHound integration is the AD operator's primary lane.
 # Note: AD_TOOLS themselves still go through the broken graph_transaction
-# shim internally; that is in scope for the same refactor.
+# shim internally — their migration to KGStore needs a dedicated
+# BloodHound-schema RFC and is NOT part of the slot adoption here.
+# What the KG slot adds is the explicit ``kg_record`` / ``kg_ingest``
+# tools (injected by KGMiddleware) so the operator can write confirmed
+# findings, credentials, and manually-traced paths to the engagement
+# graph alongside whatever AD_TOOLS legacy ingest writes.
 _STANDARD_TOOLS: dict[str, Any] = {
     t.name: t
     for t in [

--- a/packages/decepticon/decepticon/agents/standard/contract_auditor.py
+++ b/packages/decepticon/decepticon/agents/standard/contract_auditor.py
@@ -31,10 +31,13 @@ cleanly:
 
 Middleware slots (per ``SLOTS_PER_ROLE["contract_auditor"]``):
 
-  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → SANDBOX_NOTIFICATION
+  ENGAGEMENT_CONTEXT → SKILLS → FILESYSTEM → KG → SANDBOX_NOTIFICATION
     → MODEL_FALLBACK → SUMMARIZATION → PROMPT_CACHING → PATCH_TOOL_CALLS
 
-No SubAgent / OPPLAN (standalone, not an orchestrator).
+No SubAgent / OPPLAN (standalone, not an orchestrator). The KG slot
+exposes ``kg_record`` / ``kg_ingest`` so confirmed Foundry-validated
+findings and chain candidates land in the engagement graph alongside
+(not in place of) the legacy CONTRACT_TOOLS slither ingest path.
 """
 
 from __future__ import annotations
@@ -58,8 +61,11 @@ from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_
 # (Solidity pattern scanner, Slither ingest, Foundry PoC test
 # generators) is kept because it is the contract auditor's primary
 # lane. Note: slither_ingest inside CONTRACT_TOOLS still routes through
-# the broken graph_transaction shim; that is in scope for the same
-# refactor.
+# the broken graph_transaction shim — its migration to KGStore is a
+# follow-up RFC and is NOT covered by the slot adoption here. What the
+# KG slot adds is the explicit ``kg_record`` / ``kg_ingest`` tools
+# (injected by KGMiddleware) so Foundry-confirmed findings land in the
+# engagement graph as structured Finding nodes.
 _STANDARD_TOOLS: dict[str, Any] = {
     t.name: t
     for t in [


### PR DESCRIPTION
## Summary

Extends KG middleware adoption from analyst (the only KG-enabled role until now) to ``ad_operator`` and ``contract_auditor``. Slot adoption only — the legacy AD_TOOLS bh_ingest_zip and CONTRACT_TOOLS slither_ingest paths are unchanged.

## What changes

| File | Change |
|---|---|
| ``packages/decepticon-core/decepticon_core/contracts/slots.py`` | ``ad_operator`` and ``contract_auditor`` gain ``MiddlewareSlot.KG`` |
| ``packages/decepticon/decepticon/agents/standard/ad_operator.py`` | Docstring + comment reflect new KG slot and the explicit non-scope of BloodHound migration |
| ``packages/decepticon/decepticon/agents/standard/contract_auditor.py`` | Same as above for Slither |
| ``packages/decepticon/decepticon/agents/prompts/standard/ad_operator.md`` | PERSIST step + CRITICAL_RULE: confirmed creds / principals / paths / findings via ``kg_record`` |
| ``packages/decepticon/decepticon/agents/prompts/standard/contract_auditor.md`` | PERSIST step + CRITICAL_RULE: Foundry-confirmed findings via ``kg_record`` |

## What does NOT change

- AD_TOOLS (``bh_ingest_zip``, DCSync / ADCS / delegation / GPO / shadow-creds audits) — unchanged
- CONTRACT_TOOLS (``slither_ingest``, ``solidity_scan``, Foundry harness) — unchanged
- ``tools/research/_state.py`` and the ``graph_transaction`` shim — unchanged
- ``KGStore`` / ``KGMiddleware`` / ``kg_record`` / ``kg_ingest`` — already shipped in #545
- No new tools, no new schema, no migrations triggered

## Out of scope (deliberately)

- **BloodHound → KGStore migration**: needs dedicated schema RFC since BloodHound's node model (User/Computer/Group with global uniqueness) does not map cleanly to KGStore's ``(key, engagement)`` composite. Requires external research on the BloodHound 5.x schema before refactoring AD_TOOLS.
- **Slither → KGStore migration**: same shape of problem. Slither's vulnerability JSON maps to a Finding/Contract observation emitter that does not exist yet.
- Migration of REPORTING_TOOLS / AD_TOOLS / CONTRACT_TOOLS callers off of ``_state._load()``: tracked separately as PR-M1 / PR-M2 / PR-M3 in the follow-up sequence.

## Verification

- ``make ci-lint``: 0 errors (full repo)
- Diff is 5 files, 71 insertions / 19 deletions — slot wiring + docstring / comment updates + prompt PERSIST step

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)
- [ ] Agent boots when ``DECEPTICON_NEO4J_*`` is unset (KG slot is graceful — ``_make_kg`` catches ``KGStoreConfigError`` / ``KGStoreUnavailableError`` / ``ImportError`` and returns ``None``, same path analyst already exercises)
- [ ] Agent boots when Neo4j is reachable (analyst integration tests already cover this path; this PR exercises the same factory)