### PR TITLE
fix(v1.1.10): bash newline strip + parallel sub-agent session keying

### DIFF
--- a/clients/shared/streaming/src/sessions.ts
+++ b/clients/shared/streaming/src/sessions.ts
@@ -45,8 +45,19 @@ export function deriveSubAgentSessions(events: readonly StreamEvent[]): SubAgent
   const sessions: SubAgentSession[] = [];
   const openSessions = new Map<string, SubAgentSession>();
 
+  // Per-invocation key. The backend's StreamingRunnable now stamps every
+  // emit with a unique `sessionId`; older event streams (and any consumer
+  // that hasn't picked up the new field yet) fall back to the agent name.
+  // Falling back drops parallel-same-agent grouping but at least keeps
+  // single-agent runs working.
+  const sessionKey = (e: StreamEvent): string =>
+    (e.sessionId ?? "") + "::" + (e.subagent ?? "");
+
   for (const event of events) {
-    if (event.type === "subagent_start" && event.subagent) {
+    if (!event.subagent) continue;
+    const key = sessionKey(event);
+
+    if (event.type === "subagent_start") {
       const session: SubAgentSession = {
         id: event.id,
         agent: event.subagent,
@@ -57,10 +68,10 @@ export function deriveSubAgentSessions(events: readonly StreamEvent[]): SubAgent
         startTime: event.timestamp,
         status: "running",
       };
-      openSessions.set(event.subagent, session);
+      openSessions.set(key, session);
       sessions.push(session);
-    } else if (event.type === "subagent_end" && event.subagent) {
-      const session = openSessions.get(event.subagent);
+    } else if (event.type === "subagent_end") {
+      const session = openSessions.get(key);
       if (session) {
         session.endEventId = event.id;
         session.endTime = event.timestamp;
@@ -70,10 +81,10 @@ export function deriveSubAgentSessions(events: readonly StreamEvent[]): SubAgent
         session.status =
           event.status === "error" || event.error === true ? "error" : "completed";
         session.eventIds.push(event.id);
-        openSessions.delete(event.subagent);
+        openSessions.delete(key);
       }
-    } else if (event.subagent) {
-      const session = openSessions.get(event.subagent);
+    } else {
+      const session = openSessions.get(key);
       if (session) {
         session.eventIds.push(event.id);
         if (event.type === "tool_result" || event.type === "bash_result") {

--- a/clients/shared/streaming/src/types.ts
+++ b/clients/shared/streaming/src/types.ts
@@ -69,4 +69,13 @@ export interface StreamEvent {
   status?: string;
   /** Raw backend error flag on `subagent_end` (the SubagentCustomEvent contract). */
   error?: boolean;
+  /**
+   * Per-invocation id emitted by the backend's StreamingRunnable. Lets
+   * `deriveSubAgentSessions` distinguish two concurrent dispatches of the
+   * SAME agent (e.g. orchestrator calling `task("recon", ...)` twice in
+   * parallel) — before this field existed the grouping was keyed on
+   * agent name and the second start silently collapsed the first
+   * session's stream into the second.
+   */
+  sessionId?: string;
 }

--- a/packages/decepticon/decepticon/core/subagent_streaming.py
+++ b/packages/decepticon/decepticon/core/subagent_streaming.py
@@ -33,6 +33,7 @@ import asyncio
 import contextvars
 import logging
 import time
+import uuid
 from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
@@ -181,12 +182,30 @@ class StreamingRunnable(RunnableBinding):
         return ""
 
     def _emit_start(
-        self, renderer: Any, has_renderer: bool, writer: Callable | None, prompt: str
+        self,
+        renderer: Any,
+        has_renderer: bool,
+        writer: Callable | None,
+        prompt: str,
+        session_id: str,
     ) -> None:
         if has_renderer:
             renderer.on_subagent_start(self._name, prompt)
         if writer:
-            writer({"type": "subagent_start", "agent": self._name, "prompt": prompt})
+            writer(
+                {
+                    "type": "subagent_start",
+                    "agent": self._name,
+                    "prompt": prompt,
+                    # Invocation-unique id so consumers (CLI / Web) can
+                    # group events by SESSION instead of by agent name.
+                    # Two parallel ``task("recon", ...)`` dispatches yield
+                    # the same ``agent`` but different ``session_id``s;
+                    # without this field the CLI collapsed both into a
+                    # single session and lost the first one's tool calls.
+                    "session_id": session_id,
+                }
+            )
 
     def _emit_end(
         self,
@@ -194,6 +213,7 @@ class StreamingRunnable(RunnableBinding):
         has_renderer: bool,
         writer: Callable | None,
         elapsed: float,
+        session_id: str,
         *,
         cancelled: bool = False,
         error: bool = False,
@@ -208,6 +228,7 @@ class StreamingRunnable(RunnableBinding):
                     "elapsed": elapsed,
                     "cancelled": cancelled,
                     "error": error,
+                    "session_id": session_id,
                 }
             )
 
@@ -218,6 +239,7 @@ class StreamingRunnable(RunnableBinding):
         renderer: Any,
         has_renderer: bool,
         writer: Callable | None,
+        session_id: str,
     ) -> None:
         """Process new messages and emit events to channels."""
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -239,7 +261,14 @@ class StreamingRunnable(RunnableBinding):
                         if has_renderer:
                             renderer.on_subagent_message(self._name, text)
                         if writer:
-                            writer({"type": "subagent_message", "agent": self._name, "text": text})
+                            writer(
+                                {
+                                    "type": "subagent_message",
+                                    "agent": self._name,
+                                    "text": text,
+                                    "session_id": session_id,
+                                }
+                            )
 
                 if hasattr(msg, "tool_calls") and msg.tool_calls:
                     for tc in msg.tool_calls:
@@ -279,6 +308,7 @@ class StreamingRunnable(RunnableBinding):
                                     # tool name. None when the model omitted
                                     # the id (rare; logged as a warning above).
                                     "id": tc_id,
+                                    "session_id": session_id,
                                 }
                             )
 
@@ -308,6 +338,7 @@ class StreamingRunnable(RunnableBinding):
                             # originating call exactly, no per-tool-name
                             # FIFO heuristic required.
                             "id": msg.tool_call_id,
+                            "session_id": session_id,
                         }
                     )
 
