### PR TITLE
feat(kg): ADCS post-process — DCSync + GoldenCert synthesis

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -1,0 +1,158 @@
+"""ADCS post-process — BHCE-server-equivalent edge synthesis.
+
+BloodHound CE's server walks the ingested raw graph and synthesises
+the high-signal attack edges (``DCSync``, ``GoldenCert``,
+``ADCS_ESC1`` … ``ESC13``, etc.) that chain planners actually
+reason about. The Decepticon ingest in ``bloodhound.py`` only writes
+the raw collector data; this module is where the synthesis runs.
+
+Scope of this first cut (intentionally narrow — see the BloodHound
+RFC §4.3 for the full plan):
+
+  - **``DCSync``**: A principal that holds both ``GET_CHANGES`` and
+    ``GET_CHANGES_ALL`` on a Domain has effective DCSync rights.
+    BHCE collapses the pair into a single ``DCSync`` edge per
+    (principal, domain) pair.
+  - **``GoldenCert``**: A principal that holds ``OWNS`` /
+    ``WRITE_OWNER`` / ``MANAGE_CA`` on an EnterpriseCA can issue
+    arbitrary certificates as that CA — a forged-trust-anchor
+    primitive. We mint one ``GoldenCert`` edge per principal +
+    EnterpriseCA pair.
+
+ESC1/3/4/6a/6b/9a/9b/10a/10b/13 require Enroll edges (raw ACE
+right-name) that the current ingest does not yet emit — they land
+in a dedicated follow-up PR alongside Enroll ingest.
+
+The synthesis is **idempotent**: each ``MERGE`` keys on the
+(principal, target) pair so re-running the post-process produces no
+extra edges. Each new edge carries ``post_process_source`` props so
+analysts can distinguish synthesised edges from raw ACE data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from decepticon.middleware.kg_internal.store import KGStore
+
+
+@dataclass
+class PostProcessStats:
+    """Counts of edges created per algorithm. Re-runs return zero for
+    every value because each ``MERGE`` is idempotent."""
+
+    dcsync: int = 0
+    golden_cert: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return self.__dict__
+
+
+# Cypher templates — kept short + auditable so the algorithm is
+# obvious to reviewers without hunting through string concatenation.
+
+# ``r._jc`` is a transient marker the MERGE writes on the create path
+# and clears on the match path; counting it gives the true new-edge
+# count. ``count(r)`` instead returns the total ``MATCH``ed count
+# (always ≥ 1 after the first run) and breaks idempotency reporting.
+# Same trick the node-write path in ``record_observations`` uses.
+
+_DCSYNC_QUERY = (
+    "MATCH (p)-[gc:GET_CHANGES {engagement: $engagement}]->(d:Domain {engagement: $engagement}) "
+    "MATCH (p)-[gca:GET_CHANGES_ALL {engagement: $engagement}]->(d) "
+    "MERGE (p)-[r:DCSYNC {engagement: $engagement}]->(d) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'GetChanges+GetChangesAll', "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+_GOLDEN_CERT_QUERY = (
+    "MATCH (p)-[r:OWNS|WRITE_OWNER|MANAGE_CA {engagement: $engagement}]->"
+    "(ca:ADEnterpriseCA {engagement: $engagement}) "
+    "WITH DISTINCT p, ca "
+    "MERGE (p)-[gc:GOLDEN_CERT {engagement: $engagement}]->(ca) "
+    "ON CREATE SET gc.firstseen = $now, "
+    "              gc.created_by = $created_by, "
+    "              gc.source_episode_id = $source_episode_id, "
+    "              gc.post_process_source = 'Owns|WriteOwner|ManageCA on EnterpriseCA', "
+    "              gc._jc = true "
+    "ON MATCH SET gc._jc = false "
+    "SET gc.lastupdated = $now "
+    "WITH gc, gc._jc AS just_created "
+    "REMOVE gc._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
+def synthesise_adcs_post(
+    *,
+    engagement: str,
+    store: KGStore | None = None,
+    source_episode_id: str = "adcs_post",
+    created_by: str = "adcs_post",
+) -> PostProcessStats:
+    """Run every post-process synthesis algorithm in this module
+    against ``engagement``.
+
+    Args:
+        engagement: Engagement label whose raw graph to walk.
+        store: Optional pre-constructed ``KGStore`` for tests; defaults
+            to ``KGStore.from_env()`` and is closed before return.
+        source_episode_id: Provenance tag attached to every synthesised
+            edge so analysts can distinguish post-process output from
+            raw ACE data.
+        created_by: ``created_by`` provenance prop (defaults to
+            ``adcs_post`` so it sorts visibly next to ``bh_ingest``).
+
+    Returns:
+        :class:`PostProcessStats` with per-algorithm counts of edges
+        the synthesis created **this run** (excluding ones that were
+        already present and only re-touched).
+    """
+    import time
+
+    now = int(time.time())
+    owned_store = store is None
+    target_store = store if store is not None else KGStore.from_env()
+
+    stats = PostProcessStats()
+    try:
+        # DCSync
+        rows = target_store.execute_write(
+            _DCSYNC_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.dcsync = int(rows[0].get("created") or 0)
+
+        # GoldenCert
+        rows = target_store.execute_write(
+            _GOLDEN_CERT_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.golden_cert = int(rows[0].get("created") or 0)
+    finally:
+        if owned_store:
+            target_store.close()
+
+    return stats

--- a/packages/decepticon/decepticon/tools/ad/tools.py
+++ b/packages/decepticon/decepticon/tools/ad/tools.py
@@ -10,6 +10,7 @@ from zipfile import BadZipFile
 from langchain_core.tools import tool
 
 from decepticon.tools.ad.adcs import analyze_adcs_templates
+from decepticon.tools.ad.adcs_post import synthesise_adcs_post as _synthesise_adcs_post
 from decepticon.tools.ad.bloodhound import (
     ingest_bloodhound_zip as _ingest_bloodhound_zip_impl,
 )
@@ -162,12 +163,37 @@ def shadow_creds_audit() -> str:
     return _json({"findings": [f.to_dict() for f in findings], "count": len(findings)})
 
 
+@tool
+def adcs_post_process() -> str:
+    """Synthesise BHCE-server-equivalent ADCS attack edges into the KG.
+
+    Walks the engagement's raw BloodHound graph and merges high-signal
+    chain edges that the raw collector does NOT emit:
+
+      - ``DCSync`` per (principal, domain) pair where the principal
+        holds both ``GET_CHANGES`` and ``GET_CHANGES_ALL``.
+      - ``GoldenCert`` per (principal, EnterpriseCA) pair where the
+        principal holds ``OWNS`` / ``WRITE_OWNER`` / ``MANAGE_CA``.
+
+    ESC1/3/4/6a/6b/9a/9b/10a/10b/13 require Enroll-edge ingest that
+    isn't wired in yet — they land in a dedicated follow-up PR.
+
+    Run after ``bh_ingest_zip`` / ``bh_ingest_json`` finishes for the
+    engagement. Idempotent: re-running on the same engagement creates
+    no extra edges.
+    """
+    engagement = _resolve_engagement()
+    stats = _synthesise_adcs_post(engagement=engagement)
+    return _json({"synthesised": stats.to_dict()})
+
+
 AD_TOOLS = [
     bh_ingest_zip,
     bh_ingest_json,
     dcsync_check,
     kerberos_classify,
     adcs_audit,
+    adcs_post_process,
     delegation_audit,
     gpo_audit,
     shadow_creds_audit,

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -1,0 +1,205 @@
+"""KGStore-mock-based tests for ``tools.ad.adcs_post``.
+
+The synthesis runs as raw Cypher inside ``KGStore.execute_write``, so
+the unit tests verify the **shape of the calls** (engagement scoping,
+provenance threading, query content) — full algorithmic correctness
+is covered by the live dogfood against compose Neo4j (the
+post-process is fundamentally a graph traversal, not pure Python).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from decepticon.tools.ad.adcs_post import (
+    PostProcessStats,
+    synthesise_adcs_post,
+)
+
+
+class _FakeKGStore:
+    """Captures every ``execute_write`` call so tests can inspect the
+    queries and parameter shape."""
+
+    def __init__(self, *, dcsync_created: int = 1, golden_created: int = 1) -> None:
+        self.calls: list[tuple[str, dict[str, Any], str]] = []
+        self._dcsync_created = dcsync_created
+        self._golden_created = golden_created
+        self.closed = False
+
+    def execute_write(
+        self, query: str, params: dict[str, Any], *, engagement: str
+    ) -> list[dict[str, Any]]:
+        self.calls.append((query, dict(params), engagement))
+        # The two queries differ in their MATCH pattern: DCSync starts
+        # with GET_CHANGES, GoldenCert with OWNS|WRITE_OWNER|MANAGE_CA.
+        if "GET_CHANGES" in query:
+            return [{"created": self._dcsync_created}]
+        if "OWNS|WRITE_OWNER|MANAGE_CA" in query:
+            return [{"created": self._golden_created}]
+        return []
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# ── Public signature contracts ─────────────────────────────────────
+
+
+class TestPublicSignatures:
+    def test_returns_post_process_stats(self) -> None:
+        store = _FakeKGStore()
+        result = synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        assert isinstance(result, PostProcessStats)
+
+    def test_stats_carry_counts_from_each_query(self) -> None:
+        store = _FakeKGStore(dcsync_created=3, golden_created=2)
+        stats = synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        assert stats.dcsync == 3
+        assert stats.golden_cert == 2
+
+    def test_provenance_threaded_into_every_call(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t-eng",
+            store=store,  # type: ignore[arg-type]
+            source_episode_id="ep-x",
+            created_by="adcs_post_test",
+        )
+        assert len(store.calls) == 2
+        for _query, params, engagement in store.calls:
+            assert engagement == "t-eng"
+            assert params["engagement"] == "t-eng"
+            assert params["created_by"] == "adcs_post_test"
+            assert params["source_episode_id"] == "ep-x"
+
+    def test_caller_supplied_store_not_closed(self) -> None:
+        """When a caller passes ``store=``, the post-process must NOT
+        close it on return — caller owns the lifetime."""
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        assert store.closed is False
+
+
+# ── DCSync algorithm ───────────────────────────────────────────────
+
+
+class TestDcsyncQuery:
+    def _dcsync_query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "DCSYNC" in q:
+                return q
+        raise AssertionError("DCSync query not issued")
+
+    def test_dcsync_query_requires_both_get_changes_edges(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._dcsync_query(store)
+        # Both rights must MATCH on the same (principal, domain) pair.
+        assert ":GET_CHANGES" in q
+        assert ":GET_CHANGES_ALL" in q
+
+    def test_dcsync_query_scopes_match_to_engagement(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._dcsync_query(store)
+        assert q.count("engagement: $engagement") >= 3  # 2 raw + 1 merged
+
+    def test_dcsync_query_uses_jc_marker_for_idempotent_count(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._dcsync_query(store)
+        # The ``_jc`` marker pattern is what makes the run-2 stats
+        # truthfully zero. ``count(r)`` would always return ≥ 1 after
+        # the first run.
+        assert "_jc" in q
+        assert "ON CREATE SET" in q and "ON MATCH SET" in q
+
+
+# ── GoldenCert algorithm ───────────────────────────────────────────
+
+
+class TestGoldenCertQuery:
+    def _golden_query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "GOLDEN_CERT" in q:
+                return q
+        raise AssertionError("GoldenCert query not issued")
+
+    def test_golden_cert_requires_owns_writeowner_or_manageca_on_enterprise_ca(
+        self,
+    ) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._golden_query(store)
+        # The alternation covers the three rights BHCE promotes to
+        # GoldenCert.
+        assert ":OWNS|WRITE_OWNER|MANAGE_CA" in q
+        # Target must be an EnterpriseCA, not an arbitrary node.
+        assert ":ADEnterpriseCA" in q
+
+    def test_golden_cert_query_deduplicates_via_distinct(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._golden_query(store)
+        # Without ``WITH DISTINCT``, a principal with multiple rights
+        # on the same CA would mint extra GoldenCert edges.
+        assert "WITH DISTINCT" in q
+
+    def test_golden_cert_query_uses_jc_marker_for_idempotent_count(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._golden_query(store)
+        assert "_jc" in q
+        assert "ON CREATE SET" in q and "ON MATCH SET" in q
+
+
+# ── Default-store path ─────────────────────────────────────────────
+
+
+class TestDefaultStorePath:
+    def test_omitting_store_constructs_from_env(self, monkeypatch) -> None:
+        """When the caller omits ``store=``, the helper builds a
+        ``KGStore`` via ``from_env`` and closes it before return."""
+        constructed: list[_FakeKGStore] = []
+
+        def _fake_from_env() -> _FakeKGStore:  # type: ignore[override]
+            s = _FakeKGStore()
+            constructed.append(s)
+            return s
+
+        monkeypatch.setattr(
+            "decepticon.tools.ad.adcs_post.KGStore.from_env",
+            staticmethod(_fake_from_env),
+        )
+
+        synthesise_adcs_post(engagement="t")
+        assert len(constructed) == 1
+        assert constructed[0].closed is True


### PR DESCRIPTION
## Summary

First cut of the BHCE-server-equivalent ADCS edge synthesis the BloodHound RFC §4.3 plans. Adds ``tools/ad/adcs_post.py`` + tool wrapper + 11 unit tests.

| File | Change |
|---|---|
| ``tools/ad/adcs_post.py`` | New module — DCSync + GoldenCert Cypher synthesis (158 LOC) |
| ``tools/ad/tools.py`` | New ``adcs_post_process`` @tool wired into ``AD_TOOLS`` |
| ``tests/unit/ad/test_adcs_post.py`` | New — 11 KGStore-mock tests (205 LOC) |

Net diff: **+389 / -0**.

## Synthesis algorithms (this cut)

| Edge | Cypher pattern | Provenance |
|---|---|---|
| ``DCSync`` | ``MATCH (p)-[:GET_CHANGES]->(d:Domain) MATCH (p)-[:GET_CHANGES_ALL]->(d) MERGE (p)-[:DCSYNC]->(d)`` | ``post_process_source = 'GetChanges+GetChangesAll'`` |
| ``GoldenCert`` | ``MATCH (p)-[:OWNS\|WRITE_OWNER\|MANAGE_CA]->(ca:ADEnterpriseCA) WITH DISTINCT p, ca MERGE (p)-[:GOLDEN_CERT]->(ca)`` | ``post_process_source = 'Owns\|WriteOwner\|ManageCA on EnterpriseCA'`` |

Both use the ``_jc`` ON CREATE marker pattern so the returned ``created`` count is **truthfully zero** on re-runs (``count(r)`` would always return ≥ 1 after the first run and silently lie about idempotency — same trick ``record_observations`` uses).

## Live dogfood

Engagement ``dogfood-adcs-post-001`` against compose Neo4j:

```
run-1 (should be 1,1): {'dcsync': 1, 'golden_cert': 1}
run-2 (idempotent):    {'dcsync': 0, 'golden_cert': 0}
DCSYNC edges:
  P-1 → Domain  post_process_source=GetChanges+GetChangesAll
GOLDEN_CERT edges:
  P-2 → ADEnterpriseCA  post_process_source=Owns|WriteOwner|ManageCA on EnterpriseCA
```

Idempotency on re-run verified.

## Out of scope (per BloodHound RFC §4.3)

- **``ADCS_ESC1`` / ``ESC3`` / ``ESC4`` / ``ESC6a`` / ``ESC6b`` / ``ESC9a`` / ``ESC9b`` / ``ESC10a`` / ``ESC10b`` / ``ESC13``** — each requires Enroll-edge ingest from ACE ``RightName=Enroll`` that this PR does not add; land in a dedicated PR alongside Enroll ingest
- **``SyncLAPSPassword``** — requires ``ReadLAPSPassword`` traversal semantics not modelled yet
- **``CoerceAndRelayNTLMTo*`` / ``CoerceToTGT`` / ``HasTrustKeys`` / ``SyncedToEntraUser`` / ``SyncedToADUser``** — separate algorithms

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_adcs_post.py``: **11 passed**, 0 failed
- Live dogfood: synthesis correct + idempotent (above)

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)