### PR TITLE
fix(budget): wire spend enforcement via LiteLLM /spend/tags API

### DIFF
--- a/packages/decepticon/decepticon/middleware/budget.py
+++ b/packages/decepticon/decepticon/middleware/budget.py
@@ -3,7 +3,7 @@
 Decepticon engagements can spin for hours with multiple specialist sub-agents
 running in parallel, each driving an expensive frontier model. The
 LiteLLM-only timeout knob (``DECEPTICON_LLM__TIMEOUT``) is necessary but not
-sufficient — a long-running engagement on ``claude-opus-4-7 → fallback →
+sufficient — a long-running engagement on ``claude-opus-4-8 → fallback →
 fallback`` can quietly accrue hundreds of dollars in spend before a human
 operator notices.
 
@@ -14,10 +14,13 @@ This middleware exposes a single financial guardrail::
     DECEPTICON_BUDGET__SOFT_WARN_AT_PCT  emit a stream warning at this fraction
     DECEPTICON_BUDGET__POLL_SECONDS      how often to re-query LiteLLM
 
-Spend numbers come from LiteLLM's ``spend_logs`` table — already populated
-by the proxy on every completion. We query it lazily before each model call;
-the lookup is one row per agent (cheap, indexed) and is cached for the poll
-interval so we don't hammer Postgres on tight inference loops.
+Spend numbers come from the LiteLLM proxy's ``/spend/tags`` API. The
+middleware tags every outbound completion with its scope keys
+(``engagement:<slug>`` and ``agent:<slug>:<agent>`` via request
+``metadata.tags``), the proxy records them in its spend logs, and
+``/spend/tags`` returns the cumulative USD total per tag. We query it
+lazily before each model call and cache for the poll interval so we
+don't hammer the proxy on tight inference loops.
 
 Enforcement
 -----------
@@ -37,8 +40,11 @@ preserves the current behavior for users who haven't opted in.
 
 Architectural notes
 -------------------
-- LiteLLM virtual-key spend is the source of truth, NOT a local counter. A
+- LiteLLM proxy spend is the source of truth, NOT a local counter. A
   local counter would drift on crash/restart; LiteLLM persists every call.
+- Spend attribution rides the documented proxy API (``metadata.tags`` in,
+  ``/spend/tags`` out) rather than SQL against LiteLLM's internal Prisma
+  tables, so proxy upgrades can't break enforcement on a schema change.
 - The middleware does NOT block tool calls — only LLM calls. The agent can
   finish whatever tool round-trip is in flight and emit a final synthesis
   message before the next inference fails.
@@ -46,10 +52,10 @@ Architectural notes
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
-from contextlib import closing
 from typing import Any, ClassVar
 
 from langchain.agents.middleware import AgentMiddleware
@@ -87,7 +93,7 @@ class _SpendCache:
 
     Bounded at ``_MAX_ENTRIES`` so a runaway agent-id-explosion can't grow
     memory unbounded. Entries are evicted in insertion order (FIFO) on
