### PR TITLE
docs: realign internal docs (architecture, agents, cli-reference, library-usage) with v1.1.12

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-Decepticon ships **24 agents** organized by kill chain phase (21 specialists plus the Decepticon and Vulnresearch orchestrators and the Soundwave planner). Each agent starts with a **fresh context window** per objective — no accumulated noise, no context degradation. Findings persist to disk (`workspace/`) and the knowledge graph, not agent memory.
+Decepticon ships a **multi-agent stack** organized by kill chain phase: three orchestrators (Decepticon, Vulnresearch, Soundwave), a roster of specialist sub-agents under Decepticon (recon → exploit → post-exploit → domain operators), the five-stage Vulnresearch pipeline (`scanner → detector → verifier → patcher → exploiter`), and the `blue_cell` defense agent for the Offensive Vaccine loop. Each agent starts with a **fresh context window** per objective — no accumulated noise, no context degradation. Findings persist to disk (`workspace/`) and the knowledge graph, not agent memory.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,26 @@ Postgres is reused from the existing `postgres` container — `containers/postgr
 
 Agents call BHCE through `decepticon.tools.ad.bh_tools.bhce_status` / `bhce_cypher` / `bhce_ingest_zip` and the shared `decepticon.tools.ad.bhce_client.BHCEClient` HMAC-3-chain signer. The in-house `bh_ingest_zip` / `adcs_post_process` / `dcsync_check` / `delegation_audit` / `gpo_audit` / `shadow_creds_audit` / `adcs_audit` tools emit `DeprecationWarning` on every call and will move to `decepticon.compat` next minor.
 
+### Skillogy (`decepticon-net`, REST API on host port 9100)
+
+Standalone skill catalog service introduced by [ADR-0008](adr/0008-skillogy-hard-acl-phase1a.md). Three pieces:
+
+- A `python:3.13-slim`–based container (`containers/skillogy.Dockerfile`) running FastAPI over Uvicorn.
+- A dedicated Neo4j graph (separate from the engagement KG above) holding `:Skill` nodes with edges derived from skill frontmatter (`BUILDS_ON`, `CHAINS_TO`, `MITRE_RELATED`, …).
+- Three REST endpoints (`POST /v1/skills:find`, `POST /v1/skills:load`, `POST /v1/skills:traverse`) plus health (`GET /v1/health`) and a manager-of-coverage helper (`POST /v1/skills:moc`).
+
+The graph is rebuilt from disk at container start. Skill source remains the `packages/decepticon/decepticon/skills/` directory tree (`standard/`, `shared/`, plus `plugins/` from third-party bundles). Adding a skill is a new `SKILL.md` file plus a graph rebuild — no schema migration.
+
+Agents reach Skillogy through `SkillogyMiddleware`, which is a thin REST client. The middleware projects three agent-facing tools onto each role:
+
+- `find_skill(query?, subdomain?, mitre_id?, tag?, tactic_id?, limit=20)` — AND-combined relationship-aware discovery, returns frontmatter only.
+- `load_skill(name_or_path)` — fetches the body + frontmatter of one skill.
+- `traverse(from_path, edge_types?, depth=2)` — explicit BFS from a seed skill.
+
+Every middleware call carries an `allowed_path_prefixes` parameter set by the agent factory (e.g. `["skills/standard/ad/", "skills/shared/"]`); Skillogy enforces this hard ACL server-side, so prompt-injected widening attempts cannot escape the role's slice. Cross-role reads only succeed when the target lives under `skills/shared/`.
+
+The Neo4j instance Skillogy uses is **not** the same as the engagement KGStore — they have different schemas, different write semantics, and run as separate containers so a long catalog rebuild can't lock engagement reads.
+
 ### Sandbox (`sandbox-net`)
 
 Hardened Kali Linux container. Runs:
@@ -145,6 +165,8 @@ Agents execute commands through a thin `bash` tool backed by `DockerSandbox.exec
 | > 5M chars | Watchdog kills the command |
 
 ANSI escape codes are stripped and repetitive output lines are compressed before being sent to the LLM.
+
+**Background commands + auto-notification** — long-running commands (`nmap -p- -A`, full Burp scans, fuzzers) launch with `run_in_background=True` and return immediately with a session handle. The LLM doesn't block on the prompt while the command runs. When the command finishes, `SandboxNotificationMiddleware` (in `packages/decepticon/decepticon/middleware/notifications.py`) polls the sandbox's `/read_session_log_diff` once per turn, captures the new output, and injects a `<system-reminder>` `HumanMessage` carrying the exit code and stdout/stderr diff onto the agent's very next inference. The agent doesn't have to call `bash_output()` — completion comes to it. Same shape as the `OpsControlNotificationMiddleware` workload-state pattern (ADR-0006), and same shape as Claude Code's native background-bash auto-notification.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -137,9 +137,11 @@ Neo4j ports (`7474` browser, `7687` bolt) are fixed in `docker-compose.yml`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `COMPOSE_PROFILES` | `c2-sliver` | Active Docker Compose profile |
+| `COMPOSE_PROFILES` | _(empty)_ | Explicit profile override. Leave empty for normal use — heavyweight workloads are spawned on demand by the orchestrator via `ops_start(...)` ([ADR-0006](adr/0006-agent-driven-container-lifecycle.md)). |
 
