### PR TITLE
feat(kg): classify AI response-header signatures into Technology nodes at httpx ingest

### DIFF
--- a/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ai_surface.py
@@ -33,6 +33,21 @@ DETECTED_BY_PORT = "port-catalog"
 DETECTED_BY_PATH = "endpoint-path"
 DETECTED_BY_TITLE = "frontend-title"
 DETECTED_BY_BANNER = "nmap-banner"
+DETECTED_BY_HEADER = "http-header"
+
+# Distinctive HTTP *response-header* name markers (matched against httpx's
+# normalized header keys, e.g. ``x-litellm-version`` -> ``x_litellm_version``).
+# These are the vendor-documented headers each product emits — LiteLLM's
+# ``x-litellm-*`` proxy headers and text-generation-inference's
+# ``x-compute-*`` / ``x-prompt-tokens`` telemetry. A header can be added by
+# a fronting proxy, so every hit is corroborating-only (guess=True): it
+# flags a likely AI backend for the port/banner passes to confirm.
+# key-substring (normalized) -> (category, product).
+_AI_HEADER_CATALOG: tuple[tuple[str, TechnologyCategory, str], ...] = (
+    ("litellm", TechnologyCategory.AI_PROXY, "litellm"),
+    ("x_compute_type", TechnologyCategory.AI_RUNTIME, "text-generation-inference"),
+    ("x_prompt_tokens", TechnologyCategory.AI_RUNTIME, "text-generation-inference"),
+)
 
 # Word-boundary banner markers naming an AI runtime/proxy/framework in a
 # service-fingerprint string (nmap product/version/name). A banner that
