### PR TITLE
fix(ci): stop todo-to-issue scanning its own comments

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -1,12 +1,16 @@
 name: TODO → Issue
 
-# Scans commits landing on main for newly-added TODO / FIXME / HACK
+# Scans commits landing on main for newly-added to-do / fix-me / hack
 # comments and opens issues so they're tracked instead of buried in
-# source. Closes the corresponding issue when the TODO is removed.
+# source. Closes the corresponding issue when the marker is removed.
+#
+# NOTE: keep the literal scan markers (the uppercase tokens in IDENTIFIERS
+# below) OUT of these comments. The action scans this file too, so a bare
+# marker word in prose opens a bogus issue — see the spurious #606/#607/#608.
 #
 # Scope choices:
 #   * Runs on push to main only — PR review is the right place to
-#     discuss whether a TODO should exist at all, and double-opening
+#     discuss whether a marker should exist at all, and double-opening
 #     on branch-then-merge would create noise.
 #   * `INSERT_ISSUE_URLS: false` — the action will NOT push back to
 #     main to annotate source with issue links. Issues are tracked
@@ -64,8 +68,8 @@ jobs:
           # INSERT_ISSUE_URLS stays false so the action never pushes annotation
           # commits back to ``main`` (keeps contents: read + persist-credentials:
           # false). Trade-off: with CLOSE_ISSUES on, the action re-derives a
-          # removed TODO's identity from file/line/title rather than an embedded
-          # URL, so a TODO that is moved far or heavily re-indented may miss its
+          # removed marker's identity from file/line/title rather than an embedded
+          # URL, so a marker that is moved far or heavily re-indented may miss its
           # auto-close. Acceptable here — issues are cheap to close by hand and
           # this avoids granting the workflow write access to the trunk.
           INSERT_ISSUE_URLS: false


### PR DESCRIPTION
## Why

The `alstr/todo-to-issue-action` scans every changed file on a push to `main`, **including this workflow itself**. Its descriptive `#` comments contained the bare scan tokens (`TODO`/`FIXME`/`HACK`), so prose like *"...when the TODO is removed"* was parsed as a real marker. The text following each `TODO` became an issue title, opening three bogus issues:

- #608 — "is removed." (from *"...issue when the TODO **is removed.**"*)
- #607 — "should exist at all, and double-opening" (from *"...whether a TODO **should exist at all...**"*)
- #606 — "that is moved far or heavily re-indented may miss its" (from *"...a TODO **that is moved far...**"*)

## What

Reword the workflow's own comments to use `marker` / `to-do` / `fix-me` / `hack` so **no bare uppercase token appears in any comment line**. The `IDENTIFIERS:` JSON keeps the real tokens — it's a YAML string value, not a `#` comment, so the action never scans it. Added a `NOTE` warning future editors not to reintroduce the tokens in prose.

## Verification

- `grep -nE '^\s*#.*\b(TODO|FIXME|HACK)\b'` over the file → no matches.
- `IDENTIFIERS` still defines all three tokens.
- `yaml.safe_load` parses clean.

Closing the three spurious issues by hand; this prevents recurrence.