### PR TITLE
fix(llm): refresh model catalog — drop retired Haiku, add Opus 4.8 + Gemini 3.x

### DIFF
--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -22,21 +22,32 @@
 model_list:
   # ── Anthropic ────────────────────────────────────────────────────────
   # ``additional_drop_params: ["temperature"]`` on opus is required: Anthropic
-  # deprecated the temperature param for Claude Opus 4.7 (extended-thinking
+  # deprecated the temperature param for Claude Opus 4.7/4.8 (extended-thinking
   # defaults). Sending it raises a 400 invalid_request_error from the upstream
   # API, which then prevents the proxy-level fallback from firing because
   # it's a *request validation* error, not a model-failure signal. Dropping
   # the param at the proxy keeps the request well-formed regardless of which
   # client hit us.
-  # Per-1M USD as of 2026-05-14 (Anthropic API):
+  # Per-1M USD as of 2026-06-11 (Anthropic API):
+  #   opus-4-8   $5.00 / $25.00   (current top Opus; 4.7 now previous-gen)
   #   opus-4-7   $5.00 / $25.00
   #   sonnet-4-6 $3.00 / $15.00
   #   haiku-4-5  $1.00 /  $5.00
   # LiteLLM's built-in cost map ships sonnet-4-6 and haiku-4-5 correctly,
-  # but opus-4-7 is missing — explicit ``model_info`` here forces
+  # but the opus IDs are missing — explicit ``model_info`` here forces
   # /spend/logs to populate cost instead of ``None / 0``. Sonnet/Haiku
   # are pinned too so we own the price source of truth instead of
   # silently drifting if Anthropic's map updates.
+  - model_name: anthropic/claude-opus-4-8
+    litellm_params:
+      model: anthropic/claude-opus-4-8
+      api_key: os.environ/ANTHROPIC_API_KEY
+      additional_drop_params: ["temperature"]
+      max_tokens: 128000
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+
   - model_name: anthropic/claude-opus-4-7
     litellm_params:
       model: anthropic/claude-opus-4-7
@@ -143,6 +154,32 @@ model_list:
       input_cost_per_token: 0.0000001
       output_cost_per_token: 0.0000004
 
+  # ── Google Gemini 3.x (GA) ───────────────────────────────────────────
+  # The 2.5 family above is on the deprecation path (discontinue no earlier
+  # than 2026-10-16); the 3.x GA models below are the migration target.
+  # No GA Gemini 3 Pro exists yet (Pro is preview-only: gemini-3.1-pro-preview),
+  # so the HIGH tier stays on 2.5-pro until a GA 3.x Pro ships. These are
+  # added as routable options for DECEPTICON_MODEL_<ROLE> overrides plus the
+  # within-family fallback below.
+  # Per-1M USD as of 2026-06-11 (Gemini Developer API):
+  #   3.5-flash      $1.50 / $9.00
+  #   3.1-flash-lite $0.25 / $1.50
+  - model_name: gemini/gemini-3.5-flash
+    litellm_params:
+      model: gemini/gemini-3.5-flash
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      input_cost_per_token: 0.0000015
+      output_cost_per_token: 0.000009
+
+  - model_name: gemini/gemini-3.1-flash-lite
+    litellm_params:
+      model: gemini/gemini-3.1-flash-lite
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      input_cost_per_token: 0.00000025
+      output_cost_per_token: 0.0000015
+
   # ── MiniMax ──────────────────────────────────────────────────────────
   # Native LiteLLM minimax/ provider — registry-registered model IDs.
   # Per-1M USD as of 2026-06-07 (api.minimax.io):
@@ -179,6 +216,15 @@ model_list:
   # "API-equivalent cost" — useful for comparing benchmark cost across
   # paid-API and subscription routes apples-to-apples. The OSS user's
   # actual bill is the subscription fee; this number is opportunity cost.
+  - model_name: auth/claude-opus-4-8
+    litellm_params:
+      model: auth/claude-opus-4-8
+      additional_drop_params: ["temperature"]
+      max_tokens: 128000
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+
   - model_name: auth/claude-opus-4-7
     litellm_params:
       model: auth/claude-opus-4-7
@@ -297,6 +343,16 @@ model_list:
   # 5.5 % fee only applies on credit-purchase deposits). The Claude
   # pricing block above is the source of truth — we mirror those values
   # here so /spend/logs captures cost for the OpenRouter routes too.