-    overflow — cache misses cost one extra LiteLLM SQL round-trip, not
+    overflow — cache misses cost one extra LiteLLM proxy round-trip, not
     correctness, so FIFO is fine.
     """
 
@@ -145,9 +151,9 @@ class BudgetEnforcementMiddleware(AgentMiddleware):
     from request metadata each call). Spend numbers are pulled from the
     injected ``spend_provider`` callable, which is expected to return the
     cumulative USD spend for a given scope key. The default provider
-    queries LiteLLM Postgres via the connection string in
-    ``DATABASE_URL``; injecting a stub provider makes this trivially
-    unit-testable.
+    queries the LiteLLM proxy ``/spend/tags`` API using the same proxy
+    URL/key the LLM factory resolves; injecting a stub provider makes
+    this trivially unit-testable.
     """
 
     def __init__(
@@ -241,52 +247,83 @@ class BudgetEnforcementMiddleware(AgentMiddleware):
         self._check_one("engagement", f"engagement:{engagement}", self._engagement_cap)
         self._check_one("agent", f"agent:{engagement}:{agent}", self._per_agent_cap)
 
+    def _tag_request(self, request: Any) -> Any:
+        """Attach scope tags to the outbound completion via ``metadata.tags``.
+
+        The LiteLLM proxy records these tags on every spend-log row, which
+        is what makes the ``/spend/tags`` lookup in the default provider
+        work. Tags are merged non-destructively: existing ``model_settings``
+        keys (e.g. an ``extra_body.thinking`` block) and pre-existing tags
+        are preserved.
+        """
+        if not self._enabled():
+            return request
+        engagement, agent = self._scope_keys(request)
+        scope_tags = [f"engagement:{engagement}", f"agent:{engagement}:{agent}"]
+        settings = dict(getattr(request, "model_settings", None) or {})
+        extra_body = dict(settings.get("extra_body") or {})
+        metadata = dict(extra_body.get("metadata") or {})
+        tags = list(metadata.get("tags") or [])
+        tags.extend(t for t in scope_tags if t not in tags)
+        metadata["tags"] = tags
+        extra_body["metadata"] = metadata
+        settings["extra_body"] = extra_body
+        return request.override(model_settings=settings)
+
     @override
     def wrap_model_call(self, request, handler):
         self._enforce(request)
-        return handler(request)
+        return handler(self._tag_request(request))
 
     @override
     async def awrap_model_call(self, request, handler):
-        self._enforce(request)
-        return await handler(request)
+        # The default spend provider does a blocking HTTP round-trip to the
+        # LiteLLM proxy (at most once per poll interval, per scope); run it
+        # off the event loop so concurrent agents aren't stalled behind it.
+        await asyncio.to_thread(self._enforce, request)
+        return await handler(self._tag_request(request))
 
 
 def _default_litellm_spend_provider(scope_key: str) -> float:
-    """Default spend provider: query LiteLLM's Postgres ``spend_logs`` table.
+    """Default spend provider: query the LiteLLM proxy ``/spend/tags`` API.
 
-    ``scope_key`` looks like ``engagement:<slug>`` or ``agent:<slug>:<agent>``.
-    The convention is that LiteLLM virtual keys created by the launcher
-    carry these scope keys as metadata, so a single SQL ``SUM(spend)``
-    grouped by ``request_id->metadata`` yields the answer.
+    ``scope_key`` looks like ``engagement:<slug>`` or ``agent:<slug>:<agent>``
+    and matches the tags ``_tag_request`` attaches to every completion this
+    middleware wraps. ``/spend/tags`` aggregates ``SUM(spend)`` per distinct
+    tag proxy-side, so the response is one row per tag — bounded by tag
+    cardinality, not log volume.
+
+    Proxy URL and key come from the same ``DecepticonConfig`` source the LLM
+    factory uses (``DECEPTICON_LLM__PROXY_URL`` / ``__PROXY_API_KEY``), so
+    any environment that can run an agent can also enforce its budget.
 
     Returns 0.0 on any failure — the middleware treats provider exceptions
     as "no data this turn, don't enforce" rather than as a hard error,
-    so a transient Postgres blip can't terminate an active engagement.
-
-    Requires ``DATABASE_URL`` to be set; absent that, returns 0.0.
+    so a transient proxy blip can't terminate an active engagement. A
+    scope tag with no recorded spend also yields 0.0.
     """
-    db_url = os.environ.get("DATABASE_URL", "")
-    if not db_url:
+    try:
+        from decepticon_core.utils.config import load_config  # noqa: PLC0415
+
+        config = load_config()
+        base_url = config.llm.proxy_url.rstrip("/")
+        api_key = config.llm.proxy_api_key
+    except Exception as exc:  # noqa: BLE001
+        log.warning("cannot resolve LiteLLM proxy config for budget query: %s", exc)
         return 0.0
     try:
-        import psycopg2  # noqa: PLC0415
-    except ImportError:
-        log.warning("psycopg2 unavailable — install psycopg2-binary to enable budget enforcement")
+        import httpx  # noqa: PLC0415
+
+        resp = httpx.get(
+            f"{base_url}/spend/tags",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+        for row in resp.json():
+            if row.get("individual_request_tag") == scope_key:
+                return float(row.get("total_spend") or 0.0)
         return 0.0
-    try:
-        with closing(psycopg2.connect(db_url)) as conn:
-            with conn, conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT COALESCE(SUM(spend), 0)::float
-                    FROM "LiteLLM_SpendLogs"
-                    WHERE metadata->>'scope_key' = %s
-                    """,
-                    (scope_key,),
-                )
-                row = cur.fetchone()
-                return float(row[0]) if row else 0.0
     except Exception as exc:  # noqa: BLE001
         log.warning("LiteLLM spend query failed for scope=%s: %s", scope_key, exc)
         return 0.0

