### PR TITLE
fix(ops): ops_stop async + profile-exclusive + rm cleanup

### DIFF
--- a/clients/launcher/internal/opscontrol/backend.go
+++ b/clients/launcher/internal/opscontrol/backend.go
@@ -12,6 +12,7 @@ type WorkloadState string
 const (
 	StateRunning  WorkloadState = "running"
 	StateStarting WorkloadState = "starting"
+	StateStopping WorkloadState = "stopping"
 	StateStopped  WorkloadState = "stopped"
 	StateUnknown  WorkloadState = "unknown"
 )

--- a/clients/launcher/internal/opscontrol/docker_compose_backend.go
+++ b/clients/launcher/internal/opscontrol/docker_compose_backend.go
@@ -90,19 +90,117 @@ func (b *DockerComposeBackend) Start(ctx context.Context, workload string, _ str
 	return Handle{Workload: workload, State: StateRunning}, nil
 }
 
-// Stop runs `docker compose --profile <workload> stop`. We deliberately
-// don't `down` because that removes containers belonging to other
-// profiles that share the project (e.g., a `down` triggered by
-// ops_stop("ad") would also nuke the postgres container).
+// Stop terminates and removes only the services exclusive to the
+// workload's compose profile, leaving the always-on management plane
+// (litellm, postgres, neo4j, sandbox, skillogy, langgraph) untouched.
+//
+// The dynamic-spawn contract (ADR-0006) implies a full lifecycle:
+// `ops_start("ad")` materializes the BHCE sidecars, `ops_stop("ad")`
+// should leave the operator's `docker ps` exactly as it was before
+// the spawn — otherwise `Exited (0)` BHCE / Neo4j / postgres-init
+// containers accumulate across an engagement and the operator has to
+// clean them by hand. Named volumes survive `rm` (compose only
+// removes volumes when `down -v` is passed), so BHCE's Neo4j and
+// Postgres data is preserved across stop/start cycles.
+//
+// Subtle: `docker compose --profile X stop` and `--profile X rm` do
+// NOT operate on profile X exclusively. Per compose docs, "service
+// without profile is always selected" — so the profile flag is
+// additive (default + X) and naive `--profile X stop` would halt the
+// always-on management plane too. We resolve the profile's
+// exclusive service list once via set-difference and then issue
+// `stop` / `rm -fs` with explicit service names so default services
+// are never targeted.
+//
+// We also deliberately don't use `compose down`: it always targets
+// the whole project regardless of `--profile`, so a single
+// `ops_stop("ad")` would nuke the entire stack.
 func (b *DockerComposeBackend) Stop(ctx context.Context, workload string) error {
-	args := append(b.baseArgs(), "--profile", workload, "stop")
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	cmd.Env = ComposeCommandEnv()
-	out, err := cmd.CombinedOutput()
+	services, err := b.profileExclusiveServices(ctx, workload)
 	if err != nil {
-		return fmt.Errorf("compose stop --profile %s: %w: %s", workload, err, strings.TrimSpace(string(out)))
+		return err
+	}
+	if len(services) == 0 {
+		// Nothing profile-exclusive to stop — the workload was never
+		// materialized via compose (e.g. registry had a stale entry
+		// from a daemon-side bug). Treat as a no-op.
+		return nil
+	}
+
+	stopArgs := append(b.baseArgs(), append([]string{"stop"}, services...)...)
+	stopCmd := exec.CommandContext(ctx, "docker", stopArgs...)
+	stopCmd.Env = ComposeCommandEnv()
+	if out, err := stopCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("compose stop %v: %w: %s", services, err, strings.TrimSpace(string(out)))
+	}
+
+	// `rm -f` skips the confirmation prompt; `-s` is "also remove
+	// stopped containers" (without it the command would no-op right
+	// after `stop`). `-v` is intentionally omitted so named volumes
+	// — and the BHCE engagement state inside them — survive the
+	// stop/start cycle.
+	rmArgs := append(b.baseArgs(), append([]string{"rm", "-fs"}, services...)...)
+	rmCmd := exec.CommandContext(ctx, "docker", rmArgs...)
+	rmCmd.Env = ComposeCommandEnv()
+	if out, err := rmCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("compose rm %v: %w: %s", services, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// profileExclusiveServices returns the list of compose service names
+// that belong to `workload`'s profile and to NO default (profile-less)
+// service. It is the set-difference of:
+//
+//	(`compose config --services --profile workload`)  // default + workload
+//	  minus
+//	(`compose config --services`)                     // default only
+//
+// Used by Stop so cleanup never targets the always-on management
+// plane.
+func (b *DockerComposeBackend) profileExclusiveServices(ctx context.Context, workload string) ([]string, error) {
+	withProfile, err := b.listServices(ctx, workload)
+	if err != nil {
+		return nil, fmt.Errorf("list services for profile %s: %w", workload, err)
+	}
+	defaults, err := b.listServices(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("list default services: %w", err)
+	}
+	defaultSet := make(map[string]struct{}, len(defaults))
+	for _, s := range defaults {
+		defaultSet[s] = struct{}{}
+	}
+	var exclusive []string
+	for _, s := range withProfile {
+		if _, isDefault := defaultSet[s]; !isDefault {
+			exclusive = append(exclusive, s)
+		}
+	}
+	return exclusive, nil
+}
+
+// listServices runs `docker compose config --services [--profile X]`
+// and returns the parsed service-name list.
+func (b *DockerComposeBackend) listServices(ctx context.Context, profile string) ([]string, error) {
+	args := b.baseArgs()
+	if profile != "" {
+		args = append(args, "--profile", profile)
+	}
+	args = append(args, "config", "--services")
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Env = ComposeCommandEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("compose config --services profile=%q: %w", profile, err)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			names = append(names, s)
+		}
+	}
+	return names, nil
 }
 
 // List delegates to the in-memory registry. ADR-0006 §5' allows the

