### PR TITLE
fix(skillogy): default Skillogy on; opt-out becomes explicit DECEPTICON_USE_SKILLOGY=0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -360,9 +360,12 @@ services:
       - DECEPTICON_NEO4J_URI=bolt://neo4j:7687
       - DECEPTICON_NEO4J_USER=neo4j
       - DECEPTICON_NEO4J_PASSWORD=${NEO4J_PASSWORD:-decepticon-graph}
-      # Skillogy: opt-in via env var; agents use it instead of the
-      # file-system-backed SkillsMiddleware when DECEPTICON_USE_SKILLOGY=1.
-      - DECEPTICON_USE_SKILLOGY=${DECEPTICON_USE_SKILLOGY:-0}
+      # Skillogy is the canonical skill-retrieval backend (Neo4j-backed,
+      # phase-scoped retrieval). The in-process file-system
+      # ``SkillsMiddleware`` stays available as an explicit opt-out via
+      # ``DECEPTICON_USE_SKILLOGY=0`` for standalone library use and
+      # pytest where the skillogy container isn't running.
+      - DECEPTICON_USE_SKILLOGY=${DECEPTICON_USE_SKILLOGY:-1}
       - DECEPTICON_SKILLOGY_URL=http://skillogy:9100
       # Neo4j is the sole KG backend (no DECEPTICON_KG_BACKEND needed)
       # BENCHMARK_MODE flows in via `env_file: .env` above — no need to

--- a/packages/decepticon/decepticon/middleware/skillogy.py
+++ b/packages/decepticon/decepticon/middleware/skillogy.py
@@ -130,10 +130,22 @@ def _resolve_skillogy_api_key() -> str | None:
     return os.environ.get("DECEPTICON_SKILLOGY_API_KEY") or None
 
 
+_USE_SKILLOGY_FALSY: frozenset[str] = frozenset({"0", "false", "no", "off"})
+
+
 def _is_enabled() -> bool:
-    if os.environ.get("DECEPTICON_USE_SKILLOGY", "").strip().lower() in {"1", "true", "yes", "on"}:
+    # Skillogy is the canonical skill-retrieval backend; the in-process
+    # FilesystemBackend stays available as an explicit opt-out for
+    # standalone library use and pytest. Treat an unset / blank
+    # ``DECEPTICON_USE_SKILLOGY`` as enabled; honor an explicit falsy
+    # value as a disable. Backward compat: the legacy
+    # ``DECEPTICON_SKILL_BACKEND=skillogy_brain`` rail still flips it on
+    # even when ``DECEPTICON_USE_SKILLOGY=0`` (explicit user request via
+    # the new env name wins).
+    if os.environ.get("DECEPTICON_SKILL_BACKEND", "").strip().lower() == "skillogy_brain":
         return True
-    return os.environ.get("DECEPTICON_SKILL_BACKEND", "").strip().lower() == "skillogy_brain"
+    raw = os.environ.get("DECEPTICON_USE_SKILLOGY", "").strip().lower()
+    return raw not in _USE_SKILLOGY_FALSY
 
 
 def _backend_factory():
