### PR TITLE
fix(launcher): migrate stale COMPOSE_PROFILES on first v1.1.8 start

### DIFF
--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -65,6 +65,19 @@ func runStart(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
+	// 1.5. One-shot migration for v1.1.7→v1.1.8 upgraders.
+	// Old .env files ship with an active "COMPOSE_PROFILES=c2-sliver"
+	// line that forces every default start to bring up the Sliver C2
+	// container. ADR-0006 routes specialist workloads through ops_start
+	// instead; the stale line is silently rewritten to a comment (with
+	// a one-line notice and a .env.bak backup) before LoadEnv reads it,
+	// so the rest of the boot path sees the post-migration state.
+	if rewrote, mErr := config.MigrateActiveComposeProfiles(config.EnvPath()); mErr != nil {
+		ui.Warning("Could not migrate stale COMPOSE_PROFILES in .env: " + mErr.Error())
+	} else if rewrote {
+		ui.Info("Migrated stale COMPOSE_PROFILES in .env (specialist workloads now spawn via ops_start). Backup at " + config.EnvPath() + ".bak")
+	}
+
 	// 2. Load and validate .env
 	env, err := config.LoadEnv(config.EnvPath())
 	if err != nil {

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -607,3 +607,62 @@ func Get(env map[string]string, key, fallback string) string {
 	}
 	return fallback
 }
+
+// MigrateActiveComposeProfiles comments out any active "COMPOSE_PROFILES="
+// line in the .env file.
+//
+// Before ADR-0006 (v1.1.7 and earlier) the OSS .env.example shipped with
+// an active "COMPOSE_PROFILES=c2-sliver" line so `decepticon start`
+// always brought the Sliver C2 container up. ADR-0006 routes every
+// specialist workload (c2-sliver, ad, reversing, …) through the
+// opscontrol daemon; the orchestrator decides when each plane comes up
+// via `ops_start(...)`. A stale active COMPOSE_PROFILES from a v1.1.7-era
+// .env forces those workloads to spawn on every `decepticon start`,
+// defeating the dynamic-spawn design and re-introducing the idle-cost +
+// attack-surface that ADR-0006 was meant to remove.
+//
+// Behaviour:
+//   - rewrites every active "COMPOSE_PROFILES=…" line to a "# Migrated …"
+//     comment, preserving the original value inline so the operator can
+//     restore it by hand if they really want global activation
+//   - commented-out lines are left untouched (idempotent on repeat starts)
+//   - a single ".env.bak" backup is written next to the .env on the first
+//     migration; subsequent migrations skip the backup if one already
+//     exists, so a later edit-and-restart can't silently overwrite the
+//     pre-migration snapshot
+//   - returns (rewrote, error); rewrote=true is the signal for the caller
+//     to surface a one-line notice to the user
+func MigrateActiveComposeProfiles(envPath string) (bool, error) {
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	lines := strings.Split(string(data), "\n")
+	rewritten := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if k, _, ok := parseEnvLine(trimmed); ok && k == "COMPOSE_PROFILES" {
+			lines[i] = "# [v1.1.8 ADR-0006 migration] specialist workloads now spawn via ops_start; was: " + line
+			rewritten = true
+		}
+	}
+	if !rewritten {
+		return false, nil
+	}
+	backupPath := envPath + ".bak"
+	if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
+		if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+			return false, fmt.Errorf("write backup %s: %w", backupPath, err)
+		}
+	}
+	if err := os.WriteFile(envPath, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -415,3 +415,149 @@ func TestGet(t *testing.T) {
 		t.Error("expected default")
 	}
 }
