### PR TITLE
refactor(telemetry): remove silent error-swallowing in otel span writes

### DIFF
--- a/packages/decepticon/decepticon/telemetry/otel.py
+++ b/packages/decepticon/decepticon/telemetry/otel.py
@@ -198,23 +198,33 @@ def start_llm_span(model: str) -> Iterator[Any]:
             _active_llm_span.reset(llm_token)
 
 
+def _set_span_attribute(span: Any, key: str, value: Any) -> bool:
+    """Set a span attribute, returning False if the SDK rejected it.
+
+    Telemetry is observability, never control flow: a failed write must not
+    propagate to the caller. We log at debug instead of swallowing silently
+    so a broken exporter is diagnosable.
+    """
+    try:
+        span.set_attribute(key, value)
+        return True
+    except Exception as exc:
+        log.debug("otel set_attribute failed key=%s: %s", key, exc)
+        return False
+
+
 def record_llm_cost(cost_usd: float | None) -> None:
     """Attach cost to the active llm_call span, or to engagement as fallback."""
     if cost_usd is None:
         return
     llm_span = _active_llm_span.get()
-    if llm_span is not None:
-        try:
-            llm_span.set_attribute("decepticon.llm.cost_usd", float(cost_usd))
-            return
-        except Exception:
-            pass
+    if llm_span is not None and _set_span_attribute(
+        llm_span, "decepticon.llm.cost_usd", float(cost_usd)
+    ):
+        return
     eng_span = _active_engagement_span.get()
     if eng_span is not None:
-        try:
-            eng_span.set_attribute("decepticon.llm.cost_usd", float(cost_usd))
-        except Exception:
-            pass
+        _set_span_attribute(eng_span, "decepticon.llm.cost_usd", float(cost_usd))
 
 
 def record_llm_token_usage(
@@ -225,15 +235,9 @@ def record_llm_token_usage(
     if span is None:
         return
     if prompt_tokens is not None:
-        try:
-            span.set_attribute("decepticon.llm.prompt_tokens", int(prompt_tokens))
-        except Exception:
-            pass
+        _set_span_attribute(span, "decepticon.llm.prompt_tokens", int(prompt_tokens))
     if completion_tokens is not None:
-        try:
-            span.set_attribute("decepticon.llm.completion_tokens", int(completion_tokens))
-        except Exception:
-            pass
+        _set_span_attribute(span, "decepticon.llm.completion_tokens", int(completion_tokens))
 
 
 def set_current_objective_id(objective_id: str | None) -> object | None:

--- a/packages/decepticon/tests/unit/telemetry/test_otel.py
+++ b/packages/decepticon/tests/unit/telemetry/test_otel.py
@@ -152,6 +152,26 @@ def test_record_llm_cost_falls_back_to_engagement_span(
     assert _attrs(eng)["decepticon.llm.cost_usd"] == pytest.approx(2.5)
 
 
+def test_record_llm_cost_falls_back_when_llm_span_write_raises(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    """A failed write on the llm_span must not propagate, and the cost must
+    still land on the engagement span."""
+
+    class _RaisingSpan:
+        def set_attribute(self, key: str, value: Any) -> None:
+            raise RuntimeError("exporter down")
+
+    with start_engagement_span("eng-fail"):
+        token = otel_module._active_llm_span.set(_RaisingSpan())
+        try:
+            record_llm_cost(3.5)
+        finally:
+            otel_module._active_llm_span.reset(token)
+    eng = next(s for s in memory_exporter.get_finished_spans() if s.name == "decepticon.engagement")
+    assert _attrs(eng)["decepticon.llm.cost_usd"] == pytest.approx(3.5)
+
+
 def test_record_llm_cost_ignores_none(memory_exporter: InMemorySpanExporter) -> None:
     with start_engagement_span("eng-3"):
         with start_llm_span("model-x"):


### PR DESCRIPTION
## What

A focused clean-code pass on `telemetry/otel.py` applying Karpathy-style principles (simplicity, DRY, no silent failures).

`record_llm_cost` and `record_llm_token_usage` wrapped each `span.set_attribute(...)` call in an identical `try/except Exception: pass` — four copy-pasted blocks that swallowed exporter failures silently. That is two smells at once: silent failure on a best-effort path, and the same block duplicated N times.

### Change
- Extract `_set_span_attribute(span, key, value) -> bool`: one best-effort helper that **logs at debug** on failure (so a broken exporter is diagnosable instead of invisible) and returns a success bool.
- The bool preserves `record_llm_cost`'s existing control flow: write to the active `llm_span`, and fall back to the `engagement_span` only if the llm-span write is absent **or fails**.
- Net result: the runtime function is shorter and the four duplicated blocks collapse to one.

This is intentionally surgical — one file of runtime code, one logical concern. I deliberately did **not** touch other `except Exception: pass` sites I noticed (`tools/reversing/ghidra.py`, `llm/factory.py`): those are embedded-Jython / documented MCP→headless fallbacks where a silent swallow is the intended behavior, so changing them would be an out-of-scope behavior change.

## Tests
Added `test_record_llm_cost_falls_back_when_llm_span_write_raises` — the fallback-on-write-failure path was previously **untested**. It asserts a raising span does not propagate and the cost still lands on the engagement span.

## Verification
- `uv run pytest packages/decepticon/tests/unit/telemetry/test_otel.py -q` → **10 passed** (9 existing + 1 new).
- `uv run ruff check` on both changed files → clean.
- `uv run basedpyright telemetry/otel.py` → 0 errors (the 1 remaining warning is pre-existing, at line 260, in untouched code).

I did not bring the full stack up: this change is pure-Python observability glue with no compose/container surface, and the OTel SDK is exercised in-memory by the test suite.

https://claude.ai/code/session_01WVCpcEHhgZr4tGvkk6LBqp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVCpcEHhgZr4tGvkk6LBqp)_