### PR TITLE
feat(kg): BloodHound GPOChanges + UserRights ingest — direct lateral edges

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -688,6 +688,130 @@ def _ingest_local_groups(state: _IngestState, computer_key: str, obj: dict[str, 
                 )
 
 
+# Computer ``GPOChanges`` block — GptTmpl.inf-derived effective group
+# membership changes applied to the host by GPOs linked to its OU.
+#
+# Each list under GPOChanges enumerates the **principals** that the
+# GPO push grants the corresponding local primitive on **this**
+# computer. BHCE's server walks them and synthesises one direct
+# access edge per (principal, computer) pair:
+#
+#   LocalAdmins         → AdminTo
+#   RemoteDesktopUsers  → CAN_ACCESS  (CanRDP equivalent)
+#   DcomUsers           → CAN_ACCESS  (ExecuteDCOM equivalent)
+#   PSRemoteUsers       → CAN_ACCESS  (CanPSRemote equivalent)
+#
+# The provenance prop ``via_gpo_changes`` records which bucket the
+# edge came from so analysts can re-derive the chain to the GPO
+# without a separate query.
+
+_GPO_CHANGES_BUCKET_TO_EDGE: dict[str, tuple[EdgeKind, float]] = {
+    "LocalAdmins": (EdgeKind.ADMIN_TO, 0.3),
+    "RemoteDesktopUsers": (EdgeKind.CAN_ACCESS, 0.6),
+    "DcomUsers": (EdgeKind.CAN_ACCESS, 0.6),
+    "PSRemoteUsers": (EdgeKind.CAN_ACCESS, 0.5),
+}
+
+
+def _ingest_gpo_changes(state: _IngestState, computer_key: str, obj: dict[str, Any]) -> None:
+    """Computer ``GPOChanges`` → direct AdminTo / CAN_ACCESS edges per
+    principal granted that primitive on this host by linked GPOs."""
+    gpo_changes = obj.get("GPOChanges")
+    if not isinstance(gpo_changes, dict):
+        return
+    for bucket, (edge_kind, weight) in _GPO_CHANGES_BUCKET_TO_EDGE.items():
+        principals = gpo_changes.get(bucket) or []
+        if not isinstance(principals, list):
+            continue
+        for principal in principals:
+            if not isinstance(principal, dict):
+                continue
+            principal_sid = principal.get("ObjectIdentifier")
+            if not isinstance(principal_sid, str) or not principal_sid:
+                continue
+            principal_type = principal.get("ObjectType") or "User"
+            principal_type = (
+                principal_type if principal_type in _BH_TYPE_SINGULAR.values() else "User"
+            )
+            principal_key = _ensure_placeholder(
+                state, sid=principal_sid, default_type=principal_type
+            )
+            state.add_edge(
+                src_key=principal_key,
+                dst_key=computer_key,
+                kind=edge_kind,
+                weight=weight,
+                props={
+                    "bh_right": "GPOChange",
+                    "via_gpo_changes": bucket,
+                },
+            )
+
+
+# Computer ``UserRights`` block — the host's effective User Rights
+# Assignments (a different policy surface from GPOChanges). BHCE
+# maps a small whitelist of privileges to direct access edges:
+#
+#   SeRemoteInteractiveLogonRight → CAN_ACCESS (CanRDP via UR)
+#   SeInteractiveLogonRight       → CAN_ACCESS (local logon proxy)
+#   SeServiceLogonRight           → CAN_ACCESS (service-only)
+#   SeBatchLogonRight             → CAN_ACCESS (scheduled tasks)
+#
+# Privileges outside this whitelist are ignored — they don't carry
+# the lateral-movement primitive we care about on the chain graph.
+
+_USER_RIGHTS_PRIVILEGE_TO_EDGE: dict[str, tuple[EdgeKind, float]] = {
+    "SeRemoteInteractiveLogonRight": (EdgeKind.CAN_ACCESS, 0.6),
+    "SeInteractiveLogonRight": (EdgeKind.CAN_ACCESS, 0.7),
+    "SeServiceLogonRight": (EdgeKind.CAN_ACCESS, 0.7),
+    "SeBatchLogonRight": (EdgeKind.CAN_ACCESS, 0.7),
+}
+
+
+def _ingest_user_rights(state: _IngestState, computer_key: str, obj: dict[str, Any]) -> None:
+    """Computer ``UserRights[]`` → direct CAN_ACCESS edges per
+    principal that holds a known lateral-movement privilege."""
+    user_rights = obj.get("UserRights")
+    if not isinstance(user_rights, list):
+        return
+    for ur in user_rights:
+        if not isinstance(ur, dict):
+            continue
+        privilege = ur.get("Privilege")
+        if not isinstance(privilege, str):
+            continue
+        mapping = _USER_RIGHTS_PRIVILEGE_TO_EDGE.get(privilege)
+        if mapping is None:
+            continue
+        edge_kind, weight = mapping
+        results = ur.get("Results") or []
+        if not isinstance(results, list):
+            continue
+        for principal in results:
+            if not isinstance(principal, dict):
+                continue
+            principal_sid = principal.get("ObjectIdentifier")
+            if not isinstance(principal_sid, str) or not principal_sid:
+                continue
+            principal_type = principal.get("ObjectType") or "User"
+            principal_type = (
+                principal_type if principal_type in _BH_TYPE_SINGULAR.values() else "User"
+            )
+            principal_key = _ensure_placeholder(
+                state, sid=principal_sid, default_type=principal_type
+            )
+            state.add_edge(
+                src_key=principal_key,
+                dst_key=computer_key,
+                kind=edge_kind,
+                weight=weight,
+                props={
+                    "bh_right": "UserRight",
+                    "via_privilege": privilege,
+                },
+            )
+
+
 def _ingest_enterprise_ca_edges(state: _IngestState, src_key: str, obj: dict[str, Any]) -> None:
     """``EnterpriseCA`` extras: ``EnabledCertTemplates[]`` and
     ``HostingComputer``.
@@ -820,6 +944,8 @@ def _merge_one_payload(state: _IngestState, data: dict[str, Any], *, type_hint: 
             _ingest_issuance_policy_link(state, src_key, obj)
         if type_singular == "Computer":
             _ingest_local_groups(state, src_key, obj)
+            _ingest_gpo_changes(state, src_key, obj)
+            _ingest_user_rights(state, src_key, obj)
         if hasattr(state.stats, counter_attr):
             setattr(state.stats, counter_attr, getattr(state.stats, counter_attr) + 1)
 

--- a/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
+++ b/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
@@ -817,3 +817,129 @@ class TestLocalGroupsIngest:
         admin = store.edges_of_kind("ADMIN_TO")
         # Non-numeric trailing fragment skips the RID lookup entirely.
         assert all("custom-group" not in s for s, _d, _p in admin)
+
+
+# ── GPOChanges + UserRights ingest ──────────────────────────────────
+
+
+class TestGpoChangesIngest:
+    """Computer ``GPOChanges`` → direct AdminTo / CAN_ACCESS edges
+    derived from GptTmpl.inf-pushed local-group membership."""
+
+    def _bh(self, *, bucket: str, principal_sid: str) -> dict[str, Any]:
+        return {
+            "meta": {"type": "computers"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-1001",
+                    "Properties": {"name": "ws01"},
+                    "GPOChanges": {
+                        bucket: [{"ObjectIdentifier": principal_sid, "ObjectType": "User"}]
+                    },
+                }
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        "bucket,expected_kind",
+        [
+            ("LocalAdmins", "ADMIN_TO"),
+            ("RemoteDesktopUsers", "CAN_ACCESS"),
+            ("DcomUsers", "CAN_ACCESS"),
+            ("PSRemoteUsers", "CAN_ACCESS"),
+        ],
+    )
+    def test_each_bucket_emits_correct_direct_edge(self, bucket: str, expected_kind: str) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(bucket=bucket, principal_sid="S-1-5-21-1-1-1-2001"),
+            engagement="t",
+            store=store,
+        )
+        edges = store.edges_of_kind(expected_kind)
+        assert any(
+            "2001" in s
+            and "1001" in d
+            and p.get("bh_right") == "GPOChange"
+            and p.get("via_gpo_changes") == bucket
+            for s, d, p in edges
+        )
+
+    def test_unknown_bucket_emits_no_edge(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(bucket="UnknownBucket", principal_sid="S-1-5-21-1-1-1-2001"),
+            engagement="t",
+            store=store,
+        )
+        # No edges from the unknown bucket — the whitelist is the
+        # source of truth.
+        all_edges = store.edges()
+        assert not any(p.get("via_gpo_changes") for _s, _k, _d, p in all_edges)
+
+
+class TestUserRightsIngest:
+    """Computer ``UserRights[]`` → direct CAN_ACCESS edges for the
+    whitelisted lateral-movement privileges."""
+
+    def _bh(self, *, privilege: str, principal_sid: str) -> dict[str, Any]:
+        return {
+            "meta": {"type": "computers"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-1001",
+                    "Properties": {"name": "ws01"},
+                    "UserRights": [
+                        {
+                            "Privilege": privilege,
+                            "Results": [
+                                {
+                                    "ObjectIdentifier": principal_sid,
+                                    "ObjectType": "User",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        "privilege",
+        [
+            "SeRemoteInteractiveLogonRight",
+            "SeInteractiveLogonRight",
+            "SeServiceLogonRight",
+            "SeBatchLogonRight",
+        ],
+    )
+    def test_whitelisted_privilege_emits_can_access_edge(self, privilege: str) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(privilege=privilege, principal_sid="S-1-5-21-1-1-1-2001"),
+            engagement="t",
+            store=store,
+        )
+        edges = store.edges_of_kind("CAN_ACCESS")
+        assert any(
+            "2001" in s
+            and "1001" in d
+            and p.get("bh_right") == "UserRight"
+            and p.get("via_privilege") == privilege
+            for s, d, p in edges
+        )
+
+    def test_unknown_privilege_emits_no_edge(self) -> None:
+        store = _FakeKGStore()
+        merge_bloodhound_json(
+            self._bh(
+                privilege="SeUnknownPrivilegeRight",
+                principal_sid="S-1-5-21-1-1-1-2001",
+            ),
+            engagement="t",
+            store=store,
+        )
+        # The whitelist is the source of truth; unknown privileges
+        # produce no edges.
+        all_edges = store.edges()
+        assert not any(p.get("via_privilege") for _s, _k, _d, p in all_edges)


### PR DESCRIPTION
## Summary

Last two BloodHound RFC §4.4 ingest paths. Both run during Computer ingest and emit direct ``principal → computer`` access edges so chain planners see the shortcut without re-deriving it from raw policy data.

| File | Change |
|---|---|
| ``tools/ad/bloodhound.py`` | +``_ingest_gpo_changes`` + ``_ingest_user_rights`` + Computer-branch dispatch |
| ``tests/unit/ad/test_bloodhound_kgstore.py`` | +``TestGpoChangesIngest`` + ``TestUserRightsIngest`` (10 effective tests) |

Net diff: **+252 / -0**.

## GPOChanges

Each bucket maps to a distinct primitive:

| GPOChanges bucket | Edge kind | Equivalent |
|---|---|---|
| ``LocalAdmins`` | ``ADMIN_TO`` | — |
| ``RemoteDesktopUsers`` | ``CAN_ACCESS`` | CanRDP |
| ``DcomUsers`` | ``CAN_ACCESS`` | ExecuteDCOM |
| ``PSRemoteUsers`` | ``CAN_ACCESS`` | CanPSRemote |

Buckets outside this whitelist are ignored.

## UserRights

Only the lateral-movement-relevant privileges map to direct edges:

| Privilege | Edge kind |
|---|---|
| ``SeRemoteInteractiveLogonRight`` | ``CAN_ACCESS`` |
| ``SeInteractiveLogonRight`` | ``CAN_ACCESS`` |
| ``SeServiceLogonRight`` | ``CAN_ACCESS`` |
| ``SeBatchLogonRight`` | ``CAN_ACCESS`` |

Other privileges (SeBackup / SeRestore / etc.) are intentionally not modelled — they don't carry a direct chain primitive.

Every direct edge carries ``bh_right`` plus ``via_gpo_changes`` (bucket) or ``via_privilege`` (privilege name) so analysts can re-derive the chain.

## Live dogfood

Engagement ``dogfood-gpo-ur-001`` against compose Neo4j — Computer ws01 with two GPOChanges buckets + two UserRights privileges:

```
ADMIN_TO:
  P-ADM    → ws01  via_gpo=LocalAdmins
CAN_ACCESS:
  P-RDP    → ws01  via_gpo=RemoteDesktopUsers
  P-UR-RDP → ws01  via_p=SeRemoteInteractiveLogonRight
  P-UR-BAT → ws01  via_p=SeBatchLogonRight
```

## Out of scope (per BloodHound RFC §4.4)

- ``GPOChanges.AffectedComputers[]`` × bucket cross-product on the GPO node — handled here as "per-Computer effective" (the BHCE-server result). Raw cross-product surface emittable later if analysts want GPO-side queries.
- ``RegistrySessions`` (different from the existing ``Sessions`` / ``PrivilegedSessions``) — separate ingest path.

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_bloodhound_kgstore.py``: **58 passed**, 0 failed (up from 48)
- Live dogfood: all four lateral edges land with correct provenance

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)