### PR TITLE
fix(tests): align cached-alive env re-sync assertions with #668

### DIFF
--- a/packages/decepticon/tests/unit/sandbox_kernel/test_tmux_lifecycle.py
+++ b/packages/decepticon/tests/unit/sandbox_kernel/test_tmux_lifecycle.py
@@ -238,10 +238,12 @@ class TestBookkeeping:
         ):
             mgr.initialize()
 
-        # Fast path: probe pane, sync env, skip create + PS1 injection.
+        # Fast path: probe pane only — skip create, PS1 injection, AND env
+        # re-sync (the re-sync export's PS1 marker races the user command's
+        # marker; env persists from session creation).
         mock_ensure.assert_not_called()
         mock_inject.assert_not_called()
-        mock_sync.assert_called_once()
+        mock_sync.assert_not_called()
         # display-message probe must have been issued at least once.
         assert any(c.args[0][0] == "display-message" for c in mock_tmux.call_args_list)
 

--- a/packages/decepticon/tests/unit/tools/bash/test_proxy_env.py
+++ b/packages/decepticon/tests/unit/tools/bash/test_proxy_env.py
@@ -202,9 +202,13 @@ def test_sync_passthrough_env_swallows_send_errors_without_raising(
         mgr._sync_passthrough_env()
 
 
-def test_initialize_calls_sync_passthrough_env_when_cached_session_is_alive(
+def test_initialize_skips_sync_passthrough_env_when_cached_session_is_alive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Re-syncing on the cached-alive path emits an export line whose PS1
+    # marker races the user command's marker (see tmux.py initialize()).
+    # The env was synced at session creation and persists, so the fast
+    # path must NOT re-sync.
     _clear_proxy_and_decepticon_env(monkeypatch)
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy:8080")
 
@@ -216,7 +220,7 @@ def test_initialize_calls_sync_passthrough_env_when_cached_session_is_alive(
     ):
         mgr.initialize()
 
-    assert sync_calls == [1]
+    assert sync_calls == []
 
 
 def test_initialize_calls_sync_passthrough_env_after_creating_new_session(


### PR DESCRIPTION
## Summary

#668 removed the per-command `_sync_passthrough_env()` call from `TmuxSessionManager.initialize()`'s cached-alive fast path (the re-sync export emitted its own PS1 completion marker that raced the user command's marker, silently dropping output of slow/network commands). Two unit tests still asserted the **old** re-sync behavior and broke the Python lane — both on #668's own PR run and on the main push run ([27411311375](https://github.com/PurpleAILAB/Decepticon/actions/runs/27411311375)).

This updates the two stale assertions to match the merged behavior:

- `tests/unit/tools/bash/test_proxy_env.py` — renamed to `test_initialize_skips_sync_passthrough_env_when_cached_session_is_alive`; cached-alive path must **not** re-sync (`sync_calls == []`)
- `tests/unit/sandbox_kernel/test_tmux_lifecycle.py::TestBookkeeping::test_initialize_skips_when_cached_alive` — `assert_called_once()` → `assert_not_called()`

New-session-path assertions are untouched — env is still exported once at session creation.

## Verification

- `uv run pytest tests/unit/tools/bash/test_proxy_env.py tests/unit/sandbox_kernel/test_tmux_lifecycle.py -q` → **47 passed**
- `ruff check` + `ruff format --check` clean on both files
- `basedpyright --level error` → 0 errors

Unblocks the v1.1.14 release (main CI must be green before tagging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)