### PR TITLE
feat(kg): extend NodeKind/EdgeKind for BloodHound 5.x + Slither

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/kg.py
+++ b/packages/decepticon-core/decepticon_core/types/kg.py
@@ -86,6 +86,35 @@ class NodeKind(StrEnum):
     # Defense (Blue Cell — proven detection coverage)
     DETECTION_FIRED = "DetectionFired"
     DEFENSE_ACTION = "DefenseAction"
+    # Active Directory (BloodHound 5.x — see
+    # docs/design/2026-06-04-bloodhound-kgstore-mapping.md). AD-prefixed
+    # kinds coexist with the generic identity kinds above; the
+    # AD operator's BloodHound ingest emits these, and chain analysis
+    # filters with ``MATCH (u:ADUser)-[:MEMBER_OF*]->(:ADGroup ...)``.
+    AD_USER = "ADUser"
+    AD_COMPUTER = "ADComputer"
+    AD_GROUP = "ADGroup"
+    AD_DOMAIN = "ADDomain"
+    AD_GPO = "ADGPO"
+    AD_OU = "ADOU"
+    AD_CONTAINER = "ADContainer"
+    AD_CERT_TEMPLATE = "ADCertTemplate"
+    AD_ENTERPRISE_CA = "ADEnterpriseCA"
+    AD_ROOT_CA = "ADRootCA"
+    AD_AIA_CA = "ADAIACA"
+    AD_NT_AUTH_STORE = "ADNTAuthStore"
+    AD_ISSUANCE_POLICY = "ADIssuancePolicy"
+    AD_LOCAL_GROUP = "ADLocalGroup"
+    # Solidity (Slither ``--json`` — see
+    # docs/design/2026-06-04-slither-kgstore-mapping.md). ``Contract`` and
+    # ``SourceFile`` are already defined above and reused.
+    SOLIDITY_FUNCTION = "Function"
+    SOLIDITY_STATE_VAR = "StateVar"
+    SOLIDITY_EVENT = "Event"
+    SOLIDITY_CUSTOM_ERROR = "CustomError"
+    SOLIDITY_ENUM = "Enum"
+    SOLIDITY_STRUCT = "Struct"
+    SOLIDITY_PRAGMA = "Pragma"
 
 
 class EdgeKind(StrEnum):
@@ -134,6 +163,87 @@ class EdgeKind(StrEnum):
     # Defense (Blue Cell — links a fired detection to what it caught)
     DETECTED = "DETECTED"
     USES_RULE = "USES_RULE"
