### PR TITLE
feat(cli): add zip export/import for engagement workspaces

### DIFF
--- a/packages/decepticon/decepticon/cli/__main__.py
+++ b/packages/decepticon/decepticon/cli/__main__.py
@@ -7,6 +7,7 @@ import sys
 from decepticon.cli.audit import main as audit_main
 from decepticon.cli.auth import main as auth_main
 from decepticon.cli.scan import main as scan_main
+from decepticon.cli.zip import main as zip_main
 
 
 def _print_help() -> int:
@@ -15,7 +16,8 @@ def _print_help() -> int:
         "Subcommands:\n"
         "  scan    Run a one-shot security scan and emit SARIF\n"
         "  auth    Show provider/auth configuration (API keys + subscriptions)\n\n"
-        "  audit   Verify engagement audit ledgers\n\n"
+        "  audit   Verify engagement audit ledgers\n"
+        "  zip     Export/import engagement workspaces as ZIP archives\n\n"
         "Run a subcommand with --help for its flags.",
         file=sys.stderr,
     )
@@ -34,6 +36,8 @@ def main(argv: list[str] | None = None) -> int:
         return auth_main(rest)
     if sub == "audit":
         return audit_main(rest)
+    if sub == "zip":
+        return zip_main(rest)
     print(f"unknown subcommand: {sub}\n", file=sys.stderr)
     _print_help()
     return 2

--- a/packages/decepticon/decepticon/cli/zip.py
+++ b/packages/decepticon/decepticon/cli/zip.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
+import stat
 import sys
 import zipfile
 from pathlib import Path
@@ -83,6 +85,11 @@ def _build_parser() -> argparse.ArgumentParser:
             "<workspace>/engagements/<id>. Defaults to $DECEPTICON_ENGAGEMENT_WORKSPACE."
         ),
     )
+    imp.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing engagement directory instead of failing.",
+    )
     return p
 
 
@@ -120,9 +127,11 @@ def export_engagement(engagement_id: str, workspace: Path, output: Path) -> int:
 def _safe_members(zf: zipfile.ZipFile, dest_root: Path) -> tuple[set[str], list[zipfile.ZipInfo]]:
     """Validate archive entries and return (engagement_ids, members).
 
-    Rejects absolute paths and ``..`` traversal so a malicious archive cannot
-    escape ``dest_root``. Returns the set of top-level engagement ids found.
+    Rejects absolute paths, ``..`` traversal and symlink entries so a malicious
+    archive cannot escape ``dest_root`` or plant links pointing outside it.
+    Returns the set of top-level engagement ids found.
     """
+    dest_resolved = dest_root.resolve()
     engagement_ids: set[str] = set()
     members: list[zipfile.ZipInfo] = []
     for info in zf.infolist():
