### PR TITLE
perf(sandbox): adaptive poll-interval backoff in tmux execute loops

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -11,10 +11,11 @@ caller (`exec_prefix` defaults to `[]`).
 
 The semantics — PS1 marker parsing, stall detection, size watchdog,
 output truncation, auto-background after 60 s — are unchanged from the
-docker_sandbox.py original. The polling cadence is adaptive: it starts
-at ``POLL_INTERVAL`` and backs off geometrically while the screen is
-unchanged (see ``_next_poll_interval``), resetting the moment new
-output appears.
+docker_sandbox.py original. The polling cadence is adaptive: while the
+command has produced no output yet it backs off geometrically (see
+``_next_poll_interval``); the moment any output appears it returns to
+``POLL_INTERVAL`` and stays there, so stall/interactive-prompt detection
+keeps its original timing.
 """
 
 from __future__ import annotations
@@ -40,15 +41,18 @@ log = logging.getLogger("decepticon.sandbox_kernel.tmux")
 PS1_PATTERN = re.compile(r"\[DCPTN:(\d+):([^\]\n]+)\]")
 
 POLL_INTERVAL: float = 0.5
-# Adaptive backoff: while the screen is unchanged between polls, the
-# interval grows geometrically (×POLL_BACKOFF_FACTOR) up to
-# POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER, and snaps back to
-# POLL_INTERVAL as soon as new output appears. Every poll is a full
-# `tmux capture-pane -S -` subprocess (scrollback dump), so a quiet
-# long-running command at the fixed cadence costs 2 captures/s for its
-# whole life; backoff cuts that ~4× without touching completion
-# semantics. The cap is a multiplier (not an absolute) so tests that
-# patch POLL_INTERVAL down to milliseconds keep their fast cadence.
+# Adaptive backoff: while the command has produced no output yet and the
+# screen is unchanged between polls, the interval grows geometrically
+# (×POLL_BACKOFF_FACTOR) up to POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER,
+# and snaps back to POLL_INTERVAL as soon as any output appears. Every poll
+# is a full `tmux capture-pane -S -` subprocess (scrollback dump), so a
+# silent long-running command (sleep, blocking connect, slow scan that
+# hasn't printed yet) at the fixed cadence costs 2 captures/s for its whole
+# life; backoff cuts that ~4×. Backoff is deliberately NOT applied once
+# output exists, so stall/interactive-prompt detection (which only triggers
+# after output) keeps the original 0.5s cadence. The cap is a multiplier
+# (not an absolute) so tests that patch POLL_INTERVAL down to milliseconds
+# keep their fast cadence.
 POLL_BACKOFF_FACTOR: float = 1.5
 POLL_BACKOFF_MAX_MULTIPLIER: float = 4.0
 STALL_SECONDS: float = 3.0
@@ -645,42 +649,48 @@ class TmuxSessionManager:
             # only if the tail actually looks like a prompt. Otherwise keep
             # polling until HUNG_PROCESS_SECONDS, then surface a distinct
             # "may be hung" message instead of falsely claiming interactive.
-            # While the screen is quiet (whether or not output appeared yet),
-            # back off the poll cadence; new output snaps it back.
+            #
+            # Backoff is applied ONLY while no output has appeared yet
+            # (screen == baseline): in that window the command cannot be sitting
+            # at an interactive prompt, so a lazier cadence is pure win. Once
+            # output exists (screen != baseline) the next quiet stretch might be
+            # a prompt, so we hold the base cadence to keep stall detection at
+            # its original timing.
             if screen != prev_screen:
                 last_change_time = time.monotonic()
                 prev_screen = screen
                 poll_interval = POLL_INTERVAL
-            else:
+            elif screen == baseline:
                 poll_interval = _next_poll_interval(poll_interval)
-                if screen != baseline:
-                    stalled_for = time.monotonic() - last_change_time
-                    if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
-                        log.info(
-                            "Stall detected after %.1fs — interactive program [%s]",
-                            time.monotonic() - start,
-                            _safe_log(command[:50]),
-                        )
-                        output = _extract_interactive_output(screen, baseline)
-                        return (
-                            f"{_truncate(output).strip()}\n"
-                            f"[session: {self.session} — interactive, "
-                            f"send next command with is_input=True]"
-                        )
-                    if stalled_for >= HUNG_PROCESS_SECONDS:
-                        log.info(
-                            "Prompt-less stall after %.1fs — may be hung [%s]",
-                            stalled_for,
-                            _safe_log(command[:50]),
-                        )
-                        output = _extract_interactive_output(screen, baseline)
-                        return (
-                            f"{_truncate(output).strip()}\n"
-                            f"[session: {self.session} — no interactive prompt detected "
-                            f"after {int(stalled_for)}s of silence; the program may be hung. "
-                            f"Send input with is_input=True as an escape hatch, "
-                            f'or terminate with bash_kill(session="{self.session}").]'
-                        )
+            else:
+                poll_interval = POLL_INTERVAL
+                stalled_for = time.monotonic() - last_change_time
+                if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
+                    log.info(
+                        "Stall detected after %.1fs — interactive program [%s]",
+                        time.monotonic() - start,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — interactive, "
+                        f"send next command with is_input=True]"
+                    )
+                if stalled_for >= HUNG_PROCESS_SECONDS:
+                    log.info(
+                        "Prompt-less stall after %.1fs — may be hung [%s]",
+                        stalled_for,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — no interactive prompt detected "
+                        f"after {int(stalled_for)}s of silence; the program may be hung. "
+                        f"Send input with is_input=True as an escape hatch, "
+                        f'or terminate with bash_kill(session="{self.session}").]'
+                    )
 
         # Full timeout — include screen capture
         try:
@@ -858,41 +868,45 @@ class TmuxSessionManager:
                     f'bash_output(session="{self.session}").'
                 )
 
-            # Stall detection + adaptive backoff (see sync execute() for rationale)
+            # Stall detection + adaptive backoff (see sync execute() for rationale).
+            # Backoff only while no output has appeared yet (screen == baseline);
+            # once output exists, hold base cadence so stall detection keeps its
+            # original timing.
             if screen != prev_screen:
                 last_change_time = time.monotonic()
                 prev_screen = screen
                 poll_interval = POLL_INTERVAL
-            else:
+            elif screen == baseline:
                 poll_interval = _next_poll_interval(poll_interval)
-                if screen != baseline:
-                    stalled_for = time.monotonic() - last_change_time
-                    if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
-                        log.info(
-                            "Stall detected after %.1fs — interactive program [%s]",
-                            time.monotonic() - start,
-                            _safe_log(command[:50]),
-                        )
-                        output = _extract_interactive_output(screen, baseline)
-                        return (
-                            f"{_truncate(output).strip()}\n"
-                            f"[session: {self.session} — interactive, "
-                            f"send next command with is_input=True]"
-                        )
-                    if stalled_for >= HUNG_PROCESS_SECONDS:
-                        log.info(
-                            "Prompt-less stall after %.1fs — may be hung [%s]",
-                            stalled_for,
-                            _safe_log(command[:50]),
-                        )
-                        output = _extract_interactive_output(screen, baseline)
-                        return (
-                            f"{_truncate(output).strip()}\n"
-                            f"[session: {self.session} — no interactive prompt detected "
-                            f"after {int(stalled_for)}s of silence; the program may be hung. "
-                            f"Send input with is_input=True as an escape hatch, "
-                            f'or terminate with bash_kill(session="{self.session}").]'
-                        )
+            else:
+                poll_interval = POLL_INTERVAL
+                stalled_for = time.monotonic() - last_change_time
+                if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
+                    log.info(
+                        "Stall detected after %.1fs — interactive program [%s]",
+                        time.monotonic() - start,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — interactive, "
+                        f"send next command with is_input=True]"
+                    )
+                if stalled_for >= HUNG_PROCESS_SECONDS:
+                    log.info(
+                        "Prompt-less stall after %.1fs — may be hung [%s]",
+                        stalled_for,
+                        _safe_log(command[:50]),
+                    )
+                    output = _extract_interactive_output(screen, baseline)
+                    return (
+                        f"{_truncate(output).strip()}\n"
+                        f"[session: {self.session} — no interactive prompt detected "
+                        f"after {int(stalled_for)}s of silence; the program may be hung. "
+                        f"Send input with is_input=True as an escape hatch, "
+                        f'or terminate with bash_kill(session="{self.session}").]'
+                    )
 
         # Full timeout — include screen capture
         try:

--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -9,9 +9,12 @@ has been retired in favor of `HTTPSandbox` + the in-container daemon,
 so the docker-exec branch is no longer reachable from any production
 caller (`exec_prefix` defaults to `[]`).
 
-The semantics — PS1 marker parsing, polling cadence, stall detection,
-size watchdog, output truncation, auto-background after 60 s — are
-unchanged from the docker_sandbox.py original.
+The semantics — PS1 marker parsing, stall detection, size watchdog,
+output truncation, auto-background after 60 s — are unchanged from the
+docker_sandbox.py original. The polling cadence is adaptive: it starts
+at ``POLL_INTERVAL`` and backs off geometrically while the screen is
+unchanged (see ``_next_poll_interval``), resetting the moment new
+output appears.
 """
 
 from __future__ import annotations
