### PR TITLE
fix(middleware): reducers on all convergent engagement + KG state channels

### DIFF
--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -38,6 +38,7 @@ from langgraph.types import Command
 from typing_extensions import override
 
 from decepticon.middleware.opplan import _reduce_engagement_name, _reduce_workspace_path
+from decepticon.middleware.state_reducers import reduce_converging_value
 from decepticon.tools.bash.bash import bash_workspace
 from decepticon_core.utils.engagement_scope import set_active_engagement
 
@@ -56,20 +57,38 @@ class EngagementContextState(AgentState):
     # the prompt-time DECEPTICON_LANGUAGE env policy. Multi-tenant launchers
     # (SaaS) need different orgs to receive different language outputs from
     # the same container, which the env-based path cannot deliver.
-    language: NotRequired[Annotated[str, "Per-run output language (ISO 639-1)."]]
+    # All launcher-/harness-set channels below carry a reducer so an
+    # orchestrator that fans out to several subagents in one turn does not
+    # trip INVALID_CONCURRENT_GRAPH_UPDATE — every concurrent writer carries
+    # the same value (last-write-wins on non-None). Same fix as #153 for the
+    # slug/workspace channels above.
+    language: NotRequired[
+        Annotated[str, "Per-run output language (ISO 639-1).", reduce_converging_value]
+    ]
     # Benchmark / CTF challenge context — populated by the benchmark harness.
-    target_url: NotRequired[Annotated[str, "CTF challenge target URL."]]
+    target_url: NotRequired[
+        Annotated[str, "CTF challenge target URL.", reduce_converging_value]
+    ]
     target_extra_ports: NotRequired[
         Annotated[
             dict[int, int],
             "Additional published ports keyed by container target port (e.g. {22: 2222}).",
+            reduce_converging_value,
         ]
     ]
     vulnerability_tags: NotRequired[
-        Annotated[list[str], "Challenge vulnerability tags (e.g. ['sqli', 'xss'])."]
+        Annotated[
+            list[str],
+            "Challenge vulnerability tags (e.g. ['sqli', 'xss']).",
+            reduce_converging_value,
+        ]
     ]
-    flag_format: NotRequired[Annotated[str, "Expected flag format string."]]
-    mission_brief: NotRequired[Annotated[str, "Challenge name + description."]]
+    flag_format: NotRequired[
+        Annotated[str, "Expected flag format string.", reduce_converging_value]
+    ]
+    mission_brief: NotRequired[
+        Annotated[str, "Challenge name + description.", reduce_converging_value]
+    ]
 
 
 log = logging.getLogger(__name__)

--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -66,9 +66,7 @@ class EngagementContextState(AgentState):
         Annotated[str, "Per-run output language (ISO 639-1).", reduce_converging_value]
     ]
     # Benchmark / CTF challenge context — populated by the benchmark harness.
-    target_url: NotRequired[
-        Annotated[str, "CTF challenge target URL.", reduce_converging_value]
-    ]
+    target_url: NotRequired[Annotated[str, "CTF challenge target URL.", reduce_converging_value]]
     target_extra_ports: NotRequired[
         Annotated[
             dict[int, int],

--- a/packages/decepticon/decepticon/middleware/kg_internal/state.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/state.py
@@ -17,18 +17,30 @@ from typing import Annotated, NotRequired
 
 from langchain.agents import AgentState
 
+from decepticon.middleware.state_reducers import reduce_converging_value
+
 
 class KGState(AgentState):
     """State extension owned by ``KGMiddleware``.
 
     All fields are ``NotRequired`` so the schema is non-invasive — an
     agent built without the KG slot retains its original state surface.
+
+    Each channel carries ``reduce_converging_value``. The KG slot runs in
+    several subagent roles (analyst / contract_auditor / ad_operator), so an
+    orchestrator that dispatches two of them in parallel writes these channels
+    from concurrent branches. All three derive from the single shared
+    ``KGStore`` (same engagement scope, same revision token, same rendered
+    summary), so every branch carries the same value — last-write-wins is
+    correct, and the reducer satisfies LangGraph's contract for parallel writes
+    (without it, fan-out trips INVALID_CONCURRENT_GRAPH_UPDATE; cf. #183).
     """
 
     kg_engagement: NotRequired[
         Annotated[
             str,
             "Engagement scope label that every KG read / write is constrained to.",
+            reduce_converging_value,
         ]
     ]
     kg_revision: NotRequired[
@@ -39,6 +51,7 @@ class KGState(AgentState):
                 "When this differs from the prior turn the middleware "
                 "rebuilds ``kg_summary``."
             ),
+            reduce_converging_value,
         ]
     ]
     kg_summary: NotRequired[
@@ -49,5 +62,6 @@ class KGState(AgentState):
                 "message in ``wrap_model_call`` so the LLM sees current "
                 "graph state without burning tokens on read tools."
             ),
