### PR TITLE
feat(kg): TrustedForNTAuth post-process — EnterpriseCA → NTAuthStore pairing

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -51,6 +51,7 @@ class PostProcessStats:
     adcs_esc9a: int = 0
     adcs_esc9b: int = 0
     adcs_esc13: int = 0
+    trusted_for_ntauth: int = 0
 
     def to_dict(self) -> dict[str, int]:
         return self.__dict__
@@ -414,6 +415,41 @@ _ADCS_ESC9B_QUERY = (
 )
 
 
+# ``TRUSTED_FOR_NTAUTH`` — pair every EnterpriseCA whose certificate
+# thumbprint is listed in an NTAuthStore's ``certthumbprints`` with
+# the matching store. BHCE uses this edge as the trust-anchor leg
+# of every ESC* path; we synthesise it lazily here so future ESC
+# refinements can stack a ``MATCH (eca)-[:TRUSTED_FOR_NTAUTH]->(:ADNTAuthStore)``
+# precondition on top of the existing predicate without changing
+# the ingest layer.
+#
+# BHCE simplification: the upstream algorithm also handles
+# ``ADRootCA``/``ADAIACA`` chain validation via
+# ``ROOT_CA_FOR`` / ``ISSUED_SIGNED_BY``. We only model the leaf
+# ``ADEnterpriseCA`` cert here; intermediate-CA chain validation
+# is the natural follow-up.
+
+_TRUSTED_FOR_NTAUTH_QUERY = (
+    "MATCH (eca:ADEnterpriseCA {engagement: $engagement}) "
+    "WHERE eca.certthumbprint IS NOT NULL "
+    "MATCH (nta:ADNTAuthStore {engagement: $engagement}) "
+    "WHERE nta.certthumbprints IS NOT NULL "
+    "  AND eca.certthumbprint IN nta.certthumbprints "
+    "MERGE (eca)-[r:TRUSTED_FOR_NTAUTH {engagement: $engagement}]->(nta) "
+    "ON CREATE SET r.firstseen = $now, "
+    "              r.created_by = $created_by, "
+    "              r.source_episode_id = $source_episode_id, "
+    "              r.post_process_source = 'TrustedForNTAuth: thumbprint match', "
+    "              r.via_thumbprint = eca.certthumbprint, "
+    "              r._jc = true "
+    "ON MATCH SET r._jc = false "
+    "SET r.lastupdated = $now "
+    "WITH r, r._jc AS just_created "
+    "REMOVE r._jc "
+    "RETURN sum(CASE WHEN just_created THEN 1 ELSE 0 END) AS created"
+)
+
+
 def synthesise_adcs_post(
     *,
     engagement: str,
@@ -586,6 +622,22 @@ def synthesise_adcs_post(
         )
         if rows:
             stats.adcs_esc13 = int(rows[0].get("created") or 0)
+
+        # TrustedForNTAuth — runs last so analysts inspecting the
+        # post-process trace see ESC* edges then the trust-anchor
+        # pairing, matching the BHCE server's processing order.
+        rows = target_store.execute_write(
+            _TRUSTED_FOR_NTAUTH_QUERY,
+            {
+                "engagement": engagement,
+                "now": now,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            },
+            engagement=engagement,
+        )
+        if rows:
+            stats.trusted_for_ntauth = int(rows[0].get("created") or 0)
     finally:
         if owned_store:
             target_store.close()

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -34,6 +34,7 @@ class _FakeKGStore:
         esc9a_created: int = 1,
         esc9b_created: int = 1,
         esc13_created: int = 1,
+        trusted_for_ntauth_created: int = 1,
     ) -> None:
         self.calls: list[tuple[str, dict[str, Any], str]] = []
         self._dcsync_created = dcsync_created
@@ -46,6 +47,7 @@ class _FakeKGStore:
         self._esc9a_created = esc9a_created
         self._esc9b_created = esc9b_created
         self._esc13_created = esc13_created
+        self._trusted_for_ntauth_created = trusted_for_ntauth_created
         self.closed = False
 
     def execute_write(
@@ -57,6 +59,8 @@ class _FakeKGStore:
         # before falling back to the broader GoldenCert one so the
         # ``OWNS_LIMITED_RIGHTS`` substring used in ESC4 doesn't trip
         # the wrong return value.
+        if "TRUSTED_FOR_NTAUTH" in query:
+            return [{"created": self._trusted_for_ntauth_created}]
         if "ADCS_ESC13" in query:
             return [{"created": self._esc13_created}]
         if "ADCS_ESC6A" in query:
@@ -107,6 +111,7 @@ class TestPublicSignatures:
             esc9a_created=6,
             esc9b_created=7,
             esc13_created=10,
+            trusted_for_ntauth_created=12,
         )
         stats = synthesise_adcs_post(
             engagement="t",
@@ -122,6 +127,7 @@ class TestPublicSignatures:
         assert stats.adcs_esc9a == 6
         assert stats.adcs_esc9b == 7
         assert stats.adcs_esc13 == 10
+        assert stats.trusted_for_ntauth == 12
 
     def test_provenance_threaded_into_every_call(self) -> None:
         store = _FakeKGStore()
@@ -131,7 +137,7 @@ class TestPublicSignatures:
             source_episode_id="ep-x",
             created_by="adcs_post_test",
         )
-        assert len(store.calls) == 10
+        assert len(store.calls) == 11
         for _query, params, engagement in store.calls:
             assert engagement == "t-eng"
             assert params["engagement"] == "t-eng"
