### PR TITLE
feat(ops): ADR-0006 Sprint 2 — profile gate + workload lifecycle prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,10 +250,17 @@ LANGSMITH_PROJECT=decepticon
 # on-sync behavior (useful when debugging async issues in your own code).
 # LANGGRAPH_STRICT_ASYNC=1
 
-# --- C2 Framework ---
-# Default C2 server profile. Change to swap C2 frameworks.
-# Options: c2-sliver (default), c2-havoc (future)
-COMPOSE_PROFILES=c2-sliver
+# --- C2 Framework / Specialist workloads ---
+# ADR-0006 (v1.1.8+): specialist workloads (c2-sliver, c2-havoc, ad,
+# reversing, …) come up on demand through the opscontrol daemon —
+# the orchestrator agent calls `ops_start("c2-sliver")` after gaining
+# a foothold, `ops_start("ad")` once recon identifies a Windows
+# domain, and so on. Default `decepticon start` keeps every
+# specialist plane cold to minimize idle cost + attack surface.
+#
+# Override only when you need every profile up by hand (e.g. CI
+# regression of every workload at once):
+#   COMPOSE_PROFILES=cli,c2-sliver,ad,reversing
 
 # --- Paths ---
 # Install directory (used for workspace bind mount into containers).

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -47,20 +47,36 @@ func New() *Compose {
 	}
 }
 
-// Profiles defines available Docker Compose profiles.
+// Profiles defines the Docker Compose profile names this launcher
+// recognizes. The shipped catalog (cli + every specialist workload)
+// is the union — `cli` is always activated by `decepticon start`;
+// the specialist workloads come up on demand through ADR-0006's
+// opscontrol daemon. The launcher keeps the names here as constants
+// only so `down` / `stop` can sweep every container regardless of
+// which workloads the agent ended up spawning.
 var Profiles = struct {
-	CLI string
-	C2  string
+	CLI       string
+	C2        string
+	AD        string
+	Reversing string
 }{
-	CLI: "cli",
-	C2:  "c2-sliver",
+	CLI:       "cli",
+	C2:        "c2-sliver",
+	AD:        "ad",
+	Reversing: "reversing",
 }
 
-// AllProfiles returns all profile flags for complete teardown.
+// AllProfiles returns every profile flag the launcher should pass
+// to `docker compose down`. Workloads the agent never spawned are
+// silently no-ops; the cost of listing them is one cli-arg per
+// profile, which beats orphaning containers when an engagement
+// brought up an ad-hoc combination of specialists.
 func AllProfiles() []string {
 	return []string{
 		"--profile", Profiles.CLI,
 		"--profile", Profiles.C2,
+		"--profile", Profiles.AD,
+		"--profile", Profiles.Reversing,
 	}
 }
 

