### PR TITLE
fix(infra): move Neo4j off EOL versions; bound driver to v6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
   # Neo4j — Attack Chain Graph (the agent's persistent working memory)
   # On sandbox-net so cypher-shell from inside sandbox reaches bolt://neo4j:7687
   neo4j:
-    image: neo4j:5.24-community
+    image: neo4j:5.26-community
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-neo4j
     environment:
       NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-decepticon-graph}
@@ -644,7 +644,7 @@ services:
     profiles:
       - ad
   bhce-neo4j:
-    image: neo4j:4.4.42-community
+    image: neo4j:4.4.48-community
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-bhce-neo4j
     environment:
       NEO4J_AUTH: neo4j/${BHCE_NEO4J_PASSWORD:-decepticon-bhce-graph}

--- a/packages/decepticon/pyproject.toml
+++ b/packages/decepticon/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
 # driver is imported lazily inside ``KGStore.__init__``
 # (decepticon/middleware/kg_internal/store.py), so the base install
 # imports and runs everything except the KG graph tools.
-neo4j = ["neo4j>=5.24"]
+neo4j = ["neo4j>=6,<7"]
 telemetry = [
     "opentelemetry-api>=1.27",
     "opentelemetry-sdk>=1.27",

--- a/uv.lock
+++ b/uv.lock
@@ -511,7 +511,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.2.0" },
     { name = "langgraph-sdk", specifier = ">=0.1.0" },
-    { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.24" },
+    { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=6,<7" },
     { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'telemetry'", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.27" },


### PR DESCRIPTION
## What
- **Main KG / skillogy graph**: \`neo4j:5.24-community\` → \`5.26-community\`
- **BloodHound CE graph**: \`neo4j:4.4.42-community\` → \`4.4.48-community\`
- **Driver constraint**: \`neo4j>=5.24\` → \`neo4j>=6,<7\`

## Why
- **5.24 is EOL** since 2024-10-31 — it is *not* an LTS (for 5.x, only the latest minor is supported). ~20 months with no security patches. **5.26 is the LTS**, supported until 2028-06; it's a drop-in within 5.x and driver 6.2.0 is compatible with both.
- **BHCE's 4.4 line is EOL** (ended 2025-11-30); 4.4 is dictated by BloodHound CE, so we can't leave 4.4, but **4.4.48 is the final patch** it will ever get — we were 6 patches behind.
- The unbounded \`>=5.24\` let the **5.x→6.x driver major land silently** in the lockfile. \`>=6,<7\` makes the next major opt-in.

## Verification
- ✅ All three Docker Hub tags confirmed to exist (\`5.26-community\`, \`4.4.48-community\`).
- ✅ \`uv lock\` refreshed; neo4j still resolves to **6.2.0** (only the specifier metadata changed).
- ✅ Cypher migrations + queries reviewed during the audit: no deprecated syntax; modern 5.x idioms throughout, so 5.26 is non-breaking.
- ⚠️ Recommend a \`make smoke\` to confirm Neo4j healthcheck on the bumped image before merge.

## Follow-ups (separate PRs)
- Evaluate BHCE's supported \`graph_driver: pg\` (Postgres) backend to drop the EOL Neo4j 4.4 container entirely.
- Neo4j 2025.x calver jump (Java 21 + block-format) — needed if skillogy Phase 1b adopts the native \`VECTOR\` type / newer vector index providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)