@@ -486,6 +492,63 @@ class TestAdcsEsc6Queries:
         esc6a, esc6b = self._esc6_queries(store)
         assert "bh_right = 'Enroll'" in esc6a
         assert "bh_right = 'Enroll'" in esc6b
+
+
+# ── TrustedForNTAuth algorithm ─────────────────────────────────────
+
+
+class TestTrustedForNTAuthQuery:
+    def _query(self, store: _FakeKGStore) -> str:
+        for q, _params, _engagement in store.calls:
+            if "TRUSTED_FOR_NTAUTH" in q:
+                return q
+        raise AssertionError("TRUSTED_FOR_NTAUTH query not issued")
+
+    def test_matches_enterprise_ca_and_nt_auth_store(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._query(store)
+        assert ":ADEnterpriseCA" in q
+        assert ":ADNTAuthStore" in q
+
+    def test_thumbprint_membership_check(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._query(store)
+        # The CA's single thumbprint must be IN the store's list.
+        assert "eca.certthumbprint IN nta.certthumbprints" in q
+        # Both sides null-checked so a partial-ingest doesn't pair
+        # unrelated nodes via NULL = NULL.
+        assert "eca.certthumbprint IS NOT NULL" in q
+        assert "nta.certthumbprints IS NOT NULL" in q
+
+    def test_thumbprint_carried_as_provenance(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._query(store)
+        # The matching thumbprint lands on the edge so analysts can
+        # confirm which key actually closed the trust path.
+        assert "via_thumbprint" in q
+        assert "eca.certthumbprint" in q
+
+    def test_query_uses_jc_marker_for_idempotent_count(self) -> None:
+        store = _FakeKGStore()
+        synthesise_adcs_post(
+            engagement="t",
+            store=store,  # type: ignore[arg-type]
+        )
+        q = self._query(store)
+        assert "_jc" in q
+        assert "ON CREATE SET" in q and "ON MATCH SET" in q
 
 
 # ── ADCS ESC13 algorithm ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the trust-anchor leg every ESC* path depends on. BHCE pairs each EnterpriseCA whose certificate thumbprint appears in an NTAuthStore's ``certthumbprints`` array with that store — Decepticon now does the same so future ESC refinements can stack a ``MATCH (eca)-[:TRUSTED_FOR_NTAUTH]->(:ADNTAuthStore)`` precondition without touching ingest.

| File | Change |
|---|---|
| ``tools/ad/adcs_post.py`` | New ``_TRUSTED_FOR_NTAUTH_QUERY`` + counter + dispatch |
| ``tests/unit/ad/test_adcs_post.py`` | New ``TestTrustedForNTAuthQuery`` (4 tests) + fake-store routing + counter update |

Net diff: **+116 / -1**.

## Cypher pattern

```cypher
MATCH (eca:ADEnterpriseCA) WHERE eca.certthumbprint IS NOT NULL
MATCH (nta:ADNTAuthStore)  WHERE nta.certthumbprints IS NOT NULL
                            AND eca.certthumbprint IN nta.certthumbprints
MERGE (eca)-[r:TRUSTED_FOR_NTAUTH]->(nta)
SET   r.via_thumbprint = eca.certthumbprint, <_jc-marker idempotency>
```

Both ``IS NOT NULL`` guards are required — without them a partial-ingest where one side hadn't materialised the thumbprint field yet would pair unrelated nodes via NULL ≡ NULL. ``via_thumbprint`` records the matching key so analysts can sanity-check the pairing.

The synthesis dispatches **last** in ``synthesise_adcs_post`` so analysts inspecting the trace see ESC* edges then the trust-anchor pairing, matching the BHCE server's processing order.

## BHCE simplification

The upstream algorithm also walks ``ADRootCA`` / ``ADAIACA`` chains via ``ROOT_CA_FOR`` / ``ISSUED_SIGNED_BY``. We only model the leaf ``ADEnterpriseCA`` here — intermediate-CA chain validation is the natural follow-up once those edges land in ingest.

## Live dogfood

Engagement ``dogfood-trusted-ntauth-001`` against compose Neo4j:

```
EnterpriseCA(certthumbprint='AABB1122')
NTAuthStore(certthumbprints=['AABB1122', 'CCDD3344'])

run-1 trusted_for_ntauth: 1
edges:
  ECA-1 → NTA-1  via_thumbprint='AABB1122'
run-2 (idempotent) trusted_for_ntauth: 0
```

## RFC §4.3 progress

| Edge | Status |
|---|---|
| ESC1 | ✅ #567 |
| ESC3 | ✅ #573 |
| ESC4 / ESC9a / ESC9b | ✅ #568 |
| ESC6a / ESC6b | ✅ #569 |
| ESC13 | ✅ #570 |
| DCSync / GoldenCert | ✅ #565 |
| **TrustedForNTAuth** | ✅ **this PR** |
| ESC10a / ESC10b | ❌ follow-up (DC-side ``StrongCertificateBindingEnforcement``) |

## Verification

- ``make ci-lint``: **0 errors**
- ``pytest tests/unit/ad/test_adcs_post.py``: **40 passed**, 0 failed
- Live dogfood: pairing fires on thumbprint match only, idempotent on re-run

## Test plan

- [ ] CI green (Python lint + typecheck + test, CLI, Web, Launcher, Docker, Security, CodeQL)