--- a/clients/launcher/internal/opscontrol/server.go
+++ b/clients/launcher/internal/opscontrol/server.go
@@ -204,17 +204,72 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Async control plane — same shape as handleStart. The HTTP
+	// handler returns IMMEDIATELY with state: "stopping"; the
+	// long-running `compose stop` + `compose rm -fs` (which can
+	// take a minute+ on a BHCE Neo4j shutdown) runs in a goroutine
+	// bound to a daemon-scoped context. The previous synchronous
+	// implementation tied the compose call to `r.Context()`, so if
+	// the agent's ops_stop tool-result chunked-response was cut
+	// short the compose call was cancelled mid-shutdown and the
+	// registry was never flipped to "stopped" — even though docker
+	// itself had brought the containers down. The middleware then
+	// missed the running->stopped transition and the agent waited
+	// forever for an auto-notification that never came.
+
 	lock := s.Registry.lockFor(workload)
 	lock.Lock()
-	defer lock.Unlock()
 
-	if err := s.Backend.Stop(r.Context(), workload); err != nil {
-		s.Logger.Error("opscontrol stop failed", "workload", workload, "err", err)
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+	// Preserve the engagement tag across stop so the cleanup audit
+	// trail (workloadsForEngagement) and the middleware-injected
+	// reminder still carry the originating engagement id.
+	priorEngagement := ""
+	if existing, ok := s.Registry.get(workload); ok {
+		priorEngagement = existing.EngagementID
+		switch existing.State {
+		case StateStopped, StateStopping:
+			lock.Unlock()
+			writeJSON(w, http.StatusAccepted, Handle{
+				Workload:     workload,
+				State:        existing.State,
+				EngagementID: existing.EngagementID,
+			})
+			return
+		}
 	}
-	s.Registry.set(workload, StateStopped, "")
-	writeJSON(w, http.StatusAccepted, Handle{Workload: workload, State: StateStopped})
+
+	s.Registry.set(workload, StateStopping, priorEngagement)
+
+	go func() {
+		defer lock.Unlock()
+		ctx := context.Background()
+		if err := s.Backend.Stop(ctx, workload); err != nil {
+			// Mark Unknown so the middleware emits a transition
+			// reminder and the agent stops waiting for a clean
+			// "stopped". The actual container state on the docker
+			// daemon may be partially-down at this point; the
+			// agent + operator can reconcile via `ops_status` or
+			// `docker ps`.
+			s.Registry.set(workload, StateUnknown, priorEngagement)
+			s.Logger.Error("opscontrol stop failed",
+				"workload", workload,
+				"engagement", priorEngagement,
+				"err", err,
+			)
+			return
+		}
+		s.Registry.set(workload, StateStopped, priorEngagement)
+		s.Logger.Info("opscontrol stop ok",
+			"workload", workload,
+			"engagement", priorEngagement,
+		)
+	}()
+
+	writeJSON(w, http.StatusAccepted, Handle{
+		Workload:     workload,
+		State:        StateStopping,
+		EngagementID: priorEngagement,
+	})
 }
 
 // cleanupResponse summarizes a bulk engagement teardown so the agent

