### PR TITLE
fix(compose): repair BHCE Postgres bootstrap on upgrade

### DIFF
--- a/containers/postgres-init/02-bloodhound-db.sh
+++ b/containers/postgres-init/02-bloodhound-db.sh
@@ -13,10 +13,11 @@
 # the extension here as the postgres superuser so BHCE's migration
 # user can remain narrowly scoped.
 #
-# Postgres auto-runs files in /docker-entrypoint-initdb.d/ on first
-# boot only (when the data volume is empty).  To apply to an existing
-# deployment without data loss, run the equivalent commands manually
-# inside the postgres container.
+# Postgres auto-runs files in /docker-entrypoint-initdb.d/ on first boot
+# only, but Decepticon v1.1.7 also ships to users with an existing
+# postgres_data volume.  Keep this script idempotent and run it both from
+# initdb and from the compose `bhce-postgres-init` sidecar so upgrades gain
+# the BloodHound role/database without deleting user data.
 #
 # ADR: docs/adr/0005-bloodhound-via-bhce-rest-client.md
 set -euo pipefail
@@ -25,13 +26,42 @@ BHCE_DB_NAME="${BHCE_POSTGRES_DB:-bloodhound}"
 BHCE_DB_USER="${BHCE_POSTGRES_USER:-bloodhound}"
 BHCE_DB_PASSWORD="${BHCE_POSTGRES_PASSWORD:-bhce-decepticon-local}"
 
-psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" <<-EOSQL
-    CREATE ROLE "${BHCE_DB_USER}" WITH LOGIN PASSWORD '${BHCE_DB_PASSWORD}';
-    CREATE DATABASE "${BHCE_DB_NAME}" OWNER "${BHCE_DB_USER}";
-    GRANT ALL PRIVILEGES ON DATABASE "${BHCE_DB_NAME}" TO "${BHCE_DB_USER}";
+psql -v ON_ERROR_STOP=1 \
+    --username "${POSTGRES_USER}" \
+    --dbname "${POSTGRES_DB}" \
+    -v bhce_db_name="${BHCE_DB_NAME}" \
+    -v bhce_db_user="${BHCE_DB_USER}" \
+    -v bhce_db_password="${BHCE_DB_PASSWORD}" <<-'EOSQL'
+    SELECT format('CREATE ROLE %I WITH LOGIN PASSWORD %L', :'bhce_db_user', :'bhce_db_password')
+    WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'bhce_db_user')
+    \gexec
+
+    SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'bhce_db_user', :'bhce_db_password')
+    \gexec
+
+    SELECT format('CREATE DATABASE %I OWNER %I', :'bhce_db_name', :'bhce_db_user')
+    WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = :'bhce_db_name')
+    \gexec
+
+    SELECT format('ALTER DATABASE %I OWNER TO %I', :'bhce_db_name', :'bhce_db_user')
+    \gexec
+
+    SELECT format('GRANT ALL PRIVILEGES ON DATABASE %I TO %I', :'bhce_db_name', :'bhce_db_user')
+    \gexec
 EOSQL
 
-psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${BHCE_DB_NAME}" <<-EOSQL
+psql -v ON_ERROR_STOP=1 \
+    --username "${POSTGRES_USER}" \
+    --dbname "${BHCE_DB_NAME}" \
+    -v bhce_db_user="${BHCE_DB_USER}" <<-'EOSQL'
     CREATE EXTENSION IF NOT EXISTS pg_trgm;
-    GRANT ALL ON SCHEMA public TO "${BHCE_DB_USER}";
+
+    SELECT format('GRANT ALL ON SCHEMA public TO %I', :'bhce_db_user')
+    \gexec
+
+    SELECT format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %I', :'bhce_db_user')
+    \gexec
+
+    SELECT format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %I', :'bhce_db_user')
+    \gexec
 EOSQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -565,10 +565,43 @@ services:
   # See docs/adr/0005-bloodhound-via-bhce-rest-client.md §Context.
   #
   # Why reuse Postgres: BHCE only needs one Postgres database
