### PR TITLE
feat(research): add live JS secret scanner tool

### DIFF
--- a/packages/decepticon/decepticon/tools/research/secret_scanner.py
+++ b/packages/decepticon/decepticon/tools/research/secret_scanner.py
@@ -172,10 +172,11 @@ async def _classify(pattern_name: str, secret: str) -> str:
         return "unvalidated"
     try:
         return "live" if await validate_credential(pattern_name, secret) else "dead"
-    except (httpx.HTTPError, ValueError, KeyError) as exc:
-        # Never log ``exc`` itself: transport errors can embed the request
-        # (and its Authorization header / secret). Log only the type.
-        log.debug("validation probe failed for %s: %s", pattern_name, type(exc).__name__)
+    except (httpx.HTTPError, ValueError, KeyError):
+        # Never reference the exception in the log: transport errors can embed
+        # the request (and its Authorization header / secret). ``pattern_name``
+        # is a static pattern-type key, never the secret itself.
+        log.debug("validation probe failed for pattern %s", pattern_name)
         return "unvalidated"
 
 

--- a/packages/decepticon/decepticon/tools/research/secret_scanner.py
+++ b/packages/decepticon/decepticon/tools/research/secret_scanner.py
@@ -173,7 +173,9 @@ async def _classify(pattern_name: str, secret: str) -> str:
     try:
         return "live" if await validate_credential(pattern_name, secret) else "dead"
     except (httpx.HTTPError, ValueError, KeyError) as exc:
-        log.debug("validation probe failed for %s: %s", pattern_name, exc)
+        # Never log ``exc`` itself: transport errors can embed the request
+        # (and its Authorization header / secret). Log only the type.
+        log.debug("validation probe failed for %s: %s", pattern_name, type(exc).__name__)
         return "unvalidated"
 
 

--- a/packages/decepticon/decepticon/tools/research/secret_scanner.py
+++ b/packages/decepticon/decepticon/tools/research/secret_scanner.py
@@ -47,9 +47,7 @@ SECRET_PATTERNS: dict[str, re.Pattern[str]] = {
     "aws_access_key_id": re.compile(
         r"(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
     ),
-    "aws_secret_access_key": re.compile(
-        r"(?i)aws[^\n]{0,30}?['\"]([A-Za-z0-9/+=]{40})['\"]"
-    ),
+    "aws_secret_access_key": re.compile(r"(?i)aws[^\n]{0,30}?['\"]([A-Za-z0-9/+=]{40})['\"]"),
     "github_token": re.compile(r"gh[pousr]_[A-Za-z0-9]{36}"),
     "github_fine_grained_token": re.compile(r"github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}"),
     "slack_token": re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,48}"),
@@ -62,9 +60,7 @@ SECRET_PATTERNS: dict[str, re.Pattern[str]] = {
     "gitlab_pat": re.compile(r"glpat-[A-Za-z0-9_-]{20}"),
     "twilio_api_key": re.compile(r"SK[0-9a-fA-F]{32}"),
     "sendgrid_api_key": re.compile(r"SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}"),
-    "private_key": re.compile(
-        r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"
-    ),
+    "private_key": re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"),
     "jwt": re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"),
 }
 

--- a/packages/decepticon/decepticon/tools/research/secret_scanner.py
+++ b/packages/decepticon/decepticon/tools/research/secret_scanner.py
@@ -33,6 +33,14 @@ from decepticon.tools.research._state import _json
 
 DEFAULT_TIMEOUT = 8.0
 
+# Upper bound on live-credential probes per scan. ``js_content`` is often
+# attacker-controlled (it is the page we are reconnoitring); without a cap a
+# bundle stuffed with thousands of distinct pattern-matching strings would make
+# the scanner fire one outbound request per string — slow, and a fast way to get
+# our egress IP rate-limited or blocked by the probed APIs. Secrets past the
+# budget are still reported, just left ``unvalidated``.
+MAX_VALIDATION_PROBES = 50
+
 # ── Detection patterns ──────────────────────────────────────────────────
 #
 # High-signal, low-false-positive regexes. Each entry maps a stable
@@ -104,7 +112,13 @@ async def _probe_slack(client: httpx.AsyncClient, secret: str) -> bool:
     )
     if resp.status_code != 200:
         return False
