### PR TITLE
docs(architecture): record BHCE sidecar + dual-Neo4j topology

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,15 +24,21 @@ Decepticon runs on two Docker networks. Management infrastructure (LLM proxy, da
 │  Web        :3000   │       │  Victim targets              │
 │                     │       │                              │
 │  Neo4j ◀────────────┼───────┼──▶ Neo4j  :7687/:7474        │
-│  (dual-homed bolt:// for agent + sandbox writes)            │
+│  (KGStore — dual-homed bolt:// for agent + sandbox writes)  │
+│                     │       │                              │
+│  BHCE       :8081   │       │                              │
+│  BHCE-Neo4j (intl.) │       │                              │
+│  (AD attack-graph sidecar, decepticon-net only)             │
 └─────────────────────┘       └──────────────────────────────┘
        Management                       Operations
    (LLM, persistence, UI)        (exploitation, C2, targets)
 ```
 
-**Network boundaries.** The sandbox cannot reach LiteLLM, PostgreSQL, the LangGraph API, or the web dashboard — none of the management services are routable from `sandbox-net`. The agent inside LangGraph cannot reach attack tooling over a TCP socket; the only channel into the sandbox is `docker exec` via the Docker socket bind-mount.
+**Network boundaries.** The sandbox cannot reach LiteLLM, PostgreSQL, the LangGraph API, the web dashboard, the BHCE API, or BHCE's Neo4j — none of the management services are routable from `sandbox-net`. The agent inside LangGraph cannot reach attack tooling over a TCP socket; the only channel into the sandbox is `docker exec` via the Docker socket bind-mount.
 
-**Neo4j is the one shared service** — it sits on both networks because the sandbox writes findings into it (`bolt://neo4j:7687` from inside Kali) and the agent reads them back (`bolt://neo4j:7687` from inside LangGraph). It's a knowledge store, not a privileged service: the agent's credentials never traverse it, and a compromised sandbox can't pivot through Neo4j to LiteLLM or the API surface.
+**KGStore Neo4j is the one cross-network shared service** — it sits on both networks because the sandbox writes findings into it (`bolt://neo4j:7687` from inside Kali) and the agent reads them back (`bolt://neo4j:7687` from inside LangGraph). It's a knowledge store, not a privileged service: the agent's credentials never traverse it, and a compromised sandbox can't pivot through Neo4j to LiteLLM or the API surface.
+
+**BHCE has its own dedicated Neo4j** on `decepticon-net` only. Neo4j Community Edition allows one user database per server and KGStore already occupies it, so BHCE gets a separate instance to avoid label/constraint collisions with its `dawgs` driver. See [ADR-0005](adr/0005-bloodhound-via-bhce-rest-client.md). The sandbox does **not** see the BHCE Neo4j — the AD attack-graph pipeline is a management-plane concern only; the sandbox produces SharpHound ZIPs and hands them to the agent, never talks to BHCE directly.
 
 ---
 
@@ -65,14 +71,25 @@ Persistent relational storage for:
 
 Two logical databases: `litellm` (managed by LiteLLM) and `decepticon_web` (managed via Prisma in the web dashboard).
 
-### Neo4j Knowledge Graph (`sandbox-net` + `decepticon-net`, port 7687 / browser 7474)
+### Neo4j Knowledge Graph — KGStore (`sandbox-net` + `decepticon-net`, port 7687 / browser 7474)
 
-Graph database for the attack graph. Stores:
+Graph database for the cross-domain attack graph (web, cloud, smart-contract findings plus the chain planner's view across all domains). Stores:
 - Hosts, services, vulnerabilities, credentials, accounts
 - Typed relationships (EXPLOITS, REQUIRES, AFFECTS, LEADS_TO)
 - Attack chain paths for multi-hop planning
 
 **Dual-homed by design**: the sandbox writes operational findings into the graph (`cypher-shell` from inside Kali), and the agent in LangGraph reads them back to plan the next objective. Both networks see the same Neo4j instance on the same `bolt://neo4j:7687` URI.
+
+### BloodHound Community Edition sidecar (`decepticon-net`, BHCE API on host port 8081)
+
+AD attack-graph layer, introduced by [ADR-0005](adr/0005-bloodhound-via-bhce-rest-client.md). Two containers:
+
+- `bhce` — `docker.io/specterops/bloodhound` pinned to the v9.2.2 release commit. Speaks the official BHCE REST API (HMAC-signed, OpenAPI 3.0.3 at `/api/v2/spec`).
+- `bhce-neo4j` — dedicated `neo4j:4.4.42-community` for BHCE's graph. No host port exposure; only the `bhce` container talks bolt to it.
+
+Postgres is reused from the existing `postgres` container — `containers/postgres-init/02-bloodhound-db.sh` pre-creates the `bloodhound` database plus the `pg_trgm` extension so BHCE's goose migrations bootstrap cleanly on first boot.
+
+Agents call BHCE through `decepticon.tools.ad.bh_tools.bhce_status` / `bhce_cypher` / `bhce_ingest_zip` and the shared `decepticon.tools.ad.bhce_client.BHCEClient` HMAC-3-chain signer. The in-house `bh_ingest_zip` / `adcs_post_process` / `dcsync_check` / `delegation_audit` / `gpo_audit` / `shadow_creds_audit` / `adcs_audit` tools emit `DeprecationWarning` on every call and will move to `decepticon.compat` next minor.
 
 ### Sandbox (`sandbox-net`)
 
@@ -159,6 +176,7 @@ Orchestrator reads OPPLAN
 |----------|-------------|
 | Sandbox → Management services | Separate Docker networks; LiteLLM/PostgreSQL/LangGraph/Web are not routable from `sandbox-net` |
 | LangGraph → Sandbox | Docker socket only (no TCP) |
-| Sandbox → Neo4j | Allowed (intentional shared service for attack graph writes) |
-| Credential isolation | Provider API keys live on `decepticon-net`; the sandbox never sees them |
+| Sandbox → KGStore Neo4j | Allowed (intentional shared service for cross-domain attack graph writes) |
+| Sandbox → BHCE API / BHCE Neo4j | Blocked — BHCE lives on `decepticon-net` only; the sandbox produces SharpHound ZIPs and hands them to the agent, which then ingests via `bhce_ingest_zip`. There is no sandbox-side bolt or REST path into BHCE. |
+| Credential isolation | Provider API keys + the BHCE HMAC token live on `decepticon-net`; the sandbox never sees them |
 | Host isolation | All commands run inside Docker; no host filesystem access except the engagement-scoped `/workspace` bind mount |


### PR DESCRIPTION
## Summary

ADR-0005 sprint 2.  Brings \`docs/architecture.md\` in line with the BHCE migration that just landed (#580, #581, #583, #585, #586, #579).

## Changes

- Overview diagram now shows the **BHCE API** + **BHCE-Neo4j** alongside the existing KGStore Neo4j on \`decepticon-net\`.
- "Neo4j is the one shared service" is clarified: **KGStore Neo4j** is still the one cross-network shared service (sandbox + management plane), while **BHCE Neo4j** is decepticon-net only.
- New \`### BloodHound Community Edition sidecar\` Components subsection with:
  - the two containers (\`bhce\` v9.2.2 pinned by commit-SHA tag, \`bhce-neo4j\` 4.4.42)
  - the agent surface (\`bhce_status\` / \`bhce_cypher\` / \`bhce_ingest_zip\`) + the HMAC 3-chain signer
  - Postgres reuse via \`containers/postgres-init/02-bloodhound-db.sh\`
  - forward pointer to the legacy \`DeprecationWarning\` + \`decepticon.compat\` plan
- KGStore subsection retitled "Neo4j Knowledge Graph — KGStore" + reworded to make its cross-domain (web / cloud / smart-contract + AD chain planner) role explicit, separating it cleanly from BHCE's AD-only role.
- Security Boundaries table:
  - \`Sandbox → KGStore Neo4j\` row clarified (cross-domain attack graph writes)
  - new \`Sandbox → BHCE API / BHCE Neo4j\` row: **blocked**.  SharpHound ZIPs flow sandbox → agent → BHCE; there is no sandbox-side bolt or REST path into BHCE.
  - credential isolation row now mentions the BHCE HMAC token alongside provider API keys.

## Why this PR is docs-only

The behaviour described here all landed in the six ADR-0005 PRs.  This PR just makes \`docs/architecture.md\` match reality so future readers don't get a wrong mental model from a stale "one Neo4j" statement.  ADR-0005 stays the canonical *why*; \`architecture.md\` is the canonical *what runs where*.

## Verification

- \`make ci-lint\` — 0 errors, 493 warnings (no regression; docs change only).
- Diff visual review: only \`docs/architecture.md\` modified; no code paths touched.

## Test plan

- [x] CI lint passes
- [ ] reviewer confirms the BHCE container surface matches \`docker-compose.yml\` reality (image, ports, networks, depends_on)
- [ ] reviewer confirms the security boundary claim \"sandbox cannot reach BHCE\" against the compose networks list (BHCE services are on \`decepticon-net\` only)