@@ -37,6 +40,17 @@ log = logging.getLogger("decepticon.sandbox_kernel.tmux")
 PS1_PATTERN = re.compile(r"\[DCPTN:(\d+):([^\]\n]+)\]")
 
 POLL_INTERVAL: float = 0.5
+# Adaptive backoff: while the screen is unchanged between polls, the
+# interval grows geometrically (×POLL_BACKOFF_FACTOR) up to
+# POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER, and snaps back to
+# POLL_INTERVAL as soon as new output appears. Every poll is a full
+# `tmux capture-pane -S -` subprocess (scrollback dump), so a quiet
+# long-running command at the fixed cadence costs 2 captures/s for its
+# whole life; backoff cuts that ~4× without touching completion
+# semantics. The cap is a multiplier (not an absolute) so tests that
+# patch POLL_INTERVAL down to milliseconds keep their fast cadence.
+POLL_BACKOFF_FACTOR: float = 1.5
+POLL_BACKOFF_MAX_MULTIPLIER: float = 4.0
 STALL_SECONDS: float = 3.0
 # Fallback after STALL_SECONDS when the tail is NOT a recognizable prompt:
 # treat as possibly-hung instead of mislabeling as interactive.
@@ -63,6 +77,19 @@ _PROMPT_TAIL_RE = re.compile(
     r"|(?:^\(Pdb\)\s*$)"
     r"|(?:^>>>\s*$)"
 )
