### PR TITLE
feat(middleware): flag-gated Asset Coverage Brief

### DIFF
--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -40,6 +40,7 @@ from typing_extensions import override
 from decepticon.middleware.opplan import _reduce_engagement_name, _reduce_workspace_path
 from decepticon.tools.bash.bash import bash_workspace
 from decepticon.tools.research._engagement_scope import set_active_engagement
+from decepticon_core.types.asset_types import classify
 
 
 class EngagementContextState(AgentState):
@@ -218,6 +219,71 @@ def _build_deconfliction_injection(data: dict[str, Any]) -> str:
     )
 
 
+def _asset_routing_active() -> bool:
+    """Truthy evaluation of DECEPTICON_ASSET_ROUTING (default off)."""
+    return os.environ.get("DECEPTICON_ASSET_ROUTING", "").strip().lower() not in _FALSY_ENV_VALUES
+
+
+def _load_roe_scope(workspace: str) -> list[tuple[str, str]]:
+    """Return ``[(target, type), ...]`` from ``<workspace>/plan/roe.json:in_scope``."""
+    root = workspace.rstrip("/") or workspace
+    path = Path(root) / "plan" / "roe.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("engagement: failed to read %s: %s; skipping asset brief", path, exc)
+        return []
+    entries = data.get("in_scope") if isinstance(data, dict) else None
+    out: list[tuple[str, str]] = []
+    for entry in entries or []:
+        if isinstance(entry, dict):
+            target = entry.get("target")
+            kind = entry.get("type", "")
+            if isinstance(target, str) and target:
+                out.append((target, kind if isinstance(kind, str) else ""))
+    return out
+
+
+def _build_asset_coverage_injection(scope: list[tuple[str, str]]) -> str:
+    """Compact per-asset routing brief. Advice to the free-choice dispatcher."""
+    if not scope:
+        return ""
+    seen: set[str] = set()
+    lines: list[str] = []
+    for target, kind in scope:
+        asset = classify(target, hint=kind or None)
+        if asset is None or asset.id in seen:
+            continue
+        seen.add(asset.id)
+        agents = (
+            ", ".join(asset.agents)
+            if asset.agents
+            else "(no dedicated agent — orchestrate manually)"
+        )
+        flag = " — SAFETY-CRITICAL (RoE/ConOps gate)" if asset.safety_critical else ""
+        if asset.gated_by_conops:
+            flag += f" — gated_by_conops: {asset.gated_by_conops}"
+        note = (
+            ""
+            if asset.coverage == "covered"
+            else f" [coverage: {asset.coverage} — expect to improvise/extend]"
+        )
+        lines.append(
+            f"- **{asset.label}** (`{asset.id}`){flag}: route to {agents}. "
+            f'Load skills via list_skills(tag_filter=["{asset.skill_tag}"]){note}.'
+        )
+    if not lines:
+        return ""
+    return (
+        "\n\n[Asset Coverage Brief — generated from the in-scope asset types]\n"
+        "For each in-scope asset type below, dispatch the named subagent(s) and "
+        "load the tagged skills. This is guidance, not a hard constraint — you "
+        "retain free choice over dispatch.\n" + "\n".join(lines)
+    )
+
+
 def _format_extra_services(target_url: str, extra_ports: dict[int, int]) -> str:
     if not extra_ports:
         return ""
@@ -337,6 +403,11 @@ class EngagementContextMiddleware(AgentMiddleware):
                 block = _build_deconfliction_injection(deconfliction)
                 if block:
                     sections.append(block)