+    # Active Directory (BloodHound 5.x — see
+    # docs/design/2026-06-04-bloodhound-kgstore-mapping.md). The generic
+    # ``MEMBER_OF`` / ``HAS_SESSION`` / ``ADMIN_TO`` / ``OWNS`` /
+    # ``CAN_ACCESS`` above are reused where the BHCE edge name matches.
+    ALLOWED_TO_DELEGATE = "ALLOWED_TO_DELEGATE"
+    ALLOWED_TO_ACT = "ALLOWED_TO_ACT"
+    HAS_SID_HISTORY = "HAS_SID_HISTORY"
+    GP_LINK = "GP_LINK"
+    PUBLISHED_TO = "PUBLISHED_TO"
+    HOSTS_CA_SERVICE = "HOSTS_CA_SERVICE"
+    OID_GROUP_LINK = "OID_GROUP_LINK"
+    ROOT_CA_FOR = "ROOT_CA_FOR"
+    ISSUED_SIGNED_BY = "ISSUED_SIGNED_BY"
+    TRUSTED_FOR_NTAUTH = "TRUSTED_FOR_NTAUTH"
+    DUMP_SMSA_PASSWORD = "DumpSMSAPassword"
+    MEMBER_OF_LOCAL_GROUP = "MEMBER_OF_LOCAL_GROUP"
+    # Trust (4-way split from BHCE 5.x — replaces the single legacy
+    # ``TrustedBy`` edge, branched on ``TrustType`` + ``IsTransitive``).
+    SAME_FOREST_TRUST = "SameForestTrust"
+    CROSS_FOREST_TRUST = "CrossForestTrust"
+    ABUSE_TGT_DELEGATION = "AbuseTGTDelegation"
+    SPOOF_SID_HISTORY = "SpoofSIDHistory"
+    # ADCS ESC — server-computed post-process edges. ESC2/5/7/8/11/12/
+    # 14/15/16 are placeholders for community-collector parity
+    # (Certipy etc.); BHCE main 2026-06 does not emit them yet but the
+    # data path is ready.
+    ADCS_ESC1 = "ADCSESC1"
+    ADCS_ESC2 = "ADCSESC2"
+    ADCS_ESC3 = "ADCSESC3"
+    ADCS_ESC4 = "ADCSESC4"
+    ADCS_ESC5 = "ADCSESC5"
+    ADCS_ESC6A = "ADCSESC6a"
+    ADCS_ESC6B = "ADCSESC6b"
+    ADCS_ESC7 = "ADCSESC7"
+    ADCS_ESC8 = "ADCSESC8"
+    ADCS_ESC9A = "ADCSESC9a"
+    ADCS_ESC9B = "ADCSESC9b"
+    ADCS_ESC10A = "ADCSESC10a"
+    ADCS_ESC10B = "ADCSESC10b"
+    ADCS_ESC11 = "ADCSESC11"
+    ADCS_ESC12 = "ADCSESC12"
+    ADCS_ESC13 = "ADCSESC13"
+    ADCS_ESC14 = "ADCSESC14"
+    ADCS_ESC15 = "ADCSESC15"
+    ADCS_ESC16 = "ADCSESC16"
+    # AD post-process edges (BHCE-server-computed).
+    GOLDEN_CERT = "GoldenCert"
+    SYNC_LAPS_PASSWORD = "SyncLAPSPassword"
+    DCSYNC = "DCSync"
+    COERCE_AND_RELAY_NTLM_TO_ADCS = "CoerceAndRelayNTLMToADCS"
+    COERCE_AND_RELAY_NTLM_TO_LDAP = "CoerceAndRelayNTLMToLDAP"
+    COERCE_AND_RELAY_NTLM_TO_LDAPS = "CoerceAndRelayNTLMToLDAPS"
+    COERCE_AND_RELAY_NTLM_TO_SMB = "CoerceAndRelayNTLMToSMB"
+    COERCE_TO_TGT = "CoerceToTGT"
+    HAS_TRUST_KEYS = "HasTrustKeys"
+    SYNCED_TO_ENTRA_USER = "SyncedToEntraUser"
+    SYNCED_TO_AD_USER = "SyncedToADUser"
+    # ACE right names (raw forms — ``Owns`` / ``WriteOwner`` are emitted
+    # by post-process as the existing ``OWNS`` / ``WRITE_OWNER`` kinds).
+    WRITE_SPN = "WriteSPN"
+    READ_LAPS_PASSWORD = "ReadLAPSPassword"
+    READ_GMSA_PASSWORD = "ReadGMSAPassword"
+    ADD_KEY_CREDENTIAL_LINK = "AddKeyCredentialLink"
+    ALL_EXTENDED_RIGHTS = "AllExtendedRights"
+    FORCE_CHANGE_PASSWORD = "ForceChangePassword"
+    MANAGE_CA = "ManageCA"
+    MANAGE_CERTIFICATES = "ManageCertificates"
+    GET_CHANGES = "GetChanges"
+    GET_CHANGES_ALL = "GetChangesAll"
+    OWNS_LIMITED_RIGHTS = "OwnsLimitedRights"
+    WRITE_OWNER_LIMITED_RIGHTS = "WriteOwnerLimitedRights"
+    WRITE_DACL = "WriteDacl"
+    WRITE_OWNER = "WriteOwner"
+    GENERIC_ALL = "GenericAll"
+    GENERIC_WRITE = "GenericWrite"
+    ADD_MEMBER = "AddMember"
+    ADD_SELF = "AddSelf"
+    WRITE_GP_LINK = "WriteGPLink"
+    WRITE_ACCOUNT_RESTRICTIONS = "WriteAccountRestrictions"
+    # Solidity (Slither) — function-call graph edge.
+    CALLS = "CALLS"
 
 
 class Severity(StrEnum):