+  - model_name: openrouter/anthropic/claude-opus-4-8
+    litellm_params:
+      model: openrouter/anthropic/claude-opus-4-8
+      api_key: os.environ/OPENROUTER_API_KEY
+      additional_drop_params: ["temperature"]
+      max_tokens: 128000
+    model_info:
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+
   - model_name: openrouter/anthropic/claude-opus-4-7
     litellm_params:
       model: openrouter/anthropic/claude-opus-4-7
@@ -521,14 +577,14 @@ model_list:
     model_info:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
-  - model_name: nanogpt/anthropic/claude-3-5-haiku-20241022
+  - model_name: nanogpt/anthropic/claude-haiku-4.5
     litellm_params:
-      model: openai/anthropic/claude-3-5-haiku-20241022
+      model: openai/anthropic/claude-haiku-4.5
       api_base: https://nano-gpt.com/api/v1
       api_key: os.environ/NANOGPT_API_KEY
     model_info:
-      input_cost_per_token: 0.0000008
-      output_cost_per_token: 0.000004
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000005
 
   # Synthetic — https://api.synthetic.new/openai/v1 (flat plan → $0)
   - model_name: synthetic/hf:deepseek-ai/DeepSeek-V3.2
@@ -693,10 +749,13 @@ litellm_settings:
   # 'No fallback model group found for original model_group=
   # anthropic/claude-opus-4-7' error.
   fallbacks:
-    # Anthropic API path
+    # Anthropic API path (opus-4-8 is the current flagship; 4.7 is the
+    # first within-provider step down before sonnet/haiku)
+    - {"anthropic/claude-opus-4-8": ["anthropic/claude-opus-4-7"]}
     - {"anthropic/claude-opus-4-7": ["anthropic/claude-sonnet-4-6"]}
     - {"anthropic/claude-sonnet-4-6": ["anthropic/claude-haiku-4-5"]}
     # Anthropic OAuth (Claude Code subscription) path
+    - {"auth/claude-opus-4-8": ["auth/claude-opus-4-7"]}
     - {"auth/claude-opus-4-7": ["auth/claude-sonnet-4-6"]}
     - {"auth/claude-sonnet-4-6": ["auth/claude-haiku-4-5"]}
     # OAuth → paid API key cross-method backstop. When the entire OAuth
@@ -708,6 +767,7 @@ litellm_settings:
     # ANTHROPIC_API_KEY.
     - {"auth/claude-haiku-4-5": ["anthropic/claude-haiku-4-5"]}
     # OpenRouter mirrors of the Anthropic models
+    - {"openrouter/anthropic/claude-opus-4-8": ["openrouter/anthropic/claude-opus-4-7"]}
     - {"openrouter/anthropic/claude-opus-4-7": ["openrouter/anthropic/claude-sonnet-4-6"]}
     - {"openrouter/anthropic/claude-sonnet-4-6": ["openrouter/anthropic/claude-haiku-4-5"]}
     # OpenAI direct API
@@ -717,6 +777,8 @@ litellm_settings:
     # Google Gemini API path
     - {"gemini/gemini-2.5-pro": ["gemini/gemini-2.5-flash"]}
     - {"gemini/gemini-2.5-flash": ["gemini/gemini-2.5-flash-lite"]}
+    # Gemini 3.x (GA) within-family degradation — 3.5-flash → 3.1-flash-lite
+    - {"gemini/gemini-3.5-flash": ["gemini/gemini-3.1-flash-lite"]}
     # Gemini Advanced subscription fallbacks (registered dynamically)
     # MiniMax (no LOW tier)
     - {"minimax/MiniMax-M3": ["minimax/MiniMax-M2.7-highspeed"]}
@@ -748,7 +810,7 @@ litellm_settings:
     - {"venice/claude-opus-4-6": ["venice/claude-sonnet-4-6"]}
     - {"venice/claude-sonnet-4-6": ["venice/deepseek-v4-flash"]}
     - {"nanogpt/anthropic/claude-opus-4.6": ["nanogpt/anthropic/claude-sonnet-4.6"]}
-    - {"nanogpt/anthropic/claude-sonnet-4.6": ["nanogpt/anthropic/claude-3-5-haiku-20241022"]}
+    - {"nanogpt/anthropic/claude-sonnet-4.6": ["nanogpt/anthropic/claude-haiku-4.5"]}
     - {"synthetic/hf:deepseek-ai/DeepSeek-V3.2": ["synthetic/hf:meta-llama/Llama-3.3-70B-Instruct"]}
     - {"synthetic/hf:meta-llama/Llama-3.3-70B-Instruct": ["synthetic/hf:openai/gpt-oss-120b"]}
     - {"zenmux/anthropic/claude-opus-4.6": ["zenmux/anthropic/claude-sonnet-4.6"]}

