### PR TITLE
perf(middleware): cache deconfliction.json by mtime

### DIFF
--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -180,17 +180,35 @@ def _build_engagement_injection(slug: str, workspace: str) -> str:
     )
 
 
+# Cache of parsed deconfliction.json keyed by path → (mtime, value). The
+# injector runs on every model call, so without this the file was stat'd,
+# read, and JSON-parsed once per turn. Keyed on mtime so an updated
+# deconfliction file is still picked up the moment it changes.
+_DECONFLICTION_CACHE: dict[str, tuple[float, dict[str, Any] | None]] = {}
+
+
 def _load_deconfliction(workspace: str) -> dict[str, Any] | None:
     root = workspace.rstrip("/") or workspace
     path = Path(root) / "plan" / "deconfliction.json"
-    if not path.exists():
+    key = str(path)
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        # Absent (or unstattable) — drop any stale entry and skip the block.
+        _DECONFLICTION_CACHE.pop(key, None)
         return None
+    cached = _DECONFLICTION_CACHE.get(key)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         log.warning("engagement: failed to read %s: %s; skipping block", path, exc)
+        _DECONFLICTION_CACHE[key] = (mtime, None)
         return None
-    return data if isinstance(data, dict) else None
+    result = data if isinstance(data, dict) else None
+    _DECONFLICTION_CACHE[key] = (mtime, result)
+    return result
 
 
 def _build_deconfliction_injection(data: dict[str, Any]) -> str:

--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -203,9 +203,15 @@ def _load_deconfliction(workspace: str) -> dict[str, Any] | None:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
+        # Do NOT cache read/parse failures: a transient error (mid-write
+        # file, brief I/O hiccup) must not be pinned as "no deconfliction"
+        # for the lifetime of this mtime. Drop any stale entry and retry on
+        # the next call — matching the pre-cache per-call behaviour.
         log.warning("engagement: failed to read %s: %s; skipping block", path, exc)
-        _DECONFLICTION_CACHE[key] = (mtime, None)
+        _DECONFLICTION_CACHE.pop(key, None)
         return None
+    # Cache the successful read (including a valid-but-not-a-dict file, which
+    # is a deterministic "no deconfliction" — safe to memoize until mtime moves).
     result = data if isinstance(data, dict) else None
     _DECONFLICTION_CACHE[key] = (mtime, result)
     return result


### PR DESCRIPTION
## What
`EngagementContextMiddleware._inject()` runs on **every model call** and called `_load_deconfliction(workspace)`, which `stat`'d, read, and JSON-parsed `<workspace>/plan/deconfliction.json` every time — even though the file changes at most a handful of times per engagement. Over a 100-turn run that's ~100 redundant reads + parses on the inference hot path.

Now cached keyed by path → `(mtime, value)`; re-read only when the file's mtime advances.

## Why it's safe
Behaviour-preserving:
- Missing/unstattable file → `None` (and drops any stale cache entry), same as before.
- Invalid JSON → warns + `None`, same as before.
- An updated deconfliction file is picked up immediately (mtime changes on write).

## Verification
- ✅ `pytest test_engagement.py` → **49 passed**.
- ✅ `basedpyright --level error` → **0 errors** on the file.
- ✅ `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)