### PR TITLE
feat(kg): BloodHound User/Group HasSIDHistory ingest

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -645,6 +645,36 @@ def _ingest_dump_smsa_password(state: _IngestState, computer_key: str, obj: dict
         )
 
 
+def _ingest_has_sid_history(state: _IngestState, src_key: str, obj: dict[str, Any]) -> None:
+    """User/Group ``HasSIDHistory[]`` → ``HAS_SID_HISTORY`` edges.
+
+    Each entry is a ``TypedPrincipal`` whose SID appears in the
+    principal's SID history; the principal inherits that SID's access
+    cross-domain (the SIDHistory primitive — see Trimarc / SpecterOps).
+    We emit ``principal --HAS_SID_HISTORY--> historic-principal`` so
+    chain analysis can lift SIDHistory escalations.
+    """
+    entries = obj.get("HasSIDHistory") or []
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("ObjectIdentifier")
+        if not isinstance(sid, str) or not sid:
+            continue
+        target_type = entry.get("ObjectType") or "User"
+        target_type = target_type if target_type in _BH_TYPE_SINGULAR.values() else "User"
+        target_key = _ensure_placeholder(state, sid=sid, default_type=target_type)
+        state.add_edge(
+            src_key=src_key,
+            dst_key=target_key,
+            kind=EdgeKind.HAS_SID_HISTORY,
+            weight=0.3,
+            props={"bh_right": "HasSIDHistory"},
+        )
+
+
 _LOCAL_GROUP_RID_TO_EDGE: dict[str, tuple[EdgeKind, float]] = {
     "500": (EdgeKind.ADMIN_TO, 0.3),
     "555": (EdgeKind.CAN_ACCESS, 0.6),  # CanRDP
@@ -1007,6 +1037,9 @@ def _merge_one_payload(state: _IngestState, data: dict[str, Any], *, type_hint: 
             _ingest_issuance_policy_link(state, src_key, obj)
         if type_singular == "User":
             _ingest_spn_targets(state, src_key, obj)
+            _ingest_has_sid_history(state, src_key, obj)
+        if type_singular == "Group":
+            _ingest_has_sid_history(state, src_key, obj)
         if type_singular == "Computer":
             _ingest_local_groups(state, src_key, obj)
             _ingest_gpo_changes(state, src_key, obj)

--- a/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
+++ b/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
@@ -979,6 +979,46 @@ class TestSpnTargetsIngest:
         )
 
 
+class TestHasSidHistoryIngest:
+    def test_user_has_sid_history_emits_edge(self) -> None:
+        bh = {
+            "meta": {"type": "users"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-1000",
+                    "Properties": {"name": "user"},
+                    "HasSIDHistory": [
+                        {"ObjectIdentifier": "S-1-5-21-9-9-9-500", "ObjectType": "User"},
+                    ],
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        edges = store.edges_of_kind("HAS_SID_HISTORY")
+        assert any(
+            "1000" in s and "500" in d and p.get("bh_right") == "HasSIDHistory" for s, d, p in edges
+        )
+
+    def test_group_has_sid_history_emits_edge(self) -> None:
+        bh = {
+            "meta": {"type": "groups"},
+            "data": [
+                {
+                    "ObjectIdentifier": "S-1-5-21-1-1-1-512",
+                    "Properties": {"name": "Domain Admins"},
+                    "HasSIDHistory": [
+                        {"ObjectIdentifier": "S-1-5-21-9-9-9-512", "ObjectType": "Group"},
+                    ],
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        edges = store.edges_of_kind("HAS_SID_HISTORY")
+        assert any("1-512" in s and "9-512" in d for s, d, _p in edges)
+
+
 class TestDumpSmsaPasswordIngest:
     def test_dump_smsa_emits_dump_smsa_password_edge(self) -> None:
         bh = {


### PR DESCRIPTION
## Summary

- **`_ingest_has_sid_history`** — User/Group `HasSIDHistory[]` (BHCE 5.x `ad.go` `HasSIDHistory []TypedPrincipal`) → `principal -[HAS_SID_HISTORY]-> historic-principal` edges, with `ObjectType` (User/Group) honoured for placeholder typing on cross-domain SID-history pivots.
- Dispatched for both `type_singular == 'User'` and `type_singular == 'Group'` in `_merge_one_payload` (BHCE emits on both kinds).
- `bh_right="HasSIDHistory"` provenance preserved on every edge.

Covers RFC §4.2.5 BHCE 5.x SIDHistory primitive — the last User/Group-level edge gap before we move to Domain-level edges (HasSIDHistory rounds out the User/Group edge surface alongside #576 SPNTargets/SMSA).

## Cypher footprint (per entry)

```cypher
MERGE (p:ADUser|ADGroup {key:'bh::<kind>::<src-sid>', engagement:$eng})
MERGE (h:ADUser|ADGroup {key:'bh::<type>::<hist-sid>', engagement:$eng})
MERGE (p)-[r:HAS_SID_HISTORY {engagement:$eng}]->(h)
SET r.bh_right='HasSIDHistory'
```

## Dogfood (live compose Neo4j, engagement-scoped)

```
HAS_SID_HISTORY:
  ADGroup bh::Group::S-1-5-21-1-1-1-512 -HAS_SID_HISTORY-> ADGroup bh::Group::S-1-5-21-9-9-9-512  (bh_right=HasSIDHistory)
  ADUser  bh::User::S-1-5-21-1-1-1-1000 -HAS_SID_HISTORY-> ADUser  bh::User::S-1-5-21-9-9-9-500   (bh_right=HasSIDHistory)
```

Both User and Group emission paths land cleanly under engagement scope; labels reflect the `ObjectType` from the BHCE entry.

## Out of scope

- ESC10a/b DC-side `StrongCertificateBindingEnforcement` (needs registry ingest).
- Slither `--print function-summary` visibility/payable/view-pure (RFC §4.3).

## Verification

- `make ci-lint` — 0 errors, 488 warnings (no regression).
- `pytest packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py` — 62 passed (+ 2 new: `TestHasSidHistoryIngest::test_user_has_sid_history_emits_edge`, `test_group_has_sid_history_emits_edge`).
- Live compose Neo4j dogfood — both User and Group HAS_SID_HISTORY edges queryable via Cypher with correct labels (\`ADUser\` / \`ADGroup\`).

## Test plan

- [x] User HasSIDHistory entry emits HAS_SID_HISTORY edge to ADUser placeholder
- [x] Group HasSIDHistory entry emits HAS_SID_HISTORY edge to ADGroup placeholder
- [x] bh_right provenance preserved
- [x] live Neo4j engagement-scoped Cypher returns both edges with correct labels