### PR TITLE
feat(roe): default-deny categorical sensitive-TLD target guardrail

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/roe.py
+++ b/packages/decepticon-core/decepticon_core/types/roe.py
@@ -62,6 +62,14 @@ _DEFAULT_FORBIDDEN_DESTS: tuple[str, ...] = (
     "100.100.100.200",
 )
 
+# Categorical high-collateral TLDs. A typo or an over-broad subdomain glob
+# that wanders onto a government, military, education, or international-org
+# host is the kind of mistake that turns an authorized engagement into a CFAA
+# / law-enforcement incident, so they are denied by default and the operator
+# must consciously opt in (``allow_sensitive_tlds: true``) to scope one — the
+# same default-deny posture as the cloud-metadata endpoints above.
+_DEFAULT_SENSITIVE_TLDS: tuple[str, ...] = (".gov", ".mil", ".edu", ".int")
+
 
 @dataclass(frozen=True, slots=True)
 class ScopeRule:
@@ -99,6 +107,7 @@ class MachineEnforcement:
     forbidden_destinations: tuple[str, ...] = field(default_factory=tuple)
     forbidden_command_patterns: tuple[str, ...] = field(default_factory=tuple)
     allow_cloud_metadata: bool = False
+    allow_sensitive_tlds: bool = False
     max_concurrent_connections: int | None = None
     min_inter_request_delay_ms: int = 0
     authorized_windows: tuple[tuple[datetime, datetime], ...] = field(default_factory=tuple)
@@ -120,6 +129,7 @@ class MachineEnforcement:
             forbidden_destinations=tuple(data.get("forbidden_destinations") or ()),
             forbidden_command_patterns=tuple(data.get("forbidden_command_patterns") or ()),
             allow_cloud_metadata=bool(data.get("allow_cloud_metadata", False)),
+            allow_sensitive_tlds=bool(data.get("allow_sensitive_tlds", False)),
             max_concurrent_connections=data.get("max_concurrent_connections"),
             min_inter_request_delay_ms=int(data.get("min_inter_request_delay_ms") or 0),
             authorized_windows=tuple(_parse_windows(data.get("authorized_windows") or ())),
@@ -226,6 +236,26 @@ def _matches_rule(rule: ScopeRule, target: str) -> bool:
     return rule.pattern.rstrip(".").lower() == norm_target.lower()
 
 
