### PR TITLE
refactor(kg): Slither ingest emits Solidity-prefixed NodeKind (Option A endgame)

### DIFF
--- a/packages/decepticon/decepticon/tools/contracts/slither.py
+++ b/packages/decepticon/decepticon/tools/contracts/slither.py
@@ -40,15 +40,14 @@ the rewrite addresses six of the load-bearing traps catalogued in
      never partial-ingest from a failed run, and we never feed the
      upgradeability block through the detector pipeline.
 
-NodeKind values **stay on the legacy generic family** (Contract,
-SourceFile, Vulnerability, CodeLocation) so the existing contract-
-auditor tools and prompts keep working through the
-``_state`` / ``kg_adapter`` reading path. The Solidity-specific kinds
-added in V003 (Function / StateVar / Event / CustomError / Enum /
-Struct / Pragma) are reserved for a dedicated follow-up PR that
-re-emits each non-contract element with its proper label and
-migrates the analysis side in lockstep — see the Slither RFC for
-the plan.
+Every Solidity element lands under its **dedicated V003 NodeKind**
+(``Function`` / ``StateVar`` / ``Event`` / ``CustomError`` /
+``Enum`` / ``Struct`` / ``Pragma``). ``Contract`` and ``SourceFile``
+were already on dedicated labels. The ``element_type`` prop is
+preserved on every node so consumers that still filter by
+``element_type`` (e.g. AST ``node`` entries that fall back to
+``CodeLocation``) keep working. Slither RFC §4.6 endgame for the
+contract-auditor side.
 """
 
 from __future__ import annotations
@@ -74,21 +73,25 @@ _IMPACT_TO_SEVERITY: dict[str, Severity] = {
 }
 
 
-# Element types Slither emits in ``finding.elements[]``. Mapped to a
-# KGStore node ``kind`` (legacy family for opt-F point) plus a
-# semantic ``element_type`` prop so downstream queries can still
-# distinguish a function from a state variable without a new label.
+# Element types Slither emits in ``finding.elements[]``. Each maps
+# to its dedicated Solidity NodeKind from V003 (Option A). AST
+# ``node`` and ``modifier`` entries fall back to ``CODE_LOCATION``
+# / ``SOLIDITY_FUNCTION`` respectively — they don't carry a
+# distinct V003 label and folding them into the closest semantic
+# kind keeps Cypher queries readable. The ``element_type`` prop
+# survives on every node so downstream queries can still
+# distinguish a modifier from a regular function.
 _ELEMENT_KIND_MAP: dict[str, NodeKind] = {
     "contract": NodeKind.CONTRACT,
-    "function": NodeKind.CODE_LOCATION,
-    "variable": NodeKind.CODE_LOCATION,
+    "function": NodeKind.SOLIDITY_FUNCTION,
+    "modifier": NodeKind.SOLIDITY_FUNCTION,
+    "variable": NodeKind.SOLIDITY_STATE_VAR,
     "node": NodeKind.CODE_LOCATION,
-    "pragma": NodeKind.CODE_LOCATION,
-    "event": NodeKind.CODE_LOCATION,
-    "custom_error": NodeKind.CODE_LOCATION,
-    "enum": NodeKind.CODE_LOCATION,
-    "struct": NodeKind.CODE_LOCATION,
-    "modifier": NodeKind.CODE_LOCATION,
+    "pragma": NodeKind.SOLIDITY_PRAGMA,
+    "event": NodeKind.SOLIDITY_EVENT,
+    "custom_error": NodeKind.SOLIDITY_CUSTOM_ERROR,
+    "enum": NodeKind.SOLIDITY_ENUM,
+    "struct": NodeKind.SOLIDITY_STRUCT,
     "file": NodeKind.SOURCE_FILE,
 }
 

--- a/packages/decepticon/tests/unit/contracts/test_slither_kgstore.py
+++ b/packages/decepticon/tests/unit/contracts/test_slither_kgstore.py
@@ -290,8 +290,7 @@ class TestRecursiveParentWalk:
         pragma = next(
             v
             for v in store.observations
-            if v["kind"] == "CodeLocation"
-            and (v.get("props") or {}).get("element_type") == "pragma"
+            if v["kind"] == "Pragma" and (v.get("props") or {}).get("element_type") == "pragma"
         )
         assert pragma["props"].get("parent_contract") is None
         assert pragma["props"].get("directive") == "solidity ^0.8.0"
@@ -329,8 +328,7 @@ class TestLinesPreservedAsList:
         fn = next(
             v
             for v in store.observations
-            if v["kind"] == "CodeLocation"
-            and (v.get("props") or {}).get("element_type") == "function"
+            if v["kind"] == "Function" and (v.get("props") or {}).get("element_type") == "function"
         )
         assert fn["props"].get("lines") == [42, 43, 44, 45, 47, 48]
         assert fn["props"].get("first_line") == 42


### PR DESCRIPTION
## Summary

Closes Slither RFC §4.6 — every Slither element type now routes to its dedicated V003 Solidity NodeKind, mirroring the BloodHound §4.6 adoption from #572.

| Slither element | Was | Now |
|---|---|---|
| ``function`` | ``CodeLocation`` + ``element_type=function`` | ``SOLIDITY_FUNCTION`` → ``:Function`` |
| ``modifier`` | ``CodeLocation`` + ``element_type=modifier`` | ``SOLIDITY_FUNCTION`` (chains into the same call-graph surface) |
| ``variable`` | ``CodeLocation`` | ``SOLIDITY_STATE_VAR`` → ``:StateVar`` |
| ``event`` | ``CodeLocation`` | ``SOLIDITY_EVENT`` → ``:Event`` |
| ``custom_error`` | ``CodeLocation`` | ``SOLIDITY_CUSTOM_ERROR`` → ``:CustomError`` |
| ``enum`` | ``CodeLocation`` | ``SOLIDITY_ENUM`` → ``:Enum`` |
| ``struct`` | ``CodeLocation`` | ``SOLIDITY_STRUCT`` → ``:Struct`` |
| ``pragma`` | ``CodeLocation`` | ``SOLIDITY_PRAGMA`` → ``:Pragma`` |
| ``node`` (AST) | ``CodeLocation`` | ``CodeLocation`` (no dedicated label — stays generic) |
| ``contract`` / ``file`` | already on ``Contract`` / ``SourceFile`` | unchanged |

The ``element_type`` prop survives every node so any consumer that filtered by it (notably AST ``node`` entries still on ``CodeLocation``) keeps working.

Net diff: **+26 / -23**, two files touched (``slither.py`` map + two test assertions).

## Why this is safe to land standalone

Test assertions that previously expected ``CodeLocation`` for pragma + function elements are the only consumers that cared about the legacy label — both are flipped in this PR. Everywhere else filters by ``element_type`` prop, which is unchanged.

The consumer that **gains** is anything writing Cypher against the graph: ``MATCH (v:Vulnerability)-[:AFFECTS]->(f:Function {visibility: 'external'})`` and similar analyst queries (or future Foundry / mythril / echidna integrations that want a stable Solidity label namespace) now Just Work.

## Live dogfood

Engagement ``dogfood-slither-prefixed-001`` against compose Neo4j — one detector with 3 elements:

```
Labels:
  Contract       slither::el::contract::src/Vault.sol::Vault::None
  Function       slither::el::function::src/Vault.sol::withdraw::1024
  Pragma         slither::el::pragma::src/Vault.sol::pragma::0
  SourceFile     slither::file::src/Vault.sol
  StateVar       slither::el::variable::src/Vault.sol::_balance::100
  Vulnerability  slither::vuln::reentrancy-eth::abc1
```

## RFC §4 closeout (both ingest paths)

| Section | Status |
|---|---|
| BloodHound §4.1 → §4.5 | ✅ |
| BloodHound §4.6 (AD-prefixed NodeKind adoption) | ✅ #572 |
| Slither §4.1 → §4.5 | ✅ |
| **Slither §4.6 (Solidity-prefixed NodeKind adoption)** | ✅ **this PR** |

Open items: AD-side **ESC10a / ESC10b** + ``TRUSTED_FOR_NTAUTH`` chain validation; Solidity-side ``slither --print function-summary`` visibility / payable / view-pure join (RFC §4.3).

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/contracts/``: **41 passed**, 0 failed
- Live dogfood: every Slither element lands under its dedicated Solidity label

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)