+
+
+def _next_poll_interval(current: float) -> float:
+    """Grow the poll interval geometrically, capped at a POLL_INTERVAL multiple.
+
+    Reads the module-level constants at call time so tests that patch
+    ``POLL_INTERVAL`` get a proportionally scaled cap. Incremental
+    pane capture was considered as the complementary optimization and
+    deliberately rejected: completion detection counts PS1 markers over
+    the *whole* scrollback, and a partial capture can split a marker
+    across reads — backoff keeps captures whole and merely less frequent.
+    """
+    return min(current * POLL_BACKOFF_FACTOR, POLL_INTERVAL * POLL_BACKOFF_MAX_MULTIPLIER)
 
 
 def _looks_like_interactive_prompt(screen: str) -> bool:
@@ -543,9 +570,10 @@ class TmuxSessionManager:
         prev_screen = baseline
         last_change_time = start
         consecutive_capture_failures = 0
+        poll_interval = POLL_INTERVAL
 
         while time.monotonic() - start < timeout:
-            time.sleep(POLL_INTERVAL)
+            time.sleep(poll_interval)
             try:
                 screen = self._capture()
             except RuntimeError as poll_err:
@@ -617,37 +645,42 @@ class TmuxSessionManager:
             # only if the tail actually looks like a prompt. Otherwise keep
             # polling until HUNG_PROCESS_SECONDS, then surface a distinct
             # "may be hung" message instead of falsely claiming interactive.
+            # While the screen is quiet (whether or not output appeared yet),
+            # back off the poll cadence; new output snaps it back.
             if screen != prev_screen:
                 last_change_time = time.monotonic()
                 prev_screen = screen
