### PR TITLE
fix(litellm): move fallbacks to router_settings (documented location)

### DIFF
--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -748,6 +748,11 @@ litellm_settings:
   # ``anthropic/claude-opus-4-7`` (paid API path) hit the
   # 'No fallback model group found for original model_group=
   # anthropic/claude-opus-4-7' error.
+  num_retries: 3
+  retry_after: 30
+
+# --- Router Settings ---
+router_settings:
   fallbacks:
     # Anthropic API path (opus-4-8 is the current flagship; 4.7 is the
     # first within-provider step down before sonnet/haiku)
@@ -820,11 +825,6 @@ litellm_settings:
     - {"cfgateway/anthropic/claude-opus-4-6": ["cfgateway/anthropic/claude-sonnet-4-6"]}
     - {"cfgateway/anthropic/claude-sonnet-4-6": ["cfgateway/anthropic/claude-haiku-4-5"]}
     # Copilot, SuperGrok, Perplexity fallbacks (registered dynamically)
-  num_retries: 3
-  retry_after: 30
-
-# --- Router Settings ---
-router_settings:
   routing_strategy: simple-shuffle
   num_retries: 5
   timeout: 300

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -734,6 +734,11 @@ litellm_settings:
   #   - copilot      → copilot_handler.copilot_handler_instance
   #   - grok-sub     → grok_handler.grok_sub_handler_instance
   #   - pplx-sub     → perplexity_handler.perplexity_sub_handler_instance
+  num_retries: 3
+  retry_after: 30
+
+# --- Router Settings ---
+router_settings:
   # ── Within-provider tier degradation ───────────────────────────────
   # Each chain mirrors HIGH → MID → LOW for the same auth path. When a
   # primary model fails (rate limit, transient 5xx, request-validation
@@ -748,11 +753,6 @@ litellm_settings:
   # ``anthropic/claude-opus-4-7`` (paid API path) hit the
   # 'No fallback model group found for original model_group=
   # anthropic/claude-opus-4-7' error.
-  num_retries: 3
-  retry_after: 30
-
-# --- Router Settings ---
-router_settings:
   fallbacks:
     # Anthropic API path (opus-4-8 is the current flagship; 4.7 is the
     # first within-provider step down before sonnet/haiku)


### PR DESCRIPTION
## What
Moves the 43-entry within-provider fallback block from `litellm_settings.fallbacks` to `router_settings.fallbacks` — the location current LiteLLM documents and where the Router (the engine that actually executes fallbacks) consumes them directly. The legacy `litellm_settings` mirror was working but is the dated placement.

`litellm_settings` keeps its `num_retries`/`retry_after` (SDK-level knobs, distinct from the Router-level ones already in `router_settings`), so the section stays non-null and the dual-layer retry semantics are left untouched. (Deduping those was considered but they're two different layers' knobs, not a true duplicate — out of scope to avoid an unverifiable behavior change.)

## Verification
Run against the **pinned `v1.88.1` image** (the version this stack now ships):
- ✅ `yaml.safe_load` → `router_settings.fallbacks` is a 43-entry list, all well-formed `{group: [targets]}`, no entries dropped; `litellm_settings` retains only `num_retries`/`retry_after` (non-null).
- ✅ `litellm.Router(model_list, **router_settings)` constructs and stores **all 43 chains** (`router.fallbacks` len=43, `num_retries=5`, `routing_strategy=simple-shuffle`) — confirming `router_settings.fallbacks` is the consumed location in v1.88.1.

⚠️ This is config-load verification. A full fallback-firing test (primary model fails → Router picks the next chain entry) still wants `make smoke` + a live engagement before merge.

## Follow-ups (separate, unchanged here)
- Replace the direct `LiteLLM_SpendLogs` SQL in `budget.py` with the `/spend/logs` API (schema-coupling).
- Evaluate `context_window_fallbacks` / `retry_policy` (need `enable_pre_call_checks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)