### PR TITLE
chore(ci): add Renovate config for monorepo dep updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,81 @@
+{
+  // Renovate config for the Decepticon monorepo.
+  //
+  // Goals:
+  //   * Batch low-risk updates (minor / patch) so dependency PRs stay
+  //     reviewable instead of one-per-package.
+  //   * Group by ecosystem so a single PR moves a coherent slice of the
+  //     dep graph (Python via uv / pep621, Node in clients/, Go modules,
+  //     Docker base images, GH Actions versions).
+  //   * Match the repo's Conventional Commits style: `chore(deps): ...`,
+  //     `chore(ci): ...` for GH Actions.
+  //   * Never auto-merge — every PR is reviewed manually to keep main's
+  //     supply-chain story tight (cosign, SBOM, scorecard etc. all run
+  //     per PR via the existing security workflow).
+  //
+  // Activation: the Renovate GitHub App must be installed on the
+  // PurpleAILAB organization (https://github.com/apps/renovate). Once
+  // installed, Renovate picks up this file from .github/renovate.json5
+  // automatically. No secrets required.
+
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":maintainLockFilesWeekly",
+    "group:allNonMajor",
+    "schedule:weekly",
+  ],
+  timezone: "UTC",
+  semanticCommitType: "chore",
+  semanticCommitScope: "deps",
+  // Keep noise in check: at most 5 PRs/hour, 10 concurrent open.
+  prHourlyLimit: 5,
+  prConcurrentLimit: 10,
+  // External benchmark submodules — Renovate must not touch them.
+  ignorePaths: [
+    "benchmark/xbow-validation-benchmarks/**",
+    "benchmark/MHBench/**",
+  ],
+  packageRules: [
+    {
+      description: "GitHub Actions bumps → chore(ci) scope",
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+      semanticCommitScope: "ci",
+    },
+    {
+      description: "Python deps (uv-managed via pep621)",
+      matchManagers: ["pep621"],
+      groupName: "python deps",
+    },
+    {
+      description: "Node / TypeScript deps under clients/",
+      matchManagers: ["npm"],
+      groupName: "node deps",
+    },
+    {
+      description: "Go module updates",
+      matchManagers: ["gomod"],
+      groupName: "go modules",
+    },
+    {
+      description: "Docker base images (Dockerfile + docker-compose)",
+      matchManagers: ["dockerfile", "docker-compose"],
+      groupName: "docker base images",
+    },
+    {
+      description: "Major version bumps stay one-PR-per-package and are labeled",
+      matchUpdateTypes: ["major"],
+      labels: ["dependencies", "major-update"],
+    },
+  ],
+  vulnerabilityAlerts: {
+    labels: ["security", "dependencies"],
+  },
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 6am on monday"],
+  },
+}


### PR DESCRIPTION
## Summary

Adds `.github/renovate.json5` so dependency updates across all five ecosystems in the repo (Python via `pep621`/uv, Node under `clients/`, Go modules, Docker base images, GitHub Actions) flow as reviewed PRs on a weekly schedule instead of needing manual maintenance.

## Changes

- New `.github/renovate.json5` (commented JSON5) with:
  - `config:recommended` + `:dependencyDashboard` + `:semanticCommits`
  - Weekly schedule, `group:allNonMajor` to keep PR count tractable
  - Per-manager groupings: `python deps`, `node deps`, `go modules`, `docker base images`, `github-actions`
  - GitHub Actions bumps land as `chore(ci): ...` to match the existing scope convention; everything else as `chore(deps): ...`
  - **No auto-merge** — every PR is reviewed so the cosign + SBOM + Scorecard pipeline stays deterministic per merge
  - Vendored benchmark submodules (`benchmark/xbow-validation-benchmarks`, `benchmark/MHBench`) are ignored
  - Lockfile maintenance runs Monday early-AM UTC
  - Vulnerability alerts get `security` + `dependencies` labels

## Activation

The **Renovate GitHub App** must be installed at the `PurpleAILAB` org level — https://github.com/apps/renovate — before this config does anything. No repo secrets required. Once installed, Renovate picks up `.github/renovate.json5` automatically.

## Testing

- [ ] `make quality` passes (Python + CLI + Web) — N/A, config-only change, exercised by the existing `actionlint` / `Compose YAML validate` jobs on this PR
- [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks) — N/A
- [x] Manual testing: validated as JSON5 locally; schema matches `https://docs.renovatebot.com/renovate-schema.json`. Will be config-validated by Renovate itself on first run after App install.

## Related Issues

None — net new automation.