+
+func TestMigrateActiveComposeProfiles_RewritesActiveLine(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	content := `# Header
+ANTHROPIC_API_KEY=sk-ant-key
+
+# Default C2 server profile.
+COMPOSE_PROFILES=c2-sliver
+
+# Trailing comment
+`
+	if err := os.WriteFile(envFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rewrote, err := MigrateActiveComposeProfiles(envFile)
+	if err != nil {
+		t.Fatalf("MigrateActiveComposeProfiles error: %v", err)
+	}
+	if !rewrote {
+		t.Fatalf("expected rewrote=true")
+	}
+
+	out, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "\nCOMPOSE_PROFILES=c2-sliver\n") {
+		t.Errorf("active COMPOSE_PROFILES line survived migration:\n%s", out)
+	}
+	if !strings.Contains(string(out), "[v1.1.8 ADR-0006 migration]") {
+		t.Errorf("expected migration comment, got:\n%s", out)
+	}
+	// Original value preserved inline for restorability.
+	if !strings.Contains(string(out), "was: COMPOSE_PROFILES=c2-sliver") {
+		t.Errorf("expected 'was: COMPOSE_PROFILES=c2-sliver' marker in:\n%s", out)
+	}
+	// Unrelated lines untouched.
+	if !strings.Contains(string(out), "ANTHROPIC_API_KEY=sk-ant-key") {
+		t.Errorf("unrelated lines lost; got:\n%s", out)
+	}
+
+	// Backup written with the original (pre-migration) content.
+	bak, err := os.ReadFile(envFile + ".bak")
+	if err != nil {
+		t.Fatalf("backup not written: %v", err)
+	}
+	if string(bak) != content {
+		t.Errorf("backup mismatch:\n got:%s\nwant:%s", bak, content)
+	}
+}
+
+func TestMigrateActiveComposeProfiles_LeavesCommentedLineAlone(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	content := `# COMPOSE_PROFILES=c2-sliver
+ANTHROPIC_API_KEY=sk-ant-key
+`
+	if err := os.WriteFile(envFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rewrote, err := MigrateActiveComposeProfiles(envFile)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if rewrote {
+		t.Errorf("expected rewrote=false on already-commented file")
+	}
+	// File unchanged.
+	out, _ := os.ReadFile(envFile)
+	if string(out) != content {
+		t.Errorf("file modified despite no active line:\n got:%s\nwant:%s", out, content)
+	}
+	// No backup written.
+	if _, err := os.Stat(envFile + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("backup created on no-op migration")
+	}
+}
+
+func TestMigrateActiveComposeProfiles_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	content := `COMPOSE_PROFILES=c2-sliver,ad
+ANTHROPIC_API_KEY=sk-ant-key
+`
+	if err := os.WriteFile(envFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if rewrote, err := MigrateActiveComposeProfiles(envFile); err != nil || !rewrote {
+		t.Fatalf("first migration: rewrote=%v err=%v; want (true, nil)", rewrote, err)
+	}
+	first, _ := os.ReadFile(envFile)
+
+	if rewrote, err := MigrateActiveComposeProfiles(envFile); err != nil || rewrote {
+		t.Fatalf("second migration: rewrote=%v err=%v; want (false, nil)", rewrote, err)
+	}
+	second, _ := os.ReadFile(envFile)
+	if string(first) != string(second) {
+		t.Errorf("file changed across idempotent migrations:\n first:%s\nsecond:%s", first, second)
+	}
+}
+
+func TestMigrateActiveComposeProfiles_NoEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+
+	rewrote, err := MigrateActiveComposeProfiles(envFile)
+	if err != nil {
+		t.Fatalf("missing .env should not error: %v", err)
+	}
+	if rewrote {
+		t.Errorf("rewrote=true on missing file")
+	}
+}
+
+func TestMigrateActiveComposeProfiles_BackupNotOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	backupPath := envFile + ".bak"
+
+	original := "COMPOSE_PROFILES=c2-sliver\n"
+	if err := os.WriteFile(envFile, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// First migration creates the backup.
+	if _, err := MigrateActiveComposeProfiles(envFile); err != nil {
+		t.Fatal(err)
+	}
+	firstBackup, _ := os.ReadFile(backupPath)
+
+	// Operator re-enables the active line and runs migration again.
+	if err := os.WriteFile(envFile, []byte("COMPOSE_PROFILES=ad\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MigrateActiveComposeProfiles(envFile); err != nil {
+		t.Fatal(err)
+	}
+	secondBackup, _ := os.ReadFile(backupPath)
+	// Backup must still match the very first pre-migration snapshot.
+	if string(firstBackup) != string(secondBackup) {
+		t.Errorf("backup was overwritten on second migration:\n first:%s\nsecond:%s", firstBackup, secondBackup)
+	}
+}


### PR DESCRIPTION
## Summary

- Pre-ADR-0006 (v1.1.7 and earlier) `.env.example` shipped with an **active** `COMPOSE_PROFILES=c2-sliver` line so every `decepticon start` brought the Sliver C2 container up by default.
- ADR-0006 (v1.1.8) routes every specialist workload through the opscontrol daemon (`ops_start("c2-sliver")`, `ops_start("ad")`, …). PR #620 already commented the line out of `.env.example`, but **a v1.1.7-era user's existing `.env` keeps the active line on upgrade** — c2-sliver still boots on every start even though the user upgraded to v1.1.8.
- This PR adds a one-shot launcher migration that rewrites the active line to a `# [v1.1.8 ADR-0006 migration] …` comment, preserving the original value inline for restorability, with a single `.env.bak` backup.

## Behaviour

- Active `COMPOSE_PROFILES=…` line → replaced with a comment carrying the original value.
- Already-commented line → untouched (returns `rewrote=false`).
- Repeated `decepticon start` → idempotent (no-op on already-migrated `.env`).
- Backup (`.env.bak`) is written once on the first migration; later operator edits + restarts do **not** overwrite the pre-migration snapshot.
- Missing `.env` → no-op (lets the regular `runOnboard` path handle setup).
- Hooked in `runStart` immediately before `LoadEnv` so the rest of boot already sees the post-migration state.

## Why this matters for v1.1.8

Without this migration, every existing v1.1.7 install that runs `v1.1.8` keeps c2-sliver in default-start, silently defeating the dynamic-spawn design — the orchestrator's `ops_start` calls then race with a c2-sliver compose-up that was already running from boot, and the user's expectation that v1.1.8 keeps specialists cold (per the ADR) doesn't hold.

## Test plan

- [x] `go test ./internal/config/ -run TestMigrateActiveComposeProfiles -v` — 5 new tests pass (active rewrite + commented no-op + idempotent + missing-file + backup-not-overwritten)
- [x] `go test ./...` — full launcher suite passes, no regression
- [x] `go vet ./internal/config/ ./cmd/`
- [x] `go build` — launcher binary builds clean
- [x] manual: a v1.1.7-era `.env` with `COMPOSE_PROFILES=c2-sliver` is rewritten on first `decepticon start`; backup at `.env.bak`; second start is a no-op