### PR TITLE
chore(compose): add log rotation + memory caps to stack services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,14 @@
+# Shared log-rotation policy. Docker's default json-file driver ships NO
+# rotation, so container logs grow unbounded until the host disk fills and
+# the whole stack crashes. Cap every long-running service at 3×10MB.
+# Compose has no top-level logging default, so this anchor is applied
+# per-service via ``logging: *default-logging`` below.
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   # LiteLLM Proxy — LLM API Gateway
   # Handles model routing, authentication, usage tracking, billing
@@ -51,12 +62,16 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
+    logging: *default-logging
 
   # PostgreSQL — Persistent storage for LiteLLM
   # Stores: virtual keys, spend logs, user budgets, rate limits
   postgres:
     image: postgres:17-alpine
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-postgres
+    # Working set is tiny (LiteLLM spend logs + web state, shared_buffers=32MB).
+    # Cap so a runaway query can't starve the host; 2g leaves ample headroom.
+    mem_limit: 2g
     environment:
       POSTGRES_DB: litellm
       POSTGRES_USER: decepticon
@@ -87,6 +102,7 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
+    logging: *default-logging
 
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U decepticon -d litellm"]
@@ -100,6 +116,9 @@ services:
   neo4j:
     image: neo4j:5.24-community
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-neo4j
+    # heap_max 256m + pagecache 64m + JVM/APOC off-heap ≈ <1g nominal.
+    # 2g caps the JVM so a large attack-graph scan can't swap-thrash the host.
+    mem_limit: 2g
     environment:
       NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-decepticon-graph}
       NEO4J_server_memory_heap_initial__size: 64m
@@ -162,6 +181,7 @@ services:
       retries: 12
       start_period: 90s
     restart: unless-stopped
+    logging: *default-logging
 
 
   # Evasive Red Team Sandbox
@@ -258,6 +278,7 @@ services:
       neo4j:
         condition: service_healthy
     restart: unless-stopped
+    logging: *default-logging
 
 
   # Ghidra MCP — optional 245-tool reverse engineering bridge for the
@@ -310,6 +331,7 @@ services:
     mem_limit: 4g
     cpus: 2.0
     restart: unless-stopped
+    logging: *default-logging
     profiles:
       - reversing
 
@@ -409,6 +431,7 @@ services:
       - decepticon-net
       - sandbox-net
     restart: unless-stopped
+    logging: *default-logging
 
 
   # Web Dashboard — Next.js UI
@@ -453,6 +476,7 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
+    logging: *default-logging
     # v1.1.8: web dashboard is no longer brought up by default `decepticon
     # start`. The CLI exposes a `/web` slash command that runs
     # `docker compose --profile web up -d web` against the operator's
@@ -535,6 +559,7 @@ services:
       - sliver_data:/home/sliver/.sliver
     pids_limit: 512
     restart: unless-stopped
+    logging: *default-logging
     profiles:
       - c2-sliver
 
@@ -585,6 +610,7 @@ services:
     networks:
       - decepticon-net
     restart: unless-stopped
+    logging: *default-logging
 
   # ── BloodHound Community Edition (BHCE) sidecar ────────────────────
   #
@@ -663,6 +689,7 @@ services:
       retries: 12
       start_period: 60s
     restart: unless-stopped
+    logging: *default-logging
     # ADR-0006 §3 — opt-in via `ops_start("ad")`. Default
     # `decepticon start` does not spin up the AD graph DB.
     profiles:
@@ -726,6 +753,7 @@ services:
       retries: 3
       start_period: 10s
     restart: unless-stopped
+    logging: *default-logging
     # ADR-0006 §3 — workload is opt-in. The orchestrator agent calls
     # `ops_start("ad")` after recon identifies an AD environment;
     # default `decepticon start` keeps the BHCE plane cold.


### PR DESCRIPTION
## What
Two resource-hygiene gaps in `docker-compose.yml` that can take down the host:

### Log rotation (disk-fill protection)
Docker's default `json-file` driver ships **no rotation** — every container's logs grow unbounded until the host disk fills and the whole stack crashes. Added an `x-logging` anchor (3×10MB) and applied it to all 11 long-running services. Compose has no top-level logging default, so the anchor is referenced per-service via `logging: *default-logging`.

### Memory caps (host-starvation protection)
`postgres` and `neo4j` had no `mem_limit` (only `sandbox` + `ghidra-mcp` did). A runaway query or a large attack-graph scan could starve the host. Capped both at **2g** — comfortably above their configured footprints (postgres `shared_buffers=32MB`; neo4j `heap_max 256m` + `pagecache 64m`).

Left `litellm`/`langgraph` uncapped deliberately — they legitimately need variable headroom (model-map load, 19-graph compile) and an unvalidated cap there risks OOM-killing core services.

## Verification
- ✅ `docker compose -f docker-compose.yml config` resolves the anchor (`max-size: 10m` on every service) and stamps `mem_limit` (postgres/neo4j 2g, sandbox/ghidra 4g).
- ✅ Merges cleanly across base + dev + watch overlays — the CI `compose-validate` guardrail.
- ✅ All 11 `logging:` directives confirmed at correct service-property indentation, each following a `restart:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)