### PR TITLE
fix(litellm): patch CVE-2026-42208 / CVE-2026-42271 (upgrade proxy to v1.88.1)

### DIFF
--- a/containers/litellm.Dockerfile
+++ b/containers/litellm.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/berriai/litellm:main-v1.82.3-stable.patch.2
+FROM ghcr.io/berriai/litellm:v1.88.1
 
 # xxhash is required for CCH (Claude Code Hash) request signing
 RUN pip install --no-cache-dir xxhash

--- a/containers/litellm.Dockerfile
+++ b/containers/litellm.Dockerfile
@@ -1,7 +1,11 @@
 FROM ghcr.io/berriai/litellm:v1.88.1
 
-# xxhash is required for CCH (Claude Code Hash) request signing
-RUN pip install --no-cache-dir xxhash
+# xxhash is required for CCH (Claude Code Hash) request signing.
+# The v1.88.x base ships a uv-managed venv at /app/.venv (first on PATH)
+# with no pip and no uv on PATH, so a bare `pip install` fails (exit 127).
+# Bootstrap pip into that venv via ensurepip, then install with the venv's
+# python so xxhash lands where the litellm process imports from.
+RUN python -m ensurepip --upgrade && python -m pip install --no-cache-dir xxhash
 
 COPY config/http_client.py /app/http_client.py
 COPY config/oauth_token_store.py /app/oauth_token_store.py


### PR DESCRIPTION
## What

Bumps the LiteLLM proxy base image from \`main-v1.82.3-stable.patch.2\` to \`v1.88.1\`.

## Why — two actively-exploited CVEs

The pinned \`1.82.3\` sits inside the affected range of both:

| CVE | Severity | Affected | Fixed |
|---|---|---|---|
| **CVE-2026-42208** | CVSS 9.3 — pre-auth SQL injection (Authorization Bearer → unparameterized query → arbitrary SELECT on proxy Postgres) | 1.81.16–1.83.6 | 1.83.7+ |
| **CVE-2026-42271** | MCP test-endpoint command-injection RCE | 1.74.2–1.83.6 | 1.83.7+ |

CVE-2026-42208 was exploited in the wild within 36h of disclosure and added to the **CISA KEV catalog on 2026-05-08**. CVE-2026-42271's exposure here is limited (no MCP configured, proxy bound to 127.0.0.1, sandbox-net isolated) but the upgrade closes both in one move.

Also adopts the post-1.84 bare-version tag convention — the legacy \`-stable.patch.N\` suffix was eliminated upstream and the \`main-stable\` tag is being retired by 2026-06-30.

## Verification

- ✅ Confirmed \`ghcr.io/berriai/litellm:v1.88.1\` exists on GHCR (manifest HEAD → 200).
- ⚠️ **Dogfood required before merge.** This is a 6-minor jump and the proxy mounts custom config handlers (\`config/*_handler.py\`); run \`make smoke\` + \`make dogfood\` to confirm proxy boot + LiteLLM 200 on the local stack.

## Follow-ups (separate PRs)
- Relocate \`fallbacks\` to \`router_settings\` + de-dup retry keys (config hygiene flagged during the upgrade audit).
- Replace the direct \`LiteLLM_SpendLogs\` SQL in \`budget.py\` with the supported \`/spend/logs\` API (schema-coupling risk surfaces exactly at upgrades like this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)