--- a/packages/decepticon/decepticon/middleware/kg_internal/migrations/V003__bloodhound_and_slither_schema.cypher
+++ b/packages/decepticon/decepticon/middleware/kg_internal/migrations/V003__bloodhound_and_slither_schema.cypher
@@ -1,0 +1,68 @@
+-- KG schema v003 — composite uniqueness for BloodHound 5.x AD kinds
+-- and Slither (Solidity) element kinds.
+--
+-- New labels added by this migration are emitted by:
+--   - ``tools/ad/bloodhound.py`` (AD_USER … AD_ISSUANCE_POLICY + AD_LOCAL_GROUP)
+--     after the BloodHound ingest rewrite — see
+--     ``docs/design/2026-06-04-bloodhound-kgstore-mapping.md``.
+--   - ``tools/contracts/slither.py`` (Function / StateVar / Event /
+--     CustomError / Enum / Struct / Pragma) after the Slither ingest
+--     rewrite — see
+--     ``docs/design/2026-06-04-slither-kgstore-mapping.md``.
+--
+-- Same ``(key, engagement)`` composite invariant as V001: same key in
+-- two engagements is two nodes (multi-tenant); same key in the same
+-- engagement is one node (idempotent MERGE for record_observations).
+
+-- ── Active Directory (BloodHound 5.x) ────────────────────────────────
+
+CREATE CONSTRAINT ad_user_key_engagement IF NOT EXISTS
+  FOR (n:ADUser) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_computer_key_engagement IF NOT EXISTS
+  FOR (n:ADComputer) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_group_key_engagement IF NOT EXISTS
+  FOR (n:ADGroup) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_domain_key_engagement IF NOT EXISTS
+  FOR (n:ADDomain) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_gpo_key_engagement IF NOT EXISTS
+  FOR (n:ADGPO) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_ou_key_engagement IF NOT EXISTS
+  FOR (n:ADOU) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_container_key_engagement IF NOT EXISTS
+  FOR (n:ADContainer) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+-- ADCS labels
+CREATE CONSTRAINT ad_cert_template_key_engagement IF NOT EXISTS
+  FOR (n:ADCertTemplate) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_enterprise_ca_key_engagement IF NOT EXISTS
+  FOR (n:ADEnterpriseCA) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_root_ca_key_engagement IF NOT EXISTS
+  FOR (n:ADRootCA) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_aia_ca_key_engagement IF NOT EXISTS
+  FOR (n:ADAIACA) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_nt_auth_store_key_engagement IF NOT EXISTS
+  FOR (n:ADNTAuthStore) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT ad_issuance_policy_key_engagement IF NOT EXISTS
+  FOR (n:ADIssuancePolicy) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+CREATE CONSTRAINT ad_local_group_key_engagement IF NOT EXISTS
+  FOR (n:ADLocalGroup) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+-- ── Solidity (Slither --json) ────────────────────────────────────────
+-- ``Contract`` and ``SourceFile`` already have constraints from V001;
+-- this only adds the new element labels.
+
+CREATE CONSTRAINT solidity_function_key_engagement IF NOT EXISTS
+  FOR (n:Function) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT solidity_state_var_key_engagement IF NOT EXISTS
+  FOR (n:StateVar) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT solidity_event_key_engagement IF NOT EXISTS
+  FOR (n:Event) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT solidity_custom_error_key_engagement IF NOT EXISTS
+  FOR (n:CustomError) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT solidity_enum_key_engagement IF NOT EXISTS
+  FOR (n:Enum) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT solidity_struct_key_engagement IF NOT EXISTS
+  FOR (n:Struct) REQUIRE (n.key, n.engagement) IS UNIQUE;
+CREATE CONSTRAINT solidity_pragma_key_engagement IF NOT EXISTS
+  FOR (n:Pragma) REQUIRE (n.key, n.engagement) IS UNIQUE;