--- a/packages/decepticon/decepticon/middleware/budget.py
+++ b/packages/decepticon/decepticon/middleware/budget.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 import time
 from typing import Any, ClassVar
 
@@ -189,6 +190,15 @@ class BudgetEnforcementMiddleware(AgentMiddleware):
         self._cache = _SpendCache(ttl_seconds=poll)
         self._spend_provider = spend_provider or _default_litellm_spend_provider
         self._warned_scopes: set[str] = set()
+        # awrap_model_call runs _enforce in a thread-pool executor, so two
+        # concurrent agents sharing an engagement can enter _check_one on
+        # different threads. This lock keeps the cache-miss→fetch→set window
+        # and the soft-warn check-then-add on _warned_scopes atomic, so the
+        # "at most one HTTP fetch per poll interval" and "soft-warn fires once
+        # per scope" invariants hold under concurrency. It only serializes
+        # budget-enforce threads — the event loop itself is never blocked
+        # (enforcement runs off-loop via asyncio.to_thread).
+        self._lock = threading.Lock()
 
     def _enabled(self) -> bool:
         return self._engagement_cap > 0 or self._per_agent_cap > 0
@@ -213,32 +223,37 @@ class BudgetEnforcementMiddleware(AgentMiddleware):
     def _check_one(self, scope_kind: str, scope_key: str, cap_usd: float) -> None:
         if cap_usd <= 0:
             return
-        cached = self._cache.get(scope_key)
-        if cached is None:
-            try:
-                cached = float(self._spend_provider(scope_key))
-            except Exception as exc:  # noqa: BLE001
+        # Hold the lock across the whole check so a cache miss serializes
+        # concurrent agents onto a single fetch (the loser sees the warm
+        # cache), and so the soft-warn check-then-add can't double-fire.
+        with self._lock:
+            cached = self._cache.get(scope_key)
+            if cached is None:
+                try:
+                    cached = float(self._spend_provider(scope_key))
+                except Exception as exc:  # noqa: BLE001
+                    log.warning(
+                        "spend provider failed for scope=%s: %s; not enforcing this turn",
+                        scope_key,
+                        exc,
+                    )
+                    return
+                self._cache.set(scope_key, cached)
+            frac = cached / cap_usd if cap_usd else 0.0
+            if frac >= 1.0:
+                raise BudgetExceeded(scope_kind, cached, cap_usd)
+            warn_key = f"{scope_kind}:{scope_key}"
+            already_warned = warn_key in self._warned_scopes
+            if frac >= self._soft_warn and not already_warned:
+                self._warned_scopes.add(warn_key)
                 log.warning(
-                    "spend provider failed for scope=%s: %s; not enforcing this turn",
-                    scope_key,
-                    exc,
+                    "budget soft-warn: scope=%s spent=$%.4f of $%.2f (%.0f%%)",
+                    scope_kind,
+                    cached,
+                    cap_usd,
+                    frac * 100,
                 )
