### PR TITLE
fix(skillogy): resolve load_skill by exact name, not a polluted keyword search

### DIFF
--- a/docs/design/2026-06-12-skillogy-load-skill-by-name-pollution.md
+++ b/docs/design/2026-06-12-skillogy-load-skill-by-name-pollution.md
@@ -1,0 +1,85 @@
+# skillogy: load_skill by name 404s when find_skill ranking is polluted
+
+**Date:** 2026-06-12
+**Component:** `decepticon/skillogy/server/` (`app.py` load endpoint + `neo4j_backend.load_skill`)
+**Severity:** high — agents cannot load known skills by name; breaks orchestrator skill-routing
+
+## Symptom
+
+`load_skill("oauth")` and `load_skill("ssrf")` return 404 ("no Skill with name
+or path matching …") even though a `:Skill` node with `name="oauth"` exists,
+while `load_skill("sqli")` / `load_skill("idor")` / `load_skill("xss")` succeed.
+The failures are non-deterministic per skill name and depend on the rest of the
+ingested corpus.
+
+Live impact (bugclaw orchestrator skill-routing, 8x8-bounty engagement): the
+orchestrator classified recon's surface, called `find_skill` + `load_skill`
+~20×, every `load_skill` failed (by name AND by guessed path), and it never
+dispatched a hunting `task()` — the pipeline stalled at skill selection.
+
+## Root cause — name resolution goes through a polluted keyword search
+
+The `/v1/skills:load` endpoint resolved a NAME (anything not starting with
+`/skills/`) by running `find_skill(query=name, limit=10)` and filtering its hits
+for an exact-`name` match:
+
+```python
+hits = backend.find_skill(query=target, limit=10, allowed_path_prefixes=allowed)
+exact = [h for h in hits if h.get("name") == target]
+if not exact:
+    raise HTTPException(404, …)
+```
+
+`find_skill`'s `query` is a substring/keyword search over `name` /
+`description` / `when_to_use`. In a graph that ingests BOTH the standard web
+playbooks AND keyword-rich adversary-emulation (APT) skills, a query like
+`"oauth"` matches the APT skills (apt28/apt29 descriptions mention OAuth token
+theft, device-code phishing, etc.) and they **outrank the web `oauth` skill**,
+pushing it past `limit=10` → `exact` is empty → 404. `"sqli"` happens to have no
+high-ranking APT collisions, so it resolves. The behaviour is therefore a
+function of corpus pollution, not of whether the skill exists.
+
+`neo4j_backend.load_skill` itself only matched by canonical **path**
+(`MATCH (s:Skill {path: $path})`), so it could not be used for a name directly,
+and its `allowed_path_prefixes` ACL gated the *input* string — which rejects
+every bare name (a name is not under `/skills/…`).
+
+## Fix
+
+Resolve a name with a direct, exact graph lookup instead of a ranked keyword
+search.
+
+1. `neo4j_backend.load_skill` now matches **path OR exact name** (path
+   preferred) and applies the path-prefix ACL to the **resolved** skill's path,
+   not the input:
+
+   ```cypher
+   MATCH (s:Skill) WHERE s.path = $arg OR s.name = $arg
+   RETURN properties(s) AS props
+   ORDER BY CASE WHEN s.path = $arg THEN 0 ELSE 1 END
+   LIMIT 1
+   ```
+
+2. The `/v1/skills:load` endpoint calls `backend.load_skill(target)` directly
+   for both path and name inputs (the find_skill-resolution dance is removed) —
+   unambiguous and pollution-proof, with the ACL still enforced on the resolved
+   path.
+
+## Verification
+
+Post-fix, every web playbook loads by bare name, with and without an ACL
+prefix set:
+
+```
+name        bare    acl
+oauth       LOAD    LOAD
+ssrf        LOAD    LOAD
+sqli/idor/xss/jwt/saml/xxe/bfla   LOAD   LOAD
+```
+
+## Follow-up (separate, lower severity)
+
+`find_skill(query=…)` ranking is still polluted by APT skills for *discovery*
+(unscoped `find_skill("oauth")` surfaces apt29 above the web oauth skill).
+Callers should scope with `subdomain="web-exploitation"`; a ranking that
+prefers exact-name / same-subdomain matches would make discovery robust too.

--- a/packages/decepticon/decepticon/skillogy/server/app.py
+++ b/packages/decepticon/decepticon/skillogy/server/app.py
@@ -162,30 +162,24 @@ def build_app(
     async def load_skill(req: LoadReq) -> dict[str, Any]:
         target = req.name_or_path
         allowed = req.allowed_path_prefixes
-        if target.startswith("/skills/"):
-            props = backend.load_skill(target, allowed_path_prefixes=allowed)
-        else:
-            # Resolve the name through find_skill so the same path-prefix
-            # ACL guards the name → path lookup the agent sees (otherwise
-            # a name match would leak the existence of skills outside the
-            # allowlist via 404 vs success).
-            try:
-                hits = backend.find_skill(
-                    query=target,
-                    limit=10,
-                    allowed_path_prefixes=allowed,
-                )
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            exact = [h for h in hits if h.get("name") == target]
-            if not exact:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"no Skill with name or path matching {target!r}",
-                )
-            props = backend.load_skill(exact[0]["path"], allowed_path_prefixes=allowed)
+        # ``backend.load_skill`` resolves an exact canonical path OR an exact
+        # frontmatter name, and applies the path-prefix ACL to the RESOLVED
+        # path (so a name match cannot leak a skill outside the allowlist) —
+        # a single direct lookup is correct for both inputs.
+        #
+        # The previous code resolved a name via ``find_skill(query=name,
+        # limit=10)`` and filtered for an exact-name hit, which depends on the
+        # name landing in find_skill's top-10 KEYWORD ranking. The mixed
+        # APT + web skill corpus pollutes that: ``load_skill("oauth")`` 404'd
+        # because adversary-emulation skills whose descriptions mention
+        # "oauth" outranked the web ``oauth`` skill and pushed it past the
+        # limit. A direct name lookup is unambiguous and pollution-proof.
+        props = backend.load_skill(target, allowed_path_prefixes=allowed)
         if props is None:
-            raise HTTPException(status_code=404, detail=f"no Skill at path {target!r}")
+            raise HTTPException(
+                status_code=404,
+                detail=f"no Skill with name or path matching {target!r}",
+            )
         return {"props": props}
 
     @app.post("/v1/skills:traverse", dependencies=_protected)

--- a/packages/decepticon/decepticon/skillogy/server/neo4j_backend.py
+++ b/packages/decepticon/decepticon/skillogy/server/neo4j_backend.py
@@ -148,21 +148,44 @@ class Neo4jBackend:
         *,
         allowed_path_prefixes: list[str] | None = None,
     ) -> dict[str, Any] | None:
