### PR TITLE
feat(kg): BloodHound User.SPNTargets + Computer.DumpSMSAPassword ingest

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/kg.py
+++ b/packages/decepticon-core/decepticon_core/types/kg.py
@@ -177,7 +177,7 @@ class EdgeKind(StrEnum):
     ROOT_CA_FOR = "ROOT_CA_FOR"
     ISSUED_SIGNED_BY = "ISSUED_SIGNED_BY"
     TRUSTED_FOR_NTAUTH = "TRUSTED_FOR_NTAUTH"
-    DUMP_SMSA_PASSWORD = "DumpSMSAPassword"
+    DUMP_SMSA_PASSWORD = "DUMP_SMSA_PASSWORD"
     MEMBER_OF_LOCAL_GROUP = "MEMBER_OF_LOCAL_GROUP"
     # Trust (4-way split from BHCE 5.x — replaces the single legacy
     # ``TrustedBy`` edge, branched on ``TrustType`` + ``IsTransitive``).

--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -584,6 +584,67 @@ def _ingest_gp_links(state: _IngestState, src_key: str, obj: dict[str, Any]) -> 
         )
 
 
+def _ingest_spn_targets(state: _IngestState, user_key: str, obj: dict[str, Any]) -> None:
+    """User ``SPNTargets[]`` → ``WRITE_SPN`` edges per target computer.
+
+    Each entry is ``{ComputerSID, Port, Service}`` and marks a SPN
+    the user could write (Targeted Kerberoasting primitive). BHCE
+    emits these as raw ACE data; we flip into ``user --WRITE_SPN-->
+    computer`` with the SPN metadata preserved on the edge so chain
+    analysis can score by service / port.
+    """
+    targets = obj.get("SPNTargets") or []
+    if not isinstance(targets, list):
+        return
+    for entry in targets:
+        if not isinstance(entry, dict):
+            continue
+        comp_sid = entry.get("ComputerSID")
+        if not isinstance(comp_sid, str) or not comp_sid:
+            continue
+        comp_key = _ensure_placeholder(state, sid=comp_sid, default_type="Computer")
+        state.add_edge(
+            src_key=user_key,
+            dst_key=comp_key,
+            kind=EdgeKind.WRITE_SPN,
+            weight=0.4,
+            props={
+                "bh_right": "SPNTarget",
+                "port": entry.get("Port"),
+                "service": entry.get("Service"),
+            },
+        )
+
+
+def _ingest_dump_smsa_password(state: _IngestState, computer_key: str, obj: dict[str, Any]) -> None:
+    """Computer ``DumpSMSAPassword[]`` → ``DUMP_SMSA_PASSWORD`` edges.
+
+    Each entry is a ``TypedPrincipal`` pointing at the sMSA / gMSA
+    whose password the computer can extract. We emit
+    ``computer --DUMP_SMSA_PASSWORD--> principal`` so chain analysis
+    sees the credential primitive.
+    """
+    entries = obj.get("DumpSMSAPassword") or []
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("ObjectIdentifier")
+        if not isinstance(sid, str) or not sid:
+            continue
+        target_type = entry.get("ObjectType") or "User"
+        target_type = target_type if target_type in _BH_TYPE_SINGULAR.values() else "User"
+        target_key = _ensure_placeholder(state, sid=sid, default_type=target_type)
+        state.add_edge(
+            src_key=computer_key,
+            dst_key=target_key,
+            kind=EdgeKind.DUMP_SMSA_PASSWORD,
+            weight=0.3,
+            props={"bh_right": "DumpSMSAPassword"},
+        )
+
+
 _LOCAL_GROUP_RID_TO_EDGE: dict[str, tuple[EdgeKind, float]] = {
     "500": (EdgeKind.ADMIN_TO, 0.3),
     "555": (EdgeKind.CAN_ACCESS, 0.6),  # CanRDP
@@ -944,10 +1005,13 @@ def _merge_one_payload(state: _IngestState, data: dict[str, Any], *, type_hint: 
             _ingest_enterprise_ca_edges(state, src_key, obj)
         if type_singular == "IssuancePolicy":
             _ingest_issuance_policy_link(state, src_key, obj)
+        if type_singular == "User":
+            _ingest_spn_targets(state, src_key, obj)
         if type_singular == "Computer":
             _ingest_local_groups(state, src_key, obj)
             _ingest_gpo_changes(state, src_key, obj)
             _ingest_user_rights(state, src_key, obj)
+            _ingest_dump_smsa_password(state, src_key, obj)
         if hasattr(state.stats, counter_attr):
             setattr(state.stats, counter_attr, getattr(state.stats, counter_attr) + 1)
 

--- a/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
+++ b/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
@@ -943,3 +943,63 @@ class TestUserRightsIngest:
         # produce no edges.
         all_edges = store.edges()
         assert not any(p.get("via_privilege") for _s, _k, _d, p in all_edges)
+
+
+# ── User SPNTargets + Computer DumpSMSAPassword ingest ─────────────
+
+
+class TestSpnTargetsIngest:
+    def test_spn_target_emits_write_spn_edge(self) -> None:
+        bh = {
+            "meta": {"type": "users"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-500",
+                    "Properties": {"name": "user"},
+                    "SPNTargets": [
+                        {
+                            "ComputerSID": "S-1-5-21-1-1-1-1001",
+                            "Port": 1433,
+                            "Service": "MSSQLSvc",
+                        }
+                    ],
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        write_spn = store.edges_of_kind("WRITE_SPN")
+        assert any(
+            "500" in s
+            and "1001" in d
+            and p.get("bh_right") == "SPNTarget"
+            and p.get("port") == 1433
+            and p.get("service") == "MSSQLSvc"
+            for s, d, p in write_spn
+        )
+
+
+class TestDumpSmsaPasswordIngest:
+    def test_dump_smsa_emits_dump_smsa_password_edge(self) -> None:
+        bh = {
+            "meta": {"type": "computers"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-1001",
+                    "Properties": {"name": "ws01"},
+                    "DumpSMSAPassword": [
+                        {
+                            "ObjectIdentifier": "S-1-5-21-1-1-1-2000",
+                            "ObjectType": "User",
+                        }
+                    ],
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        edges = store.edges_of_kind("DUMP_SMSA_PASSWORD")
+        assert any(
+            "1001" in s and "2000" in d and p.get("bh_right") == "DumpSMSAPassword"
+            for s, d, p in edges
+        )


### PR DESCRIPTION
## Summary

- **`_ingest_spn_targets`** — User `SPNTargets[]` → `User -[WRITE_SPN]-> Computer` edge per entry, preserving `port` + `service` (downstream Kerberoasting / RBCD plays consume these props).
- **`_ingest_dump_smsa_password`** — Computer `DumpSMSAPassword[]` → `Computer -[DUMP_SMSA_PASSWORD]-> User (sMSA)` per BHCE 5.x payload.
- **`EdgeKind.DUMP_SMSA_PASSWORD` value normalised** to `UPPER_SNAKE_CASE` — PR #560 unify convention; the PascalCase value `"DumpSMSAPassword"` would be rejected by `_safe_rel_type` (fail-fast) in production.

Covers RFC §4.2.3 + §4.2.4 BHCE 5.x User/Computer edge gaps that remained after #569 / #570 / #571.

## Cypher footprint (per entry)

```cypher
// SPNTargets[]
MERGE (u:ADUser {key:'bh::User::<user-sid>', engagement:$eng})
MERGE (c:ADComputer {key:'bh::Computer::<comp-sid>', engagement:$eng})
MERGE (u)-[r:WRITE_SPN {engagement:$eng}]->(c)
SET r.bh_right='SPNTarget', r.port=<port>, r.service=<svc>

// DumpSMSAPassword[]
MERGE (c:ADComputer {key:'bh::Computer::<comp-sid>', engagement:$eng})
MERGE (s:ADUser {key:'bh::User::<smsa-sid>', engagement:$eng})
MERGE (c)-[r:DUMP_SMSA_PASSWORD {engagement:$eng}]->(s)
SET r.bh_right='DumpSMSAPassword'
```

## Dogfood (live compose Neo4j, engagement-scoped)

```
WRITE_SPN:
  {'s': 'bh::User::U-1', 'd': 'bh::Computer::C-1', 'port': 1433, 'svc': 'MSSQLSvc'}
DUMP_SMSA_PASSWORD:
  {'s': 'bh::Computer::C-1', 'd': 'bh::User::SMSA-1', 'bh_right': 'DumpSMSAPassword'}
```

Both edges land under \`engagement\` scope, survive the `_safe_rel_type` UPPER_SNAKE_CASE check, and are visible to engagement-scoped reads.

## Out of scope

- `HasSIDHistory` (User/Group → User/Group) — separate PR.
- ESC10a/b DC-side `StrongCertificateBindingEnforcement` — needs registry ingest.

## Verification

- `make ci-lint` — 0 errors, 488 warnings (no regression).
- `pytest packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py` — 60 passed (+ 2 new: `TestSpnTargetsIngest`, `TestDumpSmsaPasswordIngest`).
- Live compose Neo4j dogfood (\`bolt://localhost:7687\`) — both edges queryable via Cypher.

## Test plan

- [x] WRITE_SPN edge with port + service preserved
- [x] DUMP_SMSA_PASSWORD edge with bh_right provenance
- [x] live Neo4j engagement-scoped Cypher returns both edges
- [x] EdgeKind value passes `_safe_rel_type` regex