-    return bool(resp.json().get("ok"))
+    data = resp.json()
+    # auth.test returns a JSON object; guard against unexpected shapes so a
+    # non-dict body raises ValueError (caught by _classify) instead of a stray
+    # AttributeError that would abort the whole scan.
+    if not isinstance(data, dict):
+        raise ValueError("slack auth.test returned a non-object body")
+    return bool(data.get("ok"))
 
 
 async def _probe_gitlab(client: httpx.AsyncClient, secret: str) -> bool:
@@ -224,6 +238,7 @@ async def scan_secrets(js_content: str) -> str:
     # Cache probe results so a secret repeated across many lines is only
     # validated once.
     status_cache: dict[tuple[str, str], str] = {}
+    probes_done = 0
 
     for line_no, line in enumerate(js_content.splitlines(), start=1):
         for pattern_name, pattern in SECRET_PATTERNS.items():
@@ -237,7 +252,13 @@ async def scan_secrets(js_content: str) -> str:
                 cache_key = (pattern_name, secret)
                 status = status_cache.get(cache_key)
                 if status is None:
-                    status = await _classify(pattern_name, secret)
+                    if pattern_name in _VALIDATORS and probes_done >= MAX_VALIDATION_PROBES:
+                        # Probe budget exhausted — report without a live check.
+                        status = "unvalidated"
+                    else:
+                        if pattern_name in _VALIDATORS:
+                            probes_done += 1
+                        status = await _classify(pattern_name, secret)
                     status_cache[cache_key] = status
 
                 findings.append(

--- a/packages/decepticon/decepticon/tools/research/secret_scanner.py
+++ b/packages/decepticon/decepticon/tools/research/secret_scanner.py
@@ -30,9 +30,6 @@ import httpx
 from langchain_core.tools import tool
 
 from decepticon.tools.research._state import _json
-from decepticon_core.utils.logging import get_logger
-
-log = get_logger("research.secret_scanner")
 
 DEFAULT_TIMEOUT = 8.0
 
@@ -173,10 +170,10 @@ async def _classify(pattern_name: str, secret: str) -> str:
     try:
         return "live" if await validate_credential(pattern_name, secret) else "dead"
     except (httpx.HTTPError, ValueError, KeyError):
-        # Never reference the exception in the log: transport errors can embed
-        # the request (and its Authorization header / secret). ``pattern_name``
-        # is a static pattern-type key, never the secret itself.
-        log.debug("validation probe failed for pattern %s", pattern_name)
+        # Swallow probe failures and report the credential as unvalidated. We do
+        # NOT log here: the exception can embed the request (and its secret), and
+        # CodeQL conservatively treats any logging sink in this secret-handling
+        # frame as clear-text exposure. Liveness is best-effort by contract.
         return "unvalidated"
 
 

--- a/packages/decepticon/decepticon/tools/research/secret_scanner.py
+++ b/packages/decepticon/decepticon/tools/research/secret_scanner.py
@@ -1,0 +1,256 @@
+"""Live secret scanner for client-side JavaScript.
+
+Front-end bundles routinely leak long-lived credentials — API keys,
+tokens, private keys baked straight into the shipped ``.js``. This module
+provides a single agent-facing tool, :func:`scan_secrets`, that:
+
+1. Matches the supplied JS source against a table of high-signal secret
+   regexes (AWS, GitHub, Slack, OpenAI, Stripe, Google, GitLab, Twilio,
+   SendGrid, generic PEM private keys, JWTs, …).
+2. For the credential types we know how to probe, performs a *real* HTTP
+   call against the issuing API (e.g. ``GET https://api.github.com/user``
+   with the token as a bearer credential) to decide whether the secret is
+   still **live** or already **dead** (revoked / rotated).
+3. Returns a JSON string mapping each finding to its source line number,
+   the pattern that fired, and the validation status (``live`` / ``dead``
+   / ``unvalidated``).
+
+The probe layer is deliberately built on a throwaway :class:`httpx.AsyncClient`
+so the network surface is trivially mockable in tests — patch
+``httpx.AsyncClient`` with a :class:`httpx.MockTransport` and no real egress
+ever happens.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+
+import httpx
+from langchain_core.tools import tool
+
+from decepticon.tools.research._state import _json
+from decepticon_core.utils.logging import get_logger
+
+log = get_logger("research.secret_scanner")
+
+DEFAULT_TIMEOUT = 8.0
+
+# ── Detection patterns ──────────────────────────────────────────────────
+#
+# High-signal, low-false-positive regexes. Each entry maps a stable
+# ``pattern_name`` (used both in the output and to look up a validator) to
+# a compiled pattern. Patterns with a single capture group expose the bare
+# secret in group 1; the rest expose it as the whole match.
+
+SECRET_PATTERNS: dict[str, re.Pattern[str]] = {
+    "aws_access_key_id": re.compile(
+        r"(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
+    ),
+    "aws_secret_access_key": re.compile(
+        r"(?i)aws[^\n]{0,30}?['\"]([A-Za-z0-9/+=]{40})['\"]"
+    ),
+    "github_token": re.compile(r"gh[pousr]_[A-Za-z0-9]{36}"),
+    "github_fine_grained_token": re.compile(r"github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}"),
+    "slack_token": re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,48}"),
+    "slack_webhook": re.compile(
+        r"https://hooks\.slack\.com/services/T[A-Za-z0-9_]+/B[A-Za-z0-9_]+/[A-Za-z0-9_]+"
+    ),
+    "openai_api_key": re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{20,}"),
+    "stripe_api_key": re.compile(r"(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{24,}"),
+    "google_api_key": re.compile(r"AIza[0-9A-Za-z_-]{35}"),
+    "gitlab_pat": re.compile(r"glpat-[A-Za-z0-9_-]{20}"),
+    "twilio_api_key": re.compile(r"SK[0-9a-fA-F]{32}"),
+    "sendgrid_api_key": re.compile(r"SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}"),
+    "private_key": re.compile(
+        r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"
+    ),
+    "jwt": re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"),
+}
+
+
+# ── Validation probes ───────────────────────────────────────────────────
+#
+# Each probe takes a live client + the bare secret and returns True when
+# the issuing API accepts the credential (HTTP 200 / ``ok: true``), False
+# when it is rejected. Probes never swallow transport errors — the caller
+# decides how an unreachable API maps to a status.
+
+_Probe = Callable[[httpx.AsyncClient, str], Awaitable[bool]]
+
+
+async def _probe_github(client: httpx.AsyncClient, secret: str) -> bool:
+    resp = await client.get(
+        "https://api.github.com/user",
+        headers={
+            "Authorization": f"Bearer {secret}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    return resp.status_code == 200
+
+
+async def _probe_openai(client: httpx.AsyncClient, secret: str) -> bool:
+    resp = await client.get(
+        "https://api.openai.com/v1/models",
+        headers={"Authorization": f"Bearer {secret}"},
+    )
+    return resp.status_code == 200
+
+
+async def _probe_stripe(client: httpx.AsyncClient, secret: str) -> bool:
+    # Stripe authenticates with the secret key as HTTP-basic username.
+    resp = await client.get("https://api.stripe.com/v1/account", auth=(secret, ""))
+    return resp.status_code == 200
+
+
+async def _probe_slack(client: httpx.AsyncClient, secret: str) -> bool:
+    resp = await client.post(
+        "https://slack.com/api/auth.test",
+        headers={"Authorization": f"Bearer {secret}"},
+    )
+    if resp.status_code != 200:
+        return False
+    return bool(resp.json().get("ok"))
+
+
+async def _probe_gitlab(client: httpx.AsyncClient, secret: str) -> bool:
+    resp = await client.get(
+        "https://gitlab.com/api/v4/user",
+        headers={"PRIVATE-TOKEN": secret},
+    )
+    return resp.status_code == 200
+
+
+async def _probe_sendgrid(client: httpx.AsyncClient, secret: str) -> bool:
+    resp = await client.get(
+        "https://api.sendgrid.com/v3/scopes",
+        headers={"Authorization": f"Bearer {secret}"},
+    )
+    return resp.status_code == 200
+
+
+# Pattern names that have a live-credential probe. Anything not listed here
+# is reported as ``unvalidated``.
+_VALIDATORS: dict[str, _Probe] = {
+    "github_token": _probe_github,
+    "github_fine_grained_token": _probe_github,
+    "openai_api_key": _probe_openai,
+    "stripe_api_key": _probe_stripe,
+    "slack_token": _probe_slack,
+    "gitlab_pat": _probe_gitlab,
+    "sendgrid_api_key": _probe_sendgrid,
+}
+
+
+async def validate_credential(pattern_name: str, secret: str) -> bool:
+    """Probe ``secret`` against its issuing API and report liveness.
+
+    Performs a single authenticated HTTP request (over a throwaway
+    :class:`httpx.AsyncClient`) against the API that issued the credential
+    type identified by ``pattern_name``.
+
+    Args:
+        pattern_name: A key from :data:`SECRET_PATTERNS` (and
+            :data:`_VALIDATORS`).
+        secret: The bare credential to test.
+
+    Returns:
+        ``True`` if the API accepts the credential (it is live), ``False``
+        if it is rejected (dead/revoked).
+
+    Raises:
+        KeyError: If no probe is registered for ``pattern_name``.
+        httpx.HTTPError: If the probe request fails at the transport layer.
+    """
+    probe = _VALIDATORS.get(pattern_name)
+    if probe is None:
+        raise KeyError(f"no validator registered for pattern: {pattern_name}")
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+        return await probe(client, secret)
+
+
+async def _classify(pattern_name: str, secret: str) -> str:
+    """Resolve the validation status for a single matched secret."""
+    if pattern_name not in _VALIDATORS:
+        return "unvalidated"
+    try:
+        return "live" if await validate_credential(pattern_name, secret) else "dead"
+    except (httpx.HTTPError, ValueError, KeyError) as exc:
+        log.debug("validation probe failed for %s: %s", pattern_name, exc)
+        return "unvalidated"
+
+
+def _extract(pattern: re.Pattern[str], match: re.Match[str]) -> str:
+    """Return the bare secret — capture group 1 when present, else the match."""
+    if pattern.groups >= 1:
+        return match.group(1)
+    return match.group(0)
+
+
+@tool
+async def scan_secrets(js_content: str) -> str:
+    """Scan JavaScript for leaked credentials and probe each for liveness.
+
+    WHEN TO USE: After fetching client-side JS (inline ``<script>`` blocks,
+    bundled ``app.js``, source-map originals). Surfaces hard-coded API
+    keys, tokens, and private keys, and — for credential types we can probe
+    — tells you which ones are *still live* so you can prioritise.
+
+    Detected types include AWS access keys, GitHub tokens, Slack tokens and
+    webhooks, OpenAI/Stripe/Google/GitLab/Twilio/SendGrid keys, generic PEM
+    private keys, and JWTs.
+
+    Args:
+        js_content: Raw JavaScript source to scan.
+
+    Returns:
+        JSON string of the form::
+
+            {
+              "count": <int>,
+              "secrets": [
+                {"secret": "<value>", "line": <int>,
+                 "pattern": "<type>", "status": "live|dead|unvalidated"},
+                ...
+              ]
+            }
+
+        ``status`` is ``live`` / ``dead`` when a probe ran and resolved,
+        and ``unvalidated`` when no probe exists for that type or the probe
+        could not reach the API.
+    """
+    if not js_content:
+        return _json({"count": 0, "secrets": []})
+
+    findings: list[dict[str, object]] = []
+    seen: set[tuple[str, str, int]] = set()
+    # Cache probe results so a secret repeated across many lines is only
+    # validated once.
+    status_cache: dict[tuple[str, str], str] = {}
+
+    for line_no, line in enumerate(js_content.splitlines(), start=1):
+        for pattern_name, pattern in SECRET_PATTERNS.items():
+            for match in pattern.finditer(line):
+                secret = _extract(pattern, match)
+                key = (pattern_name, secret, line_no)
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                cache_key = (pattern_name, secret)
+                status = status_cache.get(cache_key)
+                if status is None:
+                    status = await _classify(pattern_name, secret)
+                    status_cache[cache_key] = status
+
+                findings.append(
+                    {
+                        "secret": secret,
+                        "line": line_no,
+                        "pattern": pattern_name,
+                        "status": status,
+                    }
+                )
+
+    return _json({"count": len(findings), "secrets": findings})

--- a/packages/decepticon/decepticon/tools/research/tools.py
+++ b/packages/decepticon/decepticon/tools/research/tools.py
@@ -35,6 +35,7 @@ from decepticon.tools.research.dedupe import kg_dedupe_findings
 from decepticon.tools.research.health import backend_health
 from decepticon.tools.research.patch import PATCH_TOOLS
 from decepticon.tools.research.sarif import ingest_sarif_file
+from decepticon.tools.research.secret_scanner import scan_secrets
 from decepticon.tools.research.scanner_tools import SCANNER_TOOLS
 from decepticon.tools.reversing.binary import identify_binary
 from decepticon.tools.reversing.packer import detect_packer
@@ -2395,6 +2396,7 @@ RESEARCH_TOOLS = [
     fuzz_harness,
     fuzz_record_crash,
     validate_finding,
+    scan_secrets,
     *SCANNER_TOOLS,
     *PATCH_TOOLS,
 ]

--- a/packages/decepticon/decepticon/tools/research/tools.py
+++ b/packages/decepticon/decepticon/tools/research/tools.py
@@ -35,8 +35,8 @@ from decepticon.tools.research.dedupe import kg_dedupe_findings
 from decepticon.tools.research.health import backend_health
 from decepticon.tools.research.patch import PATCH_TOOLS
 from decepticon.tools.research.sarif import ingest_sarif_file
-from decepticon.tools.research.secret_scanner import scan_secrets
 from decepticon.tools.research.scanner_tools import SCANNER_TOOLS
+from decepticon.tools.research.secret_scanner import scan_secrets
 from decepticon.tools.reversing.binary import identify_binary
 from decepticon.tools.reversing.packer import detect_packer
 from decepticon.tools.reversing.strings import extract_strings, group_by_category

--- a/packages/decepticon/tests/unit/research/test_secret_scanner.py
+++ b/packages/decepticon/tests/unit/research/test_secret_scanner.py
@@ -205,6 +205,39 @@ class TestValidationStatus:
         assert out["count"] == 2
         assert calls["n"] == 1
 
+    async def test_probe_count_capped_on_many_distinct_secrets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = {"n": 0}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, json={})
+
+        _patch_client(monkeypatch, handler)
+        cap = secret_scanner.MAX_VALIDATION_PROBES
+        overflow = 5
+        tokens = [f"ghp_{i:036d}" for i in range(cap + overflow)]
+        js = "\n".join(f"t='{t}'" for t in tokens)
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        # Every distinct secret is still detected and reported...
+        assert out["count"] == cap + overflow
+        # ...but outbound probes are bounded by the budget.
+        assert calls["n"] == cap
+        live = sum(1 for f in out["secrets"] if f["status"] == "live")
+        unval = sum(1 for f in out["secrets"] if f["status"] == "unvalidated")
+        assert live == cap
+        assert unval == overflow
+
+    async def test_slack_non_dict_body_is_unvalidated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A 200 with a non-object JSON body must not abort the scan with a
+        # stray AttributeError; it falls back to unvalidated.
+        _patch_client(monkeypatch, lambda req: httpx.Response(200, json=["unexpected"]))
+        out = _payload(await scan_secrets.ainvoke({"js_content": f"'{SLACK_TOKEN}'"}))
+        assert out["secrets"][0]["status"] == "unvalidated"
+
 
 # ── validate_credential direct ──────────────────────────────────────────
 

--- a/packages/decepticon/tests/unit/research/test_secret_scanner.py
+++ b/packages/decepticon/tests/unit/research/test_secret_scanner.py
@@ -1,0 +1,225 @@
+"""Unit tests for the live JavaScript secret scanner.
+
+All network egress is mocked: probes route through an
+:class:`httpx.MockTransport` injected into the module's
+``httpx.AsyncClient`` constructor, so no real HTTP ever happens.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable
+
+import httpx
+import pytest
+
+from decepticon.tools.research import secret_scanner
+from decepticon.tools.research.secret_scanner import (
+    SECRET_PATTERNS,
+    scan_secrets,
+    validate_credential,
+)
+
+# ── Sample credentials (synthetic, never live) ──────────────────────────
+
+GITHUB_TOKEN = "ghp_" + "a" * 36
+GITHUB_FG_TOKEN = "github_pat_" + "A" * 22 + "_" + "b" * 59
+SLACK_TOKEN = "xoxb-" + "1" * 24
+OPENAI_KEY = "sk-" + "A" * 40
+STRIPE_KEY = "sk_live_" + "0" * 30
+GOOGLE_KEY = "AIza" + "B" * 35
+GITLAB_PAT = "glpat-" + "c" * 20
+TWILIO_KEY = "SK" + "a1b2c3d4" * 4  # 32 hex chars
+SENDGRID_KEY = "SG." + "a" * 22 + "." + "b" * 43
+AWS_KEY_ID = "AKIA" + "ABCDEFGH12345678"  # AKIA + 16
+AWS_SECRET = "x" * 40
+# Built from fragments so the full webhook URL never appears contiguously in
+# source (keeps GitHub push-protection happy); the runtime value still matches.
+_SLACK_HOST = "https://hooks.slack.com/services"
+SLACK_WEBHOOK = _SLACK_HOST + "/T00000000" + "/B11111111" + "/" + "0" * 24
+PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----"
+JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N"
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    """Wire every ``httpx.AsyncClient`` in the scanner to a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+
+    def factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(secret_scanner.httpx, "AsyncClient", factory)
+
+
+def _payload(raw: str) -> dict:
+    return json.loads(raw)
+
+
+# ── Pattern coverage / detection (no network needed) ────────────────────
+
+
+class TestPatternTable:
+    def test_at_least_ten_patterns(self) -> None:
+        assert len(SECRET_PATTERNS) >= 10
+
+    @pytest.mark.parametrize(
+        ("name", "sample"),
+        [
+            ("aws_access_key_id", AWS_KEY_ID),
+            ("github_token", GITHUB_TOKEN),
+            ("github_fine_grained_token", GITHUB_FG_TOKEN),
+            ("slack_token", SLACK_TOKEN),
+            ("slack_webhook", SLACK_WEBHOOK),
+            ("openai_api_key", OPENAI_KEY),
+            ("stripe_api_key", STRIPE_KEY),
+            ("google_api_key", GOOGLE_KEY),
+            ("gitlab_pat", GITLAB_PAT),
+            ("twilio_api_key", TWILIO_KEY),
+            ("sendgrid_api_key", SENDGRID_KEY),
+            ("private_key", PRIVATE_KEY),
+            ("jwt", JWT),
+        ],
+    )
+    def test_each_pattern_matches_its_sample(self, name: str, sample: str) -> None:
+        assert SECRET_PATTERNS[name].search(sample) is not None
+
+
+class TestDetection:
+    async def test_detects_unvalidated_secret_with_line_number(self) -> None:
+        js = f"var a = 1;\nconst key = '{GOOGLE_KEY}';\n"
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        assert out["count"] == 1
+        finding = out["secrets"][0]
+        assert finding["pattern"] == "google_api_key"
+        assert finding["line"] == 2
+        assert finding["secret"] == GOOGLE_KEY
+        # No probe is registered for Google keys.
+        assert finding["status"] == "unvalidated"
+
+    async def test_capture_group_extracts_bare_aws_secret(self) -> None:
+        js = f'aws_secret_key = "{AWS_SECRET}"'
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        finding = next(f for f in out["secrets"] if f["pattern"] == "aws_secret_access_key")
+        # Bare 40-char secret, not the surrounding quotes/assignment.
+        assert finding["secret"] == AWS_SECRET
+
+    async def test_clean_content_yields_no_findings(self) -> None:
+        js = "function add(a, b) { return a + b; }\nconst x = 'hello world';"
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        assert out["count"] == 0
+        assert out["secrets"] == []
+
+    async def test_empty_input(self) -> None:
+        out = _payload(await scan_secrets.ainvoke({"js_content": ""}))
+        assert out == {"count": 0, "secrets": []}
+
+    async def test_multiple_distinct_secrets(self) -> None:
+        js = f"a='{GOOGLE_KEY}'\nb='{PRIVATE_KEY}'\nc='{TWILIO_KEY}'"
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        patterns = {f["pattern"] for f in out["secrets"]}
+        assert {"google_api_key", "private_key", "twilio_api_key"} <= patterns
+
+
+# ── Validation status via mocked probes ─────────────────────────────────
+
+
+class TestValidationStatus:
+    async def test_github_live(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, lambda req: httpx.Response(200, json={"login": "x"}))
+        js = f"const t = '{GITHUB_TOKEN}'"
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        assert out["secrets"][0]["status"] == "live"
+
+    async def test_github_dead(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, lambda req: httpx.Response(401, json={"message": "Bad"}))
+        js = f"const t = '{GITHUB_TOKEN}'"
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        assert out["secrets"][0]["status"] == "dead"
+
+    async def test_github_sends_bearer_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, str] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["auth"] = req.headers.get("Authorization", "")
+            seen["url"] = str(req.url)
+            return httpx.Response(200, json={})
+
+        _patch_client(monkeypatch, handler)
+        await scan_secrets.ainvoke({"js_content": f"'{GITHUB_TOKEN}'"})
+        assert seen["auth"] == f"Bearer {GITHUB_TOKEN}"
+        assert seen["url"] == "https://api.github.com/user"
+
+    async def test_slack_ok_true_is_live(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, lambda req: httpx.Response(200, json={"ok": True}))
+        out = _payload(await scan_secrets.ainvoke({"js_content": f"'{SLACK_TOKEN}'"}))
+        assert out["secrets"][0]["status"] == "live"
+
+    async def test_slack_ok_false_is_dead(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(
+            monkeypatch,
+            lambda req: httpx.Response(200, json={"ok": False, "error": "invalid_auth"}),
+        )
+        out = _payload(await scan_secrets.ainvoke({"js_content": f"'{SLACK_TOKEN}'"}))
+        assert out["secrets"][0]["status"] == "dead"
+
+    async def test_stripe_uses_basic_auth_username(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict[str, str] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["auth"] = req.headers.get("Authorization", "")
+            return httpx.Response(200, json={})
+
+        _patch_client(monkeypatch, handler)
+        out = _payload(await scan_secrets.ainvoke({"js_content": f"'{STRIPE_KEY}'"}))
+        assert out["secrets"][0]["status"] == "live"
+        assert seen["auth"].startswith("Basic ")
+
+    async def test_unreachable_api_falls_back_to_unvalidated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("refused")
+
+        _patch_client(monkeypatch, handler)
+        out = _payload(await scan_secrets.ainvoke({"js_content": f"'{GITHUB_TOKEN}'"}))
+        assert out["secrets"][0]["status"] == "unvalidated"
+
+    async def test_validated_secret_probed_once_when_repeated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = {"n": 0}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, json={})
+
+        _patch_client(monkeypatch, handler)
+        js = f"line1 = '{GITHUB_TOKEN}'\nline2 = '{GITHUB_TOKEN}'"
+        out = _payload(await scan_secrets.ainvoke({"js_content": js}))
+        # Same token on two lines -> two findings, one probe (cached).
+        assert out["count"] == 2
+        assert calls["n"] == 1
+
+
+# ── validate_credential direct ──────────────────────────────────────────
+
+
+class TestValidateCredential:
+    async def test_returns_true_on_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, lambda req: httpx.Response(200, json={}))
+        assert await validate_credential("github_token", GITHUB_TOKEN) is True
+
+    async def test_returns_false_on_403(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, lambda req: httpx.Response(403, json={}))
+        assert await validate_credential("openai_api_key", OPENAI_KEY) is False
+
+    async def test_unknown_pattern_raises(self) -> None:
+        with pytest.raises(KeyError):
+            await validate_credential("google_api_key", GOOGLE_KEY)

--- a/packages/decepticon/tests/unit/research/test_secret_scanner.py
+++ b/packages/decepticon/tests/unit/research/test_secret_scanner.py
@@ -167,9 +167,7 @@ class TestValidationStatus:
         out = _payload(await scan_secrets.ainvoke({"js_content": f"'{SLACK_TOKEN}'"}))
         assert out["secrets"][0]["status"] == "dead"
 
-    async def test_stripe_uses_basic_auth_username(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_stripe_uses_basic_auth_username(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: dict[str, str] = {}
 
         def handler(req: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
Closes a Tier 2 gap in the Redamon Roadmap (#593).

Adds the `scan_secrets(js_content)` async `@tool` for front-end JS bundle auditing.
- Scans JS content for sensitive keys and credentials using 14 distinct regex patterns (AWS keys, GitHub tokens, Slack tokens/webhooks, OpenAI API keys, Stripe API keys, private keys, JWTs, etc.).
- Implements `validate_credential` supporting live vendor HTTP probes for GitHub tokens/PATs, OpenAI keys, Stripe keys, Slack tokens, GitLab tokens, and SendGrid keys.
- Network calls are fully mocked via `httpx.MockTransport`.
- Returns a JSON payload showing the line number, pattern, and status (`live` / `dead` / `unvalidated`) of each secret.
- Fully unit-tested (30 tests passing).