### PR TITLE
fix(release): unblock smoke wait — skillogy async ingest + bhce healthcheck disable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -630,12 +630,19 @@ services:
         condition: service_healthy
       bhce-neo4j:
         condition: service_healthy
+    # BHCE healthcheck is intentionally disabled: the SpecterOps upstream
+    # image is distroless, so it ships with no `/bin/sh`, no `wget`, no
+    # `curl`, and no `ls` — only the `/bloodhound` Go binary. The previous
+    # `CMD-SHELL "wget ... /api/version"` test failed with `exec: /bin/sh:
+    # no such file or directory` and the `/api/version` endpoint requires
+    # authentication besides (only `/api/v2/spec` is unauthenticated per
+    # ADR-0005), so even rewriting the test would not fix the missing
+    # tooling. Downstream services do not gate on `bhce.condition:
+    # service_healthy`, so the disabled healthcheck does not affect the
+    # rest of the stack — clients (`bhce_client` in tools/ad) carry their
+    # own ready-check retry loop against `/api/v2/spec`.
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/version >/dev/null 2>&1 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 18
-      start_period: 90s
+      disable: true
     restart: unless-stopped
 
 volumes:

--- a/packages/decepticon/decepticon/skillogy/__main__.py
+++ b/packages/decepticon/decepticon/skillogy/__main__.py
@@ -26,6 +26,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -94,6 +95,30 @@ def _start_rest(backend: Neo4jBackend, port: int, started_at: float) -> None:
     uvicorn.Server(config).run()
 
 
+def _ingest_in_background(backend: Neo4jBackend) -> None:
+    """Run the boot-time cypher ingest off the main thread.
+
+    On a cold container the bundled ``skills.cypher`` is ~3.7 MB and
+    Neo4j MERGEs ~6000 statements over the bolt driver — that takes
+    several minutes on the first boot. Running it on the main thread
+    blocks ``uvicorn.run()`` from binding the listener until the
+    ingest finishes, which leaves ``/v1/health`` unreachable and
+    Docker's healthcheck flapping past ``start_period``. We move the
+    ingest to a daemon thread so the REST server comes up first and
+    the healthcheck passes immediately; the corpus then loads in the
+    background and the existing ``skill_count`` field in
+    ``/v1/health`` reports its progress.
+    """
+    try:
+        _maybe_ingest(backend)
+    except Exception as exc:  # noqa: BLE001
+        # Failing to ingest is loud but not fatal — the operator may
+        # be running against a Neo4j that was pre-loaded out of band
+        # (a different cypher file, or a manual seed). REST stays up
+        # so health probes can report the situation.
+        log.error("cypher ingest failed: %r — continuing without it", exc)
+
+
 def main() -> int:
     _setup_logging()
     rest_port = int(os.environ.get("SKILLOGY_REST_PORT", "9100"))
@@ -101,14 +126,17 @@ def main() -> int:
     backend = _build_backend()
     started_at = time.time()
 
-    try:
-        _maybe_ingest(backend)
-    except Exception as exc:  # noqa: BLE001
-        # Failing to ingest is loud but not fatal — the operator may
-        # be running against a Neo4j that was pre-loaded out of band
-        # (a different cypher file, or a manual seed). REST stays up so
-        # health probes can report the situation.
-        log.error("cypher ingest failed: %r — continuing without it", exc)
+    # Start the bulk cypher ingest off the main thread before serving so
+    # the REST listener comes up immediately. See ``_ingest_in_background``
+    # for the rationale. The thread is a daemon so a SIGTERM during ingest
+    # tears it down with the process.
+    ingest_thread = threading.Thread(
+        target=_ingest_in_background,
+        args=(backend,),
+        name="skillogy-ingest",
+        daemon=True,
+    )
+    ingest_thread.start()
 
     def _handle_term(_signum, _frame):
         log.info("SIGTERM received; closing backend and exiting")


### PR DESCRIPTION
## Why

