### PR TITLE
fix(ci): read Go toolchain from go.mod instead of a hardcoded version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,10 @@ jobs:
       - uses: actions/setup-go@v5
         if: needs.changes.outputs.launcher == 'true'
         with:
-          go-version: "1.24"
+          # Read the toolchain from go.mod so CI never drifts from the
+          # launcher's declared version (go.mod is the single source of
+          # truth; a hardcoded version here masked a 1.24/1.25 mismatch).
+          go-version-file: clients/launcher/go.mod
           cache-dependency-path: clients/launcher/go.sum
       - name: go vet
         if: needs.changes.outputs.launcher == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,9 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          # Read the toolchain from go.mod (single source of truth) so the
+          # release build never drifts from the launcher's declared version.
+          go-version-file: clients/launcher/go.mod
           cache-dependency-path: clients/launcher/go.sum
 
       - name: Run tests


### PR DESCRIPTION
## What
Both `ci.yml` (launcher lane) and `release.yml` pinned `go-version: "1.24"` in their `actions/setup-go` steps, while `clients/launcher/go.mod` declares **1.25.8**.

Switch both to:
```yaml
go-version-file: clients/launcher/go.mod
```

## Why
The 1.24/1.25 mismatch only "worked" because `GOTOOLCHAIN` silently auto-downloads the newer toolchain at build time — masking the drift and adding a per-build download. Reading the version from `go.mod` makes the launcher's declared toolchain the single source of truth, so CI and release builds always match local `go build`.

## Verification
- ✅ `go vet ./...` + `go test ./...` green on the go.mod toolchain (1.25.8) — all launcher packages pass.
- ✅ Both workflow YAMLs parse.

Note: the project `CLAUDE.md` ("Launcher: Go 1.24") is git-excluded, so the doc-line correction isn't part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)