@@ -327,7 +358,11 @@ class StreamingRunnable(RunnableBinding):
             return self._runnable.invoke(input, config, **kwargs)
 
         prompt = self._extract_prompt(input)
-        self._emit_start(renderer, has_renderer, writer, prompt)
+        # Per-invocation id so consumers can distinguish two concurrent
+        # ``task("recon", ...)`` dispatches by SESSION even though the
+        # ``agent`` field is identical.
+        session_id = uuid.uuid4().hex[:12]
+        self._emit_start(renderer, has_renderer, writer, prompt, session_id)
 
         start = time.monotonic()
         last_state = None
@@ -343,16 +378,20 @@ class StreamingRunnable(RunnableBinding):
                 new_messages = messages[last_count:]
                 last_count = len(messages)
                 self._process_messages(
-                    new_messages, active_tool_calls, renderer, has_renderer, writer
+                    new_messages, active_tool_calls, renderer, has_renderer, writer, session_id
                 )
 
         except (KeyboardInterrupt, asyncio.CancelledError):
             log.info("[%s] invoke() cancelled", self._name)
-            self._emit_end(renderer, has_renderer, writer, time.monotonic() - start, cancelled=True)
+            self._emit_end(
+                renderer, has_renderer, writer, time.monotonic() - start, session_id, cancelled=True
+            )
             raise
         except Exception as exc:
             log.error("[%s] invoke() failed: %s: %s", self._name, type(exc).__name__, exc)
-            self._emit_end(renderer, has_renderer, writer, time.monotonic() - start, error=True)
+            self._emit_end(
+                renderer, has_renderer, writer, time.monotonic() - start, session_id, error=True
+            )
             # Return error state instead of re-raising. Re-raising crashes the
             # ToolNode step, which prevents ToolMessages from being saved to the
             # thread state. On the next run, PatchToolCallsMiddleware finds the
@@ -364,7 +403,7 @@ class StreamingRunnable(RunnableBinding):
                 return last_state
             return {"messages": [AIMessage(content=error_msg)]}
 
-        self._emit_end(renderer, has_renderer, writer, time.monotonic() - start)
+        self._emit_end(renderer, has_renderer, writer, time.monotonic() - start, session_id)
         self._reset_failures()
 
         if last_state is None:
@@ -410,7 +449,10 @@ class StreamingRunnable(RunnableBinding):
             return await self._runnable.ainvoke(input, config, **kwargs)
 
         prompt = self._extract_prompt(input)
-        self._emit_start(renderer, has_renderer, writer, prompt)
+        # Per-invocation id so consumers can distinguish two concurrent
+        # ``task("recon", ...)`` dispatches by SESSION (see invoke() above).
+        session_id = uuid.uuid4().hex[:12]
+        self._emit_start(renderer, has_renderer, writer, prompt, session_id)
 
         start = time.monotonic()
         last_state = None
