### PR TITLE
feat(llm): universal LiteLLM provider support + auth/subscription stack error-proofing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ LangGraph, sandbox) keeps the always-on contract.
 
 ### Added
 
+- **Universal LiteLLM provider support.** `litellm_dynamic_config.py`
+  now carries the full LiteLLM v1.89.0 provider catalog (114 providers,
+  source-verified env vars): ~75 new single-key providers in
+  `PROVIDER_API_KEY_ENV`, a `PROVIDER_KEY_ENV_ALIASES` table for
+  multi-alias keys (Together, Fireworks, Perplexity, Cohere, …,
+  first-set-var-wins), a `PROVIDER_EXTRA_PARAMS` table for providers
+  needing base/region/project params (Azure AI, watsonx, Databricks,
+  Predibase, Snowflake, local servers), and a no-API-key set for
+  SigV4/ADC/signed providers (Bedrock, SageMaker, Vertex, OCI, …).
+  `ALLOWED_DYNAMIC_PROVIDERS` derives from the union, so any
+  `DECEPTICON_LITELLM_MODELS=<provider>/<model>` slug from the catalog
+  routes with the correct credentials; unknown prefixes get a
+  remediation message naming the supported-provider count.
+
 - **ADR-0006 agent-driven container lifecycle.** A host-binary
   `opscontrol` daemon, supervised by systemd (Linux) / launchd (macOS),
   owns the docker socket and exposes a Unix-domain socket bind-mounted
@@ -58,6 +72,21 @@ LangGraph, sandbox) keeps the always-on contract.
   workloads no longer come up by default.
 
 ### Fixed
+
+- **Auth / LiteLLM stack error-proofing.** Review pass over the
+  subscription handlers, LiteLLM glue, LLM factory, and auth CLI:
+  all six OAuth handlers now reject malformed refresh/mint/completion
+  responses with actionable `AuthenticationError`/`APIError` instead of
+  raw `KeyError`/`JSONDecodeError` tracebacks (and never echo tokens);
+  `auth/` dispatcher validates non-string/empty model ids;
+  `write_json_atomic` survives short `os.write`; `with_retry_on_401`
+  clamps non-positive attempts; `write_dynamic_config` handles
+  null-block/malformed/non-mapping YAML with clear errors; factory adds
+  a 403 remediation branch, a credential-shape redaction net for
+  unclassified provider errors, and resolves the LLM timeout before
+  creating the request coroutine (no un-awaited coroutine on
+  misconfig); CLI `auth` degrades cleanly on corrupt `.env` files and
+  inventory-probe failures.
 
 - **`SandboxNotificationMiddleware` background-completion delivery.**
   `build_sandbox_backend()` was returning a fresh `HTTPSandbox` from

--- a/config/auth_handler.py
+++ b/config/auth_handler.py
@@ -40,12 +40,24 @@ _PREFIX_HANDLERS: list[tuple[str, CustomLLM]] = [
 
 def _select_auth_handler(model: str) -> CustomLLM:
     """Resolve a ``auth/<slug>`` model name to its subscription handler."""
+    supported = ", ".join(f"{p}*" for p, _ in _PREFIX_HANDLERS)
+    if not isinstance(model, str) or not model.strip():
+        # None / non-string / empty model: LiteLLM occasionally dispatches with
+        # the model passed neither positionally nor by keyword. Fail with a typed
+        # BadRequestError instead of letting ``.split`` raise a raw TypeError.
+        raise litellm.BadRequestError(
+            message=(
+                f"auth/ provider: missing or invalid model {model!r}. "
+                f"Expected a non-empty 'auth/<slug>' string. Supported prefixes: {supported}."
+            ),
+            model=str(model),
+            llm_provider="auth",
+        )
     slug = model.split("/", 1)[-1] if "/" in model else model
     slug_lower = slug.lower()
     for prefix, handler in _PREFIX_HANDLERS:
         if slug_lower.startswith(prefix):
             return handler
-    supported = ", ".join(f"{p}*" for p, _ in _PREFIX_HANDLERS)
     raise litellm.BadRequestError(
         message=(
             f"auth/ provider: model slug {slug!r} did not match any known "

--- a/config/claude_code_handler.py
+++ b/config/claude_code_handler.py
@@ -573,10 +573,7 @@ class ClaudeCodeCustomHandler(CustomLLM):
         except (json.JSONDecodeError, ValueError) as exc:
             raise litellm.APIError(
                 status_code=resp.status_code,
-                message=(
-                    "Anthropic API returned a non-JSON response: "
-                    f"{resp.text[:500]}"
-                ),
+                message=(f"Anthropic API returned a non-JSON response: {resp.text[:500]}"),
                 model=model,
                 llm_provider="auth",
             ) from exc

--- a/config/claude_code_handler.py
+++ b/config/claude_code_handler.py
@@ -153,12 +153,26 @@ def _refresh_token(tokens: dict[str, Any]) -> dict[str, Any]:
         timeout=30,
         provider_label="auth",
     )
+    # The refresh endpoint normally returns access_token; a malformed or
+    # error-shaped response would otherwise blow up with a raw KeyError.
+    # Never interpolate ``data`` here — it carries the freshly minted
+    # access / refresh tokens. Report only the missing field name.
+    access_token = data.get("access_token")
+    if not access_token:
+        raise litellm.AuthenticationError(
+            message=(
+                "Claude Code token refresh response missing field: access_token. "
+                "Run 'claude /login' and retry."
+            ),
+            model="auth",
+            llm_provider="auth",
+        )
 
     new_tokens = {
-        "accessToken": data["access_token"],
-        "refreshToken": data.get("refresh_token", tokens["refreshToken"]),
-        "expiresAt": int(time.time() + data.get("expires_in", 3600)),
-        "scopes": data.get("scope", "").split(),
+        "accessToken": access_token,
+        "refreshToken": data.get("refresh_token") or tokens["refreshToken"],
+        "expiresAt": int(time.time() + (data.get("expires_in") or 3600)),
+        "scopes": (data.get("scope") or "").split(),
         "updatedAt": int(time.time() * 1000),
     }
 
@@ -554,25 +568,53 @@ class ClaudeCodeCustomHandler(CustomLLM):
                 llm_provider="auth",
             )
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=(
+                    "Anthropic API returned a non-JSON response: "
+                    f"{resp.text[:500]}"
+                ),
+                model=model,
+                llm_provider="auth",
+            ) from exc
+        if not isinstance(data, dict):
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=f"Anthropic API response was not a JSON object: {resp.text[:500]}",
+                model=model,
+                llm_provider="auth",
+            )
 
-        # Convert Anthropic response to LiteLLM ModelResponse (OpenAI format)
-        content_blocks = data.get("content", [])
+        # Convert Anthropic response to LiteLLM ModelResponse (OpenAI format).
+        # ``content``/``usage`` may be absent or explicitly null on edge
+        # responses; ``.get(k) or default`` keeps iteration/arithmetic safe.
+        content_blocks = data.get("content") or []
+        if not isinstance(content_blocks, list):
+            content_blocks = []
 
         # Extract text content
-        text_parts = [block["text"] for block in content_blocks if block.get("type") == "text"]
+        text_parts = [
+            block["text"]
+            for block in content_blocks
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        ]
         response_text = "\n".join(text_parts) if text_parts else None
 
         # Extract tool_use blocks → OpenAI tool_calls format
         tool_calls = []
         for block in content_blocks:
-            if block.get("type") == "tool_use":
+            if isinstance(block, dict) and block.get("type") == "tool_use":
                 tool_calls.append(
                     {
                         "id": block.get("id", ""),
                         "type": "function",
                         "function": {
-                            "name": block["name"],
+                            "name": block.get("name", ""),
                             "arguments": json.dumps(block.get("input", {})),
                         },
                     }
@@ -587,9 +629,9 @@ class ClaudeCodeCustomHandler(CustomLLM):
         if tool_calls:
             message["tool_calls"] = tool_calls
 
-        usage_data = data.get("usage", {})
-        input_tokens = usage_data.get("input_tokens", 0)
-        output_tokens = usage_data.get("output_tokens", 0)
+        usage_data = data.get("usage") or {}
+        input_tokens = usage_data.get("input_tokens") or 0
+        output_tokens = usage_data.get("output_tokens") or 0
 
         # Map finish_reason: tool_use → tool_calls (OpenAI convention)
         stop_reason = data.get("stop_reason", "end_turn")

--- a/config/codex_chatgpt_handler.py
+++ b/config/codex_chatgpt_handler.py
@@ -232,13 +232,31 @@ def _responses_input(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any
             continue
         if role == "assistant" and msg.get("tool_calls"):
             for tc in msg.get("tool_calls") or []:
-                func = tc.get("function", {}) if isinstance(tc, dict) else {}
+                # tool_calls may arrive as OpenAI dicts or as LangGraph
+                # objects; normalize both so non-dicts don't blow up with a
+                # raw AttributeError on ``tc.get``.
+                if isinstance(tc, dict):
+                    func = tc.get("function", {}) if isinstance(tc.get("function"), dict) else {}
+                    tc_id = tc.get("id")
+                    tc_name = tc.get("name")
+                    tc_args = tc.get("args", {})
+                else:
+                    func = {}
+                    fn_obj = getattr(tc, "function", None)
+                    if fn_obj is not None:
+                        func = {
+                            "name": getattr(fn_obj, "name", None),
+                            "arguments": getattr(fn_obj, "arguments", None),
+                        }
+                    tc_id = getattr(tc, "id", None)
+                    tc_name = getattr(tc, "name", None)
+                    tc_args = getattr(tc, "args", {})
                 input_items.append(
                     {
                         "type": "function_call",
-                        "call_id": tc.get("id") or f"call_{func.get('name', 'tool')}",
-                        "name": func.get("name") or tc.get("name") or "tool",
-                        "arguments": func.get("arguments") or json.dumps(tc.get("args", {})),
+                        "call_id": tc_id or f"call_{func.get('name', 'tool')}",
+                        "name": func.get("name") or tc_name or "tool",
+                        "arguments": func.get("arguments") or json.dumps(tc_args or {}),
                     }
                 )
             continue
@@ -401,7 +419,10 @@ def _completed_payload(resp: httpx.Response) -> dict[str, Any]:
             completed = event["response"]
         elif event_type in {"response.failed", "error"}:
             err = event.get("error") or (event.get("response") or {}).get("error")
-            error_message = err.get("message") if isinstance(err, dict) else str(err)
+            if isinstance(err, dict):
+                error_message = err.get("message") or json.dumps(err)
+            elif err:
+                error_message = str(err)
 
     if completed is not None:
         # Backfill output when the upstream sent an empty ``output`` array
@@ -425,10 +446,13 @@ def _completed_payload(resp: httpx.Response) -> dict[str, Any]:
             if synthesized:
                 completed["output"] = synthesized
         return completed
-
     raise litellm.APIError(
         status_code=resp.status_code,
-        message=error_message or resp.text,
+        message=(
+            error_message
+            or resp.text
+            or "ChatGPT Codex stream ended without a response.completed event."
+        ),
         model="auth",
         llm_provider="auth",
     )

--- a/config/copilot_handler.py
+++ b/config/copilot_handler.py
@@ -194,10 +194,34 @@ def _mint_copilot_token(github_token: str) -> dict[str, Any]:
             llm_provider="copilot",
         )
     resp.raise_for_status()
-    body = resp.json()
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise litellm.AuthenticationError(
+            message=(
+                "GitHub returned a non-JSON response while minting a Copilot token "
+                f"(HTTP {resp.status_code}). Body: {resp.text[:200]}"
+            ),
+            model="copilot",
+            llm_provider="copilot",
+        ) from exc
+    token = body.get("token") if isinstance(body, dict) else None
+    if not token or not isinstance(token, str):
+        raise litellm.AuthenticationError(
+            message=(
+                "GitHub mint response did not include a Copilot token — your "
+                "subscription may be inactive. Run `gh auth login --scopes copilot`."
+            ),
+            model="copilot",
+            llm_provider="copilot",
+        )
+    try:
+        expires_at = int(body.get("expires_at", 0) or 0)
+    except (TypeError, ValueError):
+        expires_at = 0
     return {
-        "copilot_token": body["token"],
-        "expires_at": int(body.get("expires_at", 0)),
+        "copilot_token": token,
+        "expires_at": expires_at,
         "endpoints": body.get("endpoints", {}),
     }
 
@@ -351,7 +375,22 @@ class CopilotHandler(CustomLLM):
                 llm_provider="copilot",
             )
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=f"Copilot returned a malformed (non-JSON) response: {resp.text[:300]}",
+                model=model,
+                llm_provider="copilot",
+            ) from exc
+        if not isinstance(data, dict):
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message="Copilot response JSON was not an object.",
+                model=model,
+                llm_provider="copilot",
+            )
         return ModelResponse(
             id=data.get("id", f"copilot-{actual_model}"),
             model=actual_model,

--- a/config/gemini_handler.py
+++ b/config/gemini_handler.py
@@ -82,10 +82,24 @@ def _refresh_google_token(tokens: dict[str, Any]) -> dict[str, Any]:
         provider_label="gemini-sub",
     )
 
