### PR TITLE
feat(scripts): asset-coverage report and roster-consistency test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ export CODEX_AUTH_VOLUME ?= $(shell test -f $(HOME)/.codex/auth.json && echo $(H
         dev cli-dev web-dev infra \
         quality quality-strict quality-cli test test-local lint lint-fix \
         ci-lint ci-test ci-test-coverage \
+        asset-coverage \
         web-build web-hotswap web-lint web-migrate \
         status logs health clean \
         node-install web-db-ensure \
@@ -78,6 +79,7 @@ help:
 	@echo "  make test-local     pytest locally (uv sync --dev; takes ARGS=)"
 	@echo "  make lint           Python lint + format check + basedpyright (all levels, local exploratory)"
 	@echo "  make lint-fix       Auto-fix Python lint + format"
+	@echo "  make asset-coverage     Coverage report: covered/partial/gap across the 75 asset types"
 	@echo ""
 	@echo "Web dashboard (single checks):"
 	@echo "  make web-build    Prisma generate + Next build"
@@ -241,6 +243,10 @@ quality-cli: node-install
 	npm run typecheck --workspace=@decepticon/cli
 	npm run build --workspace=@decepticon/cli
 	npm run test --workspace=@decepticon/cli
+
+## Asset-type coverage report — covered/partial/gap across the 75 asset types.
+asset-coverage:
+	uv run python scripts/asset_coverage.py
 
 ## PR gate — mirrors CI PR lane (errors-only typecheck + fast pytest + CLI + Web).
 ## Use before opening a PR; passing this guarantees CI will pass.

--- a/packages/decepticon/tests/unit/test_asset_roles_roster.py
+++ b/packages/decepticon/tests/unit/test_asset_roles_roster.py
@@ -1,0 +1,40 @@
+"""Every asset-type routing role is a real subagent (or a known planning role)."""
+
+from __future__ import annotations
+
+import functools
+from importlib.metadata import entry_points
+
+from decepticon_core.plugin_loader import SUBAGENTS_GROUP
+from decepticon_core.types import asset_types as at
+
+
+@functools.cache
+def _live_subagent_roles() -> set[str]:
+    roles: set[str] = set()
+    for ep in entry_points(group=SUBAGENTS_GROUP):
+        spec = ep.load()  # loads the SUBAGENT_SPEC object; does NOT call the factory
+        roles.add(spec.name)
+    return roles
+
+
+def test_catalog_agents_are_live_subagents():
+    live = _live_subagent_roles()
+    # Top-level orchestrator/planner agents: valid routing roles but never
+    # registered under SUBAGENTS_GROUP and never used in catalog .agents today.
+    non_subagent = {"decepticon", "soundwave"}
+    referenced = {role for a in at.all() for role in a.agents}
+    unknown = referenced - live - non_subagent
+    assert not unknown, f"asset catalog references non-existent roles: {sorted(unknown)}"
+
+
+def test_valid_agent_roles_constant_matches_reality():
+    live = _live_subagent_roles()
+    # We assert only live ⊆ VALID_AGENT_ROLES (a newly-registered subagent must
+    # be added to the constant). The reverse is intentionally NOT asserted:
+    # VALID_AGENT_ROLES is a deliberate superset — it also covers plugin-bundle
+    # agents (scanner/exploiter/verifier/patcher/detector/vulnresearch) and
+    # blue-team agents (blue_cell/defender) that register under separate bundles
+    # and are not visible via this standard SUBAGENTS_GROUP enumeration.
+    missing = live - at.VALID_AGENT_ROLES
+    assert not missing, f"VALID_AGENT_ROLES is stale; add: {sorted(missing)}"

--- a/scripts/asset_coverage.py
+++ b/scripts/asset_coverage.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Print the asset-type coverage report. Run via ``make asset-coverage``.
+
+Exit 0 for the report; exit 1 only if the catalog fails an internal
+integrity invariant (count != 75), so CI can wire it as a guard.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from decepticon_core.types import asset_types as at
+
+
+def main() -> int:
+    entries = at.all()
+    if len(entries) != 75:
+        print(f"INTEGRITY ERROR: expected 75 entries, found {len(entries)}", file=sys.stderr)
+        return 1
+
+    summary = at.coverage_summary()
+    print("Asset-type coverage")
+    print("===================")
+    print(f"  covered: {summary['covered']:>3}")
+    print(f"  partial: {summary['partial']:>3}")
+    print(f"  gap:     {summary['gap']:>3}")
+    print(f"  total:   {len(entries):>3}")
+    print()
+    for status in ("gap", "partial"):
+        rows = [a for a in entries if a.coverage == status]
+        if rows:
+            print(f"{status.upper()} ({len(rows)}):")
+            for a in sorted(rows, key=lambda x: x.number):
+                print(
+                    f"  #{a.number:<3} {a.id:<22} {a.category:<20} -> {', '.join(a.agents) or '(none)'}"
+                )
+            print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds tooling to track and guard asset-type coverage: a `make asset-coverage` report and a roster-consistency test that catches drift between the catalog's routing roles and the live subagent registry.

> **Stacked on #550** (`feat/asset-type-catalog`) — it imports the asset-type catalog. Base will retarget to `main` once #550 merges. Review only this PR's own diff.

## Changes

- `scripts/asset_coverage.py` + `make asset-coverage`: print covered/partial/gap counts across the 75 asset types and list the gap/partial entries; exit non-zero only on a catalog integrity failure (count != 75), so it can be wired as a CI guard.
- `test_asset_roles_roster.py`: assert every routing role referenced by the catalog is a live `decepticon.subagents` entry point (or a known planner role `decepticon`/`soundwave`), and that `VALID_AGENT_ROLES` isn't missing any live subagent.

Touches no CODEOWNERS-protected paths.

## Testing

- [x] `ruff check` + `ruff format --check` clean.
- [ ] `make smoke` (not run — no Docker stack here)
- [x] `uv run pytest .../test_asset_roles_roster.py` → **2 passed** (roster matches catalog today). `uv run python scripts/asset_coverage.py` prints 34/26/15, total 75, exit 0.

## Related Issues

Depends on #550.