-                return
-            self._cache.set(scope_key, cached)
-        frac = cached / cap_usd if cap_usd else 0.0
-        if frac >= 1.0:
-            raise BudgetExceeded(scope_kind, cached, cap_usd)
-        warn_key = f"{scope_kind}:{scope_key}"
-        if frac >= self._soft_warn and warn_key not in self._warned_scopes:
-            self._warned_scopes.add(warn_key)
-            log.warning(
-                "budget soft-warn: scope=%s spent=$%.4f of $%.2f (%.0f%%)",
-                scope_kind,
-                cached,
-                cap_usd,
-                frac * 100,
-            )
-            _emit_warning_event(scope_kind, cached, cap_usd, frac)
+                _emit_warning_event(scope_kind, cached, cap_usd, frac)
 
     def _enforce(self, request: Any) -> None:
         if not self._enabled():

--- a/packages/decepticon/tests/unit/middleware/test_budget.py
+++ b/packages/decepticon/tests/unit/middleware/test_budget.py
@@ -123,3 +123,87 @@ def test_soft_warn_fires_once_per_scope():
     assert "engagement:engagement:test" in mw._warned_scopes
     mw._enforce(_Req())
     assert len(mw._warned_scopes) == 1
+
+
+# ------------------------------------------------------------- _tag_request
+
+
+class _OverridableReq:
+    """Minimal ModelRequest stand-in supporting ``override``."""
+
+    def __init__(self, model_settings: dict | None = None):
+        self.state = {"engagement_name": "test"}
+
+        class _RT:
+            agent_name = "recon"
+
+        self.runtime = _RT()
+        self.model_settings = model_settings or {}
+
+    def override(self, **kwargs):
+        new = _OverridableReq()
+        new.__dict__.update(self.__dict__)
+        new.__dict__.update(kwargs)
+        return new
+
+
+def test_tag_request_injects_scope_tags():
+    mw = BudgetEnforcementMiddleware(
+        engagement_cap_usd=10.0,
+        per_agent_cap_usd=0.0,
+        spend_provider=lambda _k: 0.0,
+    )
+    tagged = mw._tag_request(_OverridableReq())
+    tags = tagged.model_settings["extra_body"]["metadata"]["tags"]
+    assert tags == ["engagement:test", "agent:test:recon"]
+
+
+def test_tag_request_preserves_existing_extra_body_and_tags():
+    mw = BudgetEnforcementMiddleware(
+        engagement_cap_usd=10.0,
+        per_agent_cap_usd=0.0,
+        spend_provider=lambda _k: 0.0,
+    )
+    req = _OverridableReq(
+        model_settings={
+            "extra_body": {
+                "thinking": {"type": "enabled"},
+                "metadata": {"tags": ["custom-tag"], "trace_id": "t-1"},
+            },
+            "max_tokens": 64,
+        }
+    )
+    tagged = mw._tag_request(req)
+    extra = tagged.model_settings["extra_body"]
+    assert extra["thinking"] == {"type": "enabled"}
+    assert tagged.model_settings["max_tokens"] == 64
+    assert extra["metadata"]["trace_id"] == "t-1"
+    assert extra["metadata"]["tags"] == [
+        "custom-tag",
+        "engagement:test",
+        "agent:test:recon",
+    ]
+    # the original request's settings must not be mutated in place
+    assert req.model_settings["extra_body"]["metadata"]["tags"] == ["custom-tag"]
+
+
+def test_tag_request_is_idempotent():
+    mw = BudgetEnforcementMiddleware(
+        engagement_cap_usd=10.0,
+        per_agent_cap_usd=0.0,
+        spend_provider=lambda _k: 0.0,
+    )
+    once = mw._tag_request(_OverridableReq())
+    twice = mw._tag_request(once)
+    tags = twice.model_settings["extra_body"]["metadata"]["tags"]
+    assert tags == ["engagement:test", "agent:test:recon"]
+
+
+def test_tag_request_noop_when_disabled():
+    mw = BudgetEnforcementMiddleware(
+        engagement_cap_usd=0.0,
+        per_agent_cap_usd=0.0,
+        spend_provider=lambda _k: 0.0,
+    )
+    req = _OverridableReq()
+    assert mw._tag_request(req) is req

