### PR TITLE
fix(onboard+cli): Bedrock credentials not written to .env (#674), blank answer on resume (#617)

### DIFF
--- a/clients/cli/src/commands/resume.ts
+++ b/clients/cli/src/commands/resume.ts
@@ -3,7 +3,7 @@ import type { Command } from "./types.js";
 const resume: Command = {
   name: "resume",
   description: "Resume paused run or continue previous session",
-  aliases: ["r"],
+  aliases: ["r", "continue"],
   argumentHint: "[message]",
   execute(args, ctx) {
     ctx.resume(args || undefined);

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -509,6 +509,15 @@ export function useAgent({
             } else {
               setPendingTool(null);
               completionReceived = true;
+              // Guard against blank AI responses — emit a system hint so
+              // the user isn't left staring at an empty screen (#617).
+              if (!text) {
+                addEvent({
+                  type: "system",
+                  content:
+                    "Agent returned an empty response. Use /resume to retry or send a new message.",
+                });
+              }
             }
 
           } else if (msg.type === "tool") {
@@ -685,13 +694,15 @@ export function useAgent({
       // If streaming/connecting, callers should use enqueue() instead
       if (abortRef.current) return;
 
-      // If paused, cancel the paused run before starting fresh
+      // If paused, cancel the paused run gracefully. Use "interrupt"
+      // strategy to preserve thread state so the follow-up message
+      // can see prior tool results and context (#617).
       if (runStateRef.current === "paused") {
         const threadId = threadIdRef.current;
         const runId = runIdRef.current;
         if (threadId && runId) {
           clientRef.current.runs
-            .cancel(threadId, runId, false, "rollback")
+            .cancel(threadId, runId, false, "interrupt")
             .catch(() => {});
         }
         runIdRef.current = null;

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -111,11 +111,26 @@ func WriteEnv(templatePath, outputPath string, values map[string]string) error {
 
 func writeEnvFromString(tmpl string, outputPath string, values map[string]string) error {
 	lines := strings.Split(tmpl, "\n")
+	consumed := make(map[string]bool) // track which values were written
 	var out []string
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		// Skip commented lines — keep as-is
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		if trimmed == "" {
+			out = append(out, line)
+			continue
+		}
+		// Try to match commented-out env lines: "# KEY=value" or "#KEY=value"
+		if strings.HasPrefix(trimmed, "#") {
+			uncommented := strings.TrimSpace(strings.TrimPrefix(trimmed, "#"))
+			key, _, ok := parseEnvLine(uncommented)
+			if ok {
+				if newVal, exists := values[key]; exists {
+					out = append(out, key+"="+newVal)
+					consumed[key] = true
+					continue
+				}
+			}
+			// Plain comment or no matching value — keep as-is
 			out = append(out, line)
 			continue
 		}
@@ -126,10 +141,18 @@ func writeEnvFromString(tmpl string, outputPath string, values map[string]string
 		}
 		if newVal, exists := values[key]; exists {
 			out = append(out, key+"="+newVal)
+			consumed[key] = true
 		} else {
 			out = append(out, line)
 		}
 	}
+	// Append any values that didn't match a template line (e.g. AWS_REGION_NAME)
+	for key, val := range values {
+		if !consumed[key] {
+			out = append(out, key+"="+val)
+		}
+	}
+
 
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return fmt.Errorf("create directory: %w", err)

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -391,6 +391,55 @@ DECEPTICON_MODEL_PROFILE=eco
 	}
 }
 
+func TestWriteEnv_CommentedOutLines(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, ".env.example")
+	outPath := filepath.Join(dir, "out", ".env")
+
+	// Template with commented-out AWS Bedrock vars (the bug in #674)
+	template := `# Config
+ANTHROPIC_API_KEY=your-anthropic-key-here
+# --- AWS Bedrock ---
+# AWS_ACCESS_KEY_ID=AKIA...
+# AWS_SECRET_ACCESS_KEY=...
+# AWS_REGION=us-east-1
+`
+	if err := os.WriteFile(tmplPath, []byte(template), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	values := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"AWS_REGION":            "us-west-2",
+		"AWS_REGION_NAME":       "us-west-2", // not in template at all
+	}
+
+	if err := WriteEnv(tmplPath, outPath, values); err != nil {
+		t.Fatalf("WriteEnv() error: %v", err)
+	}
+
+	env, err := LoadEnv(outPath)
+	if err != nil {
+		t.Fatalf("LoadEnv() error: %v", err)
+	}
+
+	// Commented-out lines should be uncommented and rewritten
+	if env["AWS_ACCESS_KEY_ID"] != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("AWS_ACCESS_KEY_ID = %q, want AKIAIOSFODNN7EXAMPLE", env["AWS_ACCESS_KEY_ID"])
+	}
+	if env["AWS_SECRET_ACCESS_KEY"] != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("AWS_SECRET_ACCESS_KEY not written")
+	}
+	if env["AWS_REGION"] != "us-west-2" {
+		t.Errorf("AWS_REGION = %q, want us-west-2", env["AWS_REGION"])
+	}
+	// AWS_REGION_NAME wasn't in the template — should be appended
+	if env["AWS_REGION_NAME"] != "us-west-2" {
+		t.Errorf("AWS_REGION_NAME = %q, want us-west-2 (should be appended)", env["AWS_REGION_NAME"])
+	}
+}
+
 func TestDecepticonHome(t *testing.T) {
 	// With DECEPTICON_HOME set
 	t.Setenv("DECEPTICON_HOME", "/custom/path")

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -37,38 +37,39 @@ GITHUB_TOKEN=your-github-token-here
 # --- AWS Bedrock ---
 # IAM access key + secret + region. The region must have your chosen
 # Anthropic models enabled (us-east-1 / us-west-2 are typical).
-# AWS_ACCESS_KEY_ID=AKIA...
-# AWS_SECRET_ACCESS_KEY=...
-# AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=your-aws-access-key-here
+AWS_SECRET_ACCESS_KEY=your-aws-secret-key-here
+AWS_REGION=us-east-1
+AWS_REGION_NAME=us-east-1
 
 # --- GCP Vertex AI ---
 # Service-account JSON path + project + region. Download a key from
 # IAM & Admin → Service Accounts. Project + location must match where
 # Anthropic / Gemini models are enabled.
-# GOOGLE_APPLICATION_CREDENTIALS=/abs/path/to/service-account.json
-# VERTEXAI_PROJECT=my-gcp-project-id
-# VERTEXAI_LOCATION=us-central1
+GOOGLE_APPLICATION_CREDENTIALS=your-gcp-service-account-path-here
+VERTEXAI_PROJECT=your-gcp-project-id-here
+VERTEXAI_LOCATION=us-central1
 
 # --- Azure OpenAI Service ---
 # Deployment endpoint + key + API version. Deployment names default to
 # the model id (gpt-5.5/gpt-5.4/gpt-5-nano); override per role via
 # DECEPTICON_MODEL_<ROLE> if your Azure deployment names differ.
-# AZURE_API_KEY=...
-# AZURE_API_BASE=https://<resource>.openai.azure.com
-# AZURE_API_VERSION=2024-08-01-preview
+AZURE_API_KEY=your-azure-key-here
+AZURE_API_BASE=your-azure-endpoint-here
+AZURE_API_VERSION=2024-08-01-preview
 
 # --- LM Studio (local OpenAI-compatible) ---
 # LM Studio runs a local OpenAI-compatible server on port 1234.
 # Launch the LM Studio app → Developer tab → Start Server.
-# LMSTUDIO_API_BASE=http://host.docker.internal:1234/v1
-# LMSTUDIO_MODEL=qwen2.5-coder-7b-instruct
-# LMSTUDIO_API_KEY=lm-studio  # accepts any string; sentinel for the shim
+LMSTUDIO_API_BASE=http://host.docker.internal:1234/v1
+LMSTUDIO_MODEL=your-lmstudio-model-here
+LMSTUDIO_API_KEY=lm-studio
 
 # --- Custom OpenAI-compatible Endpoint ---
 # Bring-your-own gateway (vLLM, internal LiteLLM, third-party hub, etc.).
-# CUSTOM_OPENAI_API_BASE=https://gateway.example.com/v1
-# CUSTOM_OPENAI_API_KEY=...
-# CUSTOM_OPENAI_MODEL=gpt-4o-mini
+CUSTOM_OPENAI_API_BASE=your-custom-openai-base-here
+CUSTOM_OPENAI_API_KEY=your-custom-openai-key-here
+CUSTOM_OPENAI_MODEL=your-custom-openai-model-here
 
 # --- Local LLM (Ollama) ---
 # Set both to run Decepticon against a local Ollama model. The


### PR DESCRIPTION
## Summary

Fixes two open bugs in a single PR.

### Bug 1: AWS Bedrock credentials silently dropped during onboard (#674)

**Root cause:** The `.env.example` template had all cloud gateway variables (AWS Bedrock, Vertex AI, Azure, LM Studio, Custom OpenAI) commented out with `#`. The `writeEnvFromString` function skips commented lines, so credentials entered during the onboard wizard were never written to the output `.env` file.

**Fix:**
- Uncomment all cloud gateway vars in `env.example` with placeholder values (matching the pattern used by all working providers like Anthropic, OpenAI, etc.)
- Add `AWS_REGION_NAME` which was missing from the template entirely (LiteLLM's Bedrock provider reads this)
- Harden `writeEnvFromString` to also match `# KEY=value` commented-out lines and uncomment+rewrite them when a value is provided (defense-in-depth)
- Append values that don't match any template line as a safety net

### Bug 2: Blank answer after pause/continue (#617)

**Root cause:** Multiple issues compounding:
1. `'continue'` wasn't a recognized command alias — it was treated as plain chat text
2. The paused-run handler used `'rollback'` cancel strategy, destroying thread state before starting a fresh run with just the word "continue" as input
3. When the LLM returned an empty AIMessage with no tool calls, the run completed silently with no visible output

**Fix:**
- Add `'continue'` as an alias for the `/resume` command
- Change paused-state cancel strategy from `'rollback'` to `'interrupt'` to preserve thread state
- Emit a system hint ("Agent returned an empty response. Use /resume to retry...") when the agent returns empty content with no tool calls

## Files Changed

| File | Change |
|---|---|
| `clients/launcher/internal/config/env.example` | Uncomment cloud gateway vars, add `AWS_REGION_NAME` |
| `clients/launcher/internal/config/config.go` | Harden `writeEnvFromString` to match commented-out lines |
| `clients/launcher/internal/config/config_test.go` | Add `TestWriteEnv_CommentedOutLines` |
| `clients/cli/src/commands/resume.ts` | Add `'continue'` alias |
| `clients/cli/src/hooks/useAgent.ts` | Fix cancel strategy + empty response guard |

## Testing

- All Go tests pass (`go test ./...` — 10 packages OK)
- New test `TestWriteEnv_CommentedOutLines` verifies commented-out lines are matched and rewritten, and missing keys are appended

Closes #674
Closes #617