### PR TITLE
fix(llm): honor DECEPTICON_LLM__TIMEOUT for whole-coroutine guard (#540)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -310,8 +310,16 @@ DECEPTICON_LANGUAGE=en
 
 # --- LLM client timeout ---
 # Seconds to wait for a single LLM completion before raising
-# APITimeoutError. Default 120s is too short for long Opus generations
-# with max_tokens=128000 — generations routinely exceed 120s mid-stream
-# while LiteLLM proxy keeps returning 200 OK upstream. 600s (10min)
-# covers worst-case extended-thinking + large tool_use payloads.
+# APITimeoutError / LLMTimeoutError. Default 120s (httpx transport)
+# and 600s (whole-coroutine guard in decepticon.llm.factory) are too
+# short for long Opus generations with max_tokens=128000 — generations
+# routinely exceed 120s mid-stream while LiteLLM proxy keeps returning
+# 200 OK upstream. 600s (10min) covers worst-case extended-thinking +
+# large tool_use payloads.
+#
+# This single knob drives both the httpx transport timeout
+# (``LLMConfig.timeout`` via pydantic-settings nested env) AND the
+# whole-coroutine guard (``_resolve_llm_timeout_seconds`` alias). For
+# tests or one-off overrides, ``DECEPTICON_LLM_TIMEOUT_SECONDS`` takes
+# precedence over this for the coroutine guard only.
 DECEPTICON_LLM__TIMEOUT=600

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -99,9 +99,7 @@ def _resolve_llm_timeout_seconds() -> float:
         try:
             value = float(raw)
         except ValueError as exc:
-            raise ValueError(
-                f"{source} must be a number (got {raw!r})"
-            ) from exc
+            raise ValueError(f"{source} must be a number (got {raw!r})") from exc
     else:
         value = float(DEFAULT_LLM_REQUEST_TIMEOUT_SECONDS)
     if value <= 0:

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -54,6 +54,15 @@ log = get_logger("llm.factory")
 
 DEFAULT_LLM_REQUEST_TIMEOUT_SECONDS = 600
 LLM_TIMEOUT_ENV = "DECEPTICON_LLM_TIMEOUT_SECONDS"
+# `.env.example` documents the pydantic-settings nested form
+# (``DECEPTICON_LLM__TIMEOUT``) because that's what the rest of the
+# settings tree uses (``LLMConfig.timeout`` → httpx transport). The
+# whole-coroutine guard below is a separate piece of plumbing — but
+# from the user's point of view there is only one "LLM timeout" knob,
+# so we honor the documented name too. Precedence:
+# ``DECEPTICON_LLM_TIMEOUT_SECONDS`` (explicit, whole-coroutine) >
+# ``DECEPTICON_LLM__TIMEOUT`` (the published env knob) > default.
+LLM_TIMEOUT_ENV_ALIAS = "DECEPTICON_LLM__TIMEOUT"
 
 
 class LLMTimeoutError(RuntimeError):
@@ -69,17 +78,34 @@ class LLMTimeoutError(RuntimeError):
 def _resolve_llm_timeout_seconds() -> float:
     """Resolve the per-call LLM request timeout.
 
-    Precedence: ``DECEPTICON_LLM_TIMEOUT_SECONDS`` env > default ``600``.
-    Rejects non-positive or non-numeric env values with ``ValueError`` so
-    misconfiguration fails loudly rather than silently disabling the guard.
+    Precedence: ``DECEPTICON_LLM_TIMEOUT_SECONDS`` env >
+    ``DECEPTICON_LLM__TIMEOUT`` env (the pydantic-settings nested form
+    advertised in ``.env.example``) > default ``600``. The alias is what
+    users actually set when following the published docs — without it,
+    changing the documented knob silently has no effect on the whole-
+    coroutine guard and long generations still trip the 600 s default
+    (see issue #540).
+
+    Rejects non-positive or non-numeric env values with ``ValueError``
+    so misconfiguration fails loudly rather than silently disabling the
+    guard.
     """
     raw = os.getenv(LLM_TIMEOUT_ENV, "").strip()
+    source = LLM_TIMEOUT_ENV
+    if not raw:
+        raw = os.getenv(LLM_TIMEOUT_ENV_ALIAS, "").strip()
+        source = LLM_TIMEOUT_ENV_ALIAS
     if raw:
-        value = float(raw)
+        try:
+            value = float(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"{source} must be a number (got {raw!r})"
+            ) from exc
     else:
         value = float(DEFAULT_LLM_REQUEST_TIMEOUT_SECONDS)
     if value <= 0:
-        raise ValueError(f"{LLM_TIMEOUT_ENV} must be greater than 0")
+        raise ValueError(f"{source} must be greater than 0")
     return value
 
 

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -1317,6 +1317,11 @@ class TestResolveCredentialsForLlamacpp:
 class TestLLMTimeout:
     """Whole-coroutine LLM request timeout (DECEPTICON_LLM_TIMEOUT_SECONDS)."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_timeout_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DECEPTICON_LLM_TIMEOUT_SECONDS", raising=False)
+        monkeypatch.delenv("DECEPTICON_LLM__TIMEOUT", raising=False)
+
     def test_call_with_timeout_raises_typed_exception(self) -> None:
         from decepticon.llm.factory import LLMTimeoutError, call_with_timeout
 
@@ -1399,4 +1404,35 @@ class TestLLMTimeout:
 
         monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "-5")
         with pytest.raises(ValueError, match="greater than 0"):
+            _resolve_llm_timeout_seconds()
+
+    def test_pydantic_nested_alias_takes_effect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM__TIMEOUT", "900")
+        assert _resolve_llm_timeout_seconds() == 900.0
+
+    def test_explicit_env_wins_over_pydantic_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "120")
+        monkeypatch.setenv("DECEPTICON_LLM__TIMEOUT", "900")
+        assert _resolve_llm_timeout_seconds() == 120.0
+
+    def test_alias_invalid_value_attributes_error_to_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM__TIMEOUT", "nonsense")
+        with pytest.raises(ValueError, match="DECEPTICON_LLM__TIMEOUT"):
+            _resolve_llm_timeout_seconds()
+
+    def test_alias_non_positive_attributes_error_to_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from decepticon.llm.factory import _resolve_llm_timeout_seconds
+
+        monkeypatch.setenv("DECEPTICON_LLM__TIMEOUT", "0")
+        with pytest.raises(ValueError, match="DECEPTICON_LLM__TIMEOUT.*greater than 0"):
             _resolve_llm_timeout_seconds()


### PR DESCRIPTION
Closes #540.

## Bug

The reporter set `DECEPTICON_LLM__TIMEOUT=600` (the env knob documented in `.env.example`) and still saw

```
error> LLM request timed out after 600 seconds
```

mid-generation. Tracing it down: there are two timeouts in the LLM path and only one was being driven by the published env var.

| Timeout | Set from | Default |
|---|---|---|
| httpx transport (`LLMConfig.timeout`) | `DECEPTICON_LLM__TIMEOUT` (pydantic-settings nested) | 120 s |
| whole-coroutine guard (`_resolve_llm_timeout_seconds()`) | `DECEPTICON_LLM_TIMEOUT_SECONDS` (different name) | 600 s |

So the documented knob changed the transport ceiling but not the whole-coroutine guard. The 600 s default still hit during long Opus extended-thinking + large `tool_use` payloads.

## Fix

Honor `DECEPTICON_LLM__TIMEOUT` as an env alias in `_resolve_llm_timeout_seconds()`. Precedence:

1. `DECEPTICON_LLM_TIMEOUT_SECONDS` — explicit, kept for tests / one-off overrides
2. `DECEPTICON_LLM__TIMEOUT` — the documented user-facing knob
3. `DEFAULT_LLM_REQUEST_TIMEOUT_SECONDS = 600`

Error messages attribute the offending env var by *its own* name so misconfiguration is easy to trace.

## Tests

- New autouse fixture on `TestLLMTimeout` scrubs both env vars between tests so the runner's ambient env can't leak into assertions.
- New cases: alias takes effect, explicit env wins over alias, alias attributes its own `ValueError`, alias non-positive attributes to alias.

## Docs

`.env.example` now explains the dual-timeout architecture and the precedence rule next to the knob.