### PR TITLE
feat(kg): classify AI-runtime service banners into Technology nodes at nmap ingest

### DIFF
--- a/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
@@ -24,6 +24,7 @@ recall.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from decepticon_core.types.kg import TechnologyCategory, technology_key
@@ -31,6 +32,22 @@ from decepticon_core.types.kg import TechnologyCategory, technology_key
 DETECTED_BY_PORT = "port-catalog"
 DETECTED_BY_PATH = "endpoint-path"
 DETECTED_BY_TITLE = "frontend-title"
+DETECTED_BY_BANNER = "nmap-banner"
+
+# Word-boundary banner markers naming an AI runtime/proxy/framework in a
+# service-fingerprint string (nmap product/version/name). A banner that
+# names the product is strong evidence, so these are first-class (not
+# guesses) — and they catch a runtime on a non-catalog port. Matched as
+# whole tokens so "ollama" does not fire on "follama". marker ->
+# (category, product).
+_AI_BANNER_CATALOG: tuple[tuple[str, TechnologyCategory, str], ...] = (
+    ("ollama", TechnologyCategory.AI_RUNTIME, "ollama"),
+    ("vllm", TechnologyCategory.AI_RUNTIME, "vllm"),
+    ("text-generation-inference", TechnologyCategory.AI_RUNTIME, "text-generation-inference"),
+    ("llama.cpp", TechnologyCategory.AI_RUNTIME, "llama.cpp"),
+    ("litellm", TechnologyCategory.AI_PROXY, "litellm"),
+    ("mlflow", TechnologyCategory.AI_FRAMEWORK, "mlflow"),
+)
 
 # Distinctive HTML <title> substrings of AI web front-ends. A page title
 # is operator-controllable, so every title hit is recorded guess=True