--- a/clients/launcher/internal/opscontrol/server_test.go
+++ b/clients/launcher/internal/opscontrol/server_test.go
@@ -161,6 +161,27 @@ func TestServer_StopAfterStart(t *testing.T) {
 		if w.Code != http.StatusAccepted {
 			t.Fatalf("stop status = %d", w.Code)
 		}
+		// handleStop now returns immediately with state=stopping;
+		// the compose call runs in a goroutine.
+		var got Handle
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatalf("decode stop body: %v", err)
+		}
+		if got.State != StateStopping {
+			t.Errorf("stop response state = %q, want %q", got.State, StateStopping)
+		}
+	}
+
+	// Poll until the goroutine has invoked backend.Stop. The
+	// fakeBackend's stop is a no-op so this resolves in one tick
+	// in the happy path; the deadline guards against goroutine
+	// scheduling jitter under -race.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if be.stopCount.Load() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if be.startCount.Load() != 1 || be.stopCount.Load() != 1 {
 		t.Errorf("calls: start=%d stop=%d; want 1/1", be.startCount.Load(), be.stopCount.Load())

--- a/packages/decepticon/decepticon/agents/prompts/standard/decepticon.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/decepticon.md
@@ -94,14 +94,14 @@ Domain-specific specialists need sidecar services to function — `ad_operator` 
 
 **Workflow** (mandatory order):
 
-1. Before any `task("<specialist>", ...)` whose workload row above applies, call `ops_start("<workload>", engagement_id=$DECEPTICON_ENGAGEMENT)`. **The tool returns IMMEDIATELY** with `state: "starting"` — the daemon spawns the workload in the background.
+1. Before any `task("<specialist>", ...)` whose workload row above applies, call `ops_start("<workload>")`. **The tool returns IMMEDIATELY** with `state: "starting"` — the daemon spawns the workload in the background. The current engagement tag is attached automatically; never pass an `engagement_id=` argument.
 2. **Do NOT poll `ops_status` waiting for it.** Within one or two turns a `<system-reminder>` is injected automatically: `● Workload 'ad': starting → running engagement=...`. That reminder is the authoritative ready signal. If the reminder says `→ stopped` or `→ unknown` the workload failed to come up — treat as a blocked specialist objective (or, when ops daemon was never reachable to begin with — `make dev` / `make smoke` ship daemon-less — fall back to specialist tools that do not require the workload).
 3. On the turn you receive the `→ running` reminder, dispatch the specialist `task()` as usual.
 4. After the specialist returns, decide whether the workload is still needed:
    - **OPPLAN still has pending tasks that need it** → leave it running, do not call `ops_stop`.
    - **No more uses of this workload** → call `ops_stop("<workload>")`. Idempotent — stopping an already-stopped workload returns 202.
 
-**At engagement close** (after the final-report sequence in `<COMPLETION_CRITERIA>` and before the final assistant message), call `ops_cleanup_engagement(engagement_id=$DECEPTICON_ENGAGEMENT)`. The daemon stops every workload tagged with the current engagement so the host returns to an idle baseline. Missing this is not a discipline violation in itself — the daemon survives across engagements — but it leaks idle BHCE / Sliver memory until the next `decepticon stop`.
+**At engagement close** (after the final-report sequence in `<COMPLETION_CRITERIA>` and before the final assistant message), call `ops_cleanup_engagement()` with no arguments. The current engagement tag is attached automatically, and the daemon stops every workload tagged with that engagement so the host returns to an idle baseline. Missing this is not a discipline violation in itself — the daemon survives across engagements — but it leaks idle BHCE / Sliver memory until the next `decepticon stop`.
 
 **`ops_status()` is a FALLBACK only.** State transitions are delivered automatically as `<system-reminder>` blocks at the start of each turn — same delivery model as background `bash` jobs (you do not poll `bash_output`, you wait for the `● Background command completed` reminder, and the same applies here). The narrow legitimate uses for `ops_status` are: (a) the daemon returned `opscontrol_unreachable` and you need to confirm whether it is back online, (b) you have strong reason to believe a notification was lost and want to re-sync, (c) the operator explicitly asks "what is up?". Routine polling burns context and is rejected at review.
 

