### PR TITLE
feat(ad): bhce_status / bhce_cypher / bhce_ingest_zip LangChain tools

### DIFF
--- a/packages/decepticon/decepticon/tools/ad/bh_tools.py
+++ b/packages/decepticon/decepticon/tools/ad/bh_tools.py
@@ -1,0 +1,242 @@
+"""LangChain ``@tool`` surface for the real BHCE v9.2.2 backend.
+
+These are the *new* AD attack-graph tools per ADR-0005, replacing the
+in-house ingest + ESC* post-process pipeline behind ``bh_ingest_zip``,
+``adcs_post_process``, ``dcsync_check``, etc.  They call the official
+BHCE REST API via :mod:`decepticon.tools.ad.bhce_client`.
+
+Until PR #6 of the migration lands (which flips the legacy ``bh_*``
+names to deprecation aliases pointing at this module), the new tools
+live under the ``bhce_*`` prefix.  Once the cutover completes, the
+``bh_*`` names will route here and the in-house tools move to
+``decepticon.compat``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from langchain_core.tools import tool
+
+from decepticon.tools.ad.bhce_client import (
+    BHCEClient,
+    BHCEConfigError,
+    BHCEHTTPError,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+
+
+def _make_client() -> BHCEClient | None:
+    """Construct a client from env vars or return ``None`` with an error
+    payload-friendly diagnostic logged.  The caller emits the structured
+    error string so the agent sees an actionable message."""
+    try:
+        return BHCEClient.from_env()
+    except BHCEConfigError as exc:
+        log.warning("BHCE client unavailable: %s", exc)
+        return None
+
+
+def _config_error(message: str) -> str:
+    return _json(
+        {
+            "error": message,
+            "hint": (
+                "Set BHCE_URL, BHCE_TOKEN_ID, BHCE_TOKEN_KEY in the "
+                "environment.  Provision the token via the BHCE UI "
+                "(Admin → My Profile → API Keys) or via "
+                "POST /api/v2/tokens with a JWT session."
+            ),
+        }
+    )
+
+
+# ── bhce_status ───────────────────────────────────────────────────
+
+
+@tool
+def bhce_status() -> str:
+    """Probe the BHCE sidecar — verifies version, auth, and self.
+
+    Returns a JSON blob with the BHCE server version and the principal
+    behind the configured HMAC token.  Use this when the agent needs to
+    confirm the BHCE plane is healthy before issuing queries.
+    """
+    client = _make_client()
+    if client is None:
+        return _config_error("BHCE client could not be constructed from env")
+    try:
+        with client:
+            version = client.get_version()
+            try:
+                me = client.get_self()
+            except BHCEHTTPError as exc:
+                return _json(
+                    {
+                        "version": version,
+                        "self_error": {
+                            "status_code": exc.status_code,
+                            "body": exc.body,
+                        },
+                    }
+                )
+            return _json({"version": version, "self": me})
+    except BHCEHTTPError as exc:
+        return _json({"error": "BHCE HTTP error", "status_code": exc.status_code, "body": exc.body})
+
+
+# ── bhce_cypher ───────────────────────────────────────────────────
+
+
+@tool
+def bhce_cypher(query: str, include_properties: bool = True) -> str:
+    """Run a Cypher query against the BHCE graph.
+
+    Passthrough to ``POST /api/v2/graphs/cypher``.  BHCE enforces
+    read-only by default; mutation requires
+    ``bhe_enable_cypher_mutations=true`` on the server side (off in
+    our compose by design — see ADR-0005).
+
+    Args:
+        query: Cypher query string.
+        include_properties: Include node + edge property bags in the
+            response (default True).
+    """
+    if not query or not query.strip():
+        return _json({"error": "query is required"})
+    client = _make_client()
+    if client is None:
+        return _config_error("BHCE client could not be constructed from env")
+    try:
+        with client:
+            return _json(client.run_cypher(query, include_properties=include_properties))
+    except BHCEHTTPError as exc:
+        return _json(
+            {
+                "error": "BHCE returned an error for the Cypher query",
+                "status_code": exc.status_code,
+                "body": exc.body,
+            }
+        )
+
+
+# ── bhce_ingest_zip ───────────────────────────────────────────────
+
+
+_UPLOAD_POLL_INTERVAL_SECONDS = 2.0
+_UPLOAD_POLL_TIMEOUT_SECONDS = 600.0
+
+
+@tool
+def bhce_ingest_zip(path: str) -> str:
+    """Ingest a SharpHound collection ZIP via BHCE's file-upload flow.
+
+    Runs the official 3-step BHCE v9.2.2 ingest pipeline:
+
+      1. ``POST /api/v2/file-upload/start``      (creates a job)
+      2. ``POST /api/v2/file-upload/{job_id}``   (uploads the ZIP body)
+      3. ``POST /api/v2/file-upload/{job_id}/end`` (closes the job)
+      4. Polls ``GET /api/v2/file-upload/{job_id}`` until BHCE reports
+         a terminal status or the timeout elapses.
+
+    Args:
+        path: Filesystem path to a SharpHound-generated ZIP.
+
+    Returns:
+        JSON: ``{job_id, terminal_status, last_payload, elapsed_seconds}``
+        on success, or ``{error, ...}`` with diagnostic context on
+        failure.  BHCE's parsing + analysis runs *inside* the BHCE
+        server; we do not interpret the resulting graph here.
+    """
+    zip_path = Path(path)
+    if not zip_path.is_file():
+        return _json({"error": f"not a file: {path}"})
+    try:
+        payload = zip_path.read_bytes()
+    except OSError as exc:
+        return _json({"error": f"failed to read {path}: {exc}"})
+
+    client = _make_client()
+    if client is None:
+        return _config_error("BHCE client could not be constructed from env")
+
+    started = time.monotonic()
+    try:
+        with client:
+            job_id = client.start_upload_job()
+            client.upload_chunk(
+                job_id,
+                payload,
+                content_type="application/zip",
+                filename=zip_path.name,
+            )
+            client.end_upload_job(job_id)
+
+            last: dict[str, Any] = {}
+            deadline = started + _UPLOAD_POLL_TIMEOUT_SECONDS
+            while time.monotonic() < deadline:
+                last = client.get_upload_job(job_id)
+                status = _extract_status(last)
+                if status is not None and _is_terminal(status):
+                    return _json(
+                        {
+                            "job_id": job_id,
+                            "terminal_status": status,
+                            "last_payload": last,
+                            "elapsed_seconds": round(time.monotonic() - started, 2),
+                        }
+                    )
+                time.sleep(_UPLOAD_POLL_INTERVAL_SECONDS)
+            return _json(
+                {
+                    "error": "BHCE ingest poll timed out",
+                    "job_id": job_id,
+                    "last_payload": last,
+                    "elapsed_seconds": round(time.monotonic() - started, 2),
+                }
+            )
+    except BHCEHTTPError as exc:
+        return _json(
+            {
+                "error": "BHCE returned an error during ingest",
+                "status_code": exc.status_code,
+                "body": exc.body,
+                "elapsed_seconds": round(time.monotonic() - started, 2),
+            }
+        )
+
+
+_TERMINAL_STATUSES = {"Complete", "Failed", "Cancelled", "PartiallyComplete"}
+"""BHCE v9.2.2 ``FileUploadJob.status`` enum terminal values.
+
+Source: ``packages/go/openapi/src/schemas/model.file-upload-job.yaml`` and
+``cmd/api/src/services/upload/jobs.go``.  Non-terminal: ``Created``,
+``Running``, ``Ingesting``, ``Analyzing``.
+"""
+
+
+def _extract_status(payload: dict[str, Any]) -> str | None:
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return None
+    status = data.get("status_message") or data.get("status")
+    return status if isinstance(status, str) else None
+
+
+def _is_terminal(status: str) -> bool:
+    return status in _TERMINAL_STATUSES
+
+
+BHCE_TOOLS = [bhce_status, bhce_cypher, bhce_ingest_zip]
+"""LangChain tool list — wire into the agent toolbox alongside the
+existing AD_TOOLS surface.  This list will absorb the legacy ``bh_*``
+names in PR #6 of the ADR-0005 migration."""

