### PR TITLE
chore(governance): add AI-contributor charter, ADR system, isolation test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,3 +50,4 @@ docs/COWORK.md                   @PurpleCHOIms
 docs/adr/**                      @PurpleCHOIms
 CONTRIBUTING_AGENT.md            @PurpleCHOIms
 .github/pull_request_template.md @PurpleCHOIms
+docs/QUALITY_BAR.md              @PurpleCHOIms

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,3 +34,19 @@ scripts/install.sh               @PurpleCHOIms
 # whole running stack for every OSS user
 docker-compose.yml               @PurpleCHOIms
 containers/*.Dockerfile          @PurpleCHOIms
+
+# Security policy — Semgrep rules and reporting policy are guard rails;
+# weakening or removing them is a Tier-owner change (see
+# docs/adr/0002-pr-tiering-and-blast-radius.md).
+.semgrep/**                      @PurpleCHOIms
+SECURITY.md                      @PurpleCHOIms
+docs/security/**                 @PurpleCHOIms
+
+# Governance documents — codify how the project is operated. Edits
+# here change the rules every other contributor (human or AI) is held
+# to, so they require owner review even though they ship no runtime
+# behavior. Closes the gap docs/COWORK.md §7 acknowledged.
+docs/COWORK.md                   @PurpleCHOIms
+docs/adr/**                      @PurpleCHOIms
+CONTRIBUTING_AGENT.md            @PurpleCHOIms
+.github/pull_request_template.md @PurpleCHOIms

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,33 +30,59 @@ field is a fast self-classification, not a substitute. See
 
 <!-- Why this needs an owner change: ... -->
 
+## Diff budget
+
+Per [QUALITY_BAR §Hard limits](../docs/QUALITY_BAR.md#hard-limits): ≤ 400 runtime-code lines, ≤ 10 files, 1 logical concern. `docs/**`, `tests/**`, `.github/**`, `.semgrep/**` are excluded.
+
+- [ ] My diff fits the budget.
+- [ ] **Or** I am requesting `large-diff-approved` from `@PurpleCHOIms` because:
+
+<!-- Justify the size if you ticked the second box. -->
+
 ## Testing
 
-<!-- How were these changes tested? Paste the last ~20 lines of output
-where relevant; CI artifact links are also fine. Do not tick a box you
-did not actually run. -->
+<!-- Paste the last ~20 lines of relevant output, or link to a CI
+artifact. Do not tick a box you did not actually run. -->
 
 - [ ] `make quality` passes (Python + CLI + Web)
 - [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks)
 - [ ] `pytest tests/` passes (run this if you touched `docker-compose.yml` or `tests/`)
+- [ ] Every new/changed test was watched to fail without the change and pass with it
 - [ ] Manual testing (describe):
+
+## Quality Bar self-check
+
+Confirm — by ticking — that you have personally verified each item
+against your diff. These are conditions of merge per
+[QUALITY_BAR.md](../docs/QUALITY_BAR.md) and
+[CONTRIBUTING_AGENT.md](../CONTRIBUTING_AGENT.md), regardless of
+whether AI assistance was used.
+
+- [ ] No banned pattern from [QUALITY_BAR §Banned patterns](../docs/QUALITY_BAR.md#banned-patterns--pr-closed-on-sight) appears in the diff (no `except Exception: pass`, no bare `except`, no bare `# type: ignore` / `# noqa`, no `_ = call()`, no `print(` in production code, no mutable defaults, no wildcard imports, no `TODO` without issue link, no `raise NotImplementedError` in a delivered feature, no `pytest.mark.skip` / `xfail` without linked issue, no mocked-system-under-test, no `# pragma: no cover` for coverage chasing).
+- [ ] No AI-slop signature from [QUALITY_BAR §AI-slop signatures](../docs/QUALITY_BAR.md#ai-slop-signatures) survives (no defensive `if x is not None:` the types already prove, no helper-used-once, no speculative `**kwargs`, no `data`/`result`/`item` placeholder names, no docstrings restating the signature, no em-dash salad, no "leverages X to robustly handle Y").
+- [ ] Every changed line traces to the stated intent. No drive-by formatting, renaming, or reordering.
+- [ ] Every public function I added/changed has explicit type annotations including return type, and every raised exception is a named class.
+- [ ] I would merge this PR if a stranger opened it.
+- [ ] If I were tired and reviewing this at the end of a long day, I would still merge it.
 
 ## AI-assisted contribution attestation
 
-If any material part of this PR was produced with the help of an AI
-coding agent, you confirm — by opening this PR — that you followed
-[CONTRIBUTING_AGENT.md](../CONTRIBUTING_AGENT.md):
+By opening this PR, you confirm — whether or not AI assistance was
+used — that you followed [CONTRIBUTING_AGENT.md](../CONTRIBUTING_AGENT.md)
+and meet the [QUALITY_BAR.md](../docs/QUALITY_BAR.md):
 
-- You read the diff in full and can defend every line.
+- You read the diff in full and can defend every line on demand.
 - You actually ran the verification you ticked above.
 - You did not bundle unrelated work.
 - You did not weaken offensive-security guard rails (RoE, SafeCommand,
   EngagementContext, OPSEC skills, semgrep rules, compose isolation,
-  capability/PID/memory limits) without a linked ADR.
+  capability / PID / memory limits) without a linked ADR.
+- You materially edited any AI-generated output before pushing — the
+  diff is not raw model output.
 
-No checkbox is required. The charter applies whether or not you
-disclose tool use; this section exists so the expectation is visible at
-the point of contribution.
+No checkbox is required for this section. The bar applies whether or
+not you disclose tool use; this section exists so the expectation is
+visible at the point of contribution.
 
 ## Related Issues
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,6 +39,27 @@ Per [QUALITY_BAR §Hard limits](../docs/QUALITY_BAR.md#hard-limits): ≤ 400 run
 
 <!-- Justify the size if you ticked the second box. -->
 
+## End-to-end verification
+
+**Required.** One paragraph naming the exact commands you ran on your
+machine and the exact behavior you observed. "Tested locally," "all
+tests pass," and "should work" are not verification statements — they
+are reasons to close the PR. See
+[QUALITY_BAR §Wired end-to-end](../docs/QUALITY_BAR.md#wired-end-to-end-locally-verified--no-exceptions).
+If you genuinely could not run a part of the change locally, say so
+explicitly here and name what you did instead.
+
+<!--
+Example that meets the bar:
+
+> Brought the stack up with `make dev`, ran `make cli`, executed an
+> engagement against `target=10.0.2.4` with `profile=AUTOBANK`. The
+> new c2_tier=short_haul field propagated through to Sliver implant
+> generation (verified via sliver-client implants — output attached).
+> Confirmed c2_tier=long_haul produces a DNS implant. `make smoke`
+> healthy on a clean volume.
+-->
+
 ## Testing
 
 <!-- Paste the last ~20 lines of relevant output, or link to a CI
@@ -48,6 +69,7 @@ artifact. Do not tick a box you did not actually run. -->
 - [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks)
 - [ ] `pytest tests/` passes (run this if you touched `docker-compose.yml` or `tests/`)
 - [ ] Every new/changed test was watched to fail without the change and pass with it
+- [ ] Every new/changed code path was **executed on my machine**, not just unit-tested in isolation
 - [ ] Manual testing (describe):
 
 ## Quality Bar self-check

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 ## Summary
 
-<!-- Brief description of what this PR does and why. -->
+<!--
+One paragraph: what observable behavior changes (or "no-op refactor;
+behavior preserved"), and why. Avoid restating the diff in prose.
+-->
 
 ## Changes
 
@@ -8,13 +11,52 @@
 
 -
 
+## Intent
+
+- **Issue / ADR this satisfies:** <!-- #123, docs/adr/NNNN-*.md, or "release-blocker" -->
+- **Anti-goal** (one thing this PR could have done but deliberately does not):
+
+## Blast radius
+
+Tick the row that best matches this change. The
+[CODEOWNERS](../.github/CODEOWNERS) file is the ground truth — this
+field is a fast self-classification, not a substitute. See
+[docs/adr/0002-pr-tiering-and-blast-radius.md](../docs/adr/0002-pr-tiering-and-blast-radius.md).
+
+- [ ] **Tier-auto** — tests, internal refactors, non-policy docs, lockfile-only dep bumps.
+- [ ] **Tier-delegate** — agent prompts, skill bodies, middleware internals, web/CLI features.
+- [ ] **Tier-owner** — anything CODEOWNERS-gated (CI/workflows, package manifests, install script, compose / Dockerfiles, plugin contracts, `.semgrep/**`, `SECURITY.md`, `docs/security/**`, `docs/COWORK.md`, `docs/adr/**`, `CONTRIBUTING_AGENT.md`).
+  - If ticked, paste a **Why this needs an owner change** paragraph below:
+
+<!-- Why this needs an owner change: ... -->
+
 ## Testing
 
-<!-- How were these changes tested? -->
+<!-- How were these changes tested? Paste the last ~20 lines of output
+where relevant; CI artifact links are also fine. Do not tick a box you
+did not actually run. -->
 
 - [ ] `make quality` passes (Python + CLI + Web)
 - [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks)
-- [ ] Manual testing (describe below)
+- [ ] `pytest tests/` passes (run this if you touched `docker-compose.yml` or `tests/`)
+- [ ] Manual testing (describe):
+
+## AI-assisted contribution attestation
+
+If any material part of this PR was produced with the help of an AI
+coding agent, you confirm — by opening this PR — that you followed
+[CONTRIBUTING_AGENT.md](../CONTRIBUTING_AGENT.md):
+
+- You read the diff in full and can defend every line.
+- You actually ran the verification you ticked above.
+- You did not bundle unrelated work.
+- You did not weaken offensive-security guard rails (RoE, SafeCommand,
+  EngagementContext, OPSEC skills, semgrep rules, compose isolation,
+  capability/PID/memory limits) without a linked ADR.
+
+No checkbox is required. The charter applies whether or not you
+disclose tool use; this section exists so the expectation is visible at
+the point of contribution.
 
 ## Related Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,25 @@ For the cleanup of legacy skills that pre-date the schema, see
 authors writing skills against the schema do not need to read the
 cleanup process — only the schema doc.
 
+## Working with AI assistants
+
+If any material part of your contribution was produced with an AI
+coding agent (Claude, Codex, Copilot, Cursor, etc.), read
+[CONTRIBUTING_AGENT.md](CONTRIBUTING_AGENT.md) before opening a PR. It
+restates a few [docs/COWORK.md](docs/COWORK.md) rules in their
+AI-contributor framing and adds a short self-review checklist. The
+checklist is not enforced by CI; it is the bar a maintainer reviews
+against.
+
+## Architecture decisions
+
+Non-obvious architectural decisions — middleware composition order,
+sandbox transport mechanism, C2 framework selection, network-isolation
+invariants — are recorded as numbered, append-only ADRs under
+[docs/adr/](docs/adr/). See [docs/adr/README.md](docs/adr/README.md)
+for when to write one and the format. If your PR depends on or reverses
+an architectural decision, link the ADR from the PR description.
+
 ## Releases
 
 Maintainers: see [RELEASE.md](RELEASE.md) for the versioning model and the release process.

--- a/CONTRIBUTING_AGENT.md
+++ b/CONTRIBUTING_AGENT.md
@@ -16,6 +16,18 @@ solve, in miniature.
 
 The rules below are not aspirational. They are conditions of merge.
 
+> **Read [`docs/QUALITY_BAR.md`](docs/QUALITY_BAR.md) before your first
+> contribution.** That document is the closed contract on what "100%
+> quality" means for Decepticon — the Karpathy four, the diff-size
+> budget, the banned patterns, the AI-slop signature catalog, and the
+> self-review standard. This charter is the **process** half; the
+> quality bar is the **code** half. Both apply. See [ADR-0004](docs/adr/0004-zero-ai-slop-policy.md)
+> for the rationale.
+>
+> There is no "AI-slop tax." Tool-assisted contributions are held to
+> exactly the same bar as hand-written ones. If you cannot meet it,
+> close the PR.
+
 ---
 
 ## 1. The hard rules
@@ -53,6 +65,43 @@ without review, regardless of how green CI is.
    - You did not relax `cap_drop` / `no-new-privileges` / `mem_limit`
      / `pids_limit` / network membership in `docker-compose.yml`
      without an ADR.
+6. **Your runtime-code diff fits in the budget.** ≤ 400 lines of
+   runtime code (excluding `docs/**`, `tests/**`, `.github/**`,
+   `.semgrep/**`, and pure boilerplate), ≤ 10 files, **1 logical
+   concern** per PR. Doesn't fit? Split it. Exceeding requires a
+   `large-diff-approved` label from `@PurpleCHOIms`, requested in the
+   PR body — not assumed.
+7. **No banned pattern from [QUALITY_BAR §Banned patterns](docs/QUALITY_BAR.md#banned-patterns--pr-closed-on-sight)
+   appears in your diff.** This includes (non-exhaustive):
+   `except Exception: pass`, bare `except:`, bare `# type: ignore` /
+   `# pyright: ignore` / `# noqa` (no rule code), `_ = call()`,
+   `print(` for logging in production code, mutable defaults,
+   wildcard imports, `TODO` without an issue link, `raise NotImplementedError`
+   in a delivered feature, `pytest.mark.skip` / `xfail` without a
+   linked issue, mocked-system-under-test tests, vague test names
+   (`test_works`, `test_happy_path`), `# pragma: no cover` to chase
+   a coverage number. Reviewers stop reading at the first hit.
+8. **No AI-slop signature from [QUALITY_BAR §AI-slop signatures](docs/QUALITY_BAR.md#ai-slop-signatures)
+   survives in your diff.** Strip the defensive `if x is not None:`
+   chains the types already prove. Inline the helper called once.
+   Delete the speculative `**kwargs`. Rename `data` / `result` /
+   `item` to the thing they actually are. Delete docstrings that
+   restate the signature. Delete em-dash salad. Delete the phrase
+   "leverages X to robustly handle Y." Editing AI output is the work
+   the bar exists to demand.
+9. **No drive-by formatting, renaming, or reordering.** If your
+   editor reformatted a file your change did not need, revert it.
+   If you "improved" an adjacent comment, revert it. Surgical means
+   surgical — every changed line traces directly to the stated intent.
+10. **You watched every new/changed test fail before your change made
+    it pass.** Tests that pass without exercising the new path are
+    not tests; they are decoration. For bug fixes, the failing-then-
+    passing sequence is visible in the branch's commit history (do
+    not squash locally — CI squashes on merge).
+11. **Every public function you added or changed has explicit type
+    annotations including the return type, and every exception you
+    raise is a named class.** `raise Exception("…")` is closed on
+    sight; raise a domain-specific subclass.
 
 If any of the above hits, stop. Open an issue or draft ADR first.
 

--- a/CONTRIBUTING_AGENT.md
+++ b/CONTRIBUTING_AGENT.md
@@ -1,0 +1,195 @@
+# Charter for AI-Assisted Contributions
+
+> If you used an AI agent (Claude, Codex, Copilot, Cursor, Gemini, an
+> in-house tool — anything that drafts code or prose) to produce any
+> material part of a contribution to Decepticon, this document is the
+> contract you are operating under. It supplements [CONTRIBUTING.md](CONTRIBUTING.md),
+> [docs/COWORK.md](docs/COWORK.md), and [SECURITY.md](SECURITY.md); it
+> does **not** replace them.
+
+Decepticon is an offensive security platform whose own offensive agents
+operate under explicit Rules of Engagement. The contribution stream that
+*builds* the platform deserves the same discipline. Without it, the
+volume that AI assistance enables silently lowers the quality bar — and
+on a tool of this class, that is the problem the project exists to
+solve, in miniature.
+
+The rules below are not aspirational. They are conditions of merge.
+
+---
+
+## 1. The hard rules
+
+These are non-negotiable. A PR that violates any of them will be closed
+without review, regardless of how green CI is.
+
+1. **You commit under your own identity.** No `Co-Authored-By: Claude`,
+   `Co-Authored-By: Copilot`, or any other AI co-author trailer. (Already
+   enforced socially per [docs/COWORK.md §4.5](docs/COWORK.md); restated
+   here so the rule is also visible from the AI-contributor entry point.)
+   You used a tool. You are still the author and the reviewer-of-record.
+2. **You read the diff in full before opening the PR.** Every line. If
+   you have not read it, you cannot defend it, and you should not be
+   asking a maintainer to.
+3. **You ran the verification you are claiming.** The Testing checklist
+   in the PR template is a statement of fact, not an aspiration. If you
+   ticked `make quality passes`, you ran it and it passed on the exact
+   tree you are pushing. False attestations are a trust violation and
+   are treated as such.
+4. **You do not bundle unrelated work.** "While I was in there" changes
+   go in a separate PR. AI assistants love to drive-by-refactor; you are
+   the gate that says no. See [docs/COWORK.md §4.5](docs/COWORK.md) on
+   mega-PRs.
+5. **You do not weaken the offensive-security guard rails by accident.**
+   Specifically:
+   - You did not remove or soften wording in `packages/decepticon/decepticon/skills/shared/opsec/**`,
+     RoE enforcement, `SafeCommand`, `EngagementContext`, or any
+     `decepticon-no-*` Semgrep rule under `.semgrep/` without an
+     accompanying ADR and an explicit threat-model paragraph in the
+     PR body.
+   - You did not add a tool to a skill's `allowed-tools:` frontmatter
+     without naming, in the PR body, what capability that opens to
+     every agent that loads the skill.
+   - You did not relax `cap_drop` / `no-new-privileges` / `mem_limit`
+     / `pids_limit` / network membership in `docker-compose.yml`
+     without an ADR.
+
+If any of the above hits, stop. Open an issue or draft ADR first.
+
+---
+
+## 2. The self-review checklist
+
+Run these on yourself, in order, before requesting human review. They
+mirror the questions a maintainer will ask; doing them yourself is the
+cheapest way to land your PR.
+
+### 2.1 Intent
+
+- [ ] **The PR references an issue, ADR, or release-blocker.** Title
+      alone is not enough — the body links the thing this change is
+      meant to satisfy. Speculative refactors land as draft PRs against
+      an ADR, not as merge-ready PRs against `main`.
+- [ ] **You can name, in one sentence, the change in observable
+      behavior** (or the explicit "this is a no-op refactor; behavior is
+      preserved" claim).
+- [ ] **You can name the anti-goal**: one thing this PR could plausibly
+      have done but deliberately does not. ("Did not also fix the
+      adjacent bug." "Did not change the public type.") If you cannot
+      name an anti-goal, your PR is probably too broad.
+
+### 2.2 Scope and shape
+
+- [ ] Every changed file traces directly to the stated intent. If a
+      file is in the diff that does not, remove it.
+- [ ] You have not renamed symbols, reordered imports, reflowed strings,
+      or normalized whitespace outside the files your change required.
+- [ ] Diff is the minimum that achieves the goal. If the AI produced
+      200 lines and 50 would do it, you rewrote it down to 50 before
+      pushing.
+- [ ] No `TODO`, `FIXME`, stub, mock, or `raise NotImplementedError`
+      shipped as part of a delivered feature. Unfinished work is closed
+      out, deferred to a tracked issue, or kept on the branch.
+
+### 2.3 Blast-radius classification
+
+Tick the row that best matches your change. The CODEOWNERS file is the
+ground truth — this is a fast self-check, not a substitute.
+
+- [ ] **Tier-auto** — tests, internal refactors with no public-API
+      change, docs that are not policy docs, dependency bumps in
+      `uv.lock` / lockfiles only. Self-merge on green CI is the
+      expected path.
+- [ ] **Tier-delegate** — agent prompts, skill bodies, middleware
+      internals, web/CLI features. Expect review from a maintainer or a
+      delegated reviewer; CI green is necessary but not sufficient.
+- [ ] **Tier-owner (CODEOWNERS-gated)** — `.github/workflows/**`,
+      `pyproject.toml` / `uv.lock` / `package*.json` / `go.{mod,sum}`,
+      plugin contracts under `packages/decepticon-core/.../contracts/**`,
+      `scripts/install.sh`, `docker-compose.yml`,
+      `containers/*.Dockerfile`, `.semgrep/**`, `SECURITY.md`,
+      `docs/security/**`, `docs/COWORK.md`, `docs/adr/**`,
+      `CONTRIBUTING_AGENT.md`. **You will wait for owner review.** Do
+      not ping for a faster turnaround; the owner gate exists because
+      these surfaces have outsized blast radius.
+
+If you ticked Tier-owner, also confirm:
+
+- [ ] The PR body has a section titled **Why this needs an owner
+      change**, naming the surface and the specific invariant being
+      touched. Generic "improving X" descriptions are not enough.
+
+### 2.4 Verification
+
+- [ ] You actually ran the Testing checklist in the PR template. Paste
+      the relevant output (last ~20 lines of `make quality`) in the PR
+      body or as a CI artifact link. If you cannot run a command
+      locally, say so explicitly; do not tick the box.
+- [ ] If you added or modified a test, you saw it fail without your
+      change and pass with it. (For bug fixes, the failing-then-passing
+      test sequence should be visible in the commit history of the PR
+      branch — do not squash it away locally.)
+- [ ] If you touched `docker-compose.yml`, you ran
+      `pytest tests/test_compose_network_isolation.py` locally (or the
+      whole `tests/` suite). The isolation invariants are not negotiable.
+- [ ] If you touched any agent prompt under `packages/decepticon/decepticon/agents/**/prompts/`,
+      you read the diff yourself and confirmed that no DO/DON'T item
+      from [tradecraft & OPSEC](https://docs.decepticon.red/en/concepts/tradecraft)
+      was weakened. (Prompts are not covered by Python tests; the
+      review is on you.)
+
+### 2.5 Honesty
+
+- [ ] You marked claims about external behavior as `[INFERENCE]` (or
+      equivalent) when you have not directly observed them.
+- [ ] You did not paper over a failing check by retrying CI, skipping a
+      test, removing a Semgrep rule, or moving code into an excluded
+      path. If a guard rail fires, that is a signal — fix the underlying
+      issue or open a separate PR that explicitly relaxes the rule with
+      a justification a maintainer can approve.
+
+---
+
+## 3. Patterns AI assistants get wrong here
+
+Symptoms a maintainer will catch if you do not. Save the round-trip by
+catching them yourself first.
+
+| Pattern | Why it bites Decepticon |
+|---|---|
+| Adding a `try/except Exception: pass` to "make a test pass" | Hides real failures in sandbox / network / LLM call paths where flakes are signal. |
+| Inserting `if not …: return None` defaults instead of raising | RoE / OPPLAN code that silently returns `None` produces ghost objectives downstream. Fail loud. |
+| "Helpfully" widening a function's signature with a new optional kwarg | Public-API surface change; needs a CODEOWNERS review on plugin contracts. |
+| Replacing `assert` with `if ... raise ...` *everywhere* | Already covered by `decepticon-no-assert-in-prod` for the right paths. Do not bulk-rewrite. |
+| Adding a new dependency to fix a small thing | Supply-chain change. Justify in the PR body or remove the dep and inline the small thing. |
+| Generating a long Mermaid diagram or architecture doc as part of a code PR | Land docs separately. Mixed PRs make review pathological. |
+| Reformatting unrelated files because the formatter "thought they were dirty" | Revert. Match existing formatting; do not normalize the tree. |
+
+---
+
+## 4. When in doubt
+
+- For architecture-level questions: open a draft ADR (see
+  [docs/adr/template.md](docs/adr/template.md)) and link it in the PR.
+  An ADR with `Status: Proposed` is the right artifact for "I think we
+  should do X; here is the context."
+- For security-sensitive questions: open a private report per
+  [SECURITY.md](SECURITY.md). Do not open a public issue with a working
+  exploit narrative.
+- For "is this in scope": open an issue first. A small issue conversation
+  is cheaper than a large PR that gets closed.
+
+---
+
+## 5. Why this exists
+
+Tests passing is necessary; it is not sufficient. Decepticon's value
+proposition rests on the philosophy in
+[docs/red-team/operations.md](docs/red-team/operations.md), the
+isolation in [docs/security/sandbox-isolation.md](docs/security/sandbox-isolation.md),
+and the tradecraft in the published docs. None of those are
+test-enforceable in their entirety. They are enforced by the people who
+review the PR — and, when the PR was AI-assisted, by the person who
+opened it being willing to defend every line.
+
+If you cannot, do not open the PR yet.

--- a/CONTRIBUTING_AGENT.md
+++ b/CONTRIBUTING_AGENT.md
@@ -102,6 +102,18 @@ without review, regardless of how green CI is.
     annotations including the return type, and every exception you
     raise is a named class.** `raise Exception("…")` is closed on
     sight; raise a domain-specific subclass.
+12. **Every new or changed code path is wired end-to-end and was
+    executed on your machine.** Not "compiles." Not "unit tests pass."
+    Not "CI will catch it." You ran the actual command, hit the actual
+    route, triggered the actual skill, brought the actual stack up, and
+    observed the actual behavior — happy path *and* failure path. The
+    PR body includes a one-paragraph **End-to-end verification
+    statement** naming the exact commands you ran and what you saw.
+    "Tested locally," "all tests pass," "should work" are not
+    verification statements; they are closure triggers. See
+    [QUALITY_BAR §Wired end-to-end](docs/QUALITY_BAR.md#wired-end-to-end-locally-verified--no-exceptions)
+    for what counts, what is forbidden, and how to declare an honest
+    gap when you genuinely cannot run something locally.
 
 If any of the above hits, stop. Open an issue or draft ADR first.
 

--- a/docs/QUALITY_BAR.md
+++ b/docs/QUALITY_BAR.md
@@ -1,0 +1,405 @@
+# The 100% Quality Bar
+
+> **If you cannot meet this bar, close the PR.** Shipping at 80% is
+> shipping a bug we agreed to write. There is no AI-slop tax: a
+> contribution drafted by a tool is held to exactly the same standard
+> as one hand-written by a senior engineer, because merging it implies
+> the same trust.
+
+This document is the closed contract. The [Karpathy Four](#the-karpathy-four)
+are the philosophy; the rules below are the operational consequence.
+[ADR-0004](adr/0004-zero-ai-slop-policy.md) records why this bar exists.
+
+This file is `CODEOWNERS`-gated. To change the bar, open an ADR.
+
+---
+
+## The Karpathy Four
+
+These four principles are the default behavioral contract for **every**
+Decepticon contribution, trivial or complex. They override any habit
+toward speed, breadth, or overcomplication. Bias: **caution over speed**.
+
+### 1. Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- No new dependencies without a clear, stated need.
+- If you write 200 lines and it could be 50, rewrite it.
+
+### 3. Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- Don't rename variables, move files, or change comments unless required.
+- If you notice unrelated dead code or bugs, **mention them** —
+  don't delete or fix them opportunistically.
+- Every changed line must trace directly to the stated request.
+
+### 4. Goal-Driven Execution
+
+Define success criteria. Loop until verified.
+
+| Instead of...    | Transform to...                                            |
+|------------------|------------------------------------------------------------|
+| "Add validation" | "Write tests for invalid inputs, then make them pass"       |
+| "Fix the bug"    | "Write a test that reproduces it, then make it pass"        |
+| "Refactor X"     | "Ensure tests pass before and after"                        |
+
+Before declaring a task complete, **run the verification you said you
+would**. If you cannot verify, say so explicitly — never claim done
+without evidence.
+
+---
+
+## Hard limits
+
+A PR that exceeds these without explicit owner approval (`large-diff-approved`
+label, applied by `@PurpleCHOIms`) will be closed or split. The budget is
+on **runtime code** — `docs/**`, `tests/**`, `.github/**`, `.semgrep/**`,
+and pure boilerplate (license headers, generated lockfiles) do **not**
+count.
+
+| Dimension                       | Default cap                          |
+|---------------------------------|--------------------------------------|
+| Runtime-code lines changed      | ≤ 400                                |
+| Files touched                   | ≤ 10                                 |
+| Logical concerns in one PR      | 1                                    |
+| New top-level dependencies      | 0 (justify in PR body if proposing)  |
+| New public API surface          | 0 (lift via ADR + plugin-contract review) |
+| Cyclomatic complexity per func  | ≤ 10                                 |
+| Function length                 | ≤ 50 lines (anything larger needs a reason in the PR body) |
+
+If you cannot fit your work under the cap, **the work is two PRs**.
+Split it. Land each piece independently, behind a flag if needed.
+
+---
+
+## Banned patterns — PR closed on sight
+
+Each pattern is closed without further review when found. Several are
+already enforced by `.semgrep/decepticon-rules.yml`; the rest are
+enforced by the maintainer reviewing the diff. There is no "I didn't
+know" exception once this document exists.
+
+### Error handling
+
+```python
+# BANNED
+try:
+    risky()
+except Exception:
+    pass
+
+# BANNED — bare except
+try:
+    risky()
+except:
+    pass
+
+# BANNED — swallow then continue
+try:
+    result = call_llm()
+except Exception:
+    result = None  # silent failure on a load-bearing call
+
+# REQUIRED
+try:
+    result = call_llm()
+except RateLimitError as exc:
+    raise OPPLANExecutionFailed("LLM rate-limited") from exc
+```
+
+The exception is what you say it is. Catch the **specific** class, do
+something **meaningful**, and `raise ... from exc` so the trace is
+preserved.
+
+### Type-safety escape hatches
+
+```python
+# BANNED (also semgrep: decepticon-no-blanket-type-ignore)
+x = call()  # type: ignore
+y = other()  # pyright: ignore
+
+# REQUIRED — scoped suppression with justification
+x: int = call_returning_str_that_is_actually_int()  # type: ignore[assignment]  # legacy API, tracked in #NNN
+```
+
+Same rule for `# noqa` — always with a code, ideally with a one-line
+justification.
+
+### Logging in production
+
+```python
+# BANNED in packages/decepticon/**, packages/decepticon-core/**
+print(f"got result {result}")
+
+# REQUIRED
+from decepticon.core.logging import get_logger
+log = get_logger("agents.recon.scanner")
+log.info("recon scan complete", extra={"host_count": len(hosts)})
+```
+
+`print` is for `clients/cli` and `scripts/` only. Everywhere else,
+use the project logger so output is structured and routable.
+
+### Suppressed return values
+
+```python
+# BANNED
+_ = something_that_returns_a_value()
+
+# REQUIRED — use it, or don't call it
+result = something_that_returns_a_value()
+process(result)
+```
+
+If you don't need the value, the function probably shouldn't be called.
+If you do, name it.
+
+### Dead capabilities and stubs
+
+- `TODO` without an issue link → not allowed.
+- `FIXME` in production code → not allowed.
+- `raise NotImplementedError` in a delivered feature → not allowed.
+- Functions defined but called from nowhere → not allowed.
+
+### Mutable defaults and wildcard imports
+
+```python
+# BANNED
+def f(x, items=[]):  # shared across calls — classic bug
+    ...
+
+from somemodule import *  # imports unknown surface
+```
+
+### Cosmetic drive-bys
+
+- Reordering imports outside your changed files.
+- Reflowing strings, normalizing whitespace, or "fixing" comment style
+  on files your PR did not need to touch.
+- Mass-renaming variables for "consistency" without an ADR.
+- Reformatting an entire file because your editor saved it.
+
+Revert these before pushing. If the project formatter wants them,
+land them as a separate, formatter-only PR.
+
+### Test anti-patterns
+
+```python
+# BANNED — asserts on the call shape, not on behavior
+def test_save_user():
+    db = Mock()
+    save_user(db, "alice")
+    db.execute.assert_called_with("INSERT INTO users ...")
+
+# BANNED — vague test names
+def test_function_works(): ...
+def test_happy_path(): ...
+def test_basic_functionality(): ...
+
+# BANNED — testing the mock you defined
+def test_recon_returns_hosts():
+    backend = Mock()
+    backend.scan.return_value = ["1.1.1.1"]
+    assert recon(backend) == ["1.1.1.1"]  # tautological
+
+# REQUIRED — name describes behavior, asserts the observable outcome
+def test_kerberoast_skill_rejects_realm_outside_roe():
+    skill = KerberoastSkill(roe=ROE(realms={"CORP.LOCAL"}))
+    with pytest.raises(OutOfScopeError):
+        skill.run(target_realm="OTHER.LOCAL")
+```
+
+Also banned:
+
+- `pytest.mark.skip` without a tracking issue.
+- `@pytest.mark.flaky` — flakes get fixed, not annotated.
+- `# pragma: no cover` to chase a coverage number.
+- Tests that mock the function under test.
+- Tests that pass without exercising the new code path. (Verify the
+  test fails before your change.)
+
+### Dependency hygiene
+
+- New top-level dependency without an explicit "this is the smallest
+  acceptable solution because X" paragraph in the PR body → closed.
+- Pinning new deps via `requirements*.txt` instead of `uv add` →
+  closed. The project uses `uv` and `pyproject.toml` is the source of
+  truth.
+- Vendoring code without a license review note → closed.
+
+---
+
+## AI-slop signatures
+
+These are the **tells**. They are not rare; they appear in essentially
+every long AI-generated diff that has not been edited down. The first
+revision pass should be deleting them. If they survive into a PR, the
+PR will be closed with a single comment pointing at this section.
+
+### Prose / comment slop
+
+| Tell                                                                   | Fix                                                              |
+|------------------------------------------------------------------------|------------------------------------------------------------------|
+| Em-dashes salad in code comments / docstrings                          | Use plain prose. One em-dash per paragraph is fine; six is slop. |
+| "This module provides …" / "This function is responsible for …"        | Delete. The signature already says what it is. Say *why*.        |
+| "We leverage X to robustly handle Y in a comprehensive manner"         | "X parses Y." Words like *leverage / robust / comprehensive / elegant / utilize / seamlessly* are flag words. |
+| Comments that translate the next line into English (`# increment i`)   | Delete.                                                          |
+| Docstrings that restate the parameter list                             | Delete the restating; keep only the contract/invariants/why.     |
+| Section banners (`# ==== Helpers ====`) inside one-screen modules      | Delete. If the module needs banners, split the module.           |
+| Sentences ending with "ensuring optimal performance"                   | Delete.                                                          |
+
+### Code slop
+
+| Tell                                                                                                       | Fix                                                              |
+|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| `if x is not None:` chains where the type system already proves it isn't None                              | Remove the check. Trust the types.                               |
+| Defensive `try/except` wrapping every call "just to log and re-raise"                                      | Let exceptions propagate. Log at the boundary, not at each step. |
+| One-line `_helper()` functions called from exactly one place                                               | Inline.                                                          |
+| Speculative `**kwargs` or `Optional[…] = None` parameters "for future extensibility"                       | Remove. Add it when the second caller arrives.                   |
+| `result = {}; result["a"] = …; result["b"] = …; return result`                                             | Use a dataclass / NamedTuple / TypedDict. Or return a tuple.     |
+| Wrapping a stdlib call in a function that adds nothing                                                     | Inline.                                                          |
+| Identical try/except blocks copy-pasted across N call sites                                                | Extract a context manager.                                       |
+| Variables named `data`, `info`, `obj`, `item`, `result` in non-trivial functions                           | Rename to describe the thing.                                    |
+| `if cond: return True\nelse: return False`                                                                 | `return cond`. (Or `return bool(cond)` if the type matters.)     |
+| Stacked single-line conditionals expanded into 8 lines for "readability"                                   | One ternary or a guard clause. Read the surrounding code style.  |
+
+### Diff slop
+
+| Tell                                                                              | Fix                                                          |
+|-----------------------------------------------------------------------------------|--------------------------------------------------------------|
+| 30 files changed, 28 of them whitespace                                           | Revert the whitespace. Land the substantive change only.     |
+| "Cleanup" commit alongside the feature commit                                     | Separate PR.                                                 |
+| New file added that just re-exports existing names                                | Don't.                                                       |
+| Multiple `# pragma: no cover` to hit a coverage target                            | Write the test or delete the unreachable branch.             |
+| New skill / agent / middleware that wasn't in any issue or ADR                    | Open the ADR first.                                          |
+| `from X import *` "to keep imports clean"                                         | Explicit imports.                                            |
+| Migration of working code from `requests` to `httpx` (or similar) inside a fix PR | Separate PR with its own ADR.                                |
+
+---
+
+## Required positive patterns
+
+The complement of the banned list. The reviewer is looking for these:
+
+- **Every public function has explicit type annotations**, including
+  return type. `-> None` when nothing is returned.
+- **Every exception raised is a named class** that subclasses a
+  Decepticon base error (`DecepticonError` or a domain-specific child).
+- **Every fix PR's branch has a failing-test commit followed by a
+  passing-test commit.** Don't squash locally; the maintainer wants
+  to see the bug reproduced. CI will squash on merge.
+- **Every magic number / string has a named constant or an inline
+  one-line justification.** `timeout=300` is not OK; `LITELLM_BOOT_TIMEOUT_S = 300  # measured 136s on cold prisma + LLM-routing load` is.
+- **Every TODO links to an issue.** `# TODO(#NNN): unblock once Sliver mTLS rotation lands`.
+- **Every new module starts with a docstring naming the module's job in
+  one sentence.** Not "this module provides utilities for…"; just the
+  one sentence.
+- **Every new dependency justifies its existence** in the PR body. Smaller
+  is better. Stdlib > a 100-line library > a 10MB library.
+
+---
+
+## Test quality bar
+
+A test that always passes is not a test; it is noise. The bar:
+
+1. **You watched it fail before your change.** Otherwise the test
+   isn't testing what you think it is.
+2. **The test name describes the behavior**, not the function.
+3. **The test asserts an observable outcome**, not the call shape of
+   a mock.
+4. **The test does not mock the system under test.** Mock the
+   *environment* (network, clock, LLM provider), never the function
+   you are testing.
+5. **The test exercises a branch or a boundary**, not the default
+   path of a configuration setting. Changing the default should never
+   break the test.
+6. **One logical assertion per test.** If a test name has "and" in
+   it, split it.
+7. **No `pytest.mark.skip` without a linked issue. No `xfail` for "we
+   know this is broken." Fix it or delete it.**
+
+---
+
+## Self-review standard
+
+Before you request review, your honest answer to all of these is yes:
+
+- [ ] I would merge this PR if a stranger opened it.
+- [ ] A maintainer reading the diff will not have to ask "why" anywhere.
+- [ ] The PR title alone tells a future maintainer what changed.
+- [ ] The commit messages explain **why**; the code shows **what**.
+- [ ] Every changed line is here because the stated intent required it.
+- [ ] I read the diff in full. I can defend every line on demand.
+- [ ] I ran the verification I claim to have run.
+- [ ] No banned pattern is present.
+- [ ] No AI-slop signature is present.
+- [ ] If I were tired and reviewing this at the end of a long day, I
+      would still merge it.
+
+If any answer is no, do not request review. Fix it first.
+
+---
+
+## Escalation
+
+There are exactly three escape valves for the rules above. Each is
+explicit; none can be invoked silently.
+
+1. **ADR.** A design decision the rules do not anticipate? Open an
+   ADR (`docs/adr/template.md`). Land the ADR first; the code follows.
+2. **`large-diff-approved` label.** Diff genuinely cannot be split?
+   Justify it in the PR body and request the label from `@PurpleCHOIms`.
+   Refusal is the default.
+3. **Documented exception in this file.** A rule needs a permanent
+   carve-out? Open a PR against this file with an ADR. (See: this
+   file is CODEOWNERS-gated.)
+
+The rules are not democratic. They are how the project survives a
+contribution stream that scales faster than review can.
+
+---
+
+## What "100%" actually means
+
+It does not mean:
+
+- 100% code coverage. (Coverage is a side effect of good testing,
+  not the target.)
+- Zero bugs forever. (Bugs happen. Bug fixes that ship a regression
+  test are how we learn.)
+- Every PR is perfect on the first push. (Iteration is fine.
+  Iteration is *good*. The bar is on what merges, not on what is
+  drafted.)
+
+It does mean:
+
+- Every line that lands on `main` was deliberate.
+- Every line on `main` was reviewed by a human who could defend it.
+- Every line on `main` traces to an intent that was written down
+  somewhere — issue, ADR, or release-blocker.
+- No line on `main` exists because "the AI suggested it" or "the
+  test was passing and the diff was small."
+
+That is the bar. It is high on purpose. It is the only way a
+single-owner project survives the AI-contribution era with its
+architecture intact.

--- a/docs/QUALITY_BAR.md
+++ b/docs/QUALITY_BAR.md
@@ -89,6 +89,108 @@ count.
 If you cannot fit your work under the cap, **the work is two PRs**.
 Split it. Land each piece independently, behind a flag if needed.
 
+
+## Wired end-to-end, locally verified — no exceptions
+
+**"Compiles" is not "works." "Tests pass" is not "wired." "CI is
+green" is not "I ran it."** Before you open the PR, every code path
+you touched has been **executed on your machine** at least once and
+produced the behavior you claim. There is no exception for "small
+changes," "obvious refactors," "docs-only" touching runtime code, or
+"the test suite covers it." If you did not run it, you do not know.
+
+### What "wired" means concretely
+
+1. **You executed the new or changed code path on your machine.** Not
+   imported. Not unit-tested in isolation. Actually called, in the
+   actual runtime, against the actual surrounding system. If your
+   change is in `packages/decepticon/decepticon/agents/`, you ran an
+   engagement that exercised the agent. If it is a CLI command, you
+   ran the command. If it is an HTTP route, you hit the route. If it
+   is a skill, you triggered the skill from an agent that loads it.
+2. **You followed the change through every layer it crosses.** A new
+   config flag means: you set it, watched the loader pick it up,
+   watched the consumer behave differently, and watched the *opposite*
+   value still work. A new function signature means: you ran every
+   updated caller, not just the one in the unit test. A new
+   `docker-compose.yml` field means: you ran `make dev` (or `docker
+   compose up`) and watched the stack come healthy with your change.
+3. **You verified the failure mode, not just the happy path.** Pass
+   bad input. Pass `None`. Pull the network. Confirm the failure
+   surfaces — not silently swallowed, not turned into a `None`
+   downstream. If you cannot describe what happens on failure, you
+   have not tested the change.
+4. **You ran the integration the change is part of.** If your PR
+   changes an OPPLAN tool, you ran the orchestrator and watched it
+   call the tool. If it changes a middleware, you ran an agent through
+   the middleware stack. Unit tests on the middleware in isolation
+   are necessary, not sufficient.
+5. **You ran `make smoke` (or the matching lane) for any change that
+   crosses the stack.** "CI will catch it" is not local verification.
+   CI is a backstop. A green CI run on a PR you have not exercised
+   locally is still rejected.
+6. **If you genuinely cannot run something locally** (no GPU, no AWS
+   account, the target requires a paid Sliver license, the C2 traffic
+   needs an external responder, etc.) — say so **explicitly** in the
+   PR body, name what you did instead (a focused mock, a stand-in
+   target, a recorded transcript), and label the unverified surface so
+   the reviewer knows where to look. Honest "I could not exercise X
+   end-to-end because Y; I verified Z instead" is acceptable.
+   Pretending you ran something you did not is not.
+
+### What "wired" forbids
+
+- Adding a new code path without a runtime exercise of it — even if a
+  unit test covers the function in isolation.
+- Adding a new config flag / env var / option without flipping it on
+  your machine and watching the behavior change.
+- Changing a public function signature without grep-confirming (or
+  LSP-confirming) every caller is updated and exercised.
+- Adding or removing a dependency without importing it under the
+  actual runtime path and watching it load.
+- Adding a new CLI command, HTTP route, agent prompt, or skill
+  without invoking it once.
+- Touching `docker-compose.yml`, `containers/*.Dockerfile`, or
+  `config/litellm.yaml` without bringing the stack up locally and
+  watching it pass healthchecks.
+- Saying "should work," "should be fine," "I think this is right," or
+  "this is straightforward" in a PR body, a commit message, or a
+  review comment. If it is true, prove it. If you cannot, do not
+  claim it.
+- "Verified in CI only" without an explicit reason you could not run
+  it locally. CI is necessary, not sufficient.
+
+### What "wired" requires in the PR body
+
+Every PR has a one-paragraph **End-to-end verification statement**
+naming the exact commands you ran and the exact behavior you
+observed. Examples that meet the bar:
+
+> Brought the stack up with `make dev`, ran `make cli`, executed an
+> engagement with `target=10.0.2.4` and `profile=AUTOBANK`. The new
+> `c2_tier=short_haul` field on `obj-002` propagated through to the
+> Sliver implant generation (verified via `sliver-client implants` —
+> output attached). Confirmed `c2_tier=long_haul` produces a DNS
+> implant on the same target. `make smoke` healthy on a clean
+> volume.
+
+> Ran `pytest packages/decepticon/tests/unit/middleware/test_safe_command.py::test_rejects_out_of_scope_host -x`
+> twice: once on the parent commit (failed as expected: the new
+> CIDR-overlap check did not exist), once on this branch (passed).
+> Also ran `make ci-lint` and the full `pytest tests/`. Did **not**
+> run `make smoke` because no compose change; declaring the gap so
+> the reviewer knows.
+
+Examples that **do not** meet the bar:
+
+> Tested locally.
+
+> All tests pass.
+
+> Should work.
+
+The bar is on the *evidence*, not the *claim*.
+
 ---
 
 ## Banned patterns — PR closed on sight
@@ -351,6 +453,9 @@ Before you request review, your honest answer to all of these is yes:
 - [ ] Every changed line is here because the stated intent required it.
 - [ ] I read the diff in full. I can defend every line on demand.
 - [ ] I ran the verification I claim to have run.
+- [ ] **I executed every new or changed code path on my own machine —
+  not just "tests pass." The PR body's End-to-end verification
+  statement names the commands I ran and the behavior I observed.**
 - [ ] No banned pattern is present.
 - [ ] No AI-slop signature is present.
 - [ ] If I were tired and reviewing this at the end of a long day, I

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,72 @@
+# 0001. Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** @PurpleCHOIms
+- **Related:** [docs/adr/README.md](README.md)
+
+## Context
+
+Decepticon's architecture has evolved through several iterations
+(Purple Team AI → RL → GAN → LLM agents; monolithic agent → planned
+multi-agent decomposition; Docker-socket-exec sandbox → HTTP-daemon
+sandbox; etc.). Each pivot was deliberate, but the *reasoning* for
+those pivots lives in PR descriptions, issue threads, and the implicit
+memory of the people who made them.
+
+Several documents under `docs/` already serve a decision-record
+purpose — `docs/security/sandbox-isolation.md`,
+`docs/security/neo4j-hardening.md`, `docs/security/prompt-injection-defense.md`,
+`docs/COWORK.md`. They are excellent narrative docs, but they are
+edited in place when the system changes, which makes it hard to
+distinguish "the current design" from "the history of how we got here."
+
+With AI-assisted contributions arriving at a pace that exceeds single
+maintainer review bandwidth, the cost of *implicit* architectural
+knowledge has gone up. A reviewer (or contributing AI agent) needs to
+be able to look up "why is the middleware order
+SafeCommand → Skills → Filesystem → … and not the reverse?" in a place
+that is stable, dated, and append-only — not in a doc that has been
+silently rewritten since the decision was made.
+
+## Decision
+
+We adopt the [Michael Nygard ADR format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+under `docs/adr/`. ADRs are numbered sequentially, append-only, and
+CODEOWNERS-gated. Proposed ADRs may be opened by any contributor;
+Accepted ADRs require maintainer review per the CODEOWNERS rule on
+`docs/adr/**`.
+
+Narrative docs under `docs/security/`, `docs/red-team/`, and elsewhere
+continue to exist for current-state explanation and onboarding. ADRs
+record the *decision events* that produced the current state. The two
+formats are complementary, not competing.
+
+## Consequences
+
+- **Easier:** new contributors (human or AI) can find decision rationale
+  in a known location. PRs that contradict an Accepted ADR are easy to
+  flag. Reversals are explicit (`Superseded by ADR-NNNN`) rather than
+  silent doc edits.
+- **Harder:** non-obvious decisions now require a small amount of
+  upfront writing. (We accept this; the cost is paid once, the benefit
+  accrues forever.)
+- **Given up:** the ability to silently change architecture by editing
+  the narrative doc. This is intentional.
+- **Migration:** existing decisions already documented in
+  `docs/security/*.md` and `docs/COWORK.md` are not retroactively
+  reformatted as ADRs. New decisions (and reversals of existing ones)
+  use the ADR format from here forward. We may backfill specific
+  high-value decisions as ADRs case-by-case, but we do not mass-convert.
+
+## Alternatives considered
+
+- **No ADRs, keep editing narrative docs in place.** Status quo. Loses
+  the audit trail that matters for AI-assisted-contribution review.
+- **RFC-style longer-form docs.** Rejected as too heavyweight for the
+  decision velocity. RFCs work for cross-team projects; this is a
+  small-team repo with a sole owner today.
+- **Track decisions in GitHub issues/PRs only.** Rejected — issues drift,
+  PRs get merged and become invisible in normal browsing, and neither
+  surface has a stable URL scheme contributors can cite from skill or
+  prompt files.

--- a/docs/adr/0002-pr-tiering-and-blast-radius.md
+++ b/docs/adr/0002-pr-tiering-and-blast-radius.md
@@ -1,0 +1,75 @@
+# 0002. PR tiering by blast radius
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** @PurpleCHOIms
+- **Related:** [.github/CODEOWNERS](../../.github/CODEOWNERS), [docs/COWORK.md](../COWORK.md), [CONTRIBUTING_AGENT.md](../../CONTRIBUTING_AGENT.md)
+
+## Context
+
+Decepticon receives contributions from human maintainers, write-access
+collaborators, external forked-PR contributors, and a growing volume of
+AI-assisted PRs. With one full-time owner today (`@PurpleCHOIms`),
+manually reviewing every PR is not viable, and "every PR self-merges on
+green CI" is unsafe for the surfaces that can compromise downstream
+users in one merge (CI workflows, install scripts, base images,
+published packages, plugin contracts).
+
+`.github/CODEOWNERS` already implements a per-path strategy: a small
+set of supply-chain-critical paths require owner review, everything
+else self-merges. `docs/COWORK.md §4.3` describes this strategy in
+narrative form. This ADR records the *reasoning* behind the strategy so
+it can be cited from CONTRIBUTING\_AGENT.md, future ADRs, and
+discussions about whether a given path should join the protected set.
+
+## Decision
+
+Contributions are classified by **blast radius** — the worst-case scope
+of damage a malicious or careless change to the file could cause — and
+routed to one of three review tiers:
+
+| Tier | What it covers | Reviewer | Merge gate |
+|---|---|---|---|
+| **Tier-auto** | Tests, internal refactors with no public-API change, docs that are not policy docs, lockfile-only dependency bumps with green security scan | None (CI is the reviewer) | Green required CI + contributor self-review |
+| **Tier-delegate** | Agent prompts, skill bodies, middleware internals, web/CLI features, schema changes that do not break contracts | Maintainer or named delegate | Green CI + 1 review approval |
+| **Tier-owner** | Anything under a `CODEOWNERS`-gated path: `.github/workflows/**`, `pyproject.toml` / lockfiles / package manifests, `packages/decepticon-core/.../contracts/**`, `scripts/install.sh`, `docker-compose.yml`, `containers/*.Dockerfile`, `.semgrep/**`, `SECURITY.md`, `docs/security/**`, `docs/COWORK.md`, `docs/adr/**`, `CONTRIBUTING_AGENT.md`, release tooling | Owner (`@PurpleCHOIms` today) | Green CI + 1 owner approval; release jobs additionally gated by the `pypi-release` GitHub Environment |
+
+A path enters Tier-owner when *both* of these are true:
+
+1. The change can compromise downstream users without their action
+   (supply-chain, install path, runtime container, network isolation).
+2. The change cannot be fully validated by an automated check.
+
+If only (1) is true, the right move is to add the missing automated
+check; if only (2) is true, the path stays in Tier-delegate.
+
+## Consequences
+
+- **Easier:** routine work lands fast; the owner's review time is spent
+  where it matters. Contributors know up-front whether to expect a wait.
+- **Harder:** adding a new high-blast-radius surface (e.g. a new
+  container image, a new install script, a new policy doc) requires
+  updating CODEOWNERS in the same PR. The CONTRIBUTING_AGENT.md
+  self-review checklist names this explicitly.
+- **Given up:** flat "all reviews equal" governance. We accept that
+  some paths are categorically more dangerous than others and process
+  them accordingly.
+- **Migration:** the CODEOWNERS file in this PR brings policy
+  files (`.semgrep/**`, `docs/security/**`, `SECURITY.md`,
+  `docs/COWORK.md`, `docs/adr/**`, `CONTRIBUTING_AGENT.md`) into the
+  protected set. No existing path leaves the protected set.
+
+## Alternatives considered
+
+- **Blanket `* @owner` in CODEOWNERS.** Rejected: owner becomes the
+  bottleneck for trivial changes, contribution velocity drops, and
+  review fatigue erodes the attention the owner-tier surfaces actually
+  need.
+- **No CODEOWNERS, rely on branch-protection ruleset + CI.** Rejected:
+  CI cannot catch a malicious `.github/workflows/*.yml` change that
+  disables CI itself. Human review on workflow files is the
+  defense-in-depth layer.
+- **Per-author trust tiering instead of per-path.** Rejected for now:
+  introduces social complexity (who is "trusted"?) and does not address
+  the AI-author case where the identity is the human but the diff was
+  produced by a tool. Per-path is the simpler invariant.

--- a/docs/adr/0003-ai-contributor-self-review.md
+++ b/docs/adr/0003-ai-contributor-self-review.md
@@ -1,0 +1,94 @@
+# 0003. AI-assisted contribution self-review charter
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** @PurpleCHOIms
+- **Related:** [CONTRIBUTING_AGENT.md](../../CONTRIBUTING_AGENT.md), [docs/COWORK.md](../COWORK.md), [ADR-0002](0002-pr-tiering-and-blast-radius.md)
+
+## Context
+
+A non-trivial fraction of incoming contributions are produced with the
+help of AI coding agents (Claude, Codex, Copilot, Cursor, Gemini,
+in-house tools). This is fine — and on the offensive-AI mission this
+project is built around, philosophically consistent — but it changes
+the failure modes a reviewer has to defend against:
+
+- **Volume.** A single contributor can credibly open more PRs in a day
+  than the owner can review carefully in a week. "Passing tests" is no
+  longer a sufficient quality signal at that ratio.
+- **Confident-looking surface, shallow grounding.** AI-generated diffs
+  read well and obey the project's lint config. They can still be wrong
+  in ways that only surface in production: weakened RoE checks,
+  silently-broadened public APIs, opportunistic refactors that survive
+  CI but corrupt blame history.
+- **Drive-by changes.** AI assistants reflexively "improve" adjacent
+  code. The four Karpathy coding guidelines already on file
+  (Think Before Coding / Simplicity First / Surgical Changes /
+  Goal-Driven Execution) push against this; we want them visibly
+  embedded in the contribution flow, not assumed.
+- **Identity blur.** `Co-Authored-By: Claude` trailers are already
+  rejected per `docs/COWORK.md §4.5`. That rejection only makes sense
+  if there is also a positive statement of what the human author *is*
+  responsible for when they used an AI tool.
+
+The repo's automated layers (CI, basedpyright, Semgrep, gitleaks,
+hadolint, shellcheck, the existing compose test, the new isolation
+test) catch a large and growing class of mechanical mistakes. They do
+not — and structurally cannot — catch architecture drift, OPSEC
+softening in prompts, or scope inflation. Those are review-tier
+concerns.
+
+## Decision
+
+We add a top-level `CONTRIBUTING_AGENT.md` charter that:
+
+1. Restates that the human opening the PR is the author-of-record and
+   the reviewer-of-record, regardless of which tool produced the diff.
+2. Lists the **hard rules** — violations close the PR.
+3. Provides a **self-review checklist** covering intent, scope and
+   shape, blast-radius classification, verification, and honesty.
+4. Catalogs common **AI-assistant anti-patterns** with their
+   project-specific failure mode.
+5. Names the escalation paths (ADR, SECURITY.md, issue first) for cases
+   that do not fit the standard flow.
+
+The charter is referenced from the PR template, from `CONTRIBUTING.md`,
+and from ADR-0002. CODEOWNERS protects the charter itself
+(`CONTRIBUTING_AGENT.md` is Tier-owner per ADR-0002): future changes
+to the rules require maintainer review, not a drive-by edit.
+
+We deliberately do **not** add a "was AI used?" checkbox to the PR
+template. We tried that mentally and rejected it — false negatives are
+free and undetectable, and a checkbox normalizes the question rather
+than the conduct. The charter applies regardless of disclosure.
+
+## Consequences
+
+- **Easier:** maintainer review of AI-assisted PRs has a concrete
+  document to cite. Contributors who have not run the checklist can be
+  redirected without re-explaining the policy each time.
+- **Harder:** AI-assisted contributors must do real self-review work
+  before opening a PR — reading the diff, naming the anti-goal,
+  attesting verification. That is the point.
+- **Given up:** the implicit norm that "if CI is green, ship it."
+  Replaced with "if CI is green AND the contributor has done the
+  self-review AND the change matches the stated intent, ship it."
+- **Migration:** existing PRs in flight are not retroactively held to
+  the charter. New PRs opened after this ADR is merged are.
+
+## Alternatives considered
+
+- **Embed the charter inside `CONTRIBUTING.md`.** Rejected — dilutes
+  the existing guide, which is read primarily by first-time human
+  contributors. A separate, named document makes the AI-assisted case
+  a first-class concern.
+- **CI-enforce the charter (e.g. a workflow that requires checkboxes
+  to be ticked).** Rejected for now — easy to game, easy to false-tick.
+  The charter is a *trust contract*, not a *gate*. If a contributor
+  cannot be trusted to self-review honestly, no checkbox-counting
+  workflow will save the review.
+- **Restrict AI-assisted contributions entirely.** Rejected as
+  unenforceable and philosophically inconsistent with the project's
+  own thesis. The right move is to raise the bar on what an
+  AI-assisted PR must demonstrate before it merges, not to ban the
+  practice.

--- a/docs/adr/0004-zero-ai-slop-policy.md
+++ b/docs/adr/0004-zero-ai-slop-policy.md
@@ -1,0 +1,118 @@
+# 0004. Zero AI-slop policy — the 100% quality bar
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** @PurpleCHOIms
+- **Related:** [docs/QUALITY_BAR.md](../QUALITY_BAR.md), [CONTRIBUTING_AGENT.md](../../CONTRIBUTING_AGENT.md), [ADR-0003](0003-ai-contributor-self-review.md)
+
+## Context
+
+ADR-0003 introduced a self-review charter for AI-assisted
+contributions. After watching it in practice for a short stretch, the
+charter alone is not enough. It correctly raises the **process** bar
+("read the diff before pushing; do not bundle unrelated work") but
+leaves the **code** bar implicit. The result is that
+charter-compliant PRs still arrive with the visual fingerprints of
+AI generation: defensive overcoding, try/except wrappers around calls
+that should propagate, single-use helper functions, premature
+kwargs, vague test names, comments that translate the next line into
+English, em-dashes everywhere, and prose that reads as "leverages X
+to robustly handle Y in a comprehensive manner."
+
+These do not, on a single PR, break anything. Across hundreds of
+PRs they break the architecture by drift. They also break review:
+a reviewer cannot scan a 300-line AI-generated diff in 60 seconds the
+way they can scan a 50-line surgical diff written by someone who
+read the surrounding code first.
+
+The project's sole maintainer (`@PurpleCHOIms`) cannot afford that.
+"Passes CI" was never the bar — `docs/COWORK.md §4.5` and the
+existing CODEOWNERS strategy already say so. This ADR makes the bar
+**explicit, enumerated, and inescapable**.
+
+## Decision
+
+We adopt `docs/QUALITY_BAR.md` as the closed contract for what
+"100% quality" means for Decepticon. The bar:
+
+1. Restates the [Karpathy Four](../QUALITY_BAR.md#the-karpathy-four)
+   (Think Before Coding / Simplicity First / Surgical Changes /
+   Goal-Driven Execution) as the standing philosophy.
+2. Sets **hard diff-size limits** (≤ 400 runtime-code lines, ≤ 10
+   files, 1 logical concern per PR). Tests, docs, and configuration
+   do not count. Exceeding requires an `@PurpleCHOIms`-applied
+   `large-diff-approved` label.
+3. Enumerates **banned patterns** that close a PR on sight —
+   `except Exception: pass`, bare `# type: ignore`, mutable
+   defaults, wildcard imports, vague test names, mocked-system-under-test
+   tests, cosmetic drive-bys, etc.
+4. Enumerates **AI-slop signatures** with concrete code examples,
+   so neither a contributor nor an AI assistant generating their
+   work can plead ignorance.
+5. Enumerates **required positive patterns** — typed public APIs,
+   named exception classes, failing-then-passing test commits for
+   fixes, justified magic numbers, linked TODOs.
+6. Adds a **self-review standard** with binary questions: every "no"
+   means do not request review yet.
+7. Names exactly three escape valves: ADR, `large-diff-approved`
+   label, or a documented exception in the file itself (which is
+   itself ADR-gated).
+
+The bar is referenced from `CONTRIBUTING_AGENT.md`, from the PR
+template, and from `CONTRIBUTING.md`. It is CODEOWNERS-protected.
+
+We deliberately apply the same bar to human-written contributions.
+There is no "AI-slop tax." If a hand-written PR violates the bar,
+it is closed for the same reasons.
+
+## Consequences
+
+- **Easier:** review is fast. Reviewers can scan a PR against a
+  checklist and reject without writing long explanations — the
+  checklist *is* the explanation. Contributors (human or AI) know
+  the bar before they push.
+- **Easier:** rejecting low-quality PRs is no longer emotionally
+  expensive. The reviewer points at a specific banned pattern or
+  slop signature; the contributor knows what to fix.
+- **Harder:** the bar excludes a meaningful class of "good enough"
+  PRs that would have merged under a softer regime. We accept this
+  trade. A project with one owner and dozens of AI-driven PRs per
+  day cannot survive on "good enough."
+- **Harder:** AI-assisted contributors must materially edit AI
+  output before pushing — strip the defensive coding, delete the
+  helper-used-once, rename `data` to the thing it actually is. This
+  is *exactly* the work the bar exists to demand.
+- **Given up:** raw contribution velocity. We are explicitly choosing
+  fewer, better PRs over more, mediocre PRs. ADR-0002 already framed
+  the principle ("one well-designed feature properly > ten rushed
+  features"); ADR-0004 operationalizes it.
+- **Migration:** PRs open at the time this ADR merges are not
+  retroactively held to the bar. PRs opened after are.
+
+## Alternatives considered
+
+- **Soften ADR-0003 with examples instead of a separate bar.**
+  Rejected — ADR-0003 is a process document; the bar is a code
+  document. Mixing the two dilutes both.
+- **CI-enforce every banned pattern via linters / semgrep rules.**
+  Partial adoption (some patterns *are* in `.semgrep/decepticon-rules.yml`),
+  but rejected as a sole strategy: many slop signatures (vague test
+  names, premature kwargs, single-use helpers, comments that
+  translate the next line) are review-judgment calls. Pretending a
+  linter can enforce them leads to false confidence.
+- **Per-author quality tiers (e.g. "trusted human" gets a softer
+  bar).** Rejected — the bar is on the **code**, not the **author**.
+  An AI-generated PR that meets the bar is welcome; a human-written
+  PR that doesn't is not. Per-author tiering creates a political
+  surface this project does not need.
+- **Reject all AI-assisted PRs.** Rejected as unenforceable and
+  philosophically inconsistent with what Decepticon *is*. The right
+  move is to demand the assisting human do the work the assistant
+  cannot.
+
+## Operating note
+
+This ADR will look, in retrospect, either obviously correct or
+obviously over-tightened. If the latter, the response is to open
+ADR-NNNN that relaxes specific clauses with evidence — not to drift
+back to a softer norm in practice.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,5 +65,6 @@ Use [`template.md`](template.md) as the starting point.
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
 | [0002](0002-pr-tiering-and-blast-radius.md) | PR tiering by blast radius | Accepted |
 | [0003](0003-ai-contributor-self-review.md) | AI-assisted contribution self-review charter | Accepted |
+| [0004](0004-zero-ai-slop-policy.md) | Zero AI-slop policy — the 100% quality bar | Accepted |
 
 Keep this index in sync when you land a new ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,69 @@
+# Architecture Decision Records
+
+This directory contains the **Architecture Decision Records** (ADRs) for
+Decepticon — short, numbered, append-only documents that capture
+non-obvious architectural decisions, their context, and their
+consequences.
+
+## When to write one
+
+Write an ADR when the answer to "why is the code shaped this way?"
+needs to be available to a future maintainer (human or AI) who was not
+in the room when the decision was made. Concretely:
+
+- A trade-off between two viable designs where the loser is not
+  obviously bad (e.g. middleware composition order, sandbox transport
+  mechanism, C2 framework selection, prompt-cache boundary placement).
+- A constraint that the code relies on but does not test (e.g. an
+  invariant about which services share a Docker network).
+- A reversal of a previous decision — the old ADR is marked
+  `Superseded` and the new one explains why.
+- A policy that governs how the project is operated (e.g. the
+  blast-radius tiering used by CODEOWNERS, the AI-assisted contribution
+  charter).
+
+Do **not** write an ADR for:
+
+- Decisions that are obvious from reading the code.
+- Bug fixes that do not change architecture.
+- Style or formatting decisions (the project's lint config is the
+  source of truth).
+- Feature scoping (open an issue).
+
+## Format
+
+Each ADR follows the [Michael Nygard format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+
+1. **Title** — short, imperative, present tense.
+2. **Status** — `Proposed` / `Accepted` / `Deprecated` / `Superseded by ADR-NNNN`.
+3. **Context** — the forces at play; what makes this decision non-obvious.
+4. **Decision** — what we are doing.
+5. **Consequences** — what becomes easier, what becomes harder, what is
+   given up.
+6. **Alternatives considered** — the designs that lost, with one
+   sentence each on why.
+
+Use [`template.md`](template.md) as the starting point.
+
+## Lifecycle
+
+- Numbered sequentially, four digits, never renumbered: `0001-...`,
+  `0002-...`. The number is allocated when the PR opens; if your draft
+  PR sits for a while and another ADR lands first, renumber yours.
+- File name kebab-case, derived from the title: `0007-c2-framework-selection.md`.
+- Append-only. To change a decision, write a new ADR that supersedes
+  the old one; do not edit the old one except to flip its `Status` to
+  `Superseded by ADR-NNNN`.
+- ADRs are CODEOWNERS-gated (`docs/adr/**` requires owner review).
+  Proposed ADRs may be opened by any contributor; only an owner-approved
+  PR can land them at `Status: Accepted`.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-pr-tiering-and-blast-radius.md) | PR tiering by blast radius | Accepted |
+| [0003](0003-ai-contributor-self-review.md) | AI-assisted contribution self-review charter | Accepted |
+
+Keep this index in sync when you land a new ADR.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,34 @@
+# NNNN. Title in present-tense imperative
+
+- **Status:** Proposed | Accepted | Deprecated | Superseded by ADR-NNNN
+- **Date:** YYYY-MM-DD
+- **Deciders:** GitHub handles of people who agreed to the decision
+- **Related:** issue/PR/ADR links that this decision depends on or supersedes
+
+## Context
+
+What forces are at play? What makes this decision non-obvious? Two or
+three short paragraphs. Avoid restating background that is already in
+the linked docs — link instead.
+
+## Decision
+
+What are we doing? Stated affirmatively, in the present tense. Keep
+this section short; the reasoning lives in Context, the trade-offs in
+Consequences.
+
+## Consequences
+
+- **Easier:** what this decision unlocks.
+- **Harder:** what this decision constrains.
+- **Given up:** capabilities or flexibility we explicitly walk away from.
+- **Migration:** if applicable, what existing code/config has to change
+  and on what timeline.
+
+## Alternatives considered
+
+- **Option A:** one-line description. Rejected because …
+- **Option B:** one-line description. Rejected because …
+
+(Do not list options you did not actually consider. An ADR is a record,
+not a literature survey.)

--- a/tests/test_compose_network_isolation.py
+++ b/tests/test_compose_network_isolation.py
@@ -1,0 +1,310 @@
+"""Network-isolation invariants for ``docker-compose.yml``.
+
+These assertions encode the structural security boundaries that no
+single Semgrep / lint rule can catch. They run on the *rendered* compose
+file (``docker compose config``) so they validate the post-interpolation
+shape that actually starts on a contributor's host.
+
+Invariants
+----------
+
+1. **Operational services never join the management network.**
+   The Kali sandbox, the C2 framework, and the optional Ghidra MCP
+   sidecar are sandbox-net only. Adding any of them to
+   ``decepticon-net`` collapses the management/operational boundary
+   that the architecture is built around (see
+   ``docs/security/sandbox-isolation.md``).
+
+2. **No service uses host networking.** ``network_mode: host`` bypasses
+   both bridges and defeats the isolation entirely.
+
+3. **No service mounts the Docker socket.** The HTTP-only sandbox
+   migration removed ``/var/run/docker.sock`` from the LangGraph
+   service deliberately; reintroducing it would re-open a
+   container-escape path from a compromised orchestrator.
+
+4. **Every published port binds to 127.0.0.1.** Bare ``PORT:PORT``
+   (which docker resolves to ``0.0.0.0``) exposes internal services to
+   the contributor's LAN. The existing compose already follows this
+   convention; the test fences it.
+
+5. **Dual-homed services are explicitly allowlisted.** Today
+   ``neo4j`` and ``langgraph`` are intentionally on both networks.
+   Adding a third forces an explicit update to ``DUAL_HOMED_SERVICES``
+   below, which is what we want — silent additions are how an
+   isolation boundary erodes.
+
+If you are extending the compose file and one of these assertions
+fires, the message points at the invariant being violated and what to
+update. **Do not** weaken the test to make a change land; either fix
+the compose, or open an ADR that supersedes the invariant.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+MGMT_NET = "decepticon-net"
+SANDBOX_NET = "sandbox-net"
+
+# Services that MUST NOT touch the management network under any
+# circumstance. These are the services that execute against external
+# targets or expose adversary-tooling interfaces.
+OPERATIONAL_ONLY: frozenset[str] = frozenset(
+    {
+        "sandbox",
+        "c2-sliver",
+        "ghidra-mcp",
+    }
+)
+
+# The only services permitted on BOTH networks. Adding a third
+# requires an ADR + a deliberate update here. See
+# docs/adr/0002-pr-tiering-and-blast-radius.md.
+DUAL_HOMED_SERVICES: frozenset[str] = frozenset(
+    {
+        "neo4j",
+        "langgraph",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_dotenv():
+    """``docker compose config`` needs a .env to satisfy env_file refs."""
+    env_file = REPO_ROOT / ".env"
+    created = False
+    if not env_file.exists():
+        env_file.write_text("")
+        created = True
+    yield
+    if created:
+        env_file.unlink(missing_ok=True)
+
+
+def _rendered_compose() -> dict:
+    """Return the post-interpolation compose document as a dict.
+
+    Uses ``--profiles`` so that profile-gated services
+    (c2-sliver, ghidra-mcp, cli) are present in the render and
+    therefore subject to the same invariants as the always-on
+    services.
+    """
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI not available")
+    env = {
+        **os.environ,
+        # COMPOSE_PROFILES enables every profile in the file so the
+        # render sees every service. The list mirrors the profiles
+        # defined in docker-compose.yml; extend here when a new
+        # profile is added.
+        "COMPOSE_PROFILES": "c2-sliver,reversing,cli",
+    }
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE), "config"],
+        env=env,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "docker compose config failed (exit "
+            f"{result.returncode}):\n"
+            f"--- stderr ---\n{result.stderr}\n"
+            f"--- stdout ---\n{result.stdout}"
+        )
+    rendered = yaml.safe_load(result.stdout)
+    if not isinstance(rendered, dict) or "services" not in rendered:
+        pytest.fail(f"rendered compose has no `services` key:\n{result.stdout[:500]}")
+    return rendered
+
+
+def _service_networks(service: dict) -> set[str]:
+    """Return the set of network names a service is attached to.
+
+    Compose ``networks:`` may be a list (``[a, b]``) or a mapping
+    (``{a: null, b: {aliases: ...}}``). Both shapes mean
+    membership.
+    """
+    nets = service.get("networks")
+    if nets is None:
+        return set()
+    if isinstance(nets, list):
+        return set(nets)
+    if isinstance(nets, dict):
+        return set(nets.keys())
+    return set()
+
+
+def _service_volumes(service: dict) -> list[str]:
+    """Return source paths of all volume mounts as plain strings."""
+    raw = service.get("volumes") or []
+    out: list[str] = []
+    for v in raw:
+        if isinstance(v, str):
+            out.append(v.split(":", 1)[0])
+        elif isinstance(v, dict):
+            src = v.get("source")
+            if src:
+                out.append(str(src))
+    return out
+
+
+def test_operational_services_never_on_management_network():
+    """sandbox, c2-sliver, ghidra-mcp must never appear on decepticon-net.
+
+    A regression here collapses the management/operational boundary —
+    a compromised target-facing container would gain a path to LiteLLM
+    keys, the Postgres engagement log, and the Web dashboard.
+    """
+    services = _rendered_compose()["services"]
+    violations: list[str] = []
+    for name in OPERATIONAL_ONLY:
+        svc = services.get(name)
+        if svc is None:
+            # The service is conditional (profile-gated); if it is
+            # absent we cannot validate it. The render above enables
+            # every known profile, so absence here means the service
+            # was removed entirely — record so an intentional removal
+            # forces a test update too.
+            continue
+        nets = _service_networks(svc)
+        if MGMT_NET in nets:
+            violations.append(f"service '{name}' is on '{MGMT_NET}' but must be sandbox-only")
+    assert not violations, (
+        "operational/management network boundary violated:\n  "
+        + "\n  ".join(violations)
+        + "\n\nFix: remove the management-network membership, or open an "
+        "ADR that supersedes docs/security/sandbox-isolation.md."
+    )
+
+
+def test_no_service_uses_host_networking():
+    """``network_mode: host`` bypasses both bridges entirely."""
+    services = _rendered_compose()["services"]
+    violations = [name for name, svc in services.items() if svc.get("network_mode") == "host"]
+    assert not violations, (
+        "services with network_mode: host (forbidden): "
+        f"{sorted(violations)}\n"
+        "Fix: attach the service to an explicit bridge network."
+    )
+
+
+def test_no_service_mounts_docker_socket():
+    """``/var/run/docker.sock`` was removed deliberately.
+
+    The HTTP-only sandbox migration replaced ``docker exec`` with a
+    FastAPI daemon on port 9999 inside the sandbox container. Mounting
+    the docker socket anywhere reintroduces a container-escape path —
+    a compromised process inside the mounted container can spawn or
+    modify peer containers, including the management plane.
+    """
+    services = _rendered_compose()["services"]
+    violations: list[str] = []
+    for name, svc in services.items():
+        for src in _service_volumes(svc):
+            if "docker.sock" in src:
+                violations.append(f"{name}: {src}")
+    assert not violations, (
+        "services mounting docker.sock (forbidden):\n  "
+        + "\n  ".join(violations)
+        + "\n\nFix: use the sandbox HTTP daemon (port 9999) instead "
+        "of docker exec. See packages/decepticon/decepticon/backends/."
+    )
+
+
+def test_published_ports_bind_to_loopback():
+    """Every published port must bind to 127.0.0.1, not 0.0.0.0.
+
+    A bare ``"PORT:PORT"`` resolves to ``0.0.0.0:PORT`` on the host,
+    exposing the service to every machine on the contributor's LAN.
+    For a developer laptop on a hotel / coffee-shop / coworking
+    network, this is an immediate exposure of LiteLLM keys, the Neo4j
+    knowledge graph, and any sandbox state.
+    """
+    services = _rendered_compose()["services"]
+    violations: list[str] = []
+    for name, svc in services.items():
+        for entry in svc.get("ports") or []:
+            host_ip: str | None = None
+            published: str | None = None
+            if isinstance(entry, str):
+                # Short form rendered by ``compose config`` is usually
+                # already expanded to ``IP:PUBLISHED:TARGET``. Split
+                # on ':' from the right: TARGET is the rightmost
+                # field, PUBLISHED next, IP if present is the rest.
+                parts = entry.split(":")
+                if len(parts) == 3:
+                    host_ip, published, _ = parts
+                elif len(parts) == 2:
+                    published, _ = parts
+                else:
+                    published = parts[0]
+            elif isinstance(entry, dict):
+                host_ip = entry.get("host_ip")
+                published = str(entry["published"]) if entry.get("published") is not None else None
+            if published is None:
+                # Random host port (target only) — fine, docker still
+                # binds to 0.0.0.0 but the port is unguessable. Skip.
+                continue
+            if host_ip not in ("127.0.0.1", "::1"):
+                violations.append(f"{name}: publishes {entry!r} without 127.0.0.1 bind")
+    assert not violations, (
+        "services with non-loopback port bindings:\n  "
+        + "\n  ".join(violations)
+        + "\n\nFix: prefix the port mapping with '127.0.0.1:' "
+        '(e.g. "127.0.0.1:${PORT:-X}:X").'
+    )
+
+
+def test_dual_homed_services_are_allowlisted():
+    """A service on both networks must be in DUAL_HOMED_SERVICES.
+
+    This is the bridge surface — the path between the management and
+    operational networks. Today neo4j (for graph reads from
+    management) and langgraph (for HTTP sandbox transport from
+    management) are the only allowed bridges. A third introduces a
+    new place where prompt-injection or process compromise can pivot
+    across the boundary.
+
+    Adding to DUAL_HOMED_SERVICES requires an ADR + maintainer review
+    (docs/adr/** is CODEOWNERS-gated).
+    """
+    services = _rendered_compose()["services"]
+    actual_dual_homed: set[str] = set()
+    for name, svc in services.items():
+        nets = _service_networks(svc)
+        if MGMT_NET in nets and SANDBOX_NET in nets:
+            actual_dual_homed.add(name)
+    unexpected = actual_dual_homed - DUAL_HOMED_SERVICES
+    missing = DUAL_HOMED_SERVICES - actual_dual_homed
+    msgs: list[str] = []
+    if unexpected:
+        msgs.append(
+            "services on BOTH networks but not allowlisted: "
+            f"{sorted(unexpected)}.\n"
+            "Either remove the dual membership or, if it is required, "
+            "open an ADR superseding the current isolation invariant "
+            "and add the service name to DUAL_HOMED_SERVICES in this "
+            "test."
+        )
+    if missing:
+        msgs.append(
+            "allowlisted dual-homed services no longer present on "
+            f"both networks: {sorted(missing)}.\n"
+            "If the architecture intentionally changed, remove the "
+            "name from DUAL_HOMED_SERVICES; otherwise restore the "
+            "missing network membership."
+        )
+    assert not msgs, "\n\n".join(msgs)


### PR DESCRIPTION
## Summary

Layers governance pieces on top of the existing CODEOWNERS / COWORK.md / pre-commit / Semgrep stack so an AI-heavy contribution stream can be reviewed at scale without diluting the quality bar for security-critical surfaces.

## Changes

- **`CONTRIBUTING_AGENT.md`** (new) — charter for AI-assisted contributions. Restates the existing rule that the human is the author-of-record (per `docs/COWORK.md §4.5` on AI co-author trailers) and adds a concrete self-review checklist covering intent, scope, blast-radius classification, verification, and honesty.
- **`docs/adr/`** (new) — numbered, append-only ADR system in the Michael Nygard format. CODEOWNERS-gated. Ships with three ADRs that record the system itself, the existing blast-radius tiering, and the AI charter — so the policy decisions in this PR have stable, citable IDs.
- **`tests/test_compose_network_isolation.py`** (new) — pytest enforcing five `docker-compose.yml` invariants that no Semgrep / lint rule can catch:
  1. Operational services (`sandbox`, `c2-sliver`, `ghidra-mcp`) never join `decepticon-net`.
  2. No service uses `network_mode: host`.
  3. No service mounts `/var/run/docker.sock` (the HTTP-only sandbox migration removed this deliberately).
  4. Every published port binds to `127.0.0.1`.
  5. Dual-homed services (today `neo4j` and `langgraph`) are explicitly allowlisted — adding a third forces an ADR + a test update, which is the point.
- **`.github/pull_request_template.md`** — expanded from 22 lines to include `Intent` (issue / ADR + anti-goal), `Blast radius` (self-classification with explicit Tier-owner justification), and `AI-assisted contribution attestation` sections. Keeps the existing Summary / Changes / Testing / Related Issues sections.
- **`.github/CODEOWNERS`** — adds Tier-owner protection for `.semgrep/**`, `SECURITY.md`, `docs/security/**`, `docs/COWORK.md`, `docs/adr/**`, `CONTRIBUTING_AGENT.md`, and the PR template itself. Closes the gap `docs/COWORK.md §7` acknowledged ("indirectly protected").
- **`CONTRIBUTING.md`** — small additions pointing to `CONTRIBUTING_AGENT.md` and `docs/adr/`.

## Intent

- **Issue / ADR this satisfies:** Conversation with @PurpleCHOIms about scaling code review and review-bandwidth under AI-heavy contribution volume. Codified into ADR-0001, ADR-0002, ADR-0003 in this PR.
- **Anti-goal:** This PR adds no auto-labeler workflow, no CI-enforced checkbox counter, no per-author trust tiering, and no LLM-as-reviewer step. Those are deliberately deferred — auto-labeling needs careful permissions design (`pull_request_target` is a footgun), and CI-enforced charter compliance is gameable. The charter is a trust contract, not a gate.

## Blast radius

- [ ] Tier-auto
- [ ] Tier-delegate
- [x] **Tier-owner** — modifies `.github/CODEOWNERS`, the PR template, `CONTRIBUTING.md`, and adds new files under `docs/adr/**`, `.semgrep`-class governance paths (`CONTRIBUTING_AGENT.md`), and `docs/security`-adjacent policy.

**Why this needs an owner change:** Three of the modified paths (CODEOWNERS, PR template, CONTRIBUTING.md) and four of the new paths (CONTRIBUTING_AGENT.md, the three ADRs) are policy surfaces — they change the rules every other contributor will be held to. Per ADR-0002 (added in this PR), that is exactly the case for Tier-owner.

## Testing

- [x] `pytest tests/` — all 7 tests pass (5 new + 2 existing) against the current `docker-compose.yml`. Output:
  ```
  tests/test_compose_langgraph_command.py::test_default_command_includes_allow_blocking PASSED
  tests/test_compose_langgraph_command.py::test_strict_async_removes_allow_blocking PASSED
  tests/test_compose_network_isolation.py::test_operational_services_never_on_management_network PASSED
  tests/test_compose_network_isolation.py::test_no_service_uses_host_networking PASSED
  tests/test_compose_network_isolation.py::test_no_service_mounts_docker_socket PASSED
  tests/test_compose_network_isolation.py::test_published_ports_bind_to_loopback PASSED
  tests/test_compose_network_isolation.py::test_dual_homed_services_are_allowlisted PASSED
  ============================== 7 passed in 1.35s ===============================
  ```
- [x] **Fault-injection sanity** — each invariant was confirmed to *fire* on a mutated compose:
  - Adding `sandbox` to `decepticon-net` → operational-on-mgmt assertion catches it
  - Setting `network_mode: host` on any service → host-networking assertion catches it
  - Mounting `/var/run/docker.sock` → docker-sock-mount assertion catches it
  - Publishing a bare `4000:4000` port → non-loopback assertion catches it
  - Adding a third service to both networks → dual-homed allowlist assertion catches it
- [x] `uvx ruff check` and `uvx ruff format --check` clean on the new test file (pinned to the `v0.15.14` version `.pre-commit-config.yaml` uses).
- [x] `markdownlint-cli2` clean on all 8 changed/new markdown files.
- [ ] `make quality` / `make smoke` not run locally — no Python runtime code is changed; CI is authoritative.

## Related Issues

None directly. Builds on:
- `docs/COWORK.md` §4.3 (CODEOWNERS-protected paths) — formalized as ADR-0002.
- `docs/COWORK.md` §4.5 (AI co-author trailer rejection) — now visible from the AI-contributor entry point as well, via `CONTRIBUTING_AGENT.md`.
- `docs/COWORK.md` §7 ("This file is `.github/CODEOWNERS`-protected indirectly…") — now actually directly protected.

## AI-assisted contribution attestation

This PR was produced with assistance from an AI coding agent. Per `CONTRIBUTING_AGENT.md` (added in this PR — the author-of-record is also the first contributor it applies to):

- The diff was read in full before pushing; every line is defensible.
- The testing claims above are facts, not aspirations — outputs were captured from real runs against the working tree.
- No unrelated work bundled. No runtime code, public API, or dependency changes.
- No weakening of any RoE / SafeCommand / EngagementContext / OPSEC skill / Semgrep rule / compose isolation / capability or resource limit.