+            reduce_converging_value,
         ]
     ]

--- a/packages/decepticon/decepticon/middleware/state_reducers.py
+++ b/packages/decepticon/decepticon/middleware/state_reducers.py
@@ -1,0 +1,41 @@
+"""Shared LangGraph state-channel reducers.
+
+A reducer is REQUIRED on any agent-state channel that more than one
+concurrent graph branch may write in the same superstep. The canonical
+trigger is an orchestrator that dispatches several subagents in one turn
+(parallel ``task()`` calls): each branch carries the shared middleware
+state back on join, and LangGraph rejects the simultaneous writes with
+``INVALID_CONCURRENT_GRAPH_UPDATE`` unless the channel declares how to
+merge them. (``OmitFromInput`` does NOT prevent this — see #183, which
+had to add a reducer to ``workspace_path`` despite it being
+``OmitFromInput``.)
+
+``reduce_converging_value`` is the merge for **convergent** channels:
+every concurrent writer derives the same value from a single source of
+truth (the launcher config, the benchmark harness, or a shared store),
+so last-write-wins on a non-None value is both correct and sufficient.
+
+This is deliberately NOT a fit for *accumulating* channels (a growing
+list, a monotonic counter) — there last-write-wins would silently drop a
+branch's contribution, so those need a structural merge (merge-by-id,
+max(), etc.) or must be confined to a single writer instead.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+
+def reduce_converging_value(current: _T | None, update: _T | None) -> _T | None:
+    """Last-write-wins-on-non-None merge for convergent state channels.
+
+    Use for any channel whose concurrent writers all carry the same value
+    (launcher-set context, benchmark-harness context, shared-store-derived
+    summaries). Mirrors the semantics of ``opplan._reduce_engagement_name``
+    / ``_reduce_workspace_path`` generically over the value type, so it also
+    covers ``dict`` / ``list`` channels. Returns ``update`` unless it is
+    ``None``, in which case the prior value is preserved.
+    """
+    return update if update is not None else current

--- a/packages/decepticon/tests/unit/middleware/test_engagement.py
+++ b/packages/decepticon/tests/unit/middleware/test_engagement.py
@@ -145,6 +145,92 @@ def test_workspace_path_reducer_handles_concurrent_updates(schema) -> None:
     assert result["workspace_path"] == "/workspace"
 
 
+# Every launcher-/harness-set EngagementContextState channel must survive a
+# parallel fan-out (two subagent branches writing the same inherited value in
+# one superstep). Without a reducer LangGraph raises INVALID_CONCURRENT_GRAPH_
+# UPDATE — this is the bug that crashed bugclaw's parallel hunter dispatch on
+# `language`. Each branch carries the same value, so last-write-wins converges.
+_CONVERGING_ENGAGEMENT_FIELDS = [
+    ("language", "ko"),
+    ("target_url", "http://target.example"),
+    ("target_extra_ports", {22: 2222}),
+    ("vulnerability_tags", ["xss", "sqli"]),
+    ("flag_format", "flag{...}"),
+    ("mission_brief", "Demo challenge"),
+]
+
+
+@pytest.mark.parametrize(("field", "value"), _CONVERGING_ENGAGEMENT_FIELDS)
+@pytest.mark.parametrize(
+    "schema",
+    [
+        EngagementContextState,
+        _resolve_schemas({AgentState, OPPLANState, EngagementContextState})[0],
+    ],
+)
+def test_engagement_context_fields_survive_parallel_fanout(schema, field, value) -> None:
+    def branch_a(_state):
+        return {field: value}
+
+    def branch_b(_state):
+        return {field: value}
+
+    graph = StateGraph(schema)
+    graph.add_node("branch_a", branch_a)
+    graph.add_node("branch_b", branch_b)
+    graph.add_edge(START, "branch_a")
+    graph.add_edge(START, "branch_b")
+    graph.add_edge("branch_a", END)
+    graph.add_edge("branch_b", END)
+
+    # Must not raise INVALID_CONCURRENT_GRAPH_UPDATE; value converges.
+    result = graph.compile().invoke({"messages": []})
+    assert result[field] == value
+
+
+_CONVERGING_KG_FIELDS = [
+    ("kg_engagement", "eng-scope"),
+    ("kg_revision", "rev-7"),
+    ("kg_summary", "## graph state"),
+]
+
+
+@pytest.mark.parametrize(("field", "value"), _CONVERGING_KG_FIELDS)
+def test_kg_state_fields_survive_parallel_fanout(field, value) -> None:
+    """KG slot runs in analyst / contract_auditor / ad_operator — dispatching
+    two in parallel writes these channels concurrently; the reducer must let
+    them converge instead of tripping INVALID_CONCURRENT_GRAPH_UPDATE."""
+    from decepticon.middleware.kg_internal.state import KGState
+
+    def branch_a(_state):
+        return {field: value}
+
+    def branch_b(_state):
+        return {field: value}
+
+    graph = StateGraph(KGState)
+    graph.add_node("branch_a", branch_a)
+    graph.add_node("branch_b", branch_b)
+    graph.add_edge(START, "branch_a")
+    graph.add_edge(START, "branch_b")
+    graph.add_edge("branch_a", END)
+    graph.add_edge("branch_b", END)
+
+    result = graph.compile().invoke({"messages": []})
+    assert result[field] == value
+
+
+def test_reduce_converging_value_semantics() -> None:
+    from decepticon.middleware.state_reducers import reduce_converging_value
+
+    assert reduce_converging_value("old", "new") == "new"
+    assert reduce_converging_value("keep", None) == "keep"
+    assert reduce_converging_value(None, "set") == "set"
+    # generic over container types (dict / list channels)
+    assert reduce_converging_value({22: 1}, {22: 2}) == {22: 2}
+    assert reduce_converging_value(["a"], None) == ["a"]
+
+
 # ── inject paths ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Parallel subagent fan-out (an orchestrator dispatching several specialists in one turn) crashed with **`INVALID_CONCURRENT_GRAPH_UPDATE` on the `language` channel**. Each branch carries the shared middleware state back on join, and a channel without a reducer rejects the simultaneous writes. This is the same failure **#183** fixed for `engagement_name` / `workspace_path` — but it was never extended to the rest of the launcher/harness context, nor to the KG channels.

> Discovered via a real run: bugclaw's orchestrator dispatched 3 hunters in parallel → crash on `language` after the hunters produced findings, blocking the validate→report stages.

**`OmitFromInput` does NOT prevent this** (#183 had to add a reducer to `workspace_path` despite it being `OmitFromInput`), so the fix is a reducer on every channel more than one branch may write.

## Surface (verified against `SLOTS_PER_ROLE`)

| State | Channels | Slot runs in | Fan-out collision? | Fix |
|---|---|---|---|---|
| `EngagementContextState` | `language`, `target_url`, `target_extra_ports`, `vulnerability_tags`, `flag_format`, `mission_brief` | `ENGAGEMENT_CONTEXT` = **every bash specialist** | ✅ (`language` is the proof) | reducer — all launcher/harness-set, converge on one value |
| `KGState` | `kg_engagement`, `kg_revision`, `kg_summary` | `KG` = analyst / contract_auditor / ad_operator | ✅ two KG subagents in parallel | reducer — all derive from the shared `KGStore` |
| `OPPLANState` | `objectives`, `threat_profile`, `objective_counter` | `OPPLAN` = **orchestrator-only** | ❌ single writer | **deliberately untouched** — accumulate semantics; a naive last-write-wins reducer would silently drop data |

## Implementation

- New shared `middleware/state_reducers.py` → `reduce_converging_value` (last-write-wins on non-None). This is the langgraph-idiomatic **custom reducer function** for custom merge logic (`operator.add` would *concatenate* — wrong for these scalar/convergent values). Shared module so `KGState` need not import from `opplan`; the pre-existing `_reduce_engagement_name` / `_reduce_workspace_path` stay as-is.
- Applied to the 6 `EngagementContextState` + 3 `KGState` channels.

## Tests

Parallel-fan-out regression — **two branches writing the same value in one superstep (the exact crash trigger)** — across all 6 `EngagementContextState` channels and all 3 `KGState` channels, plus reducer unit semantics. **91 passed** (skillogy disabled for speed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)