\`make smoke\` (and any other consumer of \`docker compose up --wait\`) was timing out on two healthchecks at release-verification time. Both turned out to be architectural issues, not timeout-tuning.

### skillogy — synchronous boot-time ingest

Cold-container ingest of the bundled \`skills.cypher\` (~3.7 MB, ~6000 MERGE statements over the bolt driver) takes several minutes on first boot. The previous \`main()\` ran \`_maybe_ingest(backend)\` synchronously on the main thread *before* \`uvicorn.Server(config).run()\`, so the REST listener didn't bind until the ingest finished — \`/v1/health\` was unreachable, the 30 s \`start_period\` lapsed, and the healthcheck flapped to \`unhealthy\`. \`--wait-timeout 600\` would have masked the symptom; the right fix is to have the REST listener up immediately.

### bhce — distroless image, healthcheck can't run

The SpecterOps upstream image (\`docker.io/specterops/bloodhound\`) is distroless — \`/bin/sh\`, \`wget\`, \`curl\`, even \`ls\` are absent. The previous healthcheck \`[\"CMD-SHELL\", \"wget -qO- http://localhost:8080/api/version >/dev/null 2>&1 || exit 1\"]\` failed every probe interval with:

\`\`\`
OCI runtime exec failed: exec failed: unable to start container process:
exec: \"/bin/sh\": stat /bin/sh: no such file or directory: unknown
\`\`\`

It would have failed even with a shell-bearing image — \`/api/version\` requires authentication (only \`/api/v2/spec\` is unauthenticated per [ADR-0005 §\"Authoritative facts\"](https://github.com/PurpleAILAB/Decepticon/blob/main/docs/adr/0005-bloodhound-via-bhce-rest-client.md)). And no \`CMD\` form works because there is no tool in the image to call any endpoint.

## What changes

### Skillogy (\`packages/decepticon/decepticon/skillogy/__main__.py\`, +15/-13)

- Lift the ingest out of the main thread into a new \`_ingest_in_background\` helper that runs on a daemon thread named \`skillogy-ingest\`.
- \`main()\` starts the thread, installs the SIGTERM handler, then calls \`_start_rest(...)\` immediately so uvicorn binds \`0.0.0.0:9100\` within milliseconds of process start.
- Daemon thread → SIGTERM during ingest tears it down with the process; no graceful-shutdown plumbing needed.
- Idempotent MERGE semantics in \`skills.cypher\` make re-ingest after a restart safe.
- The existing \`/v1/health\` response already carries \`skill_count\` and \`uptime_seconds\`, so operators can still watch ingest progress without a separate readiness endpoint. No new fields.

### BHCE (\`docker-compose.yml\`, +12/-5)

- Replace the broken healthcheck with \`healthcheck: { disable: true }\` and a multi-line comment explaining the distroless constraint, the \`/api/version\` auth requirement, and why no rewrite of the test fixes the image-level missing tooling.
- Verified programmatically that no service in \`docker-compose.yml\` declares \`bhce: condition: service_healthy\` as a dependency target. The only \`depends_on\` edge touching bhce is \`bhce → bhce-neo4j\` (bhce waits on its own dedicated Neo4j), so disabling bhce's healthcheck does not change any other service's startup order.
- Clients in \`packages/decepticon/decepticon/tools/ad/bhce_client.py\` carry their own ready-check retry against \`/api/v2/spec\`, which is the documented unauthenticated readiness path.

## Verification

\`\`\`bash
docker compose --profile cli up -d --build --wait --wait-timeout 600
# → exit 0, no flapping
\`\`\`

\`docker compose ps\`:

| Service | Status |
|---|---|
| decepticon-litellm | Up 2 minutes **(healthy)** |
| decepticon-postgres | Up 2 minutes **(healthy)** |
| decepticon-neo4j | Up 2 minutes **(healthy)** |
| decepticon-bhce-neo4j | Up 2 minutes **(healthy)** |
| decepticon-sandbox | Up 2 minutes **(healthy)** |
| decepticon-skillogy | Up 2 minutes **(healthy)** ← fix #1 |
| decepticon-langgraph | Up 55 seconds **(healthy)** |
| decepticon-bhce | Up About a minute (no health column = disabled, intended) ← fix #2 |
| decepticon-web | Up 17 seconds **(healthy)** |
| decepticon-cli | Up 17 seconds |

HTTP probes (run after \`up --wait\` exits):

\`\`\`
skillogy /v1/health         : 200
bhce /api/v2/spec           : 200   (unauthenticated per ADR-0005)
langgraph /ok               : 200
litellm /health/readiness   : 200
web /                       : 200
\`\`\`

## Release impact

This is a v1.1.7 release-readiness fix. \`make smoke\` previously failed at the \`up --wait\` step against the same main commits; with these two changes it passes cleanly. Without them, every \`make smoke\` / \`make dogfood\` / production \`docker compose up --wait\` against the OSS stack would time out on bhce + skillogy after 600 s and fail the run.

## Blast radius

- [x] **Tier-routine** — no protected paths touched, no dependency changes, no public API surface change.
- skillogy: behavior-equivalent boot semantics (same \`/v1/health\` payload shape; same eventual graph state; only the order of \`bind listener\` vs \`finish ingest\` changes).
- bhce: removes an always-failing probe; downstream services already do not gate on bhce's health.

## Why not bump \`start_period\` / \`--wait-timeout\` instead

Tuning the timeout knob would mask the skillogy issue at the cost of a 5-minute startup wall on every cold compose run, and would not fix bhce at all (the probe cannot succeed, even given infinite time). The architectural fixes here are the smaller, correct change.