### PR TITLE
feat(kg): BloodHound RootCA → Domain ROOT_CA_FOR ingest

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bloodhound.py
+++ b/packages/decepticon/decepticon/tools/ad/bloodhound.py
@@ -645,6 +645,31 @@ def _ingest_dump_smsa_password(state: _IngestState, computer_key: str, obj: dict
         )
 
 
+def _ingest_root_ca_for(state: _IngestState, root_ca_key: str, obj: dict[str, Any]) -> None:
+    """RootCA ``DomainSID`` → ``ROOT_CA_FOR`` edge to the trusted Domain.
+
+    BHCE 5.x emits ``rootcas[].DomainSID`` (top-level) and mirrors it
+    into ``Properties.domainsid``; we accept both and synthesise
+    ``RootCA --ROOT_CA_FOR--> Domain`` so every ESC* / GoldenCert path
+    can anchor against the trust chain root.
+    """
+    domain_sid = obj.get("DomainSID")
+    if not isinstance(domain_sid, str) or not domain_sid:
+        props = obj.get("Properties")
+        if isinstance(props, dict):
+            domain_sid = props.get("domainsid")
+    if not isinstance(domain_sid, str) or not domain_sid:
+        return
+    domain_key = _ensure_placeholder(state, sid=domain_sid, default_type="Domain")
+    state.add_edge(
+        src_key=root_ca_key,
+        dst_key=domain_key,
+        kind=EdgeKind.ROOT_CA_FOR,
+        weight=0.2,
+        props={"bh_right": "RootCAFor"},
+    )
+
+
 def _ingest_has_sid_history(state: _IngestState, src_key: str, obj: dict[str, Any]) -> None:
     """User/Group ``HasSIDHistory[]`` → ``HAS_SID_HISTORY`` edges.
 
@@ -1035,6 +1060,8 @@ def _merge_one_payload(state: _IngestState, data: dict[str, Any], *, type_hint: 
             _ingest_enterprise_ca_edges(state, src_key, obj)
         if type_singular == "IssuancePolicy":
             _ingest_issuance_policy_link(state, src_key, obj)
+        if type_singular == "RootCA":
+            _ingest_root_ca_for(state, src_key, obj)
         if type_singular == "User":
             _ingest_spn_targets(state, src_key, obj)
             _ingest_has_sid_history(state, src_key, obj)

--- a/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
+++ b/packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py
@@ -979,6 +979,59 @@ class TestSpnTargetsIngest:
         )
 
 
+class TestRootCaForIngest:
+    def test_top_level_domain_sid_emits_root_ca_for(self) -> None:
+        bh = {
+            "meta": {"type": "rootcas"},
+            "data": [
+                {
+                    "ObjectIdentifier": "ROOT-THUMB-AABB",
+                    "Properties": {"name": "ROOT-CA@LAB.LOCAL"},
+                    "DomainSID": "S-1-5-21-1-1-1",
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        edges = store.edges_of_kind("ROOT_CA_FOR")
+        assert any(
+            "ROOT-THUMB-AABB" in s and "S-1-5-21-1-1-1" in d and p.get("bh_right") == "RootCAFor"
+            for s, d, p in edges
+        )
+
+    def test_properties_domainsid_fallback(self) -> None:
+        bh = {
+            "meta": {"type": "rootcas"},
+            "data": [
+                {
+                    "ObjectIdentifier": "ROOT-THUMB-CCDD",
+                    "Properties": {
+                        "name": "ROOT-CA@LAB.LOCAL",
+                        "domainsid": "S-1-5-21-2-2-2",
+                    },
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        edges = store.edges_of_kind("ROOT_CA_FOR")
+        assert any("CCDD" in s and "S-1-5-21-2-2-2" in d for s, d, _p in edges)
+
+    def test_missing_domain_sid_skipped(self) -> None:
+        bh = {
+            "meta": {"type": "rootcas"},
+            "data": [
+                {
+                    "ObjectIdentifier": "ROOT-NODS",
+                    "Properties": {"name": "stray-root"},
+                }
+            ],
+        }
+        store = _FakeKGStore()
+        merge_bloodhound_json(bh, engagement="t", store=store)
+        assert store.edges_of_kind("ROOT_CA_FOR") == []
+
+
 class TestHasSidHistoryIngest:
     def test_user_has_sid_history_emits_edge(self) -> None:
         bh = {


### PR DESCRIPTION
## Summary

- **`_ingest_root_ca_for`** — BHCE 5.x `rootcas[]` objects emit `RootCA -[ROOT_CA_FOR]-> Domain` using top-level `DomainSID` (ad.go primary) with `Properties.domainsid` as a fallback.
- Anchors every ADCS ESC* / GoldenCert path at the **trust-chain root** so future chain-validation post-process (`EnterpriseCA → AIACA → RootCA` via `ISSUED_SIGNED_BY`) can stack on top without changing the ingest layer.
- `bh_right="RootCAFor"` provenance preserved.

This closes RFC §2.4 row `RootCA/AIACA chain → ROOT_CA_FOR (RootCA → Domain)` and unblocks the matching AIACA chain follow-up.

## Cypher footprint (per RootCA)

```cypher
MERGE (r:ADRootCA  {key:'bh::RootCA::<thumb>',    engagement:$eng})
MERGE (d:ADDomain  {key:'bh::Domain::<sid>',      engagement:$eng})
MERGE (r)-[e:ROOT_CA_FOR {engagement:$eng}]->(d)
SET e.bh_right='RootCAFor'
```

## Dogfood (live compose Neo4j, engagement-scoped)

```
ROOT_CA_FOR:
  bh::RootCA::ROOT-A -ROOT_CA_FOR-> ADDomain bh::Domain::S-1-5-21-A   (top-level DomainSID)
  bh::RootCA::ROOT-B -ROOT_CA_FOR-> ADDomain bh::Domain::S-1-5-21-B   (Properties.domainsid fallback)
```

Both paths land with the correct `ADDomain` placeholder label.

## Out of scope

- AIACA / EnterpriseCA chain (`ISSUED_SIGNED_BY`) — cert-thumbprint chain post-process, follow-up PR.
- ESC10a/b DC-side `StrongCertificateBindingEnforcement` (needs registry ingest).

## Verification

- `make ci-lint` — 0 errors, 493 warnings (no regression).
- `pytest packages/decepticon/tests/unit/ad/test_bloodhound_kgstore.py -k RootCaFor` — 3 passed (\`test_top_level_domain_sid_emits_root_ca_for\`, \`test_properties_domainsid_fallback\`, \`test_missing_domain_sid_skipped\`).
- Live compose Neo4j dogfood — both DomainSID surfaces produce \`ADRootCA -ROOT_CA_FOR-> ADDomain\`.

## Test plan

- [x] Top-level `DomainSID` emits ROOT_CA_FOR with ADDomain placeholder
- [x] `Properties.domainsid` fallback when top-level absent
- [x] Missing DomainSID skips edge emission
- [x] live Neo4j engagement-scoped Cypher returns both edges