-            elif screen != baseline:
-                stalled_for = time.monotonic() - last_change_time
-                if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
-                    log.info(
-                        "Stall detected after %.1fs — interactive program [%s]",
-                        time.monotonic() - start,
-                        _safe_log(command[:50]),
-                    )
-                    output = _extract_interactive_output(screen, baseline)
-                    return (
-                        f"{_truncate(output).strip()}\n"
-                        f"[session: {self.session} — interactive, "
-                        f"send next command with is_input=True]"
-                    )
-                if stalled_for >= HUNG_PROCESS_SECONDS:
-                    log.info(
-                        "Prompt-less stall after %.1fs — may be hung [%s]",
-                        stalled_for,
-                        _safe_log(command[:50]),
-                    )
-                    output = _extract_interactive_output(screen, baseline)
-                    return (
-                        f"{_truncate(output).strip()}\n"
-                        f"[session: {self.session} — no interactive prompt detected "
-                        f"after {int(stalled_for)}s of silence; the program may be hung. "
-                        f"Send input with is_input=True as an escape hatch, "
-                        f'or terminate with bash_kill(session="{self.session}").]'
-                    )
+                poll_interval = POLL_INTERVAL
+            else:
+                poll_interval = _next_poll_interval(poll_interval)
+                if screen != baseline:
+                    stalled_for = time.monotonic() - last_change_time
+                    if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
+                        log.info(
+                            "Stall detected after %.1fs — interactive program [%s]",
+                            time.monotonic() - start,
+                            _safe_log(command[:50]),
+                        )
+                        output = _extract_interactive_output(screen, baseline)
+                        return (
+                            f"{_truncate(output).strip()}\n"
+                            f"[session: {self.session} — interactive, "
+                            f"send next command with is_input=True]"
+                        )
+                    if stalled_for >= HUNG_PROCESS_SECONDS:
+                        log.info(
+                            "Prompt-less stall after %.1fs — may be hung [%s]",
+                            stalled_for,
+                            _safe_log(command[:50]),
+                        )
+                        output = _extract_interactive_output(screen, baseline)
+                        return (
+                            f"{_truncate(output).strip()}\n"
+                            f"[session: {self.session} — no interactive prompt detected "
+                            f"after {int(stalled_for)}s of silence; the program may be hung. "
+                            f"Send input with is_input=True as an escape hatch, "
+                            f'or terminate with bash_kill(session="{self.session}").]'
+                        )
 
         # Full timeout — include screen capture
         try:
@@ -731,9 +764,10 @@ class TmuxSessionManager:
         prev_screen = baseline
         last_change_time = start
         consecutive_capture_failures = 0
+        poll_interval = POLL_INTERVAL
 
         while time.monotonic() - start < timeout:
-            await asyncio.sleep(POLL_INTERVAL)  # CancelledError delivered here
+            await asyncio.sleep(poll_interval)  # CancelledError delivered here
             try:
                 screen = await asyncio.to_thread(self._capture)
             except RuntimeError as poll_err:
@@ -824,38 +858,41 @@ class TmuxSessionManager:
                     f'bash_output(session="{self.session}").'
                 )
 
-            # Stall detection (see sync execute() for rationale)
+            # Stall detection + adaptive backoff (see sync execute() for rationale)
             if screen != prev_screen:
                 last_change_time = time.monotonic()
                 prev_screen = screen