+def _sensitive_tld_match(target: str, tlds: tuple[str, ...]) -> str | None:
+    """Return the sensitive TLD ``target``'s hostname ends with, else None.
+
+    IP literals have no TLD, so they are never matched. A trailing ``:port``
+    is stripped first so ``foo.gov:8443`` is caught.
+    """
+    host = target.strip().lower()
+    if not host:
+        return None
+    try:
+        ipaddress.ip_address(host)
+        return None
+    except ValueError:
+        pass
+    base, _, port = host.rpartition(":")
+    if base and port.isdigit():
+        host = base
+    return next((tld for tld in tlds if host.endswith(tld)), None)
+
+
 def evaluate_target(
     target: str,
     rules: MachineEnforcement,
@@ -240,6 +270,19 @@ def evaluate_target(
                 code="FORBIDDEN_DESTINATION",
                 detail=f"{target!r} matches forbidden destination {forbidden!r}",
                 matched=(forbidden,),
+            )
+
+    if not rules.allow_sensitive_tlds:
+        sensitive = _sensitive_tld_match(target, _DEFAULT_SENSITIVE_TLDS)
+        if sensitive is not None:
+            return Decision.refuse(
+                code="SENSITIVE_TLD",
+                detail=(
+                    f"{target!r} is on the high-collateral {sensitive!r} TLD; set "
+                    f"allow_sensitive_tlds to scope it deliberately"
+                ),
+                matched=(sensitive,),
+                risk="high",
             )
 
     for rule in rules.out_of_scope:

--- a/packages/decepticon/tests/unit/middleware/test_roe.py
+++ b/packages/decepticon/tests/unit/middleware/test_roe.py
@@ -83,6 +83,49 @@ class TestMachineEnforcementSchema:
         assert decision.allow
 
 
+class TestSensitiveTldGuardrail:
+    @pytest.mark.parametrize("host", ["whitehouse.gov", "ARMY.MIL", "mit.edu", "icann.int"])
+    def test_sensitive_tlds_denied_by_default(self, host: str) -> None:
+        rules = MachineEnforcement.from_dict({"in_scope": [host]})
+        decision = evaluate_target(host, rules)
+        assert not decision.allow
+        assert decision.reason_code == "SENSITIVE_TLD"
+
+    def test_subdomain_of_sensitive_tld_denied(self) -> None:
+        rules = MachineEnforcement.from_dict({"in_scope": ["*.mit.edu"]})
+        assert not evaluate_target("portal.mit.edu", rules).allow
+
+    def test_sensitive_tld_with_port_denied(self) -> None:
+        assert not evaluate_target("foo.gov:8443", MachineEnforcement()).allow
+
+    def test_sensitive_tld_allowed_when_opted_in(self) -> None:
+        rules = MachineEnforcement.from_dict(
+            {"in_scope": ["mit.edu"], "allow_sensitive_tlds": True}
+        )
+        decision = evaluate_target("mit.edu", rules)
+        assert decision.allow
+        assert decision.reason_code == "IN_SCOPE"
+
+    def test_block_precedes_in_scope_match(self) -> None:
+        # Even an explicit in-scope entry does not override the default-deny;
+        # the operator must opt in via allow_sensitive_tlds.
+        rules = MachineEnforcement.from_dict({"in_scope": ["target.gov"]})
+        assert evaluate_target("target.gov", rules).reason_code == "SENSITIVE_TLD"
+
+    def test_commercial_tld_unaffected(self) -> None:
+        rules = MachineEnforcement.from_dict({"in_scope": ["acme.com"]})
+        assert evaluate_target("acme.com", rules).allow
+
+    def test_ip_literal_never_matches_tld(self) -> None:
+        # IPs have no TLD; the guardrail must not touch them.
+        assert evaluate_target("8.8.8.8", MachineEnforcement()).allow
+
+    def test_substring_not_suffix_is_not_matched(self) -> None:
+        # ``.international`` is not ``.int``; only a full trailing label counts.
+        rules = MachineEnforcement.from_dict({"in_scope": ["foo.international.com"]})
+        assert evaluate_target("foo.international.com", rules).allow
+
+
 class TestEvaluateTarget:
     def test_no_in_scope_means_allow_with_out_of_scope_only(self) -> None:
         rules = MachineEnforcement.from_dict(


### PR DESCRIPTION
## What & why

Implements the **Target guardrail — categorical hard-block deny-list**
Tier-1 item from the roadmap in #593.

A typo, an over-broad `*.edu` subdomain glob, or a stray copy-paste that
points an offensive agent at a `.gov` / `.mil` / `.edu` / `.int` host is
the kind of mistake that turns an authorized engagement into a
law-enforcement incident. `evaluate_target` now denies those four
high-collateral TLDs by default; the operator opts a sensitive target in
deliberately with `allow_sensitive_tlds: true` — the exact same
default-deny posture the codebase already uses for cloud-metadata IMDS
endpoints (`allow_cloud_metadata`).

**Observable behavior change:** in **enforce** mode, a target on a
sensitive TLD is now refused (`reason_code="SENSITIVE_TLD"`) unless opted
in. **Audit** (default) and **warn** modes only log/warn and proceed, so
existing engagements are unaffected until they opt into enforcement.
**Anti-goal:** does not touch `evaluate_command`, the sandbox, or any
existing scope rule; this is purely an additive target check.

## Changes

- `_DEFAULT_SENSITIVE_TLDS = (".gov", ".mil", ".edu", ".int")` + the
  `allow_sensitive_tlds` opt-out on `MachineEnforcement` (parsed in
  `from_dict`).
- `_sensitive_tld_match()` — skips IP literals (no TLD), strips a
  trailing `:port`, matches only a full trailing label so
  `.international` is **not** treated as `.int`.
- The check in `evaluate_target`, after forbidden-destinations, returning
  a `SENSITIVE_TLD` / `risk=high` refusal.

Known limitation (noted, not fixed here): second-level public suffixes
like `gov.uk` / `ac.uk` are out of scope — this matches the four literal
TLDs the roadmap named. A public-suffix-list pass can extend it later.

## Why this needs an owner change

Not CODEOWNERS-gated — `decepticon-core/types/roe.py` is outside the
gated `contracts/**` / `protocols/**` / `registry/**` set, so this is
**self-merge on green CI**. Flagged anyway because it is safety-critical:

**Threat model.** This **strengthens** the RoE guard rail — it adds a
default-deny and removes no existing restriction. It does not weaken
`SafeCommand`, RoE enforcement, `EngagementContext`, sandbox
`cap_drop`/`no-new-privileges`, or any `.semgrep` rule. The only escape
hatch is an explicit, per-engagement `allow_sensitive_tlds` opt-in,
consistent with `allow_cloud_metadata`.

## Testing

- `make ci-lint` — ruff + format clean, basedpyright **0 errors**.
- 8 new unit tests (`TestSensitiveTldGuardrail`): default-deny across all
  four TLDs (case-insensitive), subdomain match, `:port` handling,
  opt-in allow, block-precedes-in-scope, commercial-TLD untouched, IP
  literal untouched, suffix-not-substring. Confirmed they **fail**
  without the change (7 fail) and pass with it; full `test_roe.py` 134
  passed.

## End-to-end verification

`evaluate_target` is a pure RoE function, so executing it on real inputs
is the end-to-end path. Ran it directly:

```
default-deny: portal.mit.edu -> allow=False  SENSITIVE_TLD
              "'portal.mit.edu' is on the high-collateral '.edu' TLD; set
               allow_sensitive_tlds to scope it deliberately"
opted-in    : portal.mit.edu (allow_sensitive_tlds) -> allow=True  IN_SCOPE
ip literal  : 8.8.8.8 -> allow=True  OK
agency.gov / base.mil / icann.int -> SENSITIVE_TLD ;  shop.com -> OK
```

Refs #593
