### PR TITLE
feat(kg): rewrite Slither ingest on KGStore + 6 trap fixes

### DIFF
--- a/containers/skillogy.Dockerfile
+++ b/containers/skillogy.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
 # top level so ``python -m decepticon.skillogy`` works without the rest
 # of the decepticon framework being present.
 COPY packages/decepticon/decepticon/skillogy ./decepticon/skillogy
+COPY packages/decepticon/decepticon/skill_audit ./decepticon/skill_audit
 
 # CI-built graph dump. The builder emits MERGE-only Cypher so re-runs
 # against an already-loaded Neo4j are idempotent — the boot script

--- a/packages/decepticon/decepticon/tools/contracts/slither.py
+++ b/packages/decepticon/decepticon/tools/contracts/slither.py
@@ -1,31 +1,69 @@
-"""Slither JSON → KnowledgeGraph ingestion.
+"""Slither ``--json`` → KGStore observations (engagement-scoped).
 
 Slither (https://github.com/crytic/slither) is the de-facto Solidity
-static analyser. Its ``--json -`` output contains a ``results.detectors``
-array of structured findings that we lift into the graph alongside
-pattern-scanner output and SARIF from other tools.
+static analyser. Its ``--json -`` output carries a
+``results.detectors`` array of structured findings (~85 detectors
+across 5 impact tiers). This module parses that payload, builds
+observation dicts conforming to :meth:`KGStore.record_observations`,
+and writes them in a single atomic batch.
 
-This module is pure parsing — the agent calls Slither via bash, saves
-JSON to the sandbox, then invokes ``ingest_slither_json``.
+Compared to the legacy ``KnowledgeGraph`` -based ingest this replaces,
+the rewrite addresses six of the load-bearing traps catalogued in
+``docs/design/2026-06-04-slither-kgstore-mapping.md`` §2.6:
+
+  1. **Same vuln, multiple elements** — one finding can list N
+     elements (a reentrancy spans the call site + storage write +
+     function). The legacy ingest only kept the first element. We
+     now emit one ``Vulnerability`` node + N ``AFFECTS`` edges, one
+     per element.
+  2. **Stable detector id used as the dedup key** — Slither emits a
+     SHA3-256 hash over the element descriptions per finding that is
+     stable across reruns of the same source. The legacy ingest
+     keyed on ``check::file::line`` (which churned when the file
+     gained a blank line above the finding); we now use the Slither
+     hash directly so re-ingest is idempotent.
+  3. **Recursive parent walk** — ``element.type_specific_fields.parent``
+     nests arbitrarily (node → function → contract). The legacy code
+     looked one level deep only; we recurse until ``type=="contract"``
+     so the owning contract is correctly identified.
+  4. **``lines`` is a list of individual line numbers** — not a
+     ``[start, end]`` range. Iterating it as a range silently misses
+     multi-line functions with gaps. We preserve the raw list as the
+     ``lines`` prop on the source-mapped node.
+  5. **Optimization impact normalised** — some Slither versions emit
+     ``Optimization`` lowercased in JSON. We normalise via
+     ``str.title()`` before mapping to severity.
+  6. **``success=False`` short-circuit + ``upgradeability-check``
+     skip** — a failed Slither run carries an ``error`` string and
+     no detector data; the upgradeability-check block lives parallel
+     to ``detectors`` with a different (proxy/impl diff) schema. We
+     never partial-ingest from a failed run, and we never feed the
+     upgradeability block through the detector pipeline.
+
+NodeKind values **stay on the legacy generic family** (Contract,
+SourceFile, Vulnerability, CodeLocation) so the existing contract-
+auditor tools and prompts keep working through the
+``_state`` / ``kg_adapter`` reading path. The Solidity-specific kinds
+added in V003 (Function / StateVar / Event / CustomError / Enum /
+Struct / Pragma) are reserved for a dedicated follow-up PR that
+re-emits each non-contract element with its proper label and
+migrates the analysis side in lockstep — see the Slither RFC for
+the plan.
 """
 
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from decepticon_core.types.kg import (
-    Edge,
-    EdgeKind,
-    KnowledgeGraph,
-    Node,
-    NodeKind,
-    Severity,
-)
+from decepticon.middleware.kg_internal.store import KGStore
+from decepticon_core.types.kg import EdgeKind, NodeKind, Severity
 from decepticon_core.utils.logging import get_logger
 
 log = get_logger("contracts.slither")
+
 
 _IMPACT_TO_SEVERITY: dict[str, Severity] = {
     "High": Severity.HIGH,
@@ -36,93 +74,420 @@ _IMPACT_TO_SEVERITY: dict[str, Severity] = {
 }
 
 
-def ingest_slither_json(data: str | dict[str, Any], graph: KnowledgeGraph) -> int:
-    """Merge a Slither JSON output into ``graph``.
+# Element types Slither emits in ``finding.elements[]``. Mapped to a
+# KGStore node ``kind`` (legacy family for opt-F point) plus a
+# semantic ``element_type`` prop so downstream queries can still
+# distinguish a function from a state variable without a new label.
+_ELEMENT_KIND_MAP: dict[str, NodeKind] = {
+    "contract": NodeKind.CONTRACT,
+    "function": NodeKind.CODE_LOCATION,
+    "variable": NodeKind.CODE_LOCATION,
+    "node": NodeKind.CODE_LOCATION,
+    "pragma": NodeKind.CODE_LOCATION,
+    "event": NodeKind.CODE_LOCATION,
+    "custom_error": NodeKind.CODE_LOCATION,
+    "enum": NodeKind.CODE_LOCATION,
+    "struct": NodeKind.CODE_LOCATION,
+    "modifier": NodeKind.CODE_LOCATION,
+    "file": NodeKind.SOURCE_FILE,
+}
 
-    ``data`` may be a JSON string or a pre-parsed dict. Returns the count
-    of ingested detector results.
+
+@dataclass
+class _IngestState:
+    """Observation accumulator.
+
+    Mutated in place by per-finding helpers; flushed in a single
+    ``record_observations`` call when the parse finishes.
+    """
+
+    obs_by_key: dict[str, dict[str, Any]] = field(default_factory=dict)
+    finding_count: int = 0
+    edge_count: int = 0
+
+    def upsert_observation(
+        self,
+        *,
+        kind: NodeKind,
+        key: str,
+        label: str,
+        props: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        existing = self.obs_by_key.get(key)
+        if existing is None:
+            obs: dict[str, Any] = {
+                "kind": kind.value,
+                "key": key,
+                "label": label,
+                "props": {k: v for k, v in (props or {}).items() if v is not None},
+                "edges_out": [],
+            }
+            self.obs_by_key[key] = obs
+            return obs
+        if props:
+            existing.setdefault("props", {}).update(
+                {k: v for k, v in props.items() if v is not None}
+            )
+        if label and not existing.get("label"):
+            existing["label"] = label
+        return existing
+
+    def add_edge(
+        self,
+        *,
+        src_key: str,
+        dst_key: str,
+        kind: EdgeKind,
+        props: dict[str, Any] | None = None,
+    ) -> None:
+        src_obs = self.obs_by_key.get(src_key)
+        if src_obs is None:
+            return
+        src_obs.setdefault("edges_out", []).append(
+            {
+                "to_key": dst_key,
+                "kind": kind.value,
+                "weight": 1.0,
+                "props": props or {},
+            }
+        )
+        self.edge_count += 1
+
+
+# ── Key builders ────────────────────────────────────────────────────
+
+
+def _vuln_key(check: str, slither_id: str) -> str:
+    """Slither's per-finding ``id`` is a stable sha3-256 hash; we
+    prefix with ``slither::vuln::{check}::`` to keep human-readable
+    scanning of the graph easy."""
+    return f"slither::vuln::{check}::{slither_id}"
+
+
+def _file_key(filename_relative: str) -> str:
+    return f"slither::file::{filename_relative}"
+
+
+def _element_key(element_type: str, filename: str, name: str, src_start: Any) -> str:
+    """Element keys are composed of (element_type, filename, name) so
+    the same function across re-ingest dedups to one node; we also
+    fold the source ``start`` offset for elements that share a name
+    across overload (e.g. constructor overload arms)."""
+    return f"slither::el::{element_type}::{filename}::{name}::{src_start}"
+
+
+# ── Element walker ──────────────────────────────────────────────────
+
+
+def _walk_parent_to_contract(element: dict[str, Any]) -> str | None:
+    """Recurse through ``type_specific_fields.parent`` until a contract
+    is found. Returns the contract name, or ``None`` if the chain
+    never lands on a contract (pragma / file elements legitimately
+    have no contract context)."""
+    type_specific = element.get("type_specific_fields")
+    if not isinstance(type_specific, dict):
+        return None
+    parent = type_specific.get("parent")
+    while isinstance(parent, dict):
+        if parent.get("type") == "contract":
+            name = parent.get("name")
+            return name if isinstance(name, str) else None
+        nested = parent.get("type_specific_fields")
+        if not isinstance(nested, dict):
+            return None
+        parent = nested.get("parent")
+    return None
+
+
+def _ingest_element(
+    state: _IngestState,
+    *,
+    element: dict[str, Any],
+    vuln_key: str,
+) -> None:
+    """Emit a node for one ``finding.elements[i]`` + an ``AFFECTS``
+    edge from the vuln. Returns silently when the element has no
+    recognisable type or source mapping."""
+    element_type = element.get("type")
+    if not isinstance(element_type, str):
+        return
+    kind = _ELEMENT_KIND_MAP.get(element_type, NodeKind.CODE_LOCATION)
+    source_mapping = element.get("source_mapping")
+    source_mapping = source_mapping if isinstance(source_mapping, dict) else {}
+
+    # Trap 3: prefer ``filename_relative`` over absolute / used /
+    # short. Absolute leaks host fs into engagement-scoped data;
+    # filename_used may be IDE-normalised.
+    filename = (
+        source_mapping.get("filename_relative")
+        or source_mapping.get("filename_short")
+        or source_mapping.get("filename_used")
+        or source_mapping.get("filename_absolute")
+        or ""
+    )
+    if not isinstance(filename, str):
+        filename = ""
+
+    name = element.get("name")
+    name = name if isinstance(name, str) else ""
+    src_start = source_mapping.get("start")
+
+    # Pragmas attach directly to a SourceFile; everything else
+    # carries a parent_contract derived by walking the parent chain.
+    parent_contract = _walk_parent_to_contract(element)
+
+    type_specific = element.get("type_specific_fields")
+    type_specific = type_specific if isinstance(type_specific, dict) else {}
+    signature = type_specific.get("signature")
+    directive = type_specific.get("directive")
+
+    # ``lines`` is a list of individual numbers, not a range — see
+    # trap 4. We store the raw list and a convenience ``first_line``
+    # so the analyst can sort without re-parsing.
+    lines = source_mapping.get("lines")
+    lines = lines if isinstance(lines, list) else []
+    first_line = lines[0] if lines else None
+
+    if element_type == "file":
+        # ``file`` elements describe the SourceFile itself; reuse the
+        # file key so the AFFECTS edge lands on the canonical node.
+        if not filename:
+            return
+        key = _file_key(filename)
+        label = filename
+        props: dict[str, Any] = {
+            "element_type": element_type,
+            "path": filename,
+        }
+    else:
+        key = _element_key(element_type, filename, name, src_start)
+        label = (
+            signature
+            if isinstance(signature, str) and signature
+            else f"{element_type}:{name}"
+            if name
+            else element_type
+        )
+        props = {
+            "element_type": element_type,
+            "name": name or None,
+            "signature": signature if isinstance(signature, str) else None,
+            "directive": directive if isinstance(directive, str) else None,
+            "filename": filename or None,
+            "parent_contract": parent_contract,
+            "lines": lines or None,
+            "first_line": first_line,
+            "src_start": src_start,
+            "src_length": source_mapping.get("length"),
+        }
+
+    state.upsert_observation(kind=kind, key=key, label=label, props=props)
+
+    # Vuln -[AFFECTS]-> element
+    state.add_edge(
+        src_key=vuln_key,
+        dst_key=key,
+        kind=EdgeKind.AFFECTS,
+        props={"element_type": element_type},
+    )
+
+    # Element -[CONTAINED_IN]-> SourceFile (filename-bearing only)
+    if filename and element_type != "file":
+        file_key = _file_key(filename)
+        state.upsert_observation(
+            kind=NodeKind.SOURCE_FILE,
+            key=file_key,
+            label=filename,
+            props={"path": filename, "element_type": "file"},
+        )
+        state.add_edge(
+            src_key=key,
+            dst_key=file_key,
+            kind=EdgeKind.DEFINED_IN,
+            props={"reason": "source_file"},
+        )
+
+    # Function / variable / event / ... -[DEFINED_IN]-> contract
+    if parent_contract and element_type not in {"contract", "file", "pragma"}:
+        contract_key = _element_key("contract", filename, parent_contract, None)
+        state.upsert_observation(
+            kind=NodeKind.CONTRACT,
+            key=contract_key,
+            label=parent_contract,
+            props={
+                "element_type": "contract",
+                "name": parent_contract,
+                "filename": filename or None,
+            },
+        )
+        state.add_edge(
+            src_key=key,
+            dst_key=contract_key,
+            kind=EdgeKind.DEFINED_IN,
+            props={"reason": "owning_contract"},
+        )
+
+
+# ── Finding-level ingest ────────────────────────────────────────────
+
+
+def _ingest_finding(state: _IngestState, finding: dict[str, Any]) -> None:
+    check = finding.get("check") or "unknown"
+    if not isinstance(check, str):
+        return
+
+    # Slither's stable per-finding id (sha3-256 over element
+    # descriptions). The upstream schema has emitted this for every
+    # finding since 2020; fail-fast if it is missing so the operator
+    # can pin a Slither version that does emit it instead of silently
+    # creating churning Vulnerability nodes on every re-ingest.
+    slither_id = finding.get("id")
+    if not isinstance(slither_id, str) or not slither_id:
+        raise ValueError(
+            f"slither finding for check={check!r} is missing the stable 'id' field; "
+            "upgrade slither to a version that emits per-finding sha3-256 ids "
+            "(any release since 2020)."
+        )
+
+    raw_impact = finding.get("impact") or "Medium"
+    if isinstance(raw_impact, str):
+        # Trap 5: some Slither builds emit ``optimization`` lowercased.
+        normalized_impact = raw_impact.title() if raw_impact else "Medium"
+    else:
+        normalized_impact = "Medium"
+    severity = _IMPACT_TO_SEVERITY.get(normalized_impact, Severity.MEDIUM)
+    confidence = finding.get("confidence") or "Medium"
+    description = finding.get("description") or ""
+    markdown = finding.get("markdown") or ""
+    first_md_el = finding.get("first_markdown_element") or ""
+
+    # Single source of truth for the finding's key.
+    vuln_key = _vuln_key(check, slither_id)
+
+    # First-line description as a human-readable suffix on the label.
+    first_line = description.strip().splitlines()[0][:80] if description else check
+    label = f"[slither:{check}] {first_line}"
+
+    additional_fields = finding.get("additional_fields")
+    additional_fields = additional_fields if isinstance(additional_fields, dict) else {}
+
+    state.upsert_observation(
+        kind=NodeKind.VULNERABILITY,
+        key=vuln_key,
+        label=label,
+        props={
+            "scanner": "slither",
+            "rule_id": check,
+            "slither_id": slither_id,
+            "severity": severity.value,
+            "impact": normalized_impact,
+            "confidence": confidence,
+            "description": description,
+            "markdown": markdown[:2000],
+            "first_markdown_element": first_md_el,
+            "additional_fields": (
+                json.dumps(additional_fields, default=str) if additional_fields else None
+            ),
+        },
+    )
+    state.finding_count += 1
+
+    # Trap 1: emit one observation per element instead of collapsing
+    # onto the first one. Each element becomes an ``AFFECTS`` edge.
+    elements = finding.get("elements") or []
+    if isinstance(elements, list):
+        for element in elements:
+            if isinstance(element, dict):
+                _ingest_element(state, element=element, vuln_key=vuln_key)
+
+
+# ── Public API ──────────────────────────────────────────────────────
+
+
+def ingest_slither_json(
+    data: str | dict[str, Any],
+    *,
+    engagement: str,
+    store: KGStore | None = None,
+    source_episode_id: str = "slither_ingest",
+) -> int:
+    """Merge one Slither ``--json`` payload into the engagement KG.
+
+    Returns the count of detector findings successfully ingested.
+    Short-circuits to 0 when Slither reports ``success=false`` — a
+    failed run does not partial-ingest.
     """
     if isinstance(data, str):
         try:
             payload = json.loads(data)
-        except json.JSONDecodeError as e:
-            log.warning("slither json parse failed: %s", e)
+        except json.JSONDecodeError as exc:
+            log.warning("slither json parse failed: %s", exc)
             return 0
     else:
         payload = data
 
-    results = (
-        payload.get("results", {}).get("detectors")
-        if isinstance(payload.get("results"), dict)
-        else None
-    )
-    if not results:
+    if not isinstance(payload, dict):
         return 0
 
-    count = 0
-    for det in results:
-        check = det.get("check") or "unknown"
-        impact = det.get("impact", "Medium")
-        confidence = det.get("confidence", "Medium")
-        description = det.get("description") or ""
-        markdown = det.get("markdown") or ""
-        severity = _IMPACT_TO_SEVERITY.get(impact, Severity.MEDIUM)
+    # Trap 6: ``success=false`` carries no detector data. Refuse to
+    # partial-ingest from a failed run.
+    if payload.get("success") is False:
+        log.warning(
+            "slither run reported success=false; skipping ingest: %s",
+            payload.get("error"),
+        )
+        return 0
 
-        # Walk elements to extract (file, line) tuples
-        elements = det.get("elements") or []
-        file_path: str | None = None
-        line: int | None = None
-        for el in elements:
-            src = el.get("source_mapping") or {}
-            if src.get("filename_relative") or src.get("filename_absolute"):
-                file_path = src.get("filename_relative") or src.get("filename_absolute")
-                lines = src.get("lines") or []
-                if lines:
-                    line = lines[0]
-                break
+    results = payload.get("results")
+    results = results if isinstance(results, dict) else {}
+    # ``upgradeability-check`` lives parallel to ``detectors`` with a
+    # different schema; do NOT feed it through the detector pipeline.
+    detectors = results.get("detectors")
+    if not isinstance(detectors, list) or not detectors:
+        return 0
 
-        key = f"slither::{check}::{file_path}::{line}"
-        label = f"[slither:{check}] {description.strip().splitlines()[0][:80] if description else check}"
-        vuln_props: dict[str, Any] = {
-            "key": key,
-            "scanner": "slither",
-            "rule_id": check,
-            "severity": severity.value,
-            "confidence": confidence,
-            "description": description,
-            "markdown": markdown[:2000],
-            "file": file_path,
-            "line": line,
-        }
-        vuln = Node.make(NodeKind.VULNERABILITY, label, **vuln_props)
-        graph.upsert_node(vuln)
+    state = _IngestState()
+    for finding in detectors:
+        if isinstance(finding, dict):
+            _ingest_finding(state, finding)
 
-        if file_path:
-            loc_label = f"{file_path}:{line}" if line else file_path
-            loc = Node.make(
-                NodeKind.CODE_LOCATION,
-                loc_label,
-                key=f"{file_path}::{line}",
-                file=file_path,
-                start_line=line,
-            )
-            graph.upsert_node(loc)
-            graph.upsert_edge(Edge.make(vuln.id, loc.id, EdgeKind.DEFINED_IN))
-            file_node = Node.make(NodeKind.SOURCE_FILE, file_path, key=file_path)
-            graph.upsert_node(file_node)
-            graph.upsert_edge(Edge.make(loc.id, file_node.id, EdgeKind.DEFINED_IN))
+    observations = list(state.obs_by_key.values())
+    if not observations:
+        return 0
 
-        count += 1
+    owned_store = store is None
+    target_store = store if store is not None else KGStore.from_env()
+    try:
+        target_store.record_observations(
+            observations,
+            engagement=engagement,
+            created_by="slither_ingest",
+            source_episode_id=source_episode_id,
+        )
+    finally:
+        if owned_store:
+            target_store.close()
 
-    return count
+    return state.finding_count
 
 
-def ingest_slither_file(path: str | Path, graph: KnowledgeGraph) -> int:
+def ingest_slither_file(
+    path: str | Path,
+    *,
+    engagement: str,
+    store: KGStore | None = None,
+    source_episode_id: str = "slither_ingest",
+) -> int:
     """Convenience wrapper: read JSON from disk and ingest."""
     p = Path(path)
     try:
         data = p.read_text(encoding="utf-8")
-    except OSError as e:
-        log.warning("slither file read failed: %s", e)
+    except OSError as exc:
+        log.warning("slither file read failed: %s", exc)
         return 0
-    return ingest_slither_json(data, graph)
+    return ingest_slither_json(
+        data,
+        engagement=engagement,
+        store=store,
+        source_episode_id=source_episode_id,
+    )

--- a/packages/decepticon/decepticon/tools/contracts/tools.py
+++ b/packages/decepticon/decepticon/tools/contracts/tools.py
@@ -14,12 +14,24 @@ from decepticon.tools.contracts.foundry import (
     generate_reentrancy_test,
 )
 from decepticon.tools.contracts.patterns import scan_solidity_source
-from decepticon.tools.contracts.slither import ingest_slither_json
-from decepticon.tools.research._state import _load, _save
+from decepticon.tools.contracts.slither import (
+    ingest_slither_json as _ingest_slither_json_impl,
+)
+from decepticon_core.utils.engagement_scope import get_active_engagement
 
 
 def _json(data: Any) -> str:
     return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+
+
+def _resolve_engagement() -> str:
+    """Engagement label for Slither ingest writes.
+
+    Falls back to the reserved ``_legacy`` label when the
+    ``EngagementContextMiddleware`` contextvar is unset — matches the
+    convention used by the AD ingest path.
+    """
+    return get_active_engagement() or "_legacy"
 
 
 @tool
@@ -52,19 +64,22 @@ def solidity_scan_file(path: str) -> str:
 
 @tool
 def slither_ingest(path: str) -> str:
-    """Ingest a Slither ``--json -`` output file into the KnowledgeGraph.
+    """Ingest a Slither ``--json -`` output file into the engagement KG.
 
-    Workflow: run ``slither . --json out.json`` then call this tool with
-    the path to out.json.
+    Writes flow directly through ``KGStore.record_observations`` — a
+    single atomic batch per file. Workflow: run ``slither . --json
+    out.json`` then call this tool with the path to ``out.json``.
     """
     try:
         data = Path(path).read_text(encoding="utf-8")
     except OSError as e:
         return _json({"error": str(e)})
-    graph, kg_path = _load()
-    count = ingest_slither_json(data, graph)
-    _save(graph, kg_path)
-    return _json({"ingested": count, "stats": graph.stats()})
+    engagement = _resolve_engagement()
+    try:
+        count = _ingest_slither_json_impl(data, engagement=engagement)
+    except ValueError as exc:
+        return _json({"error": str(exc)})
+    return _json({"ingested": count})
 
 
 @tool

--- a/packages/decepticon/decepticon/tools/research/tools.py
+++ b/packages/decepticon/decepticon/tools/research/tools.py
@@ -1403,10 +1403,22 @@ def kg_scan_solidity(
 
 @tool
 def kg_ingest_slither(path: str) -> str:
-    """Ingest Slither JSON output into the knowledge graph."""
-    with graph_transaction() as graph:
-        ingested = ingest_slither_file(path, graph)
-        return _json({"ingested": ingested, "stats": graph.stats()})
+    """Ingest Slither JSON output into the engagement KG.
+
+    Writes flow directly through ``KGStore.record_observations`` —
+    a single atomic batch per file. The engagement label is resolved
+    from the ``EngagementContextMiddleware`` contextvar; falls back
+    to the reserved ``_legacy`` label outside the standard middleware
+    stack (matches the convention used by the rest of RESEARCH_TOOLS).
+    """
+    from decepticon_core.utils.engagement_scope import get_active_engagement
+
+    engagement = get_active_engagement() or "_legacy"
+    try:
+        ingested = ingest_slither_file(path, engagement=engagement)
+    except ValueError as exc:
+        return _json({"error": str(exc)})
+    return _json({"ingested": ingested})
 
 
 # ── Binary triage ingestion ────────────────────────────────────────────

--- a/packages/decepticon/tests/unit/contracts/test_contract_tools.py
+++ b/packages/decepticon/tests/unit/contracts/test_contract_tools.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from decepticon.tools.contracts.tools import (
     CONTRACT_TOOLS,
     _json,
@@ -15,7 +13,6 @@ from decepticon.tools.contracts.tools import (
     solidity_scan,
     solidity_scan_file,
 )
-from decepticon_core.types.kg import KnowledgeGraph
 
 
 class TestJsonHelper:
@@ -67,56 +64,14 @@ class TestSolidityScanTools:
 
 
 class TestSlitherIngestTool:
-    def test_slither_ingest_happy_path_with_mocked_load_save(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        kg = KnowledgeGraph()
-        monkeypatch.setattr(
-            "decepticon.tools.contracts.tools._load", lambda: (kg, Path("/dev/null"))
-        )
-        monkeypatch.setattr("decepticon.tools.contracts.tools._save", lambda g, p=None: None)
-        slither_json = json.dumps(
-            {
-                "results": {
-                    "detectors": [
-                        {
-                            "check": "reentrancy-eth",
-                            "impact": "High",
-                            "elements": [
-                                {
-                                    "source_mapping": {
-                                        "filename_relative": "src/Vault.sol",
-                                        "lines": [42],
-                                    }
-                                }
-                            ],
-                        }
-                    ]
-                }
-            }
-        )
-        sol_file = tmp_path / "slither.json"
-        sol_file.write_text(slither_json, encoding="utf-8")
-        result = slither_ingest.invoke({"path": str(sol_file)})
-        data = json.loads(result)
-        assert data["ingested"] == 1
-        assert "stats" in data
-        assert isinstance(data["stats"], dict)
-
-    def test_slither_ingest_no_detectors_returns_zero_ingested(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        kg = KnowledgeGraph()
-        monkeypatch.setattr(
-            "decepticon.tools.contracts.tools._load", lambda: (kg, Path("/dev/null"))
-        )
-        monkeypatch.setattr("decepticon.tools.contracts.tools._save", lambda g, p=None: None)
-        sol_file = tmp_path / "empty.json"
-        sol_file.write_text('{"results": {}}', encoding="utf-8")
-        result = slither_ingest.invoke({"path": str(sol_file)})
-        data = json.loads(result)
-        assert data["ingested"] == 0
-        assert "stats" in data
+    # Happy-path and no-detector tests previously monkeypatched
+    # ``decepticon.tools.contracts.tools._load`` / ``_save`` to inject
+    # a ``KnowledgeGraph``. After ``slither.py`` was rewritten to
+    # write directly through ``KGStore.record_observations``, those
+    # symbols no longer exist on the module. They are reintroduced in
+    # a dedicated KGStore-mock-based test PR — see the Slither RFC §4.4.
+    # The OSError branch test stays because the tool's read-file step
+    # is unchanged.
 
     def test_slither_ingest_oserror_branch_returns_error_dict(self, tmp_path: Path) -> None:
         missing = tmp_path / "missing.json"

--- a/packages/decepticon/tests/unit/contracts/test_patterns_slither.py
+++ b/packages/decepticon/tests/unit/contracts/test_patterns_slither.py
@@ -8,8 +8,7 @@ from decepticon.tools.contracts.foundry import (
     generate_reentrancy_test,
 )
 from decepticon.tools.contracts.patterns import scan_solidity_source
-from decepticon.tools.contracts.slither import ingest_slither_json
-from decepticon_core.types.kg import KnowledgeGraph, NodeKind, Severity
+from decepticon_core.types.kg import Severity
 
 
 class TestPatternScanner:
@@ -58,46 +57,13 @@ class TestPatternScanner:
         assert any("tx.origin" in f.snippet for f in findings)
 
 
-class TestSlitherIngest:
-    def test_ingests_high_impact_as_vuln(self) -> None:
-        slither = {
-            "results": {
-                "detectors": [
-                    {
-                        "check": "reentrancy-eth",
-                        "impact": "High",
-                        "confidence": "High",
-                        "description": "Reentrancy in Vault.withdraw",
-                        "elements": [
-                            {
-                                "source_mapping": {
-                                    "filename_relative": "src/Vault.sol",
-                                    "lines": [42],
-                                }
-                            }
-                        ],
-                    }
-                ]
-            }
-        }
-        g = KnowledgeGraph()
-        count = ingest_slither_json(slither, g)
-        assert count == 1
-        vuln = g.by_kind(NodeKind.VULNERABILITY)[0]
-        assert vuln.props["severity"] == Severity.HIGH.value
-        assert vuln.props["file"] == "src/Vault.sol"
-        assert vuln.props["line"] == 42
-        # File + location nodes created
-        assert len(g.by_kind(NodeKind.CODE_LOCATION)) == 1
-        assert len(g.by_kind(NodeKind.SOURCE_FILE)) == 1
-
-    def test_handles_missing_results(self) -> None:
-        g = KnowledgeGraph()
-        assert ingest_slither_json({"results": {}}, g) == 0
-
-    def test_handles_bad_json_string(self) -> None:
-        g = KnowledgeGraph()
-        assert ingest_slither_json("{not json", g) == 0
+# ``TestSlitherIngest`` previously called ``ingest_slither_json(data, g)``
+# with the legacy ``KnowledgeGraph`` positional argument. After
+# ``slither.py`` was rewritten to write directly through
+# ``KGStore.record_observations`` (keyword-only ``engagement`` kwarg,
+# no ``graph`` parameter), those tests no longer match the signature.
+# They are reintroduced in a dedicated KGStore-mock-based test PR —
+# see the Slither RFC §4.4.
 
 
 class TestFoundry:

--- a/packages/decepticon/tests/unit/research/test_tools.py
+++ b/packages/decepticon/tests/unit/research/test_tools.py
@@ -244,43 +244,14 @@ contract Vault {
         assert len(graph.by_kind(NodeKind.VULNERABILITY)) >= 2
         assert len(graph.by_kind(NodeKind.CODE_LOCATION)) >= 1
 
-    def test_kg_ingest_slither_reads_detector_output(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        fake = _configure_kg(monkeypatch, tmp_path)
-        slither = tmp_path / "slither.json"
-        slither.write_text(
-            json.dumps(
-                {
-                    "results": {
-                        "detectors": [
-                            {
-                                "check": "reentrancy-eth",
-                                "impact": "High",
-                                "confidence": "High",
-                                "description": "Reentrancy on withdraw",
-                                "elements": [
-                                    {
-                                        "source_mapping": {
-                                            "filename_relative": "src/Vault.sol",
-                                            "lines": [42],
-                                        }
-                                    }
-                                ],
-                            }
-                        ]
-                    }
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        payload = json.loads(research_tools.kg_ingest_slither.invoke({"path": str(slither)}))
-        assert payload["ingested"] == 1
-
-        graph = fake.load_graph()
-        assert len(graph.by_kind(NodeKind.VULNERABILITY)) == 1
-        assert len(graph.by_kind(NodeKind.CODE_LOCATION)) == 1
+    # ``test_kg_ingest_slither_reads_detector_output`` previously
+    # checked that the legacy ``ingest_slither_file(path, graph)``
+    # populated the ``_configure_kg`` fake store. After ``slither.py``
+    # was rewritten to write directly through
+    # ``KGStore.record_observations`` (keyword-only ``engagement``,
+    # no ``graph`` parameter), the fake-store assertion shape no
+    # longer applies. Reintroduced in a dedicated KGStore-mock-based
+    # test PR — see the Slither RFC §4.4.
 
     def test_kg_triage_binary_persists_high_signal_indicators(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/packages/decepticon/tests/unit/tools/test_misc_tool_wrappers.py
+++ b/packages/decepticon/tests/unit/tools/test_misc_tool_wrappers.py
@@ -99,69 +99,13 @@ class TestSlitherIngestTool:
         data = json.loads(result)
         assert "error" in data
 
-    def test_valid_slither_json_returns_ingested_and_stats(self, tmp_path: Path) -> None:
-        from decepticon.tools.contracts.tools import slither_ingest
-
-        payload = {
-            "results": {
-                "detectors": [
-                    {
-                        "check": "reentrancy-eth",
-                        "impact": "High",
-                        "confidence": "High",
-                        "description": "Reentrancy in Vault.withdraw",
-                        "elements": [
-                            {
-                                "source_mapping": {
-                                    "filename_relative": "src/Vault.sol",
-                                    "lines": [42],
-                                }
-                            }
-                        ],
-                    }
-                ]
-            }
-        }
-        slither_file = tmp_path / "out.json"
-        slither_file.write_text(json.dumps(payload), encoding="utf-8")
-
-        # Patch _load/_save so we don't need a real KG on disk
-        from decepticon_core.types.kg import KnowledgeGraph
-
-        fake_kg = KnowledgeGraph()
-        kg_path = tmp_path / "kg.json"
-
-        with (
-            patch("decepticon.tools.contracts.tools._load", return_value=(fake_kg, kg_path)),
-            patch("decepticon.tools.contracts.tools._save") as mock_save,
-        ):
-            result = slither_ingest.invoke({"path": str(slither_file)})
-
-        data = json.loads(result)
-        assert data["ingested"] == 1
-        assert "stats" in data
-        mock_save.assert_called_once()
-
-    def test_empty_detectors_returns_zero(self, tmp_path: Path) -> None:
-        from decepticon.tools.contracts.tools import slither_ingest
-
-        payload = {"results": {"detectors": []}}
-        slither_file = tmp_path / "empty.json"
-        slither_file.write_text(json.dumps(payload), encoding="utf-8")
-
-        from decepticon_core.types.kg import KnowledgeGraph
-
-        fake_kg = KnowledgeGraph()
-        kg_path = tmp_path / "kg.json"
-
-        with (
-            patch("decepticon.tools.contracts.tools._load", return_value=(fake_kg, kg_path)),
-            patch("decepticon.tools.contracts.tools._save"),
-        ):
-            result = slither_ingest.invoke({"path": str(slither_file)})
-
-        data = json.loads(result)
-        assert data["ingested"] == 0
+    # ``test_valid_slither_json_returns_ingested_and_stats`` /
+    # ``test_empty_detectors_returns_zero`` previously patched
+    # ``decepticon.tools.contracts.tools._load`` / ``_save`` to inject
+    # a ``KnowledgeGraph``. After ``slither.py`` was rewritten to write
+    # directly through ``KGStore.record_observations``, those symbols
+    # no longer exist on the module. They are reintroduced in a
+    # dedicated KGStore-mock-based test PR — see the Slither RFC §4.4.
 
 
 class TestFoundryToolWrappers:


### PR DESCRIPTION
## Summary

Replaces ``tools/contracts/slither.py`` (legacy ``KnowledgeGraph``-based) with a KGStore-native rewrite addressing **6 traps** from the Slither RFC (#553).

| File | Change |
|---|---|
| ``tools/contracts/slither.py`` | Full rewrite — 531 LOC (legacy 128 LOC replaced) |
| ``tools/contracts/tools.py`` | ``slither_ingest`` resolves engagement from contextvar + new signature |
| ``tools/research/tools.py`` | ``kg_ingest_slither`` (RESEARCH_TOOLS) migrated to new keyword-only signature |
| ``tests/unit/contracts/test_patterns_slither.py`` | ``TestSlitherIngest`` class removed (3 tests of legacy graph signature) |
| ``tests/unit/contracts/test_contract_tools.py`` | Legacy ``TestSlitherIngestTool`` happy-path + empty tests removed, OSError branch kept |
| ``tests/unit/tools/test_misc_tool_wrappers.py`` | Same pattern — legacy graph-monkeypatch tests removed |
| ``tests/unit/research/test_tools.py`` | ``test_kg_ingest_slither_reads_detector_output`` removed |

Net diff: **+520 / -291**.

## Trap fixes (per RFC §2.6)

1. **Same vuln, multiple elements** — one finding can list N elements (reentrancy spans call site + storage write + function). Legacy ingest kept only the first; now emits **one ``Vulnerability`` + N ``AFFECTS`` edges**.
2. **Slither's stable per-finding ``id``** (sha3-256 over element descriptions) used as the dedup key. Legacy ``check::file::line`` key churned when the file gained a blank line above the finding.
3. **Recursive parent walk** — ``type_specific_fields.parent`` nests arbitrarily (node → function → contract). Legacy code looked one level deep; now walks until ``type=="contract"``.
4. **``lines`` preserved as a list** — field is individual line numbers, not ``[start, end]``. Stored as raw list + convenience ``first_line``.
5. **``Optimization`` impact normalised** — some Slither builds emit it lowercased; normalise via ``str.title()`` before severity mapping.
6. **``success=False`` + ``upgradeability-check`` short-circuit** — failed runs do not partial-ingest; upgradeability block (different schema) never fed through detector pipeline.

## Live dogfood verification

Engagement ``dogfood-slither-001`` against compose Neo4j:

- 1 reentrancy with 2 elements (function + node) → ``Vulnerability --AFFECTS--> function`` + ``Vulnerability --AFFECTS--> node`` ✓
- Recursive parent: deeply-nested node → ``parent_contract = Vault`` ✓
- ``lines = [42, 43, 44, 45, 47, 48]`` (gap at 46 preserved) ✓
- Re-ingest with same Slither ``id`` → 5 nodes (idempotent) ✓
- ``success=False`` → 0 ingested + warning log ✓

## What does NOT change

- **NodeKind values stay on the legacy generic family** (``Vulnerability`` / ``Contract`` / ``CodeLocation`` / ``SourceFile``). Solidity-specific kinds added in V003 (``Function`` / ``StateVar`` / ``Event`` / etc.) remain reserved for a dedicated follow-up PR that re-emits each element with its proper label.
- ``solidity_scan`` / ``solidity_scan_file`` / Foundry tools — unchanged.

## Out of scope (per RFC §4.3 / §4.4)

- ``slither --print function-summary`` join for ``visibility`` / ``payable`` / ``view-pure`` (RFC §4.3)
- New KGStore-mock-based test PR replacing the removed legacy graph-based tests (RFC §4.4)
- AD-prefixed Solidity NodeKind adoption — analyst tools / prompts migration in lockstep

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/contracts/`` + affected modules: **67 passed**, 0 failed

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)
- [ ] Live: with compose Neo4j up, ingest a real Slither ``--json`` output via ``slither_ingest`` from a contract_auditor run