### PR TITLE
docs(adr): amend ADR-0006 with the full workload catalog + extension protocol

### DIFF
--- a/docs/adr/0006-agent-driven-container-lifecycle.md
+++ b/docs/adr/0006-agent-driven-container-lifecycle.md
@@ -133,6 +133,94 @@ service activation through it.  Four sub-decisions:
    `ops-control`).  Domain services are inert until something
    `ops_start`s them.
 
+### Workload catalog
+
+The allowlist in §1' enumerates the workloads the agent system may
+spawn.  The catalog below is the full specialist-to-workload mapping
+at v1.2.0 candidate scope, expanded from the §1' seed
+(`ad`, `c2-sliver`, `c2-havoc`, `reversing`, `wireless`, …) to cover
+the WAVE-3 specialist expansion landed in PR #542 plus the existing
+16 standard specialists.
+
+Each row is the logical workload name (the value passed to
+`ops_start("<name>")` and matched against the daemon-side allowlist),
+the specialist(s) that drive it, the docker-compose profile that gates
+the services, the canonical service set, and which compose network
+the spawned services bind to.  Workloads marked **`(future)`** are
+reserved in the allowlist but their compose services are not yet
+shipped; adding one is a `(profile, services)` tuple in
+`docker-compose.yml` + one entry in the daemon's allowlist + (if the
+service is a Decepticon-built image) one row in
+`.github/workflows/release.yml`'s docker matrix.
+
+| Workload | Driven by | Compose profile | Services | Network |
+|---|---|---|---|---|
+| `ad` | `ad_operator` | `[ad]` | `bhce`, `bhce-neo4j` | `decepticon-net` |
+| `c2-sliver` | `postexploit`, `exploit` | `[c2-sliver]` | `c2-sliver` | `decepticon-net` |
+| `c2-havoc` *(future)* | `postexploit`, `exploit` | `[c2-havoc]` | havoc team server + agent profile | `decepticon-net` |
+| `reversing` | `reverser` | `[reversing]` | `ghidra-mcp` (sandbox-derivative image) | `sandbox-net` |
+| `phishing` *(future)* | `phisher` | `[phishing]` | `gophish`, `evilginx2`, lookalike-domain proxy | `decepticon-net` |
+| `mobile` *(future)* | `mobile_operator` | `[mobile]` | Android emulator + Frida server | `sandbox-net` |
+| `wireless` *(future)* | `wireless_operator` | `[wireless]` | HackRF / wifi rig (host-attached) | `sandbox-net` |
+| `cloud` *(future)* | `cloud_hunter` | `[cloud]` | LocalStack / minikube cloud-emulation lab | `decepticon-net` |
+| `iot` *(future)* | `iot_operator` (#542) | `[iot]` | firmadyne, MQTT / CoAP brokers, IoT firmware images | `sandbox-net` |
+| `ics` *(future)* | `ics_operator` (#542) | `[ics]` | OpenPLC + Modbus / S7comm / DNP3 simulators | `sandbox-net` |
+| `forensics` *(future)* | `forensicator` (#542) | `[forensics]` | DFIR toolchain (Plaso, Volatility, sleuthkit) | `sandbox-net` |
+| `supply-chain` *(future)* | `supply_chain_operator` (#542) | `[supply-chain]` | CI/CD lab (Gitea, Drone, signing-key store) | `decepticon-net` |
+
+Specialists whose entire toolchain runs inside the always-on
+`sandbox` container — `recon`, `analyst`, `decepticon`, `soundwave`,
+`detector`, `verifier`, `vulnresearch`, `patcher`, `contract_auditor`,
+`osint_operator` (#542) — do not appear in the catalog: they neither
+start nor stop any sidecar.  They consume the core plane only, so
+their dispatch sequence is `task()` → specialist runs against the
+sandbox, with no `ops_start` / `ops_stop` wrapping.
+
+Two cross-cutting constraints the catalog enforces:
+
+- **Network placement.**  Adversary-facing services (the offensive
+  half of every spawn) land on `sandbox-net` so a compromised target
+  cannot reach the management plane.  Defense / OSINT / orchestration
+  services that the agent reads from over HTTP (BHCE, gophish admin,
+  LocalStack control APIs) land on `decepticon-net`.  A workload that
+  needs both a target-facing service and a management-facing UI ships
+  two compose services under the same profile, each on the
+  appropriate network — see `bhce` (decepticon-net) + `bhce-neo4j`
+  (decepticon-net only, no sandbox-net bridge) for the canonical
+  pattern.
+- **Workload uniqueness.**  A specialist may drive at most one
+  workload at a time per engagement: `postexploit` chooses
+  `c2-sliver` *or* `c2-havoc`, not both.  This is an orchestrator-side
+  policy rather than a daemon-side one — the daemon admits both names
+  and an orchestrator that issues both `ops_start` calls gets both,
+  but the system-prompt policy in §2 selects one based on the
+  engagement's RoE / customer preference.
+
+### Catalog extension protocol
+
+Adding a new workload after this revision lands does **not** require
+re-amending this ADR.  The shape is fixed; the catalog entries are
+data, not decisions.  Extension steps for an OSS workload:
+
+1. Add the `(profile, services)` tuple to `docker-compose.yml` under
+   the appropriate compose profile, choosing `sandbox-net` vs
+   `decepticon-net` per the network-placement rule above.
+2. If the workload includes a Decepticon-built image, add the matrix
+   row to `.github/workflows/release.yml`.
+3. Add the workload name string to the daemon-side allowlist (default
+   `(ad, c2-sliver, c2-havoc, reversing, phishing, mobile, wireless,
+   cloud, iot, ics, forensics, supply-chain)`).  The
+   default allowlist lives in the daemon binary, not in user-visible
+   config, so OSS users don't gain `ops_start("ad")` rights by
+   editing `.env`.
+4. Add the specialist binding to the orchestrator's system prompt so
+   it knows to call `ops_start(<name>)` before delegating.
+
+SaaS / community workloads — `KubernetesBackend` namespaces,
+`CloudRunBackend` services, etc. — extend the catalog through the
+`decepticon.workload_backends` entry-point group (§5') rather than by
+amending this ADR.
+
 4. **HITL is an orthogonal toggle.**  An optional
    `HumanInTheLoopMiddleware` slot intercepts `ops_start` /
    `ops_stop` calls when `OPS_REQUIRE_APPROVAL=true` is set on the
@@ -287,7 +375,14 @@ is amended (separate docs PR) to:
     deleted (PR #592 closed as superseded).
   - Sprint 2: add `profiles: [ad]` to `bhce` + `bhce-neo4j`; remove
     `COMPOSE_PROFILES=c2-sliver` default from `.env.example`; update
-    orchestrator system prompt to call `ops_start` / `ops_stop`.
+    orchestrator system prompt to call `ops_start` / `ops_stop`.  At
+    sprint-2 close, the catalog above's *shipped* rows (`ad`,
+    `c2-sliver`, `reversing`) are reachable via `ops_start`; the
+    *(future)* rows are reserved-but-inert until their workload PRs
+    land (each follows the four-step extension protocol).  Workload
+    PRs land independently after sprint 2 — no further ADR-0006
+    amendments are required for catalog entries; the catalog is
+    extended through the extension-protocol above.
   - Sprint 3: BHCE token bootstrap moves into `opscontrol`'s start
     handler; langgraph receives the token via the daemon's
     bootstrap-token handle pattern (`ops_start` returns


### PR DESCRIPTION
## Why

The §1' allowlist seeded in revised ADR-0006 (via #609) only enumerated five workload names — \`ad\`, \`c2-sliver\`, \`c2-havoc\`, \`reversing\`, \`wireless\` — terminated by \`…\`. The specialist roster shipped in main is wider:

- **16 standard specialists**: `decepticon`, `soundwave`, `recon`, `exploit`, `postexploit`, `ad_operator`, `reverser`, `contract_auditor`, `cloud_hunter`, `phisher`, `mobile_operator`, `wireless_operator`, `analyst`, `detector`, `verifier`, `vulnresearch` (plus `patcher`).
- **5 WAVE-3 additions** queued in #542: `osint_operator`, `iot_operator`, `ics_operator`, `forensicator`, `supply_chain_operator`.

Without a recorded specialist-to-workload mapping it is ambiguous which specialist drives which workload, which compose profile gates which service set, which compose network each spawned service binds to, and what shape future workloads must take to slot in.

## What changes

### §3 → Workload catalog (new sub-section)

A 12-row mapping table covering:

- **Shipped today** (catalog-row, compose-row, daemon-row all present): `ad`, `c2-sliver`, `reversing`.
- **Reserved-but-inert** (allowlist-only until their workload PR lands): `c2-havoc`, `phishing`, `mobile`, `wireless`, `cloud`, `iot`, `ics`, `forensics`, `supply-chain`.

Each row: workload name → driver specialist(s) → compose profile → canonical service set → network. Specialists whose toolchain runs entirely inside the always-on \`sandbox\` (\`recon\`, \`analyst\`, \`decepticon\`, \`soundwave\`, \`detector\`, \`verifier\`, \`vulnresearch\`, \`patcher\`, \`contract_auditor\`, \`osint_operator\`) are explicitly enumerated as **out-of-catalog** so reviewers don't go looking for them.

### Two cross-cutting constraints the catalog enforces

- **Network placement**: adversary-facing services on \`sandbox-net\`, management-facing services on \`decepticon-net\`. The \`bhce\` (decepticon-net) + \`bhce-neo4j\` (decepticon-net only, no sandbox-net bridge) split is documented as the canonical pattern.
- **Workload uniqueness**: a specialist drives at most one workload per engagement (\`postexploit\` picks \`c2-sliver\` xor \`c2-havoc\`). Enforced by the orchestrator system prompt in §2, not by the daemon — the daemon admits both names; the prompt selects one based on engagement RoE / customer preference.

### §3 → Catalog extension protocol (new sub-section)

The four-step shape for adding an OSS workload:

1. Add the \`(profile, services)\` tuple to \`docker-compose.yml\` under the appropriate compose profile (network placement rule above).
2. If the workload includes a Decepticon-built image, add the matrix row to \`.github/workflows/release.yml\`.
3. Add the workload name string to the daemon-side allowlist (default lives in the daemon binary, not in user-visible config, so OSS users don't gain \`ops_start("ad")\` rights by editing \`.env\`).
4. Add the specialist binding to the orchestrator's system prompt.

**Catalog extension does NOT require re-amending this ADR.** The catalog is data, the shape is the decision.

### SaaS / community workload extension

§5' (\`Backend\` Protocol) explicitly notes that SaaS / community workloads — \`KubernetesBackend\` namespaces, \`CloudRunBackend\` services — extend the catalog through the \`decepticon.workload_backends\` entry-point group, not by amending ADR-0006.

### Sprint-2 timeline clarification

The three shipped workloads (\`ad\`, \`c2-sliver\`, \`reversing\`) become reachable via \`ops_start\` at sprint-2 close. The (future) workloads land in independent PRs under the extension protocol — no further ADR-0006 amendments needed.

## Why amend ADR-0006 instead of opening ADR-0010

ADR-0006 already owns the topic (agent-driven container lifecycle). The catalog is the data the §1' allowlist alludes to with the \`…\` — recording it inside ADR-0006 keeps reviewers on a single document for the full picture rather than chasing a separate ADR-0010 cross-reference. The extension protocol explicitly makes the catalog data, not a future re-amendment treadmill.

## Blast radius

- [x] **Tier-owner** — \`docs/adr/**\` is CODEOWNERS-gated to @PurpleCHOIms.
- [x] Docs-only change; no runtime code, no dependencies, no behaviour change yet.
- [x] Diff fits the budget: 1 file, +96 / -1.

## Verification

- Markdown renders cleanly; section anchors (\`#workload-catalog\`, \`#catalog-extension-protocol\`) follow the existing § / ### convention from §1' / §5' / §6 / §CLAUDE.md invariant update.
- ADR template structure (Status / Date / Deciders / Related header, Context / Decision / Consequences / Alternatives sections) preserved.
- No conflict markers, no leaked TODOs.
- All workload names match the §1' allowlist seed verbatim.