--- a/packages/decepticon/tests/unit/middleware/test_budget_internals.py
+++ b/packages/decepticon/tests/unit/middleware/test_budget_internals.py
@@ -123,6 +123,86 @@ def test_scope_keys_ultimate_defaults(monkeypatch: pytest.MonkeyPatch):
     assert agent == "default-agent"
 
 
+# ---------------------------------------------------------------- concurrency
+
+
+def test_check_one_soft_warn_fires_once_under_concurrent_threads():
+    """The _lock keeps the soft-warn invariant under the thread-pool path.
+
+    awrap_model_call runs _enforce via asyncio.to_thread, so concurrent
+    agents land in _check_one on different OS threads. Without the lock the
+    check-then-add on _warned_scopes races and emits duplicate warnings; with
+    it, exactly one fires per scope no matter how many threads pile in.
+    """
+    import threading
+
+    emitted: list[tuple[str, float, float, float]] = []
+    barrier = threading.Barrier(8)
+
+    def provider(_k: str) -> float:
+        return 8.0  # 80% of a 10.0 cap → over the 0.7 soft-warn threshold
+
+    mw = BudgetEnforcementMiddleware(
+        engagement_cap_usd=10.0,
+        soft_warn_at_pct=0.7,
+        spend_provider=provider,
+    )
+
+    import decepticon.middleware.budget as budget_mod
+
+    # capture every emit instead of reaching into langgraph stream internals
+    def fake_emit(scope: str, spent: float, cap: float, frac: float) -> None:
+        emitted.append((scope, spent, cap, frac))
+
+    original_emit = budget_mod._emit_warning_event
+    budget_mod._emit_warning_event = fake_emit
+    try:
+
+        def worker() -> None:
+            barrier.wait()  # maximize overlap on the check-then-add
+            mw._check_one("engagement", "engagement:test", 10.0)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        budget_mod._emit_warning_event = original_emit
+
+    assert len(emitted) == 1
+    assert mw._warned_scopes == {"engagement:engagement:test"}
+
+
+def test_check_one_concurrent_cold_cache_fetches_once():
+    """A cold cache hit by N concurrent threads issues exactly one provider call."""
+    import threading
+
+    calls = {"n": 0}
+    gate = threading.Event()
+    barrier = threading.Barrier(6)
+
+    def provider(_k: str) -> float:
+        calls["n"] += 1
+        gate.wait(timeout=2.0)  # hold the first fetcher so others pile up on the lock
+        return 1.0
+
+    mw = BudgetEnforcementMiddleware(engagement_cap_usd=100.0, spend_provider=provider)
+
+    def worker() -> None:
+        barrier.wait()
+        mw._check_one("engagement", "engagement:test", 100.0)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    gate.set()
+    for t in threads:
+        t.join()
+
+    assert calls["n"] == 1  # the lock collapsed 6 cold-cache calls into one fetch
+
+
 # ---------------------------------------------------------------- wrap_model_call
 
 
@@ -247,7 +327,9 @@ class _StubConfig:
 def _install_stub_config(monkeypatch: pytest.MonkeyPatch) -> None:
     import decepticon_core.utils.config as core_config
 
-    monkeypatch.setattr(core_config, "load_config", lambda: _StubConfig())
+    # _StubConfig is itself the callable load_config should become: load_config()
+    # then constructs a fresh _StubConfig instance, matching the real signature.
+    monkeypatch.setattr(core_config, "load_config", _StubConfig)
 
 
 def test_default_provider_returns_matching_tag_spend(monkeypatch: pytest.MonkeyPatch):

