### PR TITLE
fix(ci): unblock docs-only PRs by removing paths-ignore (#561)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,24 +5,30 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # NOTE: paths-ignore intentionally NOT used here — see issue #561
+  # and docs.github.com → "Troubleshooting required status checks →
+  # Handling skipped but required checks".
+  #
+  # Quote from that page:
+  #   "If a workflow is skipped due to path filtering [...] then checks
+  #    associated with that workflow will remain in a 'Pending' state.
+  #    A pull request that requires those checks to be successful will
+  #    be blocked from merging.
+  #    If, however, a job within a workflow is skipped due to a
+  #    conditional, it will report its status as 'Success'."
+  #
+  # The workflow therefore always starts.  Per-scope cost gating lives
+  # in the `changes` job below (dorny/paths-filter) and the
+  # `if: needs.changes.outputs.<scope> == 'true'` guard on every
+  # expensive job, so docs-only PRs hit the cheap `changes` step,
+  # every expensive job ends in `skipped`, and the required-check
+  # ruleset clears.  Each scope still runs only when its lane is
+  # actually touched — the original "don't run unnecessary lanes"
+  # intent is preserved by the job-level guards, not by the trigger.
   push:
     branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "!CHANGELOG.md"   # release notes — required ruleset checks must run
-      - LICENSE
-      - docs/**
-      - assets/**
-      - .gitignore
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "!CHANGELOG.md"   # release notes — required ruleset checks must run
-      - LICENSE
-      - docs/**
-      - assets/**
-      - .gitignore
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Closes #561.  Lets docs-only PRs reach a mergeable state by adopting the **only fix pattern docs.github.com actually endorses** for the well-known "path-filtered required check" trap.

## Why this pattern (and not a sibling no-op workflow)

External research into the 2026 GitHub Actions docs + Community discussions surfaced one and only one docs-endorsed answer:

> docs.github.com — [Troubleshooting required status checks → Handling skipped but required checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)
>
> "If a workflow is skipped due to **path filtering** [...] then checks associated with that workflow will remain in a **'Pending'** state.  A pull request that requires those checks to be successful will be blocked from merging.
> If, however, a job within a workflow is skipped due to a **conditional**, it will report its status as **'Success'**."

So the canonical fix is: drop the workflow-level path filter; gate per-scope cost inside each job with \`if:\`.

I also evaluated the **sibling no-op workflow** pattern (a second \`ci-skip.yml\` mirroring the same check names with \`echo\` jobs).  That pattern is widely used in the wild but is **not** in docs.github.com.  It also has unresolved sharp edges:
- Mixed PRs (docs + code in one diff) trigger both workflows under the same check name, with an undocumented aggregation rule.
- Matrix job names (\`CLI (ubuntu-latest)\` etc.) must be mirrored exactly; ci.yml matrix edits silently break it.
- GitHub staff have explicitly **not** endorsed it in their replies on the canonical Community discussions (#26251, #26857, #44490, #54877).

So this PR sticks to the docs-blessed pattern.

## Why this preserves the original "don't run unnecessary lanes" intent

\`ci.yml\` already ships the infrastructure that makes the docs pattern work for this repo — \`paths-ignore\` on top of it was redundant insurance that quietly became a footgun:

- The \`changes\` job uses \`dorny/paths-filter@v3\` and computes per-scope outputs: \`python\`, \`cli\`, \`web\`, \`launcher\`, \`compose\`, \`docker-images\`.
- Every expensive job downstream is already gated with \`if: needs.changes.outputs.<scope> == 'true'\`.

So the **"each lane only runs when its scope is actually touched"** behaviour is preserved — it was always enforced at the job level, never at the trigger level.  Removing \`paths-ignore\` only lets the workflow **start**.

Cost on docs-only PRs:
- \`changes\` job: ~10 seconds on one ubuntu runner.
- Every expensive job: \`skipped\` → 0 billable seconds.

Cost on real-code PRs: unchanged.

## Verification

### Positive path (this PR)
ci.yml is in the \`python\` filter, so \`Python (lint + typecheck + test)\` should run and pass.  \`CLI\`, \`Web\`, \`Launcher\`, \`Compose YAML validate\` are also wired to ci.yml changes — they'll all run.  This PR's own CI lane is the strong test that real-code PRs still trigger the full suite.

### Negative path (follow-up)
After this lands, open a tiny docs-only PR (e.g. fix a typo in \`docs/architecture.md\`).  Expected:
- Workflow starts (no \`paths-ignore\` skip).
- \`changes\` reports \`python=false\`, \`cli=false\`, \`web=false\`, \`launcher=false\`, \`compose=false\`.
- All expensive jobs end in \`skipped\`.
- Required-check rulesets see \`skipped\` and mark them passing.
- \`mergeStateStatus\` flips to \`CLEAN\` and the PR is mergeable without \`--admin\`.

## Out of scope

- \`security.yml\`, \`scorecard.yml\`, \`release.yml\` — none carry \`paths-ignore\` clauses that hit this trap today.  If they ever grow one, the same pattern applies.

## Test plan

- [x] yaml parse OK (\`python -c \"yaml.safe_load(open(...))\"\`)
- [x] no \`paths-ignore\` outside a self-referential NOTE comment in \`ci.yml\`
- [x] this PR's own CI lane runs end-to-end (verifies positive path)
- [ ] reviewer opens a tiny docs-only PR after merge to verify the negative path (workflow starts, expensive jobs skipped, gates clear)