### PR TITLE
feat(kg): ADCS ESC6a + ESC6b synthesis

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -45,6 +45,8 @@ class PostProcessStats:
     golden_cert: int = 0
     adcs_esc1: int = 0
     adcs_esc4: int = 0
+    adcs_esc6a: int = 0
+    adcs_esc6b: int = 0
     adcs_esc9a: int = 0
     adcs_esc9b: int = 0
 
@@ -190,6 +192,73 @@ _ADCS_ESC4_QUERY = (
 # Both variants also need raw Enroll rights + the template to be
 # published by an EnterpriseCA.
 
+# ADCS ESC6a / ESC6b — EDITF_ATTRIBUTESUBJECTALTNAME2 abuse.
+#
+# When an EnterpriseCA has the registry flag
+# ``EDITF_ATTRIBUTESUBJECTALTNAME2`` set, callers can request any
+# SAN they like in the CSR — which means an enroller who can issue
+# any authentication-enabled template can impersonate any principal
+# (UPN / DNS) via the SAN.
+#
+# BHCE exposes this as the ``isuserspecifiessanenabled`` property
+# on the CA node. ESC6a and ESC6b only differ in whether the
+# template also has the strong-mapping security extension stripped:
+#
+#   ESC6a: any authentication-enabled template, manager approval off
+#   ESC6b: same but with ``nosecurityextension = true``
+#
+# ESC6b is rarer but strictly broader in impact (no cert-mapping
+# fallback), so we synthesise both edges so chain planners can
+# prioritise.
+
+_ADCS_ESC6A_QUERY = (
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement}) "
+    "WHERE eca.isuserspecifiessanenabled = true "
+    "MATCH (eca)-[:PUBLISHED_TO {engagement: $engagement}]->(ct:ADCertTemplate {engagement: $engagement}) "
+    "WHERE ct.authenticationenabled = true "
+    "  AND coalesce(ct.requiresmanagerapproval, false) = false "
+    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "WHERE en.bh_right = 'Enroll' "
+    "WITH DISTINCT p, eca, ct "
+    "MERGE (p)-[r:ADCS_ESC6A {engagement: $engagement}]->(eca) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC6a: SAN-enabled CA + AuthEnabled template + Enroll', "
+    "              r.via_template = ct.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+_ADCS_ESC6B_QUERY = (
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement}) "
+    "WHERE eca.isuserspecifiessanenabled = true "
+    "MATCH (eca)-[:PUBLISHED_TO {engagement: $engagement}]->(ct:ADCertTemplate {engagement: $engagement}) "
+    "WHERE ct.authenticationenabled = true "
+    "  AND ct.nosecurityextension = true "
+    "  AND coalesce(ct.requiresmanagerapproval, false) = false "
+    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "WHERE en.bh_right = 'Enroll' "
+    "WITH DISTINCT p, eca, ct "
+    "MERGE (p)-[r:ADCS_ESC6B {engagement: $engagement}]->(eca) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC6b: SAN-enabled CA + AuthEnabled + NoSecExt template + Enroll', "
+    "              r.via_template = ct.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
 _ADCS_ESC9A_QUERY = (
     "MATCH (ct:ADCertTemplate {engagement: $engagement}) "
     "WHERE ct.authenticationenabled = true "
@@ -327,6 +396,34 @@ def synthesise_adcs_post(
         )
         if rows:
             stats.adcs_esc4 = int(rows[0].get("created") or 0)
+
+        # ADCS ESC6a
+        rows = target_store.execute_write(
+            _ADCS_ESC6A_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc6a = int(rows[0].get("created") or 0)
+
+        # ADCS ESC6b
+        rows = target_store.execute_write(
+            _ADCS_ESC6B_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc6b = int(rows[0].get("created") or 0)
 
         # ADCS ESC9a
         rows = target_store.execute_write(

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -28,6 +28,8 @@ class _FakeKGStore:
         golden_created: int = 1,
         esc1_created: int = 1,
         esc4_created: int = 1,
+        esc6a_created: int = 1,
+        esc6b_created: int = 1,
         esc9a_created: int = 1,
         esc9b_created: int = 1,
     ) -> None:
@@ -36,6 +38,8 @@ class _FakeKGStore:
         self._golden_created = golden_created
         self._esc1_created = esc1_created
         self._esc4_created = esc4_created
+        self._esc6a_created = esc6a_created
+        self._esc6b_created = esc6b_created
         self._esc9a_created = esc9a_created
         self._esc9b_created = esc9b_created
         self.closed = False
@@ -45,10 +49,14 @@ class _FakeKGStore:
     ) -> list[dict[str, Any]]:
         self.calls.append((query, dict(params), engagement))
         # Each algorithm is identifiable by a distinctive substring in
-        # its MATCH pattern. Check the more-specific ESC9 / ESC4 / ESC1
-        # markers before falling back to the broader GoldenCert one
-        # so the alternation doesn't trip the GOLDEN_CERT check on
-        # the ``OWNS_LIMITED_RIGHTS`` substring used in ESC4.
+        # its MATCH pattern. Check the more-specific ESC* markers
+        # before falling back to the broader GoldenCert one so the
+        # ``OWNS_LIMITED_RIGHTS`` substring used in ESC4 doesn't trip
+        # the wrong return value.
+        if "ADCS_ESC6A" in query:
+            return [{"created": self._esc6a_created}]
+        if "ADCS_ESC6B" in query:
+            return [{"created": self._esc6b_created}]
         if "ADCS_ESC9A" in query:
             return [{"created": self._esc9a_created}]
         if "ADCS_ESC9B" in query:
@@ -85,6 +93,8 @@ class TestPublicSignatures:
             golden_created=2,
             esc1_created=4,
             esc4_created=5,
+            esc6a_created=8,
+            esc6b_created=9,
             esc9a_created=6,
             esc9b_created=7,
         )
@@ -96,6 +106,8 @@ class TestPublicSignatures:
         assert stats.golden_cert == 2
         assert stats.adcs_esc1 == 4
         assert stats.adcs_esc4 == 5
+        assert stats.adcs_esc6a == 8
+        assert stats.adcs_esc6b == 9
         assert stats.adcs_esc9a == 6
         assert stats.adcs_esc9b == 7
 
@@ -107,7 +119,7 @@ class TestPublicSignatures:
             source_episode_id="ep-x",
             created_by="adcs_post_test",
         )
