### PR TITLE
fix(sandbox): strip terminal control noise from bash_output session log

### DIFF
--- a/packages/decepticon/decepticon/sandbox_kernel/base.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/base.py
@@ -34,7 +34,12 @@ from deepagents.backends.protocol import ExecuteResponse
 from deepagents.backends.sandbox import BaseSandbox
 
 from decepticon.sandbox_kernel.jobs import BackgroundJob, BackgroundJobTracker
-from decepticon.sandbox_kernel.tmux import PS1_PATTERN, TmuxSessionManager, _safe_log
+from decepticon.sandbox_kernel.tmux import (
+    PS1_PATTERN,
+    TmuxSessionManager,
+    _safe_log,
+    strip_terminal_noise,
+)
 
 log = logging.getLogger("decepticon.sandbox_kernel.base")
 
@@ -284,7 +289,10 @@ class SandboxBase(BaseSandbox):
                 prev_offset = 0
             new_bytes = full[prev_offset:]
             self._log_offsets[key] = len(full)
-        return new_bytes.decode("utf-8", errors="replace")
+        # pipe-pane streams RAW pane bytes (escape sequences, OSC shell-
+        # integration markers, bracketed-paste toggles, PS1 markers) — strip
+        # them so bash_output returns readable text, not terminal noise.
+        return strip_terminal_noise(new_bytes.decode("utf-8", errors="replace"))
 
     def reset_session_log_offset(self, session: str, workspace_path: str | None = None) -> None:
         """Forget the read offset (used after kill / GC)."""

--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -40,6 +40,49 @@ log = logging.getLogger("decepticon.sandbox_kernel.tmux")
 # joining without relying on backtracking or on '.' implicitly excluding '\n'.
 PS1_PATTERN = re.compile(r"\[DCPTN:(\d+):([^\]\n]+)\]")
 
+# ─── Terminal-noise sanitizer (for the pipe-pane session log) ───────────
+#
+# ``capture-pane`` (foreground bash) renders to a clean screen, so its
+# output is already escape-free. ``pipe-pane`` (the streaming session log
+# behind ``bash_output``) instead streams the RAW pane bytes, which carry
+# every control sequence the shell emits: OSC shell-integration markers
+# (incl. the ``OSC 3008`` ``type=shell;cwd=…`` ones), CSI sequences
+# (colors, cursor moves, bracketed-paste ``?2004h/l`` toggles), the
+# ``[DCPTN:…]`` PS1 markers, and stray C0 control chars. Returned verbatim
+# they reach the agent / LangSmith as unreadable noise — so the log diff
+# is run through ``strip_terminal_noise`` before it is handed back.
+#
+# OSC: ESC ] … terminated by BEL or ST (ESC \).
+_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+# CSI: ESC [ params intermediates final. Covers SGR, cursor, and the
+# private ``?2004h/l`` bracketed-paste toggles.
+_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+# Other two-char ESC sequences (RIS ``ESC c``, save/restore cursor, etc.).
+# The final-byte class deliberately excludes ``[`` (0x5b) so it never eats
+# a CSI introducer; OSC is handled above.
+_ESC_RE = re.compile(r"\x1b[@-Z\\-_]")
+# Remaining C0 control chars EXCEPT tab (0x09) and newline (0x0a); carriage
+# returns are normalized away separately.
+_C0_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def strip_terminal_noise(text: str) -> str:
+    """Strip raw-terminal control noise from a pipe-pane log diff.
+
+    Removes OSC / CSI / two-char ESC sequences, the ``[DCPTN:…]`` PS1
+    markers, and stray C0 control chars; normalizes ``\\r\\n`` → ``\\n``.
+    Plain text, newlines, and tabs are preserved.
+    """
+    if not text:
+        return text
+    text = _OSC_RE.sub("", text)
+    text = _CSI_RE.sub("", text)
+    text = _ESC_RE.sub("", text)
+    text = PS1_PATTERN.sub("", text)
+    text = text.replace("\r\n", "\n").replace("\r", "")
+    return _C0_RE.sub("", text)
+
+
 POLL_INTERVAL: float = 0.5
 # Adaptive backoff: while the command has produced no output yet and the
 # screen is unchanged between polls, the interval grows geometrically