--- a/packages/decepticon/tests/unit/middleware/test_budget_internals.py
+++ b/packages/decepticon/tests/unit/middleware/test_budget_internals.py
@@ -126,7 +126,9 @@ def test_scope_keys_ultimate_defaults(monkeypatch: pytest.MonkeyPatch):
 # ---------------------------------------------------------------- concurrency
 
 
-def test_check_one_soft_warn_fires_once_under_concurrent_threads():
+def test_check_one_soft_warn_fires_once_under_concurrent_threads(
+    monkeypatch: pytest.MonkeyPatch,
+):
     """The _lock keeps the soft-warn invariant under the thread-pool path.
 
     awrap_model_call runs _enforce via asyncio.to_thread, so concurrent
@@ -148,27 +150,21 @@ def test_check_one_soft_warn_fires_once_under_concurrent_threads():
         spend_provider=provider,
     )
 
-    import decepticon.middleware.budget as budget_mod
-
     # capture every emit instead of reaching into langgraph stream internals
     def fake_emit(scope: str, spent: float, cap: float, frac: float) -> None:
         emitted.append((scope, spent, cap, frac))
 
-    original_emit = budget_mod._emit_warning_event
-    budget_mod._emit_warning_event = fake_emit
-    try:
+    monkeypatch.setattr(budget_mod, "_emit_warning_event", fake_emit)
 
-        def worker() -> None:
-            barrier.wait()  # maximize overlap on the check-then-add
-            mw._check_one("engagement", "engagement:test", 10.0)
+    def worker() -> None:
+        barrier.wait()  # maximize overlap on the check-then-add
+        mw._check_one("engagement", "engagement:test", 10.0)
 
-        threads = [threading.Thread(target=worker) for _ in range(8)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-    finally:
-        budget_mod._emit_warning_event = original_emit
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
 
     assert len(emitted) == 1
     assert mw._warned_scopes == {"engagement:engagement:test"}

--- a/packages/decepticon/tests/unit/middleware/test_budget_internals.py
+++ b/packages/decepticon/tests/unit/middleware/test_budget_internals.py
@@ -19,9 +19,6 @@ The spend source is injected, so there is no LiteLLM / Postgres dependency.
 
 from __future__ import annotations
 
-import sys
-import types
-
 import pytest
 
 from decepticon.middleware import budget as budget_mod
@@ -88,6 +85,14 @@ class _Req:
     def __init__(self, state: object = None, runtime: object = None) -> None:
         self.state = state
         self.runtime = runtime
+        self.model_settings: dict[str, object] = {}
+
+    def override(self, **kwargs: object) -> _Req:
+        # mirrors langchain's ModelRequest.override: shallow copy + updates
+        new = _Req(state=self.state, runtime=self.runtime)
+        new.__dict__.update(self.__dict__)
+        new.__dict__.update(kwargs)
+        return new
 
 
 def _mw() -> BudgetEnforcementMiddleware:
@@ -214,87 +219,105 @@ def test_emit_warning_event_swallows_writer_errors(monkeypatch: pytest.MonkeyPat
     _emit_warning_event("agent", 1.0, 2.0, 0.5)  # logged, not raised
 
 
-class _StubCursor:
-    def __init__(self, row: tuple[object, ...]) -> None:
-        self._row = row
-
-    def __enter__(self) -> _StubCursor:
-        return self
-
-    def __exit__(self, *_exc: object) -> bool:
-        return False
-
-    def execute(self, _sql: str, _params: object) -> None:
-        return None
-
-    def fetchone(self) -> tuple[object, ...]:
-        return self._row
+# ---------------------------------------------------------------- default provider
 
 
-class _StubConnection:
-    def __init__(self, row: tuple[object, ...], closed: list[int]) -> None:
-        self._row = row
-        self._closed = closed
+class _StubResponse:
+    def __init__(self, rows: list[dict[str, object]], status_error: bool = False) -> None:
+        self._rows = rows
+        self._status_error = status_error
 
-    def __enter__(self) -> _StubConnection:
-        return self
+    def raise_for_status(self) -> None:
+        if self._status_error:
+            raise RuntimeError("HTTP 500")
 
-    def __exit__(self, *_exc: object) -> bool:
-        return False
-
-    def cursor(self) -> _StubCursor:
-        return _StubCursor(self._row)
-
-    def close(self) -> None:
-        self._closed.append(1)
+    def json(self) -> list[dict[str, object]]:
+        return self._rows
 
 
-def _install_stub_psycopg2(
-    monkeypatch: pytest.MonkeyPatch,
-    row: tuple[object, ...],
-    closed: list[int],
-) -> None:
-    module = types.ModuleType("psycopg2")
-    module.connect = lambda _dsn: _StubConnection(row, closed)
-    monkeypatch.setitem(sys.modules, "psycopg2", module)
+class _StubLLMConfig:
+    proxy_url = "http://litellm:4000/"
+    proxy_api_key = "sk-test-master"
 
 
-def test_default_provider_closes_connection_once(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("DATABASE_URL", "postgresql://stub/db")
-    closed: list[int] = []
-    _install_stub_psycopg2(monkeypatch, (12.5,), closed)
-
-    result = _default_litellm_spend_provider("engagement:test")
-
-    assert result == 12.5
-    assert closed == [1]
+class _StubConfig:
+    llm = _StubLLMConfig()
 
 
-def test_default_provider_closes_connection_on_query_error(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("DATABASE_URL", "postgresql://stub/db")
-    closed: list[int] = []
+def _install_stub_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import decepticon_core.utils.config as core_config
 
-    class _BoomCursor(_StubCursor):
-        def execute(self, _sql: str, _params: object) -> None:
-            raise RuntimeError("boom")
+    monkeypatch.setattr(core_config, "load_config", lambda: _StubConfig())
 
-    module = types.ModuleType("psycopg2")
 
-    class _Conn(_StubConnection):
-        def cursor(self) -> _BoomCursor:
-            return _BoomCursor((0.0,))
+def test_default_provider_returns_matching_tag_spend(monkeypatch: pytest.MonkeyPatch):
+    import httpx
 
-    module.connect = lambda _dsn: _Conn((0.0,), closed)
-    monkeypatch.setitem(sys.modules, "psycopg2", module)
+    _install_stub_config(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def _get(url: str, *, headers: dict[str, str], timeout: float) -> _StubResponse:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _StubResponse(
+            [
+                {"individual_request_tag": "User-Agent: curl", "total_spend": 9.9},
+                {"individual_request_tag": "engagement:test", "total_spend": 12.5},
+            ]
+        )
+
+    monkeypatch.setattr(httpx, "get", _get)
+
+    assert _default_litellm_spend_provider("engagement:test") == 12.5
+    # trailing slash on proxy_url must not produce a double slash
+    assert captured["url"] == "http://litellm:4000/spend/tags"
+    assert captured["headers"] == {"Authorization": "Bearer sk-test-master"}
+
+
+def test_default_provider_unknown_tag_returns_zero(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    _install_stub_config(monkeypatch)
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_a, **_k: _StubResponse([{"individual_request_tag": "other", "total_spend": 3.0}]),
+    )
 
     assert _default_litellm_spend_provider("engagement:test") == 0.0
-    assert closed == [1]
 
 
-def test_default_provider_no_database_url(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    closed: list[int] = []
-    _install_stub_psycopg2(monkeypatch, (5.0,), closed)
+def test_default_provider_swallows_http_errors(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    _install_stub_config(monkeypatch)
+    monkeypatch.setattr(httpx, "get", lambda *_a, **_k: _StubResponse([], status_error=True))
 
     assert _default_litellm_spend_provider("engagement:test") == 0.0
-    assert closed == []
+
+
+def test_default_provider_swallows_config_errors(monkeypatch: pytest.MonkeyPatch):
+    import decepticon_core.utils.config as core_config
+
+    def _boom() -> object:
+        raise RuntimeError("no env")
+
+    monkeypatch.setattr(core_config, "load_config", _boom)
+
+    assert _default_litellm_spend_provider("engagement:test") == 0.0
+
+
+def test_default_provider_null_total_spend_is_zero(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    _install_stub_config(monkeypatch)
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_a, **_k: _StubResponse(
+            [{"individual_request_tag": "engagement:test", "total_spend": None}]
+        ),
+    )
+
+    assert _default_litellm_spend_provider("engagement:test") == 0.0


### PR DESCRIPTION
## What & why

Budget enforcement (`DECEPTICON_BUDGET__*`) has been silently dead in production:

1. The default spend provider did SQL against LiteLLM's **internal Prisma table** (`"LiteLLM_SpendLogs"` via psycopg2 + `DATABASE_URL`) — schema-coupled, so any proxy upgrade could break it.
2. It filtered on `metadata->>'scope_key'`, which **nothing in the codebase ever injected** (the docstring claimed the launcher set it; it doesn't — `grep scope_key` hits only budget.py itself).
3. `DATABASE_URL` is not set in the langgraph container (only litellm/web have it), and `psycopg2` isn't a dependency.

Any one of the three means the provider always returned `0.0` → caps never enforced. This PR replaces the whole path with the documented proxy API surface, closing the schema-coupling follow-up from the #640-648 audit *and* fixing the dead wiring.

## How

- **Tag injection**: `BudgetEnforcementMiddleware.wrap_model_call`/`awrap_model_call` now attach the scope keys (`engagement:<slug>`, `agent:<slug>:<agent>`) to every wrapped completion via `model_settings.extra_body.metadata.tags` (`request.override(...)`). Merge is non-destructive (existing `extra_body` keys like the DeepSeek `thinking` block and pre-existing tags survive) and idempotent. No-op when caps are disabled — preserves current behavior for users who haven't opted in.
- **Spend readback**: the default provider does `GET /spend/tags` on the proxy and returns the matching tag's `total_spend`. Proxy URL/key come from the same `DecepticonConfig` source the LLM factory resolves (`DECEPTICON_LLM__PROXY_URL`/`__PROXY_API_KEY`) — set in every environment that can run an agent. `/spend/tags` aggregates per distinct tag proxy-side, so the response is bounded by tag cardinality, not log volume.
- **Event-loop hygiene**: `awrap_model_call` offloads the blocking HTTP lookup (at most one per poll interval per scope, default 5s, behind the existing TTL cache) via `asyncio.to_thread`.
- Failure semantics unchanged: any provider error logs a warning and skips enforcement for the turn — a transient proxy blip can't kill an engagement.

## Verification

- **Live E2E against the pinned proxy image (v1.88.1)**: real `ChatOpenAI.bind(**model_settings)` (the exact path langchain's agent factory uses) → tags appear in `request_tags` on the spend log row → `/spend/tags` returns per-tag totals → new provider reads back `engagement`/`agent` spend (`0.00011` each); unknown tag → `0.0`. Confirmed the endpoint is **not enterprise-gated** on the OSS image.
- Unit: 34 budget tests pass, including new coverage for tag injection (merge/idempotency/disabled-no-op/no-mutation-of-original) and the HTTP provider (match, unknown tag, HTTP error, config error, null spend). The psycopg2 stub tests are deleted with the code they tested.
- Gates: `make ci-lint` clean (ruff + format + basedpyright 0 errors), `make ci-test` 4187 passed.