### PR TITLE
feat(kg): BloodHound LocalGroups ingest + RID-based direct lateral edges

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -592,6 +592,112 @@ def _ingest_gp_links(state: _IngestState, src_key: str, obj: dict[str, Any]) -> 
         )
 
 
+_LOCAL_GROUP_RID_TO_EDGE: dict[str, tuple[EdgeKind, float]] = {
+    "500": (EdgeKind.ADMIN_TO, 0.3),
+    "555": (EdgeKind.CAN_ACCESS, 0.6),  # CanRDP
+    "562": (EdgeKind.CAN_ACCESS, 0.6),  # ExecuteDCOM
+    "580": (EdgeKind.CAN_ACCESS, 0.5),  # CanPSRemote
+}
+
+
+def _rid_from_local_group_id(object_id: str) -> str | None:
+    """Extract the trailing numeric RID from a SharpHound LocalGroup id.
+
+    BHCE-emitted ids take two shapes:
+      - ``<computerSID>-<RID>`` (numeric trailing — built-in groups)
+      - ``<computerSID>__<groupname>`` (string suffix — non-built-in)
+
+    Returns the RID string when the trailing fragment is purely
+    numeric so the caller can look it up in
+    ``_LOCAL_GROUP_RID_TO_EDGE``.
+    """
+    tail = object_id.rsplit("-", 1)[-1]
+    return tail if tail.isdigit() else None
+
+
+def _ingest_local_groups(state: _IngestState, computer_key: str, obj: dict[str, Any]) -> None:
+    """Computer ``LocalGroups[]`` → ``ADLocalGroup`` nodes + direct
+    access edges per RID.
+
+    Per local group: emits one ``ADLocalGroup`` node,
+    ``computer --CONTAINS--> ADLocalGroup``, and for each member
+    ``principal --MEMBER_OF_LOCAL_GROUP--> ADLocalGroup``. When the
+    group's trailing RID matches a known lateral-movement primitive
+    (-500 / -555 / -562 / -580), an extra direct
+    ``principal --<edge>--> computer`` edge lands so the chain
+    planner sees the path without re-deriving it from
+    ``MEMBER_OF_LOCAL_GROUP`` traversal.
+    """
+    local_groups = obj.get("LocalGroups") or []
+    if not isinstance(local_groups, list):
+        return
+    for lg in local_groups:
+        if not isinstance(lg, dict):
+            continue
+        lg_id = lg.get("ObjectIdentifier")
+        if not isinstance(lg_id, str) or not lg_id:
+            continue
+        lg_name = lg.get("Name") or lg_id
+        lg_key = _key_for_object("LocalGroup", lg_id)
+        state.upsert_observation(
+            kind=NodeKind.AD_LOCAL_GROUP,
+            key=lg_key,
+            label=str(lg_name),
+            bh_type="LocalGroup",
+            props={
+                "ComputerObjectIdentifier": _bh_id_from_key(computer_key),
+                "name": lg_name,
+            },
+        )
+        state.add_edge(
+            src_key=computer_key,
+            dst_key=lg_key,
+            kind=EdgeKind.CONTAINS,
+            weight=1.0,
+            props={"bh_right": "ContainsLocalGroup"},
+        )
+
+        rid = _rid_from_local_group_id(lg_id)
+        direct_edge = _LOCAL_GROUP_RID_TO_EDGE.get(rid) if rid else None
+
+        results = lg.get("Results") or []
+        if not isinstance(results, list):
+            continue
+        for member in results:
+            if not isinstance(member, dict):
+                continue
+            principal_sid = member.get("ObjectIdentifier")
+            if not isinstance(principal_sid, str) or not principal_sid:
+                continue
+            principal_type = member.get("ObjectType") or "User"
+            principal_type = (
+                principal_type if principal_type in _BH_TYPE_SINGULAR.values() else "User"
+            )
+            principal_key = _ensure_placeholder(
+                state, sid=principal_sid, default_type=principal_type
+            )
+            state.add_edge(
+                src_key=principal_key,
+                dst_key=lg_key,
+                kind=EdgeKind.MEMBER_OF_LOCAL_GROUP,
+                weight=0.6,
+                props={"bh_right": "MemberOfLocalGroup"},
+            )
+            if direct_edge is not None:
+                edge_kind, weight = direct_edge
+                state.add_edge(
+                    src_key=principal_key,
+                    dst_key=computer_key,
+                    kind=edge_kind,
+                    weight=weight,
+                    props={
+                        "bh_right": "LocalGroupRid",
+                        "rid": rid,
+                        "via_local_group": lg_id,
+                    },
+                )
+
+
 def _ingest_enterprise_ca_edges(state: _IngestState, src_key: str, obj: dict[str, Any]) -> None:
     """``EnterpriseCA`` extras: ``EnabledCertTemplates[]`` and
     ``HostingComputer``.
@@ -722,6 +828,8 @@ def _merge_one_payload(state: _IngestState, data: dict[str, Any], *, type_hint: 
             _ingest_enterprise_ca_edges(state, src_key, obj)
         if type_singular == "IssuancePolicy":
             _ingest_issuance_policy_link(state, src_key, obj)
+        if type_singular == "Computer":
+            _ingest_local_groups(state, src_key, obj)
         if hasattr(state.stats, counter_attr):
             setattr(state.stats, counter_attr, getattr(state.stats, counter_attr) + 1)
 

--- a/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
+++ b/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
@@ -653,3 +653,167 @@ class TestAdcsIngest:
         stats = ingest_bloodhound_zip(zip_path, engagement="t", store=store)
         assert stats.certtemplates == 1
         assert any(obs["kind"] == "ADCertTemplate" for obs in store.observations)
+
+
+# ── LocalGroups ingest + RID-based direct edges ─────────────────────
+
+
+class TestLocalGroupsIngest:
+    """Computer ``LocalGroups[]`` → ``ADLocalGroup`` nodes plus the
+    BHCE-equivalent direct lateral-movement edges by built-in RID."""
+
+    def _bh(self, *, lg_id: str, members: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "meta": {"type": "computers"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-1001",
+                    "Properties": {"name": "ws01"},
+                    "LocalGroups": [
+                        {
+                            "ObjectIdentifier": lg_id,
+                            "Name": "BUILTIN\\Whatever",
+                            "Results": members,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def test_local_group_node_emitted_under_ad_local_group_label(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                lg_id="S-1-5-21-1-1-1-1001-500",
+                members=[
+                    {
+                        "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+                        "ObjectType": "User",
+                    }
+                ],
+            ),
+            engagement="t",
+            store=store,
+        )
+        node = store.nodes_by_key().get("bh::LocalGroup::S-1-5-21-1-1-1-1001-500")
+        assert node is not None
+        assert node["kind"] == "ADLocalGroup"
+
+    def test_computer_contains_local_group(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                lg_id="S-1-5-21-1-1-1-1001-500",
+                members=[
+                    {
+                        "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+                        "ObjectType": "User",
+                    }
+                ],
+            ),
+            engagement="t",
+            store=store,
+        )
+        contains = store.edges_of_kind("CONTAINS")
+        assert any(
+            "S-1-5-21-1-1-1-1001" in s
+            and "S-1-5-21-1-1-1-1001-500" in d
+            and p.get("bh_right") == "ContainsLocalGroup"
+            for s, d, p in contains
+        )
+
+    def test_member_emits_member_of_local_group_edge(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                lg_id="S-1-5-21-1-1-1-1001-500",
+                members=[
+                    {
+                        "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+                        "ObjectType": "User",
+                    }
+                ],
+            ),
+            engagement="t",
+            store=store,
+        )
+        mol = store.edges_of_kind("MEMBER_OF_LOCAL_GROUP")
+        assert any("1106" in s and "1001-500" in d for s, d, _ in mol)
+
+    @pytest.mark.parametrize(
+        "rid,expected_kind",
+        [
+            ("500", "ADMIN_TO"),  # BUILTIN\Administrators
+            ("555", "CAN_ACCESS"),  # BUILTIN\Remote Desktop Users
+            ("562", "CAN_ACCESS"),  # BUILTIN\Distributed COM Users
+            ("580", "CAN_ACCESS"),  # BUILTIN\Remote Management Users
+        ],
+    )
+    def test_built_in_rid_emits_direct_lateral_edge(self, rid: str, expected_kind: str) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                lg_id=f"S-1-5-21-1-1-1-1001-{rid}",
+                members=[
+                    {
+                        "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+                        "ObjectType": "User",
+                    }
+                ],
+            ),
+            engagement="t",
+            store=store,
+        )
+        direct_edges = store.edges_of_kind(expected_kind)
+        # The direct edge must point principal → computer (not principal
+        # → local group), with the RID + via-local-group provenance.
+        assert any(
+            "1106" in s
+            and "1001" in d
+            and "1001-500" not in d
+            and "1001-555" not in d
+            and "1001-562" not in d
+            and "1001-580" not in d
+            and p.get("rid") == rid
+            and p.get("bh_right") == "LocalGroupRid"
+            for s, d, p in direct_edges
+        )
+
+    def test_non_catalogue_rid_does_not_emit_direct_edge(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                lg_id="S-1-5-21-1-1-1-1001-999",  # RID 999 has no primitive
+                members=[
+                    {
+                        "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+                        "ObjectType": "User",
+                    }
+                ],
+            ),
+            engagement="t",
+            store=store,
+        )
+        admin = store.edges_of_kind("ADMIN_TO")
+        can_access = store.edges_of_kind("CAN_ACCESS")
+        # Only MEMBER_OF_LOCAL_GROUP — no ADMIN_TO / CAN_ACCESS direct.
+        assert all("1001-999" not in s for s, _d, _p in admin + can_access)
+
+    def test_non_numeric_suffix_id_does_not_emit_direct_edge(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                lg_id="S-1-5-21-1-1-1-1001__custom-group",
+                members=[
+                    {
+                        "ObjectIdentifier": "S-1-5-21-1-1-1-1106",
+                        "ObjectType": "User",
+                    }
+                ],
+            ),
+            engagement="t",
+            store=store,
+        )
+        admin = store.edges_of_kind("ADMIN_TO")
+        # Non-numeric trailing fragment skips the RID lookup entirely.
+        assert all("custom-group" not in s for s, _d, _p in admin)


### PR DESCRIPTION
## Summary

Adds Computer ``LocalGroups[]`` ingest — the RFC §4.4 work the post-process plan called out. Each local group becomes an ``ADLocalGroup`` node; well-known built-in RIDs (-500 / -555 / -562 / -580) also emit a **direct lateral-movement edge** so chain analysis sees the path immediately (BHCE-server-equivalent).

| File | Change |
|---|---|
| ``tools/ad/bloodhound.py`` | +108 LOC — ``_LOCAL_GROUP_RID_TO_EDGE`` catalogue + ``_ingest_local_groups`` + Computer-branch dispatch |
| ``tests/unit/ad/test_bloodhound_kgstore.py`` | +164 LOC — new ``TestLocalGroupsIngest`` class (6 tests + 4 parametrised RIDs = 9 effective) |

Net diff: **+272 / -0**.

## Per-local-group output

| BHCE source | Edge / node |
|---|---|
| ``LocalGroups[].ObjectIdentifier`` | ``ADLocalGroup`` node |
| (always) | ``computer --CONTAINS--> ADLocalGroup`` |
| ``Results[].ObjectIdentifier`` | ``principal --MEMBER_OF_LOCAL_GROUP--> ADLocalGroup`` |
| RID **-500** (BUILTIN\Administrators) | ``principal --ADMIN_TO--> computer`` |
| RID **-555** (BUILTIN\Remote Desktop Users) | ``principal --CAN_ACCESS--> computer`` (CanRDP) |
| RID **-562** (BUILTIN\Distributed COM Users) | ``principal --CAN_ACCESS--> computer`` (ExecuteDCOM) |
| RID **-580** (BUILTIN\Remote Management Users) | ``principal --CAN_ACCESS--> computer`` (CanPSRemote) |

Direct edges carry ``bh_right=LocalGroupRid`` + ``rid`` + ``via_local_group`` provenance.

## Edge cases (verified by unit tests)

- **Non-catalogue numeric RIDs** (e.g. RID 999) — no direct edge; ``MEMBER_OF_LOCAL_GROUP`` only.
- **Non-numeric id suffix** (the ``<computerSID>__<groupname>`` shape SharpHound uses for custom local groups) — no direct edge.

## Live dogfood

Engagement ``dogfood-lg-001`` against compose Neo4j:

```
NODES: 5 (1 Host, 2 ADLocalGroup, 2 User)
EDGES:
  User-1106 --ADMIN_TO--> Host           rid=500
  User-1107 --CAN_ACCESS--> Host         rid=555
  Host --CONTAINS--> ADLocalGroup × 2
  User --MEMBER_OF_LOCAL_GROUP--> ADLocalGroup × 2
```

## Out of scope (per BloodHound RFC §4.4)

- ``GPOChanges.LocalAdmins[]`` × ``AffectedComputers[]`` cross product — requires GPOChanges ingest support not yet wired
- ``UserRights`` ``SeRemoteInteractiveLogonRight`` → ``CanRDP`` derivation — separate ingest path

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_bloodhound_kgstore.py``: **48 passed**, 0 failed (up from 39)
- Live dogfood: all expected edges land

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)