### PR TITLE
feat(ops): sprint 1 — ops-control sidecar + tools/ops scaffold (ADR-0006)

### DIFF
--- a/containers/ops-control.Dockerfile
+++ b/containers/ops-control.Dockerfile
@@ -7,6 +7,13 @@
 # the host's Docker socket.  Its HTTP API exposes an allowlisted
 # subset of `docker compose --profile <name> up/stop -d` and nothing
 # else; no raw `docker run`, no image pull, no volume / network edits.
+#
+# It runs as the non-root `ops` user (UID 10001).  The container only
+# *reads* its own /app payload at runtime, so dropping root costs it
+# nothing; the one privileged operation — talking to the bind-mounted
+# /var/run/docker.sock — is granted out-of-band by adding the host's
+# docker-socket GID to the process via `group_add` in docker-compose.yml
+# (DOCKER_GID), NOT by running as root.
 # ─────────────────────────────────────────────────────────────────────
 
 FROM alpine:3.20
@@ -30,6 +37,13 @@ COPY containers/ops-control/requirements.txt /app/requirements.txt
 RUN python3 -m pip install --break-system-packages --no-cache-dir -r /app/requirements.txt
 
 COPY containers/ops-control/main.py /app/main.py
+
+# Drop to a non-root user (Trivy DS-0002 / CIS-Docker 4.1). The app only
+# reads /app, so root-owned 0644 files stay readable; socket access is
+# granted at runtime via `group_add` (see docker-compose.yml), so this
+# image needs no docker group baked in.
+RUN addgroup -S ops && adduser -S -G ops -h /app -u 10001 ops
+USER ops
 
 # Default config; overridden by docker-compose.yml at runtime.
 ENV OPS_PROFILE_ALLOWLIST="" \

--- a/containers/ops-control.Dockerfile
+++ b/containers/ops-control.Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+# ─────────────────────────────────────────────────────────────────────
+# ops-control — the single lifecycle surface for compose-defined
+# domain services.  See ADR-0006.
+#
+# This is the ONLY container in the management plane that bind-mounts
+# the host's Docker socket.  Its HTTP API exposes an allowlisted
+# subset of `docker compose --profile <name> up/stop -d` and nothing
+# else; no raw `docker run`, no image pull, no volume / network edits.
+# ─────────────────────────────────────────────────────────────────────
+
+FROM alpine:3.20
+
+# docker-cli ships /usr/bin/docker; docker-cli-compose drops the
+# compose v2 plugin into /usr/libexec/docker/cli-plugins/.  Both are
+# pinned by the apk index of the chosen Alpine release for
+# reproducibility; we explicitly do not chase :latest.
+RUN apk add --no-cache \
+        python3 \
+        py3-pip \
+        docker-cli \
+        docker-cli-compose \
+        curl \
+        tini \
+    && python3 -m pip install --break-system-packages --no-cache-dir --upgrade pip
+
+WORKDIR /app
+
+COPY containers/ops-control/requirements.txt /app/requirements.txt
+RUN python3 -m pip install --break-system-packages --no-cache-dir -r /app/requirements.txt
+
+COPY containers/ops-control/main.py /app/main.py
+
+# Default config; overridden by docker-compose.yml at runtime.
+ENV OPS_PROFILE_ALLOWLIST="" \
+    OPS_COMPOSE_PROJECT="decepticon" \
+    OPS_COMPOSE_FILE="/host/docker-compose.yml" \
+    OPS_DOCKER_BIN="docker"
+
+EXPOSE 8090
+
+# tini handles SIGTERM cleanly so the compose stop on the host doesn't
+# leave a 10s zombie wait per restart.
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8090"]
+
+HEALTHCHECK --interval=10s --timeout=3s --retries=6 --start-period=10s \
+    CMD curl -fsS http://127.0.0.1:8090/v1/health || exit 1

