### PR TITLE
fix(ci): unblock docs-only PRs by removing paths-ignore (#561)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,24 +5,23 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # NOTE: paths-ignore intentionally NOT used here — see issue #561.
+  # When the workflow is path-filtered out, the required-status-check
+  # rulesets (`Python (lint + typecheck + test)` / `CLI (ubuntu-latest)` /
+  # `CLI (macos-latest)` / `Web (lint + build)` / `Security (pip-audit +
+  # gitleaks)`) never report, which leaves docs-only PRs permanently
+  # BLOCKED.
+  #
+  # Instead the workflow always starts, the `changes` job below (uses
+  # dorny/paths-filter) computes per-scope outputs, and every expensive
+  # job is gated with `if: needs.changes.outputs.<scope> == 'true'`.
+  # Docs-only PRs run the cheap `changes` step, the expensive jobs are
+  # skipped, and GitHub treats `skipped` as passing for ruleset
+  # purposes — merge gates clear automatically.
   push:
     branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "!CHANGELOG.md"   # release notes — required ruleset checks must run
-      - LICENSE
-      - docs/**
-      - assets/**
-      - .gitignore
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "!CHANGELOG.md"   # release notes — required ruleset checks must run
-      - LICENSE
-      - docs/**
-      - assets/**
-      - .gitignore
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Closes #561.  Lets docs-only PRs reach a mergeable state instead of being permanently \`BLOCKED\` by required-check rulesets that never report.

## Root cause (from issue body)

Required-status-check rulesets on \`main\` enforce:
- \`Python (lint + typecheck + test)\`
- \`CLI (ubuntu-latest)\`
- \`CLI (macos-latest)\`
- \`Web (lint + build)\`
- \`Security (pip-audit + gitleaks)\`

The previous \`paths-ignore\` on \`push\` + \`pull_request\` prevented the workflow from starting at all when only \`docs/**\`, \`*.md\`, \`assets/**\`, \`LICENSE\`, or \`.gitignore\` changed.  Required checks that never run are treated as missing by the ruleset — so docs-only PRs ended up permanently \`BLOCKED\`.

Most recently visible on #487, #488, #489, #490, #579, #587 — the last needed an \`--admin\` merge just to move ADR-0005 sprint 2 forward.

## Fix

The infrastructure to do this **right** already exists in this workflow:
- the \`changes\` job uses \`dorny/paths-filter@v3\` to compute per-scope outputs (\`python\`, \`cli\`, \`web\`, \`launcher\`, \`compose\`, \`docker-images\`)
- every expensive job downstream is already gated with \`if: needs.changes.outputs.<scope> == 'true'\`

So removing \`paths-ignore\` from the \`on:\` block is sufficient.  Docs-only PRs run the cheap \`changes\` step, expensive jobs are skipped, and **GitHub treats \`skipped\` as passing for ruleset purposes** — the merge gate clears automatically without weakening the security posture on real code PRs.

This is option 1 from the issue ("Path-conditional required checks — GitHub's intended pattern").

## Verification

### This PR (positive path — ci.yml changes are in the \`python\` filter)
- ci.yml itself matches the \`python\` filter (\`'.github/workflows/ci.yml'\` is listed), so \`Python (lint + typecheck + test)\` should run normally.
- \`CLI\`, \`Web\`, \`Launcher\` are also wired to ci.yml changes — they'll run too.
- \`Compose YAML validate\` triggers on \`docker-compose*.yml\` or ci.yml — it'll run.
- This is the **strong positive test**: a real-code change still triggers the full suite.

### Follow-up PR (negative path — actually exercise the fix)
After this lands, open a tiny docs-only PR (e.g. fix a typo in \`docs/architecture.md\`).  Expected:
- Workflow starts (no \`paths-ignore\` skip).
- \`changes\` reports \`python=false\`, \`cli=false\`, \`web=false\`, \`launcher=false\`, \`compose=false\`.
- All expensive jobs end in \`skipped\`.
- Required-check rulesets see \`skipped\` and mark them passing.
- \`mergeStateStatus\` flips to \`CLEAN\` and the PR is mergeable without \`--admin\`.

## Out of scope

- Other workflows (\`security.yml\`, \`scorecard.yml\`, \`release.yml\`) — none of them carry \`paths-ignore\` clauses today that hit this trap.  If they ever grow one, the same pattern applies.
- The \`workflows/release.yml\` content path filters — those gate the release lane on intentional triggers, not on docs-only blocking.

## Test plan

- [x] yaml parse OK (\`python -c \"yaml.safe_load(open(...))\"\`)
- [x] this PR's own CI lane runs end-to-end (verifies the positive path)
- [ ] reviewer opens a follow-up docs-only PR after merge to verify the negative path (workflow starts, expensive jobs skipped, gates clear)