+    access_token = data.get("access_token")
+    if not access_token or not isinstance(access_token, str):
+        raise litellm.AuthenticationError(
+            message=(
+                "Google OAuth refresh response did not include an access_token — the "
+                "refresh_token may be revoked or expired. Re-extract from browser."
+            ),
+            model="gemini-sub",
+            llm_provider="gemini-sub",
+        )
+    try:
+        expires_in = int(data.get("expires_in", 3600) or 3600)
+    except (TypeError, ValueError):
+        expires_in = 3600
     new_tokens = {
         **tokens,
-        "accessToken": data["access_token"],
-        "expiresAt": int(time.time() + data.get("expires_in", 3600)),
+        "accessToken": access_token,
+        "expiresAt": int(time.time() + expires_in),
     }
 
     write_json_atomic(GEMINI_TOKENS_PATH, new_tokens)
@@ -238,16 +252,35 @@ class GeminiSubHandler(CustomLLM):
                 llm_provider="gemini-sub",
             )
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=f"Gemini returned a malformed (non-JSON) response: {resp.text[:300]}",
+                model=model,
+                llm_provider="gemini-sub",
+            ) from exc
+        if not isinstance(data, dict):
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message="Gemini response JSON was not an object.",
+                model=model,
+                llm_provider="gemini-sub",
+            )
         candidates = data.get("candidates", [])
         text = ""
         finish_reason = "stop"
-        if candidates:
-            parts = candidates[0].get("content", {}).get("parts", [])
-            text = "".join(p.get("text", "") for p in parts)
-            finish_reason = _map_finish_reason(candidates[0].get("finishReason"))
+        if candidates and isinstance(candidates[0], dict):
+            cand = candidates[0]
+            content = cand.get("content")
+            parts = content.get("parts", []) if isinstance(content, dict) else []
+            text = "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+            finish_reason = _map_finish_reason(cand.get("finishReason"))
 