-Currently supported profiles: `c2-sliver`. Future: `c2-havoc`.
+Set explicitly only when you want a workload up at launch — e.g. `COMPOSE_PROFILES=cli,c2-sliver,ad,reversing` for CI regression runs against the whole matrix.
+
+Currently allowlisted workloads (the agent can call `ops_start("X")` for any of these): `ad`, `c2-sliver`, `c2-havoc`, `reversing`, `cloud`, `mobile`, `phishing`, `forensics`, `ics`, `iot`, `supply-chain`, `wireless`. Future C2 frameworks (Havoc, Mythic) plug in as additional `c2-*` profile services.
 
 ### Observability (optional)
 

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -299,17 +299,21 @@ to honor the original semantics.
 | Import | Purpose |
 |--------|---------|
 | `decepticon.agents.standard.*`, `decepticon.agents.plugins.*` | Pre-built per-role agent factories |
-| `decepticon.agents.middleware_slots` | `MiddlewareSlot` enum, `SLOTS_PER_ROLE`, `DEFAULT_SLOT_FACTORIES` |
+| `decepticon_core.contracts.slots` | `MiddlewareSlot` enum, `SLOTS_PER_ROLE`, `DEFAULT_SLOT_FACTORIES` |
 | `decepticon.agents.build` | `build_middleware`, `build_tools`, `resolve_prompt_overrides`, `SafetyOverrideViolation` |
 | `decepticon.agents.prompts` | `load_prompt`, `PromptBuilder` |
-| `decepticon.middleware` | `SkillsMiddleware`, `FilesystemMiddleware`, `EngagementContextMiddleware`, `OPPLANMiddleware`, `SandboxNotificationMiddleware`, … |
+| `decepticon.middleware` | `SkillsMiddleware`, `FilesystemMiddleware`, `EngagementContextMiddleware`, `OPPLANMiddleware`, `SandboxNotificationMiddleware`, `OpsControlNotificationMiddleware`, `KGMiddleware`, `SkillogyMiddleware`, … |
 | `decepticon.tools.bash` | `BASH_TOOLS` (the four bash tools), `set_sandbox` |
 | `decepticon.tools.research`, `decepticon.tools.references` | KG / CVE / payload tools |
 | `decepticon.tools.interaction` | `ask_user_question`, `complete_engagement_planning` |
+| `decepticon.tools.ops` | `ops_start`, `ops_stop`, `ops_status` (orchestrator-only, ADR-0006) |
 | `decepticon.backends` | `HTTPSandbox`, `build_sandbox_backend`, `make_agent_backend` |
 | `decepticon.llm` | `LLMFactory` |
-| `decepticon.core.schemas` | `RoE`, `CONOPS`, `DeconflictionPlan`, `OPPLAN`, `ThreatProfile`, `CleanupPlan`, `AbortPlan`, `ContactPlan`, `DataHandlingPlan` |
-| `decepticon.plugin_loader` | `PluginBundle`, `SubAgentSpec`, `is_bundle_enabled`, `load_plugin_*` |
+| `decepticon_core.types.engagement` | `RoE`, `CONOPS`, `DeconflictionPlan`, `OPPLAN`, `ThreatProfile`, `CleanupPlan`, `AbortPlan`, `ContactPlan`, `DataHandlingPlan` |
+| `decepticon_core.types.kg` | `KnowledgeGraph`, `Node`, `Edge`, `EdgeKind` |
+| `decepticon_core.plugin_loader` | `PluginBundle`, `SubAgentSpec`, `is_bundle_enabled`, `load_plugin_*` |
+
+The schema / contract types live in **`decepticon-core`** (the contracts package); the framework re-exports them via the compat shim in `decepticon/__init__.py` for one minor cycle (`decepticon.core.schemas`, `decepticon.plugin_loader`, `decepticon.agents.middleware_slots`). New code should import from `decepticon_core.*` directly.
 
 ---
 


### PR DESCRIPTION
Realigns four internal documentation pages with the current OSS code as of v1.1.12.

## Changes

**\`docs/architecture.md\`**
- Adds a Skillogy component section (REST service on port 9100, Neo4j skill graph, three agent tools, hard ACL per ADR-0008).
- Adds a *Background commands + auto-notification* paragraph to the Bash Tool section covering \`run_in_background=True\` and the SandboxNotificationMiddleware injection pattern.

**\`docs/agents.md\`**
- Replaces the brittle \"24 agents\" count with a structural framing: three orchestrators (Decepticon, Vulnresearch, Soundwave), a roster of specialist sub-agents under Decepticon, the five-stage Vulnresearch pipeline, and the \`blue_cell\` defense agent for the Offensive Vaccine loop. Won't break the next time a new operator lands.

**\`docs/cli-reference.md\`**
- Corrects the \`COMPOSE_PROFILES\` default from \`c2-sliver\` (pre-ADR-0006) to empty (current). Heavyweight workloads are now spawned on demand by the orchestrator via \`ops_start(...)\`.
- Adds the opscontrol allowlist of 12 workloads (\`ad\`, \`c2-sliver\`, \`c2-havoc\`, \`reversing\`, \`cloud\`, \`mobile\`, \`phishing\`, \`forensics\`, \`ics\`, \`iot\`, \`supply-chain\`, \`wireless\`) and explains when to override via \`.env\` (CI matrix runs).

**\`docs/library-usage.md\`**
- Fixes import paths in the public API table for the 3-package split (v1.1.2+):
  - \`decepticon.core.schemas\` → \`decepticon_core.types.engagement\` (RoE, CONOPS, OPPLAN, …)
  - \`decepticon.agents.middleware_slots\` → \`decepticon_core.contracts.slots\`
  - \`decepticon.plugin_loader\` → \`decepticon_core.plugin_loader\`
- Adds new rows for \`decepticon_core.types.kg\` (KG type exports) and \`decepticon.tools.ops\` (ADR-0006 orchestrator tools).
- Adds OpsControlNotificationMiddleware, KGMiddleware, SkillogyMiddleware to the middleware row.
- Documents the compat shim that keeps the old paths working for one minor cycle.