### PR TITLE
fix(roe): canonicalize dotted octal/hex/short IPv4 so encoded IMDS can't dodge scope

### DIFF
--- a/packages/decepticon/decepticon/middleware/_command_targets.py
+++ b/packages/decepticon/decepticon/middleware/_command_targets.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import ipaddress
 import re
 import shlex
+import socket
 from collections.abc import Callable
 from urllib.parse import urlsplit
 
@@ -62,6 +63,16 @@ _URL_AUTHORITY_RE = re.compile(
 # (e.g. ``http://2852039166/`` == 169.254.169.254) rather than a port/number.
 # 2**24 keeps small integers (ports, counts) from being mangled into IPs.
 _PACKED_IPV4_MIN = 1 << 24
+# Non-canonical but resolver-valid dotted IPv4 forms that Python's ``ipaddress``
+# rejects yet libc ``inet_aton`` (and thus curl/wget/nc on the engagement host)
+# still routes to the same address: octal-padded (``0251.0376.0251.0376``),
+# dotted-hex (``0xa9.0xfe.0xa9.0xfe``), and short-octet (``127.1``) encodings.
+# Matched so ``_canon_host`` can normalize them to a dotted quad and a
+# numeric-encoding trick can't dodge an IP deny rule. Requires >= 2 dot-separated
+# numeric parts; the dotless single-integer form is handled separately above.
+_LOOSE_DOTTED_IPV4_RE = re.compile(
+    r"(?:0x[0-9a-f]+|\d+)(?:\.(?:0x[0-9a-f]+|\d+)){1,3}", re.IGNORECASE
+)
 _HOSTNAME_AFTER_VERB_RE = re.compile(
     r"\b(?:curl|wget|httpx|nmap|masscan|rustscan|ssh|scp|sftp|rsync|"
     r"smbclient|smbmap|crackmapexec|nxc|netexec|nikto|sqlmap|hydra|ffuf|"
@@ -165,7 +176,10 @@ def _canon_host(token: str) -> str:
     dotted-quad, and compresses valid IP literals to their canonical string.
     Hostnames pass through lower-cased. This closes the IMDS/forbidden-dest
     bypass where ``http://2852039166/`` or ``http://0xa9fea9fe/`` reach
-    169.254.169.254 without matching a dotted-quad deny rule.
+    169.254.169.254 without matching a dotted-quad deny rule. The same applies
+    to the *dotted* non-canonical forms that ``ipaddress`` rejects but the
+    platform resolver still accepts — octal-padded (``0251.0376.0251.0376``),
+    dotted-hex (``0xa9.0xfe.0xa9.0xfe``), and short-octet (``127.1``).
     """
     raw = token.strip()
     bare = raw[1:-1] if raw.startswith("[") and raw.endswith("]") else raw
@@ -185,6 +199,16 @@ def _canon_host(token: str) -> str:
     try:
         return str(ipaddress.ip_address(bare))
     except ValueError:
+        # ``ipaddress`` only accepts canonical dotted-decimal. Non-canonical
+        # dotted encodings that the platform resolver still routes to the same
+        # address (octal-padded, dotted-hex, short-octet) would otherwise pass
+        # through verbatim and dodge an IP deny rule. Canonicalize them via the
+        # same ``inet_aton`` the offensive tools use on the engagement host.
+        if _LOOSE_DOTTED_IPV4_RE.fullmatch(bare):
+            try:
+                return socket.inet_ntoa(socket.inet_aton(bare))
+            except OSError:
+                pass
         return bare.lower()
 
 

--- a/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
+++ b/packages/decepticon/tests/unit/middleware/test_command_targets_scope_bypass.py
@@ -1,4 +1,5 @@
 from decepticon.middleware._command_targets import extract_targets
+from decepticon_core.types.roe import MachineEnforcement, evaluate_target
 
 
 def test_userinfo_decoy_yields_real_host_not_in_scope_label():
@@ -19,6 +20,46 @@ def test_decimal_encoded_imds_normalized_to_dotted_quad():
 def test_hex_encoded_imds_normalized_to_dotted_quad():
     targets = extract_targets("curl http://0xa9fea9fe/latest/meta-data/")
     assert "169.254.169.254" in targets
+
+
+def test_octal_encoded_imds_normalized_to_dotted_quad():
+    # 0251.0376.0251.0376 == 169.254.169.254 (octal per octet). libc inet_aton
+    # — what curl/wget use on the engagement host — routes it to IMDS, so the
+    # canonicaliser must collapse it to the dotted quad the deny rule matches.
+    targets = extract_targets("curl http://0251.0376.0251.0376/latest/meta-data/")
+    assert "169.254.169.254" in targets
+
+
+def test_dotted_hex_encoded_imds_normalized_to_dotted_quad():
+    targets = extract_targets("curl http://0xa9.0xfe.0xa9.0xfe/latest/meta-data/")
+    assert "169.254.169.254" in targets
+
+
+def test_short_octet_form_normalized_to_dotted_quad():
+    # 127.1 is the classic short form for 127.0.0.1.
+    assert "127.0.0.1" in extract_targets("curl http://127.1/")
+
+
+def test_out_of_range_numeric_dotted_token_not_mangled_into_ip():
+    # Numeric-looking but out of range: must not raise and must not be coerced
+    # into a (wrong) dotted quad — it passes through as a non-IP token.
+    targets = extract_targets("curl http://999.999.999.999/")
+    assert not any(t.count(".") == 3 and t != "999.999.999.999" for t in targets)
+
+
+def test_encoded_imds_command_refused_by_forbidden_destination_gate():
+    # End-to-end: the alternate encodings must produce a target the RoE
+    # forbidden-destination gate refuses in enforce mode — the bypass is closed.
+    rules = MachineEnforcement.from_dict({"in_scope": ["10.0.0.0/8"]})
+    for cmd in (
+        "curl http://0251.0376.0251.0376/latest/meta-data/",
+        "curl http://0xa9.0xfe.0xa9.0xfe/latest/meta-data/",
+    ):
+        targets = extract_targets(cmd)
+        assert "169.254.169.254" in targets
+        assert any(
+            evaluate_target(t, rules).reason_code == "FORBIDDEN_DESTINATION" for t in targets
+        )
 
 
 def test_ipv6_literal_url_host_extracted():


### PR DESCRIPTION
**Fixes RoE numeric IP encoding bypass vulnerability.**

Canonicalizes IP address formats (dotted octal, hex, short) to prevent encoded IMDS metadata service access from bypassing scope restrictions.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>