--- a/containers/ops-control/main.py
+++ b/containers/ops-control/main.py
@@ -1,0 +1,203 @@
+"""ops-control sidecar — the single lifecycle surface for compose-defined
+domain services.
+
+ADR: docs/adr/0006-agent-driven-container-lifecycle.md
+
+This is the *only* container in the management plane that touches the
+Docker socket.  It exposes a tiny HTTP API on ``decepticon-net``:
+
+    GET  /v1/health                    - liveness, no auth, no logic
+    GET  /v1/profiles                  - allowlist + per-profile state
+    POST /v1/profiles/{name}/start     - docker compose --profile <name> up -d
+    POST /v1/profiles/{name}/stop      - docker compose --profile <name> stop
+
+``{name}`` must appear in the server-side allowlist driven by the
+``OPS_PROFILE_ALLOWLIST`` env var (comma-separated).  Anything else
+returns 400 without touching docker.  No raw ``docker run`` / image
+pull / volume / network APIs are exposed — those code paths simply
+do not exist in this binary.
+
+Implementation choice: shell out to ``docker compose`` rather than
+linking the docker SDK.  Two reasons.  First, the compose runtime
+that interprets profiles + service dependencies (the very feature we
+rely on) lives in the CLI plugin, not in the engine API; using the
+SDK would mean re-implementing profile resolution.  Second, the CLI
+binary is small, audited, and version-pinned in the container image,
+so the lifecycle surface stays small.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+log = logging.getLogger("ops-control")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+
+
+# ── Configuration (env, validated once at boot) ──────────────────────
+
+
+def _parse_allowlist(raw: str) -> set[str]:
+    """Parse the comma-separated allowlist; defensively reject anything
+    that isn't ``[a-z0-9-]{1,63}`` since these values flow into the
+    ``docker compose --profile`` argument and must not be able to
+    break out into a separate flag."""
+    items: set[str] = set()
+    for token in raw.split(","):
+        candidate = token.strip()
+        if not candidate:
+            continue
+        if not re.fullmatch(r"[a-z0-9-]{1,63}", candidate):
+            log.warning("ops-control: dropping invalid allowlist entry %r", candidate)
+            continue
+        items.add(candidate)
+    return items
+
+
+_ALLOWLIST: set[str] = _parse_allowlist(os.environ.get("OPS_PROFILE_ALLOWLIST", ""))
+_COMPOSE_PROJECT: str = os.environ.get("OPS_COMPOSE_PROJECT", "decepticon")
+_COMPOSE_FILE: str = os.environ.get("OPS_COMPOSE_FILE", "/host/docker-compose.yml")
+_DOCKER_BIN: str = os.environ.get("OPS_DOCKER_BIN", "docker")
+
+if not _ALLOWLIST:
+    log.warning(
+        "ops-control: OPS_PROFILE_ALLOWLIST is empty — every start/stop call "
+        "will be rejected.  Set it on the ops-control service (e.g. "
+        "OPS_PROFILE_ALLOWLIST=ad,c2-sliver,reversing) before issuing tools."
+    )
+
+log.info(
+    "ops-control ready: project=%s compose_file=%s allowlist=%s",
+    _COMPOSE_PROJECT,
+    _COMPOSE_FILE,
+    sorted(_ALLOWLIST),
+)
+
+
+# ── Compose invocation ──────────────────────────────────────────────
+
+
+_COMPOSE_TIMEOUT_SECONDS = 180.0
+"""Hard ceiling on a single docker compose invocation.  Profile-up on a
+cold BHCE stack takes ~30s; 180s is generous head-room."""
+
+
+def _compose(args: list[str]) -> subprocess.CompletedProcess[str]:
+    cmd = [_DOCKER_BIN, "compose", "-p", _COMPOSE_PROJECT, "-f", _COMPOSE_FILE, *args]
+    log.info("ops-control: %s", " ".join(cmd))
+    return subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=_COMPOSE_TIMEOUT_SECONDS,
+    )
+
+
+def _require_allowlisted(name: str) -> None:
+    if name not in _ALLOWLIST:
+        raise HTTPException(
+            status_code=400,
+            detail=f"profile {name!r} is not in OPS_PROFILE_ALLOWLIST",
+        )
+
+
+# ── HTTP surface ────────────────────────────────────────────────────
+
+
+app = FastAPI(title="decepticon-ops-control", version="0.1.0")
+
+
+@app.get("/v1/health")
+def health() -> dict[str, Any]:
+    """Liveness — no compose invocation, used by Docker healthcheck."""
+    return {
+        "ok": True,
+        "project": _COMPOSE_PROJECT,
+        "allowlist_size": len(_ALLOWLIST),
+        "now": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+
+@app.get("/v1/profiles")
+def list_profiles() -> dict[str, Any]:
+    """Return the allowlist plus the running-container count for each
+    profile so callers can tell ``ad`` from ``ad+spinning-up``."""
+    result = _compose(["ps", "--all", "--format", "json"])
+    profile_state: dict[str, list[str]] = {name: [] for name in _ALLOWLIST}
+    if result.returncode == 0:
+        import json
+
+        for raw in result.stdout.splitlines():
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            container_profiles = row.get("Profiles") or ""
+            for profile in container_profiles.split(","):
+                profile = profile.strip()
+                if profile and profile in profile_state:
+                    profile_state[profile].append(f"{row.get('Service')}={row.get('State')}")
+    return {
+        "allowlist": sorted(_ALLOWLIST),
+        "running": {k: v for k, v in profile_state.items() if v},
+    }
+
+
+@app.post("/v1/profiles/{name}/start", status_code=202)
+def start_profile(name: str) -> dict[str, Any]:
+    _require_allowlisted(name)
+    result = _compose(["--profile", name, "up", "-d"])
+    if result.returncode != 0:
+        log.error(
+            "ops-control start %s failed (rc=%s): %s",
+            name,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "profile": name,
+                "returncode": result.returncode,
+                "stderr": result.stderr.strip().splitlines()[-5:],
+            },
+        )
+    return {
+        "profile": name,
+        "action": "started",
+        "stdout_tail": result.stdout.strip().splitlines()[-5:],
+    }
+
+
+@app.post("/v1/profiles/{name}/stop", status_code=202)
+def stop_profile(name: str) -> dict[str, Any]:
+    _require_allowlisted(name)
+    result = _compose(["--profile", name, "stop"])
+    if result.returncode != 0:
+        log.error(
+            "ops-control stop %s failed (rc=%s): %s",
+            name,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "profile": name,
+                "returncode": result.returncode,
+                "stderr": result.stderr.strip().splitlines()[-5:],
+            },
+        )
+    return {
+        "profile": name,
+        "action": "stopped",
+        "stdout_tail": result.stdout.strip().splitlines()[-5:],
+    }

--- a/containers/ops-control/requirements.txt
+++ b/containers/ops-control/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.118.0
+uvicorn[standard]==0.32.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -656,6 +656,13 @@ services:
       context: .
       dockerfile: containers/ops-control.Dockerfile
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-ops-control
+    # The image runs as the non-root `ops` user (containers/ops-control.Dockerfile),
+    # so grant it the host docker-socket group rather than root. Set DOCKER_GID
+    # to `stat -c %g /var/run/docker.sock` on the host (999 on most Debian/Ubuntu
+    # installs, hence the default); a wrong value only affects ops-control, which
+    # 400-rejects everything outside OPS_PROFILE_ALLOWLIST regardless.
+    group_add:
+      - "${DOCKER_GID:-999}"
     environment:
       # Allowlist seeded for the imminent sprint-2 cutover; ADR-0006
       # sub-decision §3.  Profiles not listed here are 400-rejected

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -638,6 +638,50 @@ services:
       start_period: 90s
     restart: unless-stopped
 
+  # ── ops-control sidecar — single lifecycle surface ─────────────────
+  #
+  # ADR-0006.  The only container in the management plane that
+  # bind-mounts the host's Docker socket.  Exposes an allowlisted
+  # HTTP API on decepticon-net so the orchestrator agent can call
+  # docker compose --profile <name> up/stop -d for domain-specific
+  # sidecars (ad, c2-sliver, reversing, …) at runtime.
+  #
+  # No host port: only langgraph (and friends on decepticon-net)
+  # reach it over the bridge.  No raw `docker run` / image pull /
+  # volume / network surface — those code paths don't exist in
+  # main.py.
+  ops-control:
+    image: ghcr.io/purpleailab/decepticon-ops-control:${DECEPTICON_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: containers/ops-control.Dockerfile
+    container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-ops-control
+    environment:
+      # Allowlist seeded for the imminent sprint-2 cutover; ADR-0006
+      # sub-decision §3.  Profiles not listed here are 400-rejected
+      # without touching docker.
+      OPS_PROFILE_ALLOWLIST: ${OPS_PROFILE_ALLOWLIST:-ad,c2-sliver,c2-havoc,reversing}
+      OPS_COMPOSE_PROJECT: ${COMPOSE_PROJECT_NAME:-decepticon}
+      OPS_COMPOSE_FILE: /host/docker-compose.yml
+    volumes:
+      # Docker socket bind — the entire reason ops-control exists in
+      # this plane.  Not read-only: docker compose up needs write
+      # access to the engine.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Repo root mounted read-only so docker compose can see the
+      # same docker-compose.yml + .env that the host runs.  Compose
+      # never writes back through this path.
+      - ./:/host:ro
+    networks:
+      - decepticon-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8090/v1/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 15s
+
 volumes:
   postgres_data:
   sliver_data:

--- a/packages/decepticon/decepticon/tools/ops/__init__.py
+++ b/packages/decepticon/decepticon/tools/ops/__init__.py
@@ -1,0 +1,12 @@
+"""Agent-facing LangChain ``@tool`` surface for the ops-control sidecar.
+
+ADR: docs/adr/0006-agent-driven-container-lifecycle.md
+
+Only the orchestrator agent (``decepticon``) is expected to import
+this surface.  Specialist sub-agents must not see it — a compromised
+sub-agent should not be able to spin up unrelated infrastructure.
+"""
+
+from decepticon.tools.ops.tools import OPS_TOOLS, ops_start, ops_status, ops_stop
+
+__all__ = ["OPS_TOOLS", "ops_start", "ops_status", "ops_stop"]

--- a/packages/decepticon/decepticon/tools/ops/client.py
+++ b/packages/decepticon/decepticon/tools/ops/client.py
@@ -1,0 +1,96 @@
+"""HTTP client for the ops-control sidecar.
+
+ADR-0006.  The ops-control sidecar exposes:
+
+    GET  /v1/health                    - liveness
+    GET  /v1/profiles                  - allowlist + per-profile state
+    POST /v1/profiles/{name}/start     - docker compose --profile <name> up -d
+    POST /v1/profiles/{name}/stop     - docker compose --profile <name> stop
+
+This client is the single integration point the LangChain @tool
+layer (``tools/ops/tools.py``) talks through.  No docker socket
+access, no subprocess — strictly HTTP against ops-control.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+class OpsControlConfigError(RuntimeError):
+    """Raised when required configuration is missing."""
+
+
+class OpsControlHTTPError(RuntimeError):
+    """Raised when ops-control returns a non-success status."""
+
+    def __init__(self, status_code: int, body: Any) -> None:
+        super().__init__(f"ops-control returned HTTP {status_code}: {body!r}")
+        self.status_code = status_code
+        self.body = body
+
+
+class OpsControlClient:
+    """Synchronous HTTP client for the ops-control sidecar."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 60.0,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    @classmethod
+    def from_env(cls) -> OpsControlClient:
+        base = os.environ.get("OPS_CONTROL_URL", "").strip()
+        if not base:
+            raise OpsControlConfigError("OPS_CONTROL_URL is required to construct OpsControlClient")
+        timeout_str = os.environ.get("OPS_CONTROL_TIMEOUT", "60").strip() or "60"
+        try:
+            timeout = float(timeout_str)
+        except ValueError as exc:
+            raise OpsControlConfigError(
+                f"OPS_CONTROL_TIMEOUT must be a number, got {timeout_str!r}"
+            ) from exc
+        return cls(base, timeout=timeout)
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> OpsControlClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def _request(self, method: str, path: str) -> dict[str, Any]:
+        resp = self._client.request(method, f"{self._base}{path}")
+        if resp.status_code >= 400:
+            try:
+                body: Any = resp.json()
+            except Exception:
+                body = resp.text
+            raise OpsControlHTTPError(resp.status_code, body)
+        return resp.json()
+
+    # ── Endpoints (1:1 with ops-control routes) ─────────────────────
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/v1/health")
+
+    def list_profiles(self) -> dict[str, Any]:
+        return self._request("GET", "/v1/profiles")
+
+    def start_profile(self, name: str) -> dict[str, Any]:
+        return self._request("POST", f"/v1/profiles/{name}/start")
+
+    def stop_profile(self, name: str) -> dict[str, Any]:
+        return self._request("POST", f"/v1/profiles/{name}/stop")

--- a/packages/decepticon/decepticon/tools/ops/tools.py
+++ b/packages/decepticon/decepticon/tools/ops/tools.py
@@ -1,0 +1,155 @@
+"""LangChain ``@tool`` wrappers for the ops-control sidecar.
+
+ADR-0006.  Three composite tools the orchestrator agent uses to bring
+domain-specific sidecars up/down at runtime:
+
+  - ``ops_start(profile)`` — docker compose --profile <name> up -d
+  - ``ops_stop(profile)``  — docker compose --profile <name> stop
+  - ``ops_status()``       — current allowlist + running services
+
+The actual docker-socket interaction lives inside the ops-control
+container, not here.  langgraph reaches ops-control over HTTP on
+``decepticon-net``; it has no Docker access of its own.
+
+These tools belong on the orchestrator's toolbox only.  Specialist
+sub-agents (ad_operator, c2_operator, …) must not import this module.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.tools import tool
+
+from decepticon.tools.ops.client import (
+    OpsControlClient,
+    OpsControlConfigError,
+    OpsControlHTTPError,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+
+
+def _make_client() -> OpsControlClient | None:
+    try:
+        return OpsControlClient.from_env()
+    except OpsControlConfigError as exc:
+        log.warning("ops-control client unavailable: %s", exc)
+        return None
+
+
+def _config_error(message: str) -> str:
+    return _json(
+        {
+            "error": message,
+            "hint": (
+                "Set OPS_CONTROL_URL on the langgraph container (e.g. "
+                "http://ops-control:8090).  See ADR-0006."
+            ),
+        }
+    )
+
+
+# ── ops_start ──────────────────────────────────────────────────────
+
+
+@tool
+def ops_start(profile: str) -> str:
+    """Bring a domain-specific compose profile up.
+
+    Use this before delegating to a specialist whose domain needs a
+    sidecar service — e.g. call ``ops_start("ad")`` before delegating
+    to ``ad_operator`` so BHCE is healthy by the time the specialist
+    issues its first tool call.  Idempotent: re-issuing on an already
+    running profile is a no-op.
+
+    Args:
+        profile: Compose profile name on the server-side allowlist.
+    """
+    if not profile or not profile.strip():
+        return _json({"error": "profile is required"})
+    client = _make_client()
+    if client is None:
+        return _config_error("OpsControlClient could not be constructed from env")
+    try:
+        with client:
+            return _json(client.start_profile(profile.strip()))
+    except OpsControlHTTPError as exc:
+        return _json(
+            {
+                "error": "ops-control returned an error on start",
+                "status_code": exc.status_code,
+                "body": exc.body,
+            }
+        )
+
+
+# ── ops_stop ───────────────────────────────────────────────────────
+
+
+@tool
+def ops_stop(profile: str) -> str:
+    """Stop a domain-specific compose profile.
+
+    Call once the specialist has returned and no pending OPPLAN task
+    still needs that domain.  ``stop`` keeps volumes and containers
+    around so the next ``ops_start`` is fast.
+
+    Args:
+        profile: Compose profile name on the server-side allowlist.
+    """
+    if not profile or not profile.strip():
+        return _json({"error": "profile is required"})
+    client = _make_client()
+    if client is None:
+        return _config_error("OpsControlClient could not be constructed from env")
+    try:
+        with client:
+            return _json(client.stop_profile(profile.strip()))
+    except OpsControlHTTPError as exc:
+        return _json(
+            {
+                "error": "ops-control returned an error on stop",
+                "status_code": exc.status_code,
+                "body": exc.body,
+            }
+        )
+
+
+# ── ops_status ─────────────────────────────────────────────────────
+
+
+@tool
+def ops_status() -> str:
+    """List the ops-control allowlist and currently-running profiles.
+
+    Use this to confirm a profile is actually live before issuing
+    domain-specific tools, or to decide whether ``ops_stop`` is
+    needed at the end of an objective.
+    """
+    client = _make_client()
+    if client is None:
+        return _config_error("OpsControlClient could not be constructed from env")
+    try:
+        with client:
+            return _json({"health": client.health(), "profiles": client.list_profiles()})
+    except OpsControlHTTPError as exc:
+        return _json(
+            {
+                "error": "ops-control returned an error on status",
+                "status_code": exc.status_code,
+                "body": exc.body,
+            }
+        )
+
+
+OPS_TOOLS = [ops_start, ops_stop, ops_status]
+"""Wire into the orchestrator agent's toolbox.  Specialists never see
+these — agent-level gating is what keeps a compromised sub-agent from
+spinning up infrastructure outside its domain."""

--- a/packages/decepticon/tests/unit/ops/test_ops_tools.py
+++ b/packages/decepticon/tests/unit/ops/test_ops_tools.py
@@ -1,0 +1,139 @@
+"""Unit tests for the ops-control LangChain @tool surface.
+
+The agent-facing surface is small (3 @tools wrapping 4 HTTP calls),
+so the tests focus on:
+  - HTTP method + path are 1:1 with the ops-control routes
+  - JSON envelopes propagate cleanly through the @tool layer
+  - Missing OPS_CONTROL_URL produces an actionable diagnostic
+  - HTTP errors from ops-control surface to the agent as structured
+    fields (status_code + body) rather than tracebacks
+
+Wire-level docker-compose behaviour is exercised at integration /
+dogfood time against the ops-control container itself, not here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from decepticon.tools.ops.tools import ops_start, ops_status, ops_stop
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPS_CONTROL_URL", "http://ops-control:8090")
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _fake(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs.pop("timeout", None)
+        return real_client(transport=transport, timeout=5.0, *args, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", _fake)
+
+
+# ── ops_start ──────────────────────────────────────────────────────
+
+
+def test_ops_start_hits_correct_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(202, json={"profile": "ad", "action": "started"})
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(ops_start.invoke({"profile": "ad"}))
+    assert seen == {"method": "POST", "path": "/v1/profiles/ad/start"}
+    assert out["action"] == "started"
+
+
+def test_ops_start_empty_profile_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    out = json.loads(ops_start.invoke({"profile": "  "}))
+    assert "required" in out["error"]
+
+
+def test_ops_start_propagates_allowlist_400(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"detail": "profile 'mystery' is not in OPS_PROFILE_ALLOWLIST"},
+        )
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(ops_start.invoke({"profile": "mystery"}))
+    assert out["status_code"] == 400
+    assert "allowlist" in json.dumps(out["body"]).lower()
+
+
+def test_ops_start_missing_env_returns_diagnostic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPS_CONTROL_URL", raising=False)
+    out = json.loads(ops_start.invoke({"profile": "ad"}))
+    assert "OPS_CONTROL_URL" in out["hint"]
+
+
+# ── ops_stop ───────────────────────────────────────────────────────
+
+
+def test_ops_stop_hits_correct_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(202, json={"profile": "c2-sliver", "action": "stopped"})
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(ops_stop.invoke({"profile": "c2-sliver"}))
+    assert seen == {"method": "POST", "path": "/v1/profiles/c2-sliver/stop"}
+    assert out["action"] == "stopped"
+
+
+def test_ops_stop_empty_profile_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    out = json.loads(ops_stop.invoke({"profile": ""}))
+    assert "required" in out["error"]
+
+
+# ── ops_status ─────────────────────────────────────────────────────
+
+
+def test_ops_status_combines_health_and_profiles(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/health":
+            return httpx.Response(200, json={"ok": True, "allowlist_size": 4})
+        if request.url.path == "/v1/profiles":
+            return httpx.Response(
+                200,
+                json={"allowlist": ["ad", "c2-sliver"], "running": {"ad": ["bhce=running"]}},
+            )
+        raise AssertionError(f"unexpected call: {request.url.path}")
+
+    _install_transport(monkeypatch, handler)
+    out = json.loads(ops_status.invoke({}))
+    assert out["health"]["allowlist_size"] == 4
+    assert out["profiles"]["running"]["ad"] == ["bhce=running"]
+
+
+# ── plumbing ───────────────────────────────────────────────────────
+
+
+def test_ops_tools_list_exports_three() -> None:
+    from decepticon.tools.ops import OPS_TOOLS
+
+    names = sorted(t.name for t in OPS_TOOLS)
+    assert names == ["ops_start", "ops_status", "ops_stop"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,11 @@ known-first-party = ["decepticon", "decepticon_core", "decepticon_sdk"]
 "clients/**" = ["TID251"]
 "scripts/**" = ["TID251"]
 "config/**" = ["TID251"]
+# Sidecar binaries shipped under containers/ are their own runtime
+# images, not part of decepticon-core's importable surface; they may
+# depend on whatever HTTP / docker libs make sense for that sidecar
+# (e.g. ops-control's fastapi).
+"containers/**" = ["TID251"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Lands ADR-0006 sprint 1 — the scaffold the rest of the agent-driven container lifecycle migration builds on:

- New \`ops-control\` sidecar (Python + FastAPI + alpine docker-cli + compose plugin).  Allowlist-gated HTTP API; no raw \`docker run\`, no image pull / volume / network surface.
- \`docker-compose.yml\` adds \`ops-control\` on \`decepticon-net\` with the Docker socket bind + a read-only mount of the repo root.
- New \`decepticon.tools.ops\` LangChain @tool surface (\`ops_start\` / \`ops_stop\` / \`ops_status\`) wrapping an httpx-based \`OpsControlClient\`.
- ruff per-file-ignore for \`containers/**\` so sidecar binaries can depend on fastapi without violating decepticon-core's langchain/fastapi-free invariant.

ADR-0006 sub-decisions §1 + §2 land here.  §3 (default-off via profile gating on bhce + c2-sliver) and §4 (HITL toggle) are sprints 2-4.

## Verification

- \`make ci-lint\` — 0 errors, 493 warnings (no regression).
- \`pytest packages/decepticon/tests/unit/ops/\` — 8 passed (path/method 1:1 mapping, allowlist 400 propagation, missing-env diagnostic, status combines health + profiles).
- \`docker build -f containers/ops-control.Dockerfile .\` — image builds cleanly on the bundled alpine + apk versions.
- Live dogfood against an isolated compose project:
  - \`ops-control\` reaches \`Healthy\`
  - \`GET /v1/health\` returns \`{ok: true, project, allowlist_size: 4}\`
  - \`POST /v1/profiles/mystery/start\` returns \`400\` with \`'not in OPS_PROFILE_ALLOWLIST'\`
  - \`POST /v1/profiles/{name}/start|stop\` forwards correctly to \`docker compose --profile <name> up -d\` / \`stop\`

## Sprint-1 limit (intentional — resolved in sprint 2)

The compose stack does not yet carry \`profiles: [ad]\` on \`bhce\` / \`bhce-neo4j\`, and \`.env.example\` still defaults \`COMPOSE_PROFILES=c2-sliver\`.  So today, running \`docker compose --profile ad up -d\` from ops-control triggers every default-on service — not only the AD-scoped ones.  That gets resolved in sprint 2 (ADR-0006 §3): once \`profiles: [ad]\` is on the two BHCE services and the COMPOSE_PROFILES default is removed, \`ops_start(\"ad\")\` brings up exactly \`bhce + bhce-neo4j\` and nothing else.

This PR deliberately ships the scaffold first so sprint 2's profile flip can be a small, focused change.

## Out of scope (per ADR-0006 migration timeline)

- **Sprint 2** — \`profiles: [ad]\` on bhce + bhce-neo4j; \`.env.example\` default removal; orchestrator system prompt update to call \`ops_start\` / \`ops_stop\`.
- **Sprint 3** — BHCE HMAC token bootstrap moves into ops-control's start handler; langgraph receives the token over HTTP, not env var.
- **Sprint 4** — CLAUDE.md + docs/architecture.md invariant edit; Web Dashboard ops_status panel.

## Test plan

- [x] CI lint clean
- [x] unit suite passes (8 tests covering the @tool surface)
- [x] ops-control image builds
- [x] live ops-control reaches Healthy in an isolated compose project
- [x] /v1/health returns the expected envelope
- [x] allowlist enforcement: unknown profile returns 400 without invoking docker
- [x] /v1/profiles/{name}/start|stop forwards to docker compose
- [ ] reviewer confirms the sprint-1 vs sprint-2 split matches ADR-0006's migration timeline
- [ ] reviewer confirms ruff per-file-ignore scope (\`containers/**\`) doesn't accidentally loosen the rule on existing sidecars