### PR TITLE
feat(kg): ADCS ESC4 + ESC9a + ESC9b synthesis

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -44,6 +44,9 @@ class PostProcessStats:
     dcsync: int = 0
     golden_cert: int = 0
     adcs_esc1: int = 0
+    adcs_esc4: int = 0
+    adcs_esc9a: int = 0
+    adcs_esc9b: int = 0
 
     def to_dict(self) -> dict[str, int]:
         return self.__dict__
@@ -140,6 +143,102 @@ _ADCS_ESC1_QUERY = (
 )
 
 
+# ADCS ESC4 — vulnerable ACL on a published CertTemplate.
+#
+# A principal that holds ``OWNS`` / ``WRITE_OWNER`` / ``WRITE_DACL``
+# / ``GENERIC_ALL`` / ``GENERIC_WRITE`` (or their limited-rights raw
+# counterparts) on a CertTemplate that is published by an
+# EnterpriseCA can rewrite the template's flags (enrolleesuppliessubject,
+# authenticationenabled, ...) and then enrol — effectively a write-
+# then-ESC1 primitive.
+#
+# We dedup via DISTINCT so a principal with multiple writable rights
+# on the same template doesn't mint extras. The template's key lands
+# on the edge as ``via_template`` provenance.
+
+_ADCS_ESC4_QUERY = (
+    "MATCH (p)-[r:GENERIC_ALL|GENERIC_WRITE|WRITE_DACL|WRITE_OWNER|OWNS"
+    "|OWNS_LIMITED_RIGHTS|WRITE_OWNER_LIMITED_RIGHTS {engagement: $engagement}]->"
+    "(ct:ADCertTemplate {engagement: $engagement}) "
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
+    "WITH DISTINCT p, eca, ct "
+    "MERGE (p)-[e:ADCS_ESC4 {engagement: $engagement}]->(eca) "
+    "ON CREATE SET e.firstseen = $now, "
+    "              e.created_by = $created_by, "
+    "              e.source_episode_id = $source_episode_id, "
+    "              e.post_process_source = 'ESC4: writable ACL on PublishedTo CertTemplate', "
+    "              e.via_template = ct.key, "
+    "              e._jc = true "
+    "ON MATCH SET e._jc = false "
+    "SET e.lastupdated = $now "
+    "WITH e, e._jc AS just_created "
+    "REMOVE e._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
+# ADCS ESC9a / ESC9b — no security extension + subjectAlt user-controlled.
+#
+# When the CertTemplate has ``nosecurityextension = true`` and
+# ``authenticationenabled = true``, the issued certificate's strong
+# mapping to the AD account relies on a Subject Alternative Name.
+# If the SAN is user-controllable (``subjectaltrequireupn = true``
+# for ESC9a; ``subjectaltrequiredns = true`` for ESC9b) the enroller
+# can impersonate any AD principal whose UPN / DNS they put on the
+# SAN.
+#
+# Both variants also need raw Enroll rights + the template to be
+# published by an EnterpriseCA.
+
+_ADCS_ESC9A_QUERY = (
+    "MATCH (ct:ADCertTemplate {engagement: $engagement}) "
+    "WHERE ct.authenticationenabled = true "
+    "  AND ct.nosecurityextension = true "
+    "  AND ct.subjectaltrequireupn = true "
+    "  AND coalesce(ct.requiresmanagerapproval, false) = false "
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
+    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "WHERE en.bh_right = 'Enroll' "
+    "WITH DISTINCT p, eca, ct "
+    "MERGE (p)-[r:ADCS_ESC9A {engagement: $engagement}]->(eca) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC9a: no SecExt + UPN SAN + Enroll', "
+    "              r.via_template = ct.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+_ADCS_ESC9B_QUERY = (
+    "MATCH (ct:ADCertTemplate {engagement: $engagement}) "
+    "WHERE ct.authenticationenabled = true "
+    "  AND ct.nosecurityextension = true "
+    "  AND ct.subjectaltrequiredns = true "
+    "  AND coalesce(ct.requiresmanagerapproval, false) = false "
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
+    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "WHERE en.bh_right = 'Enroll' "
+    "WITH DISTINCT p, eca, ct "
+    "MERGE (p)-[r:ADCS_ESC9B {engagement: $engagement}]->(eca) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC9b: no SecExt + DNS SAN + Enroll', "
+    "              r.via_template = ct.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
 def synthesise_adcs_post(
     *,
     engagement: str,
@@ -214,6 +313,48 @@ def synthesise_adcs_post(
         )
         if rows:
             stats.adcs_esc1 = int(rows[0].get("created") or 0)
+
+        # ADCS ESC4
+        rows = target_store.execute_write(
+            _ADCS_ESC4_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc4 = int(rows[0].get("created") or 0)
+
+        # ADCS ESC9a
+        rows = target_store.execute_write(
+            _ADCS_ESC9A_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc9a = int(rows[0].get("created") or 0)
+
+        # ADCS ESC9b
+        rows = target_store.execute_write(
+            _ADCS_ESC9B_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc9b = int(rows[0].get("created") or 0)
     finally:
         if owned_store:
             target_store.close()

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -27,11 +27,17 @@ class _FakeKGStore:
         dcsync_created: int = 1,
         golden_created: int = 1,
         esc1_created: int = 1,
+        esc4_created: int = 1,
+        esc9a_created: int = 1,
+        esc9b_created: int = 1,
     ) -> None:
         self.calls: list[tuple[str, dict[str, Any], str]] = []
         self._dcsync_created = dcsync_created
         self._golden_created = golden_created
         self._esc1_created = esc1_created
+        self._esc4_created = esc4_created
+        self._esc9a_created = esc9a_created
+        self._esc9b_created = esc9b_created
         self.closed = False
 
     def execute_write(
@@ -39,13 +45,22 @@ class _FakeKGStore:
     ) -> list[dict[str, Any]]:
         self.calls.append((query, dict(params), engagement))
         # Each algorithm is identifiable by a distinctive substring in
-        # its MATCH pattern.
+        # its MATCH pattern. Check the more-specific ESC9 / ESC4 / ESC1
+        # markers before falling back to the broader GoldenCert one
+        # so the alternation doesn't trip the GOLDEN_CERT check on
+        # the ``OWNS_LIMITED_RIGHTS`` substring used in ESC4.
+        if "ADCS_ESC9A" in query:
+            return [{"created": self._esc9a_created}]
+        if "ADCS_ESC9B" in query:
+            return [{"created": self._esc9b_created}]
+        if "ADCS_ESC4" in query:
+            return [{"created": self._esc4_created}]
+        if "ADCS_ESC1" in query:
+            return [{"created": self._esc1_created}]
         if "GET_CHANGES" in query:
             return [{"created": self._dcsync_created}]
         if "OWNS|WRITE_OWNER|MANAGE_CA" in query:
             return [{"created": self._golden_created}]
-        if "ADCS_ESC1" in query:
-            return [{"created": self._esc1_created}]
         return []
 
     def close(self) -> None:
@@ -65,7 +80,14 @@ class TestPublicSignatures:
         assert isinstance(result, PostProcessStats)
 
     def test_stats_carry_counts_from_each_query(self) -> None:
-        store = _FakeKGStore(dcsync_created=3, golden_created=2, esc1_created=4)
+        store = _FakeKGStore(
+            dcsync_created=3,
+            golden_created=2,
+            esc1_created=4,
+            esc4_created=5,
+            esc9a_created=6,
+            esc9b_created=7,
+        )
         stats = synthesise_adcs_post(
             engagement="t",
             store=store,  # type: ignore[arg-type]
@@ -73,6 +95,9 @@ class TestPublicSignatures:
         assert stats.dcsync == 3
         assert stats.golden_cert == 2
         assert stats.adcs_esc1 == 4
+        assert stats.adcs_esc4 == 5
+        assert stats.adcs_esc9a == 6
+        assert stats.adcs_esc9b == 7
 
     def test_provenance_threaded_into_every_call(self) -> None:
         store = _FakeKGStore()
@@ -82,7 +107,7 @@ class TestPublicSignatures:
             source_episode_id="ep-x",
             created_by="adcs_post_test",
         )
-        assert len(store.calls) == 3
+        assert len(store.calls) == 6
         for _query, params, engagement in store.calls:
             assert engagement == "t-eng"
             assert params["engagement"] == "t-eng"
@@ -257,6 +282,115 @@ class TestAdcsEsc1Query:
         # so an analyst can trace the path back without re-running the
         # algorithm.
         assert "via_template" in q
+
+
+# ── ADCS ESC4 algorithm ─────────────────────────────────────────────
+
+
+class TestAdcsEsc4Query:
+    def _esc4_query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "ADCS_ESC4" in q:
+                return q
+        raise AssertionError("ADCS_ESC4 query not issued")
+
+    def test_writable_ace_alternation(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc4_query(store)
+        # All five "writable on the template" rights must be in the
+        # alternation, plus the OwnsLimitedRights / WriteOwnerLimitedRights
+        # raw forms that BHCE post-process otherwise promotes.
+        for kind in (
+            "GENERIC_ALL",
+            "GENERIC_WRITE",
+            "WRITE_DACL",
+            "WRITE_OWNER",
+            "OWNS",
+            "OWNS_LIMITED_RIGHTS",
+            "WRITE_OWNER_LIMITED_RIGHTS",
+        ):
+            assert kind in q
+
+    def test_published_to_required(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc4_query(store)
+        assert ":PUBLISHED_TO" in q
+        assert ":ADEnterpriseCA" in q
+        assert ":ADCertTemplate" in q
+
+    def test_via_template_provenance(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc4_query(store)
+        assert "via_template" in q
+
+
+# ── ADCS ESC9a / ESC9b algorithms ──────────────────────────────────
+
+
+class TestAdcsEsc9Queries:
+    def _esc9_queries(self, store: _FakeKGStore) -> tuple[str, str]:
+        esc9a, esc9b = None, None
+        for q, _params, _engagement in store.calls:
+            if "ADCS_ESC9A" in q:
+                esc9a = q
+            elif "ADCS_ESC9B" in q:
+                esc9b = q
+        if esc9a is None or esc9b is None:
+            raise AssertionError("ESC9a or ESC9b query missing")
+        return esc9a, esc9b
+
+    def test_both_variants_require_no_security_extension(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        esc9a, esc9b = self._esc9_queries(store)
+        assert "ct.nosecurityextension = true" in esc9a
+        assert "ct.nosecurityextension = true" in esc9b
+
+    def test_esc9a_branches_on_subjectaltrequireupn(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        esc9a, _ = self._esc9_queries(store)
+        assert "ct.subjectaltrequireupn = true" in esc9a
+        # ESC9a must NOT trigger on DNS-only templates.
+        assert "subjectaltrequiredns" not in esc9a
+
+    def test_esc9b_branches_on_subjectaltrequiredns(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        _, esc9b = self._esc9_queries(store)
+        assert "ct.subjectaltrequiredns = true" in esc9b
+        assert "subjectaltrequireupn" not in esc9b
+
+    def test_both_variants_require_enroll_via_bh_right(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        esc9a, esc9b = self._esc9_queries(store)
+        assert "bh_right = 'Enroll'" in esc9a
+        assert "bh_right = 'Enroll'" in esc9b
 
 
 # ── Default-store path ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three more BHCE-equivalent ESC algorithms in ``tools/ad/adcs_post.py``, each following the standard pattern (template predicate + Enroll / writable ACL + ``PUBLISHED_TO`` → MERGE into EnterpriseCA).

| ESC | Template predicate | Edge predicate |
|---|---|---|
| **ESC4** | (none — any published template counts) | ``principal -[GENERIC_ALL\|GENERIC_WRITE\|WRITE_DACL\|WRITE_OWNER\|OWNS(+\_LIMITED_RIGHTS)]-> CertTemplate`` |
| **ESC9a** | ``nosecurityextension=true`` + ``subjectaltrequireupn=true`` + ``authenticationenabled=true`` | ``principal -[bh_right='Enroll']-> CertTemplate`` |
| **ESC9b** | ``nosecurityextension=true`` + ``subjectaltrequiredns=true`` + ``authenticationenabled=true`` | same |

Each carries ``via_template`` provenance, ``WITH DISTINCT`` dedup, and the ``_jc`` ON CREATE marker pattern for truthful idempotent counts.

| File | Change |
|---|---|
| ``tools/ad/adcs_post.py`` | +141 LOC — three new query templates + stats counters + dispatch |
| ``tests/unit/ad/test_adcs_post.py`` | +144 LOC — ``TestAdcsEsc4Query`` + ``TestAdcsEsc9Queries`` + fake-store routing fix |

Net diff: **+280 / -5**.

## Live dogfood

Engagement ``dogfood-esc49-001`` against compose Neo4j — 3 vulnerable templates, one ACE each, all published by the same CA:

```
run-1: {'adcs_esc4': 1, 'adcs_esc9a': 1, 'adcs_esc9b': 1, ...}
ADCS_ESC4 edges:
  P-ESC4  → ECA-1  via=bh::CertTemplate::CT-WRITABLE
ADCS_ESC9A edges:
  P-ESC9A → ECA-1  via=bh::CertTemplate::CT-ESC9A
ADCS_ESC9B edges:
  P-ESC9B → ECA-1  via=bh::CertTemplate::CT-ESC9B
run-2 (idempotent): all 0
```

## Out of scope (per BloodHound RFC §4.3)

- **ESC3** — Certificate Request Agent template + Enroll Agent template chaining
- **ESC6a / ESC6b** — CA-level ``isuserspecifiessanenabled`` flag
- **ESC10a / ESC10b** — weak certificate mapping
- **ESC13** — IssuancePolicy ``GroupLink``
- **``TRUSTED_FOR_NTAUTH`` chain validation** — currently any CA publishing the vulnerable template counts

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_adcs_post.py``: **23 passed**, 0 failed
- Live dogfood: all three ESCs fire on the right template only, idempotent on re-run

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)