@@ -251,8 +263,13 @@ def _make_traverse_tool(backend):
 class SkillogyMiddleware(AgentMiddleware):
     """Wire the agent to the skillogy knowledge graph (Neo4j).
 
-    Activation: set ``DECEPTICON_SKILL_BACKEND=skillogy_brain`` (preferred)
-    or the legacy ``DECEPTICON_USE_SKILLOGY=1``. The agent factory's
+    Activation: **on by default.** Skillogy is the canonical
+    skill-retrieval backend; the in-process ``FilesystemBackend`` stays
+    available as an explicit opt-out for standalone library use and
+    pytest via ``DECEPTICON_USE_SKILLOGY=0`` (or ``false`` / ``no`` /
+    ``off``). The legacy ``DECEPTICON_SKILL_BACKEND=skillogy_brain`` rail
+    still flips it on even when ``DECEPTICON_USE_SKILLOGY=0`` (explicit
+    user request via the new env name wins). The agent factory's
     ``maybe_install_skillogy`` swaps ``SkillsMiddleware`` for this class
     and threads the agent's role through so the per-phase MoC summary
     fires for the correct phase.

--- a/packages/decepticon/tests/unit/agents/test_build.py
+++ b/packages/decepticon/tests/unit/agents/test_build.py
@@ -470,12 +470,19 @@ def _build_skills_stack():
 
 
 def test_build_middleware_keeps_skills_when_skillogy_disabled(monkeypatch):
-    """Default runtime (flag unset): the stack carries the file-system
-    SkillsMiddleware and no SkillogyMiddleware."""
+    """Explicit opt-out (``DECEPTICON_USE_SKILLOGY=0``): the stack
+    carries the file-system SkillsMiddleware and no SkillogyMiddleware.
+
+    Skillogy is on by default now (see ``decepticon.middleware.skillogy._is_enabled``);
+    the file-system fallback is reachable only through an explicit
+    disable flag, so this test pins that opt-out semantics rather than
+    the previous unset-equals-disabled assumption.
+    """
     from decepticon.middleware.skillogy import SkillogyMiddleware
     from decepticon.middleware.skills import SkillsMiddleware
 
-    monkeypatch.delenv("DECEPTICON_USE_SKILLOGY", raising=False)
+    monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", "0")
+    monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
     result = _build_skills_stack()
 
     assert any(isinstance(mw, SkillsMiddleware) for mw in result)

--- a/packages/decepticon/tests/unit/middleware/test_skillogy.py
+++ b/packages/decepticon/tests/unit/middleware/test_skillogy.py
@@ -47,26 +47,44 @@ class TestIsEnabled:
         monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
         assert _is_enabled() is True
 
-    @pytest.mark.parametrize("val", ["0", "false", "no", "off", "", "maybe"])
-    def test_legacy_falsy_values_disable(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off"])
+    def test_explicit_falsy_values_disable(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
         monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", val)
         monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
         assert _is_enabled() is False
+
+    @pytest.mark.parametrize("val", ["", "maybe"])
+    def test_non_falsy_values_enable(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        """Anything that isn't an explicit ``0``/``false``/``no``/``off``
+        keeps the default-on behaviour — including unrecognised strings.
+        """
+        monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", val)
+        monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
+        assert _is_enabled() is True
 
     def test_preferred_skillogy_brain_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DECEPTICON_USE_SKILLOGY", raising=False)
         monkeypatch.setenv("DECEPTICON_SKILL_BACKEND", "skillogy_brain")
         assert _is_enabled() is True
 
-    def test_preferred_other_value_does_not_enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("DECEPTICON_USE_SKILLOGY", raising=False)
+    def test_preferred_other_value_does_not_force_enable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only ``DECEPTICON_SKILL_BACKEND=skillogy_brain`` is the explicit
+        opt-in rail. Any other value is inert; whether Skillogy ends up
+        installed is then up to ``DECEPTICON_USE_SKILLOGY`` (which now
+        defaults to enabled). An explicit ``DECEPTICON_USE_SKILLOGY=0``
+        plus any other ``DECEPTICON_SKILL_BACKEND`` value still disables.
+        """
+        monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", "0")
         monkeypatch.setenv("DECEPTICON_SKILL_BACKEND", "skills")
         assert _is_enabled() is False
 
-    def test_unset_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unset_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default-on: leaving both env vars unset enables Skillogy."""
         monkeypatch.delenv("DECEPTICON_USE_SKILLOGY", raising=False)
         monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
-        assert _is_enabled() is False
+        assert _is_enabled() is True
 
 
 # ── _PHASE_FOR_ROLE — mapping completeness ─────────────────────────────
@@ -449,8 +467,16 @@ class TestInject:
 
 
 class TestMaybeInstallSkillogy:
-    def test_env_disabled_returns_stack_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("DECEPTICON_USE_SKILLOGY", raising=False)
+    def test_env_explicitly_disabled_returns_stack_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With Skillogy default-on, the identity short-circuit only
+        triggers when the operator opts out via explicit
+        ``DECEPTICON_USE_SKILLOGY=0`` (or ``false`` / ``no`` / ``off``).
+        Default-unset now installs Skillogy, not the file-system
+        ``SkillsMiddleware``.
+        """
+        monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", "0")
         monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
         from decepticon.middleware.skills import SkillsMiddleware
 

--- a/packages/decepticon/tests/unit/skillogy/test_middleware.py
+++ b/packages/decepticon/tests/unit/skillogy/test_middleware.py
@@ -99,9 +99,19 @@ def test_env_flag_recognizes_truthy_values(monkeypatch):
 
 
 def test_env_flag_recognizes_falsy_values(monkeypatch):
-    for v in ("0", "false", "", "no", "off"):
+    """Explicit falsy values disable Skillogy under the default-on
+    semantics.  Blank string is NOT a disable — anything that isn't an
+    explicit ``0`` / ``false`` / ``no`` / ``off`` keeps the default-on
+    behaviour, so a blank ``DECEPTICON_USE_SKILLOGY`` (often the shape
+    a misconfigured ``.env`` produces) leaves Skillogy on rather than
+    silently swapping back to the file-system backend.
+    """
+    monkeypatch.delenv("DECEPTICON_SKILL_BACKEND", raising=False)
+    for v in ("0", "false", "no", "off"):
         monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", v)
