### PR TITLE
refactor(kg): BloodHound ingest emits AD-prefixed NodeKind (Option A endgame)

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -33,13 +33,15 @@ the rewrite addresses five of the load-bearing traps catalogued in
      bitmask is preserved as a node prop on objects from each file so
      "partial collection" debugging works.
 
-NodeKind values **stay on the legacy generic family** (USER, HOST,
-GROUP, DOMAIN) so the AD analysis tools (`delegation.py`, `gpo.py`,
-`dcsync.py`, `shadow_creds.py`, `adcs.py`) keep working through their
-existing ``bh_type`` prop checks. AD-prefixed kinds (`ADUser` /
-`ADComputer` / etc.) are reserved for a dedicated follow-up PR that
-migrates the analysis tools in lockstep — see the BloodHound RFC for
-the plan.
+Every BloodHound-emitted kind lands under its **dedicated
+``AD_*`` NodeKind** value (``ADUser`` / ``ADComputer`` / ``ADGroup``
+/ ``ADDomain`` / ``ADGPO`` / ``ADOU`` / ``ADContainer`` plus the
+ADCS family). The RFC Option-A endgame for §4.6. AD analysis tools
+(``delegation`` / ``gpo`` / ``dcsync`` / ``shadow_creds`` /
+``adcs``) filter on the ``bh_type`` prop instead of ``NodeKind``, so
+the label change is transparent to them. The consumer that gains
+from real BHCE-faithful labels is the chain planner + any prompt-
+written Cypher that filters by node label.
 """
 
 from __future__ import annotations
@@ -157,25 +159,25 @@ _BH_EDGE_MAP: dict[str, tuple[EdgeKind, float]] = {
 def _node_kind_for_bh(type_name: str) -> NodeKind:
     """Map BloodHound object type to the right NodeKind.
 