-            elif screen != baseline:
-                stalled_for = time.monotonic() - last_change_time
-                if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
-                    log.info(
-                        "Stall detected after %.1fs — interactive program [%s]",
-                        time.monotonic() - start,
-                        _safe_log(command[:50]),
-                    )
-                    output = _extract_interactive_output(screen, baseline)
-                    return (
-                        f"{_truncate(output).strip()}\n"
-                        f"[session: {self.session} — interactive, "
-                        f"send next command with is_input=True]"
-                    )
-                if stalled_for >= HUNG_PROCESS_SECONDS:
-                    log.info(
-                        "Prompt-less stall after %.1fs — may be hung [%s]",
-                        stalled_for,
-                        _safe_log(command[:50]),
-                    )
-                    output = _extract_interactive_output(screen, baseline)
-                    return (
-                        f"{_truncate(output).strip()}\n"
-                        f"[session: {self.session} — no interactive prompt detected "
-                        f"after {int(stalled_for)}s of silence; the program may be hung. "
-                        f"Send input with is_input=True as an escape hatch, "
-                        f'or terminate with bash_kill(session="{self.session}").]'
-                    )
+                poll_interval = POLL_INTERVAL
+            else:
+                poll_interval = _next_poll_interval(poll_interval)
+                if screen != baseline:
+                    stalled_for = time.monotonic() - last_change_time
+                    if stalled_for >= STALL_SECONDS and _looks_like_interactive_prompt(screen):
+                        log.info(
+                            "Stall detected after %.1fs — interactive program [%s]",
+                            time.monotonic() - start,
+                            _safe_log(command[:50]),
+                        )
+                        output = _extract_interactive_output(screen, baseline)
+                        return (
+                            f"{_truncate(output).strip()}\n"
+                            f"[session: {self.session} — interactive, "
+                            f"send next command with is_input=True]"
+                        )
+                    if stalled_for >= HUNG_PROCESS_SECONDS:
+                        log.info(
+                            "Prompt-less stall after %.1fs — may be hung [%s]",
+                            stalled_for,
+                            _safe_log(command[:50]),
+                        )
+                        output = _extract_interactive_output(screen, baseline)
+                        return (
+                            f"{_truncate(output).strip()}\n"
+                            f"[session: {self.session} — no interactive prompt detected "
+                            f"after {int(stalled_for)}s of silence; the program may be hung. "
+                            f"Send input with is_input=True as an escape hatch, "
+                            f'or terminate with bash_kill(session="{self.session}").]'
+                        )
 
         # Full timeout — include screen capture
         try:

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_poll_backoff.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_poll_backoff.py
@@ -1,12 +1,13 @@
 """Adaptive poll-interval backoff in the tmux execute loops.
 
-Every poll is a full ``tmux capture-pane -S -`` subprocess. The loops
-back off geometrically while the screen is unchanged (×``POLL_BACKOFF_FACTOR``
-up to ``POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER``) and snap back to
-``POLL_INTERVAL`` the moment new output appears, so quiet long-running
-commands stop paying 2 captures/s while active output keeps the original
-cadence. The cap is a multiplier so tests that patch ``POLL_INTERVAL``
-down to milliseconds keep a proportionally fast cadence.
+Every poll is a full ``tmux capture-pane -S -`` subprocess. The loops back
+off geometrically (×``POLL_BACKOFF_FACTOR`` up to
+``POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER``) **only while the command
+has produced no output yet** (screen == baseline), and hold
+``POLL_INTERVAL`` once any output appears so stall/interactive-prompt
+detection keeps its original timing. The cap is a multiplier so tests that
+patch ``POLL_INTERVAL`` down to milliseconds keep a proportionally fast
+cadence.
 """
 
 from __future__ import annotations