@@ -132,19 +141,24 @@ def _safe_members(zf: zipfile.ZipFile, dest_root: Path) -> tuple[set[str], list[
             continue
         if Path(name).is_absolute() or ".." in parts:
             raise ValueError(f"unsafe path in archive: {name}")
+        if stat.S_ISLNK(info.external_attr >> 16):
+            raise ValueError(f"symlink entry not allowed in archive: {name}")
         target = (dest_root / name).resolve()
-        if not str(target).startswith(str(dest_root.resolve())):
+        if target != dest_resolved and not target.is_relative_to(dest_resolved):
             raise ValueError(f"path escapes destination: {name}")
         engagement_ids.add(parts[0])
         members.append(info)
     return engagement_ids, members
 
 
-def import_engagement(archive: Path, workspace: Path) -> tuple[str, int]:
+def import_engagement(archive: Path, workspace: Path, force: bool = False) -> tuple[str, int]:
     """Restore ``archive`` under ``<workspace>/engagements/``.
 
     Returns ``(engagement_id, files_restored)``. Verifies every archived
-    regular file exists on disk after extraction.
+    regular file exists on disk after extraction. Refuses to clobber an
+    existing engagement unless ``force`` is set, in which case the existing
+    directory is removed first so the restore is a clean replacement rather
+    than a merge with stale files.
     """
     if not archive.is_file():
         raise FileNotFoundError(f"archive not found: {archive}")
@@ -161,12 +175,21 @@ def import_engagement(archive: Path, workspace: Path) -> tuple[str, int]:
                 f"archive must contain exactly one engagement, found: {sorted(engagement_ids)}"
             )
         (engagement_id,) = tuple(engagement_ids)
+
+        existing = dest_root / engagement_id
+        if existing.exists() or existing.is_symlink():
+            if not force:
+                raise ValueError(
+                    f"engagement already exists: {existing} (use --force to overwrite)"
+                )
+            if existing.is_dir() and not existing.is_symlink():
+                shutil.rmtree(existing)
+            else:
+                existing.unlink()
+
+        restored = 0
         for info in members:
             zf.extract(info, dest_root)
-
-    restored = 0
-    with zipfile.ZipFile(archive, "r") as zf:
-        for info in zf.infolist():
             if info.is_dir():
                 continue
             extracted = dest_root / info.filename
@@ -197,7 +220,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "import":
         try:
-            engagement_id, restored = import_engagement(args.archive, workspace)
+            engagement_id, restored = import_engagement(args.archive, workspace, args.force)
         except FileNotFoundError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return EXIT_CONFIG

--- a/packages/decepticon/decepticon/cli/zip.py
+++ b/packages/decepticon/decepticon/cli/zip.py
@@ -1,0 +1,216 @@
+"""``decepticon-cli zip`` - package and restore engagement workspaces.
+
+An engagement's durable state lives under ``<workspace>/engagements/<id>/``
+(``events.jsonl``, persisted knowledge graphs, planning documents, the RoE
+audit ledger). Operators need to hand a finished engagement to a teammate,
+archive it off the runner, or move it between hosts. This command turns that
+directory into a single portable ZIP and restores it on the far side.
+
+Subcommands
+-----------
+- ``export`` — zip ``<workspace>/engagements/<id>/`` into a ``.zip`` file.
+  Archive entries are stored under a top-level ``<id>/`` prefix so the file
+  is self-describing and round-trips cleanly through ``import``.
+- ``import`` — restore an exported ZIP back under a workspace's
+  ``engagements/`` directory, then verify every archived file landed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_CONFIG = 2
+
+
+def _default_workspace() -> Path | None:
+    value = os.environ.get("DECEPTICON_ENGAGEMENT_WORKSPACE")
+    return Path(value) if value else None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="decepticon-cli zip",
+        description="Package and restore Decepticon engagement workspaces.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    export = sub.add_parser(
+        "export",
+        help="Zip an engagement directory into a portable .zip archive.",
+    )
+    export.add_argument(
+        "engagement_id",
+        help="Engagement identifier; the directory <workspace>/engagements/<id> is archived.",
+    )
+    export.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        help=(
+            "Workspace root containing the engagements/ directory. "
+            "Defaults to $DECEPTICON_ENGAGEMENT_WORKSPACE."
+        ),
+    )
+    export.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        required=True,
+        help="Destination path for the .zip archive.",
+    )
+
+    imp = sub.add_parser(
+        "import",
+        help="Restore an exported engagement .zip under a workspace.",
+    )
+    imp.add_argument(
+        "archive",
+        type=Path,
+        help="Path to an engagement .zip produced by `zip export`.",
+    )
+    imp.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        help=(
+            "Workspace root to restore into; the engagement lands under "
+            "<workspace>/engagements/<id>. Defaults to $DECEPTICON_ENGAGEMENT_WORKSPACE."
+        ),
+    )
+    return p
+
+
+def _resolve_workspace(arg_value: Path | None) -> Path | None:
+    return arg_value if arg_value is not None else _default_workspace()
+
+
+def export_engagement(engagement_id: str, workspace: Path, output: Path) -> int:
+    """Zip ``<workspace>/engagements/<engagement_id>/`` into ``output``.
+
+    Archive entries are stored relative to ``engagements/`` so the top-level
+    directory inside the ZIP is ``<engagement_id>/``. Returns the number of
+    files written.
+    """
+    source = workspace / "engagements" / engagement_id
+    if not source.is_dir():
+        raise FileNotFoundError(f"engagement directory not found: {source}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    base = source.parent  # <workspace>/engagements
+    count = 0
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(source.rglob("*")):
+            arcname = path.relative_to(base).as_posix()
+            if path.is_dir():
+                # Preserve empty directories explicitly.
+                if not any(path.iterdir()):
+                    zf.writestr(arcname + "/", "")
+                continue
+            zf.write(path, arcname)
+            count += 1
+    return count
+
+
+def _safe_members(zf: zipfile.ZipFile, dest_root: Path) -> tuple[set[str], list[zipfile.ZipInfo]]:
+    """Validate archive entries and return (engagement_ids, members).
+
+    Rejects absolute paths and ``..`` traversal so a malicious archive cannot
+    escape ``dest_root``. Returns the set of top-level engagement ids found.
+    """
+    engagement_ids: set[str] = set()
+    members: list[zipfile.ZipInfo] = []
+    for info in zf.infolist():
+        name = info.filename
+        parts = Path(name).parts
+        if not parts:
+            continue
+        if Path(name).is_absolute() or ".." in parts:
+            raise ValueError(f"unsafe path in archive: {name}")
+        target = (dest_root / name).resolve()
+        if not str(target).startswith(str(dest_root.resolve())):
+            raise ValueError(f"path escapes destination: {name}")
+        engagement_ids.add(parts[0])
+        members.append(info)
+    return engagement_ids, members
+
+
+def import_engagement(archive: Path, workspace: Path) -> tuple[str, int]:
+    """Restore ``archive`` under ``<workspace>/engagements/``.
+
+    Returns ``(engagement_id, files_restored)``. Verifies every archived
+    regular file exists on disk after extraction.
+    """
+    if not archive.is_file():
+        raise FileNotFoundError(f"archive not found: {archive}")
+    if not zipfile.is_zipfile(archive):
+        raise ValueError(f"not a valid ZIP archive: {archive}")
+
+    dest_root = workspace / "engagements"
+    dest_root.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(archive, "r") as zf:
+        engagement_ids, members = _safe_members(zf, dest_root)
+        if len(engagement_ids) != 1:
+            raise ValueError(
+                f"archive must contain exactly one engagement, found: {sorted(engagement_ids)}"
+            )
+        (engagement_id,) = tuple(engagement_ids)
+        for info in members:
+            zf.extract(info, dest_root)
+
+    restored = 0
+    with zipfile.ZipFile(archive, "r") as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            extracted = dest_root / info.filename
+            if not extracted.is_file():
+                raise RuntimeError(f"restore verification failed for: {info.filename}")
+            restored += 1
+    return engagement_id, restored
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    workspace = _resolve_workspace(args.workspace)
+    if workspace is None:
+        print(
+            "error: workspace not set; pass --workspace or "
+            "$DECEPTICON_ENGAGEMENT_WORKSPACE",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG
+
+    if args.command == "export":
+        try:
+            count = export_engagement(args.engagement_id, workspace, args.output)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return EXIT_CONFIG
+        print(f"exported {count} file(s) from engagement {args.engagement_id} to {args.output}")
+        return EXIT_OK
+
+    if args.command == "import":
+        try:
+            engagement_id, restored = import_engagement(args.archive, workspace)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return EXIT_CONFIG
+        except (ValueError, RuntimeError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+        dest = workspace / "engagements" / engagement_id
+        print(f"imported engagement {engagement_id} ({restored} file(s)) to {dest}")
+        return EXIT_OK
+
+    return EXIT_CONFIG
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/decepticon/decepticon/cli/zip.py
+++ b/packages/decepticon/decepticon/cli/zip.py
@@ -181,8 +181,7 @@ def main(argv: list[str] | None = None) -> int:
     workspace = _resolve_workspace(args.workspace)
     if workspace is None:
         print(
-            "error: workspace not set; pass --workspace or "
-            "$DECEPTICON_ENGAGEMENT_WORKSPACE",
+            "error: workspace not set; pass --workspace or $DECEPTICON_ENGAGEMENT_WORKSPACE",
             file=sys.stderr,
         )
         return EXIT_CONFIG

--- a/packages/decepticon/tests/unit/cli/test_zip.py
+++ b/packages/decepticon/tests/unit/cli/test_zip.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 import zipfile
 from pathlib import Path
 
@@ -167,3 +168,51 @@ def test_top_level_dispatcher_routes_zip(tmp_path: Path) -> None:
 
     assert rc == EXIT_OK
     assert archive.is_file()
+
+
+def test_import_rejects_symlink_entry(tmp_path: Path, capsys) -> None:
+    malicious = tmp_path / "link.zip"
+    with zipfile.ZipFile(malicious, "w") as zf:
+        info = zipfile.ZipInfo("acme-2026/link")
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        zf.writestr(info, "/etc/passwd")
+
+    rc = zip_main(["import", str(malicious), "--workspace", str(tmp_path / "ws")])
+
+    assert rc == EXIT_ERROR
+    assert "symlink entry not allowed" in capsys.readouterr().err
+    assert not (tmp_path / "ws" / "engagements" / "acme-2026" / "link").exists()
+
+
+def test_import_refuses_overwrite_without_force(tmp_path: Path, capsys) -> None:
+    src_ws = tmp_path / "src"
+    _seed_engagement(src_ws)
+    archive = tmp_path / "acme.zip"
+    export_engagement("acme-2026", src_ws, archive)
+
+    dst_ws = tmp_path / "dst"
+    import_engagement(archive, dst_ws)
+
+    rc = zip_main(["import", str(archive), "--workspace", str(dst_ws)])
+
+    assert rc == EXIT_ERROR
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_import_force_replaces_stale_files(tmp_path: Path) -> None:
+    src_ws = tmp_path / "src"
+    _seed_engagement(src_ws)
+    archive = tmp_path / "acme.zip"
+    export_engagement("acme-2026", src_ws, archive)
+
+    dst_ws = tmp_path / "dst"
+    import_engagement(archive, dst_ws)
+    stale = dst_ws / "engagements" / "acme-2026" / "stale.txt"
+    stale.write_text("leftover", encoding="utf-8")
+
+    engagement_id, restored = import_engagement(archive, dst_ws, force=True)
+
+    assert engagement_id == "acme-2026"
+    assert restored == 3
+    assert not stale.exists()
+    assert (dst_ws / "engagements" / "acme-2026" / "events.jsonl").is_file()

--- a/packages/decepticon/tests/unit/cli/test_zip.py
+++ b/packages/decepticon/tests/unit/cli/test_zip.py
@@ -1,0 +1,169 @@
+"""Tests for ``decepticon-cli zip``."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from decepticon.cli.__main__ import main as cli_main
+from decepticon.cli.zip import (
+    EXIT_CONFIG,
+    EXIT_ERROR,
+    EXIT_OK,
+    export_engagement,
+    import_engagement,
+)
+from decepticon.cli.zip import main as zip_main
+
+
+def _seed_engagement(workspace: Path, engagement_id: str = "acme-2026") -> Path:
+    """Create a realistic engagement directory tree under ``workspace``."""
+    eng = workspace / "engagements" / engagement_id
+    (eng / "kg").mkdir(parents=True)
+    (eng / "audit").mkdir(parents=True)
+    (eng / "events.jsonl").write_text('{"event": "start"}\n', encoding="utf-8")
+    (eng / "kg" / "graph.json").write_text('{"nodes": []}', encoding="utf-8")
+    (eng / "audit" / "roe-decisions.jsonl").write_text('{"decision": "allow"}\n', encoding="utf-8")
+    return eng
+
+
+def test_export_creates_archive_with_engagement_prefix(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    _seed_engagement(ws)
+    out = tmp_path / "out" / "acme.zip"
+
+    count = export_engagement("acme-2026", ws, out)
+
+    assert count == 3
+    assert out.is_file()
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+    assert "acme-2026/events.jsonl" in names
+    assert "acme-2026/kg/graph.json" in names
+    assert "acme-2026/audit/roe-decisions.jsonl" in names
+
+
+def test_export_missing_engagement_raises(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    (ws / "engagements").mkdir(parents=True)
+    try:
+        export_engagement("nope", ws, tmp_path / "x.zip")
+    except FileNotFoundError as exc:
+        assert "engagement directory not found" in str(exc)
+    else:  # pragma: no cover - guard
+        raise AssertionError("expected FileNotFoundError")
+
+
+def test_import_restores_files(tmp_path: Path) -> None:
+    src_ws = tmp_path / "src"
+    _seed_engagement(src_ws)
+    archive = tmp_path / "acme.zip"
+    export_engagement("acme-2026", src_ws, archive)
+
+    dst_ws = tmp_path / "dst"
+    engagement_id, restored = import_engagement(archive, dst_ws)
+
+    assert engagement_id == "acme-2026"
+    assert restored == 3
+    eng = dst_ws / "engagements" / "acme-2026"
+    assert (eng / "events.jsonl").read_text(encoding="utf-8") == '{"event": "start"}\n'
+    assert (eng / "kg" / "graph.json").is_file()
+    assert (eng / "audit" / "roe-decisions.jsonl").is_file()
+
+
+def test_export_import_round_trip_via_cli(tmp_path: Path) -> None:
+    src_ws = tmp_path / "src"
+    _seed_engagement(src_ws)
+    archive = tmp_path / "acme.zip"
+
+    rc = zip_main(["export", "acme-2026", "--workspace", str(src_ws), "-o", str(archive)])
+    assert rc == EXIT_OK
+    assert archive.is_file()
+
+    dst_ws = tmp_path / "dst"
+    rc = zip_main(["import", str(archive), "--workspace", str(dst_ws)])
+    assert rc == EXIT_OK
+    assert (dst_ws / "engagements" / "acme-2026" / "events.jsonl").is_file()
+
+
+def test_workspace_falls_back_to_env(tmp_path: Path, monkeypatch) -> None:
+    ws = tmp_path / "ws"
+    _seed_engagement(ws)
+    archive = tmp_path / "acme.zip"
+    monkeypatch.setenv("DECEPTICON_ENGAGEMENT_WORKSPACE", str(ws))
+
+    rc = zip_main(["export", "acme-2026", "-o", str(archive)])
+
+    assert rc == EXIT_OK
+    assert archive.is_file()
+
+
+def test_missing_workspace_is_config_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.delenv("DECEPTICON_ENGAGEMENT_WORKSPACE", raising=False)
+
+    rc = zip_main(["export", "acme-2026", "-o", str(tmp_path / "x.zip")])
+
+    assert rc == EXIT_CONFIG
+    assert "workspace not set" in capsys.readouterr().err
+
+
+def test_export_unknown_engagement_is_config_error(tmp_path: Path, capsys) -> None:
+    ws = tmp_path / "ws"
+    (ws / "engagements").mkdir(parents=True)
+
+    rc = zip_main(["export", "ghost", "--workspace", str(ws), "-o", str(tmp_path / "x.zip")])
+
+    assert rc == EXIT_CONFIG
+    assert "engagement directory not found" in capsys.readouterr().err
+
+
+def test_import_missing_archive_is_config_error(tmp_path: Path, capsys) -> None:
+    rc = zip_main(["import", str(tmp_path / "absent.zip"), "--workspace", str(tmp_path / "ws")])
+
+    assert rc == EXIT_CONFIG
+    assert "archive not found" in capsys.readouterr().err
+
+
+def test_import_non_zip_is_error(tmp_path: Path, capsys) -> None:
+    bogus = tmp_path / "bogus.zip"
+    bogus.write_text("not a zip", encoding="utf-8")
+
+    rc = zip_main(["import", str(bogus), "--workspace", str(tmp_path / "ws")])
+
+    assert rc == EXIT_ERROR
+    assert "not a valid ZIP archive" in capsys.readouterr().err
+
+
+def test_import_rejects_path_traversal(tmp_path: Path, capsys) -> None:
+    malicious = tmp_path / "evil.zip"
+    with zipfile.ZipFile(malicious, "w") as zf:
+        zf.writestr("../escape.txt", "pwned")
+
+    rc = zip_main(["import", str(malicious), "--workspace", str(tmp_path / "ws")])
+
+    assert rc == EXIT_ERROR
+    assert "unsafe path" in capsys.readouterr().err
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_import_rejects_multiple_engagements(tmp_path: Path, capsys) -> None:
+    multi = tmp_path / "multi.zip"
+    with zipfile.ZipFile(multi, "w") as zf:
+        zf.writestr("eng-a/events.jsonl", "{}\n")
+        zf.writestr("eng-b/events.jsonl", "{}\n")
+
+    rc = zip_main(["import", str(multi), "--workspace", str(tmp_path / "ws")])
+
+    assert rc == EXIT_ERROR
+    assert "exactly one engagement" in capsys.readouterr().err
+
+
+def test_top_level_dispatcher_routes_zip(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    _seed_engagement(ws)
+    archive = tmp_path / "acme.zip"
+
+    rc = cli_main(["zip", "export", "acme-2026", "--workspace", str(ws), "-o", str(archive)])
+
+    assert rc == EXIT_OK
+    assert archive.is_file()


### PR DESCRIPTION
Closes a Tier 2 gap in the Redamon Roadmap (#593).

Adds the `decepticon-cli zip export` and `decepticon-cli zip import` CLI subcommands.
- `export`: packages the entire engagement workspace directory (containing `events.jsonl`, knowledge graphs, plans, and audit ledgers) into a clean `.zip` archive.
- `import`: extracts the engagement zip archive safely under the specified workspace, validating paths against path traversal vulnerabilities (`_safe_members`) and verifying integrity post-restoration.
- Fully unit-tested (12 tests passing).