-    Generic identity kinds (User / Computer / Group / Domain / GPO /
-    OU / Container) stay on the legacy NodeKind family so the AD
-    analysis tools (``delegation`` / ``gpo`` / ``dcsync`` / etc.)
-    keep matching on their ``bh_type`` props. ADCS kinds use the
-    dedicated ``AD_*`` family from V003 — they had no legacy NodeKind
-    equivalent (overloading them onto ``GROUP`` would silently break
-    BHCE 5.x semantics) so this is where Option A from the BloodHound
-    RFC first lands in code.
+    Every BloodHound-emitted kind now lands under its dedicated
+    AD-prefixed NodeKind value (the RFC §4.6 Option-A endgame). The
+    AD analysis tools (``delegation`` / ``gpo`` / ``dcsync`` /
+    ``shadow_creds`` / ``adcs``) filter on the ``bh_type`` prop
+    rather than on ``NodeKind``, so the label change is transparent
+    to them. Cross-domain chain analysis (``chain.py`` / Cypher
+    queries written in agent prompts) is the consumer that now
+    sees real BHCE-faithful labels (``:ADUser`` / ``:ADComputer``
+    / ``:ADGroup`` / ``:ADDomain`` / ``:ADGPO`` / ``:ADOU`` /
+    ``:ADContainer``).
     """
     return {
-        "User": NodeKind.USER,
-        "Computer": NodeKind.HOST,
-        "Group": NodeKind.GROUP,
-        "Domain": NodeKind.DOMAIN,
-        # GPO/OU/Container act as policy / organizational containers
-        # in the legacy schema.
-        "GPO": NodeKind.GROUP,
-        "OU": NodeKind.GROUP,
-        "Container": NodeKind.GROUP,
+        "User": NodeKind.AD_USER,
+        "Computer": NodeKind.AD_COMPUTER,
+        "Group": NodeKind.AD_GROUP,
+        "Domain": NodeKind.AD_DOMAIN,
+        "GPO": NodeKind.AD_GPO,
+        "OU": NodeKind.AD_OU,
+        "Container": NodeKind.AD_CONTAINER,
         # ADCS kinds use the dedicated V003 NodeKind values.
         "CertTemplate": NodeKind.AD_CERT_TEMPLATE,
         "EnterpriseCA": NodeKind.AD_ENTERPRISE_CA,
@@ -183,7 +185,7 @@ def _node_kind_for_bh(type_name: str) -> NodeKind:
         "AIACA": NodeKind.AD_AIA_CA,
         "NTAuthStore": NodeKind.AD_NT_AUTH_STORE,
         "IssuancePolicy": NodeKind.AD_ISSUANCE_POLICY,
-    }.get(type_name, NodeKind.HOST)
+    }.get(type_name, NodeKind.AD_COMPUTER)
 
 
 def _key_for_object(type_name: str, object_id: str) -> str:


### PR DESCRIPTION
## Summary

Closes BloodHound RFC §4.6 — every BHCE-emitted object type now routes to its dedicated AD-prefixed NodeKind. The 7 generic-identity kinds previously collapsed onto the legacy ``USER`` / ``HOST`` / ``GROUP`` / ``DOMAIN`` family; the ADCS family already landed in #564.

| BHCE source | Was | Now |
|---|---|---|
| User | ``USER`` | ``AD_USER`` → ``:ADUser`` |
| Computer | ``HOST`` | ``AD_COMPUTER`` → ``:ADComputer`` |
| Group | ``GROUP`` | ``AD_GROUP`` → ``:ADGroup`` |
| Domain | ``DOMAIN`` | ``AD_DOMAIN`` → ``:ADDomain`` |
| GPO | ``GROUP`` | ``AD_GPO`` → ``:ADGPO`` |
| OU | ``GROUP`` | ``AD_OU`` → ``:ADOU`` |
| Container | ``GROUP`` | ``AD_CONTAINER`` → ``:ADContainer`` |

Net diff: **+27 / -25** in ``tools/ad/bloodhound.py``. No other module touched.

## Why this is safe to land standalone

A sweep of the AD analysis tools shows every one of ``delegation`` / ``gpo`` / ``dcsync`` / ``shadow_creds`` / ``adcs`` filters on the ``bh_type`` prop, not on ``NodeKind``. The label change is transparent to them — the ``bh_type`` prop continues to carry the singular type name (``"User"`` / ``"Computer"`` / ...) so legacy filter logic finds what it expects.

The consumer that **gains** from the switch is the chain planner + any prompt-written Cypher that filters by node label. ``MATCH (u:ADUser)-[:MEMBER_OF*]->(:ADGroup {admincount: 1})`` and similar BHCE Cypher patterns now Just Work against Decepticon-ingested data.

## Other touches

- ``_node_kind_for_bh`` fallback changes from ``NodeKind.HOST`` to ``NodeKind.AD_COMPUTER``. Anything BHCE emits without a recognised type is closer to a computer than a generic infrastructure host, and it stays inside the AD label namespace.
- Module + function docstrings updated to reflect the post-§4.6 state.

## Live dogfood

Engagement ``dogfood-ad-prefixed-001`` against compose Neo4j:

```
Labels emitted:
  ADComputer  bh_type=Computer  bh::Computer::C-1
  ADGPO       bh_type=GPO       bh::GPO::GPO-1
  ADGroup     bh_type=Group     bh::Group::G-1
  ADUser      bh_type=User      bh::User::U-1

PrimaryGroupSID synthesised edge (User → Group):
  bh::User::U-1 → bh::Group::G-1   bh_right=PrimaryGroup
```

``bh_type`` prop preserved on every node. BHCE-faithful Cypher (``MATCH (u:ADUser)-[r:MEMBER_OF]->(g:ADGroup)``) returns the synthesised edge as expected.

## RFC §4 closeout

| Section | Status |
|---|---|
| §4.1 NodeKind/EdgeKind extension + V003 migration | ✅ #555 |
| §4.2 BloodHound ingest core + 5 trap fixes | ✅ #560 |
| §4.3 ADCS ingest (CertTemplate / EnterpriseCA / IssuancePolicy etc.) | ✅ #564 |
| §4.3 ADCS post-process: DCSync, GoldenCert, ESC1, ESC4, ESC6a/b, ESC9a/b, ESC13 | ✅ #565, #567, #568, #569, #570 |
| §4.4 LocalGroups + RID-based lateral | ✅ #566 |
| §4.4 GPOChanges + UserRights | ✅ #571 |
| §4.5 KGStore-mock tests | ✅ #563 (+ growing per feature) |
| **§4.6 AD-prefixed NodeKind adoption** | ✅ **this PR** |

Open ADCS variants intentionally deferred (per the per-PR scope notes): **ESC3**, **ESC10a / ESC10b**, **TRUSTED_FOR_NTAUTH chain validation**.

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/``: **163 passed**, 0 failed (no test depends on the legacy mapping)
- Live dogfood: BHCE-faithful labels emitted, ``bh_type`` prop preserved, analysis-tool surface unchanged

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)