### PR TITLE
fix(adr): resolve git merge-conflict marker in ADR README index

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,11 +66,7 @@ Use [`template.md`](template.md) as the starting point.
 | [0002](0002-pr-tiering-and-blast-radius.md) | PR tiering by blast radius | Accepted |
 | [0003](0003-ai-contributor-self-review.md) | AI-assisted contribution self-review charter | Accepted |
 | [0004](0004-zero-ai-slop-policy.md) | Zero AI-slop policy — the 100% quality bar | Accepted |
-<<<<<<< HEAD
 | [0005](0005-bloodhound-via-bhce-rest-client.md) | Integrate BloodHound via the official BHCE REST API, not via in-house reimplementation | Accepted |
-=======
-| [0005](0005-bloodhound-via-bhce-rest-client.md) | Integrate BloodHound via the official BHCE REST API, not via in-house reimplementation | Proposed |
 | [0006](0006-agent-driven-container-lifecycle.md) | Agent-driven domain-tool container lifecycle via an ops-control sidecar | Proposed |
->>>>>>> 5c84da3c (docs(adr): 0006 — agent-driven domain-tool container lifecycle)
 
 Keep this index in sync when you land a new ADR.


### PR DESCRIPTION
## Summary

Resolves a live Git merge-conflict marker in `docs/adr/README.md` on `main`. The ADR index — the entry point that `docs/adr/README.md` itself instructs contributors to "keep in sync when you land a new ADR" — currently contains:

```
<<<<<<< HEAD
| [0005](...) | ... | Accepted |
=======
| [0005](...) | ... | Proposed |
| [0006](...) | ... | Proposed |
>>>>>>> 5c84da3c (docs(adr): 0006 — agent-driven domain-tool container lifecycle)
```

This makes the rendered table unreadable on GitHub and causes any tooling that parses the index (or any contributor following the lifecycle rules in `docs/adr/README.md`) to choke. Behaviorally observable: visit [docs/adr/README.md on main](https://github.com/PurpleAILAB/Decepticon/blob/main/docs/adr/README.md) and the conflict markers are rendered verbatim.

## Changes

- `docs/adr/README.md` — replace the conflict block with the resolution that matches each ADR file's own `- **Status:**` line:
  - **ADR 0005** → `Accepted` (matches the file, landed via #590)
  - **ADR 0006** → `Proposed` (matches the file, landed via #591)

No other lines touched.

## Intent

- **Issue / ADR this satisfies:** restoring the invariant stated in `docs/adr/README.md` §Lifecycle and §Index ("Keep this index in sync when you land a new ADR"). No separate issue — this is a content-bug on `main`.
- **Anti-goal:** not flipping statuses, not renumbering, not adding/removing ADRs, not editing any other line. Strictly a conflict-marker fix.

## Blast radius

- [x] **Tier-owner** — `docs/adr/**` is CODEOWNERS-gated to `@PurpleCHOIms` per `.github/CODEOWNERS`.

**Why this needs an owner change:** edits under `docs/adr/**` are owner-gated by the CODEOWNERS rule, even for index-only fixes, because the ADR set itself is the governance surface. The resolution chosen here is purely mechanical (it matches the `Status:` field in each ADR's own file on `main`) — flipping it the other direction would silently revert two already-merged ADR status decisions, which is a much larger change. Owner review is requested only to confirm the mechanical resolution is the intended one.

## Diff budget

Per [QUALITY_BAR §Hard limits](../docs/QUALITY_BAR.md#hard-limits): well under the 400-line / 10-file budget — 1 file, 4 deletions, 0 additions.

- [x] My diff fits the budget.

## End-to-end verification

Cloned the fork, reset to `upstream/main`, confirmed the conflict block exists at lines 69–74. Applied the fix, ran `grep -n '<<<\|>>>\|===='` against `docs/adr/README.md` — zero matches. Diffed against the two ADR files' actual `Status:` lines to confirm the chosen resolution matches reality:

```
$ grep -E "^- \*\*Status:" docs/adr/0005-bloodhound-via-bhce-rest-client.md docs/adr/0006-agent-driven-container-lifecycle.md
docs/adr/0005-bloodhound-via-bhce-rest-client.md:- **Status:** Accepted
docs/adr/0006-agent-driven-container-lifecycle.md:- **Status:** Proposed
```

Rendered the file in a Markdown previewer; the Index table now renders cleanly as a single 6-row table with no leaked conflict syntax.

## Testing

Docs-only change, no runtime code path. No `make quality` / `make smoke` exercise required for this file.

- [x] Markdown renders cleanly (no leaked conflict markers)
- [x] Index rows match each ADR file's own `- **Status:**` line on `main`
- [x] No other lines in `docs/adr/README.md` were touched

## Quality Bar self-check

- [x] No banned pattern from QUALITY_BAR §Banned patterns appears in the diff (N/A — docs).
- [x] No AI-slop signature survives (single mechanical fix, no prose padding).
- [x] Every changed line traces to the stated intent. No drive-by formatting.
- [x] Public function signatures unchanged (N/A — docs).
- [x] I would merge this PR if a stranger opened it.
- [x] If I were tired and reviewing this at the end of a long day, I would still merge it.

## AI-assisted contribution attestation

This PR was opened by me (VoidChecksum) using AI assistance per [CONTRIBUTING_AGENT.md](../CONTRIBUTING_AGENT.md). I read the full 4-line diff; the only judgment call is the direction of the conflict resolution, which I justified above by cross-checking against each ADR file's own `Status:` field. No `Co-Authored-By` trailer per §1.1 of the charter.

## Related Issues

None — the marker is visible on `main` at [docs/adr/README.md#L69-L74](https://github.com/PurpleAILAB/Decepticon/blob/main/docs/adr/README.md#L69-L74).
