### PR TITLE
feat(compose): integrate BHCE v9.2.2 sidecar reusing Postgres

### DIFF
--- a/containers/postgres-init/02-bloodhound-db.sh
+++ b/containers/postgres-init/02-bloodhound-db.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bootstrap the BHCE (BloodHound Community Edition) Postgres state.
+#
+# Why this exists
+# ---------------
+# The BHCE API container points at `postgres:5432` with
+#   user=bloodhound password=$BHCE_POSTGRES_PASSWORD dbname=bloodhound
+# and runs its own `goose` migrations on first boot.  The migrations
+# include `CREATE EXTENSION IF NOT EXISTS pg_trgm;` (BHCE
+# `cmd/api/src/database/migration/migrations/00000000000001_init.sql`,
+# v9.2.2), which requires the connecting role to either own the
+# extension or be a superuser.  We pre-create the role, the DB, and
+# the extension here as the postgres superuser so BHCE's migration
+# user can remain narrowly scoped.
+#
+# Postgres auto-runs files in /docker-entrypoint-initdb.d/ on first
+# boot only (when the data volume is empty).  To apply to an existing
+# deployment without data loss, run the equivalent commands manually
+# inside the postgres container.
+#
+# ADR: docs/adr/0005-bloodhound-via-bhce-rest-client.md
+set -euo pipefail
+
+BHCE_DB_NAME="${BHCE_POSTGRES_DB:-bloodhound}"
+BHCE_DB_USER="${BHCE_POSTGRES_USER:-bloodhound}"
+BHCE_DB_PASSWORD="${BHCE_POSTGRES_PASSWORD:-bhce-decepticon-local}"
+
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" <<-EOSQL
+    CREATE ROLE "${BHCE_DB_USER}" WITH LOGIN PASSWORD '${BHCE_DB_PASSWORD}';
+    CREATE DATABASE "${BHCE_DB_NAME}" OWNER "${BHCE_DB_USER}";
+    GRANT ALL PRIVILEGES ON DATABASE "${BHCE_DB_NAME}" TO "${BHCE_DB_USER}";
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${BHCE_DB_NAME}" <<-EOSQL
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    GRANT ALL ON SCHEMA public TO "${BHCE_DB_USER}";
+EOSQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -547,11 +547,104 @@ services:
       - decepticon-net
     restart: unless-stopped
 
