### PR TITLE
fix(backends): share HTTPSandbox across graph factories

### DIFF
--- a/packages/decepticon/decepticon/backends/factory.py
+++ b/packages/decepticon/decepticon/backends/factory.py
@@ -23,13 +23,30 @@ boundary + the ``sandbox-net`` network.
 
 from __future__ import annotations
 
+import functools
 import os
 
 from decepticon.backends.http_sandbox import HTTPSandbox
 
 
+@functools.lru_cache(maxsize=8)
+def _shared_sandbox(base_url: str, token: str | None) -> HTTPSandbox:
+    return HTTPSandbox(base_url=base_url, token=token)
+
+
 def build_sandbox_backend() -> HTTPSandbox:
     """Build the HTTP-transport sandbox backend.
+
+    Returns the same ``HTTPSandbox`` instance for every call with the
+    same ``(base_url, token)``. langgraph dev server invokes one factory
+    per registered graph at startup; without a shared client each
+    factory builds its own client + its own ``BackgroundJobTracker``,
+    and the ``SandboxNotificationMiddleware`` instance held by each
+    graph sees a different ``_jobs`` view than the bash tool actually
+    registers against — completion notifications never reach the agent.
+    Keying by ``(base_url, token)`` keeps tests that monkeypatch the env
+    isolated and supports multi-tenant SaaS deployments where pools
+    target distinct daemons.
 
     Returns:
         An ``HTTPSandbox`` instance pointed at the daemon URL.
@@ -45,4 +62,4 @@ def build_sandbox_backend() -> HTTPSandbox:
     """
     base_url = os.environ.get("SAAS_SANDBOX_URL", "http://localhost:9999")
     token = os.environ.get("SAAS_SANDBOX_TOKEN") or None
-    return HTTPSandbox(base_url=base_url, token=token)
+    return _shared_sandbox(base_url, token)

--- a/packages/decepticon/tests/unit/backends/test_factory.py
+++ b/packages/decepticon/tests/unit/backends/test_factory.py
@@ -1,0 +1,73 @@
+"""Tests for ``decepticon.backends.factory.build_sandbox_backend``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from decepticon.backends import build_sandbox_backend
+from decepticon.backends.factory import _shared_sandbox
+
+
+@pytest.fixture(autouse=True)
+def _clear_shared_sandbox_cache() -> Iterator[None]:
+    """The shared cache survives across the process, so isolate tests."""
+    _shared_sandbox.cache_clear()
+    yield
+    _shared_sandbox.cache_clear()
+
+
+def test_build_sandbox_backend_returns_shared_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated calls with the same env must return the *same* HTTPSandbox.
+
+    Why this matters: ``langgraph dev`` invokes one factory per registered
+    graph at startup. Without a shared instance every factory builds its
+    own ``HTTPSandbox`` + ``BackgroundJobTracker``, and the
+    ``SandboxNotificationMiddleware`` instance held by each graph sees a
+    different ``_jobs`` view than the bash tool actually registers
+    against — completion notifications never reach the agent.
+    """
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://sandbox:9999")
+    monkeypatch.delenv("SAAS_SANDBOX_TOKEN", raising=False)
+
+    a = build_sandbox_backend()
+    b = build_sandbox_backend()
+
+    assert a is b
+    assert a._jobs is b._jobs
+
+
+def test_build_sandbox_backend_keys_on_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distinct base URLs must produce distinct instances.
+
+    Multi-tenant SaaS pools may target different daemons in the same
+    process; the cache key must respect that.
+    """
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://sandbox-a:9999")
+    monkeypatch.delenv("SAAS_SANDBOX_TOKEN", raising=False)
+    a = build_sandbox_backend()
+
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://sandbox-b:9999")
+    b = build_sandbox_backend()
+
+    assert a is not b
+
+
+def test_build_sandbox_backend_keys_on_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distinct tokens against the same URL still produce distinct instances."""
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://sandbox:9999")
+
+    monkeypatch.setenv("SAAS_SANDBOX_TOKEN", "tenant-a")
+    a = build_sandbox_backend()
+
+    monkeypatch.setenv("SAAS_SANDBOX_TOKEN", "tenant-b")
+    b = build_sandbox_backend()
+
+    assert a is not b


### PR DESCRIPTION
## Summary

- `build_sandbox_backend()` now returns the **same `HTTPSandbox`** for the same `(base_url, token)`. Previously every `create_*_agent()` factory built its own client, and the 11 graphs registered in `langgraph dev` each got a distinct `BackgroundJobTracker` (`_jobs`).
- Bug surfaced as **`SandboxNotificationMiddleware` never injecting** the `● Background command "..." completed` reminder during recon-agent dogfood — middleware polled instance B's `pending_completions()` (always empty) while the bash tool registered jobs on instance A via the `set_sandbox` last-wins module-level fallback.
- LangSmith trace confirmed the middleware **fired 12× per turn** but every `pending_completions()` returned `[]` because the two halves were looking at different `_jobs` trackers.

## Root cause

`set_sandbox(sandbox)` writes a module-level default that survives across factory builds; the last factory wins. Bash tool's cross-thread fallback (`_sandbox_default`) picks that one. `SandboxNotificationMiddleware`, however, captures the sandbox passed to its own factory at the time the agent was assembled — a different instance. The two never agreed on `_jobs`.

## Fix

`@functools.lru_cache(maxsize=8)` on a `(base_url, token)`-keyed helper. All factories see the same instance → the `_jobs` BackgroundJobTracker is shared → bash registration is visible to the middleware → `before_model` injects the reminder.

Cache key is `(base_url, token)` so:
- Tests that monkeypatch `SAAS_SANDBOX_URL` / `SAAS_SANDBOX_TOKEN` still get isolated instances.
- Multi-tenant SaaS pools targeting different daemons in the same process keep separate clients.

## Verification

- **Unit**: 3 new tests in `packages/decepticon/tests/unit/backends/test_factory.py` — same env → same instance + shared `_jobs`, distinct URL → distinct instance, distinct token → distinct instance. `pytest` passes.
- **e2e dogfood** (`recon` graph, single user directive, no follow-up):
  - `bash(command='sleep 6', background=true, session='bgjob')` → `[BACKGROUND]` response
  - next `before_model` turn: middleware injected `<system-reminder>\nBackground sandbox sessions completed. ... ● Background command "sleep 6" completed (exit code 0) ...`
  - agent emitted `DONE` (no user follow-up, no `bash_output` polling)
- **Equivalence with `OpsControlNotificationMiddleware`** (ADR-0006) auto-notification: same `before_model` hook + backend poll + dedup cache + `HumanMessage`/`<system-reminder>` shape now works for both bash-bg completions and opscontrol workload transitions.

## Test plan

- [x] `uv run pytest packages/decepticon/tests/unit/backends/test_factory.py -v` — 3 passed
- [x] `uv run ruff check` + `uv run ruff format --check` on changed files
- [x] `uv run basedpyright --level error` on changed files — 0 errors
- [x] real e2e: agent's `bash(background=true)` → mid-loop reminder inject without user follow-up