### PR TITLE
feat(cli): /web slash command for on-demand web dashboard spawn

### DIFF
--- a/clients/cli/src/commands/registry.ts
+++ b/clients/cli/src/commands/registry.ts
@@ -14,9 +14,10 @@ import resume from "./resume.js";
 import model from "./model.js";
 import plugins from "./plugins.js";
 import agent from "./agent.js";
+import web from "./web.js";
 
 /** All registered commands. Add new commands here. */
-const COMMANDS: Command[] = [help, clear, file, quit, resume, model, plugins, agent];
+const COMMANDS: Command[] = [help, clear, file, quit, resume, model, plugins, agent, web];
 
 /** Get all registered commands. */
 export function getCommands(): Command[] {

--- a/clients/cli/src/commands/web.ts
+++ b/clients/cli/src/commands/web.ts
@@ -1,0 +1,127 @@
+import { spawn } from "node:child_process";
+import type { Command, CommandContext } from "./types.js";
+
+/**
+ * `/web` slash command — start, stop, or print the URL of the web dashboard.
+ *
+ * v1.1.8 dynamic-spawn model: the `web` compose service is gated behind
+ * `profiles: [web]` so `decepticon start` no longer brings the dashboard
+ * up by default. This command runs `docker compose --profile web up -d
+ * web` against the host docker daemon (the CLI container has docker.sock
+ * + the compose project bind-mounted, see docker-compose.yml `cli:`).
+ *
+ * Behaviour:
+ *   /web            — `up -d web` (idempotent)
+ *   /web up         — same
+ *   /web down       — `stop web` (container preserved for fast re-up)
+ *   /web stop       — same
+ *   /web url        — print the dashboard URL (no docker call)
+ */
+const web: Command = {
+  name: "web",
+  description: "Start, stop, or print the URL of the web dashboard",
+  aliases: ["dashboard"],
+  argumentHint: "[up|down|stop|url]",
+  execute: async (args, context) => {
+    const arg = args.trim().toLowerCase();
+    if (arg === "url") {
+      printURL(context);
+      return;
+    }
+    if (arg === "down" || arg === "stop") {
+      await stopWeb(context);
+      return;
+    }
+    await startWeb(context);
+  },
+};
+
+export default web;
+
+function url(): string {
+  return `http://localhost:${process.env["WEB_PORT"] ?? "3000"}`;
+}
+
+function printURL(context: CommandContext): void {
+  context.addSystemEvent(`Web dashboard URL: ${url()}`);
+}
+
+function composeArgs(): string[] {
+  const project = process.env["DECEPTICON_COMPOSE_PROJECT"] ?? "decepticon";
+  const composeFile =
+    process.env["DECEPTICON_COMPOSE_FILE"] ?? "/decepticon-home/docker-compose.yml";
+  const envFile =
+    process.env["DECEPTICON_COMPOSE_ENV_FILE"] ?? "/decepticon-home/.env";
+  return ["compose", "-p", project, "-f", composeFile, "--env-file", envFile];
+}
+
+function startWeb(context: CommandContext): Promise<void> {
+  return runDockerCompose(
+    context,
+    [...composeArgs(), "--profile", "web", "up", "-d", "--no-build", "web"],
+    {
+      pending: "Starting web dashboard…",
+      success: () => `✅ Web dashboard up: ${url()}`,
+      failure: (code, stderr) =>
+        `❌ Failed to start web (exit ${code}): ${stderr.slice(0, 400)}`,
+    },
+  );
+}
+
+function stopWeb(context: CommandContext): Promise<void> {
+  return runDockerCompose(
+    context,
+    [...composeArgs(), "stop", "web"],
+    {
+      pending: "Stopping web dashboard…",
+      success: () => "✅ Web dashboard stopped (container kept for fast re-up)",
+      failure: (code, stderr) =>
+        `❌ Failed to stop web (exit ${code}): ${stderr.slice(0, 400)}`,
+    },
+  );
+}
+
+interface RunOptions {
+  pending: string;
+  success: (stdout: string) => string;
+  failure: (code: number | null, stderr: string) => string;
+}
+
+function runDockerCompose(
+  context: CommandContext,
+  args: string[],
+  opts: RunOptions,
+): Promise<void> {
+  return new Promise((resolve) => {
+    context.addSystemEvent(opts.pending);
+    const proc = spawn("docker", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    proc.on("error", (err) => {
+      // ENOENT typically means the CLI image was built without docker
+      // CLI (pre-v1.1.8). Surface it directly so the operator does not
+      // hunt through stack traces.
+      context.addSystemEvent(
+        `❌ Could not exec docker: ${err.message}. ` +
+          "Is the docker CLI installed in this image? (cli.Dockerfile v1.1.8+)",
+      );
+      resolve();
+    });
+    proc.on("close", (code) => {
+      if (code === 0) {
+        context.addSystemEvent(opts.success(stdout));
+      } else {
+        context.addSystemEvent(opts.failure(code, stderr));
+      }
+      resolve();
+    });
+  });
+}

--- a/containers/cli.Dockerfile
+++ b/containers/cli.Dockerfile
@@ -27,6 +27,24 @@ RUN npm run build --workspace=@decepticon/cli
 FROM node:24-slim
 WORKDIR /app
 
+# v1.1.8 `/web` slash command: the CLI shells out to
+# `docker compose --profile web up -d web` against the host docker daemon
+# (the docker.sock is bind-mounted in docker-compose.yml). That requires
+# the docker CLI + compose plugin inside this image. Pulled from Docker's
+# official Debian repo so we get docker-ce-cli + docker-compose-plugin
+# without dragging in the dockerd daemon (which docker.io would).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+      > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    apt-get purge -y --auto-remove gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy compiled output + runtime dependencies. We run plain `node` on the
 # tsc-emitted dist/ — no tsx runtime loader. tsx 4.20+ registers a JSON
 # transform on the module loader that rewrites `*.json` into ESM JS, which

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,6 +453,15 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
+    # v1.1.8: web dashboard is no longer brought up by default `decepticon
+    # start`. The CLI exposes a `/web` slash command that runs
+    # `docker compose --profile web up -d web` against the operator's
+    # docker daemon (the CLI container has the host docker.sock mounted
+    # in OSS), so the web tier only spins up when the operator actually
+    # asks for it. Keeps idle cost low and removes the postgres-migration
+    # latency hit from cold starts.
+    profiles:
+      - web
 
   # Ink CLI — Interactive terminal UI
   # Runs via: docker compose run --rm cli
@@ -466,11 +475,30 @@ services:
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-cli
     stdin_open: true
     tty: true
+    # v1.1.8 `/web` slash command: the CLI shells out to `docker compose
+    # --profile web up -d web` against the host docker daemon. To do
+    # that it needs (a) the docker.sock so commands reach the host
+    # daemon and (b) the on-host compose project directory mounted at a
+    # known in-container path so `-f` and `--env-file` resolve.
+    #
+    # OSS scope: user == host owner. SaaS bundles never expose the
+    # docker socket to a tenant CLI — those deployments override this
+    # service's volumes via a compose overlay.
     environment:
       - DECEPTICON_API_URL=http://langgraph:2024
       - TERM=xterm-256color
       - COLORTERM=truecolor
       - DECEPTICON_VERSION=${DECEPTICON_VERSION:-}
+      - DECEPTICON_STACK_NAME=${DECEPTICON_STACK_NAME:-}
+      - DECEPTICON_HOME=/decepticon-home
+      - DECEPTICON_COMPOSE_FILE=/decepticon-home/docker-compose.yml
+      - DECEPTICON_COMPOSE_ENV_FILE=/decepticon-home/.env
+      - DECEPTICON_COMPOSE_PROJECT=decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}
+      - WEB_PORT=${WEB_PORT:-3000}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DECEPTICON_HOME:-~/.decepticon}:/decepticon-home
+    working_dir: /decepticon-home
     depends_on:
       langgraph:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Web dashboard is no longer brought up by every `decepticon start`. ADR-0006 (PR #619/#620) moved every specialist workload (c2-sliver, ad, reversing, …) to on-demand spawn through the opscontrol daemon; the **web service follows the same direction** — default start keeps the dashboard cold, the operator pays the postgres-migration + Next.js boot latency only when they actually need the UI.

## Changes

### `docker-compose.yml`
- **web**: added `profiles: [web]`. `decepticon start` no longer spawns the dashboard.
- **cli**: bind-mounts `/var/run/docker.sock` and `$DECEPTICON_HOME → /decepticon-home` so the CLI shells out to the **host** docker daemon against the user's compose project. New env vars pass the compose file path, env-file path, and the stack-aware project name into the slash command.

### `containers/cli.Dockerfile`
- Installs `docker-ce-cli` + `docker-compose-plugin` from Docker's official Debian repo (not `docker.io`, which would drag in `dockerd`). Image grows ~80 MB; **no daemon runs inside the container**.

### `clients/cli/src/commands/web.ts` (new)
- `/web` (or `/web up`) → `docker compose --profile web up -d --no-build web`
- `/web down` / `/web stop` → `docker compose stop web` (container preserved for fast re-up)
- `/web url` → print `http://localhost:${WEB_PORT}` (no docker call)
- `spawn()` with piped stderr so docker-CLI failures surface as one system event, not terminal noise.
- ENOENT on `docker` produces a clear message pointing at the v1.1.8 Dockerfile rebuild requirement.

### `clients/cli/src/commands/registry.ts`
- Registers `web` with alias `dashboard` so `/dashboard` works too.

## Security model

- **OSS** (this PR): user == host owner. Mounting `docker.sock` into the CLI container is equivalent to the operator running `docker` on their own host. Safe.
- **SaaS**: tenant CLI containers must never have `docker.sock` mounted — SaaS deployments override the `cli:` volumes via a separate compose overlay. Out of scope here.

## Test plan

- [x] `npm run typecheck --workspace=@decepticon/cli` — 0 errors
- [x] `npm run build --workspace=@decepticon/cli` — clean
- [ ] **Image rebuild + dogfood** (maintainer): rebuild `decepticon-cli` image with this Dockerfile (~+80 MB), launch via `decepticon start`, exercise `/web`, `/web url`, `/web down`. The slash-command path is gated behind the new Dockerfile so this is the load-bearing manual check.
- [ ] Verify the web container does **not** spawn on a fresh `decepticon start` (only after `/web`).

## Pairs with
- PR #623 — `fix(backends): share HTTPSandbox across graph factories`
- PR #624 — `fix(launcher): migrate stale COMPOSE_PROFILES on first v1.1.8 start`
- PR #619/#620 — ADR-0006 Sprint 1/2 (dynamic specialist workload spawn)