### PR TITLE
chore(llm): drop dead bedrock/vertex_ai bearer-key map entries

### DIFF
--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -32,8 +32,12 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
     "azure": "AZURE_API_KEY",
-    "bedrock": "AWS_ACCESS_KEY_ID",
-    "vertex_ai": "GOOGLE_APPLICATION_CREDENTIALS",
+    # NOTE: bedrock (SigV4) and vertex_ai (Google ADC) are key-less — they live
+    # in _NO_API_KEY_PROVIDERS, so build_model_entry never calls _resolve_key_env
+    # for them. They are still admitted to ALLOWED_DYNAMIC_PROVIDERS via the
+    # _NO_API_KEY_PROVIDERS union below. A bearer-key entry here would be dead and
+    # misleading (no AWS_ACCESS_KEY_ID / GOOGLE_APPLICATION_CREDENTIALS bearer
+    # path exists), so they are intentionally omitted from this map.
     "gemini": "GOOGLE_API_KEY",
     "google": "GOOGLE_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",


### PR DESCRIPTION
## Summary

Post-merge cleanup of a review nit from #672.

`bedrock` (SigV4) and `vertex_ai` (Google ADC) are **key-less** providers — they live in `_NO_API_KEY_PROVIDERS`, so `build_model_entry` never calls `_resolve_key_env` for them (gated at `litellm_dynamic_config.py:661`). Their `PROVIDER_API_KEY_ENV` entries (`AWS_ACCESS_KEY_ID` / `GOOGLE_APPLICATION_CREDENTIALS`) were therefore dead and misleading — they implied a bearer-key path that doesn't exist for SigV4/ADC.

This removes the two dead entries and documents why they're omitted. Both providers remain in `ALLOWED_DYNAMIC_PROVIDERS` via the `_NO_API_KEY_PROVIDERS` union, so provider validation/admission is unchanged.

## Verification
- `pytest packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py` → **268 passed**
- `ruff check` + `ruff format --check` clean
- No behavior change (key-less providers never consulted this map; catalog admission preserved via the union)