### PR TITLE
fix(tests): make oauth_token_store test self-contained and root-safe

### DIFF
--- a/packages/decepticon/tests/unit/ad/test_bh_tools.py
+++ b/packages/decepticon/tests/unit/ad/test_bh_tools.py
@@ -41,7 +41,7 @@ def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
 
     def _fake(*args: Any, **kwargs: Any) -> httpx.Client:
         kwargs.pop("timeout", None)
-        return real_client(transport=transport, timeout=5.0, *args, **kwargs)
+        return real_client(*args, transport=transport, timeout=5.0, **kwargs)
 
     monkeypatch.setattr(httpx, "Client", _fake)
 

--- a/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_token_store.py
@@ -43,7 +43,15 @@ class _StubAuthenticationError(Exception):
 if not hasattr(litellm, "AuthenticationError"):
     litellm.AuthenticationError = _StubAuthenticationError
 
-_MODULE_PATH = Path(__file__).resolve().parents[5] / "config" / "oauth_token_store.py"
+_CONFIG_DIR = Path(__file__).resolve().parents[5] / "config"
+# ``oauth_token_store`` does ``from http_client import post`` by bare name, so
+# ``config/`` must be on sys.path before we exec it. Insert it here rather than
+# relying on another test module (test_oauth_handlers) having run first — that
+# import-order coupling makes this module fail to collect in isolation.
+if str(_CONFIG_DIR) not in sys.path:
+    sys.path.insert(0, str(_CONFIG_DIR))
+
+_MODULE_PATH = _CONFIG_DIR / "oauth_token_store.py"
 _spec = importlib.util.spec_from_file_location("decepticon_oauth_token_store", _MODULE_PATH)
 assert _spec is not None
 assert _spec.loader is not None
@@ -140,6 +148,10 @@ def test_write_json_atomic_uses_unique_temp_paths(
 
 
 @pytest.mark.skipif(os.name == "nt", reason="chmod-based directory locking is a no-op on Windows")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses directory write permissions, so the 0o500 lock is a no-op",
+)
 def test_write_json_atomic_returns_false_when_target_dir_unwritable(tmp_path: Path) -> None:
     locked = tmp_path / "locked"
     locked.mkdir()


### PR DESCRIPTION
## Summary

A focused, two-file fix for three genuine defects in the **test suite** — surfaced while running the project's own gates (`ruff`, `pytest`, Go `vet`/`test`, TS typecheck). No production code is touched.

## Bugs fixed

1. **`test_oauth_token_store` — hidden test-ordering dependency.** The module under test (`config/oauth_token_store.py`) does `from http_client import post` by bare name, which only resolves when `config/` is on `sys.path`. The test relied on `test_oauth_handlers` running first to insert that path, so running it in isolation failed at collection (`ModuleNotFoundError: No module named 'http_client'`). Fixed by inserting `config/` onto `sys.path` in the module itself, mirroring the pattern `test_oauth_handlers` already uses.

2. **`test_write_json_atomic_returns_false_when_target_dir_unwritable` — failed under root.** The test `chmod`s a dir to `0o500` and expects the write to fail, but root bypasses directory write permissions, so the assertion fails in any root runner (CI containers, Docker). Added a `skipif euid == 0` guard, matching the existing Windows skip for the same "lock is a no-op here" reason. Production `write_json_atomic` is correct and unchanged.

3. **Fragile star-arg call (ruff B026).** In `test_bh_tools.py`, a monkeypatch shim unpacked positional `*args` after keyword args; reordered to `real_client(*args, transport=..., timeout=..., **kwargs)`. Behavior-neutral.

## Verification
- `ruff check .` clean; `test_oauth_token_store` now passes in isolation (previously errored on collection).
- Full fast suite green; Go launcher `vet` + `test` green; CLI/web typecheck clean.

https://claude.ai/code/session_01Yc95jdocm78mNZ7AdQ4M6H