### PR TITLE
feat(channels): Claude-Code-style soak model (latest=newest final, stable=soaked)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -278,11 +278,14 @@ LANGSMITH_PROJECT=decepticon
 # AUTO_UPDATE=false
 #
 # Update channel — which release stream `update` / auto-update track.
-# Defaults to stable. See docs/update-channels.md.
-#   stable  — final releases only (GHCR :stable). The safe default.
-#   latest  — newest release INCLUDING pre-releases / -rc builds (GHCR
-#             :latest). For early adopters who want fixes first.
+# Defaults to stable. Both channels are final-only (Claude-Code-style soak
+# model); the difference is a bake delay. See docs/update-channels.md.
+#   stable  — newest final release baked >= the soak window (default 7d).
+#             The safe default (GHCR :stable).
+#   latest  — newest final release, immediately (GHCR :latest). Fixes first.
 # DECEPTICON_CHANNEL=latest
+# Soak window (days) the stable channel waits before adopting a release:
+# DECEPTICON_STABLE_SOAK_DAYS=7
 # DECEPTICON_DEBUG=true
 
 # Multi-stack container naming (PR #216). Unset/empty keeps the default

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,0 +1,88 @@
+# Moves the GHCR :stable channel tag to the newest FINAL release that has
+# "baked" on the latest channel for at least the soak window (Claude-Code-
+# style soak model — see docs/update-channels.md). The on-tag release
+# workflow only moves :latest (immediately); :stable lags by the soak.
+#
+# Runs daily and on demand. Idempotent: re-pointing :stable to the same
+# version is a no-op cost-wise.
+name: Promote stable channel
+
+on:
+  schedule:
+    - cron: "17 6 * * *" # daily ~06:17 UTC
+  workflow_dispatch:
+    inputs:
+      soak_days:
+        description: "Soak window in days (release must be at least this old)"
+        default: "7"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: promote-stable
+  cancel-in-progress: false
+
+jobs:
+  promote-stable:
+    name: Promote :stable to the newest soaked final
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Resolve newest soaked final release
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOAK_DAYS: ${{ github.event.inputs.soak_days || '7' }}
+        run: |
+          set -euo pipefail
+          soak_seconds=$(( SOAK_DAYS * 86400 ))
+          # Newest FINAL (non-draft, non-prerelease) release whose
+          # published_at is at least the soak window in the past, by SemVer.
+          version=$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=30" --jq "
+            [ .[]
+              | select(.draft == false and .prerelease == false)
+              | select((now - (.published_at | fromdateiso8601)) >= ${soak_seconds})
+              | .tag_name | ltrimstr(\"v\")
+            ]
+            | sort_by(split(\".\") | map(tonumber? // 0))
+            | last // \"\"
+          ")
+          if [[ -z "${version}" ]]; then
+            echo "No final release has soaked >= ${SOAK_DAYS}d yet — nothing to promote."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Soaked stable target: ${version}"
+            echo "promote=true" >> "$GITHUB_OUTPUT"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Promote :<version> → :stable
+        if: steps.resolve.outputs.promote == 'true'
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          images=(
+            decepticon-litellm
+            decepticon-langgraph
+            decepticon-sandbox
+            decepticon-cli
+            decepticon-skillogy
+            decepticon-c2-sliver
+            decepticon-web
+          )
+          for img in "${images[@]}"; do
+            src="ghcr.io/purpleailab/${img}:${VERSION}"
+            dst="ghcr.io/purpleailab/${img}:stable"
+            echo "Promoting ${src} → ${dst}"
+            docker buildx imagetools create --tag "${dst}" "${src}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -663,37 +663,16 @@ jobs:
             docker buildx imagetools inspect "${ref}" >/dev/null
           done
 
-      # Channel tags (see docs/update-channels.md):
-      #   :stable — newest FINAL release only. The conservative default
-      #             the launcher's `stable` channel + the compose
-      #             ${DECEPTICON_VERSION:-stable} fallback resolve to.
-      #   :latest — newest release INCLUDING pre-releases, for the
-      #             `latest` channel (early adopters get -rc builds first).
-      # A pre-release moves :latest but NOT :stable; a final release moves
-      # both.
-      - name: Promote :<version> → :stable (final releases only)
+      # Channel tags (Claude-Code-style soak model; see
+      # docs/update-channels.md). Both channels are FINAL-only:
+      #   :latest — newest FINAL release, moved here immediately on every
+      #             final release (this step).
+      #   :stable — newest FINAL release that has baked >= the soak window;
+      #             moved separately by the scheduled `promote-stable.yml`
+      #             workflow, NOT here.
+      # Pre-releases move neither tag (the channels never auto-select them).
+      - name: Promote :<version> → :latest (final releases only)
         if: steps.version.outputs.prerelease != 'true'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          images=(
-            decepticon-litellm
-            decepticon-langgraph
-            decepticon-sandbox
-            decepticon-cli
-            decepticon-skillogy
-            decepticon-c2-sliver
-            decepticon-web
-          )
-          for img in "${images[@]}"; do
-            src="ghcr.io/purpleailab/${img}:${VERSION}"
-            dst="ghcr.io/purpleailab/${img}:stable"
-            echo "Promoting ${src} → ${dst}"
-            docker buildx imagetools create --tag "${dst}" "${src}"
-          done
-
-      - name: Promote :<version> → :latest (all releases incl. pre-releases)
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |

--- a/clients/launcher/cmd/update.go
+++ b/clients/launcher/cmd/update.go
@@ -24,7 +24,7 @@ var updateCmd = &cobra.Command{
 
 func init() {
 	updateCmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Refresh config files and Docker images even if version unchanged")
-	updateCmd.Flags().StringVar(&updateChannel, "channel", "", "Update channel for this run: stable (final releases) or latest (incl. pre-releases). Default: DECEPTICON_CHANNEL in .env, else stable")
+	updateCmd.Flags().StringVar(&updateChannel, "channel", "", "Update channel for this run: stable (soaked final) or latest (newest final). Default: DECEPTICON_CHANNEL in .env, else stable")
 	rootCmd.AddCommand(updateCmd)
 }
 

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -45,14 +45,21 @@ var APIBaseURL = "https://api.github.com/repos/" + Repo
 // wslHostIPFn pattern used in cmd/start.go.
 var executableFn = os.Executable
 
-// Channel selects which releases the updater tracks.
+// Channel selects which releases the updater tracks. The model mirrors
+// Claude Code's update channels: both are FINAL-only (pre-releases are
+// never auto-selected); the difference is a bake/soak delay, not
+// pre-release inclusion.
 //
-//   - ChannelStable: only final releases (GitHub "latest", which excludes
-//     pre-releases). Maps to the GHCR “:stable“ tag. The safe default.
-//   - ChannelLatest: the newest release INCLUDING pre-releases
-//     (“vX.Y.Z-rc.N“). Maps to GHCR “:latest“ for early adopters.
+//   - ChannelStable (default): the newest FINAL release that has baked on
+//     the latest channel for at least the soak window (default ~1 week) —
+//     a delayed, more-vetted promotion. Maps to GHCR ":stable".
+//   - ChannelLatest: the newest FINAL release, immediately (GitHub
+//     "latest", which excludes pre-releases). Maps to GHCR ":latest".
 //
-// Selected via the “DECEPTICON_CHANNEL“ key in “.env“.
+// Decepticon defaults to stable (conservative for an offensive-security
+// tool); the channel semantics match Claude Code's soak model, only the
+// default differs (Claude Code defaults to latest). Selected via the
+// "DECEPTICON_CHANNEL" key in ".env".
 type Channel string
 
 const (
@@ -60,9 +67,30 @@ const (
 	ChannelLatest Channel = "latest"
 )
 
-// ResolveChannel normalizes a raw “DECEPTICON_CHANNEL“ value. Empty or
+// nowFn is injectable so tests can pin "now" for stable soak math.
+var nowFn = time.Now
+
+// stableSoak is how long a final release must bake on the latest channel
+// before the stable channel adopts it (Claude-Code-style ~1 week).
+// Override with DECEPTICON_STABLE_SOAK_DAYS. A var so tests can pin it.
+var stableSoak = resolveStableSoak()
+
+func resolveStableSoak() time.Duration {
+	const def = 7 * 24 * time.Hour
+	raw := strings.TrimSpace(os.Getenv("DECEPTICON_STABLE_SOAK_DAYS"))
+	if raw == "" {
+		return def
+	}
+	var days float64
+	if _, err := fmt.Sscanf(raw, "%f", &days); err != nil || days < 0 {
+		return def
+	}
+	return time.Duration(days * 24 * float64(time.Hour))
+}
+
+// ResolveChannel normalizes a raw "DECEPTICON_CHANNEL" value. Empty or
 // unrecognized values resolve to the safe default (stable) so a typo can
-// never silently opt a user into pre-release images.
+// never silently opt a security-tool user onto the faster channel.
 func ResolveChannel(raw string) Channel {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case string(ChannelLatest):
@@ -74,10 +102,11 @@ func ResolveChannel(raw string) Channel {
 
 // Release represents a GitHub release.
 type Release struct {
-	TagName    string  `json:"tag_name"`
-	Assets     []Asset `json:"assets"`
-	Prerelease bool    `json:"prerelease"`
-	Draft      bool    `json:"draft"`
+	TagName     string  `json:"tag_name"`
+	Assets      []Asset `json:"assets"`
+	Prerelease  bool    `json:"prerelease"`
+	Draft       bool    `json:"draft"`
+	PublishedAt string  `json:"published_at"`
 }
 
 // Asset represents a release asset (binary download).
@@ -88,24 +117,25 @@ type Asset struct {
 
 // FetchRelease gets the release to track for the given channel.
 //
-//   - stable: GitHub's "latest" release, which already excludes
-//     pre-releases and drafts.
-//   - latest: the newest non-draft release from the releases list,
-//     INCLUDING pre-releases (so early adopters see -rc builds first).
+//   - latest: the newest FINAL release, immediately (GitHub
+//     /releases/latest, which excludes pre-releases and drafts).
+//   - stable: the newest FINAL release that has baked for at least the
+//     soak window. Falls back to the newest final when nothing has soaked
+//     yet, so stable always resolves to something installable.
 func FetchRelease(ch Channel) (*Release, error) {
-	if ch == ChannelLatest {
-		return fetchNewestIncludingPrerelease()
+	if ch == ChannelStable {
+		return fetchSoakedStable()
 	}
-	return fetchLatestStable()
+	return fetchLatestFinal()
 }
 
-// FetchLatestRelease is the stable-channel fetch, kept for callers that
-// don't (yet) thread a channel through.
+// FetchLatestRelease is the latest-channel fetch (newest final), kept for
+// callers that don't thread a channel through.
 func FetchLatestRelease() (*Release, error) {
-	return fetchLatestStable()
+	return fetchLatestFinal()
 }
 
-func fetchLatestStable() (*Release, error) {
+func fetchLatestFinal() (*Release, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(APIBaseURL + "/releases/latest")
 	if err != nil {
@@ -124,12 +154,23 @@ func fetchLatestStable() (*Release, error) {
 	return &release, nil
 }
 
-// fetchNewestIncludingPrerelease lists releases and returns the newest
-// non-draft one by SemVer precedence (pre-releases included). Falls back
-// to the stable endpoint when the list is empty.
-func fetchNewestIncludingPrerelease() (*Release, error) {
+// fetchSoakedStable lists releases and returns the newest FINAL one that
+// has baked for at least the soak window. Falls back to the newest final
+// when nothing has soaked yet (e.g. a brand-new project).
+func fetchSoakedStable() (*Release, error) {
+	releases, err := listReleases()
+	if err != nil {
+		return nil, err
+	}
+	if r := pickSoakedStable(releases, nowFn(), stableSoak); r != nil {
+		return r, nil
+	}
+	return fetchLatestFinal()
+}
+
+func listReleases() ([]Release, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(APIBaseURL + "/releases?per_page=20")
+	resp, err := client.Get(APIBaseURL + "/releases?per_page=30")
 	if err != nil {
 		return nil, fmt.Errorf("fetch releases: %w", err)
 	}
@@ -143,22 +184,23 @@ func fetchNewestIncludingPrerelease() (*Release, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
 		return nil, fmt.Errorf("decode releases: %w", err)
 	}
-	if newest := pickNewestRelease(releases); newest != nil {
-		return newest, nil
-	}
-	// Empty list (or all drafts) — fall back to the stable channel so the
-	// latest channel still resolves to *something* installable.
-	return fetchLatestStable()
+	return releases, nil
 }
 
-// pickNewestRelease returns the highest-precedence non-draft release by
-// SemVer comparison, or nil when none qualify.
-func pickNewestRelease(releases []Release) *Release {
+// pickSoakedStable returns the highest-precedence FINAL (non-draft, non-
+// prerelease) release published at least `soak` before `now`, or nil when
+// none qualify.
+func pickSoakedStable(releases []Release, now time.Time, soak time.Duration) *Release {
+	cutoff := now.Add(-soak)
 	var best *Release
 	for i := range releases {
 		r := &releases[i]
-		if r.Draft || r.TagName == "" {
+		if r.Draft || r.Prerelease || r.TagName == "" {
 			continue
+		}
+		pub, err := time.Parse(time.RFC3339, r.PublishedAt)
+		if err != nil || pub.After(cutoff) {
+			continue // unparseable timestamp, or not yet soaked
 		}
 		if best == nil || compareSemver(
 			strings.TrimPrefix(best.TagName, "v"),

--- a/clients/launcher/internal/updater/updater_test.go
+++ b/clients/launcher/internal/updater/updater_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCompareVersions(t *testing.T) {
@@ -52,6 +53,8 @@ func TestCompareVersions(t *testing.T) {
 }
 
 func TestResolveChannel(t *testing.T) {
+	// Default + unrecognized → stable (Decepticon's conservative default;
+	// soak semantics still match Claude Code, only the default differs).
 	tests := map[string]Channel{
 		"":          ChannelStable, // default
 		"stable":    ChannelStable,
@@ -60,7 +63,7 @@ func TestResolveChannel(t *testing.T) {
 		"latest":    ChannelLatest,
 		"LATEST":    ChannelLatest,
 		" latest":   ChannelLatest,
-		"garbage":   ChannelStable, // unrecognized → safe default
+		"garbage":   ChannelStable, // unrecognized → safe default (stable)
 	}
 	for in, want := range tests {
 		if got := ResolveChannel(in); got != want {
@@ -117,38 +120,14 @@ func TestFetchLatestRelease_Mock(t *testing.T) {
 	}
 }
 
-func TestFetchRelease_StableHitsLatestEndpoint(t *testing.T) {
+func TestFetchRelease_LatestUsesReleasesLatestEndpoint(t *testing.T) {
+	// latest = newest FINAL release immediately. GitHub's /releases/latest
+	// already excludes pre-releases and drafts.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/releases/latest" {
-			t.Errorf("stable channel must call /releases/latest, got %q", r.URL.Path)
+			t.Errorf("latest channel must call /releases/latest, got %q", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode(Release{TagName: "v1.2.0"})
-	}))
-	defer srv.Close()
-	defer withAPIBaseURL(srv.URL)()
-
-	rel, err := FetchRelease(ChannelStable)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rel.TagName != "v1.2.0" {
-		t.Errorf("TagName = %q, want v1.2.0", rel.TagName)
-	}
-}
-
-func TestFetchRelease_LatestPicksNewestInclPrereleaseSkipsDrafts(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/releases/latest" {
-			t.Errorf("latest channel must list /releases, not /releases/latest")
-		}
-		// Unordered; a draft newer than everything (must be skipped); a
-		// prerelease that is the newest non-draft (must win).
-		json.NewEncoder(w).Encode([]Release{
-			{TagName: "v1.2.0"},
-			{TagName: "v1.3.0-rc.2", Prerelease: true},
-			{TagName: "v2.0.0", Draft: true},
-			{TagName: "v1.1.0"},
-		})
+		json.NewEncoder(w).Encode(Release{TagName: "v1.3.0"})
 	}))
 	defer srv.Close()
 	defer withAPIBaseURL(srv.URL)()
@@ -157,23 +136,91 @@ func TestFetchRelease_LatestPicksNewestInclPrereleaseSkipsDrafts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rel.TagName != "v1.3.0-rc.2" {
-		t.Errorf("TagName = %q, want v1.3.0-rc.2", rel.TagName)
+	if rel.TagName != "v1.3.0" {
+		t.Errorf("TagName = %q, want v1.3.0", rel.TagName)
 	}
 }
 
-func TestPickNewestRelease(t *testing.T) {
-	got := pickNewestRelease([]Release{
-		{TagName: "v1.2.0"},
-		{TagName: "v1.3.0-rc.1", Prerelease: true},
-		{TagName: "v2.0.0", Draft: true}, // draft → skipped despite highest semver
-		{TagName: ""},                    // malformed → skipped
-	})
-	if got == nil || got.TagName != "v1.3.0-rc.1" {
-		t.Fatalf("pickNewestRelease = %+v, want v1.3.0-rc.1", got)
+func TestFetchRelease_StableSoaksByPublishedAt(t *testing.T) {
+	// stable = newest FINAL release that has baked for the soak window.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			t.Errorf("stable channel must list /releases, not /releases/latest")
+		}
+		json.NewEncoder(w).Encode([]Release{
+			{TagName: "v1.3.0", PublishedAt: "2026-06-10T00:00:00Z"},                        // 2d old — too fresh
+			{TagName: "v1.2.0", PublishedAt: "2026-06-01T00:00:00Z"},                        // 11d old — soaked, newest soaked
+			{TagName: "v1.1.0", PublishedAt: "2026-05-01T00:00:00Z"},                        // soaked but lower
+			{TagName: "v1.4.0-rc.1", Prerelease: true, PublishedAt: "2026-05-01T00:00:00Z"}, // prerelease — excluded
+			{TagName: "v2.0.0", Draft: true, PublishedAt: "2026-01-01T00:00:00Z"},           // draft — excluded
+		})
+	}))
+	defer srv.Close()
+	defer withAPIBaseURL(srv.URL)()
+	defer withSoakClock(time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC), 7*24*time.Hour)()
+
+	rel, err := FetchRelease(ChannelStable)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if pickNewestRelease(nil) != nil {
-		t.Errorf("pickNewestRelease(nil) should be nil")
+	if rel.TagName != "v1.2.0" {
+		t.Errorf("stable TagName = %q, want v1.2.0 (newest final older than 7d)", rel.TagName)
+	}
+}
+
+func TestFetchRelease_StableFallsBackToLatestWhenNoneSoaked(t *testing.T) {
+	// Every release is younger than the soak window (brand-new project) —
+	// stable must still resolve, by falling back to the newest final.
+	hits := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits[r.URL.Path]++
+		if r.URL.Path == "/releases/latest" {
+			json.NewEncoder(w).Encode(Release{TagName: "v1.3.0"})
+			return
+		}
+		json.NewEncoder(w).Encode([]Release{
+			{TagName: "v1.3.0", PublishedAt: "2026-06-11T00:00:00Z"}, // 1d old
+		})
+	}))
+	defer srv.Close()
+	defer withAPIBaseURL(srv.URL)()
+	defer withSoakClock(time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC), 7*24*time.Hour)()
+
+	rel, err := FetchRelease(ChannelStable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel.TagName != "v1.3.0" {
+		t.Errorf("fallback TagName = %q, want v1.3.0", rel.TagName)
+	}
+	if hits["/releases/latest"] == 0 {
+		t.Errorf("expected a fallback to /releases/latest")
+	}
+}
+
+func TestPickSoakedStable(t *testing.T) {
+	now := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	soak := 7 * 24 * time.Hour
+	got := pickSoakedStable([]Release{
+		{TagName: "v1.3.0", PublishedAt: "2026-06-10T00:00:00Z"}, // 2d — too fresh
+		{TagName: "v1.2.0", PublishedAt: "2026-06-01T00:00:00Z"}, // 11d — soaked, highest
+		{TagName: "v1.1.0", PublishedAt: "2026-05-01T00:00:00Z"}, // soaked, lower
+		{TagName: "v1.4.0-rc.1", Prerelease: true, PublishedAt: "2026-04-01T00:00:00Z"},
+		{TagName: "v2.0.0", Draft: true, PublishedAt: "2026-04-01T00:00:00Z"},
+		{TagName: "", PublishedAt: "2026-04-01T00:00:00Z"},
+	}, now, soak)
+	if got == nil || got.TagName != "v1.2.0" {
+		t.Fatalf("pickSoakedStable = %+v, want v1.2.0", got)
+	}
+	// None soaked → nil (caller falls back).
+	none := pickSoakedStable([]Release{
+		{TagName: "v1.3.0", PublishedAt: "2026-06-11T00:00:00Z"},
+	}, now, soak)
+	if none != nil {
+		t.Errorf("pickSoakedStable(all fresh) = %+v, want nil", none)
+	}
+	if pickSoakedStable(nil, now, soak) != nil {
+		t.Errorf("pickSoakedStable(nil) should be nil")
 	}
 }
 
@@ -183,6 +230,15 @@ func withAPIBaseURL(url string) func() {
 	old := APIBaseURL
 	APIBaseURL = url
 	return func() { APIBaseURL = old }
+}
+
+// withSoakClock pins the updater's "now" and soak window for deterministic
+// stable-channel soak math; returns a restore func.
+func withSoakClock(now time.Time, soak time.Duration) func() {
+	oldNow, oldSoak := nowFn, stableSoak
+	nowFn = func() time.Time { return now }
+	stableSoak = soak
+	return func() { nowFn, stableSoak = oldNow, oldSoak }
 }
 
 func TestPromptIfUpdateAvailable_SkipsDevBuilds(t *testing.T) {

--- a/docs/makefile-reference.md
+++ b/docs/makefile-reference.md
@@ -108,10 +108,10 @@ Release channel policy (see [update-channels.md](./update-channels.md) for the u
 
 - `vX.Y.Z` Git tags are the source of truth for releases.
 - GHCR version tags (`X.Y.Z`) are immutable release artifacts and should be used by installed deployments.
-- Two moving channel tags are promoted by the `publish-release` job after all version-tagged images exist and the GitHub release is undrafted:
-  - GHCR `stable` → the newest **final** release only (the conservative default; the `${DECEPTICON_VERSION:-stable}` compose fallback resolves here).
-  - GHCR `latest` → the newest release **including pre-releases**.
-- Pre-releases use SemVer suffixes such as `v1.1.0-rc.1`, stay marked as GitHub pre-releases, and move `latest` but **not** `stable`.
+- Two moving channel tags (Claude-Code-style soak model — both **final-only**):
+  - GHCR `latest` → moved to the newest **final** release **immediately**, by the `publish-release` job (after all version-tagged images exist and the GitHub release is undrafted).
+  - GHCR `stable` → moved to the newest final release **baked ≥ the soak window** (default 7 days), by the **scheduled** `promote-stable.yml` workflow — *not* on release. The conservative default; the `${DECEPTICON_VERSION:-stable}` compose fallback resolves here.
+- Pre-releases use SemVer suffixes such as `v1.1.0-rc.1`, stay marked as GitHub pre-releases, and move **neither** channel tag (the channels never auto-select them).
 - Bug fixes ship as new patch releases. Do not rebuild or rewrite an existing version tag.
 
 To cut a release:

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -1,71 +1,81 @@
 # Update channels
 
-Decepticon publishes two update channels so operators can choose between
-conservative stability and early access to fixes.
+Decepticon publishes two update channels, modeled on
+[Claude Code's release channels](https://code.claude.com/docs/en/setup#configure-release-channel).
+**Both channels deliver only _final_ releases** (never pre-releases /
+betas). The difference is a **bake/soak delay**, not pre-release inclusion.
 
-| Channel | Tracks | GHCR tag | Who it's for |
-|---------|--------|----------|--------------|
-| **stable** (default) | The newest **final** release (no pre-releases). | `:stable` | Production / most users. The safe default. |
-| **latest** | The newest release **including pre-releases** (`vX.Y.Z-rc.N`). | `:latest` | Early adopters who want fixes before they're finalized. |
+| Channel | Tracks | GHCR tag | Default |
+|---------|--------|----------|---------|
+| **stable** | The newest **final** release that has baked for at least the soak window (default 7 days). | `:stable` | ✅ default |
+| **latest** | The newest **final** release, immediately. | `:latest` | opt-in |
 
-A pre-release moves `:latest` but **not** `:stable`; a final release moves
-both. So `stable` only ever advances to vetted final releases, while
-`latest` surfaces release candidates first.
+So `latest` gets every release the moment it ships, and `stable` adopts it
+about a week later — long enough to surface regressions before
+conservative users see it.
+
+> **Claude Code parity, with one deliberate difference.** The *semantics*
+> match Claude Code (soak model, final-only). Claude Code defaults to
+> `latest`; Decepticon defaults to **`stable`** because it is an autonomous
+> offensive-security tool where a conservative default is the safer choice.
+
+`latest` is **not** "the main branch." It only moves when a release is
+cut — not on every commit. (To track a git branch's config instead of a
+release, use the separate `DECEPTICON_BRANCH` override.)
 
 ## Selecting a channel
 
-The channel lives in `DECEPTICON_CHANNEL` in your `~/.decepticon/.env`
-(default `stable` when unset or unrecognized — a typo can never silently
-opt you into pre-release images):
+The channel lives in `DECEPTICON_CHANNEL` in `~/.decepticon/.env` (default
+`stable`; unrecognized values resolve to `stable`):
 
 ```bash
 # ~/.decepticon/.env
 DECEPTICON_CHANNEL=latest
+# optional — override the stable soak window (days):
+DECEPTICON_STABLE_SOAK_DAYS=7
 ```
 
-It can be set three ways:
+Three ways to set it:
 
 - **At install** — `CHANNEL=latest curl -fsSL https://decepticon.red/install | bash`.
-  The installer resolves and pins the newest version on that channel.
-- **In `.env`** — set `DECEPTICON_CHANNEL=stable|latest`. The launch-time
+- **In `.env`** — `DECEPTICON_CHANNEL=stable|latest`. The launch-time
   self-update and `decepticon update` both honor it.
-- **Per command** — `decepticon update --channel latest` overrides `.env`
-  for that one run (does not persist).
+- **Per command** — `decepticon update --channel latest` (one run only).
 
-Pinning an exact version still wins over the channel:
-`VERSION=1.2.0 curl ... | bash` (install) or `DECEPTICON_VERSION=1.2.0`
-(compose) installs that exact tag regardless of channel.
+Pinning an exact version still wins over the channel: `VERSION=1.2.0
+curl … | bash` (install) or `DECEPTICON_VERSION=1.2.0` (compose).
 
 ## How it works
 
-- **Launcher self-update / `decepticon update`** resolve the channel via
-  `updater.ResolveChannel` and fetch accordingly:
-  - `stable` → GitHub `…/releases/latest` (which already excludes
-    pre-releases and drafts).
-  - `latest` → GitHub `…/releases` and picks the newest non-draft release
-    by SemVer precedence, pre-releases included.
-- **Version comparison** is full SemVer §11: a pre-release ranks *below*
-  its associated final version (`1.2.0-rc.1 < 1.2.0`), and prerelease
-  identifiers compare field-by-field (`rc.2 < rc.10`). This is what lets
-  the `latest` channel offer an `-rc` and then upgrade to the final, and
-  prevents the `stable` channel from ever "upgrading" to a pre-release.
-- **Docker image tags** are promoted by the release workflow's
-  `publish-release` job: `:stable` for final releases only, `:latest` for
-  every release.
+- **Launcher self-update / `decepticon update`** (`internal/updater`):
+  - `latest` → GitHub `…/releases/latest` (newest final; the endpoint
+    already excludes pre-releases and drafts).
+  - `stable` → lists `…/releases` and picks the newest **final** whose
+    `published_at` is at least `DECEPTICON_STABLE_SOAK_DAYS` (default 7) in
+    the past, by SemVer. If nothing has soaked yet, it falls back to the
+    newest final so stable always resolves.
+- **Install** (`scripts/install.sh`) resolves the same way (the stable
+  date filter needs `python3`; without it, it falls back to the newest
+  final).
+- **Docker image tags**:
+  - `:latest` is moved to every **final** release immediately by the
+    release workflow's `publish-release` job.
+  - `:stable` is moved to the newest soaked final by the **scheduled**
+    `promote-stable.yml` workflow (daily), *not* on release.
+  - Pre-releases move neither tag.
 - **Compose fallback.** When `DECEPTICON_VERSION` is unset, the images in
-  `docker-compose.yml` fall back to `:stable` (`${DECEPTICON_VERSION:-stable}`)
-  — the conservative default. In normal operation the launcher pins
-  `DECEPTICON_VERSION` to a concrete version, so the fallback is only a
-  safety net for direct `docker compose` use.
+  `docker-compose.yml` fall back to `:stable` (the conservative default).
+  In normal operation the launcher pins `DECEPTICON_VERSION` to a concrete
+  version, so the fallback is only a safety net for direct `docker compose`
+  use.
 
 ## Notes
 
-- `:stable` is seeded by the first **final** release published after this
-  feature landed; until then, pin `DECEPTICON_VERSION` if you run
-  `docker compose` directly without the launcher.
-- Drafts are never installed: GitHub omits them from anonymous
-  `…/releases` responses, and the launcher additionally skips any
-  `draft: true` entry.
-- The channel is independent of `AUTO_UPDATE` (which controls *whether*
-  updates apply automatically) and `DECEPTICON_BRANCH` (which tracks a git
-  branch's config instead of a release tag).
+- Pre-releases (`vX.Y.Z-rc.N`) are never auto-selected by either channel.
+  Install one explicitly with `VERSION=…` if needed.
+- The channel is independent of `AUTO_UPDATE` (whether updates apply
+  automatically) and `DECEPTICON_BRANCH` (track a git branch's config
+  instead of a release tag).
+- Switching from `latest` to `stable` will not downgrade an
+  already-installed newer version (updates are forward-only); stable simply
+  stops advancing until the soaked stable catches up.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,10 @@
 #   curl -fsSL https://decepticon.red/install | bash
 #
 # Environment variables:
-#   CHANNEL              — Update channel: stable (final releases, default)
-#                          or latest (includes pre-releases / -rc builds)
+#   CHANNEL              — Update channel (default: stable):
+#                            stable — newest final release baked >= SOAK days
+#                            latest — newest final release, immediately
+#   DECEPTICON_STABLE_SOAK_DAYS — stable soak window (default: 7)
 #   VERSION              — Install a specific version (overrides CHANNEL)
 #   DECEPTICON_HOME      — Install directory (default: ~/.decepticon)
 #   SKIP_PULL            — Skip Docker image pull (default: false)
@@ -19,14 +21,19 @@ set -euo pipefail
 REPO="PurpleAILAB/Decepticon"
 BRANCH="${BRANCH:-main}"
 
-# Update channel — stable (final releases only) or latest (incl.
-# pre-releases). Default + any unrecognized value resolves to stable so a
-# typo can't silently pull pre-release images.
+# Update channel (Claude-Code-style soak model; both are final-only):
+#   stable (default) — newest FINAL release baked >= STABLE_SOAK_DAYS
+#   latest           — newest FINAL release, immediately
+# Decepticon defaults to stable (conservative for a security tool); the
+# channel *semantics* match Claude Code, only the default differs.
+# Default + any unrecognized value resolves to stable.
 CHANNEL="$(printf '%s' "${CHANNEL:-stable}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
 case "$CHANNEL" in
     latest) ;;
     *) CHANNEL="stable" ;;
 esac
+# Days the stable channel waits before adopting a final release.
+STABLE_SOAK_DAYS="${DECEPTICON_STABLE_SOAK_DAYS:-7}"
 RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
 # release asset base — same host every install, used for binary +
 # checksum manifests. raw.githubusercontent.com hosts the source-tree
@@ -141,29 +148,70 @@ assert_sha256() {
 }
 
 # ── Version resolution ───────────────────────────────────────────
+# Resolve the newest FINAL release that has baked >= STABLE_SOAK_DAYS.
+# Needs python3 for the published_at date filter; prints nothing (caller
+# falls back to /releases/latest) when python3 is absent or none qualify.
+resolve_stable_soaked() {
+    command -v python3 >/dev/null 2>&1 || return 0
+    curl -s "https://api.github.com/repos/$REPO/releases?per_page=30" | python3 - "$STABLE_SOAK_DAYS" <<'PY' 2>/dev/null
+import sys, json, datetime
+try:
+    soak = float(sys.argv[1])
+except (IndexError, ValueError):
+    soak = 7.0
+now = datetime.datetime.now(datetime.timezone.utc)
+try:
+    rels = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+def key(tag):
+    base = tag.split("-", 1)[0].split(".")
+    out = []
+    for i in range(3):
+        out.append(int(base[i]) if i < len(base) and base[i].isdigit() else 0)
+    return tuple(out)
+best = None
+for r in rels if isinstance(rels, list) else []:
+    if r.get("draft") or r.get("prerelease"):
+        continue
+    tag = (r.get("tag_name") or "").lstrip("v")
+    pub = r.get("published_at")
+    if not tag or not pub:
+        continue
+    try:
+        p = datetime.datetime.fromisoformat(pub.replace("Z", "+00:00"))
+    except Exception:
+        continue
+    if (now - p).total_seconds() < soak * 86400:
+        continue  # not yet soaked
+    if best is None or key(tag) > key(best):
+        best = tag
+print(best or "")
+PY
+}
+
 resolve_version() {
     if [[ -n "${VERSION:-}" ]]; then
         DECEPTICON_VERSION="$VERSION"
         return
     fi
 
-    local resolved
-    if [[ "$CHANNEL" == "latest" ]]; then
-        # latest channel: newest published release INCLUDING pre-releases.
-        # GitHub's /releases list is newest-first and (for anonymous
-        # callers) excludes drafts, so the first tag_name is the target.
-        info "Fetching newest version (latest channel, includes pre-releases)..."
-        resolved=$(curl -s "https://api.github.com/repos/$REPO/releases?per_page=10" \
-            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n 1)
-    else
-        # stable channel: GitHub "latest" excludes pre-releases by design.
-        info "Fetching latest stable version..."
+    local resolved=""
+    if [[ "$CHANNEL" == "stable" ]]; then
+        # stable: newest FINAL release baked >= STABLE_SOAK_DAYS.
+        info "Fetching stable version (soaked >= ${STABLE_SOAK_DAYS}d)..."
+        resolved=$(resolve_stable_soaked)
+    fi
+    if [[ -z "$resolved" ]]; then
+        # latest channel, OR stable with nothing soaked / no python3 —
+        # fall back to GitHub "latest" (newest final, excludes pre-releases).
+        [[ "$CHANNEL" == "latest" ]] && info "Fetching latest version (newest final)..."
         resolved=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" \
             | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
     fi
 
     if [[ -z "$resolved" ]]; then
-        # No releases yet — fall back to the moving channel image tag.
+        # No releases at all — fall back to the moving channel image tag.
         DECEPTICON_VERSION="$CHANNEL"
         info "No releases found, using the :$CHANNEL image tag."
     else


### PR DESCRIPTION
## Why

The channels shipped in v1.1.13 used a **pre-release-inclusion** model (latest = newest incl. `-rc`). Per [Claude Code's release channels](https://code.claude.com/docs/en/setup#configure-release-channel), the real convention is a **soak/bake** model where **both channels are final-only** and the difference is a time delay. This PR realigns Decepticon to that model.

## Model

| Channel | Tracks | GHCR tag | Default |
|---------|--------|----------|---------|
| **stable** | newest **final** release baked ≥ soak window (default 7d) | `:stable` | ✅ default |
| **latest** | newest **final** release, immediately | `:latest` | opt-in |

Pre-releases are **never** auto-selected by either channel now.

> **Claude Code parity, one deliberate difference:** semantics match (soak, final-only). Claude Code defaults to `latest`; Decepticon keeps **`stable`** as the default — conservative for an autonomous offensive-security tool. (Confirmed with the maintainer.)

## Changes

**`internal/updater`**
- `FetchRelease(latest)` → `/releases/latest` (newest final).
- `FetchRelease(stable)` → `pickSoakedStable` over `/releases`: newest **final** whose `published_at` is ≥ soak in the past, by SemVer; falls back to newest final when nothing has soaked.
- Injectable `nowFn` + `stableSoak` (`resolveStableSoak` reads `DECEPTICON_STABLE_SOAK_DAYS`, default 7).
- `ResolveChannel` default + unrecognized → stable.

**`release.yml`** — `:latest` promoted on **final releases only** (immediate). The on-tag `:stable` promotion is **removed**.

**New `promote-stable.yml`** — scheduled (daily) + `workflow_dispatch`. A `jq` filter resolves the newest final release published ≥ soak ago and moves GHCR `:stable` to it.

**`install.sh`** — default channel stable; stable resolves the soaked version via a `python3` date filter (falls back to `/releases/latest` without python3); latest → `/releases/latest`.

**Docs** — `docs/update-channels.md` + `docs/makefile-reference.md` + `.env.example` rewritten to the soak model; `--channel` help text fixed.

## Tests / gates

TDD: `TestResolveChannel` (stable default), `TestFetchRelease_LatestUsesReleasesLatestEndpoint`, `TestFetchRelease_StableSoaksByPublishedAt`, `TestFetchRelease_StableFallsBackToLatestWhenNoneSoaked`, `TestPickSoakedStable` (soak filter + prerelease/draft exclusion + SemVer order, injectable clock). The SemVer §11 prerelease compare from v1.1.13 stays (used for ordering + update detection). `go vet ./...` + `go test ./...` green; `gofmt` clean; `install.sh` `bash -n` + the python soak filter verified; both workflow YAMLs valid.

Ships in **v1.1.14**.