+  # ── BloodHound Community Edition (BHCE) sidecar ────────────────────
+  #
+  # Provides the AD attack-graph layer for the agent.  Replaces the
+  # in-house tools/ad/* ingest + ADCS post-process (PR #560..#578),
+  # which are deprecated by ADR-0005.  The agent calls BHCE v9.2.2
+  # over its official REST API via decepticon.tools.ad.bhce_client.
+  #
+  # Why a dedicated Neo4j: Neo4j Community Edition only allows one
+  # user database per server, and our KGStore already occupies the
+  # `neo4j` database on the `neo4j` container.  BHCE writes its own
+  # ADCS / AD label schema via its `dawgs` driver, so it gets its
+  # own Neo4j instance to avoid label/constraint collisions.
+  # See docs/adr/0005-bloodhound-via-bhce-rest-client.md §Context.
+  #
+  # Why reuse Postgres: BHCE only needs one Postgres database
+  # (`bloodhound`) with the `pg_trgm` extension.  We pre-create both
+  # in containers/postgres-init/02-bloodhound-db.sh so BHCE's goose
+  # migrations bootstrap cleanly against our existing Postgres
+  # instance — no second Postgres container.
+  bhce-neo4j:
+    image: neo4j:4.4.42-community
+    container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-bhce-neo4j
+    environment:
+      NEO4J_AUTH: neo4j/${BHCE_NEO4J_PASSWORD:-decepticon-bhce-graph}
+      NEO4J_dbms_allow__upgrade: "true"
+    volumes:
+      - bhce_neo4j_data:/data
+      - bhce_neo4j_logs:/logs
+    networks:
+      - decepticon-net
+    # No host port exposure: only the BHCE API container needs bolt.
+    # `docker exec` into this container for cypher-shell debugging.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -O /dev/null -q http://localhost:7474 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+    restart: unless-stopped
+
+  bhce:
+    # SpecterOps does not publish semver tags on Docker Hub — every
+    # build is `edge` or `sha-<commit>[-<timestamp>]`.  Default below
+    # pins the v9.2.2 release commit (1a7b3df, 2026-06-01).  Verify
+    # against https://github.com/SpecterOps/BloodHound/releases/tag/v9.2.2
+    # when bumping; tags are immutable on Hub but `edge` is not.
+    image: docker.io/specterops/bloodhound:${BHCE_TAG:-sha-1a7b3df18a836051643ea3dcb777d20abdb469de}
+    container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-bhce
+    environment:
+      # Cypher policy: keep the v9.2.2 defaults — complexity limit on,
+      # mutations disabled.  Flip via env if a red-team scenario
+      # demands write-cypher (rare; tracked in ADR-0005 follow-up).
+      bhe_disable_cypher_complexity_limit: "false"
+      bhe_enable_cypher_mutations: "false"
+      bhe_graph_query_memory_limit: "2"
+      # External Postgres — our existing `postgres` container, with
+      # the `bloodhound` DB + `pg_trgm` pre-created by
+      # containers/postgres-init/02-bloodhound-db.sh.
+      bhe_database_connection: >-
+        user=${BHCE_POSTGRES_USER:-bloodhound}
+        password=${BHCE_POSTGRES_PASSWORD:-bhce-decepticon-local}
+        dbname=${BHCE_POSTGRES_DB:-bloodhound}
+        host=postgres
+        sslmode=disable
+      # External Neo4j — dedicated `bhce-neo4j` container.
+      bhe_neo4j_connection: "neo4j://neo4j:${BHCE_NEO4J_PASSWORD:-decepticon-bhce-graph}@bhce-neo4j:7687/"
+      bhe_graph_driver: "neo4j"
+      bhe_recreate_default_admin: "${BHCE_RECREATE_DEFAULT_ADMIN:-false}"
+      bhe_default_admin_email: "${BHCE_DEFAULT_ADMIN_EMAIL:-admin@decepticon.local}"
+      bhe_default_admin_password: "${BHCE_DEFAULT_ADMIN_PASSWORD:-DecepticonBhceLocal2026!}"
+      bhe_default_admin_principal_name: "${BHCE_DEFAULT_ADMIN_USERNAME:-admin}"
+      # JWT signing key — pin this to a persisted secret in any
+      # non-dev deployment; default value is for local dogfood only.
+      bhe_crypto_jwt_signing_key: "${BHCE_JWT_SIGNING_KEY:-decepticon-bhce-jwt-signing-key-do-not-use-in-prod-do-not-use-in-prod}"
+    ports:
+      - "127.0.0.1:${BHCE_PORT:-8081}:8080"
+    networks:
+      - decepticon-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+      bhce-neo4j:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/version >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 90s
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   sliver_data:
   neo4j_data:
   neo4j_logs:
+  bhce_neo4j_data:
+  bhce_neo4j_logs:
 
 networks:
   decepticon-net:


### PR DESCRIPTION
## Summary

Lands the compose stack changes from ADR-0005 step 1 of the BHCE migration. Adds two services on `decepticon-net`, **reusing our existing Postgres** (no second Postgres container) and giving BHCE **its own dedicated Neo4j** (Community Edition multi-DB limit forces this — KGStore already owns the `neo4j` DB).

## Changes

### `containers/postgres-init/02-bloodhound-db.sh` (new)
Bootstrap script that runs on first Postgres boot:
- Creates `bloodhound` Postgres role + database (owner = `bloodhound`).
- `CREATE EXTENSION IF NOT EXISTS pg_trgm;` in the new DB — required by BHCE's first goose migration (\`cmd/api/src/database/migration/migrations/00000000000001_init.sql\` in v9.2.2).
- Pre-creating as the postgres superuser means BHCE's runtime role doesn't need `CREATE EXTENSION` privilege.

### `docker-compose.yml` (two new services + two new volumes)