-        """Fetch one ``:Skill`` node by canonical path. Returns its full
-        property dict, or ``None`` if no such skill exists.
+        """Fetch one ``:Skill`` node by canonical path OR unique frontmatter
+        name. Returns its full property dict, or ``None`` if no such skill
+        exists.
 
-        When ``allowed_path_prefixes`` is non-empty, paths not under any
-        listed prefix return ``None`` (the same shape the agent sees for
-        a genuinely missing skill — ADR-0008). ``None`` / empty list
-        preserves the unrestricted behaviour for the standalone library,
-        the skillogy CLI, and pytest, where no role context exists.
+        Agents routinely pass a skill ``name`` (the field ``find_skill``
+        surfaces most prominently — e.g. ``load_skill("oauth")``), not the
+        ``/skills/.../SKILL.md`` path. A path-only match silently returned
+        ``None`` for every name, which forced a fragile client-side
+        ``find_skill`` fallback that the mixed APT + web skill corpus
+        pollutes (``"oauth"``/``"ssrf"`` never resolved while ``"sqli"`` did,
+        purely by which name happened to win the polluted keyword search).
+        Match by exact ``path`` first (always unique), then fall back to an
+        exact ``name`` match.
+
+        When ``allowed_path_prefixes`` is non-empty, the **resolved** skill's
+        path must be under a listed prefix, else ``None`` (the same shape the
+        agent sees for a genuinely missing skill — ADR-0008). The check is
+        applied AFTER resolution: a bare name has no prefix of its own, so
+        gating on the *input* would reject every name-based load. ``None`` /
+        empty list preserves the unrestricted behaviour for the standalone
+        library, the skillogy CLI, and pytest, where no role context exists.
         """
-        if allowed_path_prefixes and not _path_under_any_prefix(path, allowed_path_prefixes):
-            return None
-        query = "MATCH (s:Skill {path: $path}) RETURN properties(s) AS props"
+        query = (
+            "MATCH (s:Skill) WHERE s.path = $arg OR s.name = $arg "
+            "RETURN properties(s) AS props "
+            "ORDER BY CASE WHEN s.path = $arg THEN 0 ELSE 1 END "
+            "LIMIT 1"
+        )
         with self._driver.session(database=self._database, default_access_mode="READ") as session:
-            result = session.run(query, path=path).single()
-        return None if result is None else dict(result["props"])
+            result = session.run(query, arg=path).single()
+        if result is None:
+            return None
+        props = dict(result["props"])
+        if allowed_path_prefixes and not _path_under_any_prefix(
+            str(props.get("path", "")), allowed_path_prefixes
+        ):
+            return None
+        return props
 
     def health(self) -> dict[str, Any]:
         """Return service liveness + a count of :Skill nodes in the graph."""


### PR DESCRIPTION
## Symptom

`load_skill("oauth")` / `load_skill("ssrf")` return 404 ("no Skill with name or path matching …") although `:Skill` nodes with those names exist, while `load_skill("sqli")` / `idor` / `xss` succeed — **non-deterministic per name**, a function of the rest of the ingested corpus.

Live impact (bugclaw orchestrator skill-routing): the orchestrator classified recon's surface, called `find_skill`+`load_skill` ~20×, **every `load_skill` failed**, and it never dispatched a hunting `task()` — the pipeline stalled at skill selection.

## Root cause — name resolution goes through a polluted keyword search

`/v1/skills:load` resolved a NAME by running `find_skill(query=name, limit=10)` and filtering hits for an exact-`name` match:

```python
hits = backend.find_skill(query=target, limit=10, allowed_path_prefixes=allowed)
exact = [h for h in hits if h.get("name") == target]
if not exact: raise HTTPException(404, …)
```

`find_skill.query` is a substring search over name/description/when_to_use. In a graph ingesting BOTH web playbooks AND keyword-rich adversary-emulation (APT) skills, `"oauth"` matches the APT skills (apt28/apt29 OAuth token theft, device-code phishing) which **outrank the web `oauth` skill and push it past `limit=10`** → empty `exact` → 404. `"sqli"` has no high-ranking APT collision, so it resolves. `neo4j_backend.load_skill` itself only matched by canonical **path** and gated the ACL on the *input* string (which rejects every bare name).

## Fix

1. `neo4j_backend.load_skill` matches **path OR exact name** (path preferred) and applies the path-prefix ACL to the **resolved** path:
   ```cypher
   MATCH (s:Skill) WHERE s.path = $arg OR s.name = $arg
   RETURN properties(s) AS props
   ORDER BY CASE WHEN s.path = $arg THEN 0 ELSE 1 END LIMIT 1
   ```
2. `/v1/skills:load` calls `backend.load_skill(target)` directly for both path and name — unambiguous, pollution-proof, ACL still enforced on the resolved path.

## Verification

Post-fix, every web playbook loads by bare name, with and without an ACL prefix:
```
oauth/ssrf/sqli/idor/xss/jwt/saml/xxe/bfla  ->  LOAD (bare)  LOAD (acl)
```

Root-cause doc: `docs/design/2026-06-12-skillogy-load-skill-by-name-pollution.md`

## Follow-up (separate, lower severity)

`find_skill(query=…)` ranking is still APT-polluted for *discovery* — callers should scope `subdomain="web-exploitation"`; an exact-name / same-subdomain ranking preference would make discovery robust too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)