### PR TITLE
fix(cli): drop working_dir override that broke the cli entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -498,7 +498,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${DECEPTICON_HOME:-~/.decepticon}:/decepticon-home
-    working_dir: /decepticon-home
+    # Do NOT override WORKDIR — the cli image's entrypoint is
+    # `node dist/index.js` resolved relative to /app (set by
+    # containers/cli.Dockerfile). The slash command resolves the
+    # compose project via the DECEPTICON_COMPOSE_FILE / _ENV_FILE
+    # env vars above, so working_dir on this container is irrelevant.
     depends_on:
       langgraph:
         condition: service_healthy


### PR DESCRIPTION
Hotfix for PR #625 regression discovered during v1.1.8 `make smoke`. The added `working_dir: /decepticon-home` made `node dist/index.js` resolve from the wrong cwd, exiting (1) on every `docker compose run --rm cli`. `smoke` halted at the cli wait phase. The slash command's compose targeting goes through `DECEPTICON_COMPOSE_FILE` / `DECEPTICON_COMPOSE_ENV_FILE` env vars, so cwd inside the cli container is irrelevant — restore the image's WORKDIR /app.