--- a/packages/decepticon-core/decepticon_core/types/llm.py
+++ b/packages/decepticon-core/decepticon_core/types/llm.py
@@ -17,15 +17,15 @@ and can be ordered independently in the priority list.
 Examples
 --------
 User has [anthropic_api, openai_api]. Profile=eco.
-  decepticon (HIGH) → primary=anthropic/claude-opus-4-7, fallback=openai/gpt-5.5
+  decepticon (HIGH) → primary=anthropic/claude-opus-4-8, fallback=openai/gpt-5.5
   recon (LOW)       → primary=anthropic/claude-haiku-4-5, fallback=openai/gpt-5-nano
 
 User has [anthropic_oauth, anthropic_api]. Profile=eco.
-  decepticon (HIGH) → primary=auth/claude-opus-4-7, fallback=anthropic/claude-opus-4-7
+  decepticon (HIGH) → primary=auth/claude-opus-4-8, fallback=anthropic/claude-opus-4-8
   (OAuth subscription primary, paid API as fallback when subscription quota hits.)
 
 User has [anthropic_oauth] only. Profile=eco.
-  decepticon (HIGH) → primary=auth/claude-opus-4-7, fallback=None
+  decepticon (HIGH) → primary=auth/claude-opus-4-8, fallback=None
 
 User has [openai_api]. Profile=eco.
   decepticon (HIGH) → primary=openai/gpt-5.5, fallback=None
@@ -34,13 +34,13 @@ User has [openai_api]. Profile=eco.
 Tier × AuthMethod matrix
 ------------------------
                     HIGH                          MID                            LOW
-  anthropic_api    claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
-  anthropic_oauth  auth/claude-opus-4-7          auth/claude-sonnet-4-6         auth/claude-haiku-4-5
+  anthropic_api    claude-opus-4-8               claude-sonnet-4-6              claude-haiku-4-5
+  anthropic_oauth  auth/claude-opus-4-8          auth/claude-sonnet-4-6         auth/claude-haiku-4-5
   openai_api       gpt-5.5                       gpt-5.4                        gpt-5-nano
   openai_oauth     auth/gpt-5.5                  auth/gpt-5.4                   auth/gpt-5.4-mini
   google_api       gemini-2.5-pro                gemini-2.5-flash               gemini-2.5-flash-lite
   minimax_api      MiniMax-M3                    MiniMax-M2.7-highspeed         — (falls through)
-  openrouter_api   claude-opus-4-7               claude-sonnet-4-6              claude-haiku-4-5
+  openrouter_api   claude-opus-4-8               claude-sonnet-4-6              claude-haiku-4-5
   nvidia_api       llama-3.3-70b-instruct        nemotron-70b-instruct          llama-3.2-3b-instruct
   xai_api          grok-4.3                      grok-4-1-fast-reasoning        — (falls through)
   copilot_oauth    copilot/gpt-5.5               copilot/claude-sonnet-4-6      copilot/gpt-5.4-mini
@@ -173,12 +173,12 @@ class AuthMethod(StrEnum):
 
 METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
     AuthMethod.ANTHROPIC_API: {
-        Tier.HIGH: "anthropic/claude-opus-4-7",
+        Tier.HIGH: "anthropic/claude-opus-4-8",
         Tier.MID: "anthropic/claude-sonnet-4-6",
         Tier.LOW: "anthropic/claude-haiku-4-5",
     },
     AuthMethod.ANTHROPIC_OAUTH: {
-        Tier.HIGH: "auth/claude-opus-4-7",
+        Tier.HIGH: "auth/claude-opus-4-8",
         Tier.MID: "auth/claude-sonnet-4-6",
         Tier.LOW: "auth/claude-haiku-4-5",
     },
@@ -226,7 +226,7 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.MID: "mistral/codestral-latest",
     },
     AuthMethod.OPENROUTER_API: {
-        Tier.HIGH: "openrouter/anthropic/claude-opus-4-7",
+        Tier.HIGH: "openrouter/anthropic/claude-opus-4-8",
         Tier.MID: "openrouter/anthropic/claude-sonnet-4-6",
         Tier.LOW: "openrouter/anthropic/claude-haiku-4-5",
     },

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -218,7 +218,7 @@ class TestLLMFactory:
             "deepseek/deepseek-v4-pro",
             "xai/grok-4.3",
             "mistral/mistral-large-latest",
-            "openrouter/anthropic/claude-opus-4-7",
+            "openrouter/anthropic/claude-opus-4-8",
             "nvidia_nim/meta/llama-3.3-70b-instruct",
         ]
 

