### PR TITLE
docs(adr): mark 0005 as Accepted now that the migration has shipped

### DIFF
--- a/docs/adr/0005-bloodhound-via-bhce-rest-client.md
+++ b/docs/adr/0005-bloodhound-via-bhce-rest-client.md
@@ -1,6 +1,6 @@
 # 0005. Integrate BloodHound via the official BHCE REST API, not via in-house reimplementation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-05
 - **Deciders:** @PurpleCHOIms
 - **Related:** PR #560, #562, #563, #565, #567, #569, #570, #571, #572, #573, #574, #575, #576, #577, #578 (KGStore-direct ingest + ADCS post-process — to be deprecated); BloodHound CE v9.2.2 (2026-06-01)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,6 +66,6 @@ Use [`template.md`](template.md) as the starting point.
 | [0002](0002-pr-tiering-and-blast-radius.md) | PR tiering by blast radius | Accepted |
 | [0003](0003-ai-contributor-self-review.md) | AI-assisted contribution self-review charter | Accepted |
 | [0004](0004-zero-ai-slop-policy.md) | Zero AI-slop policy — the 100% quality bar | Accepted |
-| [0005](0005-bloodhound-via-bhce-rest-client.md) | Integrate BloodHound via the official BHCE REST API, not via in-house reimplementation | Proposed |
+| [0005](0005-bloodhound-via-bhce-rest-client.md) | Integrate BloodHound via the official BHCE REST API, not via in-house reimplementation | Accepted |
 
 Keep this index in sync when you land a new ADR.


### PR DESCRIPTION
## Summary

Two-line status flip from \`Proposed\` to \`Accepted\` for ADR-0005, now that the BHCE migration has shipped end-to-end (PRs #579 #580 #581 #583 #585 #586 #587 all merged).  Per the ADR \`README.md\` lifecycle policy, a \`Proposed\` ADR flips to \`Accepted\` on its owner-approved merge — this just brings the index and the ADR header into sync with that state.

## Why also the negative-path test PR for #589 / #561

This is a **docs-only** change (only \`docs/adr/0005-bloodhound-via-bhce-rest-client.md\` + \`docs/adr/README.md\`), so it exercises the exact path the #589 fix is supposed to unblock:

- Workflow should **start** (no more \`paths-ignore\` skipping it).
- \`Detect changes\` should report every scope = \`false\`.
- Every expensive job (\`Python\`, \`CLI (ubuntu-latest)\`, \`CLI (macos-latest)\`, \`Web (lint + build)\`, \`Security (pip-audit + gitleaks)\`, \`Launcher\`, \`Compose YAML validate\`, \`Docker build\`) should end in \`skipped\`.
- Required-check rulesets should treat \`skipped\` as passing per docs.github.com → [Troubleshooting required status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks).
- \`mergeStateStatus\` should be \`CLEAN\` — no \`--admin\` override needed.

If any of the above doesn't hold, #589's fix is incomplete and we revisit before relying on it.

## Test plan

- [ ] reviewer confirms the workflow started (look at the CI tab)
- [ ] reviewer confirms every required job's conclusion is \`skipped\`
- [ ] reviewer confirms \`gh pr view 590 --json mergeStateStatus -q .mergeStateStatus\` reports \`CLEAN\`
- [ ] reviewer can merge without admin override