### PR TITLE
v1.1.12 follow-up — --no-update flag + _legacy fix + opscontrol drop-in cleanup

### DIFF
--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -46,9 +46,22 @@ var (
 // applyAutoUpdate dispatches the self-update check based on AUTO_UPDATE.
 // See the inline comment in start() (section 2.5) for the value table
 // and rationale for default-on behaviour.
-func applyAutoUpdate(env map[string]string, version string) {
-	val := strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", "")))
-	switch val {
+//
+// The `skip` argument is the --no-update CLI flag. When true it
+// short-circuits *before* the env lookup so the operator's one-shot
+// override always wins over the persistent .env setting — including
+// AUTO_UPDATE=true and AUTO_UPDATE=prompt. This is the escape hatch
+// for "I know there's a newer version, I want this exact binary".
+//
+// Unrecognized values (e.g. AUTO_UPDATE=disabled, where the operator
+// probably MEANT "false") fall through to the prompt path rather than
+// silent auto-update. Fail-loud beats fail-silent — an unexpected
+// re-exec is harder to debug than a one-line prompt.
+func applyAutoUpdate(env map[string]string, version string, skip bool) {
+	if skip {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", ""))) {
 	case "", "true", "1", "yes", "on":
 		if _, err := autoUpdateFn(version); err != nil {
 			ui.Warning("Auto-update: " + err.Error())
@@ -56,11 +69,19 @@ func applyAutoUpdate(env map[string]string, version string) {
 	case "false", "0", "no", "off":
 		// self-update disabled
 	default:
+		// Includes the explicit `prompt` / `ask` / `interactive`
+		// opt-ins AND any unrecognized value (safer fallback).
 		if _, err := promptUpdateFn(version); err != nil {
 			ui.Warning("Update check: " + err.Error())
 		}
 	}
 }
+
+// skipUpdate is bound to --no-update. One-shot override for the
+// AUTO_UPDATE=true (now default) self-update path: useful in CI, when
+// debugging a specific launcher version, or when intentionally
+// running an older release against a known-good stack.
+var skipUpdate bool
 
 var startCmd = &cobra.Command{
 	Use:   "start",
@@ -71,9 +92,13 @@ var startCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(startCmd)
 
-	// Make start the default command when no subcommand given
+	// PersistentFlag on root → inherited by `start`, so both
+	// `decepticon --no-update` (no subcommand → runStart) and
+	// `decepticon start --no-update` accept the flag.
+	rootCmd.PersistentFlags().BoolVar(&skipUpdate, "no-update", false,
+		"Skip the self-update check for this launch (does not change AUTO_UPDATE in .env)")
+
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
-		// If no subcommand, run start
 		return runStart(cmd, args)
 	}
 }
@@ -206,7 +231,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// Synchronous on purpose: the prompt + unattended paths apply and re-exec
 	// before the rest of `start` proceeds. The GitHub fetch fails fast so a
 	// slow network never blocks startup.
-	applyAutoUpdate(env, version)
+	applyAutoUpdate(env, version, skipUpdate)
 
 	// 2.6. One-time GitHub star ask. Idempotent across launches — the
 	// ack file at $DECEPTICON_HOME/.starred suppresses the prompt

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -156,10 +156,29 @@ func TestApplyAutoUpdate_RoutingMatrix(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
 			auto, prompt := withUpdateStubs(t)
-			applyAutoUpdate(map[string]string{"AUTO_UPDATE": tc.envValue}, "v0.0.0-test")
+			applyAutoUpdate(map[string]string{"AUTO_UPDATE": tc.envValue}, "v0.0.0-test", false)
 			if *auto != tc.wantAuto || *prompt != tc.wantPrompt {
 				t.Errorf("AUTO_UPDATE=%q: got auto=%d prompt=%d, want auto=%d prompt=%d",
 					tc.envValue, *auto, *prompt, tc.wantAuto, tc.wantPrompt)
+			}
+		})
+	}
+}
+
+// --no-update is a one-shot override that must beat the persistent
+// .env setting in every direction — including the default-on path and
+// the explicit AUTO_UPDATE=true path. Without this short-circuit a CI
+// runner that pinned `decepticon --no-update` would still re-exec into
+// a newer binary, defeating the pin.
+func TestApplyAutoUpdate_NoUpdateFlagAlwaysWins(t *testing.T) {
+	envValues := []string{"", "true", "1", "yes", "on", "prompt", "ask", "interactive"}
+	for _, ev := range envValues {
+		t.Run("AUTO_UPDATE="+ev, func(t *testing.T) {
+			auto, prompt := withUpdateStubs(t)
+			applyAutoUpdate(map[string]string{"AUTO_UPDATE": ev}, "v0.0.0-test", true)
+			if *auto != 0 || *prompt != 0 {
+				t.Errorf("--no-update should short-circuit: AUTO_UPDATE=%q got auto=%d prompt=%d, want 0/0",
+					ev, *auto, *prompt)
 			}
 		})
 	}

--- a/clients/launcher/internal/opscontrol/systemd.go
+++ b/clients/launcher/internal/opscontrol/systemd.go
@@ -108,6 +108,19 @@ func (s *SystemdManager) Install(spec InstallSpec) error {
 		return fmt.Errorf("opscontrol: create systemd user dir: %w", err)
 	}
 
+	// Drop-in `*.conf` files override the unit we're about to write,
+	// and they survive `Uninstall()` because that only removes the
+	// .service file. v1.1.10 dogfood hit exactly this trap: a stale
+	// `override.conf` pinned ExecStart= to /tmp/decepticon-stop-v3
+	// (deleted between test runs), so `enable --now` succeeded but the
+	// daemon failed with no error surfaced to the operator — they saw
+	// `EnsureRunning` 5s socket timeout with no obvious cause.
+	//
+	// We only remove drop-ins whose ExecStart references a binary that
+	// no longer exists on disk. Legitimate operator overrides (extra
+	// env vars, restart policy tweaks) keep working.
+	dropInRemoved := s.removeStaleDropIns(filepath.Join(unitDir, s.UnitName+".service.d"))
+
 	unit := s.renderUnit(spec)
 	unitFile := filepath.Join(unitDir, s.UnitName+".service")
 	if err := os.WriteFile(unitFile, []byte(unit), 0o644); err != nil {
@@ -117,10 +130,71 @@ func (s *SystemdManager) Install(spec InstallSpec) error {
 	if out, err := exec.Command(systemctlBinary, "--user", "daemon-reload").CombinedOutput(); err != nil {
 		return fmt.Errorf("opscontrol: daemon-reload: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	if dropInRemoved {
+		// daemon-reload is required after drop-in removal too; the call
+		// above covers both rewrites of the .service file and dropped
+		// overrides in one pass.
+		_ = exec.Command(systemctlBinary, "--user", "reset-failed", s.UnitName+".service").Run()
+	}
 	if out, err := exec.Command(systemctlBinary, "--user", "enable", "--now", s.UnitName+".service").CombinedOutput(); err != nil {
 		return fmt.Errorf("opscontrol: enable --now: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// removeStaleDropIns deletes drop-in override files in `dir` whose
+// ExecStart= points to a binary that no longer exists on disk. Returns
+// true if any file was removed (the caller uses this to decide whether
+// to also reset the unit's failed state).
+//
+// Scope is deliberately narrow: we only touch *.conf files we can
+// prove are dead. Operator-authored overrides for live binaries
+// (e.g. an extra Environment= line) survive untouched.
+func (s *SystemdManager) removeStaleDropIns(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	removed := false
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		body, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, raw := range strings.Split(string(body), "\n") {
+			line := strings.TrimSpace(raw)
+			if !strings.HasPrefix(line, "ExecStart=") {
+				continue
+			}
+			// Strip the `ExecStart=` prefix and any leading modifier
+			// characters systemd accepts (`-`, `@`, `:`, `+`, `!`, `!!`).
+			value := strings.TrimLeft(strings.TrimPrefix(line, "ExecStart="), "-@:+!")
+			fields := strings.Fields(value)
+			if len(fields) == 0 {
+				continue
+			}
+			binaryPath := fields[0]
+			if _, err := os.Stat(binaryPath); errors.Is(err, os.ErrNotExist) {
+				fmt.Fprintf(os.Stderr,
+					"opscontrol: removing stale drop-in %s — ExecStart=%s no longer exists\n",
+					path, binaryPath)
+				if err := os.Remove(path); err == nil {
+					removed = true
+				}
+				break
+			}
+		}
+	}
+	// If the drop-in dir is now empty, remove it so a future
+	// `systemctl edit` starts from a clean slate.
+	if remaining, err := os.ReadDir(dir); err == nil && len(remaining) == 0 {
+		_ = os.Remove(dir)
+	}
+	return removed
 }
 
 func (s *SystemdManager) Uninstall() error {

--- a/clients/launcher/internal/opscontrol/systemd_test.go
+++ b/clients/launcher/internal/opscontrol/systemd_test.go
@@ -1,0 +1,100 @@
+package opscontrol
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoveStaleDropIns_DeletesDeadBinaryOverride covers the v1.1.10
+// dogfood regression: a `systemctl edit` override from an earlier test
+// pinned ExecStart= to /tmp/decepticon-stop-v3 (since deleted), and
+// the launcher kept silently re-using it on `install`.
+func TestRemoveStaleDropIns_DeletesDeadBinaryOverride(t *testing.T) {
+	tmp := t.TempDir()
+	dropInDir := filepath.Join(tmp, "decepticon-opscontrol.service.d")
+	if err := os.MkdirAll(dropInDir, 0o755); err != nil {
+		t.Fatalf("mkdir drop-in: %v", err)
+	}
+	staleBin := filepath.Join(tmp, "definitely-not-a-real-binary")
+	overrideBody := "[Service]\nExecStart=\nExecStart=" + staleBin + " opscontrol daemon\n"
+	overridePath := filepath.Join(dropInDir, "override.conf")
+	if err := os.WriteFile(overridePath, []byte(overrideBody), 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	s := &SystemdManager{UnitName: "decepticon-opscontrol"}
+	if !s.removeStaleDropIns(dropInDir) {
+		t.Fatalf("expected stale drop-in removal, got false")
+	}
+	if _, err := os.Stat(overridePath); !os.IsNotExist(err) {
+		t.Errorf("override.conf should be removed; stat err=%v", err)
+	}
+	// Drop-in directory is now empty, so it should also be gone — keeps
+	// `systemctl edit` from re-opening a ghost directory.
+	if _, err := os.Stat(dropInDir); !os.IsNotExist(err) {
+		t.Errorf("empty drop-in dir should be removed; stat err=%v", err)
+	}
+}
+
+// TestRemoveStaleDropIns_KeepsLiveBinaryOverride is the safety contract:
+// an operator's legitimate override (custom env vars, restart policy
+// tweaks) that points to a real binary must survive install.
+func TestRemoveStaleDropIns_KeepsLiveBinaryOverride(t *testing.T) {
+	tmp := t.TempDir()
+	dropInDir := filepath.Join(tmp, "decepticon-opscontrol.service.d")
+	if err := os.MkdirAll(dropInDir, 0o755); err != nil {
+		t.Fatalf("mkdir drop-in: %v", err)
+	}
+	// Use the test binary itself as the "live" ExecStart target.
+	liveBin, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test binary: %v", err)
+	}
+	overrideBody := "[Service]\nExecStart=\nExecStart=" + liveBin + " opscontrol daemon\n"
+	overridePath := filepath.Join(dropInDir, "override.conf")
+	if err := os.WriteFile(overridePath, []byte(overrideBody), 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	s := &SystemdManager{UnitName: "decepticon-opscontrol"}
+	if s.removeStaleDropIns(dropInDir) {
+		t.Fatalf("live drop-in should not be removed")
+	}
+	if _, err := os.Stat(overridePath); err != nil {
+		t.Errorf("override.conf should still exist; stat err=%v", err)
+	}
+}
+
+// TestRemoveStaleDropIns_AcceptsModifierPrefixes covers systemd's
+// ExecStart modifier syntax (- @ : + ! !!) so we don't false-positive
+// or false-negative on operator overrides that use them.
+func TestRemoveStaleDropIns_AcceptsModifierPrefixes(t *testing.T) {
+	tmp := t.TempDir()
+	dropInDir := filepath.Join(tmp, "decepticon-opscontrol.service.d")
+	if err := os.MkdirAll(dropInDir, 0o755); err != nil {
+		t.Fatalf("mkdir drop-in: %v", err)
+	}
+	staleBin := filepath.Join(tmp, "ghost-binary")
+	for _, prefix := range []string{"-", "@", ":", "+", "!", "!!"} {
+		sub := filepath.Join(dropInDir, "case-"+prefix+".conf")
+		body := "[Service]\nExecStart=\nExecStart=" + prefix + staleBin + " opscontrol daemon\n"
+		if err := os.WriteFile(sub, []byte(body), 0o644); err != nil {
+			t.Fatalf("write override: %v", err)
+		}
+	}
+
+	s := &SystemdManager{UnitName: "decepticon-opscontrol"}
+	if !s.removeStaleDropIns(dropInDir) {
+		t.Fatalf("expected stale removal across modifier prefixes")
+	}
+}
+
+// TestRemoveStaleDropIns_NoDirIsNoop guards against panic / error
+// when there's never been a drop-in (the common case on fresh installs).
+func TestRemoveStaleDropIns_NoDirIsNoop(t *testing.T) {
+	s := &SystemdManager{UnitName: "decepticon-opscontrol"}
+	if s.removeStaleDropIns(filepath.Join(t.TempDir(), "does-not-exist")) {
+		t.Fatalf("missing drop-in dir should not report removal")
+	}
+}

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -575,8 +575,12 @@ func AutoUpdateIfAvailable(currentVersion string) (bool, error) {
 	if !CompareVersions(currentVersion, release.TagName) {
 		return false, nil
 	}
+	// Default-on as of v1.1.12: silent self-update is the default. The
+	// suffix tells users they CAN opt out — important for the first
+	// release after the flip, when an unexpected re-exec might confuse
+	// operators who never set AUTO_UPDATE themselves.
 	ui.Info(fmt.Sprintf(
-		"Auto-updating: %s → %s (AUTO_UPDATE enabled)",
+		"Auto-updating: %s → %s (set AUTO_UPDATE=false to disable)",
 		displayVersion(currentVersion),
 		release.TagName,
 	))

--- a/packages/decepticon/decepticon/tools/ad/tools.py
+++ b/packages/decepticon/decepticon/tools/ad/tools.py
@@ -36,6 +36,7 @@ from decepticon.tools.ad.delegation import analyze_delegation
 from decepticon.tools.ad.gpo import analyze_gpo_abuse
 from decepticon.tools.ad.kerberos import classify_hashcat_hash, parse_ticket
 from decepticon.tools.ad.shadow_creds import analyze_shadow_credentials
+from decepticon.tools.research._engagement_scope import _LEGACY_ENGAGEMENT_LABEL
 from decepticon.tools.research._state import _load, _save
 from decepticon_core.utils.engagement_scope import get_active_engagement
 
@@ -61,13 +62,13 @@ def _json(data: Any) -> str:
 def _resolve_engagement() -> str:
     """Engagement label for BloodHound ingest writes.
 
-    Falls back to the reserved ``_legacy`` label when the
+    Falls back to the shared ``_LEGACY_ENGAGEMENT_LABEL`` when the
     ``EngagementContextMiddleware`` contextvar is unset — matches the
     behaviour of the legacy ``_state`` shim used by the read-mostly AD
     analysis tools below (``dcsync_check`` / ``delegation_audit`` /
     ``gpo_audit`` / ``shadow_creds_audit``).
     """
-    return get_active_engagement() or "_legacy"
+    return get_active_engagement() or _LEGACY_ENGAGEMENT_LABEL
 
 
 @tool

--- a/packages/decepticon/decepticon/tools/contracts/tools.py
+++ b/packages/decepticon/decepticon/tools/contracts/tools.py
@@ -17,6 +17,7 @@ from decepticon.tools.contracts.patterns import scan_solidity_source
 from decepticon.tools.contracts.slither import (
     ingest_slither_json as _ingest_slither_json_impl,
 )
+from decepticon.tools.research._engagement_scope import _LEGACY_ENGAGEMENT_LABEL
 from decepticon_core.utils.engagement_scope import get_active_engagement
 
 
@@ -27,11 +28,11 @@ def _json(data: Any) -> str:
 def _resolve_engagement() -> str:
     """Engagement label for Slither ingest writes.
 
-    Falls back to the reserved ``_legacy`` label when the
+    Falls back to the shared ``_LEGACY_ENGAGEMENT_LABEL`` when the
     ``EngagementContextMiddleware`` contextvar is unset — matches the
     convention used by the AD ingest path.
     """
-    return get_active_engagement() or "_legacy"
+    return get_active_engagement() or _LEGACY_ENGAGEMENT_LABEL
 
 
 @tool

--- a/packages/decepticon/decepticon/tools/research/_engagement_scope.py
+++ b/packages/decepticon/decepticon/tools/research/_engagement_scope.py
@@ -18,6 +18,7 @@ from decepticon_core.utils.engagement_scope import (
 )
 
 __all__ = [
+    "_LEGACY_ENGAGEMENT_LABEL",
     "_active_engagement",
     "get_active_engagement",
     "is_valid_engagement_label",
@@ -27,7 +28,16 @@ __all__ = [
 ]
 
 
-_LEGACY_ENGAGEMENT_LABEL = "_legacy"
+# Fallback engagement label used by tool surfaces that fire BEFORE
+# EngagementContextMiddleware has set the contextvar (CLI one-shots,
+# unit tests, kg_health smoke probes).
+#
+# v1.1.12 fix: was "_legacy" — but the leading underscore violates the
+# is_valid_engagement_label validator
+# (^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$), so every KGStore.record_*
+# call routed through this fallback raised ValueError. Renamed to
+# "legacy" — same intent, passes the validator.
+_LEGACY_ENGAGEMENT_LABEL = "legacy"
 
 
 def with_engagement_property(props: dict | None, *, override: str | None = None) -> dict:
@@ -35,10 +45,10 @@ def with_engagement_property(props: dict | None, *, override: str | None = None)
 
     Precedence (first non-empty wins): ``override`` (caller pins it) → an
     ``engagement`` already on ``props`` → the active engagement → the legacy
-    label. Preserving an existing ``engagement`` is the multi-tenant safety
+    fallback. Preserving an existing ``engagement`` is the multi-tenant safety
     invariant: it stops a ``graph_transaction`` save-back from relabelling a
-    loaded node onto the current (or ``_legacy``) engagement on a shared
-    Neo4j. See docs/security/neo4j-hardening.md.
+    loaded node onto the current (or fallback) engagement on a shared Neo4j.
+    See docs/security/neo4j-hardening.md.
     """
     out = dict(props or {})
     engagement = (

--- a/packages/decepticon/decepticon/tools/research/_state.py
+++ b/packages/decepticon/decepticon/tools/research/_state.py
@@ -40,6 +40,7 @@ from typing import Any
 
 from decepticon.middleware.kg_internal.store import KGStore
 from decepticon.tools.reporting.kg_adapter import load_engagement_graph
+from decepticon.tools.research._engagement_scope import _LEGACY_ENGAGEMENT_LABEL
 from decepticon_core.types.kg import Edge, KnowledgeGraph, Node
 from decepticon_core.utils.engagement_scope import get_active_engagement
 from decepticon_core.utils.logging import get_logger
@@ -49,14 +50,9 @@ log = get_logger("research.state")
 _GRAPH_LOCK = threading.Lock()
 _store: _LegacyStoreShim | None = None
 
-# Default engagement label for legacy callers that fire before
-# ``EngagementContextMiddleware`` has set the contextvar (unit tests,
-# CLI one-shots). KGStore demands a non-empty engagement on every call.
-_DEFAULT_LEGACY_ENGAGEMENT = "_legacy"
-
 
 def _resolve_engagement() -> str:
-    return get_active_engagement() or _DEFAULT_LEGACY_ENGAGEMENT
+    return get_active_engagement() or _LEGACY_ENGAGEMENT_LABEL
 
 
 def _node_to_observation(node: Node) -> dict[str, Any]:

--- a/packages/decepticon/decepticon/tools/research/tools.py
+++ b/packages/decepticon/decepticon/tools/research/tools.py
@@ -1408,12 +1408,14 @@ def kg_ingest_slither(path: str) -> str:
     Writes flow directly through ``KGStore.record_observations`` —
     a single atomic batch per file. The engagement label is resolved
     from the ``EngagementContextMiddleware`` contextvar; falls back
-    to the reserved ``_legacy`` label outside the standard middleware
-    stack (matches the convention used by the rest of RESEARCH_TOOLS).
+    to the shared ``_LEGACY_ENGAGEMENT_LABEL`` outside the standard
+    middleware stack (matches the convention used by the rest of
+    RESEARCH_TOOLS).
     """
+    from decepticon.tools.research._engagement_scope import _LEGACY_ENGAGEMENT_LABEL
     from decepticon_core.utils.engagement_scope import get_active_engagement
 
-    engagement = get_active_engagement() or "_legacy"
+    engagement = get_active_engagement() or _LEGACY_ENGAGEMENT_LABEL
     try:
         ingested = ingest_slither_file(path, engagement=engagement)
     except ValueError as exc:

--- a/packages/decepticon/tests/unit/research/test_engagement_scope.py
+++ b/packages/decepticon/tests/unit/research/test_engagement_scope.py
@@ -6,6 +6,7 @@ import pytest
 
 from decepticon.tools.research import _engagement_scope as _scope
 from decepticon.tools.research._engagement_scope import (
+    _LEGACY_ENGAGEMENT_LABEL,
     get_active_engagement,
     is_valid_engagement_label,
     reset_active_engagement,
@@ -125,12 +126,12 @@ class TestWithEngagementProperty:
 
     def test_legacy_when_no_engagement_set(self) -> None:
         out = with_engagement_property({"x": 1})
-        assert out["engagement"] == "_legacy"
+        assert out["engagement"] == "legacy"
 
     def test_none_props_safe(self) -> None:
         out = with_engagement_property(None)
-        assert out["engagement"] == "_legacy"
-        assert out == {"engagement": "_legacy"}
+        assert out["engagement"] == "legacy"
+        assert out == {"engagement": "legacy"}
 
     def test_input_dict_not_mutated(self) -> None:
         original = {"ip": "10.0.0.5"}
@@ -162,3 +163,20 @@ class TestWithEngagementProperty:
 # scoping via its V001 ``(key, engagement)`` composite uniqueness and
 # the mandatory ``engagement`` kwarg on every public method — covered
 # by the KG middleware's own integration tests.
+
+
+def test_legacy_fallback_passes_validator():
+    """Regression guard for the v1.1.12 bug.
+
+    Before v1.1.12 the fallback label was ``"_legacy"`` — but the
+    is_valid_engagement_label validator rejects leading underscores,
+    so every KGStore call that hit the fallback raised ValueError
+    (surfaced as a ``kg_health`` smoke failure during v1.1.8 release
+    prep). The constant has to keep passing the validator or the bug
+    silently comes back.
+    """
+    assert is_valid_engagement_label(_LEGACY_ENGAGEMENT_LABEL), (
+        f"_LEGACY_ENGAGEMENT_LABEL={_LEGACY_ENGAGEMENT_LABEL!r} fails the "
+        f"engagement-label validator — KGStore will reject it on every "
+        f"fallback write"
+    )


### PR DESCRIPTION
Follow-up to #632 (silent self-update default), still under the v1.1.12 release window. Three independent fixes that were planned for v1.1.12 but didn't make it into #632.

## 1. \`feat(launcher): --no-update flag + clearer auto-update notice\` (ba5563a0)

After #632 flipped the default to silent auto-update, operators need a one-shot escape hatch:

- \`decepticon --no-update\` (or \`decepticon start --no-update\`) — short-circuits **before** the AUTO_UPDATE env lookup, so it beats every value including \`AUTO_UPDATE=true\`. Use cases: CI pinning a specific launcher version, debugging against a known-good stack, running an older release intentionally.
- Auto-update notice no longer claims \`(AUTO_UPDATE enabled)\` — accurate when the user opted in explicitly, misleading now that auto-update is the default. Replaced with \`(set AUTO_UPDATE=false to disable)\` so the first release after the flip tells operators how to opt out.

Tests: \`TestApplyAutoUpdate_NoUpdateFlagAlwaysWins\` (8 cases — flag beats every AUTO_UPDATE env value, including the truthy aliases and the prompt aliases).

## 2. \`fix(kg): rename fallback engagement label from "_legacy" to "legacy"\` (0e5c9f1e)

The fallback label used by \`tools/research\`, \`tools/ad\`, and \`tools/contracts\` when \`EngagementContextMiddleware\` hasn't set the contextvar (CLI one-shots, unit tests, \`kg_health\` smoke) was \`_legacy\`. The leading underscore violates the engagement-label validator in \`decepticon_core.utils.engagement_scope\`:

\`\`\`
^[A-Za-z0-9][A-Za-z0-9._\-]{0,127}$
\`\`\`

\`KGStore\` calls \`is_valid_engagement_label()\` on every public method, so every write that routed through the fallback raised \`ValueError\`. First surfaced as a \`kg_health\` smoke failure during v1.1.8 release prep; held back because the workaround (set \`DECEPTICON_ENGAGEMENT\` manually) covered the production path.

Centralized into a single \`_LEGACY_ENGAGEMENT_LABEL\` constant in \`_engagement_scope.py\` and imported by all 4 call sites — no more drifting string literals. Regression test asserts the constant always passes the validator.

## 3. \`fix(launcher): remove stale systemd drop-ins on opscontrol install\` (bbb10824)

The v1.1.10 dogfood hit a sticky failure: a previous \`systemctl --user edit\` override pinned \`ExecStart=\` to \`/tmp/decepticon-stop-v3\` (deleted between test runs); \`decepticon opscontrol install\` rewrote the .service file but left the drop-in dir intact → systemd merged the dead override over the new unit → \`EnsureRunning\` failed with a 5s socket timeout no operator could trace.

\`Install()\` now walks the drop-in dir, parses \`ExecStart=\` from each \`*.conf\`, and removes only files whose binary target doesn't exist on disk. Legitimate operator overrides (extra Environment=, RestartSec= tweaks) survive untouched. systemd modifier prefixes (\`- @ : + ! !!\`) all parsed correctly.

Tests (\`clients/launcher/internal/opscontrol/systemd_test.go\`):
- DeletesDeadBinaryOverride — covers the v1.1.10 regression directly.
- KeepsLiveBinaryOverride — safety contract: legitimate overrides survive.
- AcceptsModifierPrefixes — matrix across all 6 systemd ExecStart modifier characters.
- NoDirIsNoop — no-op on fresh installs (the common case).

## Tests run locally

\`\`\`
$ cd clients/launcher && go test ./...
ok   .../launcher/cmd                  0.208s
ok   .../launcher/internal/opscontrol  0.005s
ok   .../launcher/internal/updater     ...
(all green)

$ uv run pytest packages/decepticon/tests/unit/research/test_engagement_scope.py
============== 35 passed, 3 warnings in 369.63s (0:06:09) ==============
\`\`\`

## Deferred to v1.1.13+ (separate design)

- **3a: Tag suffix detection** for image-only patch releases (\`vX.Y.Z.N\` skips PyPI/launcher binaries). Blocked on launcher↔image version decoupling — \`compareSemver\` doesn't handle 4-segment, and \`DECEPTICON_VERSION\` is bound to the launcher binary version (compose can't pick up new images without a new binary). Needs separate design doc.

## Release plan

After this merges, tag \`v1.1.12\` and let the release workflow ship the full set:
- silent self-update default (from #632)
- unrecognized-value safer fallback (from #632)
- the 3 commits in this PR