--- a/packages/decepticon/tests/unit/llm/test_models.py
+++ b/packages/decepticon/tests/unit/llm/test_models.py
@@ -54,13 +54,13 @@ class TestModelProfile:
 class TestMethodModels:
     def test_anthropic_api_full_tier_coverage(self):
         m = METHOD_MODELS[AuthMethod.ANTHROPIC_API]
-        assert m[Tier.HIGH] == "anthropic/claude-opus-4-7"
+        assert m[Tier.HIGH] == "anthropic/claude-opus-4-8"
         assert m[Tier.MID] == "anthropic/claude-sonnet-4-6"
         assert m[Tier.LOW] == "anthropic/claude-haiku-4-5"
 
     def test_anthropic_oauth_routes_to_auth_prefix(self):
         m = METHOD_MODELS[AuthMethod.ANTHROPIC_OAUTH]
-        assert m[Tier.HIGH] == "auth/claude-opus-4-7"
+        assert m[Tier.HIGH] == "auth/claude-opus-4-8"
         assert m[Tier.MID] == "auth/claude-sonnet-4-6"
         assert m[Tier.LOW] == "auth/claude-haiku-4-5"
 
@@ -164,18 +164,18 @@ class TestResolveChain:
     def test_anthropic_api_only_high(self):
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_API])
         chain = resolve_chain(Tier.HIGH, creds)
-        assert chain == ["anthropic/claude-opus-4-7"]
+        assert chain == ["anthropic/claude-opus-4-8"]
 
     def test_oauth_only_high(self):
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_OAUTH])
         chain = resolve_chain(Tier.HIGH, creds)
-        assert chain == ["auth/claude-opus-4-7"]
+        assert chain == ["auth/claude-opus-4-8"]
 
     def test_oauth_then_api_high(self):
         # Subscription primary, paid API fallback when quota hits.
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_OAUTH, AuthMethod.ANTHROPIC_API])
         chain = resolve_chain(Tier.HIGH, creds)
-        assert chain == ["auth/claude-opus-4-7", "anthropic/claude-opus-4-7"]
+        assert chain == ["auth/claude-opus-4-8", "anthropic/claude-opus-4-8"]
 
     def test_oauth_then_openai_low(self):
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_OAUTH, AuthMethod.OPENAI_API])
@@ -213,7 +213,7 @@ class TestResolveChain:
         chain = resolve_chain(Tier.HIGH, creds)
         assert chain == [
             "openai/gpt-5.5",
-            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
             "gemini/gemini-2.5-pro",
         ]
 
@@ -460,15 +460,15 @@ class TestLLMModelMapping:
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_API])
         m = LLMModelMapping.from_credentials_and_profile(creds, ModelProfile.ECO)
         a = m.get_assignment("decepticon")
-        assert a.primary == "anthropic/claude-opus-4-7"
+        assert a.primary == "anthropic/claude-opus-4-8"
         assert a.fallbacks == []
 
     def test_from_credentials_oauth_plus_api(self):
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_OAUTH, AuthMethod.ANTHROPIC_API])
         m = LLMModelMapping.from_credentials_and_profile(creds, ModelProfile.ECO)
         a = m.get_assignment("decepticon")
-        assert a.primary == "auth/claude-opus-4-7"
-        assert a.fallbacks == ["anthropic/claude-opus-4-7"]
+        assert a.primary == "auth/claude-opus-4-8"
+        assert a.fallbacks == ["anthropic/claude-opus-4-8"]
 
     def test_from_credentials_full_chain_high_tier(self):
         # Every method configured → every method appears in the HIGH-tier chain
@@ -484,9 +484,9 @@ class TestLLMModelMapping:
         )
         m = LLMModelMapping.from_credentials_and_profile(creds, ModelProfile.ECO)
         a = m.get_assignment("decepticon")
-        assert a.primary == "auth/claude-opus-4-7"
+        assert a.primary == "auth/claude-opus-4-8"
         assert a.fallbacks == [
-            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
             "openai/gpt-5.5",
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M3",
@@ -529,7 +529,7 @@ class TestLLMModelMapping:
     def test_max_profile_promotes_recon_to_high(self):
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_API])
         m = LLMModelMapping.from_credentials_and_profile(creds, ModelProfile.MAX)
-        assert m.get_assignment("recon").primary == "anthropic/claude-opus-4-7"
+        assert m.get_assignment("recon").primary == "anthropic/claude-opus-4-8"
 
     def test_test_profile_demotes_decepticon_to_low(self):
         creds = Credentials(methods=[AuthMethod.ANTHROPIC_API])
