### PR TITLE
feat(kg): add Technology node kind for AI-surface and tech-detection signals

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/kg.py
+++ b/packages/decepticon-core/decepticon_core/types/kg.py
@@ -115,6 +115,11 @@ class NodeKind(StrEnum):
     SOLIDITY_ENUM = "Enum"
     SOLIDITY_STRUCT = "Struct"
     SOLIDITY_PRAGMA = "Pragma"
+    # Technology — a named product/runtime detected on or behind a Service
+    # (AI runtimes, AI proxies, web frameworks). Recon classifiers (header /
+    # port / banner / title) write here so detections become typed, queryable
+    # graph data instead of flat Service props. See ADR-0007.
+    TECHNOLOGY = "Technology"
 
 
 class EdgeKind(StrEnum):
@@ -131,6 +136,7 @@ class EdgeKind(StrEnum):
     ROUTES_TO = "ROUTES_TO"
     PART_OF = "PART_OF"
     MANAGES = "MANAGES"
+    RUNS = "RUNS"  # Service/Host -[:RUNS]-> Technology (ADR-0007)
     # Access
     AUTHENTICATES_TO = "AUTHENTICATES_TO"
     HAS_SESSION = "HAS_SESSION"
@@ -248,6 +254,40 @@ class EdgeKind(StrEnum):
     WRITE_ACCOUNT_RESTRICTIONS = "WRITE_ACCOUNT_RESTRICTIONS"
     # Solidity (Slither) — function-call graph edge.
     CALLS = "CALLS"
+
+
+class TechnologyCategory(StrEnum):
+    """Closed vocabulary for a :attr:`NodeKind.TECHNOLOGY` node's ``category``.
+
+    Deliberately finite (ADR-0007): the category is half of a Technology
+    node's identity key, so an unbounded free-text vocabulary would split
+    the same product across spellings and defeat the parameterized,
+    injection-safe KG queries the chain planner runs against it.
+    """
+
+    # AI attack surface — the cluster this vocabulary exists to make queryable.
+    AI_RUNTIME = "ai-runtime"  # Ollama, vLLM, llama.cpp, TGI
+    AI_PROXY = "ai-proxy"  # LiteLLM, OpenRouter-style gateways
+    AI_FRAMEWORK = "ai-framework"  # LangChain server, LlamaIndex, MLflow
+    AI_SDK_CLIENT = "ai-sdk-client"  # in-page openai/anthropic SDK usage
+    # Generic web tech — tech-detection upgrade feeds CVE cross-referencing.
+    WEB_SERVER = "web-server"
+    WEB_FRAMEWORK = "web-framework"
+    CMS = "cms"
+    LANGUAGE_RUNTIME = "language-runtime"
+    DATABASE = "database"
+
+
+def technology_key(category: TechnologyCategory, name: str) -> str:
+    """Canonical ``(key, engagement)`` key for a Technology node (ADR-0007).
+
+    ``<category>:<normalized-name>`` so the same product detected by two
+    classifiers (header vs banner) MERGEs onto one node per engagement.
+    """
+    normalized = "-".join(name.strip().lower().split())
+    if not normalized:
+        raise ValueError("technology name must be non-empty")
+    return f"{category.value}:{normalized}"
 
 
 class Severity(StrEnum):