-        usage_meta = data.get("usageMetadata", {})
+        usage_meta = data.get("usageMetadata") or {}
+        if not isinstance(usage_meta, dict):
+            usage_meta = {}
 
         return ModelResponse(
             id=f"gemini-sub-{actual_model}-{int(time.time())}",

--- a/config/grok_handler.py
+++ b/config/grok_handler.py
@@ -69,17 +69,40 @@ def _load_tokens() -> dict[str, Any] | None:
 
 
 def _exchange_session_for_access(session_token: str) -> dict[str, Any]:
-    resp = httpx.get(
-        "https://grok.x.ai/api/auth/session",
-        cookies={"auth_token": session_token},
-        headers={
-            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
-        },
-        timeout=30,
-        follow_redirects=True,
-    )
-    resp.raise_for_status()
-    data = resp.json()
+    try:
+        resp = httpx.get(
+            "https://grok.x.ai/api/auth/session",
+            cookies={"auth_token": session_token},
+            headers={
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+            },
+            timeout=30,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        raise litellm.AuthenticationError(
+            message=(
+                f"Grok session exchange was rejected (HTTP {exc.response.status_code}) — "
+                "the GROK_SESSION_TOKEN cookie is expired or invalid. Re-extract it from grok.com."
+            ),
+            model="grok-sub",
+            llm_provider="grok-sub",
+        ) from exc
+    except (httpx.HTTPError, ValueError) as exc:
+        raise litellm.AuthenticationError(
+            message=f"Grok session exchange failed: {exc}. Re-extract the cookie from grok.com.",
+            model="grok-sub",
+            llm_provider="grok-sub",
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise litellm.AuthenticationError(
+            message="Grok session exchange returned an unexpected response shape. Re-extract from browser.",
+            model="grok-sub",
+            llm_provider="grok-sub",
+        )
 
     access_token = data.get("accessToken") or data.get("token")
     if not access_token:
@@ -214,7 +237,22 @@ class GrokSubHandler(CustomLLM):
                 llm_provider="grok-sub",
             )
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=f"Grok returned a malformed (non-JSON) response: {resp.text[:300]}",
+                model=model,
+                llm_provider="grok-sub",
+            ) from exc
+        if not isinstance(data, dict):
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message="Grok response JSON was not an object.",
+                model=model,
+                llm_provider="grok-sub",
+            )
         return ModelResponse(
             id=data.get("id", f"grok-sub-{actual_model}"),
             model=actual_model,

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -192,8 +192,18 @@ OPENAI_COMPAT_GATEWAYS: dict[str, tuple[str, str]] = {
 # rather than crashing proxy startup. Source-verified against litellm's
 # get_secret_str() alias chains (v1.89.0).
 PROVIDER_KEY_ENV_ALIASES: dict[str, tuple[str, ...]] = {
-    "together_ai": ("TOGETHERAI_API_KEY", "TOGETHER_API_KEY", "TOGETHER_AI_API_KEY", "TOGETHER_AI_TOKEN"),
-    "fireworks_ai": ("FIREWORKS_AI_API_KEY", "FIREWORKS_API_KEY", "FIREWORKSAI_API_KEY", "FIREWORKS_AI_TOKEN"),
+    "together_ai": (
+        "TOGETHERAI_API_KEY",
+        "TOGETHER_API_KEY",
+        "TOGETHER_AI_API_KEY",
+        "TOGETHER_AI_TOKEN",
+    ),
+    "fireworks_ai": (
+        "FIREWORKS_AI_API_KEY",
+        "FIREWORKS_API_KEY",
+        "FIREWORKSAI_API_KEY",
+        "FIREWORKS_AI_TOKEN",
+    ),
     "perplexity": ("PERPLEXITYAI_API_KEY", "PERPLEXITY_API_KEY"),
     "cohere": ("COHERE_API_KEY", "CO_API_KEY"),
     "cohere_chat": ("COHERE_API_KEY", "CO_API_KEY"),
@@ -216,11 +226,20 @@ PROVIDER_KEY_ENV_ALIASES: dict[str, tuple[str, ...]] = {
 # on the existing vertex_ai (project+location) and azure (base+version)
 # branches, now table-driven instead of an elif chain.
 PROVIDER_EXTRA_PARAMS: dict[str, dict[str, str]] = {
-    "azure": {"api_base": "os.environ/AZURE_API_BASE", "api_version": "os.environ/AZURE_API_VERSION"},
+    "azure": {
+        "api_base": "os.environ/AZURE_API_BASE",
+        "api_version": "os.environ/AZURE_API_VERSION",
+    },
     "azure_ai": {"api_base": "os.environ/AZURE_AI_API_BASE"},
-    "vertex_ai": {"vertex_project": "os.environ/VERTEXAI_PROJECT", "vertex_location": "os.environ/VERTEXAI_LOCATION"},
+    "vertex_ai": {
+        "vertex_project": "os.environ/VERTEXAI_PROJECT",
+        "vertex_location": "os.environ/VERTEXAI_LOCATION",
+    },
     "databricks": {"api_base": "os.environ/DATABRICKS_API_BASE"},
-    "watsonx": {"api_base": "os.environ/WATSONX_URL", "project_id": "os.environ/WATSONX_PROJECT_ID"},
+    "watsonx": {
+        "api_base": "os.environ/WATSONX_URL",
+        "project_id": "os.environ/WATSONX_PROJECT_ID",
+    },
     "predibase": {"tenant_id": "os.environ/PREDIBASE_TENANT_ID"},
     "snowflake": {"account_id": "os.environ/SNOWFLAKE_ACCOUNT_ID"},
     "litellm_proxy": {"api_base": "os.environ/LITELLM_PROXY_API_BASE"},
@@ -922,13 +941,9 @@ def write_dynamic_config(config_path: str | Path, output_path: str | Path) -> Pa
         with source_path.open("r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
     except FileNotFoundError as exc:
-        raise FileNotFoundError(
-            f"LiteLLM base config not found at {source_path}: {exc}"
-        ) from exc
+        raise FileNotFoundError(f"LiteLLM base config not found at {source_path}: {exc}") from exc
     except yaml.YAMLError as exc:
-        raise ValueError(
-            f"LiteLLM base config at {source_path} is not valid YAML: {exc}"
-        ) from exc
+        raise ValueError(f"LiteLLM base config at {source_path} is not valid YAML: {exc}") from exc
     if config is None:
         config = {}
     if not isinstance(config, MutableMapping):

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -75,6 +75,85 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     # have validate_model_name() accept it — the actual route is built
     # by build_model_entry() below.
     "xiaomi_mimo": "XIAOMI_MIMO_API_KEY",
+    # ── Full LiteLLM provider catalog (v1.89.0) ──────────────────────────
+    # Every native provider that authenticates via a single API-key env var,
+    # using the source-verified env name (litellm validate_environment /
+    # get_secret_str), not the derived ``<PROVIDER>_API_KEY`` guess. Keys are
+    # the ``_provider_prefix``-normalized form (hyphens → underscores), e.g.
+    # ``nano-gpt`` → ``nano_gpt``, ``text-completion-openai`` →
+    # ``text_completion_openai``. Providers with multiple accepted key aliases
+    # live in PROVIDER_KEY_ENV_ALIASES; key-less providers (SigV4 / ADC / OCI
+    # signing / OAuth exchange / local no-auth) live in _NO_API_KEY_PROVIDERS.
+    "text_completion_openai": "OPENAI_API_KEY",
+    "codestral": "CODESTRAL_API_KEY",
+    "text_completion_codestral": "CODESTRAL_API_KEY",
+    "azure_ai": "AZURE_AI_API_KEY",
+    "sambanova": "SAMBANOVA_API_KEY",
+    "databricks": "DATABRICKS_API_KEY",
+    "watsonx": "WATSONX_API_KEY",
+    "deepinfra": "DEEPINFRA_API_KEY",
+    "anyscale": "ANYSCALE_API_KEY",
+    "ai21": "AI21_API_KEY",
+    "ai21_chat": "AI21_API_KEY",
+    "nlp_cloud": "NLP_CLOUD_API_KEY",
+    "cloudflare": "CLOUDFLARE_API_KEY",
+    "baseten": "BASETEN_API_KEY",
+    "snowflake": "SNOWFLAKE_JWT",
+    "novita": "NOVITA_API_KEY",
+    "hyperbolic": "HYPERBOLIC_API_KEY",
+    "lambda_ai": "LAMBDA_API_KEY",
+    "nebius": "NEBIUS_API_KEY",
+    "galadriel": "GALADRIEL_API_KEY",
+    "gradient_ai": "GRADIENT_AI_API_KEY",
+    "predibase": "PREDIBASE_API_KEY",
+    "clarifai": "CLARIFAI_API_KEY",
+    "aleph_alpha": "ALEPH_ALPHA_API_KEY",
+    "maritalk": "MARITALK_API_KEY",
+    "empower": "EMPOWER_API_KEY",
+    "meta_llama": "LLAMA_API_KEY",
+    "nscale": "NSCALE_API_KEY",
+    "v0": "V0_API_KEY",
+    "morph": "MORPH_API_KEY",
+    "inception": "INCEPTION_API_KEY",
+    "litellm_proxy": "LITELLM_PROXY_API_KEY",
+    "vercel_ai_gateway": "VERCEL_AI_GATEWAY_API_KEY",
+    "wandb": "WANDB_API_KEY",
+    "aiml": "AIML_API_KEY",
+    "heroku": "HEROKU_API_KEY",
+    "ovhcloud": "OVHCLOUD_API_KEY",
+    "scaleway": "SCW_SECRET_KEY",
+    "compactifai": "COMPACTIFAI_API_KEY",
+    "publicai": "PUBLICAI_API_KEY",
+    "apertis": "STIMA_API_KEY",
+    "nano_gpt": "NANOGPT_API_KEY",
+    "poe": "POE_API_KEY",
+    "chutes": "CHUTES_API_KEY",
+    "parasail": "PARASAIL_API_KEY",
+    "tensormesh": "TENSORMESH_INFERENCE_API_KEY",
+    "infinity": "INFINITY_API_KEY",
+    "datarobot": "DATAROBOT_API_TOKEN",
+    "manus": "MANUS_API_KEY",
+    # Audio / image / video providers (single bearer key).
+    "deepgram": "DEEPGRAM_API_KEY",
+    "elevenlabs": "ELEVENLABS_API_KEY",
+    "assemblyai": "ASSEMBLYAI_API_KEY",
+    "recraft": "RECRAFT_API_KEY",
+    "runwayml": "RUNWAYML_API_KEY",
+    "stability": "STABILITY_API_KEY",
+    "fal_ai": "FAL_AI_API_KEY",
+    "topaz": "TOPAZ_API_KEY",
+    "bedrock_mantle": "BEDROCK_MANTLE_API_KEY",
+    "amazon_nova": "AMAZON_NOVA_API_KEY",
+    "soniox": "SONIOX_API_KEY",
+    # Local / self-hosted OpenAI-compatible servers: key (optional, any
+    # string for local) + a required api_base from PROVIDER_EXTRA_PARAMS.
+    "hosted_vllm": "HOSTED_VLLM_API_KEY",
+    "llamafile": "LLAMAFILE_API_KEY",
+    "xinference": "XINFERENCE_API_KEY",
+    "lemonade": "LEMONADE_API_KEY",
+    "docker_model_runner": "DOCKER_MODEL_RUNNER_API_KEY",
+    "ragflow": "RAGFLOW_API_KEY",
+    "openai_like": "OPENAI_LIKE_API_KEY",
 }
 
 # OpenAI-compatible gateways / aggregators with no native LiteLLM provider
@@ -104,6 +183,83 @@ OPENAI_COMPAT_GATEWAYS: dict[str, tuple[str, str]] = {
     # never proxy startup.
     "cfgateway": ("os.environ/CLOUDFLARE_AI_GATEWAY_API_BASE", "CLOUDFLARE_AI_GATEWAY_API_KEY"),
 }
+
+# Providers that accept SEVERAL key env-var names. Resolved at config-write
+# time, preferring the first var actually set in the environment (mirrors the
+# ollama_cloud OLLAMA_CLOUD_API_KEY → OLLAMA_API_KEY fallback). The first name
+# is the canonical fallback emitted when none are set, so the generated route
+# references the documented var and fails with a clear 401 at request time
+# rather than crashing proxy startup. Source-verified against litellm's
+# get_secret_str() alias chains (v1.89.0).
+PROVIDER_KEY_ENV_ALIASES: dict[str, tuple[str, ...]] = {
+    "together_ai": ("TOGETHERAI_API_KEY", "TOGETHER_API_KEY", "TOGETHER_AI_API_KEY", "TOGETHER_AI_TOKEN"),
+    "fireworks_ai": ("FIREWORKS_AI_API_KEY", "FIREWORKS_API_KEY", "FIREWORKSAI_API_KEY", "FIREWORKS_AI_TOKEN"),
+    "perplexity": ("PERPLEXITYAI_API_KEY", "PERPLEXITY_API_KEY"),
+    "cohere": ("COHERE_API_KEY", "CO_API_KEY"),
+    "cohere_chat": ("COHERE_API_KEY", "CO_API_KEY"),
+    "friendliai": ("FRIENDLIAI_API_KEY", "FRIENDLI_TOKEN"),
+    "huggingface": ("HUGGINGFACE_API_KEY", "HF_TOKEN"),
+    "openrouter": ("OPENROUTER_API_KEY", "OR_API_KEY"),
+    "voyage": ("VOYAGE_API_KEY", "VOYAGE_AI_API_KEY", "VOYAGE_AI_TOKEN"),
+    "jina_ai": ("JINA_AI_API_KEY", "JINA_AI_TOKEN"),
+    "volcengine": ("VOLCENGINE_API_KEY", "ARK_API_KEY"),
+    "featherless_ai": ("FEATHERLESS_AI_API_KEY", "FEATHERLESS_API_KEY"),
+    "black_forest_labs": ("BFL_API_KEY", "BLACK_FOREST_LABS_API_KEY"),
+    "cometapi": ("COMETAPI_API_KEY", "COMETAPI_KEY"),
+    "nvidia_riva": ("NVIDIA_RIVA_API_KEY", "NVIDIA_NIM_API_KEY"),
+}
+
+# Providers needing more than an api_key: extra litellm_params merged into the
+# route (api_base / api_version / project / tenant / account). Values are
+# ``os.environ/<NAME>`` refs resolved by LiteLLM at request time, so an unset
+# var only fails the call with a clear message — never proxy startup. Modeled
+# on the existing vertex_ai (project+location) and azure (base+version)
+# branches, now table-driven instead of an elif chain.
+PROVIDER_EXTRA_PARAMS: dict[str, dict[str, str]] = {
+    "azure": {"api_base": "os.environ/AZURE_API_BASE", "api_version": "os.environ/AZURE_API_VERSION"},
+    "azure_ai": {"api_base": "os.environ/AZURE_AI_API_BASE"},
+    "vertex_ai": {"vertex_project": "os.environ/VERTEXAI_PROJECT", "vertex_location": "os.environ/VERTEXAI_LOCATION"},
+    "databricks": {"api_base": "os.environ/DATABRICKS_API_BASE"},
+    "watsonx": {"api_base": "os.environ/WATSONX_URL", "project_id": "os.environ/WATSONX_PROJECT_ID"},
+    "predibase": {"tenant_id": "os.environ/PREDIBASE_TENANT_ID"},
+    "snowflake": {"account_id": "os.environ/SNOWFLAKE_ACCOUNT_ID"},
+    "litellm_proxy": {"api_base": "os.environ/LITELLM_PROXY_API_BASE"},
+    "heroku": {"api_base": "os.environ/HEROKU_API_BASE"},
+    # Self-hosted OpenAI-compatible servers reached by a required base URL.
+    "hosted_vllm": {"api_base": "os.environ/HOSTED_VLLM_API_BASE"},
+    "llamafile": {"api_base": "os.environ/LLAMAFILE_API_BASE"},
+    "xinference": {"api_base": "os.environ/XINFERENCE_API_BASE"},
+    "lemonade": {"api_base": "os.environ/LEMONADE_API_BASE"},
+    "docker_model_runner": {"api_base": "os.environ/DOCKER_MODEL_RUNNER_API_BASE"},
+    "ragflow": {"api_base": "os.environ/RAGFLOW_API_BASE"},
+    "openai_like": {"api_base": "os.environ/OPENAI_LIKE_API_BASE"},
+    "vllm": {"api_base": "os.environ/VLLM_API_BASE"},
+}
+
+# Providers that DON'T use an Authorization-bearer api_key: AWS SigV4
+# (bedrock/sagemaker), Google ADC (vertex_ai), OCI request signing, SAP /
+# GigaChat OAuth token exchange, and local no-auth servers (petals / triton /
+# oobabooga / vllm). LiteLLM resolves their credentials from their own env
+# vars; emitting ``api_key=os.environ/<X>_API_KEY`` here would inject a bogus
+# empty bearer. ``_provider_prefix``-normalized form.
+_NO_API_KEY_PROVIDERS = frozenset(
+    {
+        "bedrock",
+        "sagemaker",
+        "sagemaker_chat",
+        "vertex_ai",
+        "oci",
+        "sap",
+        "gigachat",
+        "petals",
+        "triton",
+        "oobabooga",
+        "vllm",
+    }
+)
+
+# OAuth device-flow providers that cannot be registered as API-key routes.
+_OAUTH_REJECTED_PROVIDERS = frozenset({"github_copilot"})
 
 ALLOWED_DYNAMIC_PROVIDERS = frozenset(
     {
@@ -139,6 +295,16 @@ ALLOWED_DYNAMIC_PROVIDERS = frozenset(ALLOWED_DYNAMIC_PROVIDERS | {"vertex_ai"})
 # explicitly or validate_model_name would reject the alias as an unknown
 # provider before the gateway branch runs.
 ALLOWED_DYNAMIC_PROVIDERS = frozenset(ALLOWED_DYNAMIC_PROVIDERS | set(OPENAI_COMPAT_GATEWAYS))
+# Alias-key, extra-param, and no-key providers may not all appear in
+# PROVIDER_API_KEY_ENV — union them so every catalog prefix validates and the
+# dynamic API-key path stays the single source of truth for "is this a known
+# provider".
+ALLOWED_DYNAMIC_PROVIDERS = frozenset(
+    ALLOWED_DYNAMIC_PROVIDERS
+    | set(PROVIDER_KEY_ENV_ALIASES)
+    | set(PROVIDER_EXTRA_PARAMS)
+    | _NO_API_KEY_PROVIDERS
+)
 
 # Environment variables that are model-selection controls, not model names.
 _MODEL_CONTROL_SUFFIXES = (
@@ -280,6 +446,12 @@ def validate_model_name(model_name: str) -> None:
             f"DECEPTICON_AUTH_<provider>=true so the route is registered "
             f"through litellm_startup.py's custom_provider_map instead."
         )
+    if provider in _OAUTH_REJECTED_PROVIDERS:
+        raise ValueError(
+            f"{provider}/* uses interactive OAuth device-flow auth, not an "
+            "API-key env var, so it cannot be registered as a dynamic model "
+            "route. It is not supported through DECEPTICON_LITELLM_MODELS."
+        )
     if provider == "ollama":
         # Legacy ``ollama/`` (/api/generate) lacks tool calling — fail
         # closed since Decepticon agents always emit tool calls.
@@ -293,12 +465,32 @@ def validate_model_name(model_name: str) -> None:
     if provider not in ALLOWED_DYNAMIC_PROVIDERS:
         raise ValueError(
             f"unsupported model provider {provider!r} for {model_name!r}; "
-            "use custom/<model> with CUSTOM_OPENAI_API_BASE for OpenAI-compatible gateways"
+            f"{len(ALLOWED_DYNAMIC_PROVIDERS)} providers are supported "
+            "(see the DECEPTICON_LITELLM_MODELS docs for the full list). "
+            "Use custom/<model> with CUSTOM_OPENAI_API_BASE for an "
+            "OpenAI-compatible gateway that isn't listed."
         )
 
 
 def _derived_api_key_env(provider: str) -> str:
     return f"{provider.upper()}_API_KEY"
+
+
+def _resolve_key_env(provider: str) -> str:
+    """Pick the api_key env var name for ``provider``.
+
+    Multi-alias providers resolve at write time to the first candidate var
+    actually set, falling back to the canonical (first-listed) name when none
+    are set. Otherwise use the explicit PROVIDER_API_KEY_ENV mapping, then the
+    derived ``<PROVIDER>_API_KEY`` guess for any provider not in either table.
+    """
+    aliases = PROVIDER_KEY_ENV_ALIASES.get(provider)
+    if aliases:
+        for name in aliases:
+            if os.environ.get(name, "").strip():
+                return name
+        return aliases[0]
+    return PROVIDER_API_KEY_ENV.get(provider, _derived_api_key_env(provider))
 
 
 def build_model_entry(model_name: str) -> dict[str, Any]:
@@ -437,25 +629,18 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
                 "api_key": f"os.environ/{cloud_key_env}",
                 "api_base": cloud_base,
             }
-        elif provider == "bedrock":
-            # AWS Bedrock — uses AWS SigV4 with three env vars rather
-            # than an Authorization header. LiteLLM reads them
-            # automatically; we just don't set api_key.
-            pass
-        elif provider == "vertex_ai":
-            # Vertex AI — service-account JSON path + project + location.
-            # LiteLLM reads GOOGLE_APPLICATION_CREDENTIALS automatically;
-            # only project + location need to be passed through.
-            params["vertex_project"] = "os.environ/VERTEXAI_PROJECT"
-            params["vertex_location"] = "os.environ/VERTEXAI_LOCATION"
-        elif provider == "azure":
-            # Azure OpenAI deployment — needs base URL + version.
-            params["api_key"] = "os.environ/AZURE_API_KEY"
-            params["api_base"] = "os.environ/AZURE_API_BASE"
-            params["api_version"] = "os.environ/AZURE_API_VERSION"
         else:
-            api_key_env = PROVIDER_API_KEY_ENV.get(provider, _derived_api_key_env(provider))
-            params["api_key"] = f"os.environ/{api_key_env}"
+            # Every other native LiteLLM provider, table-driven. Extra
+            # litellm_params (api_base / api_version / vertex_project /
+            # tenant_id / account_id ...) come from PROVIDER_EXTRA_PARAMS; the
+            # api_key env var from _resolve_key_env (alias-aware), unless the
+            # provider authenticates without a bearer key (SigV4 / ADC / OCI
+            # signing / OAuth exchange / local no-auth) — those are listed in
+            # _NO_API_KEY_PROVIDERS. Replaces the former bedrock / vertex_ai /
+            # azure / derived-key elif chain.
+            params.update(PROVIDER_EXTRA_PARAMS.get(provider, {}))
+            if provider not in _NO_API_KEY_PROVIDERS:
+                params["api_key"] = f"os.environ/{_resolve_key_env(provider)}"
 
     return {"model_name": model_name, "litellm_params": params}
 
@@ -658,11 +843,22 @@ def _inject_subscription_routes(
     enabled the auth method.
     """
     source = env if env is not None else os.environ
-    model_list = config.setdefault("model_list", [])
+    # A YAML config may carry ``model_list:`` / ``litellm_settings:`` /
+    # ``fallbacks:`` keys that parse to ``None`` (key present, no value).
+    # ``setdefault`` keeps that ``None`` (the key exists), so coerce each to
+    # the right empty container before iterating — otherwise startup dies with
+    # a raw ``'NoneType' is not iterable`` / ``has no attribute 'setdefault'``.
+    if not isinstance(config.get("model_list"), list):
+        config["model_list"] = []
+    model_list = config["model_list"]
     existing = {e.get("model_name") for e in model_list if isinstance(e, dict)}
 
-    settings = config.setdefault("litellm_settings", {})
-    fallbacks = settings.setdefault("fallbacks", [])
+    if not isinstance(config.get("litellm_settings"), MutableMapping):
+        config["litellm_settings"] = {}
+    settings = config["litellm_settings"]
+    if not isinstance(settings.get("fallbacks"), list):
+        settings["fallbacks"] = []
+    fallbacks = settings["fallbacks"]
 
     for flag, routes in _SUBSCRIPTION_ROUTES.items():
         if not _is_truthy(source.get(flag, "")):
@@ -722,8 +918,25 @@ def write_dynamic_config(config_path: str | Path, output_path: str | Path) -> Pa
     source_path = Path(config_path)
     target_path = Path(output_path)
 
-    with source_path.open("r", encoding="utf-8") as f:
-        config = yaml.safe_load(f) or {}
+    try:
+        with source_path.open("r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"LiteLLM base config not found at {source_path}: {exc}"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(
+            f"LiteLLM base config at {source_path} is not valid YAML: {exc}"
+        ) from exc
+    if config is None:
+        config = {}
+    if not isinstance(config, MutableMapping):
+        raise ValueError(
+            f"LiteLLM base config at {source_path} must be a YAML mapping "
+            f"(got {type(config).__name__}); expected top-level keys like "
+            "'model_list:' / 'litellm_settings:'."
+        )
 
     merged = merge_dynamic_models(config, os.environ)
 

--- a/config/oauth_token_store.py
+++ b/config/oauth_token_store.py
@@ -116,7 +116,17 @@ def write_json_atomic(
     try:
         # mkstemp creates with 0o600; widen/narrow only to honor ``mode``.
         os.chmod(tmp, mode)
-        os.write(fd, payload)
+        # ``os.write`` is a thin wrapper over the write(2) syscall and may
+        # write fewer bytes than requested (short write). Looping until the
+        # whole payload is flushed prevents a truncated, corrupt token file
+        # from being renamed into place.
+        written = 0
+        view = memoryview(payload)
+        while written < len(payload):
+            n = os.write(fd, view[written:])
+            if n == 0:
+                raise OSError("os.write returned 0 — device full or broken pipe")
+            written += n
         os.fsync(fd)
     except OSError as exc:
         log.warning("oauth_token_store: write failed for %s: %s", path, exc)
@@ -320,12 +330,17 @@ def with_retry_on_401(
     context. After ``max_attempts`` 401s the last response is returned for
     the caller to surface.
     """
+    # Clamp to at least one attempt: a caller passing 0 / negative would
+    # otherwise leave ``resp`` unbound and trip the assert (or, under
+    # ``python -O`` where asserts are stripped, return None and crash the
+    # caller). Always send at least once so a real response comes back.
+    attempts = max(1, max_attempts)
     resp: httpx.Response | None = None
-    for attempt in range(max_attempts):
+    for attempt in range(attempts):
         resp = send(attempt > 0)
         if resp.status_code != 401:
             return resp
-    assert resp is not None  # max_attempts >= 1 always sets resp
+    assert resp is not None  # attempts >= 1 always sets resp
     return resp
 
 

--- a/config/perplexity_handler.py
+++ b/config/perplexity_handler.py
@@ -66,17 +66,40 @@ def _load_tokens() -> dict[str, Any] | None:
 
 
 def _exchange_session_for_access(session_token: str) -> dict[str, Any]:
-    resp = httpx.get(
-        "https://www.perplexity.ai/api/auth/session",
-        cookies={"next-auth.session-token": session_token},
-        headers={
-            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
-        },
-        timeout=30,
-        follow_redirects=True,
-    )
-    resp.raise_for_status()
-    data = resp.json()
+    try:
+        resp = httpx.get(
+            "https://www.perplexity.ai/api/auth/session",
+            cookies={"next-auth.session-token": session_token},
+            headers={
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+            },
+            timeout=30,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        raise litellm.AuthenticationError(
+            message=(
+                f"Perplexity session exchange was rejected (HTTP {exc.response.status_code}) — "
+                "the PERPLEXITY_SESSION_TOKEN cookie is expired or invalid. Re-extract it from the browser."
+            ),
+            model="pplx-sub",
+            llm_provider="pplx-sub",
+        ) from exc
+    except (httpx.HTTPError, ValueError) as exc:
+        raise litellm.AuthenticationError(
+            message=f"Perplexity session exchange failed: {exc}. Re-extract the cookie from the browser.",
+            model="pplx-sub",
+            llm_provider="pplx-sub",
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise litellm.AuthenticationError(
+            message="Perplexity session exchange returned an unexpected response shape. Re-extract from browser.",
+            model="pplx-sub",
+            llm_provider="pplx-sub",
+        )
 
     access_token = data.get("accessToken") or data.get("token")
     if not access_token:
@@ -203,7 +226,22 @@ class PerplexitySubHandler(CustomLLM):
                 llm_provider="pplx-sub",
             )
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message=f"Perplexity returned a malformed (non-JSON) response: {resp.text[:300]}",
+                model=model,
+                llm_provider="pplx-sub",
+            ) from exc
+        if not isinstance(data, dict):
+            raise litellm.APIError(
+                status_code=resp.status_code,
+                message="Perplexity response JSON was not an object.",
+                model=model,
+                llm_provider="pplx-sub",
+            )
         return ModelResponse(
             id=data.get("id", f"pplx-sub-{actual_model}"),
             model=actual_model,

--- a/packages/decepticon/decepticon/cli/auth.py
+++ b/packages/decepticon/decepticon/cli/auth.py
@@ -74,7 +74,9 @@ def _load_env_file(path: Path) -> int:
     """Set unset keys from a KEY=VALUE .env file. Never overrides the live env."""
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # Missing, unreadable, or non-UTF-8 / corrupt .env: degrade to "nothing
+        # loaded" rather than letting a raw decode traceback escape the CLI.
         return 0
     loaded = 0
     for raw in text.splitlines():
@@ -167,9 +169,16 @@ def main(argv: list[str] | None = None) -> int:
             _load_env_file(path)
 
     # Imported lazily: pulls in the LLM stack, which is overkill for --help.
-    from decepticon.llm.factory import auth_inventory  # noqa: PLC0415
+    # Both the import and inventory probe touch the filesystem and parse
+    # credential files; a failure there is a misconfiguration, not a crash —
+    # report it actionably instead of dumping a traceback at the operator.
+    try:
+        from decepticon.llm.factory import auth_inventory  # noqa: PLC0415
 
-    inv = auth_inventory()
+        inv = auth_inventory()
+    except Exception as exc:  # noqa: BLE001 — top-level CLI guard; report, don't crash
+        print(f"error: could not inspect auth configuration: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
     print(_render_json(inv) if args.json else _render_text(inv))
 
     if args.command == "doctor":

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -836,11 +836,14 @@ class _ProxiedChatOpenAI(ChatOpenAI):
         return result
 
     async def ainvoke(self, *args, **kwargs):
+        # Resolve the timeout *before* creating the request coroutine. A
+        # misconfigured ``DECEPTICON_LLM_TIMEOUT_SECONDS`` raises ValueError;
+        # if that were evaluated as the second argument to
+        # ``call_with_timeout`` the ``super().ainvoke(...)`` coroutine would
+        # already exist and leak un-awaited ("coroutine was never awaited").
+        timeout = _resolve_llm_timeout_seconds()
         try:
-            result = await call_with_timeout(
-                super().ainvoke(*args, **kwargs),
-                _resolve_llm_timeout_seconds(),
-            )
+            result = await call_with_timeout(super().ainvoke(*args, **kwargs), timeout)
         except LLMTimeoutError:
             raise
         except Exception as exc:
@@ -999,9 +1002,13 @@ class _DeepSeekThinkingChatOpenAI(_ProxiedChatOpenAI):
 
     async def _agenerate(self, messages: list[BaseMessage], *args: Any, **kwargs: Any) -> Any:
         """Wrap _agenerate to preserve reasoning_content in the response."""
+        # Resolve the timeout before creating the request coroutine so a
+        # misconfigured timeout env raises ValueError without leaving the
+        # ``super()._agenerate(...)`` coroutine un-awaited.
+        timeout = _resolve_llm_timeout_seconds()
         result = await call_with_timeout(
             super()._agenerate(messages, *args, **kwargs),
-            _resolve_llm_timeout_seconds(),
+            timeout,
         )
         return result
 
@@ -1155,6 +1162,18 @@ _SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # Generic long opaque tokens (>=24 chars of key-ish alphabet) that survive
     # the targeted passes above — e.g. provider keys without an sk- prefix.
     (re.compile(r"\b[A-Za-z0-9_\-]{24,}\b"), "[REDACTED]"),
+)
+
+# High-confidence credential shapes used to decide whether an *unclassified*
+# provider error would leak a secret if its text were re-raised verbatim.
+# Deliberately excludes the broad ``>=24-char`` catch-all from
+# ``_SECRET_PATTERNS`` (that one also matches long model ids / hashes and
+# would over-trigger), keeping only the unambiguous ``Bearer``/``sk-``/
+# ``authorization:`` shapes.
+_CREDENTIAL_SHAPE = re.compile(
+    r"(?i)\bBearer\s+[\w.\-+/=]+"
+    r"|\bsk-(?:ant-)?[\w.\-]{8,}"
+    r"|['\"]?(?:authorization|x-api-key|api[_-]?key)['\"]?\s*[:=]\s*['\"]?[^'\"\s,}]+"
 )
 
 
@@ -1317,6 +1336,19 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
             f"or run 'decepticon onboard --reset'.\nUnderlying: {safe_msg}"
         ) from exc
 
+    if (
+        "permissiondenied" in err_type.lower()
+        or "forbidden" in err_type.lower()
+        or "code: 403" in msg_lower
+    ):
+        raise RuntimeError(
+            f"{fatal_prefix}Model '{model_name}' refused access (403). The "
+            f"provider accepted your credentials but forbids this model "
+            f"(region lock, plan tier, or org policy). Verify your account "
+            f"can use that model, or route to another method via "
+            f"DECEPTICON_AUTH_PRIORITY.\nUnderlying: {safe_msg}"
+        ) from exc
+
     if "ratelimit" in err_type.lower() or "code: 429" in msg_lower:
         raise RuntimeError(
             f"Model '{model_name}' hit the provider's rate limit (429). "
@@ -1331,6 +1363,20 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
             f"actually pulled ('ollama list'). For cloud providers, check "
             f"that the model id matches config/litellm.yaml.\n"
             f"Underlying: {safe_msg}"
+        ) from exc
+
+    # Final safety net for *unclassified* provider errors. None of the
+    # branches above matched, so the caller's trailing ``raise`` would
+    # re-raise ``exc`` verbatim. If its text carries a credential-shaped
+    # substring (e.g. an echoed Authorization header on a 500/422/region
+    # error we don't special-case), re-raising raw would leak the secret
+    # into CLI output and logs. Re-wrap with the scrubbed copy. Errors with
+    # no credential shape fall through untouched so their original traceback
+    # is preserved (see test_unmatched_error_passes_through).
+    if _CREDENTIAL_SHAPE.search(msg):
+        raise RuntimeError(
+            f"{fatal_prefix}Model '{model_name}' failed with an unclassified "
+            f"provider error. Underlying: {safe_msg}"
         ) from exc
 
 

--- a/packages/decepticon/tests/unit/cli/test_auth_branches.py
+++ b/packages/decepticon/tests/unit/cli/test_auth_branches.py
@@ -321,3 +321,27 @@ def test_main_doctor_fake_inventory_with_active(monkeypatch, capsys):
     rc = auth_main(["doctor", "--no-env-file"])
     assert rc == 0
     capsys.readouterr()
+
+
+def test_load_env_file_non_utf8_returns_zero_without_raising(tmp_path):
+    # A corrupt / binary .env must not crash the CLI with a raw UnicodeDecodeError
+    # (which is a ValueError, not an OSError) — it degrades to "nothing loaded".
+    env_file = tmp_path / ".env"
+    env_file.write_bytes(b"OPENAI_API_KEY=\xff\xfe\x00bad\x80value")
+    assert auth._load_env_file(env_file) == 0
+
+
+def test_main_inventory_failure_reports_cleanly(monkeypatch, capsys):
+    # A misconfiguration surfacing from the factory probe (e.g. a malformed
+    # credential file) must yield an actionable message + EXIT_CONFIG, never a
+    # bare traceback at the operator.
+    def _boom():
+        raise RuntimeError("malformed credential file")
+
+    monkeypatch.setattr(factory, "auth_inventory", _boom)
+    rc = auth_main(["status", "--no-env-file"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "could not inspect auth configuration" in captured.err
+    assert "malformed credential file" in captured.err
+    assert "Traceback" not in captured.err

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -1436,3 +1436,35 @@ class TestLLMTimeout:
         monkeypatch.setenv("DECEPTICON_LLM__TIMEOUT", "0")
         with pytest.raises(ValueError, match="DECEPTICON_LLM__TIMEOUT.*greater than 0"):
             _resolve_llm_timeout_seconds()
+
+    def test_ainvoke_resolves_timeout_before_creating_request_coroutine(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A misconfigured timeout env must fail loudly *without* creating
+        (and leaking un-awaited) the upstream request coroutine. Regression:
+        the timeout was previously resolved as the second argument to
+        ``call_with_timeout``, so ``super().ainvoke(...)`` was already
+        evaluated — a ValueError then left that coroutine never awaited."""
+        from langchain_openai import ChatOpenAI
+        from pydantic import SecretStr
+
+        from decepticon.llm.factory import _ProxiedChatOpenAI
+
+        called = False
+
+        async def _tracking_ainvoke(self, *args, **kwargs):  # noqa: ANN001
+            nonlocal called
+            called = True
+            return "should-not-happen"
+
+        monkeypatch.setattr(ChatOpenAI, "ainvoke", _tracking_ainvoke)
+        monkeypatch.setenv("DECEPTICON_LLM_TIMEOUT_SECONDS", "-5")
+
+        model = _ProxiedChatOpenAI(
+            model="openai/gpt-5.5",
+            base_url="http://localhost:4000",
+            api_key=SecretStr("test-key"),
+        )
+        with pytest.raises(ValueError, match="greater than 0"):
+            asyncio.run(model.ainvoke("hi"))
+        assert called is False, "upstream request coroutine must not be created on bad timeout"

--- a/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
+++ b/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
@@ -125,3 +125,76 @@ class TestActionableMessageFatalLabel:
         msg = str(info.value)
         assert "non-retryable provider error" not in msg
         assert "rate limit (429)" in msg
+
+
+class TestActionableMessage403Forbidden:
+    """403 PermissionDenied is a distinct fatal class. Before the fix the
+    helper had no branch for it, so it fell through to the caller's bare
+    ``raise`` — surfacing the raw provider exception (no remediation, and the
+    un-redacted body could leak an echoed Authorization header)."""
+
+    def test_403_by_status_attr_gives_actionable_message(self):
+        exc = _exc_with_status("PermissionDeniedError", 403, "Error code: 403 - forbidden")
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "anthropic/claude-opus-4-7")
+        msg = str(info.value)
+        assert "refused access (403)" in msg
+        assert "non-retryable provider error" in msg
+        assert "DECEPTICON_AUTH_PRIORITY" in msg
+
+    def test_403_message_only_gives_actionable_message(self):
+        exc = Exception("litellm.PermissionDeniedError: Error code: 403 - region not allowed")
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "openai/gpt-5.5")
+        assert "refused access (403)" in str(info.value)
+
+    def test_403_redacts_echoed_bearer_token(self):
+        exc = _exc_with_status(
+            "PermissionDeniedError",
+            403,
+            "Error code: 403 - Authorization: Bearer sk-ant-FORBIDDENLEAKTOKEN12345",
+        )
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "anthropic/claude-opus-4-7")
+        msg = str(info.value)
+        assert "sk-ant-FORBIDDENLEAKTOKEN12345" not in msg
+        assert "FORBIDDENLEAKTOKEN12345" not in msg
+        assert "[REDACTED]" in msg
+
+
+class TestUnclassifiedErrorSecretNet:
+    """Final safety net: an *unclassified* provider error (no 4xx branch
+    matched) whose body echoes a credential must be re-wrapped with the
+    scrubbed text instead of re-raised verbatim — otherwise the caller's
+    trailing ``raise`` would leak the secret into CLI output / logs."""
+
+    def test_unclassified_500_with_bearer_is_redacted_and_wrapped(self):
+        # 500 is retryable and not special-cased in the actionable branches,
+        # so it lands on the fallthrough. The echoed token must not survive.
+        exc = Exception(
+            "Error code: 500 - upstream error; sent Authorization: Bearer "
+            "sk-LEAKYINTERNALSERVERTOKEN9999"
+        )
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "openai/gpt-5.5")
+        msg = str(info.value)
+        assert "sk-LEAKYINTERNALSERVERTOKEN9999" not in msg
+        assert "LEAKYINTERNALSERVERTOKEN9999" not in msg
+        assert "[REDACTED]" in msg
+        assert "unclassified provider error" in msg
+
+    def test_unclassified_with_api_key_kwarg_is_redacted(self):
+        exc = Exception("weird upstream blob api_key=sk-ANOTHERLEAKEDVALUE0001 happened")
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "openai/gpt-5.5")
+        assert "sk-ANOTHERLEAKEDVALUE0001" not in str(info.value)
+        assert "[REDACTED]" in str(info.value)
+
+    def test_unrelated_error_without_credential_passes_through(self):
+        # No credential shape → helper must NOT raise; caller re-raises the
+        # original exception with its traceback intact (regression guard for
+        # the safety net's narrow trigger). A long model id alone (which the
+        # broad >=24-char redaction pattern matches) must not trip it.
+        exc = ValueError("planner produced no model for anthropic/claude-opus-4-7-experimental")
+        # Returns None (no raise).
+        assert _reraise_with_actionable_message(exc, "anthropic/claude-opus-4-7") is None

--- a/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
@@ -20,6 +20,11 @@ merge_dynamic_models = _module.merge_dynamic_models
 validate_model_name = _module.validate_model_name
 OPENAI_COMPAT_GATEWAYS = _module.OPENAI_COMPAT_GATEWAYS
 ALLOWED_DYNAMIC_PROVIDERS = _module.ALLOWED_DYNAMIC_PROVIDERS
+write_dynamic_config = _module.write_dynamic_config
+_provider_prefix = _module._provider_prefix
+_NO_API_KEY_PROVIDERS = _module._NO_API_KEY_PROVIDERS
+PROVIDER_KEY_ENV_ALIASES = _module.PROVIDER_KEY_ENV_ALIASES
+PROVIDER_EXTRA_PARAMS = _module.PROVIDER_EXTRA_PARAMS
 
 
 def test_collect_requested_models_includes_global_and_role_overrides() -> None:
@@ -374,3 +379,311 @@ def test_merge_dynamic_models_registers_gateway_override() -> None:
         "api_key": "os.environ/ZENMUX_API_KEY",
         "api_base": "https://zenmux.ai/api/v1",
     }
+
+# ── error-proofing: null / malformed YAML config blocks ─────────────────
+
+
+def test_merge_dynamic_models_tolerates_null_model_list() -> None:
+    """A YAML config with a bare ``model_list:`` key parses to ``None``.
+
+    ``_inject_subscription_routes`` must coerce it to ``[]`` instead of
+    iterating ``None`` (regression: raw ``'NoneType' is not iterable``).
+    """
+    merged = merge_dynamic_models({"model_list": None}, {})
+    assert merged["model_list"] == []
+
+
+def test_merge_dynamic_models_tolerates_null_litellm_settings() -> None:
+    """A bare ``litellm_settings:`` key parses to ``None``; injecting a
+    subscription route must not call ``.setdefault`` on ``None``."""
+    merged = merge_dynamic_models(
+        {"litellm_settings": None}, {"DECEPTICON_AUTH_CHATGPT": "true"}
+    )
+    assert isinstance(merged["litellm_settings"], dict)
+    names = [e.get("model_name", "") for e in merged["model_list"]]
+    assert any(n.startswith("auth/gpt") for n in names)
+
+
+def test_write_dynamic_config_rejects_non_mapping_yaml(tmp_path: Path) -> None:
+    """A top-level YAML list is not a valid LiteLLM config — surface an
+    actionable ValueError rather than a cryptic ``dict()`` TypeError."""
+    src = tmp_path / "bad.yaml"
+    src.write_text("- one\n- two\n")
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        write_dynamic_config(src, tmp_path / "out.yaml")
+
+
+def test_write_dynamic_config_rejects_malformed_yaml(tmp_path: Path) -> None:
+    """Malformed YAML raises a clear ValueError naming the config path."""
+    src = tmp_path / "broken.yaml"
+    src.write_text("model_list: [unclosed\n")
+    with pytest.raises(ValueError, match="not valid YAML"):
+        write_dynamic_config(src, tmp_path / "out.yaml")
+
+
+def test_write_dynamic_config_tolerates_null_blocks(tmp_path: Path) -> None:
+    """A config whose ``model_list:`` / ``litellm_settings:`` keys are null
+    must write a usable generated config instead of crashing at boot."""
+    import yaml
+
+    src = tmp_path / "cfg.yaml"
+    src.write_text("model_list:\nlitellm_settings:\n")
+    out = write_dynamic_config(src, tmp_path / "out.yaml")
+    data = yaml.safe_load(out.read_text())
+    assert isinstance(data["model_list"], list)
+
+# ── full LiteLLM provider catalog coverage (v1.89.0) ────────────────────
+# Source of truth: the 114 providers researched from litellm 1.89.0 source.
+# Pinned here (not read from the catalog JSON, which isn't shipped to the
+# container) so this test fails loudly if a provider regresses out of the
+# tables. ``(prefix, expected_key_env)``: expected_key_env is the api_key env
+# var the route must reference, or None for key-less / local-no-key routes.
+_REJECTED_CATALOG_PREFIXES = {"ollama", "github_copilot"}
+
+_CATALOG: list[tuple[str, str | None]] = [
+    ("openai", "OPENAI_API_KEY"),
+    ("text-completion-openai", "OPENAI_API_KEY"),
+    ("anthropic", "ANTHROPIC_API_KEY"),
+    ("gemini", "GOOGLE_API_KEY"),
+    ("vertex_ai", None),
+    ("azure", "AZURE_API_KEY"),
+    ("azure_ai", "AZURE_AI_API_KEY"),
+    ("bedrock", None),
+    ("sagemaker", None),
+    ("sagemaker_chat", None),
+    ("mistral", "MISTRAL_API_KEY"),
+    ("codestral", "CODESTRAL_API_KEY"),
+    ("text-completion-codestral", "CODESTRAL_API_KEY"),
+    ("groq", "GROQ_API_KEY"),
+    ("together_ai", "TOGETHERAI_API_KEY"),
+    ("fireworks_ai", "FIREWORKS_AI_API_KEY"),
+    ("deepseek", "DEEPSEEK_API_KEY"),
+    ("xai", "XAI_API_KEY"),
+    ("cohere", "COHERE_API_KEY"),
+    ("cohere_chat", "COHERE_API_KEY"),
+    ("perplexity", "PERPLEXITYAI_API_KEY"),
+    ("openrouter", "OPENROUTER_API_KEY"),
+    ("cerebras", "CEREBRAS_API_KEY"),
+    ("sambanova", "SAMBANOVA_API_KEY"),
+    ("nvidia_nim", "NVIDIA_API_KEY"),
+    ("databricks", "DATABRICKS_API_KEY"),
+    ("watsonx", "WATSONX_API_KEY"),
+    ("ollama", None),
+    ("ollama_chat", None),
+    ("vllm", None),
+    ("hosted_vllm", "HOSTED_VLLM_API_KEY"),
+    ("deepinfra", "DEEPINFRA_API_KEY"),
+    ("anyscale", "ANYSCALE_API_KEY"),
+    ("replicate", "REPLICATE_API_TOKEN"),
+    ("huggingface", "HUGGINGFACE_API_KEY"),
+    ("ai21", "AI21_API_KEY"),
+    ("ai21_chat", "AI21_API_KEY"),
+    ("nlp_cloud", "NLP_CLOUD_API_KEY"),
+    ("voyage", "VOYAGE_API_KEY"),
+    ("jina_ai", "JINA_AI_API_KEY"),
+    ("cloudflare", "CLOUDFLARE_API_KEY"),
+    ("baseten", "BASETEN_API_KEY"),
+    ("snowflake", "SNOWFLAKE_JWT"),
+    ("github", "GITHUB_API_KEY"),
+    ("github_copilot", None),
+    ("lm_studio", "LMSTUDIO_API_KEY"),
+    ("llamafile", "LLAMAFILE_API_KEY"),
+    ("novita", "NOVITA_API_KEY"),
+    ("hyperbolic", "HYPERBOLIC_API_KEY"),
+    ("lambda_ai", "LAMBDA_API_KEY"),
+    ("nebius", "NEBIUS_API_KEY"),
+    ("dashscope", "DASHSCOPE_API_KEY"),
+    ("moonshot", "MOONSHOT_API_KEY"),
+    ("zai", "ZAI_API_KEY"),
+    ("minimax", "MINIMAX_API_KEY"),
+    ("volcengine", "VOLCENGINE_API_KEY"),
+    ("friendliai", "FRIENDLIAI_API_KEY"),
+    ("featherless_ai", "FEATHERLESS_AI_API_KEY"),
+    ("galadriel", "GALADRIEL_API_KEY"),
+    ("gradient_ai", "GRADIENT_AI_API_KEY"),
+    ("predibase", "PREDIBASE_API_KEY"),
+    ("clarifai", "CLARIFAI_API_KEY"),
+    ("aleph_alpha", "ALEPH_ALPHA_API_KEY"),
+    ("petals", None),
+    ("maritalk", "MARITALK_API_KEY"),
+    ("xinference", "XINFERENCE_API_KEY"),
+    ("empower", "EMPOWER_API_KEY"),
+    ("meta_llama", "LLAMA_API_KEY"),
+    ("nscale", "NSCALE_API_KEY"),
+    ("v0", "V0_API_KEY"),
+    ("morph", "MORPH_API_KEY"),
+    ("inception", "INCEPTION_API_KEY"),
+    ("litellm_proxy", "LITELLM_PROXY_API_KEY"),
+    ("vercel_ai_gateway", "VERCEL_AI_GATEWAY_API_KEY"),
+    ("wandb", "WANDB_API_KEY"),
+    ("cometapi", "COMETAPI_API_KEY"),
+    ("aiml", "AIML_API_KEY"),
+    ("heroku", "HEROKU_API_KEY"),
+    ("oci", None),
+    ("gigachat", None),
+    ("datarobot", "DATAROBOT_API_TOKEN"),
+    ("ovhcloud", "OVHCLOUD_API_KEY"),
+    ("scaleway", "SCW_SECRET_KEY"),
+    ("lemonade", "LEMONADE_API_KEY"),
+    ("docker_model_runner", "DOCKER_MODEL_RUNNER_API_KEY"),
+    ("ragflow", "RAGFLOW_API_KEY"),
+    ("compactifai", "COMPACTIFAI_API_KEY"),
+    ("publicai", "PUBLICAI_API_KEY"),
+    ("synthetic", "SYNTHETIC_API_KEY"),
+    ("apertis", "STIMA_API_KEY"),
+    ("nano-gpt", "NANOGPT_API_KEY"),
+    ("poe", "POE_API_KEY"),
+    ("chutes", "CHUTES_API_KEY"),
+    ("parasail", "PARASAIL_API_KEY"),
+    ("tensormesh", "TENSORMESH_INFERENCE_API_KEY"),
+    ("infinity", "INFINITY_API_KEY"),
+    ("triton", None),
+    ("oobabooga", None),
+    ("deepgram", "DEEPGRAM_API_KEY"),
+    ("elevenlabs", "ELEVENLABS_API_KEY"),
+    ("assemblyai", "ASSEMBLYAI_API_KEY"),
+    ("recraft", "RECRAFT_API_KEY"),
+    ("runwayml", "RUNWAYML_API_KEY"),
+    ("stability", "STABILITY_API_KEY"),
+    ("fal_ai", "FAL_AI_API_KEY"),
+    ("black_forest_labs", "BFL_API_KEY"),
+    ("topaz", "TOPAZ_API_KEY"),
+    ("bedrock_mantle", "BEDROCK_MANTLE_API_KEY"),
+    ("amazon_nova", "AMAZON_NOVA_API_KEY"),
+    ("soniox", "SONIOX_API_KEY"),
+    ("nvidia_riva", "NVIDIA_RIVA_API_KEY"),
+    ("sap", None),
+    ("openai_like", "OPENAI_LIKE_API_KEY"),
+    ("manus", "MANUS_API_KEY"),
+]
+
+
+def test_catalog_has_full_provider_count() -> None:
+    """Guard against silent shrinkage of the pinned catalog list."""
+    assert len(_CATALOG) == 114
+
+
+@pytest.mark.parametrize("prefix", [p for p, _ in _CATALOG if p not in _REJECTED_CATALOG_PREFIXES])
+def test_every_catalog_provider_validates_and_builds(prefix: str) -> None:
+    """Every supported catalog provider prefix passes validation and builds a
+    route whose ``model_name`` is preserved verbatim."""
+    model = f"{prefix}/some-model"
+    validate_model_name(model)  # must not raise
+    entry = build_model_entry(model)
+    assert entry["model_name"] == model
+    assert entry["litellm_params"]["model"]  # a model is always set
+    provider = _provider_prefix(model)
+    # Key-bearing providers must reference an api_key env; key-less ones
+    # (SigV4 / ADC / OCI / OAuth / local-no-auth, plus local ollama_chat)
+    # legitimately omit it.
+    if provider not in _NO_API_KEY_PROVIDERS and provider != "ollama_chat":
+        assert "api_key" in entry["litellm_params"], provider
+
+
+@pytest.mark.parametrize("prefix,expected_key", [(p, k) for p, k in _CATALOG if p not in _REJECTED_CATALOG_PREFIXES])
+def test_every_catalog_provider_uses_source_verified_key_env(
+    prefix: str, expected_key: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The api_key env ref must be the source-verified name, not the derived
+    ``<PROVIDER>_API_KEY`` guess. Run with a clean env so alias providers fall
+    back to their canonical (first-listed) var."""
+    for _, candidates in PROVIDER_KEY_ENV_ALIASES.items():
+        for name in candidates:
+            monkeypatch.delenv(name, raising=False)
+    params = build_model_entry(f"{prefix}/some-model")["litellm_params"]
+    if expected_key is None:
+        assert "api_key" not in params
+    else:
+        assert params["api_key"] == f"os.environ/{expected_key}"
+
+
+@pytest.mark.parametrize("prefix", sorted(_REJECTED_CATALOG_PREFIXES))
+def test_rejected_catalog_providers_raise(prefix: str) -> None:
+    with pytest.raises(ValueError):
+        validate_model_name(f"{prefix}/some-model")
+
+
+def test_github_copilot_rejected_as_oauth() -> None:
+    with pytest.raises(ValueError, match="OAuth"):
+        validate_model_name("github_copilot/gpt-4o")
+
+
+def test_unsupported_provider_error_mentions_count_and_docs() -> None:
+    with pytest.raises(ValueError, match="providers are supported") as exc:
+        validate_model_name("totally-made-up/model")
+    assert "DECEPTICON_LITELLM_MODELS" in str(exc.value)
+    assert str(len(ALLOWED_DYNAMIC_PROVIDERS)) in str(exc.value)
+
+
+def test_bedrock_route_has_no_api_key() -> None:
+    params = build_model_entry("bedrock/anthropic.claude-3-5-sonnet")["litellm_params"]
+    assert "api_key" not in params
+    assert params == {"model": "bedrock/anthropic.claude-3-5-sonnet"}
+
+
+def test_vertex_ai_route_passes_project_and_location_without_key() -> None:
+    params = build_model_entry("vertex_ai/gemini-2.0-flash")["litellm_params"]
+    assert "api_key" not in params
+    assert params["vertex_project"] == "os.environ/VERTEXAI_PROJECT"
+    assert params["vertex_location"] == "os.environ/VERTEXAI_LOCATION"
+
+
+def test_watsonx_route_carries_url_and_project_params() -> None:
+    params = build_model_entry("watsonx/ibm/granite-13b-chat-v2")["litellm_params"]
+    assert params["api_key"] == "os.environ/WATSONX_API_KEY"
+    assert params["api_base"] == "os.environ/WATSONX_URL"
+    assert params["project_id"] == "os.environ/WATSONX_PROJECT_ID"
+
+
+def test_predibase_route_carries_tenant_id() -> None:
+    params = build_model_entry("predibase/llama-3-8b-instruct")["litellm_params"]
+    assert params["api_key"] == "os.environ/PREDIBASE_API_KEY"
+    assert params["tenant_id"] == "os.environ/PREDIBASE_TENANT_ID"
+
+
+def test_alias_key_prefers_first_env_var_actually_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """together_ai accepts 4 key aliases; the route must reference the first
+    one actually set, not always the canonical TOGETHERAI_API_KEY."""
+    for name in PROVIDER_KEY_ENV_ALIASES["together_ai"]:
+        monkeypatch.delenv(name, raising=False)
+    # None set → canonical fallback.
+    assert (
+        build_model_entry("together_ai/x")["litellm_params"]["api_key"]
+        == "os.environ/TOGETHERAI_API_KEY"
+    )
+    # Only a non-canonical alias set → that one wins.
+    monkeypatch.setenv("TOGETHER_AI_TOKEN", "secret")
+    assert (
+        build_model_entry("together_ai/x")["litellm_params"]["api_key"]
+        == "os.environ/TOGETHER_AI_TOKEN"
+    )
+
+
+def test_cohere_falls_back_to_co_api_key_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in PROVIDER_KEY_ENV_ALIASES["cohere"]:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("CO_API_KEY", "secret")
+    assert (
+        build_model_entry("cohere/command-r")["litellm_params"]["api_key"]
+        == "os.environ/CO_API_KEY"
+    )
+
+
+def test_local_no_key_providers_accepted_with_api_base() -> None:
+    """vllm/hosted_vllm/lemonade/llamafile are accepted and pinned to their
+    api_base env ref."""
+    assert build_model_entry("vllm/m")["litellm_params"]["api_base"] == "os.environ/VLLM_API_BASE"
+    assert (
+        build_model_entry("lemonade/m")["litellm_params"]["api_base"]
+        == "os.environ/LEMONADE_API_BASE"
+    )
+
+
+def test_every_catalog_prefix_is_allowed_or_rejected() -> None:
+    """No catalog provider falls through the cracks: each normalized prefix is
+    either in ALLOWED_DYNAMIC_PROVIDERS or explicitly rejected."""
+    for prefix, _ in _CATALOG:
+        provider = _provider_prefix(f"{prefix}/x")
+        if prefix in _REJECTED_CATALOG_PREFIXES:
+            continue
+        assert provider in ALLOWED_DYNAMIC_PROVIDERS, prefix

--- a/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
@@ -380,6 +380,7 @@ def test_merge_dynamic_models_registers_gateway_override() -> None:
         "api_base": "https://zenmux.ai/api/v1",
     }
 
+
 # ── error-proofing: null / malformed YAML config blocks ─────────────────
 
 
@@ -396,9 +397,7 @@ def test_merge_dynamic_models_tolerates_null_model_list() -> None:
 def test_merge_dynamic_models_tolerates_null_litellm_settings() -> None:
     """A bare ``litellm_settings:`` key parses to ``None``; injecting a
     subscription route must not call ``.setdefault`` on ``None``."""
-    merged = merge_dynamic_models(
-        {"litellm_settings": None}, {"DECEPTICON_AUTH_CHATGPT": "true"}
-    )
+    merged = merge_dynamic_models({"litellm_settings": None}, {"DECEPTICON_AUTH_CHATGPT": "true"})
     assert isinstance(merged["litellm_settings"], dict)
     names = [e.get("model_name", "") for e in merged["model_list"]]
     assert any(n.startswith("auth/gpt") for n in names)
@@ -431,6 +430,7 @@ def test_write_dynamic_config_tolerates_null_blocks(tmp_path: Path) -> None:
     out = write_dynamic_config(src, tmp_path / "out.yaml")
     data = yaml.safe_load(out.read_text())
     assert isinstance(data["model_list"], list)
+
 
 # ── full LiteLLM provider catalog coverage (v1.89.0) ────────────────────
 # Source of truth: the 114 providers researched from litellm 1.89.0 source.
@@ -580,7 +580,9 @@ def test_every_catalog_provider_validates_and_builds(prefix: str) -> None:
         assert "api_key" in entry["litellm_params"], provider
 
 
-@pytest.mark.parametrize("prefix,expected_key", [(p, k) for p, k in _CATALOG if p not in _REJECTED_CATALOG_PREFIXES])
+@pytest.mark.parametrize(
+    "prefix,expected_key", [(p, k) for p, k in _CATALOG if p not in _REJECTED_CATALOG_PREFIXES]
+)
 def test_every_catalog_provider_uses_source_verified_key_env(
     prefix: str, expected_key: str | None, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/decepticon/tests/unit/llm/test_oauth_handlers.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_handlers.py
@@ -336,6 +336,7 @@ class TestCompletionMalformedResponse:
         with pytest.raises(mod.litellm.APIError):
             handler.completion(model=model, messages=[{"role": "user", "content": "hi"}])
 
+
 # ── Claude refresh hardening: malformed refresh response ────────────────
 
 

--- a/packages/decepticon/tests/unit/llm/test_oauth_handlers.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_handlers.py
@@ -98,9 +98,11 @@ def _load(name: str) -> Any:
 
 
 codex = _load("codex_chatgpt_handler")
+claude = _load("claude_code_handler")
 copilot = _load("copilot_handler")
 grok = _load("grok_handler")
 gemini = _load("gemini_handler")
+perplexity = _load("perplexity_handler")
 
 
 def _response(message: dict[str, Any], finish_reason: str = "stop") -> Any:
@@ -211,3 +213,290 @@ class TestGeminiFinishReason:
     )
     def test_map_finish_reason(self, reason, expected) -> None:
         assert gemini._map_finish_reason(reason) == expected
+
+
+# ── error-proofing: brittle provider-response parsing ───────────────────
+
+
+class _ParseResp:
+    """Minimal httpx.Response stand-in for handler parsing paths."""
+
+    def __init__(self, status_code=200, json_data=None, text="", raise_json=False):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+        self._raise_json = raise_json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                "err", request=httpx.Request("GET", "https://example.test"), response=self
+            )
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("Expecting value")
+        return self._json_data
+
+
+class TestCopilotMintHardening:
+    def test_missing_token_raises_actionable_error_without_leaking_source(self, monkeypatch):
+        secret = "gho_SUPER_SECRET_SOURCE_TOKEN"
+        monkeypatch.setattr(
+            copilot, "_http_post", lambda *a, **k: _ParseResp(200, {"expires_at": 123})
+        )
+        with pytest.raises(copilot.litellm.AuthenticationError) as exc:
+            copilot._mint_copilot_token(secret)
+        assert "subscription" in exc.value.message.lower()
+        assert secret not in exc.value.message
+
+    def test_non_json_mint_response_degrades_cleanly(self, monkeypatch):
+        monkeypatch.setattr(
+            copilot,
+            "_http_post",
+            lambda *a, **k: _ParseResp(200, raise_json=True, text="<html>gateway</html>"),
+        )
+        with pytest.raises(copilot.litellm.AuthenticationError):
+            copilot._mint_copilot_token("gho_x")
+
+    def test_garbage_expires_at_does_not_crash(self, monkeypatch):
+        monkeypatch.setattr(
+            copilot,
+            "_http_post",
+            lambda *a, **k: _ParseResp(200, {"token": "ct", "expires_at": "not-a-number"}),
+        )
+        minted = copilot._mint_copilot_token("gho_x")
+        assert minted["copilot_token"] == "ct"
+        assert minted["expires_at"] == 0
+
+
+class TestGeminiRefreshHardening:
+    def test_missing_access_token_raises_without_leaking_refresh(self, monkeypatch):
+        secret = "REFRESH-SECRET-do-not-leak"
+        monkeypatch.setattr(
+            gemini, "oauth_refresh_request", lambda *a, **k: {"expires_in": 3600, "scope": "x"}
+        )
+        with pytest.raises(gemini.litellm.AuthenticationError) as exc:
+            gemini._refresh_google_token({"refreshToken": secret})
+        assert "access_token" in exc.value.message
+        assert secret not in exc.value.message
+
+
+@pytest.mark.parametrize(
+    ("mod", "fn"),
+    [
+        (grok, "_exchange_session_for_access"),
+        (perplexity, "_exchange_session_for_access"),
+    ],
+)
+class TestSessionExchangeHardening:
+    def test_rejected_cookie_raises_auth_error_not_raw_traceback(self, monkeypatch, mod, fn):
+        session = "SESSION-COOKIE-SECRET"
+        monkeypatch.setattr(mod.httpx, "get", lambda *a, **k: _ParseResp(401, text="unauthorized"))
+        with pytest.raises(mod.litellm.AuthenticationError) as exc:
+            getattr(mod, fn)(session)
+        assert "401" in exc.value.message
+        assert session not in exc.value.message
+
+    def test_non_json_session_response_degrades_cleanly(self, monkeypatch, mod, fn):
+        monkeypatch.setattr(
+            mod.httpx, "get", lambda *a, **k: _ParseResp(200, raise_json=True, text="not json")
+        )
+        with pytest.raises(mod.litellm.AuthenticationError):
+            getattr(mod, fn)("SESSION")
+
+
+@pytest.mark.parametrize(
+    ("mod", "handler", "model"),
+    [
+        (copilot, copilot.copilot_handler_instance, "copilot/gpt-5"),
+        (grok, grok.grok_sub_handler_instance, "grok-sub/grok-4.3"),
+        (gemini, gemini.gemini_sub_handler_instance, "gemini-sub/gemini-2.5-pro"),
+        (perplexity, perplexity.perplexity_sub_handler_instance, "pplx-sub/sonar-pro"),
+    ],
+)
+class TestCompletionMalformedResponse:
+    def test_non_json_200_raises_api_error(self, monkeypatch, mod, handler, model):
+        monkeypatch.setattr(
+            mod,
+            "with_retry_on_401",
+            lambda send, **k: _ParseResp(200, raise_json=True, text="<html>oops</html>"),
+        )
+        with pytest.raises(mod.litellm.APIError):
+            handler.completion(model=model, messages=[{"role": "user", "content": "hi"}])
+
+    def test_non_dict_json_200_raises_api_error(self, monkeypatch, mod, handler, model):
+        monkeypatch.setattr(
+            mod,
+            "with_retry_on_401",
+            lambda send, **k: _ParseResp(200, json_data=["not", "an", "object"]),
+        )
+        with pytest.raises(mod.litellm.APIError):
+            handler.completion(model=model, messages=[{"role": "user", "content": "hi"}])
+
+# ── Claude refresh hardening: malformed refresh response ────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class TestClaudeRefreshHardening:
+    def test_missing_access_token_raises_clean_auth_error(self, monkeypatch) -> None:
+        # A refresh response without access_token must not blow up with a
+        # raw KeyError, and must never echo the token payload back.
+        secret = "sk-ant-oat01-LEAKED-REFRESH"
+        monkeypatch.setattr(
+            claude,
+            "oauth_refresh_request",
+            lambda *a, **k: {"refresh_token": secret, "expires_in": 3600},
+        )
+        with pytest.raises(claude.litellm.AuthenticationError) as exc:
+            claude._refresh_token({"refreshToken": "old"})
+        message = exc.value.message
+        assert "access_token" in message
+        assert secret not in message
+
+    def test_null_expires_in_and_scope_do_not_crash(self, monkeypatch) -> None:
+        # expires_in / scope arriving as null must not raise TypeError /
+        # AttributeError; defaults apply.
+        monkeypatch.setattr(
+            claude,
+            "oauth_refresh_request",
+            lambda *a, **k: {
+                "access_token": "sk-ant-oat01-new",
+                "expires_in": None,
+                "scope": None,
+            },
+        )
+        monkeypatch.setattr(claude, "write_json_atomic", lambda *a, **k: True)
+        monkeypatch.setattr(claude._credentials_cache, "replace", lambda *a, **k: None)
+        new = claude._refresh_token({"refreshToken": "old"})
+        assert new["accessToken"] == "sk-ant-oat01-new"
+        assert new["scopes"] == []
+        assert isinstance(new["expiresAt"], int)
+        # refreshToken falls back to the prior value when absent from response.
+        assert new["refreshToken"] == "old"
+
+
+# ── Claude completion: brittle provider-response parsing ─────────────────
+
+
+class TestClaudeCompletionParsing:
+    def _patch_send(self, monkeypatch, resp) -> None:
+        monkeypatch.setattr(claude, "with_retry_on_401", lambda send: resp)
+
+    def test_non_json_200_body_raises_api_error_not_traceback(self, monkeypatch) -> None:
+        import json as _json
+
+        resp = _FakeResp(
+            200, payload=_json.JSONDecodeError("x", "<html>", 0), text="<html>oops</html>"
+        )
+        self._patch_send(monkeypatch, resp)
+        with pytest.raises(claude.litellm.APIError):
+            claude.claude_code_handler_instance.completion(
+                model="auth/claude-x", messages=[{"role": "user", "content": "hi"}]
+            )
+
+    def test_null_content_and_usage_do_not_crash(self, monkeypatch) -> None:
+        # content/usage explicitly null must not raise TypeError on iteration
+        # or token arithmetic.
+        captured: dict[str, Any] = {}
+
+        class _DummyModelResponse:
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+        monkeypatch.setattr(claude, "ModelResponse", _DummyModelResponse)
+        resp = _FakeResp(
+            200,
+            payload={"content": None, "usage": None, "stop_reason": "end_turn", "id": "msg_1"},
+        )
+        self._patch_send(monkeypatch, resp)
+        claude.claude_code_handler_instance.completion(
+            model="auth/claude-x", messages=[{"role": "user", "content": "hi"}]
+        )
+        assert captured["usage"]["total_tokens"] == 0
+        assert captured["choices"][0]["message"]["content"] is None
+
+    def test_tool_use_block_missing_name_does_not_keyerror(self, monkeypatch) -> None:
+        captured: dict[str, Any] = {}
+
+        class _DummyModelResponse:
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+        monkeypatch.setattr(claude, "ModelResponse", _DummyModelResponse)
+        resp = _FakeResp(
+            200,
+            payload={
+                "content": [{"type": "tool_use", "id": "t1", "input": {"a": 1}}],
+                "usage": {"input_tokens": 2, "output_tokens": 3},
+                "stop_reason": "tool_use",
+            },
+        )
+        self._patch_send(monkeypatch, resp)
+        claude.claude_code_handler_instance.completion(
+            model="auth/claude-x", messages=[{"role": "user", "content": "hi"}]
+        )
+        tool_calls = captured["choices"][0]["message"]["tool_calls"]
+        assert tool_calls[0]["function"]["name"] == ""
+        assert captured["choices"][0]["finish_reason"] == "tool_calls"
+
+
+# ── Codex input parsing: object-form tool_calls ─────────────────────────
+
+
+class TestCodexResponsesInput:
+    def test_object_form_tool_call_does_not_attributeerror(self) -> None:
+        class _Fn:
+            name = "run_shell"
+            arguments = '{"cmd": "ls"}'
+
+        class _TC:
+            id = "call_obj"
+            function = _Fn()
+
+        msg = {"role": "assistant", "tool_calls": [_TC()]}
+        items, _instr = codex._responses_input([msg])
+        fc = [i for i in items if i.get("type") == "function_call"]
+        assert len(fc) == 1
+        assert fc[0]["call_id"] == "call_obj"
+        assert fc[0]["name"] == "run_shell"
+        assert fc[0]["arguments"] == '{"cmd": "ls"}'
+
+
+# ── Codex stream error classification ───────────────────────────────────
+
+
+class TestCodexCompletedPayloadErrors:
+    def test_null_error_does_not_surface_literal_none(self) -> None:
+        sse = 'data: {"type": "error", "error": null}\n'
+        resp = _FakeResp(200, text=sse)
+        with pytest.raises(codex.litellm.APIError) as exc:
+            codex._completed_payload(resp)
+        assert exc.value.message != "None"
+
+    def test_error_dict_without_message_is_serialized(self) -> None:
+        sse = 'data: {"type": "response.failed", "response": {"error": {"code": "boom"}}}\n'
+        resp = _FakeResp(200, text=sse)
+        with pytest.raises(codex.litellm.APIError) as exc:
+            codex._completed_payload(resp)
+        assert "boom" in exc.value.message
+
+    def test_empty_stream_uses_fallback_message(self) -> None:
+        resp = _FakeResp(200, text="")
+        with pytest.raises(codex.litellm.APIError) as exc:
+            codex._completed_payload(resp)
+        assert "completed" in exc.value.message.lower()

--- a/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
@@ -437,6 +437,7 @@ def test_with_retry_on_401_does_not_retry_other_4xx() -> None:
     assert resp.status_code == 403
     assert calls == [False]
 
+
 def test_with_retry_on_401_clamps_nonpositive_attempts() -> None:
     # max_attempts <= 0 must still send once and return a real response —
     # not leave ``resp`` unbound (AssertionError, or None under python -O).

--- a/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
@@ -43,7 +43,14 @@ class _StubAuthenticationError(Exception):
 if not hasattr(litellm, "AuthenticationError"):
     litellm.AuthenticationError = _StubAuthenticationError
 
-_MODULE_PATH = Path(__file__).resolve().parents[5] / "config" / "oauth_token_store.py"
+_CONFIG_DIR = Path(__file__).resolve().parents[5] / "config"
+# ``oauth_token_store`` does ``from http_client import post`` by bare name, so
+# ``config/`` must be importable. Insert it here instead of relying on a sibling
+# test module (test_oauth_handlers) having run first — that ordering dependency
+# made this file fail when run in isolation.
+if str(_CONFIG_DIR) not in sys.path:
+    sys.path.insert(0, str(_CONFIG_DIR))
+_MODULE_PATH = _CONFIG_DIR / "oauth_token_store.py"
 _spec = importlib.util.spec_from_file_location("decepticon_oauth_token_store", _MODULE_PATH)
 assert _spec is not None
 assert _spec.loader is not None
@@ -429,3 +436,39 @@ def test_with_retry_on_401_does_not_retry_other_4xx() -> None:
     resp = with_retry_on_401(send)
     assert resp.status_code == 403
     assert calls == [False]
+
+def test_with_retry_on_401_clamps_nonpositive_attempts() -> None:
+    # max_attempts <= 0 must still send once and return a real response —
+    # not leave ``resp`` unbound (AssertionError, or None under python -O).
+    calls: list[bool] = []
+
+    def send(force_refresh: bool) -> httpx.Response:
+        calls.append(force_refresh)
+        return _stub_response(200)
+
+    resp = with_retry_on_401(send, max_attempts=0)
+    assert resp.status_code == 200
+    assert calls == [False]
+
+
+# ── write_json_atomic: short os.write ───────────────────────────────────
+
+
+@pytest.mark.skipif(os.name == "nt", reason="os.write short-write loop is POSIX-specific")
+def test_write_json_atomic_handles_short_os_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # os.write may write fewer bytes than requested (short write). The helper
+    # must loop until the whole payload is flushed; otherwise a truncated,
+    # corrupt token file gets renamed into place.
+    path = tmp_path / "tokens.json"
+    payload = {"access_token": "x" * 200, "refresh_token": "y" * 200}
+    real_write = os.write
+
+    def short_write(fd: int, data: Any) -> int:
+        # Honor at most 8 bytes per call to force the loop to iterate.
+        return real_write(fd, bytes(data)[:8])
+
+    monkeypatch.setattr(_module.os, "write", short_write)
+    assert write_json_atomic(path, payload) is True
+    assert json.loads(path.read_text()) == payload


### PR DESCRIPTION
## What

Two tracks in one PR, both confined to the auth / LiteLLM / API + subscription-authentication stack.

### 1. Universal LiteLLM provider support (`config/litellm_dynamic_config.py`)

The dynamic-route layer now supports **every provider LiteLLM v1.89.0 ships** — 114 providers, enumerated from `litellm.types.utils.LlmProviders` and env-var-verified against `validate_environment` / `get_llm_provider` / `get_secret_str` usage in the litellm source (not guessed):

- `PROVIDER_API_KEY_ENV`: ~75 new single-key providers with source-verified env names (incl. non-obvious ones: `apertis→STIMA_API_KEY`, `meta_llama→LLAMA_API_KEY`, `scaleway→SCW_SECRET_KEY`, `datarobot→DATAROBOT_API_TOKEN`). Existing entries untouched.
- `PROVIDER_KEY_ENV_ALIASES`: multi-alias keys (Together ×4, Fireworks ×4, `PERPLEXITYAI_API_KEY`, `CO_API_KEY`, `FRIENDLI_TOKEN`, …) resolved at write time, first-set-var-wins with canonical fallback.
- `PROVIDER_EXTRA_PARAMS`: table-driven params for providers needing more than a key (Azure/Azure AI base+version, watsonx URL+project, Databricks, Predibase tenant, Snowflake account, and local OpenAI-compatible servers: vLLM, llamafile, Xinference, …). Replaces the growing `elif` chain for bedrock/vertex/azure.
- `_NO_API_KEY_PROVIDERS`: SigV4/ADC/signed-auth providers (Bedrock, SageMaker, Vertex AI, OCI, SAP AI Core, GigaChat, Triton, …) route without an `api_key` ref so LiteLLM's native credential resolution applies.
- `ALLOWED_DYNAMIC_PROVIDERS` derives from the union (134 prefixes). Any `DECEPTICON_LITELLM_MODELS=<provider>/<model>` from the catalog now routes with correct credentials; unknown prefixes get a remediation error naming the supported-provider count. `github_copilot` (OAuth device flow) and subscription prefixes stay rejected with their dedicated hints.

Coverage: parametrized test over all 112 routable catalog prefixes asserting `validate_model_name` accepts and `build_model_entry` emits the source-verified env ref, plus targeted tests (bedrock no-key, watsonx params, alias preference, local-base providers).

### 2. Error-proofing the auth stack

Review pass over every file in the auth path; each fix has a regression test.

**OAuth subscription handlers (`config/*_handler.py`)** — all six (Claude Code, Codex ChatGPT, Copilot, Gemini, Grok, Perplexity):
- Malformed/error-shaped refresh, mint, and session-exchange responses now raise actionable `litellm.AuthenticationError` naming the missing field — previously raw `KeyError`/`TypeError`/`JSONDecodeError`/`httpx.HTTPStatusError` tracebacks. No path interpolates the token payload (no secret leak).
- Non-JSON 200s and non-dict JSON completion bodies → `litellm.APIError` with a truncated snippet instead of crashes deep in `.get()` chains; null `content`/`usage`/`candidates` degrade safely.
- Codex: object-form (LangGraph) `tool_calls` no longer `AttributeError`; SSE `response.failed` with a null error no longer surfaces the literal string `"None"`.

**LiteLLM glue (`config/`)**:
- `auth_handler.py`: `None`/empty/non-string model → typed `BadRequestError` instead of `TypeError`.
- `oauth_token_store.py`: `write_json_atomic` loops on short `os.write` (no truncated token file renamed into place); `with_retry_on_401` clamps non-positive attempts.
- `litellm_dynamic_config.py`: null YAML blocks (`model_list:` with no value), malformed YAML, and non-mapping top-level YAML now fail with actionable messages at startup instead of `'NoneType' is not iterable`.

**LLM factory (`packages/decepticon/decepticon/llm/factory.py`)**:
- 403 Forbidden gets its own remediation branch (was falling through unredacted).
- Redaction safety net: unclassified provider errors whose body carries a credential shape (`Bearer …`, `sk-…`, authorization fields) are re-wrapped scrubbed; errors without credential shapes keep their original traceback.
- LLM timeout resolved **before** the request coroutine is created — bad `DECEPTICON_LLM_TIMEOUT_SECONDS` no longer leaks an un-awaited coroutine.

**CLI (`decepticon/cli/auth.py`)**: corrupt/binary `.env` (UnicodeDecodeError) and inventory-probe failures degrade to clean exit-2 messages.

## Verification

```
uv run pytest tests/unit/llm/ tests/unit/cli/test_auth.py tests/unit/cli/test_auth_branches.py -q
622 passed (60+ added in this PR)
```

CHANGELOG updated under 1.1.8 Added/Fixed.