--- a/packages/decepticon/tests/unit/sandbox_kernel/test_log_sanitize.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_log_sanitize.py
@@ -1,0 +1,76 @@
+"""Tests for ``strip_terminal_noise`` — the pipe-pane session-log sanitizer.
+
+``read_session_log_diff`` (the ``bash_output`` backing) returns the raw
+``pipe-pane`` log, which streams unrendered pane bytes: OSC shell-
+integration markers, CSI sequences (colors, bracketed-paste ``?2004h/l``),
+the ``[DCPTN:…]`` PS1 markers, and stray control chars. Unlike
+``capture-pane`` (which renders to a clean screen), none of that is
+stripped — so it leaked to the agent / LangSmith. These pin the cleanup.
+"""
+
+from __future__ import annotations
+
+from decepticon.sandbox_kernel.tmux import strip_terminal_noise
+
+
+def test_strips_osc_3008_shell_integration():
+    raw = "\x1b]3008;start=abc;machineid=z;type=shell;cwd=/workspace/x\x1b\\hello\n"
+    assert strip_terminal_noise(raw) == "hello\n"
+
+
+def test_strips_osc_terminated_by_bel():
+    raw = "\x1b]0;window title\x07payload\n"
+    assert strip_terminal_noise(raw) == "payload\n"
+
+
+def test_strips_bracketed_paste_toggles():
+    raw = "\x1b[?2004hcmd line\x1b[?2004l\n"
+    assert strip_terminal_noise(raw) == "cmd line\n"
+
+
+def test_strips_sgr_color_codes():
+    raw = "\x1b[31mred\x1b[0m normal\n"
+    assert strip_terminal_noise(raw) == "red normal\n"
+
+
+def test_strips_ps1_dcptn_markers():
+    raw = "[DCPTN:0:/workspace/recon] echo hi\n"
+    assert strip_terminal_noise(raw) == " echo hi\n"
+
+
+def test_normalizes_crlf_and_strips_c0_controls():
+    raw = "line1\r\nline2\x00\x07\n"
+    assert strip_terminal_noise(raw) == "line1\nline2\n"
+
+
+def test_keeps_plain_text_newlines_and_tabs():
+    raw = "plain\ttext\nsecond line\n"
+    assert strip_terminal_noise(raw) == "plain\ttext\nsecond line\n"
+
+
+def test_idle_marker_passes_through_unchanged():
+    raw = "[IDLE] No background job in session 'recon'.\n"
+    assert strip_terminal_noise(raw) == raw
+
+
+def test_empty_input():
+    assert strip_terminal_noise("") == ""
+
+
+def test_realistic_pipe_pane_sample_is_clean():
+    raw = (
+        "\x1b]3008;start=e2e;machineid=abc;type=shell;cwd=/workspace/recon\x1b\\"
+        "\x1b[?2004h[DCPTN:0:/workspace/recon] cd /workspace/recon\x1b[?2004l\n"
+        "\x1b[?2004himport subprocess\x1b[?2004l\n"
+        "\x1b]3008;start=c9;type=command;cwd=/workspace/recon\x1b\\"
+        "[+] Querying crt.sh for semrush.com...\n"
+    )
+    out = strip_terminal_noise(raw)
+    assert "\x1b" not in out  # no escape bytes
+    assert "3008" not in out  # OSC shell-integration gone
+    assert "2004" not in out  # bracketed-paste gone
+    assert "DCPTN" not in out  # PS1 marker gone
+    # Real content survives.
+    assert "cd /workspace/recon" in out
+    assert "import subprocess" in out
+    assert "[+] Querying crt.sh for semrush.com..." in out


### PR DESCRIPTION
## Problem

`bash_output` returned unreadable terminal noise to the agent (and LangSmith) for background sessions — e.g.:

```
]3008;start=…;type=shell;cwd=/workspace/…\[?2004h[DCPTN:0:/workspace/…] cd …
[?2004limport subprocess
[?2004l
```

## Root cause

`SandboxBase.read_session_log_diff` (the `bash_output` backing) returns the **raw `pipe-pane` session log**. `pipe-pane -o "cat >> log"` streams the **unrendered pane bytes**, which carry every control sequence the shell emits:

- **OSC** shell-integration markers — incl. the `OSC 3008` `type=shell;cwd=…` ones (ST-terminated)
- **CSI** sequences — colors, cursor moves, and bracketed-paste `?2004h/l` toggles (one pair per heredoc input line)
- the `[DCPTN:…]` **PS1 markers**
- stray **C0** control chars

Unlike the foreground path (`capture-pane`, which renders to a clean screen and slices after the PS1 marker), the log diff was returned **verbatim**.

## Fix

- Add `strip_terminal_noise()` in `sandbox_kernel/tmux.py`: removes OSC / CSI / two-char-ESC sequences and the `[DCPTN:…]` markers, normalizes `\r\n` → `\n`, strips remaining C0 controls — while preserving plain text, newlines, and tabs.
- Apply it in `read_session_log_diff` before returning the decoded diff.

Foreground `bash` is unaffected (it never carried these). Minimal, targeted change in the sandbox kernel (ships in the sandbox image; stdlib-only).

## Tests

New `test_log_sanitize.py` pins OSC 3008 / BEL-OSC / bracketed-paste / SGR / PS1 / CRLF / C0 stripping, plaintext-passthrough, the `[IDLE]` passthrough, and a realistic pipe-pane sample (asserts no `\x1b`/`3008`/`2004`/`DCPTN` remain, real content survives). `pytest` 42 passed (incl. existing tmux lifecycle — no regression); `basedpyright` 0 errors; `ruff` clean.