### PR TITLE
refactor(reporting): migrate from legacy _state shim to new KGStore

### DIFF
--- a/packages/decepticon/decepticon/tools/reporting/kg_adapter.py
+++ b/packages/decepticon/decepticon/tools/reporting/kg_adapter.py
@@ -1,0 +1,157 @@
+"""Adapter — read engagement-scoped KG data from the new KGStore and
+build an in-memory :class:`KnowledgeGraph` for the reporting renderers.
+
+The renderers in ``reporting/{hackerone,bugcrowd,executive,sarif,timeline}.py``
+all operate on the :class:`KnowledgeGraph` Pydantic model. Rather than
+rewriting every renderer in the same PR, this adapter reads from the
+new :class:`KGStore` (the post-#545 backend) and constructs the same
+``KnowledgeGraph`` shape — preserving deterministic Node / Edge IDs so
+downstream consumers and existing test patches remain stable.
+
+This module is the seam that lets ``tools/reporting`` retire the old
+``tools/research/_state._load`` shim without touching the renderer
+code or the back-end Neo4j wiring used by the (still legacy) AD /
+Contract tool surfaces — those migrate in dedicated follow-up PRs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from decepticon.middleware.kg_internal.store import (
+    KGStore,
+    KGStoreConfigError,
+    KGStoreUnavailableError,
+)
+from decepticon_core.types.kg import (
+    Edge,
+    EdgeKind,
+    KnowledgeGraph,
+    Node,
+    NodeKind,
+)
+
+# Provenance / reserved property names that ``KGStore`` auto-injects on
+# every observation. They live on the Neo4j node so we can read them
+# back when rebuilding the in-memory graph, but they don't belong on
+# ``Node.props`` / ``Edge.props`` — those carry the agent-supplied
+# props only. Strip them before constructing the Pydantic model.
+_RESERVED_NODE_PROPS = frozenset(
+    {
+        "engagement",
+        "key",
+        "label",
+        "firstseen",
+        "lastupdated",
+        "created_by",
+        "source_episode_id",
+    }
+)
+_RESERVED_EDGE_PROPS = frozenset(
+    {
+        "engagement",
+        "key",
+        "firstseen",
+        "lastupdated",
+        "created_by",
+        "source_episode_id",
+        "weight",
+    }
+)
+
+
+def _coerce_props(raw: Any, reserved: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    return {k: v for k, v in raw.items() if k not in reserved}
+
+
+def load_engagement_graph(engagement: str) -> KnowledgeGraph:
+    """Build a :class:`KnowledgeGraph` from the new KGStore for one engagement.
+
+    Returns an empty graph if the store is unavailable or unreachable —
+    matches the soft-fail behaviour of the legacy ``_state._load`` so
+    the reporting tools degrade gracefully when Neo4j is not running.
+    """
+    try:
+        store = KGStore.from_env()
+    except (KGStoreConfigError, KGStoreUnavailableError, ImportError):
+        return KnowledgeGraph()
+
+    graph = KnowledgeGraph()
+    try:
+        node_rows = store.execute_read(
+            (
+                "MATCH (n) WHERE n.engagement = $engagement "
+                "RETURN labels(n)[0] AS kind, "
+                "       n.key AS key, "
+                "       n.label AS label, "
+                "       properties(n) AS props, "
+                "       coalesce(n.firstseen, 0.0) AS created_at, "
+                "       coalesce(n.lastupdated, 0.0) AS updated_at"
+            ),
+            {"engagement": engagement},
+            engagement=engagement,
+        )
+        for row in node_rows or []:
+            kind_raw = row.get("kind")
+            if not isinstance(kind_raw, str):
+                continue
+            try:
+                kind = NodeKind(kind_raw)
+            except ValueError:
+                continue
+            key = row.get("key") or ""
+            label = row.get("label") or key or kind_raw
+            props = _coerce_props(row.get("props"), _RESERVED_NODE_PROPS)
+            node = Node.make(kind, str(label), key=str(key), **props)
+            node.created_at = float(row.get("created_at") or 0.0)
+            node.updated_at = float(row.get("updated_at") or 0.0)
+            graph.nodes[node.id] = node
+
+        edge_rows = store.execute_read(
+            (
+                "MATCH (a)-[r]->(b) WHERE r.engagement = $engagement "
+                "RETURN labels(a)[0] AS src_kind, "
+                "       a.key AS src_key, "
+                "       labels(b)[0] AS dst_kind, "
+                "       b.key AS dst_key, "
+                "       type(r) AS kind, "
+                "       coalesce(r.weight, 1.0) AS weight, "
+                "       properties(r) AS props, "
+                "       coalesce(r.firstseen, 0.0) AS created_at"
+            ),
+            {"engagement": engagement},
+            engagement=engagement,
+        )
+        for row in edge_rows or []:
+            kind_raw = row.get("kind")
+            src_kind_raw = row.get("src_kind")
+            dst_kind_raw = row.get("dst_kind")
+            src_key = row.get("src_key")
+            dst_key = row.get("dst_key")
+            if not (
+                isinstance(kind_raw, str)
+                and isinstance(src_kind_raw, str)
+                and isinstance(dst_kind_raw, str)
+                and isinstance(src_key, str)
+                and isinstance(dst_key, str)
+            ):
+                continue
+            try:
+                kind = EdgeKind(kind_raw)
+                src_kind = NodeKind(src_kind_raw)
+                dst_kind = NodeKind(dst_kind_raw)
+            except ValueError:
+                continue
+            src_id = Node.make(src_kind, src_key, key=src_key).id
+            dst_id = Node.make(dst_kind, dst_key, key=dst_key).id
+            weight = float(row.get("weight") or 1.0)
+            props = _coerce_props(row.get("props"), _RESERVED_EDGE_PROPS)
+            edge = Edge.make(src_id, dst_id, kind, weight=weight, **props)
+            edge.created_at = float(row.get("created_at") or 0.0)
+            graph.edges[edge.id] = edge
+
+        return graph
+    finally:
+        store.close()

--- a/packages/decepticon/decepticon/tools/reporting/tools.py
+++ b/packages/decepticon/decepticon/tools/reporting/tools.py
@@ -1,4 +1,13 @@
-"""LangChain @tool wrappers for the reporting package."""
+"""LangChain @tool wrappers for the reporting package.
+
+The reporting tools read the engagement KG that ``KGMiddleware`` and
+``kg_record`` / ``kg_ingest`` write to (the post-#545 backend) — they
+no longer use the legacy ``tools/research/_state`` shim. The
+engagement label is resolved from the ``EngagementContextMiddleware``
+contextvar; if it is not set (e.g. agent invoked outside the standard
+middleware stack), every report tool returns the structure for an
+empty graph and the agent can recover.
+"""
 
 from __future__ import annotations
 
@@ -11,9 +20,29 @@ from langchain_core.tools import tool
 from decepticon.tools.reporting.bugcrowd import render_bugcrowd_csv
 from decepticon.tools.reporting.executive import render_executive_summary
 from decepticon.tools.reporting.hackerone import render_hackerone_markdown
+from decepticon.tools.reporting.kg_adapter import load_engagement_graph
 from decepticon.tools.reporting.sarif import render_sarif
 from decepticon.tools.reporting.timeline import extract_timeline
-from decepticon.tools.research._state import _load
+from decepticon_core.types.kg import KnowledgeGraph
+from decepticon_core.utils.engagement_scope import get_active_engagement
+
+
+def _load() -> tuple[KnowledgeGraph, None]:
+    """Load the engagement KG for reporting.
+
+    Reads the engagement label from the contextvar
+    (``EngagementContextMiddleware`` sets it for every tool dispatch).
+    Returns an empty graph when no engagement is active so the renderer
+    sees a well-formed (but empty) shape.
+
+    Kept under this name so the existing ``mock.patch(
+    "decepticon.tools.reporting.tools._load", ...)`` test surface
+    continues to work — only the implementation changed.
+    """
+    engagement = get_active_engagement()
+    if not engagement:
+        return KnowledgeGraph(), None
+    return load_engagement_graph(engagement), None
 
 
 def _json(data: Any) -> str:


### PR DESCRIPTION
## Summary

Migrates the reporting tools off the legacy ``tools/research/_state`` shim to the new ``KGStore`` from #545. Read-only migration — no schema work, no data move.

## What changes

| File | Change |
|---|---|
| ``tools/reporting/kg_adapter.py`` (new, 157 LOC) | Reads engagement-scoped data from ``KGStore`` and rebuilds the in-memory ``KnowledgeGraph`` Pydantic model so the renderers can consume it unchanged |
| ``tools/reporting/tools.py`` (+33 / -2) | Drops ``_state._load`` import; defines its own ``_load()`` that pulls the engagement from ``get_active_engagement()`` and delegates to the adapter |

## Why now

The legacy ``_state.py`` + ``neo4j_store.py`` backend has four known issues:
1. **Schema-level global uniqueness** — multiple engagements cannot coexist
2. **Read-modify-save** — no Neo4j-level atomicity, partial writes survive
3. **No provenance** — no ``firstseen`` / ``lastupdated`` / ``created_by`` / ``source_episode_id``
4. **No engagement scoping at the API** — contextvar is best-effort only

``KGStore`` fixes all four (composite ``(key, engagement) UNIQUE`` from V001, atomic ``record_observations`` upserts with deadlock retry, auto-injected provenance, mandatory ``engagement`` kwarg on every method).

Reporting is the lowest-risk caller (read-only — no mutations through the legacy path) so it migrates first. AD and Contract migrate in dedicated follow-ups (BloodHound / Slither schemas need external research first).

## What does NOT change

- Renderer surface (``hackerone.py`` / ``bugcrowd.py`` / ``executive.py`` / ``sarif.py`` / ``timeline.py``) — bit-for-bit identical
- ``KnowledgeGraph`` Pydantic model — data shape is preserved
- AD_TOOLS / CONTRACT_TOOLS — still on ``_state`` (tracked separately)
- ``tools/research/_state.py`` / ``tools/research/neo4j_store.py`` — kept until AD / Contract migrate
- Test surface — the local ``_load`` symbol in ``reporting/tools.py`` is preserved so existing patches keep working

## Verification

- ``make ci-lint``: 0 errors
- ``pytest packages/decepticon/tests/unit/reporting/``: **120 passed, 0 failed** (no test changes needed)
- Soft-fail path verified: ``_load()`` returns an empty ``KnowledgeGraph`` when no engagement is active OR when ``KGStore`` is unreachable (matches legacy shim behaviour)

## Out of scope (follow-up PRs)

- **PR-M2** — AD_TOOLS migration off ``_state``: needs BloodHound 5.x schema RFC first (global-unique User / Computer / Group does not map cleanly to ``(key, engagement)`` composite)
- **PR-M3** — CONTRACT_TOOLS migration: Slither JSON → KGStore observation emitter
- **PR-M4** — Final removal of ``tools/research/{_state.py,neo4j_store.py}`` once M2 + M3 land

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)
- [ ] Live integration: with compose Neo4j up, write data via ``kg_record`` and confirm ``report_executive`` / ``report_hackerone`` see it