### PR TITLE
feat(kg): ADCS ESC1 synthesis + verbatim Properties preservation

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -43,6 +43,7 @@ class PostProcessStats:
 
     dcsync: int = 0
     golden_cert: int = 0
+    adcs_esc1: int = 0
 
     def to_dict(self) -> dict[str, int]:
         return self.__dict__
@@ -87,6 +88,54 @@ _GOLDEN_CERT_QUERY = (
     "SET gc.lastupdated = $now "
     "WITH gc, gc._jc AS just_created "
     "REMOVE gc._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
+# ADCS ESC1 — minimum-viable variant.
+#
+# BHCE's full ESC1 algorithm also requires the EnterpriseCA to chain
+# to an NTAuthStore via ``TRUSTED_FOR_NTAUTH``, but we don't emit
+# that edge yet (NTAuthStore.certthumbprints + EnterpriseCA cert chain
+# matching is a follow-up). For now we accept any EnterpriseCA that
+# publishes the vulnerable template — false-positives are unlikely
+# in a real engagement because raw collector output won't include
+# an unrelated CA in the same domain.
+#
+# Template conditions (per
+# https://bloodhound.specterops.io/resources/edges/adcs-esc1):
+#   - authenticationenabled = true
+#   - enrolleesuppliessubject = true   (the core ESC1 primitive)
+#   - requiresmanagerapproval = false  (default false when missing)
+#
+# Edge requirements:
+#   - principal -[bh_right='Enroll']-> CertTemplate (raw ACE)
+#   - EnterpriseCA -[:PUBLISHED_TO]-> CertTemplate
+#
+# Result: principal --ADCS_ESC1--> EnterpriseCA, dedup'd via DISTINCT
+# so a principal with multiple matching templates on the same CA
+# doesn't mint extra edges.
+
+_ADCS_ESC1_QUERY = (
+    "MATCH (ct:ADCertTemplate {engagement: $engagement}) "
+    "WHERE ct.authenticationenabled = true "
+    "  AND ct.enrolleesuppliessubject = true "
+    "  AND coalesce(ct.requiresmanagerapproval, false) = false "
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
+    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "WHERE en.bh_right = 'Enroll' "
+    "WITH DISTINCT p, eca, ct "
+    "MERGE (p)-[r:ADCS_ESC1 {engagement: $engagement}]->(eca) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC1: vulnerable template + Enroll + PublishedTo', "
+    "              r.via_template = ct.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
     "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
 )
 
@@ -151,6 +200,20 @@ def synthesise_adcs_post(
         )
         if rows:
             stats.golden_cert = int(rows[0].get("created") or 0)
+
+        # ADCS ESC1
+        rows = target_store.execute_write(
+            _ADCS_ESC1_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc1 = int(rows[0].get("created") or 0)
     finally:
         if owned_store:
             target_store.close()

--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -333,28 +333,18 @@ def _ingest_object(state: _IngestState, obj: dict[str, Any], type_name: str) -> 
     label = properties.get("name") or obj.get("Name") or object_id
     kind = _node_kind_for_bh(type_name)
 
-    # Preserve the headline BloodHound props the analysis tools read.
-    bh_props: dict[str, Any] = {
-        "domain": properties.get("domain"),
-        "domainsid": properties.get("domainsid"),
-        "distinguishedname": properties.get("distinguishedname"),
-        "enabled": properties.get("enabled"),
-        "admincount": properties.get("admincount"),
-        "haslaps": properties.get("haslaps"),
-        "hasspn": properties.get("hasspn"),
-        "dontreqpreauth": properties.get("dontreqpreauth"),
-        "trustedfordelegation": properties.get("trustedfordelegation"),
-        "unconstraineddelegation": properties.get("unconstraineddelegation"),
-        "passwordnotreqd": properties.get("passwordnotreqd"),
-        "pwdlastset": properties.get("pwdlastset"),
-        "lastlogon": properties.get("lastlogon"),
-        "sidhistory": properties.get("sidhistory"),
-        "description": properties.get("description"),
-        "samaccountname": properties.get("samaccountname"),
-        "operatingsystem": properties.get("operatingsystem"),
-        "isdc": properties.get("isdc"),
-        "name": properties.get("name"),
-    }
+    # Preserve every BloodHound ``Properties`` field verbatim so the
+    # ADCS template predicates (``authenticationenabled`` /
+    # ``enrolleesuppliessubject`` / ``requiresmanagerapproval`` /
+    # ``nosecurityextension`` / ``ekus`` / etc.) and any future
+    # BHCE-emitted fields are available to downstream consumers
+    # without per-key extraction maintenance. The legacy explicit
+    # allow-list (User / Computer-centric: ``admincount`` /
+    # ``dontreqpreauth`` / ``haslaps`` / etc.) silently dropped
+    # everything else; ESC1 / ESC4 / ESC9 traversal needs the full
+    # set, and the analysis tools that filter by name still find
+    # what they look for.
+    bh_props: dict[str, Any] = dict(properties)
     if obj.get("IsDeleted"):
         bh_props["isdeleted"] = True
     if obj.get("IsACLProtected"):

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -21,22 +21,31 @@ class _FakeKGStore:
     """Captures every ``execute_write`` call so tests can inspect the
     queries and parameter shape."""
 
-    def __init__(self, *, dcsync_created: int = 1, golden_created: int = 1) -> None:
+    def __init__(
+        self,
+        *,
+        dcsync_created: int = 1,
+        golden_created: int = 1,
+        esc1_created: int = 1,
+    ) -> None:
         self.calls: list[tuple[str, dict[str, Any], str]] = []
         self._dcsync_created = dcsync_created
         self._golden_created = golden_created
+        self._esc1_created = esc1_created
         self.closed = False
 
     def execute_write(
         self, query: str, params: dict[str, Any], *, engagement: str
     ) -> list[dict[str, Any]]:
         self.calls.append((query, dict(params), engagement))
-        # The two queries differ in their MATCH pattern: DCSync starts
-        # with GET_CHANGES, GoldenCert with OWNS|WRITE_OWNER|MANAGE_CA.
+        # Each algorithm is identifiable by a distinctive substring in
+        # its MATCH pattern.
         if "GET_CHANGES" in query:
             return [{"created": self._dcsync_created}]
         if "OWNS|WRITE_OWNER|MANAGE_CA" in query:
             return [{"created": self._golden_created}]
+        if "ADCS_ESC1" in query:
+            return [{"created": self._esc1_created}]
         return []
 
     def close(self) -> None:
@@ -56,13 +65,14 @@ class TestPublicSignatures:
         assert isinstance(result, PostProcessStats)
 
     def test_stats_carry_counts_from_each_query(self) -> None:
-        store = _FakeKGStore(dcsync_created=3, golden_created=2)
+        store = _FakeKGStore(dcsync_created=3, golden_created=2, esc1_created=4)
         stats = synthesise_adcs_post(
             engagement="t",
             store=store,  # type: ignore[arg-type]
         )
         assert stats.dcsync == 3
         assert stats.golden_cert == 2
+        assert stats.adcs_esc1 == 4
 
     def test_provenance_threaded_into_every_call(self) -> None:
         store = _FakeKGStore()
@@ -72,7 +82,7 @@ class TestPublicSignatures:
             source_episode_id="ep-x",
             created_by="adcs_post_test",
         )
-        assert len(store.calls) == 2
+        assert len(store.calls) == 3
         for _query, params, engagement in store.calls:
             assert engagement == "t-eng"
             assert params["engagement"] == "t-eng"
@@ -179,6 +189,74 @@ class TestGoldenCertQuery:
         q = self._golden_query(store)
         assert "_jc" in q
         assert "ON CREATE SET" in q and "ON MATCH SET" in q
+
+
+# ── ADCS ESC1 algorithm ─────────────────────────────────────────────
+
+
+class TestAdcsEsc1Query:
+    def _esc1_query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "ADCS_ESC1" in q:
+                return q
+        raise AssertionError("ADCS_ESC1 query not issued")
+
+    def test_template_conditions_required(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc1_query(store)
+        # The core ESC1 template predicates.
+        assert "ct.authenticationenabled = true" in q
+        assert "ct.enrolleesuppliessubject = true" in q
+        assert "ct.requiresmanagerapproval" in q  # checked via coalesce
+
+    def test_enroll_edge_required_via_bh_right(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc1_query(store)
+        # Enroll matches on the ``bh_right`` ACE prop rather than a
+        # dedicated edge type — the ingest writes the ACE under the
+        # generic ENABLES fallback so we match on the prop.
+        assert "bh_right = 'Enroll'" in q
+
+    def test_published_to_required(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc1_query(store)
+        # EnterpriseCA must publish the vulnerable template.
+        assert ":PUBLISHED_TO" in q
+        assert ":ADEnterpriseCA" in q
+
+    def test_query_uses_jc_marker_for_idempotent_count(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc1_query(store)
+        assert "_jc" in q
+        assert "ON CREATE SET" in q and "ON MATCH SET" in q
+
+    def test_via_template_provenance_attached(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc1_query(store)
+        # The vulnerable template's key is preserved on the ESC1 edge
+        # so an analyst can trace the path back without re-running the
+        # algorithm.
+        assert "via_template" in q
 
 
 # ── Default-store path ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two coupled changes that make the BHCE ESC1 algorithm actually fire on Decepticon-ingested data.

| File | Change |
|---|---|
| ``tools/ad/bloodhound.py`` | ``_ingest_object`` now copies ``Properties`` verbatim instead of allow-listing User/Computer-centric keys |
| ``tools/ad/adcs_post.py`` | Adds the minimum-viable ESC1 algorithm + ``via_template`` provenance |
| ``tests/unit/ad/test_adcs_post.py`` | +5 tests in ``TestAdcsEsc1Query`` + counter updates |

Net diff: **+158 / -27**.

## Why verbatim Properties preservation matters

The legacy allow-list (``admincount`` / ``dontreqpreauth`` / ``haslaps`` / ``hasspn`` / …) was User/Computer-centric. ADCS template predicates the ESC algorithms need — ``authenticationenabled`` / ``enrolleesuppliessubject`` / ``requiresmanagerapproval`` / ``nosecurityextension`` / ``ekus`` / ``effectiveekus`` / ``certificatenameflag`` / ``schemaversion`` — all got silently dropped. Without them ESC1 / ESC4 / ESC9 fire on zero rows in real data.

The new code copies ``Properties`` wholesale into ``bh_props``. Analysis tools filtering by name still find what they look for; this just stops hiding everything else.

## ESC1 algorithm

```
MATCH (ct:ADCertTemplate)
WHERE ct.authenticationenabled = true
  AND ct.enrolleesuppliessubject = true
  AND coalesce(ct.requiresmanagerapproval, false) = false
MATCH (eca:ADEnterpriseCA)-[:PUBLISHED_TO]->(ct)
MATCH (p)-[en]->(ct) WHERE en.bh_right = 'Enroll'
WITH DISTINCT p, eca, ct
MERGE (p)-[r:ADCS_ESC1]->(eca)
SET  r.via_template = ct.key
RETURN <jc-marker count>
```

- ``WITH DISTINCT`` dedups when a principal can enrol via multiple matching templates on the same CA.
- ``_jc`` ON CREATE marker pattern keeps idempotency stats truthful.
- ``via_template`` carries the vulnerable template's key so analysts can trace the path back without re-running.

## Scope simplification

Full BHCE ESC1 also chains the EnterpriseCA to an ``NTAuthStore`` via ``TRUSTED_FOR_NTAUTH``. That edge isn't emitted yet (NTAuthStore cert-thumbprint matching is a follow-up). Real engagements don't include unrelated CAs in the same domain, so false positives are unlikely.

## Live dogfood

Engagement ``dogfood-esc1-002`` against compose Neo4j:

```
1 vulnerable template (CT-VULN-1) + 1 safe template (CT-SAFE-1,
requiresmanagerapproval=true), one principal per template via Enroll ACE.

run-1: {'dcsync': 0, 'golden_cert': 0, 'adcs_esc1': 1}
ADCS_ESC1 edges:
  P-1 → ECA-1  via=bh::CertTemplate::CT-VULN-1
run-2 (idempotent): {'dcsync': 0, 'golden_cert': 0, 'adcs_esc1': 0}
```

Only the vulnerable template's principal gets the ESC1 edge; CT-SAFE-1 correctly excluded.

## Out of scope (per BloodHound RFC §4.3)

- **ESC3 / ESC4 / ESC6a / ESC6b / ESC9a / ESC9b / ESC10a / ESC10b / ESC13** — each has its own template-predicate + edge pattern; follow-up incremental PRs
- **``TRUSTED_FOR_NTAUTH`` chain validation**
- **SubjectAlt EKU branch of ESC1** (when ``enrolleesuppliessubject = false`` but a UPN / DNS SAN is required)

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/``: **138 passed**, 0 failed
- Live dogfood: ESC1 fires on vulnerable template only, idempotent on re-run

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)