### PR TITLE
fix(v1.1.9): post-v1.1.8 hotfix bundle — disconnect / ask envelope / skillogy CLI

### DIFF
--- a/clients/cli/src/components/messages/ToolCallMessage.tsx
+++ b/clients/cli/src/components/messages/ToolCallMessage.tsx
@@ -31,7 +31,13 @@ const TOOL_DISPLAY: Record<string, string> = {
   write_todos: "Todos",
   ask_user_question: "Ask",
   complete_engagement_planning: "Plan complete",
+  // Skillogy 3-tool surface (ADR-0008 / v0.2.2). load_skill is the
+  // expensive full-text fetch; find_skill / traverse are the cheap
+  // discovery primitives. Label all three so the activity stream stays
+  // legible during the skill-retrieval phase.
   load_skill: "Skill",
+  find_skill: "Find skill",
+  traverse: "Traverse skills",
 };
 
 // ── Tool call header ──────────────────────────────────────────────
@@ -169,6 +175,39 @@ export const ToolCallMessage = React.memo(function ToolCallMessage({
           <Text color="green">{`${GLYPH_DOT} `}</Text>
           <Text color="white" bold>{"Skill"}</Text>
           <Text color="gray" italic>{` (${skillName})`}</Text>
+        </Text>
+      </Box>
+    );
+  }
+
+  // Skillogy discovery tools (find_skill, traverse) — JSON payload is
+  // useful to the model but illegible in the activity stream. Show a
+  // compact header so the operator can SEE the call without being
+  // drowned in raw JSON. Same treatment as load_skill above.
+  if (event.toolName === "find_skill" || event.toolName === "traverse") {
+    const args = event.toolArgs ?? {};
+    const hint = (() => {
+      if (event.toolName === "find_skill") {
+        const q = args.query as string | undefined;
+        const sub = args.subdomain as string | undefined;
+        const mitre = args.mitre_id as string | undefined;
+        const tag = args.tag as string | undefined;
+        const tactic = args.tactic_id as string | undefined;
+        return q ?? sub ?? mitre ?? tag ?? tactic ?? "";
+      }
+      const from = (args.from_path as string | undefined) ?? "";
+      return from.includes("/")
+        ? from.split("/").slice(-2, -1)[0] ?? from
+        : from;
+    })();
+    const label = event.toolName === "find_skill" ? "Find skill" : "Traverse skills";
+    const dotColor = event.status === "error" ? "red" : "green";
+    return (
+      <Box flexDirection="column" marginTop={1}>
+        <Text>
+          <Text color={dotColor}>{`${GLYPH_DOT} `}</Text>
+          <Text color="white" bold>{label}</Text>
+          {hint ? <Text color="gray" italic>{` (${hint})`}</Text> : null}
         </Text>
       </Box>
     );

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -548,8 +548,17 @@ export function useAgent({
         }
       }
 
-      // Detect unexpected disconnection: stream ended but no completion event
-      if (!completionReceived && !abortController.signal.aborted) {
+      // Detect unexpected disconnection: stream ended but no completion event.
+      //
+      // ``ask_user_question`` ends the stream by raising LangGraph's
+      // ``interrupt()`` \u2014 the run is PAUSED, not lost. ``activeQuestionRef``
+      // is the same signal ``handleStreamComplete`` already uses to keep
+      // runState=paused and render the picker. Without this guard every
+      // interview turn surfaced a bogus "Connection to server lost" notice
+      // even though the run was sitting in a clean interrupt waiting for the
+      // operator's pick.
+      const interrupted = activeQuestionRef.current !== null;
+      if (!completionReceived && !abortController.signal.aborted && !interrupted) {
         addSystemEvent(
           "\u26a0\ufe0f Connection to server lost. The run continues server-side. "
           + "Use /resume to reconnect.",

--- a/clients/cli/src/utils/format.ts
+++ b/clients/cli/src/utils/format.ts
@@ -22,12 +22,26 @@ export function formatNumber(n: number): string {
 }
 
 /** Extract skill name from a /skills/... path. Returns null if not a skill path.
- *  Recognizes both `read_file({file_path})` and `load_skill({skill_path})`. */
+ *  Recognizes:
+ *    - read_file({file_path})       — legacy filesystem skills
+ *    - load_skill({skill_path})     — legacy SkillsMiddleware
+ *    - load_skill({name_or_path})   — Skillogy v0.2.2 tool
+ *
+ *  The Skillogy ``name_or_path`` value can be either a /skills/.../SKILL.md
+ *  path OR a bare frontmatter name (e.g. ``kerberoasting``); in the
+ *  bare-name case we return it as-is so the activity stream still shows
+ *  ``● Skill (kerberoasting)`` instead of the raw JSON body. */
 export function extractSkillName(args: Record<string, unknown>): string | null {
   const filePath =
     (args.skill_path as string | undefined) ??
-    (args.file_path as string | undefined);
-  if (!filePath || !filePath.includes("/skills/")) return null;
+    (args.file_path as string | undefined) ??
+    (args.name_or_path as string | undefined);
+  if (!filePath) return null;
+  if (!filePath.includes("/skills/")) {
+    // Bare frontmatter name — no slashes, no Markdown to parse. Use it
+    // verbatim so the header still labels the skill.
+    return filePath.includes("/") ? null : filePath;
+  }
   const parts = filePath.split("/");
   const skillsIdx = parts.indexOf("skills");
   const skillDir = parts[parts.length - 2];

--- a/packages/decepticon/decepticon/middleware/prompt_injection_shield.py
+++ b/packages/decepticon/decepticon/middleware/prompt_injection_shield.py
@@ -292,6 +292,13 @@ _FRAMEWORK_TOOL_NAMES: frozenset[str] = frozenset(
         "write_file",
         "list_directory",
         "task",
+        # ``ask_user_question`` is the operator-interview tool: the model
+        # asks the operator a multiple-choice question via LangGraph
+        # interrupt and the operator's pick is sent back as the tool
+        # result. That payload originates with the operator running the
+        # CLI / Web — not with an attacker — so the quarantine envelope
+        # is noise and visually breaks the interview UX. Trust it.
+        "ask_user_question",
     }
 )
 


### PR DESCRIPTION
Hotfix bundle from the first end-user v1.1.8 dogfood. Four small UX bugs surfaced in a single CLI session.

## Changes

### 1. Bogus "Connection to server lost" on every SOUNDWAVE interview turn
\`clients/cli/src/hooks/useAgent.ts\` — \`ask_user_question\` pauses the run via LangGraph \`interrupt()\`; the SSE stream ends without a \`completion\` event, and the disconnect detector treated that pause as an unexpected drop. \`handleStreamComplete\` already uses \`activeQuestionRef\` to keep the picker rendered — the disconnect branch now respects it too.

### 2. \`<untrusted_tool_output>\` envelope on \`ask_user_question\` results
\`packages/decepticon/decepticon/middleware/prompt_injection_shield.py\` — the payload is the operator's own multiple-choice pick, not attacker-controlled tool output. Added to \`_FRAMEWORK_TOOL_NAMES\` allowlist alongside the other operator-driven framework tools.

### 3. \`load_skill\` dumped the entire SKILL.md JSON body
\`clients/cli/src/utils/format.ts\` — Skillogy's \`load_skill({name_or_path})\` v0.2.2 arg shape was not recognized by \`extractSkillName\`, so the helper returned \`null\` and the raw \`ResultContent\` renderer fired with the full JSON. Now accepts \`name_or_path\` and degrades cleanly to a bare frontmatter name.

### 4. \`find_skill\` / \`traverse\` had no header-only rendering
\`clients/cli/src/components/messages/ToolCallMessage.tsx\` — added friendly labels + a compact \`● Find skill (query)\` / \`● Traverse skills (seed)\` header rendering, same treatment as \`load_skill\`.

## Test plan

- [x] \`npm run typecheck --workspace=@decepticon/cli\` clean
- [x] \`npm run build --workspace=@decepticon/cli\` clean
- [x] \`uv run pytest -k "prompt_injection or shield"\` — 26 pass

## v1.1.8 immutability

v1.1.8 wheels / GHCR tags / GitHub Release stay as published. This is a v1.1.9 patch release that ships only end-user UX fixes — no API changes.