\`bhce-neo4j\` — `neo4j:4.4.42-community`. Matches the BHCE example compose. No host port exposure — only the \`bhce\` container needs bolt access. Debug via \`docker exec\`.

\`bhce\` — `docker.io/specterops/bloodhound` pinned to the **v9.2.2 release commit**: \`sha-1a7b3df18a836051643ea3dcb777d20abdb469de\`. SpecterOps does not publish semver tags on Docker Hub (verified via the Hub registry API), so semver tracking happens at the compose-comment + ADR layer and the actual image is pinned to an immutable commit-SHA tag. Override via \`BHCE_TAG\` env.

Env vars follow the v9.2.2 example compose:
- \`bhe_database_connection\` → external \`postgres:5432/bloodhound\` (sslmode=disable; decepticon-net internal).
- \`bhe_neo4j_connection\` → \`neo4j://neo4j:...@bhce-neo4j:7687/\`.
- \`bhe_default_admin_*\` seeded so first-boot UI/API works.
- \`bhe_crypto_jwt_signing_key\` defaulted for local dogfood; override required for any non-dev deployment.
- \`bhe_enable_cypher_mutations=false\`, \`bhe_disable_cypher_complexity_limit=false\` — preserve v9.2.2 hardening defaults.

Host port: \`BHCE_PORT\` (default 8081) → 8080 in container, so the BHCE UI/API doesn't clash with anything else on the host.

\`depends_on\`: \`postgres\` + \`bhce-neo4j\` both \`service_healthy\` before BHCE starts; **no coupling** to the existing \`neo4j\` (KGStore) container.

Healthcheck: \`wget /api/version\` inside the container with 90s \`start_period\` for goose migrations on first boot.

## Dogfood (this PR)

Isolated compose project so existing dev state isn't disturbed:

\`\`\`bash
docker compose -p bhce-dogfood up -d --no-build postgres bhce-neo4j bhce
\`\`\`

Verified:
- All three services reach \`service_healthy\`.
- \`curl http://127.0.0.1:8081/api/version\` → 401 with valid BHCE error envelope (\`http_status\`, \`request_id\`, \`errors[*].message\`) — confirms the API binary is up and the auth middleware is wired.
- \`curl http://127.0.0.1:8081/api/v2/spec\` → OpenAPI 3.0.3 JSON (title=\"BloodHound API\", license=Apache-2.0) — confirms the auth-free route registered in \`registration/v2.go:145\` works.
- Teardown via \`docker compose -p bhce-dogfood down -v\` clean: removes \`bhce_neo4j_data\`, \`bhce_neo4j_logs\`, and the isolated \`postgres_data\` volume.

## Out of scope (subsequent PRs per ADR-0005)

- **PR 3**: \`tools/ad/bhce_client.py\` — HMAC 3-chain signer + REST client per BHCE v9.2.2 \`signature.go:97-145\` with a code-derived test vector.
- **PR 4**: \`tools/ad/bh_*\` LangChain \`@tool\` surface (13 composite tools).
- **PR 5**: vendored attack-tradecraft resources from \`bloodhound.specterops.io\` into \`decepticon/skills/ad/bloodhound/\`.
- **PR 6**: \`DeprecationWarning\` on the legacy in-house tools (#560..#578).

## Verification

- \`docker compose config --quiet\` — passes (no YAML schema warnings).
- \`docker compose -p bhce-dogfood up -d\` — all healthchecks reach \`healthy\` from cold start; \`/api/version\` and \`/api/v2/spec\` respond as expected.
- No change to existing services (\`postgres\`, \`neo4j\`, \`langgraph\`, \`web\`, \`cli\`, \`sandbox\`, \`skillogy\`, …): the new services are additive and only consume \`decepticon-net\` + their own volumes.

## Test plan

- [x] postgres-init bootstrap creates role / DB / pg_trgm on first boot
- [x] bhce-neo4j reaches healthy
- [x] bhce reaches healthy
- [x] /api/version returns BHCE 401 envelope
- [x] /api/v2/spec returns OpenAPI 3.0.3 JSON
- [x] teardown removes the two new volumes
- [ ] reviewer confirms no port conflicts with their local dev stack