### PR TITLE
feat(kg): classify AI service ports into Technology nodes at nmap ingest

### DIFF
--- a/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
@@ -1,0 +1,64 @@
+"""AI-attack-surface classification for recon ingest (ADR-0007).
+
+The ``llm-redteam`` plugin can attack an exposed Ollama / framework
+endpoint, but recon historically had no way to *recognize* one — an open
+``11434`` landed as a ``Service`` with ``service=unknown``. This maps the
+port the scanner already saw to a typed ``Technology`` node so the plugin
+and the chain planner can route on it.
+
+Port detection is the cheapest, most deterministic signal; the header /
+banner / title classifiers (separate ingest passes) corroborate it and
+add provenance. Two confidence tiers:
+
+  * ``dedicated=True``  — a single-purpose AI default port (Ollama's
+    11434). Recorded as a first-class detection.
+  * ``dedicated=False`` — AI-associated but shared with generic services
+    (Gradio / Ray dashboards also host non-AI apps). Recorded with
+    ``guess=True`` so it cannot, on its own, drive an exploit chain
+    (ADR-0007 corroborating-only rule).
+
+The catalog is intentionally conservative — only ports whose AI default
+is well documented — to keep precision high; banner/header passes widen
+recall.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from decepticon_core.types.kg import TechnologyCategory, technology_key
+
+DETECTED_BY_PORT = "port-catalog"
+
+# port -> (category, product, dedicated)
+_AI_PORT_CATALOG: dict[int, tuple[TechnologyCategory, str, bool]] = {
+    11434: (TechnologyCategory.AI_RUNTIME, "ollama", True),
+    7860: (TechnologyCategory.AI_FRAMEWORK, "gradio", False),
+    8265: (TechnologyCategory.AI_FRAMEWORK, "ray", False),
+}
+
+
+def technology_for_port(port: int, source: str) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Classify a service port as an AI Technology.
+
+    Returns ``(technology_node_observation, runs_edge)`` to append to the
+    ingest batch — the edge belongs on the owning ``Service`` node's
+    ``edges_out`` so it MERGEs as ``(Service)-[:RUNS]->(Technology)``.
+    Returns ``None`` for any port not in the catalog.
+    """
+    entry = _AI_PORT_CATALOG.get(port)
+    if entry is None:
+        return None
+    category, product, dedicated = entry
+    key = technology_key(category, product)
+    props: dict[str, Any] = {
+        "name": product,
+        "category": category.value,
+        "detected_by": DETECTED_BY_PORT,
+        "source": source,
+    }
+    if not dedicated:
+        props["guess"] = True
+    node = {"kind": "Technology", "key": key, "label": product, "props": props}
+    edge = {"to_key": key, "kind": "RUNS", "props": {"detected_by": DETECTED_BY_PORT}}
+    return node, edge

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 
 import defusedxml.ElementTree as ET
 
+from decepticon.middleware.kg_internal.ai_surface import technology_for_port
 from decepticon.middleware.kg_internal.store import KGStore
 from decepticon_core.utils.logging import get_logger
 