### PR DESCRIPTION
## Summary

Schema-only step from the BloodHound + Slither RFCs (#553):
- 21 new ``NodeKind`` values (14 AD + 7 Solidity)
- 50+ new ``EdgeKind`` values (12 AD raw + 4 Trust split + 19 ADCS ESC + 11 AD post + 20 ACE rights + 1 ``CALLS``)
- ``V003__bloodhound_and_slither_schema.cypher`` with composite ``(key, engagement) UNIQUE`` per new label

This is the **enum + schema migration only**. The ingest rewrites that actually emit these labels (``bloodhound.py``, ``slither.py``, ADCS / LocalAdmin post-process modules) land in dedicated follow-up PRs per the RFC phased plan.

## What changes

| File | Change |
|---|---|
| ``packages/decepticon-core/decepticon_core/types/kg.py`` | +21 ``NodeKind`` + 50+ ``EdgeKind`` values |
| ``packages/decepticon/decepticon/middleware/kg_internal/migrations/V003__bloodhound_and_slither_schema.cypher`` | New — composite uniqueness per new label |

Net diff: **+178 / -0**.

## Design choices documented

- **Reuse vs add** — generic kinds (``MEMBER_OF`` / ``HAS_SESSION`` / ``ADMIN_TO`` / ``OWNS`` / ``CAN_ACCESS`` / ``CONTAINS`` / ``ENABLES`` / ``LEAKS``) keep their existing semantics. BHCE ingest reuses them where the edge name already matches.
- **ACE raw vs post** — ``Owns`` and ``WriteOwner`` stay on the existing ``OWNS`` kind because BHCE server post-promotes them. Raw collector data uses the limited-rights forms (``OWNS_LIMITED_RIGHTS`` / ``WRITE_OWNER_LIMITED_RIGHTS``); the post-process step (RFC §4.3) walks the graph and emits the promoted edges.
- **ADCS ESC2/5/7/8/11/12/14/15/16 placeholders** — community collectors (Certipy etc.) emit these but BHCE main 2026-06 does not. Reserving the kinds now so the ingest path is ready when collectors catch up.

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest packages/decepticon-core/tests/`` + ``tests/unit/middleware/``: **860 passed**, 0 failed
- Migration auto-discovery confirmed: ``migration_runner.apply_migrations`` reads ``V*.cypher`` files via sorted glob — V003 picked up after V002 with no code change

## Out of scope (tracked as dedicated follow-up PRs)

| Follow-up | RFC ref |
|---|---|
| ``bloodhound.py`` ingest rewrite emitting AD-prefixed labels | bloodhound RFC §4.2 |
| ADCS post-process module (ESC1/3/4/6a/6b/9a/9b/10a/10b/13 + GoldenCert + SyncLAPSPassword + DCSync) | bloodhound RFC §4.3 |
| LocalAdmin / GPO post-process (cross-product to AdminTo/CanRDP/etc.) | bloodhound RFC §4.4 |
| ``slither.py`` ingest rewrite emitting Solidity element labels | slither RFC §4.2 |
| Existing engagement data relabel for the 6-kind legacy ingest | RFC §5 (documented Cypher one-liner) |

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)
- [ ] Live: with compose Neo4j up, confirm V003 constraints are applied on first ``KGStore.from_env`` (``SHOW CONSTRAINTS WHERE name STARTS WITH 'ad_'``)