--- a/packages/decepticon/decepticon/tools/ad/bhce_client.py
+++ b/packages/decepticon/decepticon/tools/ad/bhce_client.py
@@ -21,10 +21,16 @@ Signature scheme (HMAC 3-chain, ``cmd/api/src/api/signature.go:97-145``):
 Where:
 
 - ``METHOD`` is the upper-case HTTP verb (``GET``/``POST``/...).
-- ``URI_PATH`` is ``request.URL.Path`` in the Go reference — **path only,
-  no query string**.  This matters because BHCE's server-side
-  verification feeds the same path-only string back into the same
-  algorithm; signing with a query string attached will hash-mismatch.
+- ``URI_PATH`` is the **full Request-URI** including the query string
+  when present (i.e. ``path?query`` when ``query`` is non-empty, else
+  just ``path``).  BHCE's server-side verifier feeds
+  ``request.RequestURI`` into the signature (``cmd/api/src/api/auth.go:355``),
+  while its Go client signs only ``request.URL.Path``
+  (``signature.go:160``) — an internal asymmetry that doesn't matter
+  for query-less requests but breaks every signed GET that carries
+  query parameters (e.g. paginated ``/api/v2/file-upload``).  We
+  match the **server** side because that is what determines accept /
+  reject.
 - ``RFC3339[:13]`` is the first 13 characters of the RFC3339 datetime,
   i.e. truncated to the hour (e.g. ``2026-06-05T07``).  The header
   ``RequestDate`` carries the **full** RFC3339 datetime; only the