@@ -151,5 +168,26 @@ def technology_for_title(
         if needle in normalized:
             return _classification(
                 category, product, detected_by=DETECTED_BY_TITLE, source=source, dedicated=False
+            )
+    return None
+
+
+def technology_for_banner(
+    banner: str | None, source: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Classify a service-fingerprint banner that names an AI runtime.
+
+    A banner naming the product (nmap ``product``/``version``/``name``) is
+    strong evidence, so hits are first-class — and they catch a runtime on
+    a non-catalog port. Matched on token boundaries so ``ollama`` does not
+    fire inside ``follama``. Returns ``None`` for an empty/unmatched banner.
+    """
+    if not banner:
+        return None
+    normalized = banner.strip().lower()
+    for marker, category, product in _AI_BANNER_CATALOG:
+        if re.search(rf"(?<![a-z0-9]){re.escape(marker)}(?![a-z0-9])", normalized):
+            return _classification(
+                category, product, detected_by=DETECTED_BY_BANNER, source=source, dedicated=True
             )
     return None

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse
 import defusedxml.ElementTree as ET
 
 from decepticon.middleware.kg_internal.ai_surface import (
+    technology_for_banner,
     technology_for_path,
     technology_for_port,
     technology_for_title,
@@ -190,13 +191,24 @@ def _adapt_nmap_xml(
                     "source": "nmap",
                 },
             }
-            # AI-surface: a recognized AI port becomes a typed Technology node
-            # the service RUNS, so the llm-redteam plugin can find it (ADR-0007).
-            classified = technology_for_port(port, "nmap")
-            if classified is not None:
-                tech_node, runs_edge = classified
-                service_obs["edges_out"] = [runs_edge]
-                observations.append(tech_node)
+            # AI-surface: a recognized AI port or a service banner naming an
+            # AI runtime becomes a typed Technology the service RUNS, so the
+            # llm-redteam plugin can find it (ADR-0007). Deduped by tech key
+            # so a port+banner double-hit lands one node.
+            banner = " ".join(p for p in (product, version, svc_name) if p)
+            ai_nodes: dict[str, dict[str, Any]] = {}
+            ai_edges: dict[str, dict[str, Any]] = {}
+            for classified in (
+                technology_for_port(port, "nmap"),
+                technology_for_banner(banner, "nmap"),
+            ):
+                if classified is not None:
+                    tech_node, runs_edge = classified
+                    ai_nodes.setdefault(tech_node["key"], tech_node)
+                    ai_edges.setdefault(runs_edge["to_key"], runs_edge)
+            if ai_edges:
+                service_obs["edges_out"] = list(ai_edges.values())
+                observations.extend(ai_nodes.values())
             observations.append(service_obs)
             services_count += 1
 

--- a/packages/decepticon/tests/unit/middleware/test_ai_surface.py
+++ b/packages/decepticon/tests/unit/middleware/test_ai_surface.py
@@ -9,9 +9,11 @@ AI runtime recon already saw.
 from __future__ import annotations
 
 from decepticon.middleware.kg_internal.ai_surface import (
+    DETECTED_BY_BANNER,
     DETECTED_BY_PATH,
     DETECTED_BY_PORT,
     DETECTED_BY_TITLE,
+    technology_for_banner,
     technology_for_path,
     technology_for_port,
     technology_for_title,
@@ -108,3 +110,30 @@ def test_empty_or_unknown_title_is_not_classified() -> None:
     assert technology_for_title(None, "httpx") is None
     assert technology_for_title("", "httpx") is None
     assert technology_for_title("Welcome to nginx!", "httpx") is None
+
+
+def test_banner_naming_runtime_is_confident() -> None:
+    node, edge = technology_for_banner("Ollama 0.1.32", "nmap")  # type: ignore[misc]
+    assert node["key"] == "ai-runtime:ollama"
+    assert node["props"]["detected_by"] == DETECTED_BY_BANNER
+    # A banner naming the product is strong evidence — not a guess.
+    assert "guess" not in node["props"]
+    assert edge["to_key"] == "ai-runtime:ollama"
+
+
+def test_banner_proxy_category() -> None:
+    node, _ = technology_for_banner("LiteLLM proxy", "nmap")  # type: ignore[misc]
+    assert node["key"] == "ai-proxy:litellm"
+
+
+def test_banner_matches_on_token_boundary_only() -> None:
+    # "ollama" must not fire inside an unrelated token.
+    assert technology_for_banner("follamatic 1.0", "nmap") is None
+    # but punctuation-delimited is a real hit.
+    assert technology_for_banner("server: ollama/0.1", "nmap") is not None
+
+
+def test_empty_or_unmatched_banner_is_not_classified() -> None:
+    assert technology_for_banner(None, "nmap") is None
+    assert technology_for_banner("", "nmap") is None
+    assert technology_for_banner("nginx 1.18", "nmap") is None

--- a/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
@@ -243,6 +243,64 @@ def test_nmap_adapter_classifies_ai_port_as_technology(tmp_path: Path) -> None:
     } in svc.get("edges_out", [])
 
 
+def test_nmap_adapter_classifies_ai_runtime_banner_on_nonstandard_port(tmp_path: Path) -> None:
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.9" addrtype="ipv4"/>
+            <ports>
+              <port portid="8000" protocol="tcp">
+                <state state="open"/>
+                <service name="http" product="vLLM" version="0.6.3"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_nmap_xml(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    tech = next(o for o in obs if o["kind"] == "Technology")
+    assert tech["key"] == "ai-runtime:vllm"
+    assert tech["props"]["detected_by"] == "nmap-banner"
+
+
+def test_nmap_adapter_dedups_port_and_banner_double_hit(tmp_path: Path) -> None:
+    # 11434 (port catalog) AND product "Ollama" (banner) both say Ollama;
+    # the service must end up with exactly one Technology node + RUNS edge.
+    f = tmp_path / "scan.xml"
+    f.write_text(
+        """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <status state="up"/>
+            <address addr="10.0.0.10" addrtype="ipv4"/>
+            <ports>
+              <port portid="11434" protocol="tcp">
+                <state state="open"/>
+                <service name="http" product="Ollama"/>
+              </port>
+            </ports>
+          </host>
+        </nmaprun>
+        """,
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_nmap_xml(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    techs = [o for o in obs if o["kind"] == "Technology"]
+    assert len(techs) == 1
+    assert techs[0]["key"] == "ai-runtime:ollama"
+    svc = next(o for o in obs if o["kind"] == "Service")
+    assert len(svc["edges_out"]) == 1
+
+
 def test_nmap_adapter_leaves_non_ai_ports_unclassified(tmp_path: Path) -> None:
     f = tmp_path / "scan.xml"
     f.write_text(


### PR DESCRIPTION
## What & why

Implements the **nmap AI-runtime banner regex** — the second half of the
"title-regex + banner-regex" Tier-1 item in #593 (#602 did the title
half) — completing the nmap-side AI-attack-surface detection alongside
the port catalog (#600).

The port catalog finds a runtime by its *default* port. But an operator
who moved Ollama to `:8000`, or a vLLM server on an arbitrary port, is
invisible to it. When `nmap -sV` fingerprints the service and names the
product, that banner is strong evidence — so this pass reads the nmap
`product`/`version`/`name` and records a matching runtime as a
`Technology` the service `RUNS` (ADR-0007).

**Observable behavior change:** an nmap service whose banner names an AI
runtime now also writes a `Technology` node + `RUNS` edge, even on a
non-catalog port. **Anti-goal:** no HTTP-header matching (separate item).

## Changes

- `ai_surface.py` — `technology_for_banner(banner, source)` + a small
  `_AI_BANNER_CATALOG` (Ollama, vLLM, text-generation-inference,
  llama.cpp, LiteLLM→ai-proxy, MLflow→ai-framework). A banner naming the
  product is high-confidence, so hits are **first-class (not guesses)**.
- Token-boundary match (`(?<![a-z0-9])marker(?![a-z0-9])`) so `ollama`
  does not fire inside `follama` but does on `ollama/0.1`.
- `_adapt_nmap_xml` now runs port **and** banner classification and
  **dedups by tech key**, so a port+banner double-hit (`:11434` +
  product `Ollama`) lands exactly one node and one `RUNS` edge.

## Testing

- `make ci-lint` — ruff + format clean, basedpyright **0 errors**.
- New unit tests + two nmap integration tests (banner on a non-standard
  port; port+banner dedup). Token-boundary, proxy-category, and
  empty/unmatched cases covered. Confirmed the banner integration test
  **fails** without the change and passes with it.

## End-to-end verification

`neo4j:5.24-community` up, real migrations, then the **actual**
`ingest("nmap_xml", ...)` pipeline against the live store:

```
:8000  product "vLLM 0.6.3"          -> service::10.0.0.9:8000  -RUNS-> ai-runtime:vllm   (nmap-banner)
:11434 product "Ollama" (port+banner) -> service::10.0.0.9:11434 -RUNS-> ai-runtime:ollama (port-catalog)
ai-runtime:ollama node count = 1   # double-hit deduped to one node
all Technology nodes: ['ai-runtime:ollama', 'ai-runtime:vllm']
```

Container torn down after.

Refs #593, ADR-0007