-  # (`bloodhound`) with the `pg_trgm` extension.  We pre-create both
-  # in containers/postgres-init/02-bloodhound-db.sh so BHCE's goose
-  # migrations bootstrap cleanly against our existing Postgres
-  # instance — no second Postgres container.
+  # (`bloodhound`) with the `pg_trgm` extension.  The idempotent
+  # `bhce-postgres-init` sidecar below creates/repairs that state on
+  # both fresh installs and upgrades with an existing `postgres_data`
+  # volume, so users do not have to delete data after BHCE is added.
+  bhce-postgres-init:
+    image: postgres:17-alpine
+    container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-bhce-postgres-init
+    environment:
+      POSTGRES_USER: decepticon
+      POSTGRES_DB: litellm
+      PGPASSWORD: ${POSTGRES_PASSWORD:-decepticon}
+      PGHOST: postgres
+      BHCE_POSTGRES_DB: ${BHCE_POSTGRES_DB:-bloodhound}
+      BHCE_POSTGRES_USER: ${BHCE_POSTGRES_USER:-bloodhound}
+      BHCE_POSTGRES_PASSWORD: ${BHCE_POSTGRES_PASSWORD:-bhce-decepticon-local}
+    volumes:
+      - ./containers/postgres-init/02-bloodhound-db.sh:/decepticon/ensure-bloodhound-db.sh:ro
+    command:
+      - bash
+      - -c
+      - |
+        bash /decepticon/ensure-bloodhound-db.sh
+        exec sleep 2147483647
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          test "$$(psql -v ON_ERROR_STOP=1 --username "$${POSTGRES_USER}" --dbname "$${BHCE_POSTGRES_DB}" -tAc "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')")" = "t"
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    networks:
+      - decepticon-net
   bhce-neo4j:
     image: neo4j:4.4.42-community
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-bhce-neo4j
@@ -606,8 +639,8 @@ services:
       bhe_enable_cypher_mutations: "false"
       bhe_graph_query_memory_limit: "2"
       # External Postgres — our existing `postgres` container, with
-      # the `bloodhound` DB + `pg_trgm` pre-created by
-      # containers/postgres-init/02-bloodhound-db.sh.
+      # the `bloodhound` DB + `pg_trgm` ensured by the idempotent
+      # `bhce-postgres-init` sidecar above.
       bhe_database_connection: >-
         user=${BHCE_POSTGRES_USER:-bloodhound}
         password=${BHCE_POSTGRES_PASSWORD:-bhce-decepticon-local}
@@ -631,21 +664,22 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      bhce-postgres-init:
+        condition: service_healthy
       bhce-neo4j:
         condition: service_healthy
-    # BHCE healthcheck is intentionally disabled: the SpecterOps upstream
-    # image is distroless, so it ships with no `/bin/sh`, no `wget`, no
-    # `curl`, and no `ls` — only the `/bloodhound` Go binary. The previous
-    # `CMD-SHELL "wget ... /api/version"` test failed with `exec: /bin/sh:
-    # no such file or directory` and the `/api/version` endpoint requires
-    # authentication besides (only `/api/v2/spec` is unauthenticated per
-    # ADR-0005), so even rewriting the test would not fix the missing
-    # tooling. Downstream services do not gate on `bhce.condition:
-    # service_healthy`, so the disabled healthcheck does not affect the
-    # rest of the stack — clients (`bhce_client` in tools/ad) carry their
-    # own ready-check retry loop against `/api/v2/spec`.
+    # The upstream image is distroless: no `/bin/sh`, curl, wget, or Python.
+    # Docker Compose `up --wait` rejects services with no healthcheck, so use
+    # the only executable the image provides as a liveness check. API clients
+    # still perform the real readiness probe/retry against `/api/v2/spec`;
+    # this check exists to keep compose wait semantics from failing before the
+    # client-level readiness loop can run.
     healthcheck:
-      disable: true
+      test: ["CMD", "/bloodhound", "-version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

Fixes #615 — v1.1.6 → v1.1.7 upgraders cannot start Decepticon because
BHCE crash-loops on `password authentication failed for user "bloodhound"`,
which makes `docker compose up --wait` time out and the CLI exit non-zero.

Root cause: `containers/postgres-init/02-bloodhound-db.sh` ships in v1.1.7
but Postgres only runs `/docker-entrypoint-initdb.d` on **first boot**
(empty data volume). Upgraders already have a populated `postgres_data`
volume (litellm + web DBs), so the `bloodhound` role/database is never
created. PR #611's healthcheck-disable only papered over fresh installs;
the underlying bootstrap was still missing on upgrade.

This PR is strictly the upgrade-path bug fix. Three changes:

- `02-bloodhound-db.sh` rewritten with `WHERE NOT EXISTS` + `\gexec`
  guards so it is safe to run repeatedly on existing volumes.
- New `bhce-postgres-init` sidecar runs the script against the live
  `postgres` after it is healthy, with a healthcheck that asserts
  `bloodhound` DB + `pg_trgm` exist. `bhce.depends_on` waits on that
  healthcheck — BHCE never starts before its DB is ready.
- BHCE healthcheck re-enabled with `["CMD","/bloodhound","-version"]`
  — the only executable the distroless upstream image exposes — so
  `up --wait` has a real liveness signal.

## Scope narrowed (from the original posted patch)

The original patch on the issue also moved `bhce`/`bhce-neo4j` behind
a `--profile ad` gate. That belongs to **ADR-0006 Sprint 2**, which is
unblocked by the **`opscontrol` daemon (ADR-0006 Sprint 1)** that the
orchestrator agent will use to call `ops_start("ad")` automatically
after recon detects an AD environment.

Shipping the profile gate without the daemon would silently lose BHCE
for AD users on the OSS launcher path (`clients/launcher/cmd/start.go`
hard-codes `--profile cli`, no `Profiles.AD` in
`clients/launcher/internal/compose/compose.go`). So this PR keeps BHCE
in the default `cli` profile and the profile flip lands together with
opscontrol in follow-up PRs targeting **v1.1.8**.

## v1.1.8 release plan

1. **This PR — bootstrap fix only.**
2. **ADR-0006 Sprint 1 PR** — host-binary `opscontrol` daemon
   (`clients/launcher/cmd/opscontrol`) + Unix-socket HTTP API +
   `decepticon.tools.ops` LangChain `@tool` surface + langgraph
   socket bind-mount.
3. **ADR-0006 Sprint 2 PR** — `profiles: [ad]` on `bhce` +
   `bhce-neo4j`, remove `COMPOSE_PROFILES=c2-sliver` default from
   `.env.example`, update orchestrator system prompt to call
   `ops_start("ad")` / `ops_stop("ad")` around AD specialist dispatch.

## Test plan

- [x] `make smoke` — BHCE + `bhce-neo4j` + `bhce-postgres-init` come
      up Healthy in the default `cli` profile.
- [x] Upgrade simulation — after `DROP DATABASE bloodhound; DROP ROLE
      bloodhound;` on the running postgres, `compose rm` +
      `up bhce-postgres-init bhce` triggers the sidecar to log
      `CREATE ROLE / ALTER ROLE / CREATE DATABASE / ALTER DATABASE /
      GRANT / CREATE EXTENSION / GRANT(×3)`, and BHCE reaches Healthy
      in ~18 s.
- [ ] CI `make quality` (PR lane) before merge.

## Notes for reviewers

- The sidecar holds an idle `sleep 2147483647` after running the
  script so its healthcheck can keep evaluating; this satisfies
  `depends_on: service_healthy` from `bhce`. An alternative would be
  `service_completed_successfully` + a separate signaler, but the
  current pattern matches the patch as authored and dogfooded.
- BHCE's `/bloodhound -version` healthcheck is liveness-only, not
  readiness — clients (`bhce_client`) still implement their own
  retry loop against `/api/v2/spec`.
- `make smoke`'s pre-down step uses `PROFILES_ALL = --profile cli
  --profile c2-sliver`; this PR does not touch that. Out of scope.

Closes #615.

Credit: original patch + diagnosis by @yegors in #615.