@@ -92,9 +98,10 @@ def sign_request(
             "Token ID" in the BHCE UI's ``Admin → Manage Users``).
         token_secret: BHCE API token secret (the private half).
         method: Upper-case HTTP verb.
-        url: Fully-qualified request URL.  Only ``urlsplit(url).path`` is
-            fed into the signature; the host/scheme/query are ignored to
-            match ``request.URL.Path`` in ``signature.go:160``.
+        url: Fully-qualified request URL.  The path and query string
+            are fed into the signature (matching the server-side
+            ``request.RequestURI`` per ``auth.go:355``); scheme and
+            host are ignored.
         body: Request body bytes.  Use ``b""`` for empty.
         request_date: Optional RFC3339 datetime override (used by tests
             for deterministic signatures).  Defaults to ``_rfc3339_now()``.
@@ -104,11 +111,14 @@ def sign_request(
         ``Authorization``, ``RequestDate``, ``Signature``.
     """
     datetime_str = request_date or _rfc3339_now()
-    path = urlsplit(url).path or "/"
+    parts = urlsplit(url)
+    request_uri = parts.path or "/"
+    if parts.query:
+        request_uri = f"{request_uri}?{parts.query}"
 
     op_key = hmac.new(
         token_secret.encode("utf-8"),
-        (method.upper() + path).encode("utf-8"),
+        (method.upper() + request_uri).encode("utf-8"),
         hashlib.sha256,
     ).digest()
     date_key = hmac.new(op_key, datetime_str[:13].encode("utf-8"), hashlib.sha256).digest()
@@ -298,8 +308,33 @@ class BHCEClient:
         self._request("POST", f"/api/v2/file-upload/{job_id}/end")
 
     def get_upload_job(self, job_id: int) -> dict[str, Any]:
-        """``GET /api/v2/file-upload/{job_id}`` — poll for status."""
-        return self._request("GET", f"/api/v2/file-upload/{job_id}").json()
+        """Return the FileUploadJob payload for ``job_id``.
+
+        BHCE v9.2.2 only exposes ``GET /api/v2/file-upload`` (paginated
+        list) and ``GET /api/v2/file-upload/{id}/completed-tasks`` —
+        there is **no** ``GET /api/v2/file-upload/{id}`` route
+        (``cmd/api/src/api/registration/v2.go`` shows only POST on the
+        ``/{id}`` and ``/{id}/end`` paths).  We page through the list
+        until we find the matching id, then return the wrapped object
+        in a ``{data: …}`` envelope so callers can treat single-job
+        and list responses uniformly.
+        """
+        skip = 0
+        page_size = 100
+        while True:
+            page = self._request(
+                "GET",
+                f"/api/v2/file-upload?skip={skip}&limit={page_size}",
+            ).json()
+            items = page.get("data") if isinstance(page, dict) else None
+            if not isinstance(items, list) or not items:
+                return {"data": None}
+            for item in items:
+                if isinstance(item, dict) and item.get("id") == job_id:
+                    return {"data": item}
+            if len(items) < page_size:
+                return {"data": None}
+            skip += page_size
 
     def get_domain(self, object_id: str) -> dict[str, Any]:
         """``GET /api/v2/domains/{object_id}``."""

--- a/packages/decepticon/tests/unit/ad/test_bh_tools.py
+++ b/packages/decepticon/tests/unit/ad/test_bh_tools.py
@@ -1,0 +1,205 @@
+"""Unit tests for the BHCE-backed ``bhce_*`` LangChain tool surface.
+
+The tools wrap :mod:`decepticon.tools.ad.bhce_client`; here we stub the
+HTTP layer (``httpx.Client``) so we exercise just the tool-side
+behaviour: JSON envelope shape, missing-env diagnostic, the
+file-upload 3-step + poll loop, and error propagation.
+
+Wire-level HMAC compatibility is covered separately in
+``test_bhce_client.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import Any
+
+import httpx
+import pytest
+
+from decepticon.tools.ad.bh_tools import (
+    bhce_cypher,
+    bhce_ingest_zip,
+    bhce_status,
+)
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BHCE_URL", "http://bhce.local:8080")
+    monkeypatch.setenv("BHCE_TOKEN_ID", "tid")
+    monkeypatch.setenv("BHCE_TOKEN_KEY", "tkey")
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+    """Replace the default httpx.Client constructor with one wired to a
+    ``MockTransport`` so the tools' internal ``BHCEClient.from_env``
+    yields a non-network client."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _fake(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs.pop("timeout", None)
+        return real_client(transport=transport, timeout=5.0, *args, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", _fake)
+
+
+def _ok(json_body: Any, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=json_body)
+
+
+# ── bhce_status ───────────────────────────────────────────────────
+
+
+def test_bhce_status_returns_version_and_self(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/version":
+            return _ok({"data": {"server_version": "v9.2.2", "product_edition": "community"}})
+        if request.url.path == "/api/v2/self":
+            return _ok({"data": {"id": "u-1", "principal_name": "admin"}})
+        return _ok({"data": {}})
+
+    _install_transport(monkeypatch, handler)
+    payload = json.loads(bhce_status.invoke({}))
+    assert payload["version"]["data"]["server_version"] == "v9.2.2"
+    assert payload["self"]["data"]["principal_name"] == "admin"
+
+
+def test_bhce_status_missing_env_returns_diagnostic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BHCE_URL", raising=False)
+    payload = json.loads(bhce_status.invoke({}))
+    assert payload["error"]
+    assert "BHCE_URL" in payload["hint"]
+
+
+# ── bhce_cypher ───────────────────────────────────────────────────
+
+
+def test_bhce_cypher_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v2/graphs/cypher"
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return _ok({"data": {"nodes": {}, "edges": [], "literals": [{"value": 42, "key": "c"}]}})
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(
+        bhce_cypher.invoke({"query": "MATCH (n) RETURN count(n) AS c", "include_properties": False})
+    )
+    assert out["data"]["literals"][0]["value"] == 42
+    assert captured["body"]["query"] == "MATCH (n) RETURN count(n) AS c"
+    assert captured["body"]["include_properties"] is False
+
+
+def test_bhce_cypher_empty_query_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    out = json.loads(bhce_cypher.invoke({"query": "   "}))
+    assert "required" in out["error"]
+
+
+def test_bhce_cypher_propagates_bhce_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"http_status": 400, "errors": [{"message": "syntax error"}]},
+        )
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(bhce_cypher.invoke({"query": "MATCH (n RETURN n"}))
+    assert out["status_code"] == 400
+    assert "syntax error" in json.dumps(out["body"])
+
+
+# ── bhce_ingest_zip ───────────────────────────────────────────────
+
+
+def _make_tiny_zip(tmp_path) -> str:
+    z = tmp_path / "sample.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("sample.json", '{"meta":{"type":"users"},"data":[]}')
+    return str(z)
+
+
+def test_bhce_ingest_zip_runs_three_step_and_polls_until_terminal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _set_env(monkeypatch)
+    zip_path = _make_tiny_zip(tmp_path)
+    monkeypatch.setattr("decepticon.tools.ad.bh_tools._UPLOAD_POLL_INTERVAL_SECONDS", 0.01)
+
+    calls: list[tuple[str, str]] = []
+    poll_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        calls.append((request.method, path))
+        if request.method == "POST" and path == "/api/v2/file-upload/start":
+            return httpx.Response(201, json={"data": {"id": 7}})
+        if request.method == "POST" and path == "/api/v2/file-upload/7":
+            assert request.headers.get("Content-Type") == "application/zip"
+            assert request.content  # body forwarded
+            return httpx.Response(202)
+        if request.method == "POST" and path == "/api/v2/file-upload/7/end":
+            return httpx.Response(200)
+        if request.method == "GET" and path == "/api/v2/file-upload":
+            poll_count["n"] += 1
+            status = "Running" if poll_count["n"] < 2 else "Complete"
+            return _ok({"data": [{"id": 7, "status": status}]})
+        raise AssertionError(f"unexpected call: {request.method} {path}")
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(bhce_ingest_zip.invoke({"path": zip_path}))
+    assert out["job_id"] == 7
+    assert out["terminal_status"] == "Complete"
+    # The 3 mutating steps each happen exactly once.
+    methods_paths = [(m, p) for m, p in calls if m == "POST"]
+    assert ("POST", "/api/v2/file-upload/start") in methods_paths
+    assert ("POST", "/api/v2/file-upload/7") in methods_paths
+    assert ("POST", "/api/v2/file-upload/7/end") in methods_paths
+    # And at least two polls occurred before the terminal status.
+    assert poll_count["n"] >= 2
+
+
+def test_bhce_ingest_zip_missing_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    out = json.loads(bhce_ingest_zip.invoke({"path": "/no/such/path.zip"}))
+    assert "not a file" in out["error"]
+
+
+def test_bhce_ingest_zip_propagates_start_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _set_env(monkeypatch)
+    zip_path = _make_tiny_zip(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"http_status": 403, "errors": [{"message": "GraphDBIngest required"}]},
+        )
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(bhce_ingest_zip.invoke({"path": zip_path}))
+    assert out["status_code"] == 403
+    assert "GraphDBIngest" in json.dumps(out["body"])
+
+
+# ── plumbing sanity ──────────────────────────────────────────────
+
+
+def test_bhce_tools_list_exports_three(monkeypatch: pytest.MonkeyPatch) -> None:
+    from decepticon.tools.ad.bh_tools import BHCE_TOOLS
+
+    names = sorted(t.name for t in BHCE_TOOLS)
+    assert names == ["bhce_cypher", "bhce_ingest_zip", "bhce_status"]
+
+
+def test_consume_io_isnt_required_to_import_bh_tools() -> None:
+    # Importing bh_tools must not hit the network or require env vars.
+    assert io.BytesIO is not None  # imported in test scope; smoke check

--- a/packages/decepticon/tests/unit/ad/test_bhce_client.py
+++ b/packages/decepticon/tests/unit/ad/test_bhce_client.py
@@ -62,13 +62,15 @@ def test_sign_post_empty_body_negative_offset_matches_go_reference() -> None:
 # ── Behavioural contracts on the sign_request helper ────────────────
 
 
-def test_sign_strips_query_string_from_uri_in_signature() -> None:
-    """BHCE signs ``request.URL.Path`` only — query is excluded.
-
-    If we accidentally fed the query through, ``…/self?a=1`` would
-    produce a different signature than ``…/self``, but per
-    ``signature.go:160`` (``request.URL.Path``) BHCE strips it before
-    the HMAC.  Sanity-check that we strip it too.
+def test_sign_includes_query_string_in_signature() -> None:
+    """BHCE's *server-side* verifier feeds ``request.RequestURI`` —
+    path + query — into the signature (``cmd/api/src/api/auth.go:355``),
+    even though its Go *client* signs only ``request.URL.Path``
+    (``signature.go:160``).  We match the server because that is what
+    decides accept/reject.  Verified empirically against the live
+    v9.2.2 sidecar on the paginated ``GET /api/v2/file-upload?skip=…``
+    poll path (signature mismatched when we stripped query, matched
+    when we included it).
     """
     without_query = sign_request(
         "id", "s", "GET", "http://h/api/v2/self", b"", request_date="2026-06-05T07:00:00Z"
@@ -81,7 +83,7 @@ def test_sign_strips_query_string_from_uri_in_signature() -> None:
         b"",
         request_date="2026-06-05T07:00:00Z",
     )["Signature"]
-    assert without_query == with_query
+    assert without_query != with_query
 
 
 def test_sign_truncates_datetime_to_hour_for_signature_only() -> None:


### PR DESCRIPTION
Re-open of #582 (auto-closed after parent #581 squash-merged into main).

Three composite @tool wrappers on top of the BHCE REST client (now on main): bhce_status, bhce_cypher, bhce_ingest_zip.

Live BHCE v9.2.2 dogfood:
- bhce_status → server_version=v9.2.2, principal=admin
- bhce_cypher 'MATCH (n) RETURN count(n)' → 200
- bhce_ingest_zip → terminal_status=Complete (28.46s BHCE-side analysis)

See #582 body for full detail.