### PR TITLE
docs(adr): revise ADR-0006 §1' — host-binary opscontrol daemon over Unix socket

### DIFF
--- a/docs/adr/0006-agent-driven-container-lifecycle.md
+++ b/docs/adr/0006-agent-driven-container-lifecycle.md
@@ -1,9 +1,9 @@
 # 0006. Agent-driven domain-tool container lifecycle via an ops-control sidecar
 
-- **Status:** Proposed
-- **Date:** 2026-06-05
+- **Status:** Proposed (revised 2026-06-06)
+- **Date:** 2026-06-05 (original) / 2026-06-06 (revision — see §1' and §6)
 - **Deciders:** @PurpleCHOIms
-- **Related:** [ADR-0005](0005-bloodhound-via-bhce-rest-client.md) (BHCE introduced as a sidecar, currently always-on); CLAUDE.md invariants on Bash-as-single-execution-surface and sandbox/management isolation
+- **Related:** [ADR-0001](0001-record-architecture-decisions.md) (cites the "Docker-socket-exec sandbox → HTTP-daemon sandbox" pivot whose reasoning §1' inherits); [ADR-0005](0005-bloodhound-via-bhce-rest-client.md) (BHCE introduced as a sidecar, currently always-on); PR #236 + PR #263 (precedent for retiring docker-socket bind in favor of an out-of-network daemon); CLAUDE.md invariants on Bash-as-single-execution-surface and sandbox/management isolation
 
 ## Context
 
@@ -60,26 +60,52 @@ We introduce a new sidecar **`ops-control`** that owns container
 lifecycle on behalf of the agent system, and route specialist-driven
 service activation through it.  Four sub-decisions:
 
-1. **`ops-control` sidecar — the only container that touches the
-   docker socket.**  `containers/ops-control.Dockerfile` ships a
-   minimal Go (or Python) binary on `decepticon-net` with
-   `/var/run/docker.sock` bind-mounted **read-only where possible**.
-   It exposes a tiny HTTP API on an internal port (not host-exposed):
+1. **`opscontrol` host-binary daemon — the only process that touches
+   the docker socket.**  The daemon ships as a sub-command of
+   `clients/launcher/` (Go binary), runs on the host outside any
+   compose-defined network, and is installed by the launcher's onboard
+   flow.  It exposes a tiny HTTP API over a **Unix domain socket**
+   bind-mounted into the langgraph container only:
 
    ```
+   /var/run/decepticon-ops.sock
+
    POST /v1/profiles/{name}/start   → 202 Accepted (idempotent)
    POST /v1/profiles/{name}/stop    → 202 Accepted (idempotent)
    GET  /v1/profiles                → [{name, state, since}]
    GET  /v1/health                  → liveness
    ```
 
+   No TCP exposure, no host port, no `decepticon-net` membership.
+   The socket-file bind mount is the capability grant; only the
+   container that receives the mount can address the API.  Containers
+   on `decepticon-net` without the mount (litellm, postgres, web,
+   neo4j, bhce, sliver) cannot reach `opscontrol`.
+
    `{name}` is matched against a server-side **allowlist** (`ad`,
    `c2-sliver`, `c2-havoc`, `reversing`, `wireless`, …).  Anything
    else returns 400 without touching docker.  Implementation calls
    `docker compose --profile <name> up -d` (or the equivalent SDK
-   call) and `docker compose --profile <name> stop`.  No raw
-   `docker run` / image pull / volume create / network edit — those
-   surfaces never exist.
+   call) and `docker compose --profile <name> stop` *on the host*.
+   No raw `docker run` / image pull / volume create / network edit —
+   those surfaces never exist.
+
+   **Why a host-binary daemon and not an ops-control sidecar
+   container?**  Putting the daemon inside a container on
+   `decepticon-net` (the original §1 of this ADR, 2026-06-05)
+   re-introduces the socket-bind trapdoor M1 was rejected for: a
+   prompt-injection that reaches the ops-control HTTP API has
+   *exactly the same hop count* to host docker as one that reaches
+   langgraph directly with the socket bound — the narrowness of the
+   allowlist is an application-layer guard, not a trust boundary.
+   This codebase already retired the equivalent pattern for command
+   execution (ADR-0001, PR #236, PR #263 — *"the agent process no
+   longer needs /var/run/docker.sock (a host-escape vector for any
+   prompt-injection-driven RCE inside the LLM agent)"*).  The same
+   reasoning applies to lifecycle authority.  External validation in
+   §6 (Anthropic Claude Code, Vercel Sandbox, Fly Machines) converges
+   on the same shape: capability granted by a socket file bound into
+   the caller, not by network membership.
 
 2. **Agent surface — `decepticon.tools.ops`.**  Three LangChain
    `@tool` wrappers:
@@ -114,21 +140,84 @@ service activation through it.  Four sub-decisions:
    scheduled runs; training / evaluation runs flip the toggle and
    get explicit one-click approvals via the existing HITL UI.
 
-5. **Runtime-agnostic interface.**  ops-control is the *interface*
-   the orchestrator depends on, not a Docker-specific component.
-   The HTTP API above is deliberately generic — `profile` is an
-   opaque allowlist key, not a docker-compose feature.  The bundled
-   OSS implementation backs that interface with a Docker Compose
-   adapter (the simplest concrete case), but the interface admits
-   alternative orchestrator backends (Kubernetes API,
-   HashiCorp Nomad, container-runtime SDKs, managed cluster
-   environments) under the same allowlist + same HTTP contract.
-   Those alternative adapters live outside this repo; the OSS
-   surface ships only the Docker Compose path.  Keeping the agent
-   side independent of which lifecycle backend runs underneath is
-   what lets the same `ops_start("ad")` call work in a developer's
-   docker-compose stack and in a managed cluster without any
-   change to agent code.
+5. **Runtime-agnostic via `Backend` Protocol.**  `opscontrol` fronts
+   a formal `Backend` Protocol with pluggable implementations
+   selected by `OPS_BACKEND` (default: `docker-compose`):
+
+   - `DockerComposeBackend` — sprint 1 only implementation, shells
+     out to host `docker compose` CLI.  Covers OSS self-hosted and
+     SaaS per-engagement Spot VM tiers (the VM runs the OSS compose
+     stack and the daemon manages it from the VM host context).
+   - `KubernetesBackend` — sprint 5+, applies namespace-scoped CRDs
+     through admission-validated Sigstore policy-controller.  Covers
+     managed-cluster deployments (EKS / GKE / AKS / OpenShift).
+   - `CloudRunBackend` / `FargateBackend` / `NomadBackend` —
+     community / SaaS plug-ins via the `decepticon.workload_backends`
+     entry-point group.  Not shipped in OSS.
+
+   The HTTP API and the `(workload, lifecycle_op)` tuple are
+   backend-independent.  The agent calls `ops_start("ad")` and the
+   selected backend resolves it — Docker Compose profile in OSS,
+   Kubernetes CRD in managed-cluster deployments, Cloud Run service
+   in serverless.  Connection resolution follows the same shape:
+   `ops_start` returns a logical handle (`{workload_id,
+   endpoint_url, bootstrap_token_ref}`); the agent fetches secrets
+   by handle, never by network discovery, so the same agent code
+   resolves Docker bridge DNS in OSS and K8s Service DNS in managed
+   clusters without change.
+
+### External validation
+
+The host-binary-daemon-with-Unix-socket pattern in §1' and the
+`Backend` Protocol in §5' converge with three independent production
+exemplars and two security-framework references.  Each external
+source was selected because its mechanism — not just its outcome —
+matches what §1'/§5' prescribe.
+
+- **Anthropic Claude Code sandboxing.** *"Network isolation, by only
+  allowing internet access through a unix domain socket connected to
+  a proxy server running outside the sandbox."*  The sandboxed
+  process has its network namespace removed entirely; the only path
+  to the proxy is a host-bind-mounted Unix socket — capability
+  granted by socket file, not by network membership. [1]
+- **Vercel Sandbox.** `Sandbox.create()` provisions a Firecracker
+  microVM on Vercel's infrastructure; client code never touches the
+  hypervisor or container daemon.  Per-task isolation, external
+  managed control plane.  *"This provides stronger isolation than
+  container-based solutions, which makes sandboxes ideal for running
+  untrusted code."* [2]
+- **Fly Machines API.** `api.machines.dev/v1` is the external HTTP
+  control plane for per-app machine spawn.  Fly explicitly positions
+  the pattern as *"a safe execution sandbox for even the sketchiest
+  user-generated (or LLM-generated) code"* and recommends *"dedicated
+  per-user (or per-robot) Fly apps... each containing isolated Fly
+  Machines"* because *"a compromised user environment can reach
+  every other Machine if consolidated."*  The per-app isolation maps
+  directly to Decepticon's per-engagement Spot VM tier. [3]
+
+The `Backend` Protocol surface (§5') and the `(workload,
+lifecycle_op)` tuple (§2) match prescribed least-privilege patterns
+in two authoritative security references:
+
+- **NIST SP 800-190 §4.3.1.** *"Orchestrators should use a least
+  privilege access model in which users are only granted the ability
+  to perform the specific actions on the specific hosts, containers,
+  and images their job roles require."*  The `(workload,
+  lifecycle_op)` tuple is the canonical instance of this scoping
+  prescription. [4]
+- **OWASP LLM06:2025 Excessive Agency.** *"Avoid the use of
+  open-ended extensions where possible (e.g., run a shell command,
+  fetch a URL, etc.) and use extensions with more granular
+  functionality"* because *"the scope for undesirable actions is
+  very large (any other shell command could be executed)."*  A raw
+  docker control API exposed to a prompt-injectable agent is the
+  textbook open-ended extension this guidance disqualifies. [5]
+
+[1] https://www.anthropic.com/engineering/claude-code-sandboxing
+[2] https://vercel.com/docs/sandbox/concepts
+[3] https://fly.io/docs/blueprints/per-user-dev-environments/
+[4] https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-190.pdf
+[5] https://genai.owasp.org/llmrisk/llm062025-excessive-agency/
 
 ### CLAUDE.md invariant update
 
@@ -142,10 +231,12 @@ The existing rule:
 is amended (separate docs PR) to:
 
 > Bash tool is the single execution surface for in-target commands.
-> `ops-control` is the single lifecycle surface for compose-defined
-> services.  Docker socket binds are limited to those two containers
-> (sandbox, ops-control) and nowhere else — langgraph, web, cli, c2,
-> bhce all cannot reach the docker socket.
+> `opscontrol` is the single lifecycle surface for compose-defined
+> services.  The docker socket is bound to exactly one process —
+> the host-installed `opscontrol` daemon — and to no container on
+> any compose-defined network.  langgraph, web, cli, c2, bhce,
+> sandbox all cannot reach the docker socket (sandbox already
+> retired its socket bind in PR #263 per ADR-0001).
 
 ## Consequences
 
@@ -185,26 +276,55 @@ is amended (separate docs PR) to:
     mental model for new contributors.  The README onboarding flow
     will spell out the new default explicitly.
 
-- **Migration timeline**
-  - Sprint 1: this ADR + scaffold `containers/ops-control.Dockerfile`
-    + minimal HTTP API + `tools/ops` LangChain wrappers; **no**
-    behaviour change to existing services yet.
+- **Migration timeline** (revised 2026-06-06)
+  - Sprint 1 (revised): this revised ADR + `clients/launcher/cmd/opscontrol`
+    Go daemon (HTTP-over-Unix-socket) + `Backend` Protocol +
+    `DockerComposeBackend` + onboard-flow install + `tools/ops`
+    LangChain wrappers (preserved from the original PR #592, with the
+    httpx client switched to UDS transport via `httpx.HTTPTransport(uds=...)`).
+    No behaviour change to existing services yet.  The original
+    `containers/ops-control.Dockerfile` + sidecar compose entry are
+    deleted (PR #592 closed as superseded).
   - Sprint 2: add `profiles: [ad]` to `bhce` + `bhce-neo4j`; remove
     `COMPOSE_PROFILES=c2-sliver` default from `.env.example`; update
     orchestrator system prompt to call `ops_start` / `ops_stop`.
-  - Sprint 3: BHCE token bootstrap moves into `ops-control`'s start
-    handler; langgraph receives the token over HTTP, not env var.
+  - Sprint 3: BHCE token bootstrap moves into `opscontrol`'s start
+    handler; langgraph receives the token via the daemon's
+    bootstrap-token handle pattern (`ops_start` returns
+    `{workload_id, endpoint_url, bootstrap_token_ref}`; the agent
+    fetches the secret by handle from `opscontrol`, never from disk
+    or env var).
   - Sprint 4: CLAUDE.md + `docs/architecture.md` invariant edit;
     Web Dashboard `ops_status` panel.
+  - Sprint 5+: `KubernetesBackend` implementation + Sigstore
+    policy-controller catalog signing for FedRAMP / air-gapped tier.
+    `OPS_BACKEND=kubernetes` flips the active implementation with
+    no agent-side change.
 
 ## Alternatives considered
 
 - **(M1) Give langgraph a docker socket bind so its `@tool` can run
-  `docker compose up -d <profile>` directly.**  Rejected.  Any
-  prompt-injection in langgraph then has full host-Docker control
-  (`docker run -v /:/host …`).  This is the trapdoor the existing
-  CLAUDE.md invariant exists to close, and there is no upside that
-  ops-control's narrow allowlist API doesn't already deliver.
+  `docker compose up -d <profile>` directly.**  Rejected (original
+  reasoning stands).  Any prompt-injection in langgraph then has full
+  host-Docker control (`docker run -v /:/host …`).  This is the
+  trapdoor the existing CLAUDE.md invariant exists to close.
+
+- **(M1') Put the daemon in an `ops-control` sidecar *container* on
+  `decepticon-net` with `/var/run/docker.sock` bind-mounted.**
+  Initially adopted as §1 of this ADR (2026-06-05); **revised out
+  2026-06-06 — see §1' and §6.**  The narrowness of the allowlist
+  HTTP API is application-layer, not architectural: a
+  prompt-injection that reaches the ops-control HTTP API on
+  `decepticon-net` has the same effective control over the host
+  docker daemon as one that reaches langgraph directly with the
+  socket bound — the hop count to host root is identical.  The
+  Decepticon-side precedent (ADR-0001, PR #236, PR #263 retiring the
+  equivalent pattern for command execution) and the external
+  validation cited in §6 converge on host-binary daemon + Unix
+  socket as the correct alternative.  M1' is preserved in this list
+  as an explicit audit-trail entry because it was the original
+  decision and the revision matters for reviewers comparing the two
+  shapes.
 
 - **(M3) Human-in-the-loop only — no autonomous lifecycle.**
   Rejected as the *default*; the agent system has to be able to run
@@ -213,12 +333,17 @@ is amended (separate docs PR) to:
   available without being forced.
 
 - **(M4) Move lifecycle into the host-side Go launcher
-  (`clients/launcher`) and have the launcher poll OPPLAN to decide
-  what to bring up.**  Rejected for this cycle: the launcher is
-  currently boot-only (one shot), and turning it into a long-lived
-  bidirectional control plane is a much bigger redesign than
-  ops-control.  May become attractive later when the launcher already
-  has a daemon mode for other reasons.
+  (`clients/launcher`) and have the launcher carry the lifecycle
+  daemon.**  **Adopted in revised form per §1'** (2026-06-06).  The
+  launcher gains a daemon sub-command (`decepticon opscontrol
+  daemon`) that the onboard flow installs and supervises.  The
+  original objection ("turning the launcher into a long-lived
+  bidirectional control plane is a much bigger redesign") was an
+  overestimate: the daemon is a stateless HTTP server reading a
+  static allowlist catalog and shelling out to `docker compose`, not
+  a poller of agent state.  The OPPLAN polling shape M4 was
+  originally rejected for is explicitly out of scope — the daemon
+  reacts to agent-driven `ops_start` / `ops_stop` calls only.
 
 - **(M5) Static profile-gate + manual `COMPOSE_PROFILES=` on every
   run.**  Rejected as the *only* mechanism: it solves idle cost but


### PR DESCRIPTION
## Why

The original §1 of ADR-0006 (2026-06-05) chose to put the lifecycle daemon in an \`ops-control\` sidecar *container* on \`decepticon-net\` with \`/var/run/docker.sock\` bind-mounted. That recreates the trapdoor the same ADR's M1 explicitly rejected for langgraph:

> A prompt-injection that reaches the ops-control HTTP API on the LLM-reachable network has the *same hop count to host docker* as one that reaches langgraph directly with the socket bound. The narrowness of the allowlist is an application-layer guard, not a trust boundary.

This codebase has made the equivalent pivot before — **ADR-0001** records the *"Docker-socket-exec sandbox → HTTP-daemon sandbox"* pivot, and **PR #263** deleted DockerSandbox citing *"a host-escape vector for any prompt-injection-driven RCE inside the LLM agent."* The same reasoning applies to lifecycle authority.

## What changes

| Section | Change |
|---|---|
| **Header** | Status: \`Proposed (revised 2026-06-06)\`; Date carries both dates; Related expanded to cite ADR-0001 + PR #236/#263 precedent |
| **§1 → §1'** | Replaced. Host-binary \`opscontrol\` daemon as a sub-command of \`clients/launcher/\` (Go binary), HTTP over a **Unix domain socket** bind-mounted into the langgraph container only. No TCP exposure, no \`decepticon-net\` membership |
| **§2, §3, §4** | **Unchanged** — agent surface, default-off profiles, HITL toggle were sound |
| **§5 → §5'** | Replaced. Formal \`Backend\` Protocol with \`DockerComposeBackend\` (sprint 1), \`KubernetesBackend\` (sprint 5+ stub), \`CloudRunBackend\`/\`FargateBackend\`/\`NomadBackend\` (community/SaaS plug-ins via \`decepticon.workload_backends\` entry-point group). Connection resolution via daemon-returned handle |
| **§6 (new) — External validation** | Five cited sources: Anthropic Claude Code sandboxing, Vercel Sandbox, Fly Machines API, NIST SP 800-190 §4.3.1, OWASP LLM06:2025 |
| **CLAUDE.md invariant text** | sandbox removed from the docker-socket list (PR #263 already retired it). Only the host-installed \`opscontrol\` daemon holds the socket |
| **Migration timeline** | sprint 1 redefined; sprint 5+ added for KubernetesBackend |
| **Alternatives** | M1 unchanged; **M1' added** as audit-trail entry for the original §1 that was revised out; **M4** (host-side launcher) marked as **Adopted in revised form** |

## External validation (cited in §6)

| Source | Mechanism that matches §1'/§5' |
|---|---|
| Anthropic Claude Code sandboxing | Unix socket proxy outside sandbox, capability granted by socket file not network |
| Vercel Sandbox | \`Sandbox.create()\` external managed control plane, Firecracker microVM |
| Fly Machines API | \`api.machines.dev/v1\` external HTTP control plane, per-app isolation |
| NIST SP 800-190 §4.3.1 | \"least privilege access model... specific actions on specific hosts, containers, and images\" — \`(workload, lifecycle_op)\` tuple shape |
| OWASP LLM06:2025 Excessive Agency | \"avoid open-ended extensions where possible... use extensions with more granular functionality\" — disqualifies raw docker control API to a prompt-injectable agent |

## Follow-ups (not in this PR)

1. **PR #592 will be closed as superseded** once this amendment lands (it implemented the now-revised §1). The agent-side \`tools/ops\` httpx client and \`@tool\` surface drafted in PR #592 are preserved verbatim — only the transport switches from TCP to UDS (\`httpx.HTTPTransport(uds=...)\`).
2. **New sprint 1 PR**: \`clients/launcher/cmd/opscontrol\` Go daemon + \`Backend\` Protocol + \`DockerComposeBackend\` + onboard-flow install + \`tools/ops\` preservation.
3. **Sprint 5+**: \`KubernetesBackend\` + Sigstore policy-controller catalog signing for FedRAMP/air-gapped tier.

## Why this isn't a new ADR-NNNN

ADR-0006 is still \`Proposed\` (never \`Accepted\`) — no implementation has shipped to main. ADRs are append-only for *Accepted* decisions; *Proposed* decisions may be revised in place. The §6 External validation block and the M1' audit-trail entry ensure the original direction is preserved for reviewers comparing the two shapes.

## Blast radius

- [x] **Tier-owner** — \`docs/adr/**\` is CODEOWNERS-gated to @PurpleCHOIms
- [x] Docs-only change (\`docs/adr/0006-*.md\` only); no runtime code; no dependencies
- [x] Diff fits the budget: 1 file, +172/-47

## Verification

- Markdown renders cleanly; section anchors intact (\`#-decision\`, \`#-consequences\`, \`#-alternatives-considered\`).
- No conflict markers left over.
- All external links resolve (5 sources cited in §6).
- ADR template structure preserved (Status/Date/Deciders/Related header, Context/Decision/Consequences/Alternatives sections).