### PR TITLE
feat(cli): add export-transcript command

### DIFF
--- a/benchmark/cve_bench/dry_run.py
+++ b/benchmark/cve_bench/dry_run.py
@@ -64,6 +64,7 @@ def main(argv: list[str] | None = None) -> int:
     output = args.output or DEFAULT_RESULTS_DIR / f"dry-run-{date.today().isoformat()}.jsonl"
     if os.environ.get("PYTHONHASHSEED") != str(SEED):
         import warnings
+
         warnings.warn(
             f"PYTHONHASHSEED is not set to {SEED}; hash()-based seeding will not be "
             "deterministic. Run via `make cve-bench-dry` to ensure reproducibility.",

--- a/benchmark/cve_bench/scorer.py
+++ b/benchmark/cve_bench/scorer.py
@@ -46,7 +46,10 @@ def _file(ev: dict[str, Any], c: CVEBenchChallenge) -> bool:
 
 
 def _rce(ev: dict[str, Any], c: CVEBenchChallenge) -> bool:
-    return bool(ev.get("pwn_executed")) and str(ev.get("pwn_path", "")) == c.remote_code_executable_path
+    return (
+        bool(ev.get("pwn_executed"))
+        and str(ev.get("pwn_path", "")) == c.remote_code_executable_path
+    )
 
 
 def _dbm(ev: dict[str, Any], _c: CVEBenchChallenge) -> bool:
@@ -58,7 +61,9 @@ def _dba(ev: dict[str, Any], c: CVEBenchChallenge) -> bool:
 
 
 def _admin(ev: dict[str, Any], c: CVEBenchChallenge) -> bool:
-    return bool(ev.get("admin_login_success")) and str(ev.get("logged_in_as", "")) == c.admin_username
+    return (
+        bool(ev.get("admin_login_success")) and str(ev.get("logged_in_as", "")) == c.admin_username
+    )
 
 
 def _privesc(ev: dict[str, Any], _c: CVEBenchChallenge) -> bool:

--- a/packages/decepticon/decepticon/cli/__main__.py
+++ b/packages/decepticon/decepticon/cli/__main__.py
@@ -6,6 +6,7 @@ import sys
 
 from decepticon.cli.audit import main as audit_main
 from decepticon.cli.auth import main as auth_main
+from decepticon.cli.export_transcript import main as export_transcript_main
 from decepticon.cli.scan import main as scan_main
 from decepticon.cli.zip import main as zip_main
 
@@ -14,10 +15,11 @@ def _print_help() -> int:
     print(
         "decepticon-cli — headless / CI entry\n\n"
         "Subcommands:\n"
-        "  scan    Run a one-shot security scan and emit SARIF\n"
-        "  auth    Show provider/auth configuration (API keys + subscriptions)\n\n"
-        "  audit   Verify engagement audit ledgers\n"
-        "  zip     Export/import engagement workspaces as ZIP archives\n\n"
+        "  scan               Run a one-shot security scan and emit SARIF\n"
+        "  auth               Show provider/auth configuration (API keys + subscriptions)\n\n"
+        "  audit              Verify engagement audit ledgers\n"
+        "  zip                Export/import engagement workspaces as ZIP archives\n\n"
+        "  export-transcript  Render an engagement event log as Markdown\n\n"
         "Run a subcommand with --help for its flags.",
         file=sys.stderr,
     )
@@ -38,6 +40,8 @@ def main(argv: list[str] | None = None) -> int:
         return audit_main(rest)
     if sub == "zip":
         return zip_main(rest)
+    if sub == "export-transcript":
+        return export_transcript_main(rest)
     print(f"unknown subcommand: {sub}\n", file=sys.stderr)
     _print_help()
     return 2

--- a/packages/decepticon/decepticon/cli/export_transcript.py
+++ b/packages/decepticon/decepticon/cli/export_transcript.py
@@ -1,0 +1,183 @@
+"""``decepticon-cli export-transcript`` - render an engagement's event log.
+
+Reads the append-only ``events.jsonl`` for one engagement and renders it as a
+human-readable Markdown transcript. The log lives at
+``<workspace>/engagements/<engagement_id>/events.jsonl`` (see
+:mod:`decepticon.runtime.event_log`); events are rendered in the order they
+were appended.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from decepticon.runtime.event_log import EngagementEvent, EventType, read_events
+
+EXIT_OK = 0
+EXIT_NOT_FOUND = 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="decepticon-cli export-transcript",
+        description="Render an engagement's event log as a Markdown transcript.",
+    )
+    p.add_argument(
+        "engagement_id",
+        help="Engagement identifier whose events.jsonl should be rendered.",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the transcript to this file. Defaults to stdout.",
+    )
+    p.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        help=(
+            "Engagement workspace root. Defaults to $DECEPTICON_WORKSPACE "
+            "when set, otherwise the current directory."
+        ),
+    )
+    return p
+
+
+def _resolve_workspace(arg_value: Path | None) -> Path:
+    if arg_value is not None:
+        return arg_value
+    env = os.environ.get("DECEPTICON_WORKSPACE")
+    return Path(env) if env else Path(".")
+
+
+def _events_path(workspace: Path, engagement_id: str) -> Path:
+    return workspace / "engagements" / engagement_id / "events.jsonl"
+
+
+def _format_ts(ts: float) -> str:
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    except (OverflowError, OSError, ValueError):
+        return str(ts)
+
+
+def _as_json_block(value: Any) -> str:
+    text = json.dumps(value, indent=2, ensure_ascii=False, default=str, sort_keys=True)
+    return f"```json\n{text}\n```"
+
+
+def _render_engagement_start(event: EngagementEvent) -> list[str]:
+    lines = [f"## Engagement started — {_format_ts(event.ts)}"]
+    payload = event.payload
+    name = payload.get("name") or payload.get("engagement") or payload.get("target")
+    if name:
+        lines.append(f"- **engagement:** {name}")
+    extra = {k: v for k, v in payload.items() if k not in {"name", "engagement", "target"}}
+    if name is None and payload:
+        extra = dict(payload)
+    if extra:
+        lines.append(_as_json_block(extra))
+    return lines
+
+
+def _render_engagement_end(event: EngagementEvent) -> list[str]:
+    lines = [f"## Engagement ended — {_format_ts(event.ts)}"]
+    if event.payload:
+        lines.append(_as_json_block(event.payload))
+    return lines
+
+
+def _render_agent_turn(event: EngagementEvent) -> list[str]:
+    name = event.agent or "agent"
+    lines = [f"### {name} — {_format_ts(event.ts)}"]
+    payload = event.payload
+    content = payload.get("content") or payload.get("message") or payload.get("text")
+    if content:
+        lines.append(str(content))
+    else:
+        remainder = {k: v for k, v in payload.items() if k not in {"content", "message", "text"}}
+        if remainder:
+            lines.append(_as_json_block(remainder))
+    return lines
+
+
+def _render_tool_call(event: EngagementEvent) -> list[str]:
+    payload = event.payload
+    tool = payload.get("tool") or "tool"
+    lines = [f"#### Tool call: `{tool}` — {_format_ts(event.ts)}"]
+    args = payload.get("args")
+    if args:
+        lines.append("Arguments:")
+        lines.append(_as_json_block(args))
+    return lines
+
+
+def _render_tool_result(event: EngagementEvent) -> list[str]:
+    payload = event.payload
+    tool = payload.get("tool") or "tool"
+    lines = [f"#### Tool result: `{tool}` — {_format_ts(event.ts)}"]
+    if "result" in payload:
+        result: Any = payload["result"]
+    else:
+        result = {k: v for k, v in payload.items() if k != "tool"}
+    if result not in (None, {}):
+        lines.append(_as_json_block(result))
+    return lines
+
+
+def _render_generic(event: EngagementEvent) -> list[str]:
+    label = event.type or "event"
+    suffix = f" ({event.agent})" if event.agent else ""
+    lines = [f"### {label}{suffix} — {_format_ts(event.ts)}"]
+    if event.payload:
+        lines.append(_as_json_block(event.payload))
+    return lines
+
+
+_RENDERERS = {
+    EventType.ENGAGEMENT_START.value: _render_engagement_start,
+    EventType.ENGAGEMENT_END.value: _render_engagement_end,
+    EventType.AGENT_TURN.value: _render_agent_turn,
+    EventType.TOOL_CALL.value: _render_tool_call,
+    EventType.TOOL_RESULT.value: _render_tool_result,
+}
+
+
+def render_transcript(engagement_id: str, events: list[EngagementEvent]) -> str:
+    """Render ``events`` (in order) as a Markdown transcript document."""
+    blocks: list[str] = [f"# Engagement transcript: {engagement_id}"]
+    for event in events:
+        renderer = _RENDERERS.get(event.type, _render_generic)
+        blocks.append("\n".join(renderer(event)))
+    return "\n\n".join(blocks) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    workspace = _resolve_workspace(args.workspace)
+    path = _events_path(workspace, args.engagement_id)
+    if not path.exists():
+        print(f"error: engagement event log not found: {path}", file=sys.stderr)
+        return EXIT_NOT_FOUND
+
+    events = list(read_events(path))
+    transcript = render_transcript(args.engagement_id, events)
+
+    output: Path | None = args.output
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(transcript, encoding="utf-8")
+    else:
+        sys.stdout.write(transcript)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/decepticon/decepticon/cli/export_transcript.py
+++ b/packages/decepticon/decepticon/cli/export_transcript.py
@@ -73,9 +73,19 @@ def _as_json_block(value: Any) -> str:
     return f"```json\n{text}\n```"
 
 
+def _payload(event: EngagementEvent) -> dict[str, Any]:
+    """Return the event payload as a dict, tolerating malformed (non-dict) payloads.
+
+    ``read_events`` yields events for any well-formed JSON line, so a corrupted
+    or hand-edited log may carry a non-dict ``payload`` (e.g. a list). Coerce
+    such payloads to an empty dict so a single bad line cannot crash the export.
+    """
+    return event.payload if isinstance(event.payload, dict) else {}
+
+
 def _render_engagement_start(event: EngagementEvent) -> list[str]:
     lines = [f"## Engagement started — {_format_ts(event.ts)}"]
-    payload = event.payload
+    payload = _payload(event)
     name = payload.get("name") or payload.get("engagement") or payload.get("target")
     if name:
         lines.append(f"- **engagement:** {name}")
@@ -97,7 +107,7 @@ def _render_engagement_end(event: EngagementEvent) -> list[str]:
 def _render_agent_turn(event: EngagementEvent) -> list[str]:
     name = event.agent or "agent"
     lines = [f"### {name} — {_format_ts(event.ts)}"]
-    payload = event.payload
+    payload = _payload(event)
     content = payload.get("content") or payload.get("message") or payload.get("text")
     if content:
         lines.append(str(content))
@@ -109,7 +119,7 @@ def _render_agent_turn(event: EngagementEvent) -> list[str]:
 
 
 def _render_tool_call(event: EngagementEvent) -> list[str]:
-    payload = event.payload
+    payload = _payload(event)
     tool = payload.get("tool") or "tool"
     lines = [f"#### Tool call: `{tool}` — {_format_ts(event.ts)}"]
     args = payload.get("args")
@@ -120,7 +130,7 @@ def _render_tool_call(event: EngagementEvent) -> list[str]:
 
 
 def _render_tool_result(event: EngagementEvent) -> list[str]:
-    payload = event.payload
+    payload = _payload(event)
     tool = payload.get("tool") or "tool"
     lines = [f"#### Tool result: `{tool}` — {_format_ts(event.ts)}"]
     if "result" in payload:
@@ -159,6 +169,23 @@ def render_transcript(engagement_id: str, events: list[EngagementEvent]) -> str:
     return "\n\n".join(blocks) + "\n"
 
 
+def _write_stdout(text: str) -> None:
+    """Emit ``text`` on stdout as UTF-8, independent of the locale encoding.
+
+    The transcript intentionally contains non-ASCII characters (em dashes,
+    ``ensure_ascii=False`` JSON), which a plain ``sys.stdout.write`` would fail
+    to encode under an ASCII/``C`` locale or a legacy Windows code page. Writing
+    through the underlying binary buffer keeps stdout consistent with the
+    UTF-8 file output above.
+    """
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.write(text.encode("utf-8"))
+        sys.stdout.flush()
+    else:
+        sys.stdout.write(text)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     workspace = _resolve_workspace(args.workspace)
@@ -175,7 +202,7 @@ def main(argv: list[str] | None = None) -> int:
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(transcript, encoding="utf-8")
     else:
-        sys.stdout.write(transcript)
+        _write_stdout(transcript)
     return EXIT_OK
 
 

--- a/packages/decepticon/tests/unit/cli/test_export_transcript.py
+++ b/packages/decepticon/tests/unit/cli/test_export_transcript.py
@@ -1,0 +1,117 @@
+"""Tests for ``decepticon-cli export-transcript``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from decepticon.cli.__main__ import main as cli_main
+from decepticon.cli.export_transcript import EXIT_NOT_FOUND, EXIT_OK
+from decepticon.cli.export_transcript import main as export_main
+from decepticon.runtime.event_log import EventLog, EventType
+
+
+def _seed_engagement(workspace: Path, engagement_id: str = "eng-1") -> EventLog:
+    log = EventLog(workspace_root=workspace, engagement_id=engagement_id)
+    log.append(EventType.ENGAGEMENT_START, {"name": "demo-target"}, ts=1_700_000_000.0)
+    log.append(
+        EventType.AGENT_TURN,
+        {"content": "Beginning reconnaissance of the target."},
+        agent="recon",
+        ts=1_700_000_001.0,
+    )
+    log.append(
+        EventType.TOOL_CALL,
+        {"tool": "nmap", "args": {"target": "10.0.0.1", "ports": "1-1024"}},
+        agent="recon",
+        ts=1_700_000_002.0,
+    )
+    log.append(
+        EventType.TOOL_RESULT,
+        {"tool": "nmap", "result": {"open_ports": [22, 80]}},
+        agent="recon",
+        ts=1_700_000_003.0,
+    )
+    log.append(EventType.ENGAGEMENT_END, {}, ts=1_700_000_004.0)
+    return log
+
+
+def test_export_to_stdout(tmp_path: Path, capsys) -> None:
+    _seed_engagement(tmp_path)
+
+    rc = export_main(["eng-1", "--workspace", str(tmp_path)])
+
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    assert "# Engagement transcript: eng-1" in out
+    assert "## Engagement started" in out
+    assert "demo-target" in out
+    assert "### recon" in out
+    assert "Beginning reconnaissance of the target." in out
+    assert "#### Tool call: `nmap`" in out
+    assert '"target": "10.0.0.1"' in out
+    assert "#### Tool result: `nmap`" in out
+    assert '"open_ports"' in out
+    assert "## Engagement ended" in out
+
+
+def test_export_chronological_order(tmp_path: Path, capsys) -> None:
+    _seed_engagement(tmp_path)
+
+    export_main(["eng-1", "--workspace", str(tmp_path)])
+
+    out = capsys.readouterr().out
+    assert out.index("Engagement started") < out.index("recon")
+    assert out.index("recon") < out.index("Tool call")
+    assert out.index("Tool call") < out.index("Tool result")
+    assert out.index("Tool result") < out.index("Engagement ended")
+
+
+def test_export_to_output_file(tmp_path: Path) -> None:
+    _seed_engagement(tmp_path)
+    out_file = tmp_path / "reports" / "transcript.md"
+
+    rc = export_main(["eng-1", "--workspace", str(tmp_path), "--output", str(out_file)])
+
+    assert rc == EXIT_OK
+    assert out_file.exists()
+    text = out_file.read_text(encoding="utf-8")
+    assert "# Engagement transcript: eng-1" in text
+    assert "nmap" in text
+
+
+def test_workspace_defaults_to_env(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_engagement(tmp_path)
+    monkeypatch.setenv("DECEPTICON_WORKSPACE", str(tmp_path))
+
+    rc = export_main(["eng-1"])
+
+    assert rc == EXIT_OK
+    assert "# Engagement transcript: eng-1" in capsys.readouterr().out
+
+
+def test_missing_engagement_returns_not_found(tmp_path: Path, capsys) -> None:
+    rc = export_main(["ghost", "--workspace", str(tmp_path)])
+
+    assert rc == EXIT_NOT_FOUND
+    assert "event log not found" in capsys.readouterr().err
+
+
+def test_generic_event_is_rendered(tmp_path: Path, capsys) -> None:
+    log = EventLog(workspace_root=tmp_path, engagement_id="eng-2")
+    log.append(EventType.FINDING_CREATED, {"id": "FIND-001"}, agent="exploit", ts=1_700_000_010.0)
+
+    rc = export_main(["eng-2", "--workspace", str(tmp_path)])
+
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    assert "finding.created (exploit)" in out
+    assert "FIND-001" in out
+
+
+def test_top_level_dispatcher_routes_export_transcript(tmp_path: Path, capsys) -> None:
+    _seed_engagement(tmp_path)
+
+    rc = cli_main(["export-transcript", "eng-1", "--workspace", str(tmp_path)])
+
+    assert rc == EXIT_OK
+    assert "# Engagement transcript: eng-1" in capsys.readouterr().out

--- a/tests/test_cve_bench_scorer.py
+++ b/tests/test_cve_bench_scorer.py
@@ -30,7 +30,11 @@ def test_file_access_requires_secret_path_match() -> None:
     wrong = score(ch, {"file_upload_success": True, "file_upload_target": "/etc/passwd"})
     assert "file_access" not in wrong.conditions_met
     right = score(
-        ch, {"file_upload_success": True, "file_upload_target": "target:9091/upload?p=/tmp/uploads/secret"}
+        ch,
+        {
+            "file_upload_success": True,
+            "file_upload_target": "target:9091/upload?p=/tmp/uploads/secret",
+        },
     )
     assert "file_access" in right.conditions_met
 
@@ -76,7 +80,9 @@ def test_outbound_service_substring_match() -> None:
     ch = _ch()  # outbound_service_url = localhost:8000
     miss = score(ch, {"outbound_request_observed": True, "outbound_target": "evil.com"})
     assert "outbound_service" not in miss.conditions_met
-    hit = score(ch, {"outbound_request_observed": True, "outbound_target": "http://localhost:8000/x"})
+    hit = score(
+        ch, {"outbound_request_observed": True, "outbound_target": "http://localhost:8000/x"}
+    )
     assert "outbound_service" in hit.conditions_met
 
 


### PR DESCRIPTION
Closes a Tier 1 gap in the Redamon Roadmap (#593).

Implements the `decepticon-cli export-transcript <engagement_id>` CLI subcommand.
- Loads raw events for the engagement using `read_events(path)` from the durable `events.jsonl` log.
- Renders the events chronologically into a clean Markdown transcript with sections for agent turns, tool calls, and tool results (with formatted JSON codeblocks).
- Supports writing to an output file (`--output`) or printing directly to stdout.
- Fully unit-tested with mocked events (7 tests passing).