@@ -172,21 +173,27 @@ def _adapt_nmap_xml(
             version = svc_el.get("version") if svc_el is not None else ""
             svc_key = f"service::{ip}:{port}"
             host_edges.append({"to_key": svc_key, "kind": "HOSTS", "weight": 0.5})
-            observations.append(
-                {
-                    "kind": "Service",
-                    "key": svc_key,
-                    "label": f"{ip}:{port}/{proto}",
-                    "props": {
-                        "port": port,
-                        "protocol": proto,
-                        "service": svc_name,
-                        "product": product or "",
-                        "version": version or "",
-                        "source": "nmap",
-                    },
-                }
-            )
+            service_obs: dict[str, Any] = {
+                "kind": "Service",
+                "key": svc_key,
+                "label": f"{ip}:{port}/{proto}",
+                "props": {
+                    "port": port,
+                    "protocol": proto,
+                    "service": svc_name,
+                    "product": product or "",
+                    "version": version or "",
+                    "source": "nmap",
+                },
+            }
+            # AI-surface: a recognized AI port becomes a typed Technology node
+            # the service RUNS, so the llm-redteam plugin can find it (ADR-0007).
+            classified = technology_for_port(port, "nmap")
+            if classified is not None:
+                tech_node, runs_edge = classified
+                service_obs["edges_out"] = [runs_edge]
+                observations.append(tech_node)
+            observations.append(service_obs)
             services_count += 1
 
             if port in _WEB_PORTS:

--- a/packages/decepticon/tests/unit/middleware/test_ai_surface.py
+++ b/packages/decepticon/tests/unit/middleware/test_ai_surface.py
@@ -1,0 +1,53 @@
+"""Unit tests for the AI-surface port classifier (ADR-0007).
+
+``technology_for_port`` turns a scanned port into a typed ``Technology``
+node + a ``RUNS`` edge the owning service carries, so the ``llm-redteam``
+plugin can find an exposed AI runtime recon already saw.
+"""
+
+from __future__ import annotations
+
+from decepticon.middleware.kg_internal.ai_surface import (
+    DETECTED_BY_PORT,
+    technology_for_port,
+)
+from decepticon_core.types.kg import TechnologyCategory, technology_key
+
+
+def test_dedicated_port_is_confident_technology() -> None:
+    result = technology_for_port(11434, "nmap")
+    assert result is not None
+    node, edge = result
+    assert node["kind"] == "Technology"
+    assert (
+        node["key"]
+        == technology_key(TechnologyCategory.AI_RUNTIME, "ollama")
+        == "ai-runtime:ollama"
+    )
+    assert node["props"]["detected_by"] == DETECTED_BY_PORT
+    # Dedicated ports are NOT guesses — they can anchor an exploit chain.
+    assert "guess" not in node["props"]
+    assert edge == {
+        "to_key": "ai-runtime:ollama",
+        "kind": "RUNS",
+        "props": {"detected_by": DETECTED_BY_PORT},
+    }
+
+
+def test_shared_port_is_corroborating_guess_only() -> None:
+    result = technology_for_port(7860, "nmap")
+    assert result is not None
+    node, _edge = result
+    # Shared ports are flagged guess=True so they cannot drive a chain alone.
+    assert node["props"]["guess"] is True
+    assert node["key"] == "ai-framework:gradio"
+
+
+def test_unknown_port_is_not_classified() -> None:
+    assert technology_for_port(22, "nmap") is None
+    assert technology_for_port(443, "nmap") is None
+
+
+def test_edge_to_key_matches_node_key() -> None:
+    node, edge = technology_for_port(11434, "nmap")  # type: ignore[misc]
+    assert edge["to_key"] == node["key"]

--- a/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
@@ -208,6 +208,63 @@ def test_nmap_adapter_extracts_host_service_entrypoint(tmp_path: Path) -> None:
     assert any(e["kind"] == "HOSTS" for e in host_obs.get("edges_out", []))
 
 
+def test_nmap_adapter_classifies_ai_port_as_technology(tmp_path: Path) -> None:
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.7" addrtype="ipv4"/>
+            <ports>
+              <port portid="11434" protocol="tcp">
+                <state state="open"/>
+                <service name="unknown"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_nmap_xml(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+
+    obs = store.calls[0]["observations"]
+    tech = next(o for o in obs if o["kind"] == "Technology")
+    assert tech["key"] == "ai-runtime:ollama"
+    assert tech["props"]["detected_by"] == "port-catalog"
+    # The owning Service must RUNS-> the Technology so the planner can traverse.
+    svc = next(o for o in obs if o["kind"] == "Service")
+    assert {
+        "to_key": "ai-runtime:ollama",
+        "kind": "RUNS",
+        "props": {"detected_by": "port-catalog"},
+    } in svc.get("edges_out", [])
+
+
+def test_nmap_adapter_leaves_non_ai_ports_unclassified(tmp_path: Path) -> None:
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.8" addrtype="ipv4"/>
+            <ports>
+              <port portid="22" protocol="tcp"><state state="open"/><service name="ssh"/></port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_nmap_xml(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    assert not any(o["kind"] == "Technology" for o in obs)
+
+
 def test_nmap_adapter_skips_down_hosts(tmp_path: Path) -> None:
     f = tmp_path / "scan.xml"
     f.write_text(


### PR DESCRIPTION
## What & why

Implements the **AI port catalog with two-tier disambiguation** Tier-1
item from #593 — the second AI-attack-surface classifier on top of the
`Technology` node (ADR-0007, landed in #598).

Recon already saw the open port; it just could not *name* it. An exposed
Ollama instance on `11434` was ingested as a `Service` with
`service=unknown`, so the `llm-redteam` plugin — which can attack it —
never knew it was there. The nmap adapter now maps a recognized AI
default port to a typed `Technology` node the service `RUNS`, turning the
AI attack surface into queryable graph data the chain planner can route
on.

**Observable behavior change:** ingesting nmap XML with an AI port now
also writes a `Technology` node + `(Service)-[:RUNS]->(Technology)` edge.
**Anti-goal:** does not touch the httpx/header path or add a banner-regex
classifier (those are separate #593 PRs); port signal only.

## Changes

- `kg_internal/ai_surface.py` — `technology_for_port(port, source)` +
  a deliberately small, high-precision `_AI_PORT_CATALOG`.
  - **Tier 1 — dedicated** (`11434` → Ollama): first-class detection.
  - **Tier 2 — shared** (`7860` Gradio, `8265` Ray): flagged
    `guess=True` so a shared port can't anchor an exploit chain alone
    (ADR-0007 corroborating-only rule).
- `_adapt_nmap_xml` calls it per service: on a hit it appends the
  `Technology` observation and a `RUNS` edge on the owning `Service`.

## Testing

- `make ci-lint` — ruff + format clean, basedpyright **0 errors**.
- New unit tests (`test_ai_surface.py`) + two nmap-adapter integration
  tests: dedicated vs guess tiering, unknown ports unclassified, edge
  key matches node key, and ssh/other ports produce no Technology.
  Confirmed the integration test **fails** without the change and passes
  with it.

## End-to-end verification

Brought up `neo4j:5.24-community`, applied the real migrations (V001–V004
including the Technology constraint), then ran the **actual** ingest
pipeline against the live store with a real `httpx`-independent nmap XML
(`/tmp/httpx` was also fetched to verify the schema for the follow-up
header classifier, not used here):

```
apply_migrations -> [..., 'V004__technology_node']
ingest("nmap_xml", ...) -> hosts=1 services=2 records={created:4, edges:3}
Graph query  MATCH (s:Service)-[:RUNS]->(t:Technology):
  service::10.10.0.5:11434 -RUNS-> ai-runtime:ollama
     name=ollama category=ai-runtime detected_by=port-catalog guess=None
all Technology nodes: ['ai-runtime:ollama']   # ssh :22 produced none
```

So a scanned `11434` lands in Neo4j as a first-class, traversable
`Technology` and a non-AI port does not. Container torn down after.

Refs #593, ADR-0007
