### PR TITLE
feat(kg): classify AI web-UI page titles into Technology nodes at httpx ingest

### DIFF
--- a/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
@@ -30,6 +30,19 @@ from decepticon_core.types.kg import TechnologyCategory, technology_key
 
 DETECTED_BY_PORT = "port-catalog"
 DETECTED_BY_PATH = "endpoint-path"
+DETECTED_BY_TITLE = "frontend-title"
+
+# Distinctive HTML <title> substrings of AI web front-ends. A page title
+# is operator-controllable, so every title hit is recorded guess=True
+# (corroborating-only, ADR-0007) — it flags a likely AI UI for the
+# header/port passes to confirm, never anchors an exploit chain alone.
+# lowercase-substring -> (category, product).
+_AI_TITLE_CATALOG: tuple[tuple[str, TechnologyCategory, str], ...] = (
+    ("comfyui", TechnologyCategory.AI_FRAMEWORK, "comfyui"),
+    ("open webui", TechnologyCategory.AI_FRAMEWORK, "open-webui"),
+    ("text generation web ui", TechnologyCategory.AI_FRAMEWORK, "text-generation-webui"),
+    ("stable diffusion", TechnologyCategory.AI_FRAMEWORK, "stable-diffusion"),
+)
 
 # port -> (category, product, dedicated)
 _AI_PORT_CATALOG: dict[int, tuple[TechnologyCategory, str, bool]] = {
@@ -120,3 +133,23 @@ def technology_for_path(
     return _classification(
         category, product, detected_by=DETECTED_BY_PATH, source=source, dedicated=dedicated
     )
+
+
+def technology_for_title(
+    title: str | None, source: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Classify an HTML page title as a likely AI web front-end.
+
+    Always corroborating-only (``guess=True``): a title is operator
+    controllable, so it flags an AI UI for a confirming pass, never
+    anchors a chain. Returns ``None`` for an empty or unrecognized title.
+    """
+    if not title:
+        return None
+    normalized = title.strip().lower()
+    for needle, category, product in _AI_TITLE_CATALOG:
+        if needle in normalized:
+            return _classification(
+                category, product, detected_by=DETECTED_BY_TITLE, source=source, dedicated=False
+            )
+    return None

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -31,6 +31,7 @@ import defusedxml.ElementTree as ET
 from decepticon.middleware.kg_internal.ai_surface import (
     technology_for_path,
     technology_for_port,
+    technology_for_title,
 )
 from decepticon.middleware.kg_internal.store import KGStore
 from decepticon_core.utils.logging import get_logger
@@ -397,14 +398,21 @@ def _adapt_httpx_jsonl(
             },
         }
         # AI-surface: a probed AI inference route (Ollama /api/tags, the
-        # OpenAI-compatible /v1/* surface) becomes a typed Technology the
-        # service RUNS, so the llm-redteam plugin can find it (ADR-0007).
+        # OpenAI-compatible /v1/* surface) or a recognized AI web-UI title
+        # becomes a typed Technology the service RUNS, so the llm-redteam
+        # plugin can find it (ADR-0007).
         status_int = status_code if isinstance(status_code, int) else None
-        classified = technology_for_path(parsed_url.path, status_int, "httpx")
-        if classified is not None:
-            tech_node, runs_edge = classified
-            service_obs["edges_out"] = [runs_edge]
-            observations.append(tech_node)
+        ai_edges: list[dict[str, Any]] = []
+        for classified in (
+            technology_for_path(parsed_url.path, status_int, "httpx"),
+            technology_for_title(row.get("title"), "httpx"),
+        ):
+            if classified is not None:
+                tech_node, runs_edge = classified
+                observations.append(tech_node)
+                ai_edges.append(runs_edge)
+        if ai_edges:
+            service_obs["edges_out"] = ai_edges
 
         observations.extend(
             [

--- a/packages/decepticon/tests/unit/middleware/test_ai_surface.py
+++ b/packages/decepticon/tests/unit/middleware/test_ai_surface.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 from decepticon.middleware.kg_internal.ai_surface import (
     DETECTED_BY_PATH,
     DETECTED_BY_PORT,
+    DETECTED_BY_TITLE,
     technology_for_path,
     technology_for_port,
+    technology_for_title,
 )
 from decepticon_core.types.kg import TechnologyCategory, technology_key
 
@@ -86,3 +88,23 @@ def test_404_path_is_not_classified() -> None:
 def test_non_ai_path_is_not_classified() -> None:
     assert technology_for_path("/", 200, "httpx") is None
     assert technology_for_path("/admin/login", 200, "httpx") is None
+
+
+def test_ai_ui_title_is_corroborating_guess() -> None:
+    node, edge = technology_for_title("ComfyUI", "httpx")  # type: ignore[misc]
+    assert node["key"] == "ai-framework:comfyui"
+    assert node["props"]["detected_by"] == DETECTED_BY_TITLE
+    # A title is operator-controllable -> always guess-only (ADR-0007).
+    assert node["props"]["guess"] is True
+    assert edge["to_key"] == "ai-framework:comfyui"
+
+
+def test_ai_ui_title_matches_substring_case_insensitively() -> None:
+    node, _ = technology_for_title("My Open WebUI - chat", "httpx")  # type: ignore[misc]
+    assert node["key"] == "ai-framework:open-webui"
+
+
+def test_empty_or_unknown_title_is_not_classified() -> None:
+    assert technology_for_title(None, "httpx") is None
+    assert technology_for_title("", "httpx") is None
+    assert technology_for_title("Welcome to nginx!", "httpx") is None

--- a/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
@@ -392,6 +392,31 @@ def test_httpx_adapter_classifies_ai_endpoint_path(tmp_path: Path) -> None:
     assert any(e["to_key"] == "ai-runtime:ollama" and e["kind"] == "RUNS" for e in svc["edges_out"])
 
 
+def test_httpx_adapter_classifies_ai_ui_title(tmp_path: Path) -> None:
+    f = tmp_path / "httpx.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "url": "http://10.0.0.6:8188/",
+                "host": "10.0.0.6",
+                "port": 8188,
+                "status-code": 200,
+                "title": "ComfyUI",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_httpx_jsonl(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    tech = next(o for o in obs if o["kind"] == "Technology")
+    assert tech["key"] == "ai-framework:comfyui"
+    assert tech["props"]["guess"] is True
+    svc = next(o for o in obs if o["kind"] == "Service")
+    assert any(e["to_key"] == "ai-framework:comfyui" for e in svc["edges_out"])
+
+
 def test_httpx_adapter_ignores_404_and_non_ai_paths(tmp_path: Path) -> None:
     f = tmp_path / "httpx.jsonl"
     f.write_text(


### PR DESCRIPTION
## What & why

Implements the **AI frontend title-regex** half of the
"title-regex + banner-regex" Tier-1 item in #593 (the nmap-banner-regex
is a separate follow-up). It extends the AI-surface classifier
(`ai_surface.py`) from ports (#600) and API paths (#601) to the
presentation layer.

The endpoint-path pass finds inference *APIs* (which serve JSON). The AI
*web UIs* — ComfyUI, Open WebUI, text-generation-webui, the Stable
Diffusion web UI — serve HTML with a distinctive `<title>`, so they slip
past it. This pass reads the httpx `title` field and records a matching
UI as a `Technology` the service `RUNS` (ADR-0007).

**Observable behavior change:** ingesting httpx JSONL whose `title`
matches a known AI UI now also writes a `Technology` node + `RUNS` edge.
**Anti-goal:** no header matching and no nmap banner regex here.

## Changes

- `ai_surface.py` — `technology_for_title(title, source)` + a small
  documented `_AI_TITLE_CATALOG` of distinctive lowercase substrings.
- **Every title hit is `guess=True`** — a page title is
  operator-controllable, so per ADR-0007 it is corroborating-only: it
  flags a likely AI UI for the port/endpoint passes to confirm and can
  never anchor an exploit chain alone. This neutralizes the
  false-positive risk of an arbitrary "...Stable Diffusion..." title.
- `_adapt_httpx_jsonl` now collects path **and** title classifications
  into the service's `edges_out`.

## Testing

- `make ci-lint` — ruff + format clean, basedpyright **0 errors**.
- New unit tests + an httpx-adapter integration test: ComfyUI/Open WebUI
  matches, case-insensitive substring, empty/unknown title ignored,
  `guess=True` enforced. Confirmed the integration test **fails** without
  the change and passes with it.

## End-to-end verification

`neo4j:5.24-community` up, real migrations applied, then the **actual**
`ingest("httpx_jsonl", ...)` pipeline against the live store:

```
title "ComfyUI"        -> service::10.0.0.6:8188 -RUNS-> ai-framework:comfyui    guess=True
title "My Open WebUI"  -> service::10.0.0.6:7860 -RUNS-> ai-framework:open-webui guess=True
title "Welcome to nginx!" -> ignored
all Technology nodes: ['ai-framework:comfyui', 'ai-framework:open-webui']
```

detected_by=frontend-title on both. Container torn down after.

Refs #593, ADR-0007