+            if _asset_routing_active():
+                scope = _load_roe_scope(workspace)
+                asset_block = _build_asset_coverage_injection(scope)
+                if asset_block:
+                    sections.append(asset_block)
         if _benchmark_mode_active():
             sections.append(
                 _build_benchmark_injection(

--- a/packages/decepticon/tests/unit/middleware/test_engagement_asset_brief.py
+++ b/packages/decepticon/tests/unit/middleware/test_engagement_asset_brief.py
@@ -1,0 +1,61 @@
+"""DECEPTICON_ASSET_ROUTING gates an Asset Coverage Brief into the prompt."""
+
+from __future__ import annotations
+
+import json
+
+from decepticon.middleware.engagement import (
+    _asset_routing_active,
+    _build_asset_coverage_injection,
+    _load_roe_scope,
+)
+
+
+def _write_roe(tmp_path, entries):
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    (plan / "roe.json").write_text(json.dumps({"in_scope": entries}), encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_load_roe_scope(tmp_path):
+    ws = _write_roe(
+        tmp_path,
+        [
+            {"target": "*.acme.com", "type": "wildcard"},
+            {"target": "api.acme.com", "type": "graphql-endpoint"},
+        ],
+    )
+    scope = _load_roe_scope(ws)
+    assert scope == [("*.acme.com", "wildcard"), ("api.acme.com", "graphql-endpoint")]
+
+
+def test_load_roe_scope_missing(tmp_path):
+    assert _load_roe_scope(str(tmp_path)) == []
+
+
+def test_brief_names_agents_and_tags():
+    brief = _build_asset_coverage_injection(
+        [("api.acme.com", "graphql-endpoint"), ("device", "ics-scada")]
+    )
+    assert "Asset Coverage Brief" in brief
+    assert "graphql-endpoint" in brief
+    assert "asset:graphql-endpoint" in brief
+    assert "exploit" in brief
+    assert "SAFETY-CRITICAL" in brief
+    assert "ics-scada" in brief
+
+
+def test_brief_empty_when_no_scope():
+    assert _build_asset_coverage_injection([]) == ""
+
+
+def test_asset_routing_flag_gate(monkeypatch):
+    monkeypatch.delenv("DECEPTICON_ASSET_ROUTING", raising=False)
+    assert _asset_routing_active() is False
+    for falsy in ("", "0", "false", "no", "off"):
+        monkeypatch.setenv("DECEPTICON_ASSET_ROUTING", falsy)
+        assert _asset_routing_active() is False
+    for truthy in ("1", "true", "yes", "on", "anything-else"):
+        monkeypatch.setenv("DECEPTICON_ASSET_ROUTING", truthy)
+        assert _asset_routing_active() is True


### PR DESCRIPTION
## Summary

Extends `EngagementContextMiddleware` to inject a compact **Asset Coverage Brief** into the orchestrator's prompt: for each in-scope asset type, the handling subagent(s), the `asset:<id>` skill tag to load, a safety-critical/ConOps-gate flag, and a coverage note. It's **advice** to the existing free-choice dispatcher — not a hard filter — so it respects the project's LLM-routing design.

> **Stacked on #550** (`feat/asset-type-catalog`) — it imports the asset-type catalog. Base will retarget to `main` once #550 merges. Review only this PR's own diff.

## Changes

- `EngagementContextMiddleware._inject`: when an engagement is active **and** `DECEPTICON_ASSET_ROUTING` is set, resolve each `roe.json:in_scope` entry to an `AssetType` (deduped) and append the brief.
- New module helpers: `_asset_routing_active()` (env gate, mirrors `_benchmark_mode_active`), `_load_roe_scope()` (defensive `plan/roe.json` parse — a malformed file cannot break agent boot), `_build_asset_coverage_injection()`.

**Lands dark:** gated by `DECEPTICON_ASSET_ROUTING` (default off). With the flag unset the injected system prompt is byte-identical to baseline. Touches no CODEOWNERS-protected paths.

## Testing

- [x] `ruff check` + `ruff format --check` clean; `basedpyright` clean on the changed source.
- [ ] `make smoke` (not run — no Docker stack here)
- [x] `uv run pytest packages/decepticon/tests/unit/middleware` → **613 passed** (5 new: roe-scope parse, missing-file, agent/tag/safety rendering, empty-scope, and the full flag-truthiness matrix). Flag-off path verified to leave the prompt unchanged.

## Related Issues

Depends on #550.