@@ -433,16 +475,20 @@ class StreamingRunnable(RunnableBinding):
                         len(messages),
                     )
                 self._process_messages(
-                    new_messages, active_tool_calls, renderer, has_renderer, writer
+                    new_messages, active_tool_calls, renderer, has_renderer, writer, session_id
                 )
 
         except (KeyboardInterrupt, asyncio.CancelledError):
             log.info("[%s] ainvoke() cancelled", self._name)
-            self._emit_end(renderer, has_renderer, writer, time.monotonic() - start, cancelled=True)
+            self._emit_end(
+                renderer, has_renderer, writer, time.monotonic() - start, session_id, cancelled=True
+            )
             raise
         except Exception as exc:
             log.error("[%s] ainvoke() failed: %s: %s", self._name, type(exc).__name__, exc)
-            self._emit_end(renderer, has_renderer, writer, time.monotonic() - start, error=True)
+            self._emit_end(
+                renderer, has_renderer, writer, time.monotonic() - start, session_id, error=True
+            )
             # Return error state instead of re-raising. Re-raising crashes the
             # ToolNode step, which prevents ToolMessages from being saved to the
             # thread state. On the next run, PatchToolCallsMiddleware finds the
@@ -454,7 +500,7 @@ class StreamingRunnable(RunnableBinding):
                 return last_state
             return {"messages": [AIMessage(content=error_msg)]}
 
-        self._emit_end(renderer, has_renderer, writer, time.monotonic() - start)
+        self._emit_end(renderer, has_renderer, writer, time.monotonic() - start, session_id)
         self._reset_failures()
 
         if last_state is None:

--- a/packages/decepticon/decepticon/tools/bash/bash.py
+++ b/packages/decepticon/decepticon/tools/bash/bash.py
@@ -412,6 +412,20 @@ async def bash(
 
     await _prune_old_scratch(workspace_path)
 
+    # Strip leading/trailing newlines before sending to the sandbox.
+    # LLM agents frequently wrap commands in block-form like
+    # ``"\necho foo\n"`` (the trailing newline is especially common
+    # because Claude likes to terminate code blocks with a newline);
+    # the sandbox's PS1-marker output capture treats that trailing
+    # newline as a fresh prompt cycle and swallows the real stdout,
+    # so every block-formatted command returns
+    # ``[Command completed with no output. Exit code: 0]`` despite
+    # actually running. is_input=True is exempt because control
+    # sequences (C-c / C-z / etc.) are literal byte payloads, not
+    # commands; stripping them would corrupt the signal.
+    if command and not is_input:
+        command = command.strip("\n")
+
     # Background mode: send command and return immediately
     if background and command:
         _reset_passive_read(workspace_path, session)


### PR DESCRIPTION
Two UX bugs from the first v1.1.9 dogfood.

## 1. `bash` tool silently returned no output for every block-formatted command

LLMs wrap shell into Markdown fenced blocks, serialized as `"\necho foo\n"`. The sandbox's PS1-marker output capture treats the trailing `\n` as a fresh prompt cycle, swallowing real stdout. Every command returned `[Command completed with no output. Exit code: 0]` despite actually running on the tmux pane. The agent retreated through fresh / net_recon / recon sessions, hit the same dead end every time, and gave up writing partial documents.

Fix on the agent side: `command.strip("\n")` immediately before `execute_tmux_async` / `start_background`. `is_input=True` exempt so control sequences flow through as literal bytes.

## 2. Parallel `task("recon", ...)` dispatches lost the first session's stream

`StreamingRunnable` writer emitted events keyed only on `agent` name; `deriveSubAgentSessions` therefore overwrote the first session in `openSessions` when a second `recon` start arrived. Every event for agent "recon" then landed in session #2.

Backend now stamps every `subagent_start / _tool_call / _message / _end / _tool_result` emit with a `session_id` (`uuid4().hex[:12]`). The shared StreamEvent type carries a matching `sessionId` field; the derive helper groups by `(sessionId, subagent)`. Old streams without the field fall back to agent-name keying.

## Test plan

- [x] `uv run pytest -k 'prompt_injection or shield'` — 26 pass (unrelated to changes here)
- [x] `npm run typecheck --workspace=@decepticon/cli` clean
- [x] `npm run build --workspace=@decepticon/streaming` + cli clean
- [x] `npm run test --workspace=@decepticon/cli -- sub-agent-sessions` — 8 pass
- [x] hot-patched bash.py into dogfood langgraph + direct sandbox `execute_tmux` call: `"\necho hot-patched-works\n"` now returns `hot-patched-works` instead of `[Command completed with no output]`

## v1.1.9 immutability

v1.1.9 stays as published on PyPI / GHCR / GitHub Release. This is a v1.1.10 patch — the bash newline fix is critical for any operator using the agent right now.
