### PR TITLE
v1.1.12 — silent self-update + hotfix gap closure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,7 +270,11 @@ LANGSMITH_PROJECT=decepticon
 # DECEPTICON_HOME=/home/youruser/.decepticon
 
 # --- Advanced (optional) ---
-# Disable automatic self-update checks on startup
+# Self-update behaviour on `decepticon start`. Defaults to silent
+# auto-update — every hotfix lands on the next launch with no user
+# interaction. Override to opt out:
+#   AUTO_UPDATE=false   # air-gapped / version-pinned deploys
+#   AUTO_UPDATE=prompt  # ask on TTY before applying (pre-v1.1.12 default)
 # AUTO_UPDATE=false
 # DECEPTICON_DEBUG=true
 

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -47,16 +47,17 @@ var (
 // See the inline comment in start() (section 2.5) for the value table
 // and rationale for default-on behaviour.
 func applyAutoUpdate(env map[string]string, version string) {
-	switch strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", ""))) {
-	case "false", "0", "no", "off":
-		// self-update disabled
-	case "prompt", "ask", "interactive":
-		if _, err := promptUpdateFn(version); err != nil {
-			ui.Warning("Update check: " + err.Error())
-		}
-	default:
+	val := strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", "")))
+	switch val {
+	case "", "true", "1", "yes", "on":
 		if _, err := autoUpdateFn(version); err != nil {
 			ui.Warning("Auto-update: " + err.Error())
+		}
+	case "false", "0", "no", "off":
+		// self-update disabled
+	default:
+		if _, err := promptUpdateFn(version); err != nil {
+			ui.Warning("Update check: " + err.Error())
 		}
 	}
 }

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -36,7 +36,30 @@ func nullDevice() string {
 var (
 	isWSLFn     = platform.IsWSL
 	wslHostIPFn = platform.WSLHostIP
+
+	// Indirected so tests can assert which AUTO_UPDATE branch ran
+	// without making network calls into GitHub.
+	autoUpdateFn   = updater.AutoUpdateIfAvailable
+	promptUpdateFn = updater.PromptIfUpdateAvailable
 )
+
+// applyAutoUpdate dispatches the self-update check based on AUTO_UPDATE.
+// See the inline comment in start() (section 2.5) for the value table
+// and rationale for default-on behaviour.
+func applyAutoUpdate(env map[string]string, version string) {
+	switch strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", ""))) {
+	case "false", "0", "no", "off":
+		// self-update disabled
+	case "prompt", "ask", "interactive":
+		if _, err := promptUpdateFn(version); err != nil {
+			ui.Warning("Update check: " + err.Error())
+		}
+	default:
+		if _, err := autoUpdateFn(version); err != nil {
+			ui.Warning("Auto-update: " + err.Error())
+		}
+	}
+}
 
 var startCmd = &cobra.Command{
 	Use:   "start",
@@ -166,25 +189,23 @@ func runStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// 2.5. Update check, gated by AUTO_UPDATE in .env:
-	//   unset (default) → interactive prompt on a TTY, passive notice otherwise
-	//   true            → fully unattended: apply the update + re-exec
+	//   unset (default) → fully unattended: apply the update + re-exec
+	//   true / 1 / yes  → same as default (kept for backwards-compat)
+	//   prompt / ask    → interactive prompt on a TTY, passive notice otherwise
 	//   false           → skip entirely (air-gapped / version-pinned deploys)
+	//
+	// Default-on rationale: every released hotfix is dead weight until the
+	// operator picks it up. The previous default ("prompt on TTY, notice
+	// otherwise") meant a bug-fix release sat on the user's machine,
+	// un-applied, until they noticed the notice and re-ran. Silent self-
+	// update collapses the "fix shipped" → "fix running on user host" gap
+	// from days/weeks to the next `decepticon start`, which is the same
+	// behaviour Discord/Slack/electron-updater apps already use.
+	//
 	// Synchronous on purpose: the prompt + unattended paths apply and re-exec
 	// before the rest of `start` proceeds. The GitHub fetch fails fast so a
 	// slow network never blocks startup.
-	switch strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", ""))) {
-	case "false", "0", "no", "off":
-		// self-update disabled
-	case "true", "1", "yes", "on":
-		if _, err := updater.AutoUpdateIfAvailable(version); err != nil {
-			ui.Warning("Auto-update: " + err.Error())
-		}
-	default:
-		if _, err := updater.PromptIfUpdateAvailable(version); err != nil {
-			// Non-fatal — warn and continue on the current launcher.
-			ui.Warning("Update check: " + err.Error())
-		}
-	}
+	applyAutoUpdate(env, version)
 
 	// 2.6. One-time GitHub star ask. Idempotent across launches — the
 	// ack file at $DECEPTICON_HOME/.starred suppresses the prompt

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -148,6 +148,10 @@ func TestApplyAutoUpdate_RoutingMatrix(t *testing.T) {
 		{"0", 0, 0, "0 → skip"},
 		{"no", 0, 0, "no → skip"},
 		{"off", 0, 0, "off → skip"},
+		// Unrecognized / garbage values default to prompt, not silent auto-update
+		{"disabled", 0, 1, "unrecognized value disabled → interactive prompt"},
+		{"skip", 0, 1, "unrecognized value skip → interactive prompt"},
+		{"garbage", 0, 1, "unrecognized value garbage → interactive prompt"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -103,3 +103,60 @@ func TestCandidateProbeURLs_PreservesScheme(t *testing.T) {
 		t.Errorf("scheme/path should be preserved across candidates:\n got %v\nwant %v", got, want)
 	}
 }
+
+// withUpdateStubs swaps the auto-update / prompt-update function variables
+// for the duration of one test, restoring them via t.Cleanup. The stubs
+// record which branch ran (and how many times) without touching GitHub.
+func withUpdateStubs(t *testing.T) (auto, prompt *int) {
+	t.Helper()
+	autoCount, promptCount := 0, 0
+	prevAuto := autoUpdateFn
+	prevPrompt := promptUpdateFn
+	autoUpdateFn = func(string) (bool, error) { autoCount++; return false, nil }
+	promptUpdateFn = func(string) (bool, error) { promptCount++; return false, nil }
+	t.Cleanup(func() {
+		autoUpdateFn = prevAuto
+		promptUpdateFn = prevPrompt
+	})
+	return &autoCount, &promptCount
+}
+
+func TestApplyAutoUpdate_RoutingMatrix(t *testing.T) {
+	cases := []struct {
+		envValue     string
+		wantAuto     int
+		wantPrompt   int
+		description  string
+	}{
+		// Default-on: unset triggers silent auto-update. This is the
+		// key behaviour change from v1.1.12 — fix-shipped → fix-applied
+		// no longer requires the user to act.
+		{"", 1, 0, "unset → silent auto-update"},
+		{"  ", 1, 0, "whitespace-only → silent auto-update"},
+		{"true", 1, 0, "true → silent auto-update (backwards-compat)"},
+		{"1", 1, 0, "1 → silent auto-update (backwards-compat)"},
+		{"yes", 1, 0, "yes → silent auto-update (backwards-compat)"},
+		{"on", 1, 0, "on → silent auto-update (backwards-compat)"},
+		{"TRUE", 1, 0, "case-insensitive: TRUE → silent auto-update"},
+		// Opt-in to the pre-v1.1.12 default of prompting on a TTY.
+		{"prompt", 0, 1, "prompt → interactive prompt"},
+		{"ask", 0, 1, "ask → interactive prompt"},
+		{"interactive", 0, 1, "interactive → interactive prompt"},
+		{"PROMPT", 0, 1, "case-insensitive: PROMPT → interactive prompt"},
+		// Air-gapped / version-pinned: skip entirely.
+		{"false", 0, 0, "false → skip"},
+		{"0", 0, 0, "0 → skip"},
+		{"no", 0, 0, "no → skip"},
+		{"off", 0, 0, "off → skip"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			auto, prompt := withUpdateStubs(t)
+			applyAutoUpdate(map[string]string{"AUTO_UPDATE": tc.envValue}, "v0.0.0-test")
+			if *auto != tc.wantAuto || *prompt != tc.wantPrompt {
+				t.Errorf("AUTO_UPDATE=%q: got auto=%d prompt=%d, want auto=%d prompt=%d",
+					tc.envValue, *auto, *prompt, tc.wantAuto, tc.wantPrompt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Every hotfix release (v1.1.9 → v1.1.10 → v1.1.11) was dead weight until the operator noticed the launcher banner and re-ran. The previous default (`unset → prompt on TTY, passive notice otherwise`) meant a critical bug fix could sit on a user's host for days, un-applied.

This is the **root cause** of \"왜 핫픽스마다 새 릴리즈를 해야 하나\" — not the release pipeline, but the **update model**. Discord, Slack, electron-updater apps all default to silent self-update for exactly this reason.

## What

Flip `AUTO_UPDATE` default in `clients/launcher/cmd/start.go`:

| `AUTO_UPDATE` | Before (≤v1.1.11) | After (v1.1.12+) |
|---|---|---|
| unset / empty | Prompt on TTY, notice otherwise | **Silent auto-apply + re-exec** ← changed |
| `true` / `1` / `yes` / `on` | Silent auto-apply | Silent auto-apply (unchanged) |
| `prompt` / `ask` / `interactive` | (fell to default → prompt) | Explicit prompt-on-TTY (opt-in) |
| `false` / `0` / `no` / `off` | Skip | Skip (unchanged) |

Existing configs that explicitly set `AUTO_UPDATE=true` or `AUTO_UPDATE=false` keep working unchanged. Operators who liked the pre-v1.1.12 prompt can opt back in with `AUTO_UPDATE=prompt`.

## Architecture

Extracted the inline switch in \`start()\` into \`applyAutoUpdate(env, version)\` + indirected the two updater calls (\`autoUpdateFn\`, \`promptUpdateFn\`) so the routing matrix is unit-testable without making GitHub calls.

## Tests

\`TestApplyAutoUpdate_RoutingMatrix\` — 15 cases covering unset, all truthy aliases, all prompt aliases, all falsy aliases, case-insensitivity, and whitespace handling. All pass.

\`\`\`
$ go test -run TestApplyAutoUpdate -v ./cmd/
--- PASS: TestApplyAutoUpdate_RoutingMatrix (0.00s)
    --- PASS: .../unset_→_silent_auto-update (0.00s)
    --- PASS: .../whitespace-only_→_silent_auto-update (0.00s)
    --- PASS: .../true_→_silent_auto-update_(backwards-compat) (0.00s)
    ... (15 total)
PASS
\`\`\`

## Impact

Once v1.1.12 ships:
- Users on v1.1.12+ get **all future hotfixes applied automatically** on the next \`decepticon start\` — no manual update step.
- The release cadence pressure drops: a hotfix released at 3pm hits user hosts within hours, not days.
- Existing \`AUTO_UPDATE=true\` / \`AUTO_UPDATE=false\` configs are unaffected.

## Follow-ups (v1.2.0+, separate PRs)

Phase 2 / 3 from the root-cause analysis (config layer split, daily \`:nightly\`, channels) remain valid follow-ups but are out of scope here.