@@ -539,7 +539,7 @@ class TestLLMModelMapping:
     def test_from_profile_uses_all_api_methods(self):
         m = LLMModelMapping.from_profile(ModelProfile.ECO)
         a = m.get_assignment("decepticon")
-        assert a.primary == "anthropic/claude-opus-4-7"
+        assert a.primary == "anthropic/claude-opus-4-8"
         assert a.fallbacks == [
             "openai/gpt-5.5",
             "gemini/gemini-2.5-pro",
@@ -547,7 +547,7 @@ class TestLLMModelMapping:
             "deepseek/deepseek-v4-pro",
             "xai/grok-4.3",
             "mistral/mistral-large-latest",
-            "openrouter/anthropic/claude-opus-4-7",
+            "openrouter/anthropic/claude-opus-4-8",
             "nvidia_nim/meta/llama-3.3-70b-instruct",
         ]
 

--- a/packages/decepticon/tests/unit/llm/test_router.py
+++ b/packages/decepticon/tests/unit/llm/test_router.py
@@ -23,7 +23,7 @@ class TestModelRouter:
         assert self.router.resolve("recon") == "anthropic/claude-haiku-4-5"
 
     def test_resolve_decepticon_is_high_tier(self):
-        assert self.router.resolve("decepticon") == "anthropic/claude-opus-4-7"
+        assert self.router.resolve("decepticon") == "anthropic/claude-opus-4-8"
 
     def test_resolve_with_fallback_returns_chain(self):
         chain = self.router.resolve_with_fallback("recon")
@@ -39,14 +39,14 @@ class TestModelRouter:
     def test_resolve_with_fallback_high_tier_full_chain(self):
         chain = self.router.resolve_with_fallback("decepticon")
         assert chain == [
-            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
             "openai/gpt-5.5",
             "gemini/gemini-2.5-pro",
             "minimax/MiniMax-M3",
             "deepseek/deepseek-v4-pro",
             "xai/grok-4.3",
             "mistral/mistral-large-latest",
-            "openrouter/anthropic/claude-opus-4-7",
+            "openrouter/anthropic/claude-opus-4-8",
             "nvidia_nim/meta/llama-3.3-70b-instruct",
         ]
 


### PR DESCRIPTION
## What
Model-currency pass on the LiteLLM catalog + the core model registry, as of 2026-06-11.

### Retired model removed
- NanoGPT route `claude-3-5-haiku-20241022` → `claude-haiku-4.5`. Anthropic **retired** `claude-3-5-haiku-20241022` on 2026-02-19; it was the *terminal fallback* of the NanoGPT sonnet chain, so a degraded chain landed on a dead model.

### New models added (verified against provider docs/pricing)
- **Claude Opus 4.8** (`claude-opus-4-8`, \$5/\$25) — the current top Opus. Added to the Anthropic direct, OAuth (`auth/`), and OpenRouter routes, and **promoted to the HIGH-tier default** in `METHOD_MODELS` for those three methods. It's a strict, same-price successor to 4-7 (which becomes the first within-provider fallback step). Client-side temperature-drop already covers it via the `claude-opus-4` prefix match. **Bedrock/Vertex HIGH stay on 4-7** — their 4.8 model-ID formats weren't verifiable, so left untouched.
- **Gemini 3.5 Flash** (\$1.50/\$9) and **Gemini 3.1 Flash-Lite** (\$0.25/\$1.50), both GA — added as routable options + a within-family fallback. **HIGH tier stays on 2.5-pro** since no GA Gemini 3 *Pro* exists yet (preview-only); the 2.5 family is still valid until its ≥2026-10-16 discontinue date.

### Fallback chains
Updated for the new Anthropic flagship across the Anthropic API / OAuth / OpenRouter paths (`opus-4-8 → opus-4-7 → sonnet-4-6 → haiku-4-5`).

### Verified still-current (no change)
GPT-5.5 (\$5/\$30), Grok-4.3, DeepSeek-V4 confirmed current against official pricing pages. OpenAI `gpt-5-nano`/`gpt-5.3-codex` left as-is (maintainer's dated comment documents the intent; couldn't independently verify, so not touched).

## Verification
- ✅ YAML parses; 65 model entries, no duplicate `model_name`; every fallback source/target resolves to a registered model.
- ✅ `pytest` llm/test_models.py + test_router.py + test_litellm_dynamic_config.py → **94 passed** (HIGH-tier assertions updated 4-7→4-8).
- ✅ `ruff check` + `ruff format --check` clean on changed files.
- ⚠️ Provider model IDs/pricing post-date the assistant's training cutoff and were taken from official docs at audit time — a maintainer with live API access should sanity-check the new IDs resolve before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)