--- a/packages/decepticon-core/tests/test_kg_technology_types.py
+++ b/packages/decepticon-core/tests/test_kg_technology_types.py
@@ -1,0 +1,77 @@
+"""Regression tests for the Technology KG vocabulary (ADR-0007).
+
+AI-surface and tech-detection recon classifiers (HTTP header, port
+catalog, nmap banner, frontend title) write detected products as
+``Technology`` nodes linked ``(Service)-[:RUNS]->(Technology)``.
+
+``NodeKind`` values are Neo4j labels and ``EdgeKind`` values are Neo4j
+relationship types (1:1, per the ``kg`` module docstring), and the
+``technology_key`` format is the ``(key, engagement)`` MERGE contract the
+V004 migration's uniqueness constraint enforces. Pin the exact strings
+here so a rename can't silently break the classifier ingest or the
+chain-planner queries that read these nodes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from decepticon_core.types.kg import (
+    EdgeKind,
+    Node,
+    NodeKind,
+    TechnologyCategory,
+    technology_key,
+)
+
+
+def test_technology_node_kind_has_neo4j_label() -> None:
+    assert NodeKind.TECHNOLOGY == "Technology"
+
+
+def test_runs_edge_kind_has_neo4j_relationship_type() -> None:
+    assert EdgeKind.RUNS == "RUNS"
+
+
+def test_technology_categories_are_the_closed_vocabulary() -> None:
+    # The AI-surface cluster ADR-0007 exists to make queryable.
+    assert TechnologyCategory.AI_RUNTIME == "ai-runtime"
+    assert TechnologyCategory.AI_PROXY == "ai-proxy"
+    assert TechnologyCategory.AI_FRAMEWORK == "ai-framework"
+    assert TechnologyCategory.AI_SDK_CLIENT == "ai-sdk-client"
+
+
+def test_technology_key_is_category_prefixed_and_normalized() -> None:
+    assert technology_key(TechnologyCategory.AI_RUNTIME, "Ollama") == "ai-runtime:ollama"
+    # Whitespace collapses so banner "vLLM  server" and header "vLLM server"
+    # MERGE onto one node.
+    assert (
+        technology_key(TechnologyCategory.AI_RUNTIME, "  vLLM  server ") == "ai-runtime:vllm-server"
+    )
+
+
+def test_technology_key_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        technology_key(TechnologyCategory.AI_RUNTIME, "   ")
+
+
+def test_two_classifiers_same_product_dedup_to_one_node() -> None:
+    key = technology_key(TechnologyCategory.AI_RUNTIME, "ollama")
+    from_header = Node.make(NodeKind.TECHNOLOGY, "ollama", key=key, detected_by="httpx-ai-header")
+    from_banner = Node.make(NodeKind.TECHNOLOGY, "ollama", key=key, detected_by="nmap-banner")
+    # Same (kind, key) → same deterministic id → one node after merge.
+    assert from_header.id == from_banner.id
+
+
+def test_distinct_categories_are_distinct_nodes() -> None:
+    runtime = Node.make(
+        NodeKind.TECHNOLOGY,
+        "ollama",
+        key=technology_key(TechnologyCategory.AI_RUNTIME, "ollama"),
+    )
+    proxy = Node.make(
+        NodeKind.TECHNOLOGY,
+        "ollama",
+        key=technology_key(TechnologyCategory.AI_PROXY, "ollama"),
+    )
+    assert runtime.id != proxy.id

--- a/packages/decepticon/decepticon/middleware/kg_internal/migrations/V004__technology_node.cypher
+++ b/packages/decepticon/decepticon/middleware/kg_internal/migrations/V004__technology_node.cypher
@@ -1,0 +1,22 @@
+-- KG schema v004 — Technology node kind for AI-surface and tech-detection
+-- signals (ADR-0007).
+--
+-- A Technology node is a named product/runtime detected on or behind a
+-- Service — an AI runtime (Ollama, vLLM), an AI proxy, a web framework.
+-- Recon classifiers (HTTP header, port catalog, nmap banner, frontend
+-- title) MERGE into this label and link it ``(Service)-[:RUNS]->(Technology)``
+-- so detections become typed, queryable graph data the chain planner and
+-- the llm-redteam plugin can route on, instead of flat Service properties.
+--
+-- Same ``(key, engagement)`` composite invariant as V001/V003: the same
+-- ``<category>:<name>`` key in two engagements is two nodes (multi-tenant);
+-- the same key in one engagement is one node (idempotent MERGE so two
+-- classifiers corroborating the same product converge).
+
+CREATE CONSTRAINT technology_key_engagement IF NOT EXISTS
+  FOR (n:Technology) REQUIRE (n.key, n.engagement) IS UNIQUE;
+
+-- Engagement-scoped category lookup — "which AI runtimes did we find in
+-- this engagement" is the primary read path for the llm-redteam plugin.
+CREATE INDEX engagement_technology_category IF NOT EXISTS
+  FOR (n:Technology) ON (n.engagement, n.category);

--- a/packages/decepticon/tests/unit/middleware/test_kg_migration_runner.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_migration_runner.py
@@ -295,6 +295,22 @@ def test_v002_creates_vector_index_for_future_semantic_recall() -> None:
     assert "cosine" in text
 
 
+def test_v004_creates_technology_key_engagement_constraint() -> None:
+    """V004 must enforce the ``(key, engagement)`` MERGE invariant for the
+    Technology label (ADR-0007) so corroborating classifier writes dedup."""
+    from decepticon.middleware.kg_internal.migration_runner import _DEFAULT_MIGRATIONS_DIR
+
+    v004 = next((_DEFAULT_MIGRATIONS_DIR).glob("V004__*.cypher"))
+    text = v004.read_text(encoding="utf-8")
+    stmts = _split_cypher_statements(text)
+    assert any("(n:Technology)" in s and "(n.key, n.engagement) IS UNIQUE" in s for s in stmts), (
+        "V004 must add the Technology (key, engagement) uniqueness constraint"
+    )
+    assert any("FOR (n:Technology) ON (n.engagement, n.category)" in s for s in stmts), (
+        "V004 must add the engagement-scoped category index"
+    )
+
+
 # ── KGStore record_observations must not interfere with migration log ───
 
 


### PR DESCRIPTION
## What & why

Implements the **prerequisite** from the roadmap in #593: a first-class
`Technology` knowledge-graph node kind, as decided in **ADR-0007**.

Today a detected product/runtime has nowhere typed to live — an open
`11434` is a `Service` with `service=unknown`, an AI-runtime banner is
copied verbatim from nmap, and a response header naming a stack is a flat
property no agent routes on. This PR adds the typed, queryable target the
upcoming recon classifiers (HTTP header, port catalog, nmap banner,
frontend title) MERGE into, so the `llm-redteam` plugin and the chain
planner can traverse `(Service)-[:RUNS]->(Technology)` instead of parsing
strings.

**Observable behavior change:** none yet at runtime — this is the schema
foundation. The classifiers that *write* Technology nodes land as their
own PRs (#593). **Anti-goal:** deliberately does *not* add any ingester
or classifier here; schema only.

## Changes

- `NodeKind.TECHNOLOGY` (`"Technology"`) + `EdgeKind.RUNS` (`"RUNS"`).
- `TechnologyCategory` — closed category vocabulary (AI runtime/proxy/
  framework/SDK-client + generic web tech). Closed by design: the
  category is half the node identity, so free text would split a product
  across spellings (ADR-0007).
- `technology_key(category, name)` — the single canonical encoder for the
  `(key, engagement)` MERGE identity (`<category>:<normalized-name>`).
- `V004__technology_node.cypher` — `(key, engagement)` uniqueness
  constraint + engagement-scoped category index, same composite invariant
  as V001/V003.

## Why this needs an owner change

Touches `containers`/contracts? **No.** `types/kg.py` and the
`kg_internal/migrations/**` are not CODEOWNERS-gated paths, so this is
**Tier-auto / self-merge on green CI**. Flagging explicitly per the
self-review checklist: no public plugin contract, workflow, dependency,
compose, or security path is touched.

## Testing

- `make ci-lint` — ruff check + format clean, basedpyright **0 errors**.
- New unit tests (`test_kg_technology_types.py`, +1 in
  `test_kg_migration_runner.py`): NodeKind/EdgeKind labels, the closed
  category vocabulary, `technology_key` normalization + empty-name
  `ValueError`, two-classifier dedup, cross-category separation, and the
  V004 constraint/index shape. Confirmed they **fail** without the change
  (`ImportError: cannot import name 'TechnologyCategory'`) and pass with it.

## End-to-end verification

Brought up `neo4j:5.24-community` (the stack's KG engine) and applied
V004's two statements via `cypher-shell`, then exercised the invariant:

- `SHOW CONSTRAINTS` → `technology_key_engagement` on
  `["Technology"]` / `["key","engagement"]`.
- Two MERGEs of `ai-runtime:ollama` in engagement `e1` (simulating an
  httpx-header detection then an nmap-banner detection) → **1 node**
  (corroborating classifiers converge).
- Same key in engagement `e2` → **separate node** (multi-tenant isolation
  holds).
- Raw `CREATE` of the duplicate → rejected:
  `Node(0) already exists with label 'Technology' and properties
  'key' = 'ai-runtime:ollama', 'engagement' = 'e1'`.

Container torn down after.

Refs #593, ADR-0007 (`docs/adr/0007-ai-surface-technology-node.md`, PR #594).