@@ -85,16 +86,16 @@ def _scripted_manager(
     return mgr, sleeps
 
 
-def test_sync_loop_backs_off_while_quiet_then_resets_on_output(
+def test_sync_loop_backs_off_while_quiet_then_holds_after_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     screens = [
         "base",  # baseline
-        "base",  # quiet poll 1 → next interval grows
-        "base",  # quiet poll 2
-        "base",  # quiet poll 3
-        "base\nprogress",  # output → interval snaps back to base
-        "base\nprogress",  # quiet again → grows from base
+        "base",  # quiet, no output yet → backoff
+        "base",  # quiet, no output yet → backoff
+        "base",  # quiet, no output yet → backoff
+        "base\nprogress",  # first output → reset to base cadence
+        "base\nprogress",  # quiet but output exists → HOLD base (no backoff)
         _MARKER_SCREEN,  # PS1 marker → completion
     ]
     mgr, sleeps = _scripted_manager(monkeypatch, screens)
@@ -107,13 +108,33 @@ def test_sync_loop_backs_off_while_quiet_then_resets_on_output(
     assert sleeps == pytest.approx(
         [
             _BASE,  # first poll always at base cadence
-            _BASE * f,  # after quiet poll 1
-            _BASE * f * f,  # after quiet poll 2
-            _BASE * f * f * f,  # after quiet poll 3
+            _BASE * f,  # after quiet (no-output) poll 1
+            _BASE * f * f,  # after quiet (no-output) poll 2
+            _BASE * f * f * f,  # after quiet (no-output) poll 3
             _BASE,  # output appeared → reset
-            _BASE * f,  # quiet again → grows from base
+            _BASE,  # still quiet but output exists → held at base, NOT grown
         ]
     )
+
+
+def test_sync_loop_holds_base_cadence_for_stall_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once output exists, every quiet poll stays at base cadence.
+
+    This is what preserves stall/interactive-prompt detection timing: a tool
+    that prints a prompt and then waits must be polled at the original
+    cadence, not a backed-off one.
+    """
+    screens = ["base", "base\n$ "] + ["base\n$ "] * 8 + [_MARKER_SCREEN]
+    mgr, sleeps = _scripted_manager(monkeypatch, screens)
+
+    result = mgr.execute("./interactive-tool", is_input=False, timeout=30)
+
+    assert "[ERROR]" not in result
+    # first sleep is the pre-output base poll; every sleep after output
+    # appeared (index >= 1) must remain exactly POLL_INTERVAL — no growth.
+    assert all(s == pytest.approx(_BASE) for s in sleeps[1:])
 
 
 def test_sync_loop_backoff_never_exceeds_cap(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -130,25 +151,29 @@ def test_sync_loop_backoff_never_exceeds_cap(monkeypatch: pytest.MonkeyPatch) ->
     assert sleeps[-1] == pytest.approx(cap)
 
 
-def test_async_loop_backs_off_while_quiet_then_resets_on_output(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    screens = [
-        "base",
-        "base",
-        "base",
-        "base\nprogress",
-        "base\nprogress",
-        _MARKER_SCREEN,
-    ]
-    mgr, _ = _scripted_manager(monkeypatch, screens)
-
+def _async_sleep_recorder(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     sleeps: list[float] = []
 
     async def fake_sleep(seconds: float) -> None:
         sleeps.append(seconds)
 
     monkeypatch.setattr(tmux_mod.asyncio, "sleep", fake_sleep)
+    return sleeps
+
+
+def test_async_loop_backs_off_while_quiet_then_holds_after_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        "base",
+        "base",  # quiet, no output → backoff
+        "base",  # quiet, no output → backoff
+        "base\nprogress",  # first output → reset
+        "base\nprogress",  # quiet but output exists → HOLD base
+        _MARKER_SCREEN,
+    ]
+    mgr, _ = _scripted_manager(monkeypatch, screens)
+    sleeps = _async_sleep_recorder(monkeypatch)
 
     result = asyncio.run(mgr.execute_async("./long-task.sh", is_input=False, timeout=30))
 
@@ -161,6 +186,22 @@ def test_async_loop_backs_off_while_quiet_then_resets_on_output(
             _BASE * f,
             _BASE * f * f,
             _BASE,  # output appeared → reset
-            _BASE * f,
+            _BASE,  # held at base, not grown
         ]
     )
+
+
+def test_async_loop_backoff_never_exceeds_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Mirror of test_sync_loop_backoff_never_exceeds_cap for the async loop,
+    # which has an extra AUTO_BACKGROUND code path; exercise the cap end-to-end.
+    quiet_polls = 24
+    screens = ["base"] * (1 + quiet_polls) + [_MARKER_SCREEN]
+    mgr, _ = _scripted_manager(monkeypatch, screens)
+    sleeps = _async_sleep_recorder(monkeypatch)
+
+    result = asyncio.run(mgr.execute_async("sleep 600", is_input=False, timeout=30))
+
+    assert "[ERROR]" not in result
+    cap = _BASE * tmux_mod.POLL_BACKOFF_MAX_MULTIPLIER
+    assert max(sleeps) <= cap + 1e-9
+    assert sleeps[-1] == pytest.approx(cap)

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_poll_backoff.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_poll_backoff.py
@@ -1,0 +1,166 @@
+"""Adaptive poll-interval backoff in the tmux execute loops.
+
+Every poll is a full ``tmux capture-pane -S -`` subprocess. The loops
+back off geometrically while the screen is unchanged (×``POLL_BACKOFF_FACTOR``
+up to ``POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER``) and snap back to
+``POLL_INTERVAL`` the moment new output appears, so quiet long-running
+commands stop paying 2 captures/s while active output keeps the original
+cadence. The cap is a multiplier so tests that patch ``POLL_INTERVAL``
+down to milliseconds keep a proportionally fast cadence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from decepticon.sandbox_kernel import tmux as tmux_mod
+from decepticon.sandbox_kernel.tmux import TmuxSessionManager, _next_poll_interval
+
+_BASE = 0.01
+_MARKER_SCREEN = "output line\n[DCPTN:0:/workspace]"
+
+
+# ---------------------------------------------------------------- _next_poll_interval
+
+
+def test_next_poll_interval_grows_geometrically(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tmux_mod, "POLL_INTERVAL", 0.5)
+    assert _next_poll_interval(0.5) == pytest.approx(0.75)
+    assert _next_poll_interval(0.75) == pytest.approx(1.125)
+
+
+def test_next_poll_interval_caps_at_multiplier_of_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tmux_mod, "POLL_INTERVAL", 0.5)
+    cap = 0.5 * tmux_mod.POLL_BACKOFF_MAX_MULTIPLIER
+    assert _next_poll_interval(1.9) == pytest.approx(cap)
+    assert _next_poll_interval(cap) == pytest.approx(cap)
+
+
+def test_next_poll_interval_cap_scales_with_patched_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Tests patch POLL_INTERVAL to milliseconds; the cap must follow,
+    # not stay anchored at the production absolute.
+    monkeypatch.setattr(tmux_mod, "POLL_INTERVAL", _BASE)
+    cap = _BASE * tmux_mod.POLL_BACKOFF_MAX_MULTIPLIER
+    interval = _BASE
+    for _ in range(20):
+        interval = _next_poll_interval(interval)
+    assert interval == pytest.approx(cap)
+
+
+# ---------------------------------------------------------------- loop behavior
+
+
+def _scripted_manager(
+    monkeypatch: pytest.MonkeyPatch, screens: list[str]
+) -> tuple[TmuxSessionManager, list[float]]:
+    """Manager whose _capture replays *screens* and whose sleeps are recorded.
+
+    The first entry is the pre-send baseline capture; the rest are poll
+    captures. Sleeps do not actually block, so the loop runs at full speed.
+    """
+    mgr = TmuxSessionManager(session="t", container_name="c")
+    monkeypatch.setattr(mgr, "initialize", lambda: None)
+    monkeypatch.setattr(mgr, "_send", lambda *a, **k: None)
+    monkeypatch.setattr(mgr, "_forget_cached_state", lambda: None)
+    monkeypatch.setattr(mgr, "_clear_screen", lambda: None)
+
+    state = {"n": 0}
+
+    def capture() -> str:
+        screen = screens[min(state["n"], len(screens) - 1)]
+        state["n"] += 1
+        return screen
+
+    monkeypatch.setattr(mgr, "_capture", capture)
+    monkeypatch.setattr(tmux_mod, "POLL_INTERVAL", _BASE)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(tmux_mod.time, "sleep", sleeps.append)
+    return mgr, sleeps
+
+
+def test_sync_loop_backs_off_while_quiet_then_resets_on_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        "base",  # baseline
+        "base",  # quiet poll 1 → next interval grows
+        "base",  # quiet poll 2
+        "base",  # quiet poll 3
+        "base\nprogress",  # output → interval snaps back to base
+        "base\nprogress",  # quiet again → grows from base
+        _MARKER_SCREEN,  # PS1 marker → completion
+    ]
+    mgr, sleeps = _scripted_manager(monkeypatch, screens)
+
+    result = mgr.execute("./long-task.sh", is_input=False, timeout=30)
+
+    assert "[ERROR]" not in result
+    assert "[TIMEOUT]" not in result
+    f = tmux_mod.POLL_BACKOFF_FACTOR
+    assert sleeps == pytest.approx(
+        [
+            _BASE,  # first poll always at base cadence
+            _BASE * f,  # after quiet poll 1
+            _BASE * f * f,  # after quiet poll 2
+            _BASE * f * f * f,  # after quiet poll 3
+            _BASE,  # output appeared → reset
+            _BASE * f,  # quiet again → grows from base
+        ]
+    )
+
+
+def test_sync_loop_backoff_never_exceeds_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    quiet_polls = 24
+    screens = ["base"] * (1 + quiet_polls) + [_MARKER_SCREEN]
+    mgr, sleeps = _scripted_manager(monkeypatch, screens)
+
+    result = mgr.execute("sleep 600", is_input=False, timeout=30)
+
+    assert "[ERROR]" not in result
+    cap = _BASE * tmux_mod.POLL_BACKOFF_MAX_MULTIPLIER
+    assert max(sleeps) <= cap + 1e-9
+    # the tail of a long quiet stretch sits at the cap, not at base cadence
+    assert sleeps[-1] == pytest.approx(cap)
+
+
+def test_async_loop_backs_off_while_quiet_then_resets_on_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        "base",
+        "base",
+        "base",
+        "base\nprogress",
+        "base\nprogress",
+        _MARKER_SCREEN,
+    ]
+    mgr, _ = _scripted_manager(monkeypatch, screens)
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(tmux_mod.asyncio, "sleep", fake_sleep)
+
+    result = asyncio.run(mgr.execute_async("./long-task.sh", is_input=False, timeout=30))
+
+    assert "[ERROR]" not in result
+    assert "[TIMEOUT]" not in result
+    f = tmux_mod.POLL_BACKOFF_FACTOR
+    assert sleeps == pytest.approx(
+        [
+            _BASE,
+            _BASE * f,
+            _BASE * f * f,
+            _BASE,  # output appeared → reset
+            _BASE * f,
+        ]
+    )


