### PR TITLE
docs(v1.1.8): reflect ADR-0006 dynamic spawn + /web slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,80 @@ follows [Semantic Versioning](https://semver.org/) from `1.0.0`
 onward (the `0.x` cycle is pre-stable per the core/framework/sdk split
 design spec, §13.4).
 
+## [1.1.8] — Unreleased
+
+The agent-driven dynamic infrastructure release. Specialist workloads
+(BloodHound CE, Sliver C2, Ghidra MCP, …) and the web dashboard no
+longer come up on `decepticon start` — the orchestrator brings them
+up on demand. Core management plane (LiteLLM, PostgreSQL, Skillogy,
+LangGraph, sandbox) keeps the always-on contract.
+
+### Added
+
+- **ADR-0006 agent-driven container lifecycle.** A host-binary
+  `opscontrol` daemon, supervised by systemd (Linux) / launchd (macOS),
+  owns the docker socket and exposes a Unix-domain socket bind-mounted
+  into the langgraph container. The orchestrator's `ops_start("ad")`,
+  `ops_stop("ad")`, `ops_status` tools route through that socket.
+  Async control plane: `ops_start` returns immediately with
+  `state: "starting"`; the daemon's background goroutine runs the
+  compose-up off the request path. The orchestrator's
+  `OpsControlNotificationMiddleware` polls the registry once per turn
+  and injects a `<system-reminder>` HumanMessage when a workload
+  transitions to `running` / `stopped` / `unknown`, so the agent
+  learns about completions without polling `ops_status`. (#619, #620)
+- **`/web` slash command in the CLI.** The web dashboard is now
+  dynamic-spawn — bring it up with `/web` (`/web up` / `/web stop` /
+  `/web url` / alias `/dashboard`) from inside the terminal CLI.
+  The CLI image ships with `docker-ce-cli` + `docker-compose-plugin`;
+  the compose entry bind-mounts the host docker socket and the
+  operator's `$DECEPTICON_HOME` so the slash command shells out
+  against the operator's compose project. OSS scope only — SaaS
+  bundles override these volumes via a separate compose overlay. (#625)
+- **One-shot upgrade migration** for the stale
+  `COMPOSE_PROFILES=c2-sliver` line that pre-ADR-0006 (v1.1.7 and
+  earlier) shipped in `.env.example`. On first v1.1.8 launch the
+  launcher rewrites that line to a comment (preserving the original
+  value inline) and writes a single `.env.bak` backup. Idempotent on
+  repeat starts; the backup is not overwritten when an operator
+  reintroduces the active line. (#624)
+
+### Changed
+
+- `docker-compose.yml`: the `web` service moves from default-start
+  to `profiles: [web]`. Specialist workload services (`bhce` /
+  `bhce-neo4j` / `bhce-postgres-init` under `[ad]`, `c2-sliver`,
+  `ghidra-mcp` under `[reversing]`) keep their profile gates and are
+  now driven exclusively by the orchestrator's `ops_start(...)`
+  calls. (#620, #625)
+- `decepticon start` UX: the message in the README and the launcher
+  banner now states "Start the core stack and drop into the terminal
+  CLI" rather than "Start everything" — the dashboard and specialist
+  workloads no longer come up by default.
+
+### Fixed
+
+- **`SandboxNotificationMiddleware` background-completion delivery.**
+  `build_sandbox_backend()` was returning a fresh `HTTPSandbox` from
+  every graph factory; with 11 graphs in `langgraph dev`, the bash
+  tool registered jobs on instance A (via the `set_sandbox` last-wins
+  module-level fallback) while every middleware instance polled its
+  own factory-time instance B — every `_jobs.pending_completions()`
+  returned an empty list and the `● Background command "..."
+  completed (exit code N)` reminder never reached the agent.
+  `build_sandbox_backend()` is now `(base_url, token)`-keyed
+  cached so every graph + middleware + tool sees the same
+  `BackgroundJobTracker`. Tests that monkeypatch the env keep their
+  isolation; multi-tenant SaaS pools targeting different daemons
+  keep separate clients. (#623)
+- **BHCE PostgreSQL bootstrap on v1.1.6/v1.1.7 → v1.1.8 upgrades.**
+  The Postgres `init.d` script only runs on an empty data volume, so
+  any existing user upgrading into the BHCE-Neo4j topology hit a
+  `database "bloodhound" does not exist` failure on the first
+  `ops_start("ad")`. v1.1.8 adds an idempotent `bhce-postgres-init`
+  init service that creates the database (and the BHCE role) before
+  BHCE starts, on every cold start. (#618)
+
 ## [1.1.6] — 2026-06-01
 
 Re-cut of `v1.1.5` to restore version coherence — no functional change.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Supported on macOS (Apple Silicon + Intel), Linux (amd64 + arm64), and Windows (
 ```bash
 curl -fsSL https://decepticon.red/install | bash
 decepticon onboard   # Interactive setup wizard (provider, API key, model profile)
-decepticon           # Start everything: terminal CLI + web dashboard at http://localhost:3000
+decepticon           # Start the core stack and drop into the terminal CLI
 ```
+
+The default start brings up the core management plane (LiteLLM, PostgreSQL, Neo4j, Skillogy, LangGraph, sandbox) and launches the terminal CLI. Specialist workloads (BloodHound CE, Sliver C2, Ghidra MCP, …) and the web dashboard come up on demand — the orchestrator spawns specialists via `ops_start("ad")` etc., and you bring up the dashboard from inside the CLI with `/web` (see [Web Dashboard](docs/web-dashboard.md)).
 
 **Windows (PowerShell, native)**
 ```powershell
@@ -133,7 +135,7 @@ But more importantly: it operates under the discipline that separates red teamer
   <img src="assets/decepticon_infra.svg" alt="Decepticon Infrastructure" width="680">
 </div>
 
-Two-network design — management services (LiteLLM, PostgreSQL, LangGraph, Web) on `decepticon-net`; sandbox, C2 server, and targets on `sandbox-net`. Neo4j is dual-homed so the agent (on management) can persist findings written from inside the sandbox.
+Two-network design. The **always-on** management plane (LiteLLM, PostgreSQL, Skillogy, LangGraph) and the always-on sandbox plane stay up across the whole engagement; everything else is **dynamic-spawn** — the Web dashboard comes up on `/web` from the CLI, and specialist workloads (BloodHound CE, Sliver C2, Ghidra MCP, …) come up only when the orchestrator calls `ops_start(...)` (see [ADR-0006](docs/adr/0006-agent-driven-container-lifecycle.md)). Networks: management on `decepticon-net`; sandbox + C2 server + targets on `sandbox-net`. Neo4j is dual-homed so the agent (on management) can persist findings written from inside the sandbox.
 
 → **[Architecture deep dive](docs/architecture.md)** · **[Knowledge graph](docs/knowledge-graph.md)**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,18 +101,30 @@ Hardened Kali Linux container. Runs:
 
 The sandbox is the only place where commands actually execute. LangGraph reaches it via the Docker socket, not the network.
 
-### C2 Server (`sandbox-net`, Sliver)
+### C2 Server (`sandbox-net`, Sliver — dynamic-spawn)
 
 Sliver team server runs alongside the sandbox on the operational network. Features:
 - mTLS, HTTPS, and DNS-based C2 channels
 - Implant generation (Windows, Linux, macOS)
 - Session management for post-exploitation
 
-Activated via `COMPOSE_PROFILES=c2-sliver` (default). Future profiles: `c2-havoc`.
+Brought up on demand by the orchestrator via `ops_start("c2-sliver")` after a foothold is gained — see [ADR-0006](adr/0006-agent-driven-container-lifecycle.md). Default `decepticon start` keeps the C2 plane cold. Future profile: `c2-havoc` (slated for a later release; the orchestrator's prompt and the opscontrol allowlist already accept it).
 
-### Web Dashboard (`decepticon-net`, port 3000 + terminal WebSocket on 3003)
+### Web Dashboard (`decepticon-net`, port 3000 + terminal WebSocket on 3003 — dynamic-spawn)
 
-Next.js 16 application providing a browser-based control plane. See [Web Dashboard](web-dashboard.md).
+Next.js 16 application providing a browser-based control plane. v1.1.8 made this dynamic: it no longer comes up on `decepticon start`. From inside the CLI, run `/web` to spawn it; `/web url` prints the URL; `/web down` stops the container without removing it. See [Web Dashboard](web-dashboard.md).
+
+### Dynamic Workload Lifecycle ([ADR-0006](adr/0006-agent-driven-container-lifecycle.md))
+
+The orchestrator (and only the orchestrator) controls specialist infrastructure through three tools:
+
+- `ops_start("<workload>")` — returns immediately with `state: "starting"`. The opscontrol daemon (a host-binary supervised by systemd / launchd) calls `docker compose --profile <workload> up -d` in a background goroutine and tracks the state machine `starting → running → stopped` per workload.
+- `ops_status` — fallback for daemon reachability checks; routine polling is discouraged because the middleware below already delivers transitions.
+- `ops_stop("<workload>")` — graceful shutdown via `docker compose stop`.
+
+The `OpsControlNotificationMiddleware` polls the daemon's `/v1/profiles` socket once per turn and, when a workload's state changes, injects a `<system-reminder>` HumanMessage on the very next inference — so the agent learns about a BHCE cold-start completion (or failure) without polling. Same shape as Claude Code's background-bash auto-notification pattern.
+
+Allowed workloads: `ad`, `c2-sliver`, `c2-havoc`, `reversing`, `cloud`, `mobile`, `phishing`, `forensics`, `ics`, `iot`, `supply-chain`, `wireless`. Today's compose ships sidecar services for `ad`, `c2-sliver`, and `reversing`; the rest of the allowlist names workloads whose specialist agents work directly inside the sandbox.
 
 ---
 

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -10,15 +10,28 @@ The web dashboard is an open-source (Apache 2.0) browser-based control plane for
 
 **End users:**
 ```bash
-decepticon
+decepticon                    # starts the core stack + drops into the terminal CLI
 ```
-The dashboard is part of the default service stack. Open <http://localhost:3000>.
+
+The dashboard is **dynamic-spawn** (v1.1.8+): it does NOT come up on `decepticon start`. Bring it up from inside the CLI with the `/web` slash command, then open <http://localhost:3000>:
+
+| CLI command | Effect |
+|---|---|
+| `/web` (or `/web up`) | `docker compose --profile web up -d web` against the host daemon |
+| `/web down` (or `/web stop`) | stops the container; preserves it so the next `/web up` is fast |
+| `/web url` | prints `http://localhost:${WEB_PORT}` without touching docker |
+| `/dashboard` | alias for `/web` |
+
+Headless operators (no CLI, e.g. CI) can drive the same lifecycle from the host shell:
+```bash
+docker compose -p decepticon --profile web up -d --no-build web
+```
 
 **Contributors (full stack with hot-reload):**
 ```bash
 make dev
 ```
-Builds and starts every service with source-sync hot-reload. Open <http://localhost:3000>.
+Builds and starts every service with source-sync hot-reload. The web service still requires the `web` profile to be active — e.g. `COMPOSE_PROFILES=web make dev` — or bring it up after the fact with `/web up`. Open <http://localhost:3000>.
 
 **Contributors (local Next.js dev server):**
 ```bash


### PR DESCRIPTION
## Summary

Documentation was written for the pre-v1.1.8 world where `decepticon start` brought every service up by default. v1.1.8 moves the web dashboard and every specialist workload behind dynamic spawn; this PR catches the docs up.

## Changes

### `README.md`
- Quick-start no longer claims the web dashboard comes up at <http://localhost:3000> as part of `decepticon`. The new line states what the default start actually brings up (core stack + terminal CLI) and points operators at `ops_start(...)` / `/web`.
- Architecture blurb rewritten to distinguish the **always-on management plane** (LiteLLM / PostgreSQL / Skillogy / LangGraph + sandbox) from the **dynamic-spawn plane** (web + specialists), with a link to [ADR-0006](docs/adr/0006-agent-driven-container-lifecycle.md).

### `docs/architecture.md`
- C2 Server section: drops `COMPOSE_PROFILES=c2-sliver (default)`, replaces it with the `ops_start("c2-sliver")` model.
- Web Dashboard section: same — `/web` slash command + `/web url` / `/web down`.
- New **Dynamic Workload Lifecycle** subsection summarizes the three `ops_*` tools, the `OpsControlNotificationMiddleware` delivery contract, and the workload allowlist (today's compose ships sidecars for `ad`, `c2-sliver`, `reversing`; the rest work directly in the sandbox).

### `docs/web-dashboard.md`
- Replaces "the dashboard is part of the default service stack" with the full `/web` slash-command table (up / down / url / alias `/dashboard`) and a host-shell escape hatch for headless operators.

### `CHANGELOG.md`
- Adds the v1.1.8 (Unreleased) entry — ADR-0006 daemon + middleware (#619/#620), `/web` slash (#625), one-shot env migration (#624), shared `HTTPSandbox` fix (#623), BHCE bootstrap fix (#618). v1.1.7 entry is intentionally untouched here — that's a separate cleanup PR if maintainers want one.

## Out of scope

- 9-workload sidecar/containerization design (c2-havoc, phishing, cloud, mobile, wireless, …). Specialist agents currently install needed tooling at runtime via apt; sidecar planning lives in a follow-up release.
- Onboard wizard copy tweaks to match.

## Pairs with
- PR #618 — BHCE bootstrap fix
- PR #619/#620 — ADR-0006 Sprint 1/2
- PR #623 — `fix(backends): share HTTPSandbox across graph factories`
- PR #624 — `fix(launcher): migrate stale COMPOSE_PROFILES on first v1.1.8 start`
- PR #625 — `feat(cli): /web slash command for on-demand web dashboard spawn`