### PR TITLE
feat(launcher): stable/latest update channels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,6 +276,13 @@ LANGSMITH_PROJECT=decepticon
 #   AUTO_UPDATE=false   # air-gapped / version-pinned deploys
 #   AUTO_UPDATE=prompt  # ask on TTY before applying (pre-v1.1.12 default)
 # AUTO_UPDATE=false
+#
+# Update channel — which release stream `update` / auto-update track.
+# Defaults to stable. See docs/update-channels.md.
+#   stable  — final releases only (GHCR :stable). The safe default.
+#   latest  — newest release INCLUDING pre-releases / -rc builds (GHCR
+#             :latest). For early adopters who want fixes first.
+# DECEPTICON_CHANNEL=latest
 # DECEPTICON_DEBUG=true
 
 # Multi-stack container naming (PR #216). Unset/empty keeps the default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -609,13 +609,13 @@ jobs:
 
   # Atomic release gate. Waits until every Docker image AND the launcher
   # binaries are pushed, verifies each :<version> manifest exists on GHCR,
-  # then promotes :<version> → :latest and flips the GitHub release from
-  # draft → published. Until this job succeeds:
+  # then promotes :<version> → channel tags (:stable for finals, :latest
+  # for all) and flips the GitHub release from draft → published. Until
+  # this job succeeds:
   #   - GitHub `releases/latest` keeps returning the previous version, so
-  #     the launcher's update notice never points users at images that are
-  #     still mid-push.
-  #   - The :latest tag is not moved, so `${DECEPTICON_VERSION:-latest}`
-  #     fallbacks keep resolving to the previous (working) release.
+  #     the launcher's stable channel never points at images mid-push.
+  #   - The channel tags are not moved, so a `${DECEPTICON_VERSION:-stable}`
+  #     fallback keeps resolving to the previous (working) release.
   publish-release:
     name: Verify images & publish release
     needs: [launcher, docker, docker-heavy-merge, docker-web-merge]
@@ -663,8 +663,37 @@ jobs:
             docker buildx imagetools inspect "${ref}" >/dev/null
           done
 