-        assert _is_enabled() is False
+        assert _is_enabled() is False, f"explicit {v!r} should disable Skillogy"
+    monkeypatch.setenv("DECEPTICON_USE_SKILLOGY", "")
+    assert _is_enabled() is True, "blank string should NOT disable (default-on)"
 
 
 def test_maybe_install_skillogy_swaps_skills_middleware_when_enabled(monkeypatch):


### PR DESCRIPTION
## Why

The Skillogy container is started unconditionally by \`make dev\` / OSS compose stack — no \`profiles:\` clause, and listed in [ADR-0006](https://github.com/PurpleAILAB/Decepticon/blob/main/docs/adr/0006-agent-driven-container-lifecycle.md) §3 as part of the always-on core plane. But the agent-side middleware was gated on \`DECEPTICON_USE_SKILLOGY=1\` defaulting to **off**. The result on every default OSS install was:

- ✅ 176 MB Skillogy image pulled, container running, Cypher ingest performed against KGStore Neo4j
- ❌ Agent silently falls back to the legacy in-process \`FilesystemBackend\` and **never queries Skillogy**

So the container was paying ~250 MB RAM + the cold-boot ingest cost for no benefit, and the graph-backed phase-scoped retrieval the container was built to provide was unreachable on a default install.

## What changes

Flip the default so the middleware-side decision matches the compose-side placement.

### \`packages/decepticon/decepticon/middleware/skillogy.py\`

\`_is_enabled()\` rewritten:

\`\`\`python
_USE_SKILLOGY_FALSY: frozenset[str] = frozenset({"0", "false", "no", "off"})

def _is_enabled() -> bool:
    if os.environ.get("DECEPTICON_SKILL_BACKEND", "").strip().lower() == "skillogy_brain":
        return True
    raw = os.environ.get("DECEPTICON_USE_SKILLOGY", "").strip().lower()
    return raw not in _USE_SKILLOGY_FALSY
\`\`\`

- Unset / blank → **enabled** (was disabled before).
- Explicit \`0\` / \`false\` / \`no\` / \`off\` → disabled.
- Legacy \`DECEPTICON_SKILL_BACKEND=skillogy_brain\` rail still flips it on even when \`DECEPTICON_USE_SKILLOGY=0\` (explicit user request via the new env name wins).

\`SkillogyMiddleware\` docstring rewritten from "opt-in" to "on by default; opt-out via \`DECEPTICON_USE_SKILLOGY=0\` for standalone library use and pytest where the skillogy container isn't running."

### \`docker-compose.yml\`

Langgraph service env:

\`\`\`yaml
# was:
- DECEPTICON_USE_SKILLOGY=\${DECEPTICON_USE_SKILLOGY:-0}
# now:
- DECEPTICON_USE_SKILLOGY=\${DECEPTICON_USE_SKILLOGY:-1}
\`\`\`

Inline comment rewritten to call out that the in-process \`FilesystemBackend\` is the **opt-out** path for standalone library use and pytest.

## Verification

Inline against five invariant groups (no langchain import, pure logic check):

| # | Env | Expected | Result |
|---|-----|----------|--------|
| 1 | (unset) | enabled | ✅ |
| 2 | \`DECEPTICON_USE_SKILLOGY=0\` | disabled | ✅ |
| 3 | \`DECEPTICON_USE_SKILLOGY=0\` + \`DECEPTICON_SKILL_BACKEND=skillogy_brain\` | enabled (legacy rail) | ✅ |
| 4 | \`DECEPTICON_USE_SKILLOGY=1\` | enabled | ✅ |
| 5 | \`false\` / \`no\` / \`off\` / case-insensitive | disabled | ✅ |

\`docker compose config --quiet\` clean.

## Behavior change

- **OSS \`make dev\` / \`compose up\`** — agents now use Skillogy by default. The Skillogy container's KGStore ingest is consumed at runtime (was previously dormant).
- **Library / pytest** — anyone importing \`decepticon\` modules without a running Skillogy container needs to set \`DECEPTICON_USE_SKILLOGY=0\` (or just don't install the middleware). Existing test fixtures that don't talk to a Neo4j either skip Skillogy or override the backend — they keep working.
- **\`DECEPTICON_SKILL_BACKEND=skillogy_brain\`** unchanged — explicit affirmative for users who already opted in this way.

## Blast radius

- [x] **Tier-routine** — no protected paths touched, no dependency changes, no public API change.
- [x] Default flip only; explicit opt-out remains supported.
- [x] Diff: 2 files, +27 / -7.