### PR TITLE
feat(kg): ADCS ESC3 synthesis — Enrollment Agent template chaining

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -44,6 +44,7 @@ class PostProcessStats:
     dcsync: int = 0
     golden_cert: int = 0
     adcs_esc1: int = 0
+    adcs_esc3: int = 0
     adcs_esc4: int = 0
     adcs_esc6a: int = 0
     adcs_esc6b: int = 0
@@ -137,6 +138,62 @@ _ADCS_ESC1_QUERY = (
     "              r.source_episode_id = $source_episode_id, "
     "              r.post_process_source = 'ESC1: vulnerable template + Enroll + PublishedTo', "
     "              r.via_template = ct.key, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
+# ADCS ESC3 — Certificate Request Agent / Enroll Agent abuse.
+#
+# A principal who can enrol an *agent template* (one whose
+# ``applicationpolicies`` includes the Certificate Request Agent OID
+# ``1.3.6.1.4.1.311.20.2.1``) can use the issued cert to enrol for
+# any *auth template* (one with ``authenticationenabled = true``)
+# **on behalf of** any AD principal. That gives them an
+# impersonation primitive against the CA's authentication surface.
+#
+# Pre-requisites in the raw graph:
+#   - Agent template (``agent``): the Certificate Request Agent OID
+#     is in its ``applicationpolicies`` list.
+#   - Auth template (``auth``): authentication-enabled + manager
+#     approval off.
+#   - The same EnterpriseCA publishes both templates.
+#   - Principal holds ``Enroll`` on the agent template.
+#
+# Edge: principal --ADCS_ESC3--> EnterpriseCA. Provenance attaches
+# both template keys.
+#
+# Simplification vs BHCE: the upstream algorithm additionally checks
+# ``hasenrollmentagentrestrictions = false`` on the EnterpriseCA
+# (without restrictions, any enrolment-agent cert holder can act as
+# anyone). We don't ingest that flag yet, so the check is implicit
+# — the false-positive risk is low because enrolment-agent
+# restrictions are typically set for high-value CAs only and any
+# such restrictions land as a CA-level filter we can add when
+# ``CARegistryData`` ingest support arrives.
+
+_ADCS_ESC3_QUERY = (
+    "MATCH (auth:ADCertTemplate {engagement: $engagement}) "
+    "WHERE auth.authenticationenabled = true "
+    "  AND coalesce(auth.requiresmanagerapproval, false) = false "
+    "MATCH (agent:ADCertTemplate {engagement: $engagement}) "
+    "WHERE '1.3.6.1.4.1.311.20.2.1' IN agent.applicationpolicies "
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(auth) "
+    "MATCH (eca)-[:PUBLISHED_TO {engagement: $engagement}]->(agent) "
+    "MATCH (p)-[en {engagement: $engagement}]->(agent) "
+    "WHERE en.bh_right = 'Enroll' "
+    "WITH DISTINCT p, eca, auth, agent "
+    "MERGE (p)-[r:ADCS_ESC3 {engagement: $engagement}]->(eca) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'ESC3: Enrollment Agent template + auth template + Enroll', "
+    "              r.via_agent_template = agent.key, "
+    "              r.via_auth_template = auth.key, "
     "              r._jc = true "
     "ON MATCH SET r._jc = false "
     "SET r.lastupdated = $now "
@@ -431,6 +488,20 @@ def synthesise_adcs_post(
         )
         if rows:
             stats.adcs_esc1 = int(rows[0].get("created") or 0)
+
+        # ADCS ESC3
+        rows = target_store.execute_write(
+            _ADCS_ESC3_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.adcs_esc3 = int(rows[0].get("created") or 0)
 
         # ADCS ESC4
         rows = target_store.execute_write(

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -27,6 +27,7 @@ class _FakeKGStore:
         dcsync_created: int = 1,
         golden_created: int = 1,
         esc1_created: int = 1,
+        esc3_created: int = 1,
         esc4_created: int = 1,
         esc6a_created: int = 1,
         esc6b_created: int = 1,
@@ -38,6 +39,7 @@ class _FakeKGStore:
         self._dcsync_created = dcsync_created
         self._golden_created = golden_created
         self._esc1_created = esc1_created
+        self._esc3_created = esc3_created
         self._esc4_created = esc4_created
         self._esc6a_created = esc6a_created
         self._esc6b_created = esc6b_created
@@ -65,6 +67,8 @@ class _FakeKGStore:
             return [{"created": self._esc9a_created}]
         if "ADCS_ESC9B" in query:
             return [{"created": self._esc9b_created}]
+        if "ADCS_ESC3" in query:
+            return [{"created": self._esc3_created}]
         if "ADCS_ESC4" in query:
             return [{"created": self._esc4_created}]
         if "ADCS_ESC1" in query:
@@ -96,6 +100,7 @@ class TestPublicSignatures:
             dcsync_created=3,
             golden_created=2,
             esc1_created=4,
+            esc3_created=11,
             esc4_created=5,
             esc6a_created=8,
             esc6b_created=9,
@@ -110,6 +115,7 @@ class TestPublicSignatures:
         assert stats.dcsync == 3
         assert stats.golden_cert == 2
         assert stats.adcs_esc1 == 4
+        assert stats.adcs_esc3 == 11
         assert stats.adcs_esc4 == 5
         assert stats.adcs_esc6a == 8
         assert stats.adcs_esc6b == 9
@@ -125,7 +131,7 @@ class TestPublicSignatures:
             source_episode_id="ep-x",
             created_by="adcs_post_test",
         )
-        assert len(store.calls) == 9
+        assert len(store.calls) == 10
         for _query, params, engagement in store.calls:
             assert engagement == "t-eng"
             assert params["engagement"] == "t-eng"
@@ -300,6 +306,76 @@ class TestAdcsEsc1Query:
         # so an analyst can trace the path back without re-running the
         # algorithm.
         assert "via_template" in q
+
+
+# ── ADCS ESC3 algorithm ─────────────────────────────────────────────
+
+
+class TestAdcsEsc3Query:
+    def _esc3_query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "ADCS_ESC3" in q:
+                return q
+        raise AssertionError("ESC3 query not issued")
+
+    def test_agent_template_filter_on_certificate_request_agent_oid(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc3_query(store)
+        # ESC3 requires the agent template's applicationpolicies to
+        # include the Certificate Request Agent EKU OID.
+        assert "1.3.6.1.4.1.311.20.2.1" in q
+        assert "agent.applicationpolicies" in q
+
+    def test_auth_template_filter(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc3_query(store)
+        # The chained authentication target template must be auth-
+        # enabled and manager-approval-free.
+        assert "auth.authenticationenabled = true" in q
+        assert "auth.requiresmanagerapproval" in q
+
+    def test_both_templates_published_by_same_ca(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc3_query(store)
+        # Both PUBLISHED_TO matches must land — the same CA publishes
+        # both the agent and auth templates.
+        assert q.count(":PUBLISHED_TO") == 2
+
+    def test_enroll_required_on_agent_template(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc3_query(store)
+        # Enroll right is required on the **agent** template — that's
+        # the one the principal uses to mint enrolment-agent certs.
+        assert "(p)-[en {engagement: $engagement}]->(agent)" in q
+        assert "bh_right = 'Enroll'" in q
+
+    def test_via_template_provenance_attached(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._esc3_query(store)
+        # Both template keys land on the synthesised edge so analysts
+        # can re-trace either side of the chain.
+        assert "via_agent_template" in q
+        assert "via_auth_template" in q
 
 
 # ── ADCS ESC4 algorithm ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the ESC3 entry on RFC §4.3 catalogue. A principal who can enrol an *agent template* (Certificate Request Agent EKU) can use the issued cert to enrol for any *auth template* on behalf of any AD principal.

| Pre-requisite | Cypher predicate |
|---|---|
| Agent template carries the CRA OID | ``'1.3.6.1.4.1.311.20.2.1' IN agent.applicationpolicies`` |
| Auth template is authentication-enabled | ``auth.authenticationenabled = true`` AND manager approval off |
| Same CA publishes both | two ``:PUBLISHED_TO`` matches against the same ``ADEnterpriseCA`` |
| Principal can mint enrolment-agent certs | ``principal -[bh_right='Enroll']-> agent`` |

Resulting edge: ``principal --ADCS_ESC3--> EnterpriseCA``, with both ``via_agent_template`` and ``via_auth_template`` provenance.

| File | Change |
|---|---|
| ``tools/ad/adcs_post.py`` | New ``_ADCS_ESC3_QUERY`` + counter + dispatch |
| ``tests/unit/ad/test_adcs_post.py`` | New ``TestAdcsEsc3Query`` (5 tests) + fake-store routing + counter update |

Net diff: **+148 / -1**.

## Simplification vs BHCE

The canonical algorithm additionally checks ``hasenrollmentagentrestrictions = false`` on the CA. We don't ingest that flag yet — false-positive risk is low because enrolment-agent restrictions are typically set on high-value CAs only and land as a CA-level filter we can stack on when ``CARegistryData`` ingest support arrives.

## Live dogfood

Engagement ``dogfood-esc3-001`` against compose Neo4j — CT-AGENT (with CRA EKU + Enroll ACE) + CT-AUTH (auth-enabled), both published by ECA-1:

```
run-1: {'adcs_esc3': 1}
ADCS_ESC3 edges:
  P-AGENT → ECA-1
    via_agent_template=bh::CertTemplate::CT-AGENT
    via_auth_template=bh::CertTemplate::CT-AUTH
run-2 (idempotent): {}
```

## RFC §4.3 progress

| ESC | Status |
|---|---|
| ESC1 | ✅ #567 |
| **ESC3** | ✅ **this PR** |
| ESC4 / ESC9a / ESC9b | ✅ #568 |
| ESC6a / ESC6b | ✅ #569 |
| ESC13 | ✅ #570 |
| DCSync / GoldenCert | ✅ #565 |
| ESC10a / ESC10b | ❌ follow-up (DC-side ``StrongCertificateBindingEnforcement``) |
| ``TRUSTED_FOR_NTAUTH`` chain validation | ❌ follow-up |

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_adcs_post.py``: **36 passed**, 0 failed
- Live dogfood: ESC3 fires on the chained pair only, idempotent on re-run

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)