-      - name: Promote :<version> → :latest
+      # Channel tags (see docs/update-channels.md):
+      #   :stable — newest FINAL release only. The conservative default
+      #             the launcher's `stable` channel + the compose
+      #             ${DECEPTICON_VERSION:-stable} fallback resolve to.
+      #   :latest — newest release INCLUDING pre-releases, for the
+      #             `latest` channel (early adopters get -rc builds first).
+      # A pre-release moves :latest but NOT :stable; a final release moves
+      # both.
+      - name: Promote :<version> → :stable (final releases only)
         if: steps.version.outputs.prerelease != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          images=(
+            decepticon-litellm
+            decepticon-langgraph
+            decepticon-sandbox
+            decepticon-cli
+            decepticon-skillogy
+            decepticon-c2-sliver
+            decepticon-web
+          )
+          for img in "${images[@]}"; do
+            src="ghcr.io/purpleailab/${img}:${VERSION}"
+            dst="ghcr.io/purpleailab/${img}:stable"
+            echo "Promoting ${src} → ${dst}"
+            docker buildx imagetools create --tag "${dst}" "${src}"
+          done
+
+      - name: Promote :<version> → :latest (all releases incl. pre-releases)
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -61,9 +61,11 @@ func applyAutoUpdate(env map[string]string, version string, skip bool) {
 	if skip {
 		return
 	}
+	// Which release stream to track (stable | latest). Default stable.
+	ch := updater.ResolveChannel(config.Get(env, "DECEPTICON_CHANNEL", ""))
 	switch strings.ToLower(strings.TrimSpace(config.Get(env, "AUTO_UPDATE", ""))) {
 	case "", "true", "1", "yes", "on":
-		if _, err := autoUpdateFn(version); err != nil {
+		if _, err := autoUpdateFn(version, ch); err != nil {
 			ui.Warning("Auto-update: " + err.Error())
 		}
 	case "false", "0", "no", "off":
@@ -71,7 +73,7 @@ func applyAutoUpdate(env map[string]string, version string, skip bool) {
 	default:
 		// Includes the explicit `prompt` / `ask` / `interactive`
 		// opt-ins AND any unrecognized value (safer fallback).
-		if _, err := promptUpdateFn(version); err != nil {
+		if _, err := promptUpdateFn(version, ch); err != nil {
 			ui.Warning("Update check: " + err.Error())
 		}
 	}

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"reflect"
 	"testing"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/updater"
 )
 
 // withProbeStubs swaps the WSL detection function variables for the
@@ -112,8 +114,8 @@ func withUpdateStubs(t *testing.T) (auto, prompt *int) {
 	autoCount, promptCount := 0, 0
 	prevAuto := autoUpdateFn
 	prevPrompt := promptUpdateFn
-	autoUpdateFn = func(string) (bool, error) { autoCount++; return false, nil }
-	promptUpdateFn = func(string) (bool, error) { promptCount++; return false, nil }
+	autoUpdateFn = func(string, updater.Channel) (bool, error) { autoCount++; return false, nil }
+	promptUpdateFn = func(string, updater.Channel) (bool, error) { promptCount++; return false, nil }
 	t.Cleanup(func() {
 		autoUpdateFn = prevAuto
 		promptUpdateFn = prevPrompt
@@ -123,10 +125,10 @@ func withUpdateStubs(t *testing.T) (auto, prompt *int) {
 
 func TestApplyAutoUpdate_RoutingMatrix(t *testing.T) {
 	cases := []struct {
-		envValue     string
-		wantAuto     int
-		wantPrompt   int
-		description  string
+		envValue    string
+		wantAuto    int
+		wantPrompt  int
+		description string
 	}{
 		// Default-on: unset triggers silent auto-update. This is the
 		// key behaviour change from v1.1.12 — fix-shipped → fix-applied

--- a/clients/launcher/cmd/update.go
+++ b/clients/launcher/cmd/update.go
@@ -11,7 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var forceUpdate bool
+var (
+	forceUpdate   bool
+	updateChannel string
+)
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
@@ -21,13 +24,27 @@ var updateCmd = &cobra.Command{
 
 func init() {
 	updateCmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Refresh config files and Docker images even if version unchanged")
+	updateCmd.Flags().StringVar(&updateChannel, "channel", "", "Update channel for this run: stable (final releases) or latest (incl. pre-releases). Default: DECEPTICON_CHANNEL in .env, else stable")
 	rootCmd.AddCommand(updateCmd)
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
-	ui.Info("Checking for updates...")
+	// Load env first so the channel (and branch override) are known
+	// before the release fetch.
+	env := make(map[string]string)
+	if config.EnvExists() {
+		env, _ = config.LoadEnv(config.EnvPath())
+	}
+	// --channel overrides .env for this invocation only.
+	rawChannel := updateChannel
+	if rawChannel == "" {
+		rawChannel = config.Get(env, "DECEPTICON_CHANNEL", "")
+	}
+	ch := updater.ResolveChannel(rawChannel)
 
-	release, err := updater.FetchLatestRelease()
+	ui.Info(fmt.Sprintf("Checking for updates (%s channel)...", ch))
+
+	release, err := updater.FetchRelease(ch)
 	if err != nil {
 		return fmt.Errorf("check updates: %w", err)
 	}
@@ -44,11 +61,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		ui.Info("Refreshing configuration files and Docker images...")
 	}
 
-	// Load env for branch info
-	env := make(map[string]string)
-	if config.EnvExists() {
-		env, _ = config.LoadEnv(config.EnvPath())
-	}
 	ref := release.TagName
 	if branch := strings.TrimSpace(env["DECEPTICON_BRANCH"]); branch != "" {
 		ref = branch

--- a/clients/launcher/internal/compose/compose.go
+++ b/clients/launcher/internal/compose/compose.go
@@ -142,8 +142,8 @@ func ContainerName(svc string) string {
 
 // readVersion returns the installed version from $DECEPTICON_HOME/.version,
 // or an empty string if the file is missing or unreadable. The launcher
-// (install + explicit update) is the single writer; compose falls back to :latest
-// when the marker is absent.
+// (install + explicit update) is the single writer; compose falls back to
+// :stable (the conservative default channel tag) when the marker is absent.
 func (c *Compose) readVersion() string {
 	data, err := os.ReadFile(filepath.Join(c.Home, ".version"))
 	if err != nil {
@@ -156,7 +156,7 @@ func (c *Compose) readVersion() string {
 // from the .version file plus any runtime-derived env (DOCKER_HOST for
 // Podman, etc.). docker compose treats the process environment as
 // higher precedence than --env-file, so this overrides any stale value the
-// user may have written into .env and avoids the silent `:latest` drift
+// user may have written into .env and avoids the silent `:stable` drift
 // that occurs when the variable is unset.
 func (c *Compose) composeEnv() []string {
 	// Single source of truth for compose interpolation env (STACK_NAME +

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -33,19 +33,51 @@ const BinaryChecksumsAsset = "checksums.txt"
 
 const (
 	Repo       = "PurpleAILAB/Decepticon"
-	APIBaseURL = "https://api.github.com/repos/" + Repo
 	RawBaseURL = "https://raw.githubusercontent.com/" + Repo
 )
+
+// APIBaseURL is a var (not const) so tests can point release fetches at
+// an httptest server.
+var APIBaseURL = "https://api.github.com/repos/" + Repo
 
 // executableFn is a var so tests can redirect binary writes to a temp dir
 // instead of overwriting the test binary itself. Matches the isWSLFn /
 // wslHostIPFn pattern used in cmd/start.go.
 var executableFn = os.Executable
 
+// Channel selects which releases the updater tracks.
+//
+//   - ChannelStable: only final releases (GitHub "latest", which excludes
+//     pre-releases). Maps to the GHCR “:stable“ tag. The safe default.
+//   - ChannelLatest: the newest release INCLUDING pre-releases
+//     (“vX.Y.Z-rc.N“). Maps to GHCR “:latest“ for early adopters.
+//
+// Selected via the “DECEPTICON_CHANNEL“ key in “.env“.
+type Channel string
+
+const (
+	ChannelStable Channel = "stable"
+	ChannelLatest Channel = "latest"
+)
+
+// ResolveChannel normalizes a raw “DECEPTICON_CHANNEL“ value. Empty or
+// unrecognized values resolve to the safe default (stable) so a typo can
+// never silently opt a user into pre-release images.
+func ResolveChannel(raw string) Channel {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(ChannelLatest):
+		return ChannelLatest
+	default:
+		return ChannelStable
+	}
+}
+
 // Release represents a GitHub release.
 type Release struct {
-	TagName string  `json:"tag_name"`
-	Assets  []Asset `json:"assets"`
+	TagName    string  `json:"tag_name"`
+	Assets     []Asset `json:"assets"`
+	Prerelease bool    `json:"prerelease"`
+	Draft      bool    `json:"draft"`
 }
 
 // Asset represents a release asset (binary download).
@@ -54,8 +86,26 @@ type Asset struct {
 	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
-// FetchLatestRelease gets the latest release info from GitHub.
+// FetchRelease gets the release to track for the given channel.
+//
+//   - stable: GitHub's "latest" release, which already excludes
+//     pre-releases and drafts.
+//   - latest: the newest non-draft release from the releases list,
+//     INCLUDING pre-releases (so early adopters see -rc builds first).
+func FetchRelease(ch Channel) (*Release, error) {
+	if ch == ChannelLatest {
+		return fetchNewestIncludingPrerelease()
+	}
+	return fetchLatestStable()
+}
+
+// FetchLatestRelease is the stable-channel fetch, kept for callers that
+// don't (yet) thread a channel through.
 func FetchLatestRelease() (*Release, error) {
+	return fetchLatestStable()
+}
+
+func fetchLatestStable() (*Release, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(APIBaseURL + "/releases/latest")
 	if err != nil {
@@ -74,6 +124,52 @@ func FetchLatestRelease() (*Release, error) {
 	return &release, nil
 }
 
+// fetchNewestIncludingPrerelease lists releases and returns the newest
+// non-draft one by SemVer precedence (pre-releases included). Falls back
+// to the stable endpoint when the list is empty.
+func fetchNewestIncludingPrerelease() (*Release, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(APIBaseURL + "/releases?per_page=20")
+	if err != nil {
+		return nil, fmt.Errorf("fetch releases: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var releases []Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("decode releases: %w", err)
+	}
+	if newest := pickNewestRelease(releases); newest != nil {
+		return newest, nil
+	}
+	// Empty list (or all drafts) — fall back to the stable channel so the
+	// latest channel still resolves to *something* installable.
+	return fetchLatestStable()
+}
+
+// pickNewestRelease returns the highest-precedence non-draft release by
+// SemVer comparison, or nil when none qualify.
+func pickNewestRelease(releases []Release) *Release {
+	var best *Release
+	for i := range releases {
+		r := &releases[i]
+		if r.Draft || r.TagName == "" {
+			continue
+		}
+		if best == nil || compareSemver(
+			strings.TrimPrefix(best.TagName, "v"),
+			strings.TrimPrefix(r.TagName, "v"),
+		) < 0 {
+			best = r
+		}
+	}
+	return best
+}
+
 // CompareVersions returns true if latest > current using numeric semver comparison.
 func CompareVersions(current, latest string) bool {
 	current = strings.TrimPrefix(current, "v")
@@ -84,8 +180,44 @@ func CompareVersions(current, latest string) bool {
 	return compareSemver(current, latest) < 0
 }
 
-// compareSemver compares two semver strings numerically. Returns -1, 0, or 1.
+// compareSemver compares two semver strings. Returns -1, 0, or 1. Honors
+// SemVer §11 prerelease precedence: a prerelease (“1.2.0-rc.1“) ranks
+// LOWER than its associated normal version (“1.2.0“), and prerelease
+// identifiers are compared field-by-field. Build metadata (“+...“) is
+// ignored. This matters for the “latest“ channel, which surfaces -rc
+// builds the “stable“ channel never sees.
 func compareSemver(a, b string) int {
+	aBase, aPre := splitPrerelease(a)
+	bBase, bPre := splitPrerelease(b)
+	if c := compareNumericBase(aBase, bBase); c != 0 {
+		return c
+	}
+	// Bases equal — apply prerelease precedence.
+	switch {
+	case aPre == "" && bPre == "":
+		return 0
+	case aPre == "":
+		return 1 // a is a normal version, b is a prerelease → a > b
+	case bPre == "":
+		return -1 // a is a prerelease, b is a normal version → a < b
+	default:
+		return comparePrerelease(aPre, bPre)
+	}
+}
+
+// splitPrerelease strips build metadata and splits “base-prerelease“.
+func splitPrerelease(v string) (base, pre string) {
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		return v[:i], v[i+1:]
+	}
+	return v, ""
+}
+
+// compareNumericBase compares the major.minor.patch triple numerically.
+func compareNumericBase(a, b string) int {
 	aParts := strings.SplitN(a, ".", 3)
 	bParts := strings.SplitN(b, ".", 3)
 	for i := 0; i < 3; i++ {
@@ -104,6 +236,63 @@ func compareSemver(a, b string) int {
 		}
 	}
 	return 0
+}
+
+// comparePrerelease compares dot-separated prerelease identifiers per
+// SemVer §11: numeric identifiers compare numerically, alphanumerics
+// compare lexically, numeric ranks below alphanumeric, and when every
+// shared identifier is equal the longer set has higher precedence.
+func comparePrerelease(a, b string) int {
+	aIDs := strings.Split(a, ".")
+	bIDs := strings.Split(b, ".")
+	for i := 0; i < len(aIDs) && i < len(bIDs); i++ {
+		ai, bi := aIDs[i], bIDs[i]
+		aNum, aIsNum := parseUint(ai)
+		bNum, bIsNum := parseUint(bi)
+		switch {
+		case aIsNum && bIsNum:
+			if aNum != bNum {
+				if aNum < bNum {
+					return -1
+				}
+				return 1
+			}
+		case aIsNum && !bIsNum:
+			return -1 // numeric identifiers have lower precedence
+		case !aIsNum && bIsNum:
+			return 1
+		default:
+			if ai != bi {
+				if ai < bi {
+					return -1
+				}
+				return 1
+			}
+		}
+	}
+	switch {
+	case len(aIDs) < len(bIDs):
+		return -1
+	case len(aIDs) > len(bIDs):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// parseUint reports whether s is all-digits and its value if so.
+func parseUint(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n, true
 }
 
 // SyncConfigFiles downloads updated docker-compose.yml and litellm.yaml.
@@ -376,8 +565,8 @@ func WriteVersion(version string) error {
 //
 // Used as the fallback path when “PromptIfUpdateAvailable“ cannot present
 // an interactive prompt (e.g. stdin is not a TTY in CI / piped invocation).
-func NotifyIfUpdateAvailable(currentVersion string) bool {
-	release, err := FetchLatestRelease()
+func NotifyIfUpdateAvailable(currentVersion string, ch Channel) bool {
+	release, err := FetchRelease(ch)
 	if err != nil {
 		return false // Silent fail; startup should not depend on GitHub.
 	}
@@ -454,16 +643,16 @@ func ApplyUpdate(release *Release, ref string) error {
 //   - the latest release is not newer than “currentVersion“.
 //   - stdin is not a TTY — CI / piped invocations fall back to
 //     “NotifyIfUpdateAvailable“ so the user still sees the notice.
-func PromptIfUpdateAvailable(currentVersion string) (bool, error) {
+func PromptIfUpdateAvailable(currentVersion string, ch Channel) (bool, error) {
 	if currentVersion == "" || currentVersion == "dev" {
 		return false, nil
 	}
 	if !isInteractiveStdin() {
-		NotifyIfUpdateAvailable(currentVersion)
+		NotifyIfUpdateAvailable(currentVersion, ch)
 		return false, nil
 	}
 
-	release, err := FetchLatestRelease()
+	release, err := FetchRelease(ch)
 	if err != nil {
 		return false, nil // Silent skip — startup must not depend on GitHub.
 	}
@@ -564,11 +753,11 @@ func applyAndReexec(release *Release, currentVersion string) (bool, error) {
 // the AUTO_UPDATE=true launch path for fully-unattended self-update (servers,
 // CI runners, kiosk deployments). Skips silently on dev builds, when offline,
 // or when already current — a self-update must never block or break a launch.
-func AutoUpdateIfAvailable(currentVersion string) (bool, error) {
+func AutoUpdateIfAvailable(currentVersion string, ch Channel) (bool, error) {
 	if currentVersion == "" || currentVersion == "dev" {
 		return false, nil
 	}
-	release, err := FetchLatestRelease()
+	release, err := FetchRelease(ch)
 	if err != nil {
 		return false, nil // offline / GitHub down — never block launch
 	}

--- a/clients/launcher/internal/updater/updater_test.go
+++ b/clients/launcher/internal/updater/updater_test.go
@@ -28,11 +28,43 @@ func TestCompareVersions(t *testing.T) {
 		{"1.10.0", "1.9.0", false},
 		{"2.0.0", "1.99.99", false},
 		{"0.9.9", "1.0.0", true},
+		// SemVer §11 prerelease precedence: a prerelease is LOWER than
+		// its associated normal version. Matters for the `latest`
+		// channel, which surfaces -rc builds.
+		{"1.2.0-rc.1", "1.2.0", true},      // rc → final is an update
+		{"1.2.0", "1.2.0-rc.1", false},     // final → rc is NOT an update (downgrade)
+		{"1.2.0-rc.1", "1.2.0-rc.2", true}, // rc.1 → rc.2 is an update
+		{"1.2.0-rc.2", "1.2.0-rc.1", false},
+		{"1.2.0-rc.2", "1.2.0-rc.10", true}, // numeric identifiers compare numerically (10 > 2)
+		{"1.2.0-rc.1", "1.2.0-rc.1", false},
+		{"1.1.0", "1.2.0-rc.1", true}, // a prerelease of a higher version still beats a lower final
+		{"1.2.0-rc.1", "1.1.0", false},
+		{"v1.2.0-rc.1", "v1.2.0", true},      // tolerates the leading v
+		{"1.2.0-alpha", "1.2.0-beta", true},  // alphanumeric identifiers compare lexically
+		{"1.2.0-rc.1", "1.2.0-rc.1.1", true}, // more fields > fewer when the prefix is equal
 	}
 	for _, tt := range tests {
 		got := CompareVersions(tt.current, tt.latest)
 		if got != tt.want {
 			t.Errorf("CompareVersions(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+		}
+	}
+}
+
+func TestResolveChannel(t *testing.T) {
+	tests := map[string]Channel{
+		"":          ChannelStable, // default
+		"stable":    ChannelStable,
+		"STABLE":    ChannelStable,
+		"  stable ": ChannelStable,
+		"latest":    ChannelLatest,
+		"LATEST":    ChannelLatest,
+		" latest":   ChannelLatest,
+		"garbage":   ChannelStable, // unrecognized → safe default
+	}
+	for in, want := range tests {
+		if got := ResolveChannel(in); got != want {
+			t.Errorf("ResolveChannel(%q) = %q, want %q", in, got, want)
 		}
 	}
 }
@@ -85,11 +117,79 @@ func TestFetchLatestRelease_Mock(t *testing.T) {
 	}
 }
 
+func TestFetchRelease_StableHitsLatestEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/latest" {
+			t.Errorf("stable channel must call /releases/latest, got %q", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(Release{TagName: "v1.2.0"})
+	}))
+	defer srv.Close()
+	defer withAPIBaseURL(srv.URL)()
+
+	rel, err := FetchRelease(ChannelStable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel.TagName != "v1.2.0" {
+		t.Errorf("TagName = %q, want v1.2.0", rel.TagName)
+	}
+}
+
+func TestFetchRelease_LatestPicksNewestInclPrereleaseSkipsDrafts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			t.Errorf("latest channel must list /releases, not /releases/latest")
+		}
+		// Unordered; a draft newer than everything (must be skipped); a
+		// prerelease that is the newest non-draft (must win).
+		json.NewEncoder(w).Encode([]Release{
+			{TagName: "v1.2.0"},
+			{TagName: "v1.3.0-rc.2", Prerelease: true},
+			{TagName: "v2.0.0", Draft: true},
+			{TagName: "v1.1.0"},
+		})
+	}))
+	defer srv.Close()
+	defer withAPIBaseURL(srv.URL)()
+
+	rel, err := FetchRelease(ChannelLatest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel.TagName != "v1.3.0-rc.2" {
+		t.Errorf("TagName = %q, want v1.3.0-rc.2", rel.TagName)
+	}
+}
+
+func TestPickNewestRelease(t *testing.T) {
+	got := pickNewestRelease([]Release{
+		{TagName: "v1.2.0"},
+		{TagName: "v1.3.0-rc.1", Prerelease: true},
+		{TagName: "v2.0.0", Draft: true}, // draft → skipped despite highest semver
+		{TagName: ""},                    // malformed → skipped
+	})
+	if got == nil || got.TagName != "v1.3.0-rc.1" {
+		t.Fatalf("pickNewestRelease = %+v, want v1.3.0-rc.1", got)
+	}
+	if pickNewestRelease(nil) != nil {
+		t.Errorf("pickNewestRelease(nil) should be nil")
+	}
+}
+
+// withAPIBaseURL points the updater at a test server and returns a
+// restore func.
+func withAPIBaseURL(url string) func() {
+	old := APIBaseURL
+	APIBaseURL = url
+	return func() { APIBaseURL = old }
+}
+
 func TestPromptIfUpdateAvailable_SkipsDevBuilds(t *testing.T) {
 	// "dev" / empty version means a local build that does not track
 	// published releases — no prompt, no GitHub round-trip.
 	for _, v := range []string{"dev", ""} {
-		applied, err := PromptIfUpdateAvailable(v)
+		applied, err := PromptIfUpdateAvailable(v, ChannelStable)
 		if err != nil {
 			t.Errorf("PromptIfUpdateAvailable(%q) err = %v", v, err)
 		}
@@ -105,7 +205,7 @@ func TestPromptIfUpdateAvailable_SkipsNonInteractive(t *testing.T) {
 	// without ever calling huh.Run. A non-zero version that would
 	// otherwise fail the "is dev?" gate is safe — the function returns
 	// silently on the TTY check before fetching anything.
-	applied, err := PromptIfUpdateAvailable("0.0.0")
+	applied, err := PromptIfUpdateAvailable("0.0.0", ChannelStable)
 	if err != nil {
 		t.Errorf("PromptIfUpdateAvailable err = %v", err)
 	}
@@ -325,7 +425,7 @@ func TestAutoUpdateIfAvailable_SkipsDevBuilds(t *testing.T) {
 	// releases — the unattended AUTO_UPDATE path must no-op without any
 	// GitHub round-trip (mirrors PromptIfUpdateAvailable's dev gate).
 	for _, v := range []string{"dev", ""} {
-		applied, err := AutoUpdateIfAvailable(v)
+		applied, err := AutoUpdateIfAvailable(v, ChannelStable)
 		if err != nil {
 			t.Errorf("AutoUpdateIfAvailable(%q) err = %v", v, err)
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   # LiteLLM Proxy — LLM API Gateway
   # Handles model routing, authentication, usage tracking, billing
   litellm:
-    image: ghcr.io/purpleailab/decepticon-litellm:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-litellm:${DECEPTICON_VERSION:-stable}
     build:
       context: .
       dockerfile: containers/litellm.Dockerfile
@@ -192,7 +192,7 @@ services:
   # via ``/var/run/docker.sock`` was removed in the HTTP-only migration —
   # see decepticon/backends/factory.py for the rationale.
   sandbox:
-    image: ghcr.io/purpleailab/decepticon-sandbox:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-sandbox:${DECEPTICON_VERSION:-stable}
     # Multi-arch image — linux/amd64 + linux/arm64. Apple Silicon and
     # Linux arm64 hosts pull the native manifest; no Rosetta needed.
     # On an unusual arch the manifest list won't match — force a
@@ -310,7 +310,7 @@ services:
         # an upgrade is a single-line change here. To verify, see
         # https://github.com/NationalSecurityAgency/ghidra/releases.
         GHIDRA_SHA256: ""
-    image: decepticon-sandbox-reversing:${DECEPTICON_VERSION:-latest}
+    image: decepticon-sandbox-reversing:${DECEPTICON_VERSION:-stable}
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-ghidra-mcp
     # Keep the container alive with a long-running analyzeHeadless that
     # imports a placeholder binary. The MCP plugin (when installed) auto-
@@ -339,7 +339,7 @@ services:
   # Exposes all agents (decepticon, soundwave, recon, exploit, postexploit)
   # as a streaming API on port 2024. Ink CLI connects here.
   langgraph:
-    image: ghcr.io/purpleailab/decepticon-langgraph:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-langgraph:${DECEPTICON_VERSION:-stable}
     # Append --allow-blocking by default so blockbuster doesn't fatally
     # abort runs on sync I/O in third-party deps (e.g. deepagents'
     # subagents.py uses a sync httpx send in its atask path). Decepticon's
@@ -437,7 +437,7 @@ services:
   # Web Dashboard — Next.js UI
   # Migrations run automatically at startup via web-entrypoint.sh (prisma migrate deploy).
   web:
-    image: ghcr.io/purpleailab/decepticon-web:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-web:${DECEPTICON_VERSION:-stable}
     build:
       context: .
       dockerfile: containers/web.Dockerfile
@@ -490,7 +490,7 @@ services:
   # Ink CLI — Interactive terminal UI
   # Runs via: docker compose run --rm cli
   cli:
-    image: ghcr.io/purpleailab/decepticon-cli:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-cli:${DECEPTICON_VERSION:-stable}
     build:
       context: .
       dockerfile: containers/cli.Dockerfile
@@ -545,7 +545,7 @@ services:
   # `ops_start("c2-havoc")` once that workload ships.
   # Agent connects via: sliver-client (pre-installed in sandbox)
   c2-sliver:
-    image: ghcr.io/purpleailab/decepticon-c2-sliver:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-c2-sliver:${DECEPTICON_VERSION:-stable}
     # Multi-arch image — see decepticon-sandbox above for the same notes.
     build:
       context: .
@@ -585,7 +585,7 @@ services:
   #   - OTEL_SERVICE_NAME=decepticon
 
   skillogy:
-    image: ghcr.io/purpleailab/decepticon-skillogy:${DECEPTICON_VERSION:-latest}
+    image: ghcr.io/purpleailab/decepticon-skillogy:${DECEPTICON_VERSION:-stable}
     build:
       context: .
       dockerfile: containers/skillogy.Dockerfile

--- a/docs/makefile-reference.md
+++ b/docs/makefile-reference.md
@@ -104,12 +104,14 @@ To regenerate just the Prisma client (without a full build): `cd clients/web && 
 
 There is no `make sync-version` or pre-tag commit. Source-tree version fields carry a `"0.0.0"` sentinel in `pyproject.toml`, `clients/cli/package.json`, and `clients/web/package.json`. The release workflow stamps the real tag into the images at Docker build time via `--build-arg VERSION=<tag>`. The Go launcher is similarly stamped via GoReleaser ldflags.
 
-Release channel policy:
+Release channel policy (see [update-channels.md](./update-channels.md) for the user-facing view):
 
-- `vX.Y.Z` Git tags are the source of truth for stable releases.
+- `vX.Y.Z` Git tags are the source of truth for releases.
 - GHCR version tags (`X.Y.Z`) are immutable release artifacts and should be used by installed deployments.
-- GHCR `latest` is a moving pointer to the newest fully verified stable release only. It is promoted after all version-tagged images exist and the GitHub release is undrafted.
-- Pre-releases should use SemVer suffixes such as `v1.1.0-rc.1`, stay marked as GitHub pre-releases, and should not move `latest`.
+- Two moving channel tags are promoted by the `publish-release` job after all version-tagged images exist and the GitHub release is undrafted:
+  - GHCR `stable` → the newest **final** release only (the conservative default; the `${DECEPTICON_VERSION:-stable}` compose fallback resolves here).
+  - GHCR `latest` → the newest release **including pre-releases**.
+- Pre-releases use SemVer suffixes such as `v1.1.0-rc.1`, stay marked as GitHub pre-releases, and move `latest` but **not** `stable`.
 - Bug fixes ship as new patch releases. Do not rebuild or rewrite an existing version tag.
 
 To cut a release:

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -1,0 +1,71 @@
+# Update channels
+
+Decepticon publishes two update channels so operators can choose between
+conservative stability and early access to fixes.
+
+| Channel | Tracks | GHCR tag | Who it's for |
+|---------|--------|----------|--------------|
+| **stable** (default) | The newest **final** release (no pre-releases). | `:stable` | Production / most users. The safe default. |
+| **latest** | The newest release **including pre-releases** (`vX.Y.Z-rc.N`). | `:latest` | Early adopters who want fixes before they're finalized. |
+
+A pre-release moves `:latest` but **not** `:stable`; a final release moves
+both. So `stable` only ever advances to vetted final releases, while
+`latest` surfaces release candidates first.
+
+## Selecting a channel
+
+The channel lives in `DECEPTICON_CHANNEL` in your `~/.decepticon/.env`
+(default `stable` when unset or unrecognized — a typo can never silently
+opt you into pre-release images):
+
+```bash
+# ~/.decepticon/.env
+DECEPTICON_CHANNEL=latest
+```
+
+It can be set three ways:
+
+- **At install** — `CHANNEL=latest curl -fsSL https://decepticon.red/install | bash`.
+  The installer resolves and pins the newest version on that channel.
+- **In `.env`** — set `DECEPTICON_CHANNEL=stable|latest`. The launch-time
+  self-update and `decepticon update` both honor it.
+- **Per command** — `decepticon update --channel latest` overrides `.env`
+  for that one run (does not persist).
+
+Pinning an exact version still wins over the channel:
+`VERSION=1.2.0 curl ... | bash` (install) or `DECEPTICON_VERSION=1.2.0`
+(compose) installs that exact tag regardless of channel.
+
+## How it works
+
+- **Launcher self-update / `decepticon update`** resolve the channel via
+  `updater.ResolveChannel` and fetch accordingly:
+  - `stable` → GitHub `…/releases/latest` (which already excludes
+    pre-releases and drafts).
+  - `latest` → GitHub `…/releases` and picks the newest non-draft release
+    by SemVer precedence, pre-releases included.
+- **Version comparison** is full SemVer §11: a pre-release ranks *below*
+  its associated final version (`1.2.0-rc.1 < 1.2.0`), and prerelease
+  identifiers compare field-by-field (`rc.2 < rc.10`). This is what lets
+  the `latest` channel offer an `-rc` and then upgrade to the final, and
+  prevents the `stable` channel from ever "upgrading" to a pre-release.
+- **Docker image tags** are promoted by the release workflow's
+  `publish-release` job: `:stable` for final releases only, `:latest` for
+  every release.
+- **Compose fallback.** When `DECEPTICON_VERSION` is unset, the images in
+  `docker-compose.yml` fall back to `:stable` (`${DECEPTICON_VERSION:-stable}`)
+  — the conservative default. In normal operation the launcher pins
+  `DECEPTICON_VERSION` to a concrete version, so the fallback is only a
+  safety net for direct `docker compose` use.
+
+## Notes
+
+- `:stable` is seeded by the first **final** release published after this
+  feature landed; until then, pin `DECEPTICON_VERSION` if you run
+  `docker compose` directly without the launcher.
+- Drafts are never installed: GitHub omits them from anonymous
+  `…/releases` responses, and the launcher additionally skips any
+  `draft: true` entry.
+- The channel is independent of `AUTO_UPDATE` (which controls *whether*
+  updates apply automatically) and `DECEPTICON_BRANCH` (which tracks a git
+  branch's config instead of a release tag).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,9 @@
 #   curl -fsSL https://decepticon.red/install | bash
 #
 # Environment variables:
-#   VERSION              — Install a specific version (default: latest)
+#   CHANNEL              — Update channel: stable (final releases, default)
+#                          or latest (includes pre-releases / -rc builds)
+#   VERSION              — Install a specific version (overrides CHANNEL)
 #   DECEPTICON_HOME      — Install directory (default: ~/.decepticon)
 #   SKIP_PULL            — Skip Docker image pull (default: false)
 # ─────────────────────────────────────────────────────────────────────
@@ -16,6 +18,15 @@ set -euo pipefail
 # ── Constants ─────────────────────────────────────────────────────
 REPO="PurpleAILAB/Decepticon"
 BRANCH="${BRANCH:-main}"
+
+# Update channel — stable (final releases only) or latest (incl.
+# pre-releases). Default + any unrecognized value resolves to stable so a
+# typo can't silently pull pre-release images.
+CHANNEL="$(printf '%s' "${CHANNEL:-stable}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+case "$CHANNEL" in
+    latest) ;;
+    *) CHANNEL="stable" ;;
+esac
 RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
 # release asset base — same host every install, used for binary +
 # checksum manifests. raw.githubusercontent.com hosts the source-tree
@@ -136,17 +147,27 @@ resolve_version() {
         return
     fi
 
-    info "Fetching latest version..."
-    local latest
-    latest=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" \
-        | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-
-    if [[ -z "$latest" ]]; then
-        # No releases yet — use branch
-        DECEPTICON_VERSION="latest"
-        info "No releases found, using latest from $BRANCH branch."
+    local resolved
+    if [[ "$CHANNEL" == "latest" ]]; then
+        # latest channel: newest published release INCLUDING pre-releases.
+        # GitHub's /releases list is newest-first and (for anonymous
+        # callers) excludes drafts, so the first tag_name is the target.
+        info "Fetching newest version (latest channel, includes pre-releases)..."
+        resolved=$(curl -s "https://api.github.com/repos/$REPO/releases?per_page=10" \
+            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n 1)
     else
-        DECEPTICON_VERSION="$latest"
+        # stable channel: GitHub "latest" excludes pre-releases by design.
+        info "Fetching latest stable version..."
+        resolved=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" \
+            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+    fi
+
+    if [[ -z "$resolved" ]]; then
+        # No releases yet — fall back to the moving channel image tag.
+        DECEPTICON_VERSION="$CHANNEL"
+        info "No releases found, using the :$CHANNEL image tag."
+    else
+        DECEPTICON_VERSION="$resolved"
         # Pin config downloads to the release tag (not the moving main branch)
         RAW_BASE="https://raw.githubusercontent.com/$REPO/v$DECEPTICON_VERSION"
     fi
@@ -172,9 +193,18 @@ download_files() {
         if ! grep -q "^DECEPTICON_HOME=" "$install_dir/.env" 2>/dev/null; then
             echo "DECEPTICON_HOME=$install_dir" >> "$install_dir/.env"
         fi
+        # Record the update channel so future `decepticon update` runs and
+        # the launch-time self-update track the same stream. An existing
+        # value is preserved (the user's prior choice wins).
+        if ! grep -q "^DECEPTICON_CHANNEL=" "$install_dir/.env" 2>/dev/null; then
+            echo "DECEPTICON_CHANNEL=$CHANNEL" >> "$install_dir/.env"
+        fi
         info ".env already exists, preserving your configuration."
     else
         info "No .env yet — run 'decepticon onboard' to create one."
+        if [[ "$CHANNEL" == "latest" ]]; then
+            info "After onboarding, set DECEPTICON_CHANNEL=latest in .env to keep tracking the latest channel."
+        fi
     fi
 
     # LiteLLM config
@@ -201,7 +231,7 @@ download_files() {
 # release job (.github/workflows/release.yml).
 verify_config_manifest() {
     local install_dir="$1"
-    if [[ "$DECEPTICON_VERSION" == "latest" ]]; then
+    if [[ "$DECEPTICON_VERSION" == "latest" || "$DECEPTICON_VERSION" == "stable" ]]; then
         # resolve_version's fallback path. No release tag → no manifest.
         # We already abort the launcher download in that branch, so this
         # path is only hit when someone runs the installer with branch-
@@ -260,7 +290,7 @@ create_launcher() {
 
     local binary_name="decepticon-${os}-${arch}"
 
-    if [[ "$DECEPTICON_VERSION" == "latest" ]]; then
+    if [[ "$DECEPTICON_VERSION" == "latest" || "$DECEPTICON_VERSION" == "stable" ]]; then
         error "Could not resolve a release version automatically."
         error "Set VERSION explicitly with a tag from:"
         error "  https://github.com/$REPO/releases"


### PR DESCRIPTION
## Summary

Implements two selectable **update channels** so operators choose between conservative stability and early access to fixes. (Previously there was a single implicit channel — `:latest` = newest stable.)

| Channel | Tracks | GHCR tag | Default |
|---------|--------|----------|---------|
| **stable** | newest **final** release (no pre-releases) | `:stable` | ✅ default |
| **latest** | newest release **including** pre-releases (`-rc`) | `:latest` | opt-in |

A pre-release moves `:latest` but **not** `:stable`; a final release moves both. Maps cleanly onto GitHub's API: `…/releases/latest` already excludes pre-releases (stable), `…/releases` includes them (latest).

## Selecting a channel

- **`.env`**: `DECEPTICON_CHANNEL=stable|latest` (default + any unrecognized value → stable, so a typo can't silently pull pre-releases).
- **Install**: `CHANNEL=latest curl -fsSL https://decepticon.red/install | bash`.
- **Per command**: `decepticon update --channel latest` (one run, no persist).

Pinning `DECEPTICON_VERSION` / `VERSION=` still wins over the channel.

## Changes

**`internal/updater`**
- `Channel` type + `ResolveChannel` (default-stable).
- `FetchRelease(ch)`: stable → `/releases/latest`; latest → `/releases`, newest non-draft incl. prerelease (`pickNewestRelease`).
- `compareSemver` rewritten for **SemVer §11 prerelease precedence** (`1.2.0-rc.1 < 1.2.0`, `rc.2 < rc.10`, numeric < alphanumeric, longer set wins). This is what lets `latest` move `rc → final` and stops `stable` ever "upgrading" to a pre-release.
- Channel threaded through `Auto/Prompt/Notify` update paths.

**Launcher wiring** — `start.go` resolves `DECEPTICON_CHANNEL` and passes it to the self-update; `update.go` reads it + adds a `--channel` flag.

**`release.yml`** — `publish-release` promotes `:<version>` → `:stable` (finals only) and → `:latest` (all releases). `:stable` is seeded by the first final release after this lands.

**`docker-compose.yml`** — the unpinned fallback flips `${DECEPTICON_VERSION:-latest}` → `:-stable` (conservative; the launcher normally pins a concrete version, so this is only a direct-`docker compose` safety net).

**`install.sh`** — `CHANNEL` env resolves stable/latest, pins the resolved version, and persists `DECEPTICON_CHANNEL`.

**Docs** — new `docs/update-channels.md`; `.env.example` + `docs/makefile-reference.md` updated.

## Tests / gates

TDD on the updater core: `TestCompareVersions` extended with the prerelease matrix, new `TestResolveChannel`, `TestFetchRelease_*` (stable vs latest endpoint routing), `TestPickNewestRelease` (skips drafts, highest semver). `go vet ./...` + `go test ./...` green; `gofmt` clean; `install.sh` `bash -n` clean; `release.yml` + `docker-compose.yml` YAML valid.