--- a/clients/launcher/internal/compose/compose_test.go
+++ b/clients/launcher/internal/compose/compose_test.go
@@ -26,11 +26,18 @@ func TestNew(t *testing.T) {
 
 func TestAllProfiles(t *testing.T) {
 	profiles := AllProfiles()
-	if len(profiles) != 4 {
-		t.Errorf("AllProfiles() len = %d, want 4 (2 pairs)", len(profiles))
+	// ADR-0006 Sprint 2 expanded the catalog to cover every workload
+	// the launcher may need to tear down: cli + c2-sliver + ad +
+	// reversing = 4 profiles = 8 cli args (--profile NAME).
+	expected := []string{
+		"--profile", "cli",
+		"--profile", "c2-sliver",
+		"--profile", "ad",
+		"--profile", "reversing",
 	}
-	// Verify pairs
-	expected := []string{"--profile", "cli", "--profile", "c2-sliver"}
+	if len(profiles) != len(expected) {
+		t.Fatalf("AllProfiles() len = %d, want %d", len(profiles), len(expected))
+	}
 	for i, v := range expected {
 		if profiles[i] != v {
 			t.Errorf("profiles[%d] = %q, want %q", i, profiles[i], v)

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -190,10 +190,17 @@ LANGSMITH_PROJECT=decepticon
 # POSTGRES_PORT=5432
 # WEB_PORT=3000
 
-# --- C2 Framework ---
-# Default C2 server profile. Change to swap C2 frameworks.
-# Options: c2-sliver (default), c2-havoc (future)
-COMPOSE_PROFILES=c2-sliver
+# --- C2 Framework / Specialist workloads ---
+# ADR-0006 (v1.1.8+): specialist workloads (c2-sliver, c2-havoc, ad,
+# reversing, …) come up on demand through the opscontrol daemon —
+# the orchestrator agent calls `ops_start("c2-sliver")` after gaining
+# a foothold, `ops_start("ad")` once recon identifies a Windows
+# domain, and so on. Default `decepticon start` keeps every
+# specialist plane cold to minimize idle cost + attack surface.
+#
+# Override only when you need every profile up by hand (e.g. CI
+# regression of every workload at once):
+#   COMPOSE_PROFILES=cli,c2-sliver,ad,reversing
 
 # --- Paths ---
 # Install directory (used for workspace bind mount into containers).

--- a/clients/launcher/internal/opscontrol/registry.go
+++ b/clients/launcher/internal/opscontrol/registry.go
@@ -90,3 +90,19 @@ func (r *registry) snapshot() []WorkloadStatus {
 	}
 	return out
 }
+
+// workloadsForEngagement returns the names of every workload currently
+// associated with engagementID and not already in StateStopped. The
+// caller is responsible for taking per-workload mutexes before
+// stopping each one; this method is read-only.
+func (r *registry) workloadsForEngagement(engagementID string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := []string{}
+	for workload, e := range r.entries {
+		if e.EngagementID == engagementID && e.State != StateStopped {
+			out = append(out, workload)
+		}
+	}
+	return out
+}

--- a/clients/launcher/internal/opscontrol/server.go
+++ b/clients/launcher/internal/opscontrol/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -97,6 +98,7 @@ func (s *Server) mux() http.Handler {
 	mux.HandleFunc("GET /v1/profiles", s.handleList)
 	mux.HandleFunc("POST /v1/profiles/{workload}/start", s.handleStart)
 	mux.HandleFunc("POST /v1/profiles/{workload}/stop", s.handleStop)
+	mux.HandleFunc("POST /v1/engagements/{engagement}/cleanup", s.handleCleanupEngagement)
 	return mux
 }
 
@@ -213,6 +215,51 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	}
 	s.Registry.set(workload, StateStopped, "")
 	writeJSON(w, http.StatusAccepted, Handle{Workload: workload, State: StateStopped})
+}
+
+// cleanupResponse summarizes a bulk engagement teardown so the agent
+// can confirm what was stopped (or surface which workloads errored
+// out and stayed up).
+type cleanupResponse struct {
+	Engagement string   `json:"engagement"`
+	Stopped    []string `json:"stopped"`
+	Errors     map[string]string `json:"errors,omitempty"`
+}
+
+// engagementName matches what RFC 1123-style identifiers and our
+// engagement picker emit. We are intentionally lax (allow dots /
+// underscores) because engagement IDs are operator-chosen and have
+// no shell-injection blast radius — the daemon only uses the ID as a
+// registry key, never as a shell argument.
+var engagementName = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+
+func (s *Server) handleCleanupEngagement(w http.ResponseWriter, r *http.Request) {
+	engagement := r.PathValue("engagement")
+	if !engagementName.MatchString(engagement) {
+		writeError(w, http.StatusBadRequest, "engagement id contains illegal characters")
+		return
+	}
+	targets := s.Registry.workloadsForEngagement(engagement)
+	resp := cleanupResponse{Engagement: engagement, Stopped: []string{}, Errors: map[string]string{}}
+	for _, workload := range targets {
+		lock := s.Registry.lockFor(workload)
+		lock.Lock()
+		err := s.Backend.Stop(r.Context(), workload)
+		if err != nil {
+			s.Logger.Error("opscontrol cleanup stop failed",
+				"engagement", engagement, "workload", workload, "err", err)
+			resp.Errors[workload] = err.Error()
+			lock.Unlock()
+			continue
+		}
+		s.Registry.set(workload, StateStopped, "")
+		resp.Stopped = append(resp.Stopped, workload)
+		lock.Unlock()
+	}
+	if len(resp.Errors) == 0 {
+		resp.Errors = nil
+	}
+	writeJSON(w, http.StatusAccepted, resp)
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/clients/launcher/internal/opscontrol/server_test.go
+++ b/clients/launcher/internal/opscontrol/server_test.go
@@ -167,6 +167,75 @@ func TestServer_StopAfterStart(t *testing.T) {
 	}
 }
 
+func TestServer_CleanupEngagementStopsTaggedWorkloads(t *testing.T) {
+	s, be := newTestServer(t)
+
+	// Tag two workloads with eng-1, one with eng-2.
+	for _, payload := range []struct{ workload, engagement string }{
+		{"ad", "eng-1"},
+		{"c2-sliver", "eng-1"},
+		{"reversing", "eng-2"},
+	} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost,
+			"/v1/profiles/"+payload.workload+"/start?engagement="+payload.engagement, nil)
+		s.mux().ServeHTTP(w, r)
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("seed start %s: %d", payload.workload, w.Code)
+		}
+	}
+
+	// Cleanup eng-1.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/engagements/eng-1/cleanup", nil)
+	s.mux().ServeHTTP(w, r)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("cleanup status = %d", w.Code)
+	}
+	var resp cleanupResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Stopped) != 2 {
+		t.Errorf("stopped = %v; want 2 entries", resp.Stopped)
+	}
+	if be.stopCount.Load() != 2 {
+		t.Errorf("backend.Stop called %d times; want 2", be.stopCount.Load())
+	}
+	// reversing (eng-2) must still be running.
+	be.mu.Lock()
+	stillUp := be.running["reversing"]
+	be.mu.Unlock()
+	if !stillUp {
+		t.Error("reversing (eng-2) was stopped; cleanup must only touch its own engagement")
+	}
+}
+
+func TestServer_CleanupEngagementRejectsBadID(t *testing.T) {
+	s, _ := newTestServer(t)
+	for _, bad := range []string{
+		"../etc",
+		"with space",
+		"$(rm -rf)",
+		"",
+	} {
+		w := httptest.NewRecorder()
+		// Replace whitespace so http.NewRequest accepts the URL; the
+		// handler validation must still reject it.
+		urlPath := "/v1/engagements/" + strings.ReplaceAll(bad, " ", "%20") + "/cleanup"
+		r := httptest.NewRequest(http.MethodPost, urlPath, nil)
+		s.mux().ServeHTTP(w, r)
+		// ServeMux returns 301 (path normalization) for `../etc` and
+		// empty-segment paths before our handler runs; that is still
+		// "rejected before the backend was called", which is the
+		// security property we care about. The handler-level 400 covers
+		// names that survive mux normalization.
+		if w.Code < 300 || w.Code >= 500 {
+			t.Errorf("engagement=%q got status %d; want a 3xx/4xx rejection", bad, w.Code)
+		}
+	}
+}
+
 func TestServer_ListReflectsRegistry(t *testing.T) {
 	s, _ := newTestServer(t)
 	// Empty before any start.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -481,8 +481,12 @@ services:
 
   # ── C2 Infrastructure (profile-based, default: c2-sliver) ───────────
   # Each C2 framework runs as a profile-based service on sandbox-net.
-  # Default: COMPOSE_PROFILES=c2-sliver in .env → starts with `docker compose up -d`
-  # Swap: change COMPOSE_PROFILES to c2-havoc, etc.
+  # ADR-0006 (v1.1.8+): C2 frameworks are opt-in workloads spawned by
+  # the orchestrator agent through opscontrol — the orchestrator calls
+  # `ops_start("c2-sliver")` after gaining a foothold. Default
+  # `decepticon start` keeps the C2 plane cold.
+  # Swap framework: change `ops_start("c2-sliver")` to
+  # `ops_start("c2-havoc")` once that workload ships.
   # Agent connects via: sliver-client (pre-installed in sandbox)
   c2-sliver:
     image: ghcr.io/purpleailab/decepticon-c2-sliver:${DECEPTICON_VERSION:-latest}
@@ -602,6 +606,11 @@ services:
       start_period: 5s
     networks:
       - decepticon-net
+    # ADR-0006 §3 — workload is opt-in via the opscontrol daemon.
+    # Default `decepticon start` does NOT bring this up; the agent
+    # spawns it on demand via `ops_start("ad")`.
+    profiles:
+      - ad
   bhce-neo4j:
     image: neo4j:4.4.42-community
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-bhce-neo4j
@@ -622,6 +631,10 @@ services:
       retries: 12
       start_period: 60s
     restart: unless-stopped
+    # ADR-0006 §3 — opt-in via `ops_start("ad")`. Default
+    # `decepticon start` does not spin up the AD graph DB.
+    profiles:
+      - ad
 
   bhce:
     # SpecterOps does not publish semver tags on Docker Hub — every
@@ -681,6 +694,11 @@ services:
       retries: 3
       start_period: 10s
     restart: unless-stopped
+    # ADR-0006 §3 — workload is opt-in. The orchestrator agent calls
+    # `ops_start("ad")` after recon identifies an AD environment;
+    # default `decepticon start` keeps the BHCE plane cold.
+    profiles:
+      - ad
 
 volumes:
   postgres_data:

--- a/packages/decepticon-core/decepticon_core/contracts/slots.py
+++ b/packages/decepticon-core/decepticon_core/contracts/slots.py
@@ -39,6 +39,11 @@ class MiddlewareSlot(StrEnum):
     KG = "kg"
     EVENT_LOG = "event-log"
     SANDBOX_NOTIFICATION = "sandbox-notification"
+    # ADR-0006: the orchestrator-only middleware that turns opscontrol
+    # daemon state transitions into Claude-Code-style
+    # ``● Workload 'ad': starting → running`` system-reminders so the
+    # agent does not poll ``ops_status`` in a loop.
+    OPSCONTROL_NOTIFICATION = "opscontrol-notification"
     BUDGET = "budget"
     MODEL_OVERRIDE = "model-override"
     MODEL_FALLBACK = "model-fallback"
@@ -82,6 +87,14 @@ SAFETY_CRITICAL_SLOTS: frozenset[MiddlewareSlot] = frozenset(
         # the CLI's ``? Background command`` event. Disabling it leaves
         # operator visibility broken on every background tool call.
         MiddlewareSlot.SANDBOX_NOTIFICATION,
+        # OpscontrolNotification is the orchestrator-only equivalent
+        # for the ADR-0006 ops_* tools: it surfaces workload state
+        # transitions (BHCE cold-start finished, c2-sliver healthy, …)
+        # as system-reminders. Disabling it forces the agent into a
+        # polling loop on ops_status, which both wastes tokens and
+        # creates the same bash-stale-poll failure mode the
+        # SandboxNotification middleware exists to prevent.
+        MiddlewareSlot.OPSCONTROL_NOTIFICATION,
         # HITLApprovalMiddleware is the operator-approval gate for
         # high-impact actions (credential dumping, destructive ops).
         # Disabling it lets an agent execute gated tools without any
@@ -153,6 +166,11 @@ SLOTS_PER_ROLE: dict[str, frozenset[MiddlewareSlot]] = {
         MiddlewareSlot.OPPLAN,
         MiddlewareSlot.MODEL_OVERRIDE,
         MiddlewareSlot.HITL_APPROVAL,
+        # Only the orchestrator carries ops_* tools (ADR-0006 §2), so
+        # only the orchestrator gets the workload-completion delivery
+        # middleware. Specialists never see workload notifications
+        # because they cannot start workloads.
+        MiddlewareSlot.OPSCONTROL_NOTIFICATION,
     },
     # ── Standard non-bash agent (planning + interview) ──
     "soundwave": _BASE_SLOTS | {MiddlewareSlot.ENGAGEMENT_CONTEXT},

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -54,6 +54,9 @@ from decepticon.middleware.hitl import (
 )
 from decepticon.middleware.model_override import ModelOverrideMiddleware
 from decepticon.middleware.notifications import SandboxNotificationMiddleware
+from decepticon.middleware.opscontrol_notifications import (
+    OpsControlNotificationMiddleware,
+)
 from decepticon.middleware.prompt_injection_shield import PromptInjectionShieldMiddleware
 from decepticon.middleware.roe import build_default_sink
 
@@ -206,6 +209,18 @@ def _make_sandbox_notification(*, sandbox: Any = None, **_: Any):
     return SandboxNotificationMiddleware(sandbox=sandbox)
 
 
+def _make_opscontrol_notification(**_: Any):
+    """ADR-0006 workload-state-transition delivery for the orchestrator.
+
+    Returns a middleware that polls the opscontrol UDS once per turn and
+    injects ``<system-reminder>`` blocks for state transitions
+    (starting → running / stopped / unknown). When the daemon is
+    unreachable (``make dev`` / ``make smoke`` paths, or pre-Sprint-1
+    installs) the middleware degrades to a no-op so boot does not break.
+    """
+    return OpsControlNotificationMiddleware()
+
+
 def _make_model_override(**_: Any):
     return ModelOverrideMiddleware()
 
@@ -346,6 +361,7 @@ DEFAULT_SLOT_FACTORIES: dict[MiddlewareSlot, SlotFactory] = {
     MiddlewareSlot.KG: _make_kg,
     MiddlewareSlot.EVENT_LOG: _make_event_log,
     MiddlewareSlot.SANDBOX_NOTIFICATION: _make_sandbox_notification,
+    MiddlewareSlot.OPSCONTROL_NOTIFICATION: _make_opscontrol_notification,
     MiddlewareSlot.BUDGET: _make_budget,
     MiddlewareSlot.MODEL_OVERRIDE: _make_model_override,
     MiddlewareSlot.MODEL_FALLBACK: _make_model_fallback,

--- a/packages/decepticon/decepticon/agents/prompts/standard/decepticon.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/decepticon.md
@@ -94,18 +94,20 @@ Domain-specific specialists need sidecar services to function — `ad_operator` 
 
 **Workflow** (mandatory order):
 
-1. Before any `task("<specialist>", ...)` whose workload row above applies, call `ops_start("<workload>", engagement_id=$DECEPTICON_ENGAGEMENT)`. The tool returns a JSON envelope; treat `state: "running"` as ready. An `error: "opscontrol_unreachable"` diagnostic means the daemon is not installed on this host (`make dev` / `make smoke` are daemon-less by design) — record the gap and either invoke specialist tools that do not need the workload OR mark the AD/C2 objective `blocked` if the workload is mandatory.
-2. Dispatch the specialist `task()` as usual.
-3. After the specialist returns, decide whether the workload is still needed:
+1. Before any `task("<specialist>", ...)` whose workload row above applies, call `ops_start("<workload>", engagement_id=$DECEPTICON_ENGAGEMENT)`. **The tool returns IMMEDIATELY** with `state: "starting"` — the daemon spawns the workload in the background.
+2. **Do NOT poll `ops_status` waiting for it.** Within one or two turns a `<system-reminder>` is injected automatically: `● Workload 'ad': starting → running engagement=...`. That reminder is the authoritative ready signal. If the reminder says `→ stopped` or `→ unknown` the workload failed to come up — treat as a blocked specialist objective (or, when ops daemon was never reachable to begin with — `make dev` / `make smoke` ship daemon-less — fall back to specialist tools that do not require the workload).
+3. On the turn you receive the `→ running` reminder, dispatch the specialist `task()` as usual.
+4. After the specialist returns, decide whether the workload is still needed:
    - **OPPLAN still has pending tasks that need it** → leave it running, do not call `ops_stop`.
    - **No more uses of this workload** → call `ops_stop("<workload>")`. Idempotent — stopping an already-stopped workload returns 202.
 
 **At engagement close** (after the final-report sequence in `<COMPLETION_CRITERIA>` and before the final assistant message), call `ops_cleanup_engagement(engagement_id=$DECEPTICON_ENGAGEMENT)`. The daemon stops every workload tagged with the current engagement so the host returns to an idle baseline. Missing this is not a discipline violation in itself — the daemon survives across engagements — but it leaks idle BHCE / Sliver memory until the next `decepticon stop`.
 
-**`ops_status()`** is a read-only probe of the daemon's current view. Use it when an `ops_start` returned an unexpected error envelope, or when debugging "should this workload be up by now?" Do not poll it in a loop — workload state transitions are seconds, not turns.
+**`ops_status()` is a FALLBACK only.** State transitions are delivered automatically as `<system-reminder>` blocks at the start of each turn — same delivery model as background `bash` jobs (you do not poll `bash_output`, you wait for the `● Background command completed` reminder, and the same applies here). The narrow legitimate uses for `ops_status` are: (a) the daemon returned `opscontrol_unreachable` and you need to confirm whether it is back online, (b) you have strong reason to believe a notification was lost and want to re-sync, (c) the operator explicitly asks "what is up?". Routine polling burns context and is rejected at review.
 
 **Anti-patterns**:
 
+- Calling `ops_status` (or any other tool) in a polling loop to wait for `running` — the auto-injected `<system-reminder>` is the delivery channel. Polling here is the same anti-pattern as polling `bash_output` instead of trusting the `● Background command completed` reminder.
 - Calling `ops_start("ad")` before recon has run on a non-AD target — wastes ~30 s of BHCE cold start for nothing. Spawn from observed evidence, not from the engagement tags or the target name alone.
 - Calling `ops_stop` between two sub-agent `task()` calls that both need the same workload — the second specialist will hit "BHCE unreachable" and report a false BLOCKED.
 - Forgetting `ops_cleanup_engagement` when many workloads accumulated — surfaces as `decepticon stop` looking slow because compose has to tear down every accumulated specialist.

--- a/packages/decepticon/decepticon/agents/prompts/standard/decepticon.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/decepticon.md
@@ -81,6 +81,34 @@ Every re-dispatch MUST include the output-redirection instruction (see section E
   - `find` / `ls -R` → pipe to `head -50` or `wc -l`
   - `nmap` / `gobuster` / `ffuf` → `-o file` then extract
   - Each multi-KB inline output triggers SummarizationMiddleware compaction next turn; compaction is expensive and disrupts progress.
+
+## F. Specialist Workload Lifecycle (ADR-0006)
+
+Domain-specific specialists need sidecar services to function — `ad_operator` calls BHCE for attack-graph queries, `postexploit` / `exploit` may need a Sliver C2 team server, `reverser` needs the Ghidra MCP bridge. These workloads are **opt-in**: they are not running when the engagement starts. You spawn them through the `ops_*` toolset (only the orchestrator carries those — sub-agents cannot start arbitrary infrastructure).
+
+| Specialist | Workload to spawn | When |
+|---|---|---|
+| `ad_operator` | `ad` | Recon SUMMARY.md reports an Active Directory environment (SMB / Kerberos / LDAP / DC banner / Windows-domain naming) |
+| `postexploit` (and `exploit` if it needs C2-bound payloads) | `c2-sliver` | After foothold — initial RCE / cred dump / sandbox shell is captured |
+| `reverser` | `reversing` | A binary needs decompilation / static analysis that bash cannot drive |
+
+**Workflow** (mandatory order):
+
+1. Before any `task("<specialist>", ...)` whose workload row above applies, call `ops_start("<workload>", engagement_id=$DECEPTICON_ENGAGEMENT)`. The tool returns a JSON envelope; treat `state: "running"` as ready. An `error: "opscontrol_unreachable"` diagnostic means the daemon is not installed on this host (`make dev` / `make smoke` are daemon-less by design) — record the gap and either invoke specialist tools that do not need the workload OR mark the AD/C2 objective `blocked` if the workload is mandatory.
+2. Dispatch the specialist `task()` as usual.
+3. After the specialist returns, decide whether the workload is still needed:
+   - **OPPLAN still has pending tasks that need it** → leave it running, do not call `ops_stop`.
+   - **No more uses of this workload** → call `ops_stop("<workload>")`. Idempotent — stopping an already-stopped workload returns 202.
+
+**At engagement close** (after the final-report sequence in `<COMPLETION_CRITERIA>` and before the final assistant message), call `ops_cleanup_engagement(engagement_id=$DECEPTICON_ENGAGEMENT)`. The daemon stops every workload tagged with the current engagement so the host returns to an idle baseline. Missing this is not a discipline violation in itself — the daemon survives across engagements — but it leaks idle BHCE / Sliver memory until the next `decepticon stop`.
+
+**`ops_status()`** is a read-only probe of the daemon's current view. Use it when an `ops_start` returned an unexpected error envelope, or when debugging "should this workload be up by now?" Do not poll it in a loop — workload state transitions are seconds, not turns.
+
+**Anti-patterns**:
+
+- Calling `ops_start("ad")` before recon has run on a non-AD target — wastes ~30 s of BHCE cold start for nothing. Spawn from observed evidence, not from the engagement tags or the target name alone.
+- Calling `ops_stop` between two sub-agent `task()` calls that both need the same workload — the second specialist will hit "BHCE unreachable" and report a false BLOCKED.
+- Forgetting `ops_cleanup_engagement` when many workloads accumulated — surfaces as `decepticon stop` looking slow because compose has to tear down every accumulated specialist.
 </CRITICAL_RULES>
 
 <COMPLETION_CRITERIA>

--- a/packages/decepticon/decepticon/middleware/opscontrol_notifications.py
+++ b/packages/decepticon/decepticon/middleware/opscontrol_notifications.py
@@ -1,0 +1,213 @@
+"""Push opscontrol workload state transitions into the agent message stream.
+
+Mirror of :mod:`decepticon.middleware.notifications` (which handles bash
+background-job completion) for the ADR-0006 opscontrol daemon. When a
+workload the agent spawned with ``ops_start("ad")`` transitions to
+``running`` (or ``stopped`` / ``unknown`` on failure), this middleware:
+
+  1. Polls ``GET /v1/profiles`` once per turn via the daemon's
+     Unix-domain socket bind-mount.
+  2. Diffs the registry snapshot against the last-seen state per
+     workload, dedup'd so a workload already announced as ``running``
+     does not re-notify on every turn.
+  3. Injects a ``HumanMessage`` tagged ``<system-reminder>`` carrying the
+     transition summary, so the agent can react on its very next
+     inference turn without calling ``ops_status``.
+
+Hook: ``before_model`` — runs every turn, so completions land on the
+very next inference even if the user did nothing between turns.
+
+Design intent
+-------------
+The agent calls ``ops_start("ad")`` and IMMEDIATELY moves on. It does
+NOT call ``ops_status`` in a polling loop — this middleware is the
+delivery mechanism. The model is told (via the orchestrator prompt
+``Section F``) to expect a system-reminder when the workload is
+ready, and to delegate to the specialist on that turn.
+
+Convergent industry pattern: Claude Code's ``Bash(run_in_background)``
+→ background-completion notification, Decepticon's own
+``SandboxNotificationMiddleware`` for tmux session completions, and the
+LangChain ``async-deep-agents`` reference implementation all use this
+shape. See docs/adr/0006 §6 for the full reference list.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, cast
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from decepticon.tools.ops.client import (
+    OpsControlClient,
+    OpsControlError,
+    OpsControlUnreachableError,
+)
+
+log = logging.getLogger(__name__)
+
+# Workload state strings — must match the daemon's internal
+# ``WorkloadState`` constants (clients/launcher/internal/opscontrol/backend.go).
+STATE_RUNNING = "running"
+STATE_STARTING = "starting"
+STATE_STOPPED = "stopped"
+STATE_UNKNOWN = "unknown"
+
+# State transitions that warrant a notification. Starting → running is
+# the load-bearing case (BHCE cold-start completion); → stopped / →
+# unknown surface failure modes so the agent doesn't silently wait
+# forever for a workload that crashed.
+_NOTIFIABLE_TARGETS = (STATE_RUNNING, STATE_STOPPED, STATE_UNKNOWN)
+
+
+# Per-turn system-prompt injection that codifies the ops_* tool
+# contract. Mirrors how `EngagementContextMiddleware` carries
+# `<ENGAGEMENT_CONTEXT>` and `LANGUAGE_POLICY` blocks — same shape,
+# same delivery channel (request.override(system_message=...)).
+#
+# Why this lives in the middleware rather than the static system
+# prompt: the auto-notification contract is what justifies "do not
+# poll ops_status." Coupling the wording to the middleware that
+# DELIVERS the notifications guarantees the two never drift — if the
+# middleware is swapped out by a plugin the wording must come with it.
+_OPS_POLICY_BLOCK = """
+<OPSCONTROL_POLICY>
+- `ops_start("<workload>")` returns immediately with `state: "starting"`.
+  A `<system-reminder>` is auto-injected on a later turn:
+  `● Workload 'ad': starting → running`. That reminder is the ready
+  signal. Do NOT poll `ops_status` waiting for it.
+- `→ stopped` / `→ unknown` in the reminder means spawn failed —
+  block the dependent specialist objective.
+- `ops_status` is a fallback (daemon reachability check, suspected
+  lost notification, operator asking "what is up?"). Routine polling
+  burns context.
+</OPSCONTROL_POLICY>
+""".strip()
+
+
+class OpsControlNotificationMiddleware(AgentMiddleware):
+    """Auto-deliver opscontrol workload state transitions to the agent."""
+
+    def __init__(self, client: OpsControlClient | None = None) -> None:
+        super().__init__()
+        # Lazy construction — instantiating the client does not open a
+        # socket connection, so this is cheap even when no daemon is
+        # available (e.g. ``make dev`` / ``make smoke`` paths). Tests
+        # may inject a stub client.
+        self._client = client or OpsControlClient()
+        # Per-workload last announced state. We notify only when the
+        # incoming state differs AND is one of _NOTIFIABLE_TARGETS, so
+        # the model sees one reminder per transition, not one per turn.
+        self._last_state: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def _snapshot(self) -> list[dict[str, Any]] | None:
+        """Pull the current registry. None on any daemon-side error so
+        the middleware degrades gracefully — a temporary daemon hiccup
+        must not crash the agent's model step.
+        """
+        try:
+            return self._client.list_profiles()
+        except OpsControlUnreachableError:
+            # Common in daemon-less stacks (make dev / make smoke); not
+            # worth logging at WARN every turn.
+            log.debug("opscontrol daemon unreachable; skipping notification poll")
+            return None
+        except OpsControlError as exc:
+            log.warning("opscontrol /v1/profiles returned %d: %s", exc.status_code, exc.body)
+            return None
+        except Exception as exc:  # noqa: BLE001 — defensive
+            log.warning("opscontrol notification poll failed: %s", exc)
+            return None
+
+    def _format_block(self, record: dict[str, Any], previous: str | None) -> str:
+        workload = record.get("workload", "?")
+        state = record.get("state", "?")
+        engagement = record.get("engagement_id") or ""
+        since = record.get("since") or ""
+        prev = previous or "new"
+        parts = [f"workload={workload!r}", f"state={prev}->{state}"]
+        if engagement:
+            parts.append(f"engagement={engagement}")
+        if since:
+            parts.append(f"since={since}")
+        return "- " + " ".join(parts)
+
+    def _build_message(self) -> dict | None:
+        snapshot = self._snapshot()
+        if not snapshot:
+            return None
+
+        blocks: list[str] = []
+        with self._lock:
+            for record in snapshot:
+                workload = record.get("workload")
+                state = record.get("state")
+                if not workload or not state:
+                    continue
+                previous = self._last_state.get(workload)
+                if state == previous:
+                    continue
+                if state not in _NOTIFIABLE_TARGETS:
+                    # starting → starting / not yet entered a
+                    # notifiable terminal state. Update the cache so a
+                    # later transition includes the right "from" hint
+                    # but emit nothing.
+                    self._last_state[workload] = state
+                    continue
+                blocks.append(self._format_block(record, previous))
+                self._last_state[workload] = state
+
+        if not blocks:
+            return None
+
+        body = "\n".join(blocks)
+        reminder = (
+            "<system-reminder>\n"
+            "Workload state transitions delivered by the opscontrol daemon. "
+            "Authoritative — do not call ops_status to re-confirm:\n"
+            f"{body}\n"
+            "</system-reminder>"
+        )
+        # HumanMessage matches the existing SandboxNotificationMiddleware
+        # convention and the Claude Code system-reminder shape (user-role
+        # message wrapping a tagged block). Keeps the agent's
+        # turn-taking transcript clean: assistant -> tool -> human
+        # reminder -> assistant, never two consecutive assistant turns.
+        return {"messages": [HumanMessage(content=reminder)]}
+
+    def before_model(self, state, runtime):  # type: ignore[override]
+        return self._build_message()
+
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        # The underlying httpx client is sync; this is a sub-millisecond
+        # local UDS call so we don't wrap it in asyncio.to_thread for
+        # latency reasons. Keep the async sibling so subclasses can
+        # override with a true-async client if they wire one in.
+        return self._build_message()
+
+    def wrap_model_call(self, request, handler):  # type: ignore[override]
+        return handler(self._inject(request))
+
+    async def awrap_model_call(self, request, handler):  # type: ignore[override]
+        return await handler(self._inject(request))
+
+    def _inject(self, request):
+        """Append the OPSCONTROL_POLICY block to the request's system
+        message. Mirrors EngagementContextMiddleware's pattern so the
+        two cooperate cleanly (each appends to whatever the previous
+        middleware produced).
+        """
+        injection = _OPS_POLICY_BLOCK
+        if request.system_message is not None:
+            new_content = [
+                *request.system_message.content_blocks,
+                {"type": "text", "text": "\n\n" + injection},
+            ]
+        else:
+            new_content = [{"type": "text", "text": injection}]
+        new_system = SystemMessage(content=cast("list[str | dict[str, str]]", new_content))
+        return request.override(system_message=new_system)

--- a/packages/decepticon/decepticon/tools/ops/__init__.py
+++ b/packages/decepticon/decepticon/tools/ops/__init__.py
@@ -14,13 +14,20 @@ from decepticon.tools.ops.client import (
     OpsControlError,
     OpsControlUnreachableError,
 )
-from decepticon.tools.ops.tools import OPS_TOOLS, ops_start, ops_status, ops_stop
+from decepticon.tools.ops.tools import (
+    OPS_TOOLS,
+    ops_cleanup_engagement,
+    ops_start,
+    ops_status,
+    ops_stop,
+)
 
 __all__ = [
     "OPS_TOOLS",
     "OpsControlClient",
     "OpsControlError",
     "OpsControlUnreachableError",
+    "ops_cleanup_engagement",
     "ops_start",
     "ops_status",
     "ops_stop",

--- a/packages/decepticon/decepticon/tools/ops/client.py
+++ b/packages/decepticon/decepticon/tools/ops/client.py
@@ -102,3 +102,6 @@ class OpsControlClient:
 
     def stop(self, workload: str) -> dict[str, Any]:
         return self._request("POST", f"/v1/profiles/{workload}/stop")
+
+    def cleanup_engagement(self, engagement_id: str) -> dict[str, Any]:
+        return self._request("POST", f"/v1/engagements/{engagement_id}/cleanup")

--- a/packages/decepticon/decepticon/tools/ops/tools.py
+++ b/packages/decepticon/decepticon/tools/ops/tools.py
@@ -105,6 +105,46 @@ def ops_stop(workload: str) -> str:
 
 
 @tool
+def ops_cleanup_engagement(engagement_id: str | None = None) -> str:
+    """Stop every workload tagged with the given engagement_id.
+
+    Call this once at engagement close — typically after the final
+    report has been written but before the orchestrator returns its
+    completion summary. The daemon walks its registry and issues
+    ``stop`` for every workload whose ``engagement_id`` field matches.
+    Idempotent: an already-stopped workload is reported in
+    ``stopped`` exactly once.
+
+    ``engagement_id`` defaults to ``DECEPTICON_ENGAGEMENT`` from the
+    container env (set by the launcher's engagement picker) so the
+    orchestrator does not have to thread the id through every
+    response.
+
+    Returns a JSON envelope:
+        ``{"engagement": "eng-...", "stopped": ["ad", "c2-sliver"], "errors": {...}}``
+    or an error envelope on failure.
+    """
+    if engagement_id is None:
+        engagement_id = os.environ.get("DECEPTICON_ENGAGEMENT") or None
+    if not engagement_id:
+        return _envelope(
+            {
+                "error": "missing_engagement_id",
+                "hint": (
+                    "ops_cleanup_engagement requires an engagement_id "
+                    "(argument or DECEPTICON_ENGAGEMENT env)."
+                ),
+            }
+        )
+    try:
+        return _envelope(OpsControlClient().cleanup_engagement(engagement_id))
+    except OpsControlUnreachableError as exc:
+        return _diagnose_unreachable(exc)
+    except OpsControlError as exc:
+        return _diagnose_http(exc)
+
+
+@tool
 def ops_status() -> str:
     """List every workload the opscontrol daemon has touched this session.
 
@@ -131,4 +171,4 @@ def ops_status() -> str:
         return _diagnose_http(exc)
 
 
-OPS_TOOLS = [ops_start, ops_stop, ops_status]
+OPS_TOOLS = [ops_start, ops_stop, ops_cleanup_engagement, ops_status]

--- a/packages/decepticon/tests/unit/agents/test_build.py
+++ b/packages/decepticon/tests/unit/agents/test_build.py
@@ -596,6 +596,7 @@ def test_middleware_slot_enum_order_is_assembly_order():
         "kg",
         "event-log",
         "sandbox-notification",
+        "opscontrol-notification",
         "budget",
         "model-override",
         "model-fallback",

--- a/packages/decepticon/tests/unit/ops/test_tools.py
+++ b/packages/decepticon/tests/unit/ops/test_tools.py
@@ -13,7 +13,13 @@ from typing import Any
 
 import pytest
 
-from decepticon.tools.ops import OPS_TOOLS, ops_start, ops_status, ops_stop
+from decepticon.tools.ops import (
+    OPS_TOOLS,
+    ops_cleanup_engagement,
+    ops_start,
+    ops_status,
+    ops_stop,
+)
 from decepticon.tools.ops.client import OpsControlError, OpsControlUnreachableError
 
 
@@ -50,6 +56,11 @@ class _FakeClient:
         self.calls.append(("stop", {"workload": workload}))
         self._maybe_raise("stop")
         return self._stop
+
+    def cleanup_engagement(self, engagement_id):
+        self.calls.append(("cleanup_engagement", {"engagement_id": engagement_id}))
+        self._maybe_raise("cleanup_engagement")
+        return {"engagement": engagement_id, "stopped": ["ad", "c2-sliver"]}
 
 
 @pytest.fixture
@@ -128,6 +139,28 @@ def test_ops_status_merges_health_and_profiles(patch_client) -> None:
     assert data["workloads"][0]["workload"] == "ad"
 
 
+def test_ops_cleanup_engagement_returns_envelope(patch_client) -> None:
+    out = ops_cleanup_engagement.invoke({"engagement_id": "eng-99"})
+    data = json.loads(out)
+    assert data == {"engagement": "eng-99", "stopped": ["ad", "c2-sliver"]}
+    assert patch_client.calls[0] == ("cleanup_engagement", {"engagement_id": "eng-99"})
+
+
+def test_ops_cleanup_engagement_pulls_from_env(monkeypatch, patch_client) -> None:
+    monkeypatch.setenv("DECEPTICON_ENGAGEMENT", "eng-from-env")
+    ops_cleanup_engagement.invoke({})
+    assert patch_client.calls[0][1]["engagement_id"] == "eng-from-env"
+
+
+def test_ops_cleanup_engagement_requires_engagement(monkeypatch) -> None:
+    monkeypatch.delenv("DECEPTICON_ENGAGEMENT", raising=False)
+    out = ops_cleanup_engagement.invoke({})
+    data = json.loads(out)
+    # No id provided and env unset — the tool must surface a clear
+    # diagnostic rather than calling the daemon with the empty string.
+    assert data["error"] == "missing_engagement_id"
+
+
 def test_tools_registered_in_OPS_TOOLS() -> None:
     names = {t.name for t in OPS_TOOLS}
-    assert names == {"ops_start", "ops_stop", "ops_status"}
+    assert names == {"ops_start", "ops_stop", "ops_cleanup_engagement", "ops_status"}


### PR DESCRIPTION
## Summary

Sprint 2 of [ADR-0006](docs/adr/0006-agent-driven-container-lifecycle.md):
BHCE / Sliver C2 / Ghidra MCP no longer come up by default. The
orchestrator agent spawns them through the opscontrol daemon
(`ops_start("ad")` after recon identifies an AD environment,
`ops_start("c2-sliver")` after foothold) and tears them down when
they're not needed.

**Depends on [#618](https://github.com/PurpleAILAB/Decepticon/pull/618)
and [#619](https://github.com/PurpleAILAB/Decepticon/pull/619)** —
this branch is stacked on top of both. Once they land, rebasing on
`main` reduces this PR's diff to just the Sprint 2 commit.

## Changes

### Compose profile gate

| Service | Profile |
|---|---|
| `bhce`, `bhce-neo4j`, `bhce-postgres-init` | `profiles: [ad]` (new) |
| `c2-sliver` | `profiles: [c2-sliver]` (already gated; default activation removed) |
| `ghidra-mcp` | `profiles: [reversing]` (already gated) |

`docker compose --profile cli config --services` now lists 8 services
(no `bhce*`). `docker compose --profile cli --profile ad config
--services` lists 11.

### `.env.example` (root + launcher embed)

`COMPOSE_PROFILES=c2-sliver` default is removed. The replacement
comment documents the new model and an explicit-override example
for CI runs that want every profile up at once.

### Launcher (`clients/launcher/internal/compose/compose.go`)

`Profiles` struct gains `AD` and `Reversing` constants. `AllProfiles()`
now sweeps cli + c2-sliver + ad + reversing so `decepticon stop`
catches every workload the agent may have spawned during the session.

### Opscontrol daemon — bulk-cleanup endpoint

- `internal/opscontrol/registry.go` — new `workloadsForEngagement(id)`
  method walks the registry and returns workload names tagged with
  the given engagement.
- `internal/opscontrol/server.go` — new `POST /v1/engagements/{id}/cleanup`
  handler. Stricter `engagementName` regex (RFC1123-style, allowing
  dots and underscores). Per-workload mutex still serializes each
  `Stop` even during a cleanup sweep.
- `internal/opscontrol/server_test.go` — covers two cases:
  `CleanupEngagementStopsTaggedWorkloads` (eng-1's two workloads stop;
  eng-2's lone workload stays up) and `CleanupEngagementRejectsBadID`
  (path traversal / shell metas rejected before any backend call).

### Python tools

- `OpsControlClient.cleanup_engagement(engagement_id)` — typed wrapper.
- `ops_cleanup_engagement(engagement_id=None)` @tool — agent-facing
  surface. Picks `engagement_id` from `DECEPTICON_ENGAGEMENT` when
  caller omits it; surfaces a `missing_engagement_id` diagnostic when
  neither arg nor env is set so the agent doesn't burn a
  guaranteed-400 round-trip.
- `OPS_TOOLS` grows to 4. Tests assert exactly
  `{ops_start, ops_stop, ops_cleanup_engagement, ops_status}`.

### Orchestrator system prompt — Section F

New `<CRITICAL_RULES>` section "F. Specialist Workload Lifecycle
(ADR-0006)" placed AFTER section E so existing cross-references stay
correct. Includes:

- Mapping table (specialist → workload → when-to-spawn).
- Mandatory workflow: `ops_start` before `task()`, `ops_stop` after
  if no pending OPPLAN task needs the workload, `ops_cleanup_engagement`
  at engagement close.
- Anti-patterns: premature `ops_start` before recon evidence,
  `ops_stop` between two specialists that share a workload,
  `ops_cleanup_engagement` omission.

## Verification

- [x] `docker compose --profile cli config --services` excludes bhce*.
- [x] `docker compose --profile cli --profile ad config --services`
      includes bhce + bhce-neo4j + bhce-postgres-init.
- [x] Full sweep (`cli`+`c2-sliver`+`ad`+`reversing`) lists all 13
      services so teardown via `AllProfiles()` covers every workload
      the agent could spawn.
- [x] `go test ./...` in `clients/launcher/` — full suite green
      (compose's `TestAllProfiles` updated to the 4-profile catalog,
      opscontrol gains `CleanupEngagement{StopsTaggedWorkloads,
      RejectsBadID}`).
- [x] `uv run pytest packages/decepticon/tests/unit/ops/` — 17 pass
      (+3 for cleanup tool envelope, env-fallback, missing-id
      diagnostic).
- [ ] End-to-end orchestrator dogfood (`decepticon start` → engagement
      → recon → `ops_start("ad")` round-trip → BHCE up via daemon →
      ad_operator runs → `ops_stop("ad")` → BHCE down) — requires
      Sprint 1 PR merged first; recommend doing it in the v1.1.8
      pre-tag dogfood gate once all three PRs are on main.

## What is intentionally NOT here

- **Sprint 3** — BHCE HMAC token bootstrap moves into the daemon's
  start handler. The `EndpointURL` / `BootstrapTokenRef` fields on
  `Handle` are reserved for that.
- **Sprint 4** — `CLAUDE.md` / `docs/architecture.md` invariant
  edits and the Web Dashboard `ops_status` panel.

## v1.1.8 merge order

1. [#618](https://github.com/PurpleAILAB/Decepticon/pull/618) (BHCE bootstrap fix) — independent.
2. [#619](https://github.com/PurpleAILAB/Decepticon/pull/619) (Sprint 1 daemon + Alt A supervisor) — independent.
3. **THIS PR (Sprint 2)** — rebases cleanly on main once 1 and 2 land.
4. `make quality-strict && make smoke && make dogfood` → `git tag v1.1.8`.

Closes the ADR-0006 Sprint 2 line item.