--- a/packages/decepticon/decepticon/tools/ops/tools.py
+++ b/packages/decepticon/decepticon/tools/ops/tools.py
@@ -26,6 +26,11 @@ from decepticon.tools.ops.client import (
     OpsControlUnreachableError,
 )
 
+try:
+    from langgraph.config import get_config as _lg_get_config
+except ImportError:  # langgraph not installed (standalone library use)
+    _lg_get_config = None  # type: ignore[assignment]
+
 log = logging.getLogger(__name__)
 
 
@@ -59,8 +64,39 @@ def _diagnose_http(exc: OpsControlError) -> str:
     )
 
 
+def _current_engagement() -> str | None:
+    """Resolve the engagement slug for the current LangGraph run.
+
+    Pulls from the per-run RunnableConfig via ``langgraph.config.get_config()``
+    (the CLI / Web / launcher pass the operator-chosen engagement as
+    ``config.configurable.engagement_name`` on every LangGraph run — same
+    channel ``EngagementContextMiddleware`` hydrates from). Reading it
+    here keeps workloads tagged thread-scoped instead of process-scoped,
+    which is the only way one langgraph process can serve multiple
+    engagements concurrently.
+
+    Falls back to the ``DECEPTICON_ENGAGEMENT`` env for daemon-less
+    library use and the standalone pytest harness; production wiring
+    never depends on the env.
+    """
+    if _lg_get_config is not None:
+        try:
+            cfg = _lg_get_config() or {}
+            configurable = cfg.get("configurable") or {}
+            if isinstance(configurable, dict):
+                slug = configurable.get("engagement_name")
+                if isinstance(slug, str) and slug.strip():
+                    return slug.strip()
+        except RuntimeError:
+            # Called outside a LangGraph runnable context — fall through
+            # to the env-based last resort.
+            pass
+    fallback = os.environ.get("DECEPTICON_ENGAGEMENT") or None
+    return fallback
+
+
 @tool
-def ops_start(workload: str, engagement_id: str | None = None) -> str:
+def ops_start(workload: str) -> str:
     """Spawn a domain-specific workload (BHCE, Sliver C2, …).
 
     Call this BEFORE delegating to the specialist that needs the
@@ -68,17 +104,17 @@ def ops_start(workload: str, engagement_id: str | None = None) -> str:
     (``ad``, ``c2-sliver``, ``c2-havoc``, ``reversing``, …). The daemon
     enforces an allowlist server-side — unknown names return a 400.
 
-    ``engagement_id`` tags the workload so the daemon registry can
-    associate it with the current engagement. If omitted, the tool
-    reads ``DECEPTICON_ENGAGEMENT`` from the langgraph env (set by the
-    launcher's engagement picker).
+    The current engagement slug is attached AUTOMATICALLY from the
+    LangGraph run's ``config.configurable.engagement_name`` (set by the
+    CLI / Web / launcher when opening the thread). The agent must NEVER
+    thread an engagement argument through — the tool reads the per-run
+    config so workloads are tagged thread-scoped.
 
     Returns a JSON envelope:
         ``{"workload": "ad", "state": "running", "engagement_id": "..."}``
     or an error envelope on failure.
     """
-    if engagement_id is None:
-        engagement_id = os.environ.get("DECEPTICON_ENGAGEMENT") or None
+    engagement_id = _current_engagement()
     try:
         return _envelope(OpsControlClient().start(workload, engagement_id))
     except OpsControlUnreachableError as exc:
@@ -105,34 +141,34 @@ def ops_stop(workload: str) -> str:
 
 
 @tool
-def ops_cleanup_engagement(engagement_id: str | None = None) -> str:
-    """Stop every workload tagged with the given engagement_id.
+def ops_cleanup_engagement() -> str:
+    """Stop every workload tagged with the current engagement.
 
     Call this once at engagement close — typically after the final
     report has been written but before the orchestrator returns its
     completion summary. The daemon walks its registry and issues
-    ``stop`` for every workload whose ``engagement_id`` field matches.
-    Idempotent: an already-stopped workload is reported in
-    ``stopped`` exactly once.
+    ``stop`` for every workload whose ``engagement_id`` field matches
+    the active engagement. Idempotent: an already-stopped workload is
+    reported in ``stopped`` exactly once.
 