-        assert len(store.calls) == 6
+        assert len(store.calls) == 8
         for _query, params, engagement in store.calls:
             assert engagement == "t-eng"
             assert params["engagement"] == "t-eng"
@@ -334,6 +346,64 @@ class TestAdcsEsc4Query:
         )
         q = self._esc4_query(store)
         assert "via_template" in q
+
+
+# ── ADCS ESC6a / ESC6b algorithms ──────────────────────────────────
+
+
+class TestAdcsEsc6Queries:
+    def _esc6_queries(self, store: _FakeKGStore) -> tuple[str, str]:
+        esc6a, esc6b = None, None
+        for q, _params, _engagement in store.calls:
+            if "ADCS_ESC6A" in q:
+                esc6a = q
+            elif "ADCS_ESC6B" in q:
+                esc6b = q
+        if esc6a is None or esc6b is None:
+            raise AssertionError("ESC6a or ESC6b query missing")
+        return esc6a, esc6b
+
+    def test_both_variants_require_is_user_specifies_san_enabled(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        esc6a, esc6b = self._esc6_queries(store)
+        # ``EDITF_ATTRIBUTESUBJECTALTNAME2`` surfaces as this CA prop.
+        assert "eca.isuserspecifiessanenabled = true" in esc6a
+        assert "eca.isuserspecifiessanenabled = true" in esc6b
+
+    def test_esc6b_requires_no_security_extension(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        _, esc6b = self._esc6_queries(store)
+        # ESC6b is strictly broader: no security-extension fallback.
+        assert "ct.nosecurityextension = true" in esc6b
+
+    def test_esc6a_does_not_filter_on_no_security_extension(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        esc6a, _ = self._esc6_queries(store)
+        # ESC6a matches authentication-enabled templates with or
+        # without the security extension.
+        assert "ct.nosecurityextension" not in esc6a
+
+    def test_both_variants_require_enroll_via_bh_right(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        esc6a, esc6b = self._esc6_queries(store)
+        assert "bh_right = 'Enroll'" in esc6a
+        assert "bh_right = 'Enroll'" in esc6b
 
 
 # ── ADCS ESC9a / ESC9b algorithms ──────────────────────────────────


### PR DESCRIPTION
## Summary

Two more BHCE-equivalent ESC algorithms targeting EnterpriseCAs with the registry flag ``EDITF_ATTRIBUTESUBJECTALTNAME2`` set (surfaced as ``isuserspecifiessanenabled = true`` on the CA node).

| ESC | CA predicate | Template predicate |
|---|---|---|
| **ESC6a** | ``eca.isuserspecifiessanenabled = true`` | ``ct.authenticationenabled = true`` + manager approval off |
| **ESC6b** | same | same **plus** ``ct.nosecurityextension = true`` |

Both edges require ``principal -[bh_right='Enroll']-> CertTemplate`` and ``EnterpriseCA -[:PUBLISHED_TO]-> CertTemplate``. ESC6b is strictly broader in impact than ESC6a — we emit both edges so the chain planner can prioritise.

| File | Change |
|---|---|
| ``tools/ad/adcs_post.py`` | +97 LOC — ``_ADCS_ESC6A_QUERY`` / ``_ADCS_ESC6B_QUERY`` + counters + dispatch |
| ``tests/unit/ad/test_adcs_post.py`` | +80 LOC — ``TestAdcsEsc6Queries`` (4 tests) + fake-store routing + counter update |

Net diff: **+172 / -5**.

## Live dogfood

Engagement ``dogfood-esc6-001`` against compose Neo4j — vulnerable CA + two templates (CT-A auth-only, CT-B auth + nosecurityextension):

```
run-1: {'adcs_esc6a': 2, 'adcs_esc6b': 1, ...}
ADCS_ESC6A edges:
  P-A → ECA-1  via=CT-A      (CT-A hits ESC6a only)
  P-B → ECA-1  via=CT-B      (CT-B hits both)
ADCS_ESC6B edges:
  P-B → ECA-1  via=CT-B      (CT-B has nosecurityextension)
run-2 (idempotent): all 0
```

## Out of scope (per BloodHound RFC §4.3)

- **ESC3** — Certificate Request Agent template chaining
- **ESC10a / ESC10b** — weak certificate mapping (DC-side flags)
- **ESC13** — IssuancePolicy ``GroupLink`` (edge type exists from #564; pairing with Enroll is the synthesis work)
- **``TRUSTED_FOR_NTAUTH`` chain validation**

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_adcs_post.py``: **27 passed**, 0 failed
- Live dogfood: correct templates trigger correct ESCs; idempotent on re-run

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)