@@ -189,5 +204,27 @@ def technology_for_banner(
         if re.search(rf"(?<![a-z0-9]){re.escape(marker)}(?![a-z0-9])", normalized):
             return _classification(
                 category, product, detected_by=DETECTED_BY_BANNER, source=source, dedicated=True
+            )
+    return None
+
+
+def technology_for_headers(
+    headers: dict[str, Any] | None, source: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Classify a response-header set that carries an AI product's headers.
+
+    Always corroborating-only (``guess=True``): a header can be injected by
+    a fronting proxy, so a hit flags a likely AI backend for the
+    port/banner passes to confirm, never anchors a chain. ``headers`` is
+    httpx's normalized name->value map; matching is on header *names*.
+    Returns ``None`` for empty headers or no match.
+    """
+    if not isinstance(headers, dict) or not headers:
+        return None
+    keys = [str(k).lower() for k in headers]
+    for marker, category, product in _AI_HEADER_CATALOG:
+        if any(marker in key for key in keys):
+            return _classification(
+                category, product, detected_by=DETECTED_BY_HEADER, source=source, dedicated=False
             )
     return None

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -30,6 +30,7 @@ import defusedxml.ElementTree as ET
 
 from decepticon.middleware.kg_internal.ai_surface import (
     technology_for_banner,
+    technology_for_headers,
     technology_for_path,
     technology_for_port,
     technology_for_title,
@@ -410,21 +411,25 @@ def _adapt_httpx_jsonl(
             },
         }
         # AI-surface: a probed AI inference route (Ollama /api/tags, the
-        # OpenAI-compatible /v1/* surface) or a recognized AI web-UI title
-        # becomes a typed Technology the service RUNS, so the llm-redteam
-        # plugin can find it (ADR-0007).
+        # OpenAI-compatible /v1/* surface), a recognized AI web-UI title, or
+        # an AI product's response headers becomes a typed Technology the
+        # service RUNS, so the llm-redteam plugin can find it (ADR-0007).
+        # Deduped by tech key so multiple signals for one product land one node.
         status_int = status_code if isinstance(status_code, int) else None
-        ai_edges: list[dict[str, Any]] = []
+        ai_nodes: dict[str, dict[str, Any]] = {}
+        ai_edges: dict[str, dict[str, Any]] = {}
         for classified in (
             technology_for_path(parsed_url.path, status_int, "httpx"),
             technology_for_title(row.get("title"), "httpx"),
+            technology_for_headers(row.get("header"), "httpx"),
         ):
             if classified is not None:
                 tech_node, runs_edge = classified
-                observations.append(tech_node)
-                ai_edges.append(runs_edge)
+                ai_nodes.setdefault(tech_node["key"], tech_node)
+                ai_edges.setdefault(runs_edge["to_key"], runs_edge)
         if ai_edges:
-            service_obs["edges_out"] = ai_edges
+            service_obs["edges_out"] = list(ai_edges.values())
+            observations.extend(ai_nodes.values())
 
         observations.extend(
             [

--- a/packages/decepticon/tests/unit/middleware/test_ai_surface.py
+++ b/packages/decepticon/tests/unit/middleware/test_ai_surface.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 from decepticon.middleware.kg_internal.ai_surface import (
     DETECTED_BY_BANNER,
+    DETECTED_BY_HEADER,
     DETECTED_BY_PATH,
     DETECTED_BY_PORT,
     DETECTED_BY_TITLE,
     technology_for_banner,
+    technology_for_headers,
     technology_for_path,
     technology_for_port,
     technology_for_title,
@@ -137,3 +139,32 @@ def test_empty_or_unmatched_banner_is_not_classified() -> None:
     assert technology_for_banner(None, "nmap") is None
     assert technology_for_banner("", "nmap") is None
     assert technology_for_banner("nginx 1.18", "nmap") is None
+
+
+def test_litellm_proxy_header_is_corroborating_guess() -> None:
+    headers = {
+        "server": "uvicorn",
+        "x_litellm_version": "1.40.0",
+        "content_type": "application/json",
+    }
+    node, edge = technology_for_headers(headers, "httpx")  # type: ignore[misc]
+    assert node["key"] == "ai-proxy:litellm"
+    assert node["props"]["detected_by"] == DETECTED_BY_HEADER
+    # A header is proxy-injectable -> guess-only (ADR-0007).
+    assert node["props"]["guess"] is True
+    assert edge["to_key"] == "ai-proxy:litellm"
+
+
+def test_tgi_compute_header_is_classified() -> None:
+    node, _ = technology_for_headers({"x_compute_type": "gpu", "x_prompt_tokens": "12"}, "httpx")  # type: ignore[misc]
+    assert node["key"] == "ai-runtime:text-generation-inference"
+
+
+def test_headers_without_ai_marker_are_not_classified() -> None:
+    assert technology_for_headers({"server": "nginx", "content_type": "text/html"}, "httpx") is None
+
+
+def test_empty_or_non_dict_headers_are_not_classified() -> None:
+    assert technology_for_headers(None, "httpx") is None
+    assert technology_for_headers({}, "httpx") is None
+    assert technology_for_headers("server: nginx", "httpx") is None  # type: ignore[arg-type]

--- a/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_ingest_unit.py
@@ -475,6 +475,31 @@ def test_httpx_adapter_classifies_ai_ui_title(tmp_path: Path) -> None:
     assert any(e["to_key"] == "ai-framework:comfyui" for e in svc["edges_out"])
 
 
+def test_httpx_adapter_classifies_ai_response_header(tmp_path: Path) -> None:
+    f = tmp_path / "httpx.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "url": "http://10.0.0.7:4000/",
+                "host": "10.0.0.7",
+                "port": 4000,
+                "status-code": 200,
+                "header": {"server": "uvicorn", "x_litellm_version": "1.40.0"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+    _adapt_httpx_jsonl(f, store, "acme", "recon", "ep-1")  # type: ignore[arg-type]
+    obs = store.calls[0]["observations"]
+    tech = next(o for o in obs if o["kind"] == "Technology")
+    assert tech["key"] == "ai-proxy:litellm"
+    assert tech["props"]["detected_by"] == "http-header"
+    svc = next(o for o in obs if o["kind"] == "Service")
+    assert any(e["to_key"] == "ai-proxy:litellm" for e in svc["edges_out"])
+
+
 def test_httpx_adapter_ignores_404_and_non_ai_paths(tmp_path: Path) -> None:
     f = tmp_path / "httpx.jsonl"
     f.write_text(


### PR DESCRIPTION
## What & why

Implements the **HTTP-header AI-stack signature matcher** Tier-1 item from
#593 — the last AI-attack-surface classifier, completing the set
(port #600, path #601, title #602, banner #603, header here).

Port/path/title/banner all need the AI service to be directly visible.
When it sits **behind a reverse proxy**, those are masked — but a backend
response header often leaks through. This pass reads httpx's response
headers and flags a recognized AI product as a `Technology` the service
`RUNS` (ADR-0007).

**Observable behavior change:** an httpx row whose response headers carry
an AI product's marker now also writes a `Technology` node + `RUNS` edge.
**Anti-goal:** no new egress, no banner/title changes.

## Changes

- `ai_surface.py` — `technology_for_headers(headers, source)` + a small
  `_AI_HEADER_CATALOG` of **vendor-documented** distinctive header names:
  LiteLLM's `x-litellm-*` proxy headers → `ai-proxy:litellm`;
  text-generation-inference's `x-compute-type` / `x-prompt-tokens`
  telemetry → `ai-runtime:text-generation-inference`.
- **Every header hit is `guess=True`** — a header is proxy-injectable, so
  per ADR-0007 it is corroborating-only and cannot anchor a chain alone.
- `_adapt_httpx_jsonl` now dedups path + title + header signals by tech
  key into the service's `edges_out`.

## Testing

- `make ci-lint` — ruff + format clean, basedpyright **0 errors**.
- New unit tests + an httpx integration test: LiteLLM/TGI header matches,
  non-AI headers ignored, empty/non-dict guarded, `guess=True` enforced.
  Confirmed the integration test **fails** without the change and passes
  with it.

## End-to-end verification

This one I verified against **real httpx output**, not just a crafted
fixture:

1. Stood up a mock emitting `X-LiteLLM-Version` / `X-LiteLLM-Model-Id`
   and ran the real `httpx -json -include-response-header` against it.
   httpx normalized them to `x_litellm_version` / `x_litellm_model_id`
   — exactly the keys the matcher expects (confirming the schema
   assumption end-to-end).
2. Fed that **real header shape** through the actual
   `ingest("httpx_jsonl", ...)` pipeline into a live `neo4j:5.24`:

```
header {server:uvicorn, x_litellm_version, x_litellm_model_id} ->
   service::10.0.0.7:4000 -RUNS-> ai-proxy:litellm  (http-header, guess=True)
header {server:nginx} -> ignored
all Technology nodes: ['ai-proxy:litellm']
```

The TGI `x-compute-*` signatures are vendor-documented and run through
the identical (verified) code path; I did not stand up a live TGI server.
Containers torn down after.

Refs #593, ADR-0007
