### PR TITLE
feat(kg): ADCS ESC13 synthesis — OID-group-link abuse

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -49,6 +49,7 @@ class PostProcessStats:
     adcs_esc6b: int = 0
     adcs_esc9a: int = 0
     adcs_esc9b: int = 0
+    adcs_esc13: int = 0
 
     def to_dict(self) -> dict[str, int]:
         return self.__dict__
@@ -283,6 +284,54 @@ _ADCS_ESC9A_QUERY = (
     "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
 )
 
+# ADCS ESC13 — OID-group-link abuse.
+#
+# When a CertTemplate's ``issuancepolicies`` field references the OID
+# of an ``IssuancePolicy`` whose ``GroupLink`` points to a group,
+# enrolling for that template implicitly grants membership in the
+# target group for the duration of the issued cert. A principal who
+# can enrol thus gains group membership without ever being added to
+# the group itself.
+#
+# Edge: principal --ADCS_ESC13--> target group.
+#
+# Pre-requisites in the raw graph:
+#   - CertTemplate is authentication-enabled, no manager approval.
+#   - ``ct.issuancepolicies`` (list of OID strings) contains the
+#     ``IssuancePolicy.certtemplateoid`` of some IssuancePolicy node.
+#   - That IssuancePolicy has an ``OID_GROUP_LINK`` edge to the
+#     target group.
+#   - EnterpriseCA publishes the template.
+#   - Principal has Enroll right on the template.
+
+_ADCS_ESC13_QUERY = (
+    "MATCH (ct:ADCertTemplate {engagement: $engagement}) "
+    "WHERE ct.authenticationenabled = true "
+    "  AND coalesce(ct.requiresmanagerapproval, false) = false "
+    "  AND ct.issuancepolicies IS NOT NULL "
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
+    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "WHERE en.bh_right = 'Enroll' "
+    "MATCH (pol:ADIssuancePolicy {engagement: $engagement}) "
+    "WHERE pol.certtemplateoid IN ct.issuancepolicies "
+    "MATCH (pol)-[:OID_GROUP_LINK {engagement: $engagement}]->(g) "
+    "WITH DISTINCT p, g, ct, pol "
+    "MERGE (p)-[r:ADCS_ESC13 {engagement: $engagement}]->(g) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC13: IssuancePolicy.GroupLink + Enroll on PublishedTo template', "
+    "              r.via_template = ct.key, "
+    "              r.via_policy = pol.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
 _ADCS_ESC9B_QUERY = (
     "MATCH (ct:ADCertTemplate {engagement: $engagement}) "
     "WHERE ct.authenticationenabled = true "
@@ -452,6 +501,20 @@ def synthesise_adcs_post(
         )
         if rows:
             stats.adcs_esc9b = int(rows[0].get("created") or 0)
+
+        # ADCS ESC13
+        rows = target_store.execute_write(
+            _ADCS_ESC13_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc13 = int(rows[0].get("created") or 0)
     finally:
         if owned_store:
             target_store.close()

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -32,6 +32,7 @@ class _FakeKGStore:
         esc6b_created: int = 1,
         esc9a_created: int = 1,
         esc9b_created: int = 1,
+        esc13_created: int = 1,
     ) -> None:
         self.calls: list[tuple[str, dict[str, Any], str]] = []
         self._dcsync_created = dcsync_created
@@ -42,6 +43,7 @@ class _FakeKGStore:
         self._esc6b_created = esc6b_created
         self._esc9a_created = esc9a_created
         self._esc9b_created = esc9b_created
+        self._esc13_created = esc13_created
         self.closed = False
 
     def execute_write(
@@ -53,6 +55,8 @@ class _FakeKGStore:
         # before falling back to the broader GoldenCert one so the
         # ``OWNS_LIMITED_RIGHTS`` substring used in ESC4 doesn't trip
         # the wrong return value.
+        if "ADCS_ESC13" in query:
+            return [{"created": self._esc13_created}]
         if "ADCS_ESC6A" in query:
             return [{"created": self._esc6a_created}]
         if "ADCS_ESC6B" in query:
@@ -97,6 +101,7 @@ class TestPublicSignatures:
             esc6b_created=9,
             esc9a_created=6,
             esc9b_created=7,
+            esc13_created=10,
         )
         stats = synthesise_adcs_post(
             engagement="t",
@@ -110,6 +115,7 @@ class TestPublicSignatures:
         assert stats.adcs_esc6b == 9
         assert stats.adcs_esc9a == 6
         assert stats.adcs_esc9b == 7
+        assert stats.adcs_esc13 == 10
 
     def test_provenance_threaded_into_every_call(self) -> None:
         store = _FakeKGStore()
@@ -119,7 +125,7 @@ class TestPublicSignatures:
             source_episode_id="ep-x",
             created_by="adcs_post_test",
         )
-        assert len(store.calls) == 8
+        assert len(store.calls) == 9
         for _query, params, engagement in store.calls:
             assert engagement == "t-eng"
             assert params["engagement"] == "t-eng"
@@ -404,6 +410,62 @@ class TestAdcsEsc6Queries:
         esc6a, esc6b = self._esc6_queries(store)
         assert "bh_right = 'Enroll'" in esc6a
         assert "bh_right = 'Enroll'" in esc6b
+
+
+# ── ADCS ESC13 algorithm ───────────────────────────────────────────
+
+
+class TestAdcsEsc13Query:
+    def _esc13_query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "ADCS_ESC13" in q:
+                return q
+        raise AssertionError("ESC13 query not issued")
+
+    def test_template_must_have_issuancepolicies(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc13_query(store)
+        # The OID-list field must be present (a null check) and the
+        # IssuancePolicy's OID must be contained in it.
+        assert "ct.issuancepolicies IS NOT NULL" in q
+        assert "pol.certtemplateoid IN ct.issuancepolicies" in q
+
+    def test_requires_oid_group_link_to_target_group(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc13_query(store)
+        # The IssuancePolicy must publish an ``OID_GROUP_LINK`` edge
+        # to the group whose membership is implicit on enrol.
+        assert ":OID_GROUP_LINK" in q
+        assert ":ADIssuancePolicy" in q
+
+    def test_requires_enroll_via_bh_right(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc13_query(store)
+        assert "bh_right = 'Enroll'" in q
+
+    def test_via_template_and_via_policy_provenance(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc13_query(store)
+        # ESC13 carries both the vulnerable template and the abused
+        # policy on the edge so analysts can trace either side.
+        assert "via_template" in q
+        assert "via_policy" in q
 
 
 # ── ADCS ESC9a / ESC9b algorithms ──────────────────────────────────


### PR DESCRIPTION
## Summary

Final straightforward ESC variant from the RFC §4.3 catalogue. When a CertTemplate's ``issuancepolicies`` list contains the OID of an ``ADIssuancePolicy`` whose ``GroupLink`` points to a group, enrolling for that template implicitly grants membership in the target group for the duration of the issued cert.

| File | Change |
|---|---|
| ``tools/ad/adcs_post.py`` | New ``_ADCS_ESC13_QUERY`` + counter + dispatch |
| ``tests/unit/ad/test_adcs_post.py`` | ``TestAdcsEsc13Query`` (4 tests) + fake-store routing + counter update |

Net diff: **+126 / -1**.

## Algorithm

```cypher
MATCH (ct:ADCertTemplate)
WHERE ct.authenticationenabled = true
  AND coalesce(ct.requiresmanagerapproval, false) = false
  AND ct.issuancepolicies IS NOT NULL
MATCH (eca:ADEnterpriseCA)-[:PUBLISHED_TO]->(ct)
MATCH (p)-[en]->(ct) WHERE en.bh_right = 'Enroll'
MATCH (pol:ADIssuancePolicy)
WHERE pol.certtemplateoid IN ct.issuancepolicies
MATCH (pol)-[:OID_GROUP_LINK]->(g)
WITH DISTINCT p, g, ct, pol
MERGE (p)-[r:ADCS_ESC13]->(g)
SET   r.via_template = ct.key, r.via_policy = pol.key
RETURN <jc-marker count>
```

Resulting edge: ``principal --ADCS_ESC13--> Group``. Provenance attaches **both** the via template and the via policy keys so analysts can trace either side of the chain.

## Live dogfood

Engagement ``dogfood-esc13-001`` against compose Neo4j — CT-POL with ``issuancepolicies=['1.3.6.1.4.1.311.21.8.99']`` + matching IssuancePolicy with ``OID_GROUP_LINK`` to Group-513 + principal P-13 with Enroll:

```
run-1: {'adcs_esc13': 1, ...}
ADCS_ESC13 edges:
  P-13 → Group-513  via_t=CT-POL  via_p=POL-1
run-2 (idempotent): {'adcs_esc13': 0, ...}
```

## RFC §4.3 progress

| ESC | Status |
|---|---|
| ESC1 | ✅ #567 |
| ESC4 / ESC9a / ESC9b | ✅ #568 |
| ESC6a / ESC6b | ✅ #569 |
| **ESC13** | ✅ **this PR** |
| ESC3 / ESC10a / ESC10b | ❌ follow-up |

## Out of scope (RFC §4.3, follow-up)

- **ESC3** — Certificate Request Agent template + Enroll Agent template chaining (two-hop algorithm)
- **ESC10a / ESC10b** — weak certificate mapping (DC-side ``StrongCertificateBindingEnforcement`` registry flag)
- **``TRUSTED_FOR_NTAUTH`` chain validation**

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_adcs_post.py``: **31 passed**, 0 failed
- Live dogfood: edge lands on right principal / group pair with both provenance props; idempotent on re-run

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)