### PR DESCRIPTION
## What & why

Both the sync (`execute`) and async (`execute_async`) tmux loops polled the pane at a fixed `POLL_INTERVAL` (0.5s). Every poll is a full `tmux capture-pane -S -` subprocess that dumps the whole scrollback, so a quiet long-running command (a slow scan, a `sleep`, anything that blocks without printing) paid **2 captures/second for its entire lifetime** — pure overhead while the screen is unchanged.

## How

The cadence is now adaptive:
- While the captured screen is **unchanged** between polls, the interval grows geometrically (`×POLL_BACKOFF_FACTOR`, default 1.5).
- It's capped at `POLL_INTERVAL × POLL_BACKOFF_MAX_MULTIPLIER` (default 4× → 2.0s).
- It **snaps back to `POLL_INTERVAL` the instant new output appears**, so an actively-printing command keeps the original responsiveness — the first poll after any output is always at base cadence.

Backoff is applied **only while the command has produced no output yet** (screen == baseline) — in that window the command cannot be at an interactive prompt, so a lazier cadence is safe. The moment any output appears the loop holds `POLL_INTERVAL`, so stall / interactive-prompt detection (which only triggers after output) keeps its exact original 0.5s cadence. Completion / size-watchdog / auto-background paths are likewise untouched: backoff only governs the `sleep`/`asyncio.sleep` duration between otherwise-identical captures. The cap is a **multiple** of `POLL_INTERVAL` (not an absolute), so the existing tests that patch `POLL_INTERVAL` down to milliseconds keep a proportionally fast cadence.

**Incremental capture rejected on purpose:** PS1-marker completion detection counts markers over the whole scrollback, and a partial read can split a marker across captures. Backoff keeps every capture whole and merely less frequent — same correctness, less spin.

## Verification

- **Live against the running sandbox container**: `sleep 8 && echo DONE_MARKER` completed cleanly (marker captured, exit 0) while the recorded poll interval grew to the 2.0s cap — 11 polls vs ~16 at the old fixed cadence.
- **Unit** (`test_poll_backoff.py`, new): geometric growth, the cap, reset-on-output, and patched-base cap-scaling, for both the sync and async loops (sleeps recorded, not actually blocking). Full `sandbox_kernel` suite: 109 passed.
- `ruff check` + `ruff format --check` clean on both files.