### PR TITLE
fix(sandbox): bash tmux output capture lifecycle management

### DIFF
--- a/packages/decepticon/decepticon/backends/http_sandbox.py
+++ b/packages/decepticon/decepticon/backends/http_sandbox.py
@@ -433,6 +433,13 @@ class HTTPSandbox(BaseSandbox):
             "/kill_session",
             json={"session": session, "workspace_path": workspace_path},
         )
+        # Clear the agent-side mirror job. The daemon already dropped its own
+        # tracker entry inside the /kill_session route (base.kill_session), but
+        # bash_status / pending_completions read THIS local mirror — without
+        # this remove a killed session lingers as "running" until a later
+        # poll_completion reconciles it. Keeps the two transports' local state
+        # in parity (idempotent: remove() is a no-op when absent).
+        self._jobs.remove(session, key=_mirror_key(session, workspace_path))
 
     def read_session_log_diff(
         self,

--- a/packages/decepticon/decepticon/middleware/notifications.py
+++ b/packages/decepticon/decepticon/middleware/notifications.py
@@ -147,9 +147,7 @@ class SandboxNotificationMiddleware(AgentMiddleware):
         while len(self._notified) > _NOTIFIED_KEYS_MAX:
             self._notified.popitem(last=False)
 
-    def _pull_diff(
-        self, session: str, workspace_path: str | None
-    ) -> tuple[str, str | None, bool]:
+    def _pull_diff(self, session: str, workspace_path: str | None) -> tuple[str, str | None, bool]:
         """Read the accumulated diff for ``session``.
 
         Returns ``(output, log_path, read_ok)``. ``read_ok`` is False ONLY when

--- a/packages/decepticon/decepticon/middleware/notifications.py
+++ b/packages/decepticon/decepticon/middleware/notifications.py
@@ -46,6 +46,14 @@ log = logging.getLogger(__name__)
 # acceptable (the alternative is uncapped growth).
 _NOTIFIED_KEYS_MAX = 4096
 
+# Completion delivery is once-only (a job is marked consumed + notified after
+# we push its output). If the diff read fails transiently AT delivery time we
+# defer — leave the job pending + un-notified — and retry on the next
+# before_model tick instead of burning the one delivery on an empty stub. After
+# this many failed attempts we give up and deliver the "(no output captured)"
+# stub so the job lifecycle still closes (the agent can bash_output to recover).
+_PULL_RETRY_MAX = 3
+
 # Output budget for the notification body. Anything larger gets sliced
 # to a head+tail preview with a pointer to the on-disk session log so
 # the agent has the option to read the full content if it cares.
@@ -114,6 +122,11 @@ class SandboxNotificationMiddleware(AgentMiddleware):
         # insertion order. Values are unused; we keep ``True`` to make the
         # intent explicit at call sites.
         self._notified: OrderedDict[str, bool] = OrderedDict()
+        # Per-job failed-diff-read counter, so a transient read failure defers
+        # delivery rather than consuming the once-only notification. Cleared on
+        # successful delivery; bounded by _PULL_RETRY_MAX (entries are removed
+        # once a job is delivered, so this cannot grow without bound).
+        self._pull_attempts: dict[str, int] = {}
         self._lock = threading.Lock()
 
     def _jobs_view(self):
@@ -134,26 +147,30 @@ class SandboxNotificationMiddleware(AgentMiddleware):
         while len(self._notified) > _NOTIFIED_KEYS_MAX:
             self._notified.popitem(last=False)
 
-    def _pull_diff(self, session: str, workspace_path: str | None) -> tuple[str, str | None]:
-        """Read the accumulated diff for ``session`` and return (output, log_path).
+    def _pull_diff(
+        self, session: str, workspace_path: str | None
+    ) -> tuple[str, str | None, bool]:
+        """Read the accumulated diff for ``session``.
 
-        Both calls are wrapped in try/except: a transient sandbox blip
-        cannot crash the agent's model step, and the worst case is that
-        the agent sees a "(no output captured)" stub instead of full
-        results. The job is still marked done so the lifecycle finishes
-        cleanly.
+        Returns ``(output, log_path, read_ok)``. ``read_ok`` is False ONLY when
+        the diff read itself raised — distinct from a genuinely empty diff — so
+        the caller can defer the once-only completion notification and retry
+        next turn instead of delivering an empty stub. A transient sandbox blip
+        still cannot crash the agent's model step.
         """
         kwargs = {"workspace_path": workspace_path} if workspace_path else {}
+        read_ok = True
         try:
             diff = self._sandbox.read_session_log_diff(session, **kwargs)
         except Exception as exc:  # noqa: BLE001
             log.warning("read_session_log_diff failed for session=%s: %s", session, exc)
             diff = ""
+            read_ok = False
         try:
             log_path = self._sandbox.session_log_path(session, **kwargs)
         except Exception:  # noqa: BLE001
             log_path = None
-        return _sanitize(diff), log_path
+        return _sanitize(diff), log_path, read_ok
 
     def _emit_stream_event(self, job, output: str) -> None:
         """Push a custom stream event for the CLI to render the ● bullet."""
@@ -203,24 +220,54 @@ class SandboxNotificationMiddleware(AgentMiddleware):
             new = [j for j in pending if j.key not in self._notified]
             if not new:
                 return None
-            self._record_notified(j.key for j in new)
+            # NOTE: do NOT record_notified here — only after a job's output has
+            # actually been delivered (below), so a transient diff-read failure
+            # leaves the job pending + un-notified and is retried next tick.
 
         blocks: list[str] = []
+        delivered: list = []
         for job in new:
-            diff, log_path = self._pull_diff(job.session, job.workspace_path)
+            diff, log_path, read_ok = self._pull_diff(job.session, job.workspace_path)
+            if not read_ok:
+                attempts = self._pull_attempts.get(job.key, 0) + 1
+                self._pull_attempts[job.key] = attempts
+                if attempts < _PULL_RETRY_MAX:
+                    # Defer: leave the completion pending + un-notified so the
+                    # next before_model re-attempts the diff read. The once-only
+                    # delivery is not spent on an empty stub.
+                    log.info(
+                        "deferring completion for session=%s (diff read failed %d/%d)",
+                        job.session,
+                        attempts,
+                        _PULL_RETRY_MAX,
+                    )
+                    continue
+                # Gave up after the retry cap — fall through and deliver the
+                # "(no output captured)" stub so the job lifecycle still closes.
+                log.warning(
+                    "delivering stub completion for session=%s after %d failed diff reads",
+                    job.session,
+                    attempts,
+                )
             formatted = _format_output(diff, log_path)
             blocks.append(self._format_block(job, formatted))
             self._emit_stream_event(job, formatted)
-            # Mark the daemon-side mirror consumed so a later
-            # ``bash_output`` call returns ``(no new output)`` rather
-            # than re-delivering the same diff, and so
-            # ``pending_completions`` skips it on subsequent middleware
-            # ticks. ``self._notified`` is a belt-and-suspenders dedupe
-            # for the case where mark_consumed silently fails.
+            delivered.append(job)
+            self._pull_attempts.pop(job.key, None)
+            # Mark the daemon-side mirror consumed so a later ``bash_output``
+            # call returns ``(no new output)`` rather than re-delivering the
+            # same diff, and so ``pending_completions`` skips it on subsequent
+            # middleware ticks. ``self._notified`` (recorded below) is a
+            # belt-and-suspenders dedupe for when mark_consumed silently fails.
             try:
                 jobs.mark_consumed(session=job.session, key=job.key)
             except Exception:  # noqa: BLE001 — best-effort
                 log.warning("mark_consumed failed for session=%s", job.session, exc_info=True)
+
+        if not delivered:
+            return None
+        with self._lock:
+            self._record_notified(j.key for j in delivered)
 
         body = "\n\n".join(blocks)
         reminder = (

--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -1031,9 +1031,7 @@ def _extract_interactive_output(screen: str, baseline: str) -> str:
     return "\n".join(new_lines) if new_lines else screen.strip()
 
 
-def _extract_output(
-    screen: str, command: str, since_count: int = 0
-) -> tuple[str, int, str]:
+def _extract_output(screen: str, command: str, since_count: int = 0) -> tuple[str, int, str]:
     """Extract a foreground command's output, exit code, and cwd from the pane.
 
     ``since_count`` is the number of PS1 markers present in the *baseline*

--- a/packages/decepticon/decepticon/sandbox_kernel/tmux.py
+++ b/packages/decepticon/decepticon/sandbox_kernel/tmux.py
@@ -661,7 +661,7 @@ class TmuxSessionManager:
             current_count = len(PS1_PATTERN.findall(screen))
 
             if current_count > initial_count:
-                output, exit_code, cwd = _extract_output(screen, command)
+                output, exit_code, cwd = _extract_output(screen, command, initial_count)
                 log.info(
                     "Command completed: exit=%s cwd=%s [%s]",
                     exit_code,
@@ -861,7 +861,7 @@ class TmuxSessionManager:
             current_count = len(PS1_PATTERN.findall(screen))
 
             if current_count > initial_count:
-                output, exit_code, cwd = _extract_output(screen, command)
+                output, exit_code, cwd = _extract_output(screen, command, initial_count)
                 log.info(
                     "Command completed: exit=%s cwd=%s [%s]",
                     exit_code,
@@ -895,12 +895,19 @@ class TmuxSessionManager:
                     f"{_truncate(output).strip()}\n\n"
                     f"[SIZE LIMIT] Output exceeded {SIZE_WATCHDOG_CHARS // 1_000_000}M chars. "
                     f"Command interrupted.\n"
-                    f"Redirect output to a file: command > /workspace/output.txt"
+                    f"Redirect output to a file: command > {self._workspace_path}/output.txt"
                 )
 
-            # Auto-background: convert blocking commands after threshold
+            # Auto-background: convert blocking commands after threshold.
+            # Exempt is_input: auto-background exists to detach a blocking
+            # *foreground command* the agent is waiting on. is_input is the
+            # agent interacting with an already-running process (msfconsole /
+            # sliver / pdb); it emits no terminating foreground PS1 marker, so
+            # backgrounding it would strand the job as forever-"running" and
+            # corrupt the interactive session. Slow interactive turns fall
+            # through to the stall/hung path below instead.
             elapsed = time.monotonic() - start
-            if elapsed >= AUTO_BACKGROUND_SECONDS and command:
+            if elapsed >= AUTO_BACKGROUND_SECONDS and command and not is_input:
                 log.info(
                     "Auto-backgrounding after %.0fs [%s] in session '%s'",
                     elapsed,
@@ -1024,18 +1031,47 @@ def _extract_interactive_output(screen: str, baseline: str) -> str:
     return "\n".join(new_lines) if new_lines else screen.strip()
 
 
-def _extract_output(screen: str, command: str) -> tuple[str, int, str]:
+def _extract_output(
+    screen: str, command: str, since_count: int = 0
+) -> tuple[str, int, str]:
+    """Extract a foreground command's output, exit code, and cwd from the pane.
+
+    ``since_count`` is the number of PS1 markers present in the *baseline*
+    capture (before the command ran). Completion is detected upstream as
+    "≥1 new marker since baseline" (``current_count > initial_count``), so the
+    command's output is *everything between the baseline's last marker and the
+    final marker* — regardless of how many markers landed in between.
+
+    Slicing between only the final two markers (the old behaviour) silently
+    dropped earlier output whenever a single ``bash()`` call produced 2+ new
+    markers (a multi-line / compound command, a subshell that re-cycles the
+    prompt, or any injected prompt line): the detector fires on the first new
+    marker but the extractor would return only the last segment. Anchoring the
+    slice on ``since_count`` keeps detection and extraction in lockstep.
+
+    In the common single-new-marker case (``current_count == initial_count + 1``)
+    this is identical to the old ``matches[-2]..last`` slice, so existing
+    behaviour and tests are unchanged.
+    """
     matches = list(PS1_PATTERN.finditer(screen))
     if not matches:
         return screen, -1, ""
     last = matches[-1]
     exit_code = int(last.group(1))
     cwd = last.group(2)
-    if len(matches) >= 2:
+    # Start at the end of the baseline's last marker; the final marker is the
+    # completion prompt. Fall back to start-of-screen when the baseline had no
+    # marker (cold session) or when since_count is out of range.
+    if 1 <= since_count <= len(matches) - 1:
+        raw = screen[matches[since_count - 1].end() : last.start()]
+    elif len(matches) >= 2:
         raw = screen[matches[-2].end() : last.start()]
     else:
         raw = screen[: last.start()]
     lines = raw.strip().split("\n")
+    # Drop any intermediate PS1 marker lines (extra prompt cycles from a
+    # multi-line command) so the sentinels never leak into returned output.
+    lines = [ln for ln in lines if not PS1_PATTERN.search(ln)]
     if lines and command and lines[0].strip().endswith(command.strip()):
         lines = lines[1:]
     return "\n".join(lines).strip(), exit_code, cwd

--- a/packages/decepticon/decepticon/tools/bash/bash.py
+++ b/packages/decepticon/decepticon/tools/bash/bash.py
@@ -69,6 +69,12 @@ _current_workspace_path: contextvars.ContextVar[str] = contextvars.ContextVar(
 INLINE_LIMIT = 15_000  # ≤15K chars: return inline; >15K: offload to <engagement>/.scratch/
 # >5M: size watchdog in sandbox_kernel/tmux.py kills the command (SIZE_WATCHDOG_CHARS)
 
+# Tool-status control markers — NEVER offloaded to .scratch/ (they are
+# messages the agent parses, not command output, and they carry their own
+# truncation). _truncate() caps at 30K > INLINE_LIMIT (15K), so a status-
+# bearing screen >15K could otherwise be re-offloaded and double-wrapped as if
+# it were real output. This list must stay in sync with the full marker
+# taxonomy emitted by sandbox_kernel/tmux.py + this module.
 _STATUS_PREFIXES = (
     "[BACKGROUND]",
     "[RUNNING",
@@ -77,6 +83,13 @@ _STATUS_PREFIXES = (
     "[KILLED]",
     "[EMPTY]",
     "[STALE]",
+    "[AUTO-BACKGROUND]",
+    "[SIZE LIMIT]",
+    "[TIMEOUT]",
+    "[ERROR]",
+    "[UNKNOWN]",
+    "[session:",
+    "[cwd:",
 )
 
 # ─── Scratch-file TTL prune (bounds <engagement>/.scratch/ growth) ────────

--- a/packages/decepticon/decepticon/tools/bash/prompt.py
+++ b/packages/decepticon/decepticon/tools/bash/prompt.py
@@ -27,7 +27,7 @@ bash(command, session="main", background=False, timeout=120, is_input=False, des
 | `command` | `""` | Shell command. Empty = read current screen |
 | `session` | `"main"` | Different names = parallel sessions. Use a dedicated name for background jobs |
 | `background` | `False` | Start without waiting. Returns `[BACKGROUND]` immediately |
-| `timeout` | `120` | Max seconds to wait. Commands running >60s auto-background |
+| `timeout` | `120` | Upper bound on blocking. Foreground commands **auto-background at 60s**, so values >60 never take effect; only set <60 to give up sooner |
 | `is_input` | `False` | True ONLY when sending input to a waiting interactive process |
 | `description` | `""` | Short UI label |
 
@@ -36,9 +36,14 @@ Return-value markers from `bash()`:
 - `[BACKGROUND]` — `background=True` accepted; job tracking started
 - `[AUTO-BACKGROUND]` — command exceeded 60s and was auto-converted; partial output preview included
 - `[SIZE LIMIT]` — output exceeded 5M chars; command was interrupted; redirect to file
-- `[TIMEOUT]` — `timeout` reached; session still occupied (use a different session for new commands; check this one with `bash_output`)
-- `[session: <name> — interactive, send next command with is_input=True]` — interactive prompt detected (msf, sliver, REPL)
+- `[TIMEOUT]` — only when you set `timeout` BELOW 60; session still occupied (use a different session for new commands; check this one with `bash_output`). At the default, a long command auto-backgrounds instead.
+- `[session: <name> — interactive, send next command with is_input=True]` — interactive prompt detected (msf, sliver, REPL). Reply with `is_input=True`; interactive turns are NEVER auto-backgrounded.
 - `[ERROR]` — sandbox/tmux failure; message explains; retry or `bash_kill`
+
+Empty `command` (passive screen read of `session`) returns one of:
+- `[RUNNING] cwd=<dir>` — a foreground command is still occupying the shell (distinct from `bash_output`'s `[RUNNING elapsed=Ts]`, which is about a *background job*)
+- `[IDLE] exit_code=<N> — Session is ready` — shell is at a prompt, ready for the next command (distinct from `bash_output`'s `[IDLE]` = "no background job in this session")
+- `[UNKNOWN]` — pane state could not be parsed; re-issue the read or run a concrete command
 
 ### bash_output(session="main") — fetch new output / completion status
 
@@ -271,10 +276,12 @@ Recovery, in order:
 
 1. Open a NEW bash session (e.g. tag it `<challenge>_recovery` so the original
    tmux name does not collide).
-2. `pkill -9 -f <script>` AND `rm -f /tmp/log` AND
-   `tmux kill-session -t main 2>/dev/null` (the `2>/dev/null` covers the
-   no-such-session case so the recovery does not error out before the next
-   step).
+2. `pkill -9 -f <script>` AND `rm -f /tmp/log`, then tear down the wedged
+   session with `bash_kill(session=<wedged>)`. Do NOT run raw
+   `tmux kill-session` inside the shell — the sandbox manages tmux on a private
+   `-L` socket, so a bare `tmux kill-session -t main` targets the wrong server
+   (or kills your own live session). `bash_kill` is the correct socket-aware
+   teardown and preserves the session log.
 3. Re-launch the same probe **inline** —
    `timeout 60 python3 -u -c '<inlined harness>' 2>&1 | tee log.txt` —
    bypassing tmux entirely. Inline `python3 -u -c` writes to the tool's
@@ -288,7 +295,7 @@ Recovery, in order:
 
 | Symptom | Cause | Recovery |
 |---------|-------|----------|
-| `ps -p <PID>` alive, `/tmp/log` empty across consecutive polls, script has progress logging | Tmux pipe degradation (writes silently dropped) | New session, pkill + rm log + tmux kill-session, switch to inline `timeout <bounded> python3 -u -c '...' \\| tee log.txt`. |
+| `ps -p <PID>` alive, `/tmp/log` empty across consecutive polls, script has progress logging | Tmux pipe degradation (writes silently dropped) | New session, pkill + rm log + `bash_kill(session=<wedged>)`, switch to inline `timeout <bounded> python3 -u -c '...' \\| tee log.txt`. |
 | `ps -p <PID>` dead, `/tmp/log` empty | Process crashed before first flush (likely import error or syntax error) | `python3 -c '<harness>'` directly to surface the traceback (no `&`, no log redirect). Fix syntax, retry. |
 | `ps -p <PID>` alive, `/tmp/log` has bytes but stops growing | Network wedge (no `sock.settimeout`, slow-loris peer, or sandbox throttling) | Apply Wedged-Session Recovery above. Add `sock.settimeout(5)` before connect AND each recv. Outer `timeout 60`. |
 | 3+ consecutive empty-command polls (`""`, `echo`, `pwd`) on the SAME shell session | The previous tool call wedged the shell stdin/stdout pump | Open a fresh bash session immediately. Polling the wedged shell will not unwedge it. |


### PR DESCRIPTION
**Fixes bash tmux output capture lifecycle issues in sandbox.**

Ensures proper cleanup and lifecycle management of tmux sessions during bash tool execution.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>