### PR TITLE
feat(ad): BHCE v9.2.2 REST client with HMAC 3-chain signer

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bhce_client.py
+++ b/packages/decepticon/decepticon/tools/ad/bhce_client.py
@@ -1,0 +1,314 @@
+"""Thin Python client for the BloodHound Community Edition v9.2.2 REST API.
+
+ADR: docs/adr/0005-bloodhound-via-bhce-rest-client.md
+
+This module exists so the agent surface (``decepticon.tools.ad.bh_*``)
+can call the real BHCE instead of the in-house ingest + post-process
+pipeline being deprecated under ADR-0005.
+
+Every authoritative behaviour cites BHCE v9.2.2 source.  The community
+wrapper (mwnickerson/bloodhound_mcp) is **not** a source of truth — it
+is at most an interface-shape hint for the tool surface that calls into
+this client.
+
+Signature scheme (HMAC 3-chain, ``cmd/api/src/api/signature.go:97-145``):
+
+    OperationKey = HMAC_SHA256(token_secret,            METHOD || URI_PATH)
+    DateKey      = HMAC_SHA256(OperationKey,            RFC3339[:13])
+    BodyKey      = HMAC_SHA256(DateKey,                 body_bytes)
+    Signature    = base64.standard_b64encode(BodyKey)
+
+Where:
+
+- ``METHOD`` is the upper-case HTTP verb (``GET``/``POST``/...).
+- ``URI_PATH`` is ``request.URL.Path`` in the Go reference — **path only,
+  no query string**.  This matters because BHCE's server-side
+  verification feeds the same path-only string back into the same
+  algorithm; signing with a query string attached will hash-mismatch.
+- ``RFC3339[:13]`` is the first 13 characters of the RFC3339 datetime,
+  i.e. truncated to the hour (e.g. ``2026-06-05T07``).  The header
+  ``RequestDate`` carries the **full** RFC3339 datetime; only the
+  signature input is hour-truncated.
+- Empty body still runs the third HMAC (writing zero bytes), so the
+  algorithm is uniform across GET and POST.
+
+Authentication headers (``signature.go:169-171``):
+
+- ``Authorization: bhesignature <TOKEN_ID>``
+- ``RequestDate:   <full RFC3339 datetime>``
+- ``Signature:     <base64 of BodyKey, standard padding>``
+
+Clock skew is enforced at ``±1 hour`` on the server
+(``cmd/api/src/api/auth.go:276-296``), so the docs' "2 hour" paraphrase
+is incorrect — keep client + server clocks within an hour.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+
+_AUTH_SCHEME = "bhesignature"
+"""Matches BHCE's ``AuthorizationSchemeBHESignature`` constant."""
+
+
+def _rfc3339_now() -> str:
+    """RFC3339 timestamp matching Go's ``time.Format(time.RFC3339)``.
+
+    Go's RFC3339 format is ``2006-01-02T15:04:05Z07:00`` — second-resolution
+    with a numeric timezone offset.  Python's ``datetime.isoformat`` emits
+    microseconds and a ``+00:00`` offset.  We strip microseconds and
+    canonicalise the offset to ``+HH:MM``; UTC stays as ``+00:00`` (Go
+    emits ``Z`` only when the location is exactly ``UTC``, but BHCE's
+    server-side validator accepts both per ``time.Parse(time.RFC3339, …)``).
+    """
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sign_request(
+    token_id: str,
+    token_secret: str,
+    method: str,
+    url: str,
+    body: bytes = b"",
+    *,
+    request_date: str | None = None,
+) -> dict[str, str]:
+    """Return the BHCE auth headers for the given HTTP request.
+
+    Args:
+        token_id: BHCE API token ID (the public half — also called
+            "Token ID" in the BHCE UI's ``Admin → Manage Users``).
+        token_secret: BHCE API token secret (the private half).
+        method: Upper-case HTTP verb.
+        url: Fully-qualified request URL.  Only ``urlsplit(url).path`` is
+            fed into the signature; the host/scheme/query are ignored to
+            match ``request.URL.Path`` in ``signature.go:160``.
+        body: Request body bytes.  Use ``b""`` for empty.
+        request_date: Optional RFC3339 datetime override (used by tests
+            for deterministic signatures).  Defaults to ``_rfc3339_now()``.
+
+    Returns:
+        A ``dict`` of HTTP headers to attach to the outgoing request:
+        ``Authorization``, ``RequestDate``, ``Signature``.
+    """
+    datetime_str = request_date or _rfc3339_now()
+    path = urlsplit(url).path or "/"
+
+    op_key = hmac.new(
+        token_secret.encode("utf-8"),
+        (method.upper() + path).encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    date_key = hmac.new(op_key, datetime_str[:13].encode("utf-8"), hashlib.sha256).digest()
+    body_key = hmac.new(date_key, body, hashlib.sha256).digest()
+
+    return {
+        "Authorization": f"{_AUTH_SCHEME} {token_id}",
+        "RequestDate": datetime_str,
+        "Signature": base64.standard_b64encode(body_key).decode("ascii"),
+    }
+
+
+class BHCEConfigError(RuntimeError):
+    """Raised when required BHCE configuration is missing."""
+
+
+class BHCEHTTPError(RuntimeError):
+    """Raised when BHCE returns a non-success status.
+
+    Carries ``status_code`` and the parsed BHCE error envelope when
+    available (BHCE v9.2.2 emits ``{http_status, timestamp, request_id,
+    errors:[{context, message}]}``).
+    """
+
+    def __init__(self, status_code: int, body: Any, message: str | None = None) -> None:
+        super().__init__(message or f"BHCE returned HTTP {status_code}: {body!r}")
+        self.status_code = status_code
+        self.body = body
+
+
+class BHCEClient:
+    """Synchronous BHCE v9.2.2 REST client.
+
+    Constructed with ``BHCEClient.from_env()`` in production.  The env
+    surface mirrors the BHCE example compose:
+
+    - ``BHCE_URL``         — base URL (e.g. ``http://bhce:8080``).
+    - ``BHCE_TOKEN_ID``    — HMAC token ID.
+    - ``BHCE_TOKEN_KEY``   — HMAC token secret.
+    - ``BHCE_TIMEOUT``     — request timeout in seconds (default 30).
+
+    The 11 methods below each map to **one** documented BHCE endpoint;
+    aggregate "composite" tools live in the LangChain @tool layer above
+    this client, not here.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        token_id: str | None = None,
+        token_key: str | None = None,
+        *,
+        timeout: float = 30.0,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._token_id = token_id
+        self._token_key = token_key
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    @classmethod
+    def from_env(cls) -> BHCEClient:
+        base = os.environ.get("BHCE_URL", "").strip()
+        if not base:
+            raise BHCEConfigError("BHCE_URL is required to construct BHCEClient")
+        token_id = os.environ.get("BHCE_TOKEN_ID") or None
+        token_key = os.environ.get("BHCE_TOKEN_KEY") or None
+        timeout_str = os.environ.get("BHCE_TIMEOUT", "30").strip() or "30"
+        try:
+            timeout = float(timeout_str)
+        except ValueError as exc:
+            raise BHCEConfigError(f"BHCE_TIMEOUT must be a number, got {timeout_str!r}") from exc
+        return cls(base, token_id, token_key, timeout=timeout)
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> BHCEClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: bytes | None = None,
+        content_type: str = "application/json",
+        signed: bool = True,
+    ) -> httpx.Response:
+        url = f"{self._base}{path}"
+        payload = body or b""
+        headers: dict[str, str] = {}
+        if payload or content_type != "application/json":
+            headers["Content-Type"] = content_type
+        if signed:
+            if not self._token_id or not self._token_key:
+                raise BHCEConfigError(
+                    "BHCE_TOKEN_ID and BHCE_TOKEN_KEY are required for signed requests"
+                )
+            headers.update(
+                sign_request(
+                    self._token_id,
+                    self._token_key,
+                    method,
+                    url,
+                    payload,
+                )
+            )
+        resp = self._client.request(method, url, content=payload, headers=headers)
+        if resp.status_code >= 400:
+            try:
+                body_parsed: Any = resp.json()
+            except Exception:
+                body_parsed = resp.text
+            raise BHCEHTTPError(resp.status_code, body_parsed)
+        return resp
+
+    # ── Public endpoint methods (1:1 with BHCE v9.2.2 routes) ───────
+
+    def get_version(self) -> dict[str, Any]:
+        """``GET /api/version`` — authenticated.
+
+        Despite living under ``/api/version`` (no ``v2`` prefix), this
+        endpoint enforces auth in v9.2.2.  Only ``GET /api/v2/spec`` is
+        ``security: []`` per the in-repo OpenAPI spec.
+        """
+        return self._request("GET", "/api/version").json()
+
+    def get_spec(self) -> str:
+        """``GET /api/v2/spec`` — OpenAPI 3.0.3 (text/x-yaml).  No auth."""
+        return self._request("GET", "/api/v2/spec", signed=False).text
+
+    def get_self(self) -> dict[str, Any]:
+        """``GET /api/v2/self`` — the principal behind the credentials."""
+        return self._request("GET", "/api/v2/self").json()
+
+    def run_cypher(self, query: str, *, include_properties: bool = True) -> dict[str, Any]:
+        """``POST /api/v2/graphs/cypher``.
+
+        BHCE's ``cypherquery.go`` handler enforces read-only by default
+        (mutations require ``bhe_enable_cypher_mutations=true`` on the
+        server).  Returns ``{data: UnifiedGraph}``.
+        """
+        import json
+
+        payload = json.dumps({"query": query, "include_properties": include_properties}).encode(
+            "utf-8"
+        )
+        return self._request("POST", "/api/v2/graphs/cypher", body=payload).json()
+
+    def start_upload_job(self) -> int:
+        """``POST /api/v2/file-upload/start`` — returns the new ``job_id``."""
+        resp = self._request("POST", "/api/v2/file-upload/start").json()
+        data = resp.get("data") if isinstance(resp, dict) else None
+        if not isinstance(data, dict) or "id" not in data:
+            raise BHCEHTTPError(200, resp, message="BHCE start_upload_job: missing data.id")
+        return int(data["id"])
+
+    def upload_chunk(
+        self,
+        job_id: int,
+        payload: bytes,
+        *,
+        content_type: str = "application/json",
+        filename: str | None = None,
+    ) -> None:
+        """``POST /api/v2/file-upload/{job_id}``.
+
+        Accepted ``content_type`` per
+        ``packages/go/openapi/src/paths/collection-uploads.file-upload.id.yaml``:
+        ``application/json``, ``application/zip``, ``application/zip-compressed``,
+        ``application/x-zip-compressed``.
+        """
+        path = f"/api/v2/file-upload/{job_id}"
+        resp = self._request("POST", path, body=payload, content_type=content_type)
+        # 202 No Content per spec; we just confirm success.
+        if filename and resp.headers.get("X-File-Upload-Name"):
+            log.debug("BHCE chunk accepted: %s", resp.headers.get("X-File-Upload-Name"))
+
+    def end_upload_job(self, job_id: int) -> None:
+        """``POST /api/v2/file-upload/{job_id}/end`` — close the job."""
+        self._request("POST", f"/api/v2/file-upload/{job_id}/end")
+
+    def get_upload_job(self, job_id: int) -> dict[str, Any]:
+        """``GET /api/v2/file-upload/{job_id}`` — poll for status."""
+        return self._request("GET", f"/api/v2/file-upload/{job_id}").json()
+
+    def get_domain(self, object_id: str) -> dict[str, Any]:
+        """``GET /api/v2/domains/{object_id}``."""
+        return self._request("GET", f"/api/v2/domains/{object_id}").json()
+
+    def get_user(self, object_id: str) -> dict[str, Any]:
+        """``GET /api/v2/users/{object_id}``."""
+        return self._request("GET", f"/api/v2/users/{object_id}").json()
+
+    def get_computer(self, object_id: str) -> dict[str, Any]:
+        """``GET /api/v2/computers/{object_id}``."""
+        return self._request("GET", f"/api/v2/computers/{object_id}").json()

--- a/packages/decepticon/tests/unit/ad/test_bhce_client.py
+++ b/packages/decepticon/tests/unit/ad/test_bhce_client.py
@@ -1,0 +1,148 @@
+"""Unit tests for the BHCE v9.2.2 REST client.
+
+The signature test vectors are NOT computed by re-running our own
+algorithm against itself.  They were extracted from a verbatim
+``crypto/hmac`` reproduction of BHCE's ``NewRequestSignature``
+(``cmd/api/src/api/signature.go:97-145``, commit ``1a7b3df``) using
+``go run`` — see /tmp/bhce-sign-vector/main.go in dev notes.  Pinning
+the Go-generated base64 here gives us byte-precision compatibility
+with the BHCE server-side validator.
+"""
+
+from __future__ import annotations
+
+from decepticon.tools.ad.bhce_client import (
+    BHCEClient,
+    BHCEConfigError,
+    sign_request,
+)
+
+# ── HMAC 3-chain reference vectors (Go-generated, do not edit) ──────
+
+
+def test_sign_empty_get_self_matches_go_reference() -> None:
+    headers = sign_request(
+        token_id="my-id",
+        token_secret="test-secret-aaaa",
+        method="GET",
+        url="http://bhce.local/api/v2/self",
+        body=b"",
+        request_date="2026-06-05T07:00:00Z",
+    )
+    assert headers["Signature"] == "Ppy6aC4h43xQOxf9TwE/wPFnFU5oU/imtIIZXI3m0NI="
+    assert headers["Authorization"] == "bhesignature my-id"
+    assert headers["RequestDate"] == "2026-06-05T07:00:00Z"
+
+
+def test_sign_post_cypher_with_offset_tz_matches_go_reference() -> None:
+    body = b'{"query":"MATCH (n) RETURN n LIMIT 1","include_properties":true}'
+    headers = sign_request(
+        token_id="id-2",
+        token_secret="test-secret-bbbb",
+        method="POST",
+        url="http://bhce.local/api/v2/graphs/cypher",
+        body=body,
+        request_date="2026-06-05T07:00:00+09:00",
+    )
+    assert headers["Signature"] == "9G0Uf1XQ5h0uKg0ebv/HkVMJyWQf9wkRlxltAZfn4c4="
+
+
+def test_sign_post_empty_body_negative_offset_matches_go_reference() -> None:
+    headers = sign_request(
+        token_id="id-3",
+        token_secret="another-secret",
+        method="POST",
+        url="http://bhce.local/api/v2/file-upload/42/end",
+        body=b"",
+        request_date="2026-01-15T23:59:59-05:00",
+    )
+    assert headers["Signature"] == "CPaTRCh7gZf+z0hsYRMV8CHDjIKvIXnl0kzmKVcUjuA="
+
+
+# ── Behavioural contracts on the sign_request helper ────────────────
+
+
+def test_sign_strips_query_string_from_uri_in_signature() -> None:
+    """BHCE signs ``request.URL.Path`` only — query is excluded.
+
+    If we accidentally fed the query through, ``…/self?a=1`` would
+    produce a different signature than ``…/self``, but per
+    ``signature.go:160`` (``request.URL.Path``) BHCE strips it before
+    the HMAC.  Sanity-check that we strip it too.
+    """
+    without_query = sign_request(
+        "id", "s", "GET", "http://h/api/v2/self", b"", request_date="2026-06-05T07:00:00Z"
+    )["Signature"]
+    with_query = sign_request(
+        "id",
+        "s",
+        "GET",
+        "http://h/api/v2/self?a=1&b=2",
+        b"",
+        request_date="2026-06-05T07:00:00Z",
+    )["Signature"]
+    assert without_query == with_query
+
+
+def test_sign_truncates_datetime_to_hour_for_signature_only() -> None:
+    """Minute / second changes within the same hour produce the same
+    signature (per ``signature.go:123`` ``datetime[:13]``), but the
+    ``RequestDate`` header carries the **full** datetime."""
+    h1 = sign_request("id", "s", "GET", "http://h/p", b"", request_date="2026-06-05T07:00:00Z")
+    h2 = sign_request("id", "s", "GET", "http://h/p", b"", request_date="2026-06-05T07:59:59Z")
+    assert h1["Signature"] == h2["Signature"]
+    assert h1["RequestDate"] != h2["RequestDate"]
+
+
+def test_sign_changes_when_hour_rolls() -> None:
+    """Crossing the hour boundary changes the DateKey and so the sig."""
+    h1 = sign_request("id", "s", "GET", "http://h/p", b"", request_date="2026-06-05T07:59:59Z")
+    h2 = sign_request("id", "s", "GET", "http://h/p", b"", request_date="2026-06-05T08:00:00Z")
+    assert h1["Signature"] != h2["Signature"]
+
+
+def test_sign_body_changes_signature() -> None:
+    h1 = sign_request("id", "s", "POST", "http://h/p", b"{}", request_date="2026-06-05T07:00:00Z")
+    h2 = sign_request(
+        "id", "s", "POST", "http://h/p", b'{"a":1}', request_date="2026-06-05T07:00:00Z"
+    )
+    assert h1["Signature"] != h2["Signature"]
+
+
+# ── Client wiring (env / errors) ────────────────────────────────────
+
+
+def test_from_env_requires_url(monkeypatch) -> None:
+    monkeypatch.delenv("BHCE_URL", raising=False)
+    try:
+        BHCEClient.from_env()
+    except BHCEConfigError as exc:
+        assert "BHCE_URL" in str(exc)
+    else:
+        raise AssertionError("BHCEConfigError not raised on missing BHCE_URL")
+
+
+def test_from_env_invalid_timeout(monkeypatch) -> None:
+    monkeypatch.setenv("BHCE_URL", "http://bhce.local:8080")
+    monkeypatch.setenv("BHCE_TIMEOUT", "not-a-number")
+    try:
+        BHCEClient.from_env()
+    except BHCEConfigError as exc:
+        assert "BHCE_TIMEOUT" in str(exc)
+    else:
+        raise AssertionError("BHCEConfigError not raised on bad BHCE_TIMEOUT")
+
+
+def test_signed_call_without_token_raises(monkeypatch) -> None:
+    monkeypatch.setenv("BHCE_URL", "http://bhce.local:8080")
+    monkeypatch.delenv("BHCE_TOKEN_ID", raising=False)
+    monkeypatch.delenv("BHCE_TOKEN_KEY", raising=False)
+    client = BHCEClient.from_env()
+    try:
+        client.get_self()
+    except BHCEConfigError as exc:
+        assert "BHCE_TOKEN" in str(exc)
+    else:
+        raise AssertionError("BHCEConfigError not raised on missing token")
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

Lands the BHCE REST client per ADR-0005 step 2.  This is the thin Python layer the upcoming \`tools/ad/bh_*\` LangChain \`@tool\` surface will call.  Replaces the in-house ingest + post-process pipeline being deprecated under ADR-0005 (PRs #560..#578).

Depends on the compose stack from PR #580 for the live integration path, but the unit-test suite stands on its own.

## Authoritative sources

Every behaviour traces to BHCE v9.2.2 source at commit \`1a7b3df\` (2026-06-01):

- HMAC 3-chain — \`cmd/api/src/api/signature.go:97-145\`
  \`\`\`
  OperationKey = HMAC_SHA256(token_secret, METHOD || URL.Path)
  DateKey      = HMAC_SHA256(OperationKey, RFC3339[:13])
  BodyKey      = HMAC_SHA256(DateKey,      body_bytes)
  Signature    = base64.standard_b64encode(BodyKey)
  \`\`\`
- Headers — \`signature.go:169-171\` (\`Authorization: bhesignature <id>\`, \`RequestDate: <full RFC3339>\`, \`Signature: <b64>\`)
- URI is \`request.URL.Path\` — **path only, no query string** (\`signature.go:160\`).  Mismatched stripping is the classic 401 source for third-party clients.
- Clock skew is **±1 hour** (\`cmd/api/src/api/auth.go:276-296\`); the docs page's "2h" paraphrase is incorrect — code wins.
- \`GET /api/version\` requires auth in v9.2.2 (only \`GET /api/v2/spec\` is \`security: []\` per the in-repo OpenAPI spec).

The community \`mwnickerson/bloodhound_mcp\` wrapper informed the interface-shape of the upcoming \`@tool\` layer but is **not** a source of truth for any behaviour here.

## Test vectors NOT generated by our own algorithm

Three reference HMAC vectors were extracted from a stdlib-only Go program that mirrors \`NewRequestSignature\` byte-for-byte, then pinned in \`test_bhce_client.py\`:

| case | secret | method + path | datetime | body | signature |
|---|---|---|---|---|---|
| empty GET self | \`test-secret-aaaa\` | \`GET /api/v2/self\` | \`2026-06-05T07:00:00Z\` | empty | \`Ppy6aC4h43xQOxf9TwE/wPFnFU5oU/imtIIZXI3m0NI=\` |
| POST cypher tiny | \`test-secret-bbbb\` | \`POST /api/v2/graphs/cypher\` | \`2026-06-05T07:00:00+09:00\` | \`{"query":"MATCH (n) RETURN n LIMIT 1",...}\` | \`9G0Uf1XQ5h0uKg0ebv/HkVMJyWQf9wkRlxltAZfn4c4=\` |
| POST upload-end | \`another-secret\` | \`POST /api/v2/file-upload/42/end\` | \`2026-01-15T23:59:59-05:00\` | empty | \`CPaTRCh7gZf+z0hsYRMV8CHDjIKvIXnl0kzmKVcUjuA=\` |

Behavioural contracts also enforced (query-string stripping, hour-truncation invariance within the hour, signature change at hour rollover, signature change on body mutation).

## Client surface (11 methods, each 1:1 with one v9.2.2 endpoint)

| method | endpoint | spec ref |
|---|---|---|
| \`get_version\` | \`GET /api/version\` | \`paths/api-info.version.yaml\` |
| \`get_spec\` | \`GET /api/v2/spec\` | \`paths/api-info.spec.yaml\` (\`security: []\`) |
| \`get_self\` | \`GET /api/v2/self\` | \`paths/auth.self.yaml\` |
| \`run_cypher\` | \`POST /api/v2/graphs/cypher\` | \`paths/cypher.graphs.cypher.yaml\` |
| \`start_upload_job\` | \`POST /api/v2/file-upload/start\` | \`paths/collection-uploads.file-upload.start.yaml\` |
| \`upload_chunk\` | \`POST /api/v2/file-upload/{job_id}\` | \`paths/collection-uploads.file-upload.id.yaml\` |
| \`end_upload_job\` | \`POST /api/v2/file-upload/{job_id}/end\` | \`paths/collection-uploads.file-upload.id.end.yaml\` |
| \`get_upload_job\` | \`GET /api/v2/file-upload/{job_id}\` | (same file as upload, GET op) |
| \`get_domain\` | \`GET /api/v2/domains/{object_id}\` | \`paths/entity-info.domains.id.yaml\` |
| \`get_user\` | \`GET /api/v2/users/{object_id}\` | \`paths/entity-info.users.id.yaml\` |
| \`get_computer\` | \`GET /api/v2/computers/{object_id}\` | \`paths/entity-info.computers.id.yaml\` |

Composite tools live in the upcoming \`tools/ad/bh_*\` LangChain layer, not here — keeping this module 1:1 with the BHCE OpenAPI catalog makes drift detection straightforward.

## Live BHCE v9.2.2 dogfood (against PR #580 compose stack)

After fixing the JWT signing key (must be base64-encoded — BHCE's first-boot init swallows otherwise) and verifying we have the right \`bhe_default_admin_*\` keys (\`_email_address\` not \`_email\`):

\`\`\`
GET /api/version -> 200 {server_version:'v9.2.2', edition:'community'}
GET /api/v2/spec -> 200 OpenAPI 3.0.3 JSON
GET /api/v2/self -> 200, principal_name='admin' (HMAC accepted)
POST /api/v2/graphs/cypher 'MATCH (n) RETURN count(n) AS c'
                          -> 200 {data:{literals:[{value:1,key:'c'}]}}
\`\`\`

The HMAC 3-chain is byte-for-byte compatible with the BHCE server-side validator.

## Out of scope (subsequent PRs per ADR-0005)

- **PR 4**: \`tools/ad/bh_*\` LangChain \`@tool\` surface (13 composite tools).
- **PR 5**: vendored attack-tradecraft resources from \`bloodhound.specterops.io\` into \`decepticon/skills/ad/bloodhound/\`.
- **PR 6**: \`DeprecationWarning\` on the legacy in-house tools.
- Other client paths (search, ingest jobs list, asset groups, attack paths, …) — only the minimum surface for the upcoming \`@tool\` layer is in this PR.

## Verification

- \`make ci-lint\` — 0 errors, 493 warnings (no regression).
- \`pytest packages/decepticon/tests/unit/ad/test_bhce_client.py\` — 10 passed (3 Go-pinned signature vectors + 7 behavioural contracts).
- Live BHCE v9.2.2 dogfood as above.

## Test plan

- [x] HMAC 3-chain matches Go reference byte-for-byte (3 fixed vectors)
- [x] query string stripped from signature input
- [x] hour-truncation: minute / second changes within hour give same signature
- [x] hour rollover changes signature
- [x] body change changes signature
- [x] from_env validates BHCE_URL + BHCE_TIMEOUT + token presence
- [x] live BHCE 200 on /api/version, /api/v2/spec, /api/v2/self, /api/v2/graphs/cypher