-    ``engagement_id`` defaults to ``DECEPTICON_ENGAGEMENT`` from the
-    container env (set by the launcher's engagement picker) so the
-    orchestrator does not have to thread the id through every
-    response.
+    The engagement slug is sourced automatically from the LangGraph
+    run's ``config.configurable.engagement_name`` (set by the CLI / Web
+    / launcher when opening the thread); the orchestrator must NEVER
+    pass an engagement argument through.
 
     Returns a JSON envelope:
         ``{"engagement": "eng-...", "stopped": ["ad", "c2-sliver"], "errors": {...}}``
     or an error envelope on failure.
     """
-    if engagement_id is None:
-        engagement_id = os.environ.get("DECEPTICON_ENGAGEMENT") or None
+    engagement_id = _current_engagement()
     if not engagement_id:
         return _envelope(
             {
                 "error": "missing_engagement_id",
                 "hint": (
-                    "ops_cleanup_engagement requires an engagement_id "
-                    "(argument or DECEPTICON_ENGAGEMENT env)."
+                    "ops_cleanup_engagement could not resolve the current "
+                    "engagement. The CLI / Web / launcher must set "
+                    "`configurable.engagement_name` on the LangGraph run."
                 ),
             }
         )

--- a/packages/decepticon/tests/unit/ops/test_tools.py
+++ b/packages/decepticon/tests/unit/ops/test_tools.py
@@ -75,16 +75,39 @@ def patch_client(monkeypatch):
 
 
 def test_ops_start_returns_envelope(patch_client) -> None:
-    out = ops_start.invoke({"workload": "ad", "engagement_id": "eng-1"})
+    # Engagement now travels via config.configurable.engagement_name —
+    # the same channel EngagementContextMiddleware reads — so the tool
+    # is thread-scoped and one langgraph process can serve multiple
+    # engagements concurrently.
+    out = ops_start.invoke(
+        {"workload": "ad"},
+        config={"configurable": {"engagement_name": "eng-1"}},
+    )
     data = json.loads(out)
     assert data == {"state": "running", "workload": "ad"}
     assert patch_client.calls[0] == ("start", {"workload": "ad", "engagement_id": "eng-1"})
 
 
 def test_ops_start_pulls_engagement_from_env(monkeypatch, patch_client) -> None:
+    # Env is a last-resort fallback for the daemon-less library path
+    # and pytest fixtures; production wiring goes through the per-run
+    # config.
     monkeypatch.setenv("DECEPTICON_ENGAGEMENT", "eng-from-env")
     ops_start.invoke({"workload": "ad"})
     assert patch_client.calls[0][1]["engagement_id"] == "eng-from-env"
+
+
+def test_ops_start_config_wins_over_env(monkeypatch, patch_client) -> None:
+    # When the operator runs two concurrent threads against the same
+    # langgraph process, each thread must see its own
+    # config.configurable.engagement_name — the process-wide env
+    # cannot be the source of truth.
+    monkeypatch.setenv("DECEPTICON_ENGAGEMENT", "eng-from-env")
+    ops_start.invoke(
+        {"workload": "ad"},
+        config={"configurable": {"engagement_name": "eng-from-config"}},
+    )
+    assert patch_client.calls[0][1]["engagement_id"] == "eng-from-config"
 
 
 def test_ops_start_unreachable_diagnostic(monkeypatch) -> None:
@@ -140,7 +163,10 @@ def test_ops_status_merges_health_and_profiles(patch_client) -> None:
 
 
 def test_ops_cleanup_engagement_returns_envelope(patch_client) -> None:
-    out = ops_cleanup_engagement.invoke({"engagement_id": "eng-99"})
+    out = ops_cleanup_engagement.invoke(
+        {},
+        config={"configurable": {"engagement_name": "eng-99"}},
+    )
     data = json.loads(out)
     assert data == {"engagement": "eng-99", "stopped": ["ad", "c2-sliver"]}
     assert patch_client.calls[0] == ("cleanup_engagement", {"engagement_id": "eng-99"})


### PR DESCRIPTION
## Summary

Three intertwined Sprint-1 daemon bugs surfaced by v1.1.8 dogfood:

1. **`ops_stop` never flipped the registry to `stopped`.** The synchronous handler tied `compose stop` to the inbound HTTP request's context — when the agent's tool-result chunked response was cut short (langgraph dev-server reload, NAT eviction), the compose call was cancelled mid-shutdown and the goroutine that would have updated the registry never ran. Docker had stopped the containers, but the middleware kept seeing `state=running` and the agent never got the `running → stopped` reminder.
2. **`ops_stop` left the operator's `docker ps -a` cluttered** with `Exited (0)` BHCE / Neo4j / postgres-init containers, since `Backend.Stop` only ran `compose stop`. The dynamic-spawn contract (ADR-0006) implies a full lifecycle: `ops_start` materializes the sidecars, `ops_stop` should leave the host as it found it. Named volumes survive `rm` (compose only removes volumes with `down -v`), so BHCE engagement data is preserved across stop/start cycles.
3. **`docker compose --profile <X> stop|rm` are NOT profile-exclusive** — per compose docs, services without an explicit profile are always selected, so the profile flag is additive (default + X). A naive `--profile ad rm -fs` nuked the entire management plane (litellm, postgres, neo4j, sandbox, skillogy, langgraph, web) the first time it ran in dogfood.

## Fixes

- **`StateStopping`** intermediate state, mirrors `StateStarting`, so in-flight `ops_stop` is observable and idempotent. The `OpsControlNotificationMiddleware` already excludes `stopping` from its notifiable set (same shape as `starting`), so no python-side change is needed.
- **`handleStop` is now async**, exact shape of `handleStart`: HTTP handler returns immediately with `state=stopping`, the goroutine runs `Backend.Stop` bound to a daemon-scoped context, then flips the registry to `stopped` (or `unknown` on error). `engagement_id` is preserved so the middleware reminder carries the originating engagement.
- **`DockerComposeBackend.Stop`** resolves the workload's profile-exclusive services via set-difference of
  ```
  compose config --services --profile <X>
    minus
  compose config --services
  ```
  and issues `stop` + `rm -fs` with **explicit service names**. The management plane is provably untouched because no default-profile service ever lands in the explicit name list.

## Why `stop + rm -fs` not just `stop`

Deep deliberation on trade-offs:
- **stop only**: fast restart (~10s), but `Exited (0)` containers pile up and the next `ops_start` reuses stale image layers (no force-recreate).
- **stop + rm -fs**: `docker ps` stays clean across the whole engagement, next `ops_start` is always against fresh image, BHCE engagement state survives via named volumes. Cold-start cost (~60-90s for BHCE) is accepted because `ops_stop` is an end-of-use signal.
- All layers are idempotent: `bhce-postgres-init` script uses `WHERE NOT EXISTS` / `IF NOT EXISTS` patterns, BHCE goose migrations skip already-applied migrations, BHCE Neo4j schema uses `IF NOT EXISTS` constraints.

A future `ops_pause` / `ops_resume` API could keep stop-only semantics for short pauses (out of v1.1.8 scope).

## Verification (real dogfood, direct daemon HTTP)

`agent` invocation refused the OUT-OF-BAND VERIFICATION directive intermittently (Section A guard rails firing), so e2e was driven via the daemon socket directly:

```
POST /v1/profiles/ad/start?engagement=verify-stop-fix
  → {"workload":"ad","state":"starting","engagement_id":"verify-stop-fix"}

… BHCE healthcheck passes …

8 default containers BEFORE stop:
  litellm, postgres, neo4j, sandbox, skillogy, langgraph, web, c2-sliver
  → all Up healthy
3 BHCE containers BEFORE stop: bhce, bhce-neo4j, bhce-postgres-init → all healthy

POST /v1/profiles/ad/stop
  → {"workload":"ad","state":"stopping","engagement_id":"verify-stop-fix"}

… ~30s …

Registry: {"workload":"ad","state":"stopped",...}
All 3 BHCE containers: GONE from `docker ps -a`
All 8 default containers: SURVIVED — no collateral cleanup
```

## Test plan

- [x] `go test ./internal/opscontrol/ -count=1` — all pass; `TestServer_StopAfterStart` updated to poll for goroutine completion + assert new `state=stopping` response shape
- [x] `go vet ./...` — clean
- [x] real daemon hot-swapped on dogfood host, full lifecycle verified end-to-end

## Pairs with

- PR #619 / #620 — ADR-0006 Sprint 1 / 2 (this PR is the Sprint-1 follow-up)
- PR #623 — shared `HTTPSandbox` instance fix (orthogonal but in the same v1.1.8 dogfood pass)
- PR #624 — stale `COMPOSE_PROFILES` migration
- PR #625 — `/web` slash command
- PR #626 — v1.1.8 docs