### PR TITLE
feat(kg): classify AI inference endpoints into Technology nodes at httpx ingest

### DIFF
--- a/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
@@ -29,6 +29,7 @@ from typing import Any
 from decepticon_core.types.kg import TechnologyCategory, technology_key
 
 DETECTED_BY_PORT = "port-catalog"
+DETECTED_BY_PATH = "endpoint-path"
 
 # port -> (category, product, dedicated)
 _AI_PORT_CATALOG: dict[int, tuple[TechnologyCategory, str, bool]] = {
@@ -36,6 +37,45 @@ _AI_PORT_CATALOG: dict[int, tuple[TechnologyCategory, str, bool]] = {
     7860: (TechnologyCategory.AI_FRAMEWORK, "gradio", False),
     8265: (TechnologyCategory.AI_FRAMEWORK, "ray", False),
 }
+
+# Exact request paths that name an AI inference interface. Ollama's REST
+# routes are product-specific; the OpenAI-compatible routes are the
+# de-facto standard vLLM / LiteLLM / LocalAI / text-generation-webui all
+# expose, so they identify the *interface* even when the product is not
+# yet pinned. path -> (category, product, dedicated).
+_AI_PATH_CATALOG: dict[str, tuple[TechnologyCategory, str, bool]] = {
+    "/api/tags": (TechnologyCategory.AI_RUNTIME, "ollama", True),
+    "/api/version": (TechnologyCategory.AI_RUNTIME, "ollama", True),
+    "/api/generate": (TechnologyCategory.AI_RUNTIME, "ollama", True),
+    "/api/chat": (TechnologyCategory.AI_RUNTIME, "ollama", True),
+    "/v1/chat/completions": (TechnologyCategory.AI_RUNTIME, "openai-compatible-api", True),
+    "/v1/completions": (TechnologyCategory.AI_RUNTIME, "openai-compatible-api", True),
+    "/v1/embeddings": (TechnologyCategory.AI_RUNTIME, "openai-compatible-api", True),
+    "/v1/models": (TechnologyCategory.AI_RUNTIME, "openai-compatible-api", True),
+}
+
+# Path prefixes (sub-routed APIs).
+_AI_PATH_PREFIXES: tuple[tuple[str, TechnologyCategory, str, bool], ...] = (
+    ("/sdapi/v1", TechnologyCategory.AI_FRAMEWORK, "automatic1111", True),
+)
+
+
+def _classification(
+    category: TechnologyCategory, product: str, *, detected_by: str, source: str, dedicated: bool
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the ``(Technology node, RUNS edge)`` observation pair."""
+    key = technology_key(category, product)
+    props: dict[str, Any] = {
+        "name": product,
+        "category": category.value,
+        "detected_by": detected_by,
+        "source": source,
+    }
+    if not dedicated:
+        props["guess"] = True
+    node = {"kind": "Technology", "key": key, "label": product, "props": props}
+    edge = {"to_key": key, "kind": "RUNS", "props": {"detected_by": detected_by}}
+    return node, edge
 
 
 def technology_for_port(port: int, source: str) -> tuple[dict[str, Any], dict[str, Any]] | None:
@@ -50,15 +90,33 @@ def technology_for_port(port: int, source: str) -> tuple[dict[str, Any], dict[st
     if entry is None:
         return None
     category, product, dedicated = entry
-    key = technology_key(category, product)
-    props: dict[str, Any] = {
-        "name": product,
-        "category": category.value,
-        "detected_by": DETECTED_BY_PORT,
-        "source": source,
-    }
-    if not dedicated:
-        props["guess"] = True
-    node = {"kind": "Technology", "key": key, "label": product, "props": props}
-    edge = {"to_key": key, "kind": "RUNS", "props": {"detected_by": DETECTED_BY_PORT}}
-    return node, edge
+    return _classification(
+        category, product, detected_by=DETECTED_BY_PORT, source=source, dedicated=dedicated
+    )
+
+
+def technology_for_path(
+    path: str, status_code: int | None, source: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Classify a probed URL path as an AI inference interface.
+
+    A ``404`` means the path was probed and is absent, so it is never
+    classified; any other response (200/401/403/405 — auth or
+    method-not-allowed still prove the route exists) is eligible.
+    Returns the same ``(node, edge)`` pair shape as :func:`technology_for_port`.
+    """
+    if status_code == 404:
+        return None
+    normalized = path.split("?", 1)[0].rstrip("/").lower() or "/"
+    entry = _AI_PATH_CATALOG.get(normalized)
+    if entry is None:
+        for prefix, category, product, dedicated in _AI_PATH_PREFIXES:
+            if normalized.startswith(prefix):
+                entry = (category, product, dedicated)
+                break
+    if entry is None:
+        return None
+    category, product, dedicated = entry
+    return _classification(
+        category, product, detected_by=DETECTED_BY_PATH, source=source, dedicated=dedicated
+    )

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -28,7 +28,10 @@ from urllib.parse import urlparse
 
 import defusedxml.ElementTree as ET
 
-from decepticon.middleware.kg_internal.ai_surface import technology_for_port
+from decepticon.middleware.kg_internal.ai_surface import (
+    technology_for_path,
+    technology_for_port,
+)
 from decepticon.middleware.kg_internal.store import KGStore
 from decepticon_core.utils.logging import get_logger
 
@@ -382,6 +385,27 @@ def _adapt_httpx_jsonl(
         svc_key = f"service::{host_value}:{port_int}"
         ep_key = f"entrypoint::{url}"
 
+        service_obs: dict[str, Any] = {
+            "kind": "Service",
+            "key": svc_key,
+            "label": f"{host_value}:{port_int}/tcp",
+            "props": {
+                "port": port_int,
+                "scheme": scheme,
+                "status_code": status_code,
+                "source": "httpx",
+            },
+        }
+        # AI-surface: a probed AI inference route (Ollama /api/tags, the
+        # OpenAI-compatible /v1/* surface) becomes a typed Technology the
+        # service RUNS, so the llm-redteam plugin can find it (ADR-0007).
+        status_int = status_code if isinstance(status_code, int) else None
+        classified = technology_for_path(parsed_url.path, status_int, "httpx")
+        if classified is not None:
+            tech_node, runs_edge = classified
+            service_obs["edges_out"] = [runs_edge]
+            observations.append(tech_node)
+
         observations.extend(
             [
                 {
@@ -390,17 +414,7 @@ def _adapt_httpx_jsonl(
                     "label": host_value,
                     "props": {"hostname": host_value, "source": "httpx"},
                 },
-                {
-                    "kind": "Service",
-                    "key": svc_key,
-                    "label": f"{host_value}:{port_int}/tcp",
-                    "props": {
-                        "port": port_int,
-                        "scheme": scheme,
-                        "status_code": status_code,
-                        "source": "httpx",
-                    },
-                },
+                service_obs,
                 {
                     "kind": "Entrypoint",
                     "key": ep_key,

--- a/packages/decepticon/tests/unit/middleware/test_ai_surface.py
+++ b/packages/decepticon/tests/unit/middleware/test_ai_surface.py
@@ -1,14 +1,17 @@
-"""Unit tests for the AI-surface port classifier (ADR-0007).
+"""Unit tests for the AI-surface classifiers (ADR-0007).
 
-``technology_for_port`` turns a scanned port into a typed ``Technology``
-node + a ``RUNS`` edge the owning service carries, so the ``llm-redteam``
-plugin can find an exposed AI runtime recon already saw.
+``technology_for_port`` / ``technology_for_path`` turn a scanned port or a
+probed URL path into a typed ``Technology`` node + a ``RUNS`` edge the
+owning service carries, so the ``llm-redteam`` plugin can find an exposed
+AI runtime recon already saw.
 """
 
 from __future__ import annotations
 
 from decepticon.middleware.kg_internal.ai_surface import (
+    DETECTED_BY_PATH,
     DETECTED_BY_PORT,
+    technology_for_path,
     technology_for_port,
 )
 from decepticon_core.types.kg import TechnologyCategory, technology_key
@@ -51,3 +54,35 @@ def test_unknown_port_is_not_classified() -> None:
 def test_edge_to_key_matches_node_key() -> None:
     node, edge = technology_for_port(11434, "nmap")  # type: ignore[misc]
     assert edge["to_key"] == node["key"]
+
+
+def test_ollama_native_path_is_classified() -> None:
+    node, edge = technology_for_path("/api/tags", 200, "httpx")  # type: ignore[misc]
+    assert node["key"] == "ai-runtime:ollama"
+    assert node["props"]["detected_by"] == DETECTED_BY_PATH
+    assert edge["to_key"] == "ai-runtime:ollama"
+
+
+def test_openai_compatible_path_is_classified() -> None:
+    node, _ = technology_for_path("/v1/chat/completions", 405, "httpx")  # type: ignore[misc]
+    # 405 (GET on a POST-only route) still proves the endpoint exists.
+    assert node["key"] == "ai-runtime:openai-compatible-api"
+
+
+def test_path_prefix_match_for_subrouted_api() -> None:
+    node, _ = technology_for_path("/sdapi/v1/txt2img", 200, "httpx")  # type: ignore[misc]
+    assert node["key"] == "ai-framework:automatic1111"
+
+
+def test_path_with_trailing_slash_and_query_normalizes() -> None:
+    assert technology_for_path("/api/tags/?pretty=1", 200, "httpx") is not None
+
+
+def test_404_path_is_not_classified() -> None:
+    # The route was probed and is absent — not a detection.
+    assert technology_for_path("/v1/chat/completions", 404, "httpx") is None
+
+
+def test_non_ai_path_is_not_classified() -> None:
+    assert technology_for_path("/", 200, "httpx") is None
+    assert technology_for_path("/admin/login", 200, "httpx") is None

--- a/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
@@ -368,6 +368,45 @@ def test_httpx_adapter_extracts_host_service_entrypoint(tmp_path: Path) -> None:
     assert "Entrypoint" in kinds
 
 
+def test_httpx_adapter_classifies_ai_endpoint_path(tmp_path: Path) -> None:
+    f = tmp_path / "httpx.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "url": "http://10.0.0.5:11434/api/tags",
+                "host": "10.0.0.5",
+                "port": 11434,
+                "status-code": 200,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_httpx_jsonl(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    tech = next(o for o in obs if o["kind"] == "Technology")
+    assert tech["key"] == "ai-runtime:ollama"
+    assert tech["props"]["detected_by"] == "endpoint-path"
+    svc = next(o for o in obs if o["kind"] == "Service")
+    assert any(e["to_key"] == "ai-runtime:ollama" and e["kind"] == "RUNS" for e in svc["edges_out"])
+
+
+def test_httpx_adapter_ignores_404_and_non_ai_paths(tmp_path: Path) -> None:
+    f = tmp_path / "httpx.jsonl"
+    f.write_text(
+        json.dumps({"url": "http://h:8080/v1/chat/completions", "host": "h", "status-code": 404})
+        + "\n"
+        + json.dumps({"url": "http://h:8080/", "host": "h", "status-code": 200})
+        + "\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_httpx_jsonl(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    assert not any(o["kind"] == "Technology" for o in obs)
+
+
 def test_httpx_adapter_skips_rows_without_url(tmp_path: Path) -> None:
     f = tmp_path / "httpx.jsonl"
     f.write_text(json.dumps({"status-code": 200}) + "\n", encoding="utf-8")


### PR DESCRIPTION
## What & why

Implements the **Endpoint AI interface-type classifier** Tier-1 item from
#593, extending the AI-surface detection from ports (#600) to the
application layer.

Recon walks a host and finds `/api/tags` or `/v1/chat/completions`, but
those landed only as `Entrypoint` URLs — the `llm-redteam` plugin had no
typed signal that an inference API was sitting there. The httpx adapter
now maps a probed AI route to a `Technology` node the service `RUNS`
(ADR-0007), so the inference surface becomes queryable graph data.

**Observable behavior change:** ingesting httpx JSONL whose URL path is a
known AI route now also writes a `Technology` node +
`(Service)-[:RUNS]->(Technology)`. **Anti-goal:** does not add header or
title signature matching (separate #593 PRs); request-path only.

## Changes

- `ai_surface.py` — `technology_for_path(path, status_code, source)` + a
  small documented catalog. Ollama's REST routes (`/api/tags`,
  `/api/generate`, `/api/chat`, `/api/version`) are product-specific; the
  OpenAI-compatible routes (`/v1/chat/completions`, `/v1/completions`,
  `/v1/embeddings`, `/v1/models`) identify the de-facto-standard
  interface; `/sdapi/v1` → Automatic1111. A shared `_classification`
  helper now backs both the port and path classifiers.
- A **404 gate**: a probed-but-absent route is never classified;
  200/401/403/405 (auth or method-not-allowed still prove the route
  exists) are eligible. Path is normalized (query + trailing slash
  stripped, lowercased).
- `_adapt_httpx_jsonl` calls it per row and attaches the `RUNS` edge to
  the owning `Service`.

## Testing

- `make ci-lint` — ruff + format clean, basedpyright **0 errors**.
- New unit tests (`test_ai_surface.py`) + two httpx-adapter integration
  tests: Ollama/OpenAI/Automatic1111 routes, 405-still-counts,
  404-ignored, root/non-AI ignored, query+slash normalization.
  Confirmed the integration test **fails** without the change and passes
  with it.

## End-to-end verification

`neo4j:5.24-community` up, real migrations applied, then the **actual**
`ingest("httpx_jsonl", ...)` pipeline against the live store with a JSONL
of four discovered URLs:

```
/api/tags            (200) -> service::10.0.0.9:11434 -RUNS-> ai-runtime:ollama
/v1/chat/completions (405) -> service::10.0.0.9:8000  -RUNS-> ai-runtime:openai-compatible-api
/v1/embeddings       (404) -> ignored (absent)
/                    (200) -> ignored (non-AI)
all Technology nodes: ['ai-runtime:ollama', 'ai-runtime:openai-compatible-api']
```

detected_by=endpoint-path on both. Container torn down after.

Refs #593, ADR-0007
