### PR TITLE
feat(skillogy): LightRAG-style hybrid find_skill (ADR-0011)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ NVIDIA_API_KEY=your-nvidia-key-here
 DEEPSEEK_API_KEY=your-deepseek-key-here
 XAI_API_KEY=your-xai-key-here
 MISTRAL_API_KEY=your-mistral-key-here
+# Voyage AI — embeddings for skillogy hybrid retrieval (ADR-0011). Anthropic's
+# official embedding partner, so an Anthropic-key deployment can power skillogy
+# semantics with this alone (set DECEPTICON_SKILLOGY_EMBED_MODEL=voyage/voyage-3).
+VOYAGE_API_KEY=your-voyage-key-here
 
 # --- Cloud Gateways (added in the OpenClaude provider migration) ---
 # All routed through LiteLLM's native provider implementations. The
@@ -140,6 +144,13 @@ POSTGRES_PASSWORD=decepticon
 # Generate a strong one with `openssl rand -base64 32`. See
 # docs/security/neo4j-hardening.md for the full hardening posture.
 NEO4J_PASSWORD=decepticon-graph
+
+# Skillogy hybrid retrieval (ADR-0011) embedding model, routed through litellm.
+# Default is openai/text-embedding-3-small (needs OPENAI_API_KEY). Switch to
+# voyage/voyage-3 (VOYAGE_API_KEY) or gemini/gemini-embedding-001 (GEMINI_API_KEY)
+# for non-OpenAI deployments. Unset/unreachable → find_skill falls back to
+# substring search (semantics off, everything else works).
+# DECEPTICON_SKILLOGY_EMBED_MODEL=openai/text-embedding-3-small
 
 # --- Model Profile ---
 # eco  = per-agent tier (production default)

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -135,6 +135,26 @@ model_list:
       mode: embedding
       input_cost_per_token: 0.00000002
 
+  # Alternatives for non-OpenAI deployments — select via
+  # DECEPTICON_SKILLOGY_EMBED_MODEL (the helper carries the matching dim:
+  # voyage-3 → 1024, gemini-embedding-001 → 3072). Voyage is Anthropic's
+  # official embedding partner, so an Anthropic-ecosystem operator can run
+  # skillogy semantics with a VOYAGE_API_KEY and no OpenAI key; Gemini
+  # likewise for a GEMINI_API_KEY-only deployment.
+  - model_name: voyage/voyage-3
+    litellm_params:
+      model: voyage/voyage-3
+      api_key: os.environ/VOYAGE_API_KEY
+    model_info:
+      mode: embedding
+      input_cost_per_token: 0.00000006
+  - model_name: gemini/gemini-embedding-001
+    litellm_params:
+      model: gemini/gemini-embedding-001
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: embedding
+
   # ── Google ───────────────────────────────────────────────────────────
   # Per-1M USD as of 2026-05-14 (Gemini Developer API, ≤200K context):
   #   2.5-pro        $1.25 / $10.00

--- a/config/litellm.yaml
+++ b/config/litellm.yaml
@@ -122,6 +122,19 @@ model_list:
       input_cost_per_token: 0.00000175
       output_cost_per_token: 0.000014
 
+  # ── Embeddings ─────────────────────────────────────────────────────────
+  # Skillogy hybrid retrieval (ADR-0011) embeds each skill at boot and each
+  # find_skill query at runtime through this route. text-embedding-3-small
+  # (1536 dims) is the OSS default — same model the KG layer pins as its
+  # OSS default (kg_internal migration V002). $0.02 / 1M input tokens.
+  - model_name: openai/text-embedding-3-small
+    litellm_params:
+      model: openai/text-embedding-3-small
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      mode: embedding
+      input_cost_per_token: 0.00000002
+
   # ── Google ───────────────────────────────────────────────────────────
   # Per-1M USD as of 2026-05-14 (Gemini Developer API, ≤200K context):
   #   2.5-pro        $1.25 / $10.00

--- a/containers/skillogy.Dockerfile
+++ b/containers/skillogy.Dockerfile
@@ -3,9 +3,10 @@
 #
 # The skill catalog is stored in Neo4j and queried over REST. This image
 # carries no langchain/langgraph/sandbox dependencies and no agent
-# runtime — just FastAPI + uvicorn + the Neo4j driver + the skillogy
-# server module + the CI-built ``skills.cypher`` dump that gets ingested
-# on boot.
+# runtime — just FastAPI + uvicorn + the Neo4j driver + httpx (the
+# ADR-0011 embedding client that talks to the litellm proxy) + the
+# skillogy server module + the CI-built ``skills.cypher`` dump that
+# gets ingested on boot.
 
 FROM python:3.13-slim
 
@@ -32,7 +33,8 @@ RUN pip install --no-cache-dir \
     "fastapi>=0.115.0" \
     "uvicorn[standard]>=0.30.0" \
     "pydantic>=2.0.0" \
-    "neo4j>=5.24"
+    "neo4j>=5.24" \
+    "httpx>=0.27.0"
 
 RUN groupadd -r skillogy && useradd -r -g skillogy -d /app -s /sbin/nologin skillogy \
     && chown -R skillogy:skillogy /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -593,6 +593,11 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+      # Boot-time embedding backfill (ADR-0011) calls the litellm proxy.
+      # Wait for it to be healthy so the first ingest can embed the corpus;
+      # if it were absent the ingest degrades to substring-only retrieval.
+      litellm:
+        condition: service_healthy
     ports:
       - "127.0.0.1:${SKILLOGY_REST_PORT:-9100}:9100"
     environment:
@@ -601,6 +606,12 @@ services:
       - SKILLOGY_NEO4J_USER=neo4j
       - SKILLOGY_NEO4J_PASSWORD=${NEO4J_PASSWORD:-decepticon-graph}
       - SKILLOGY_AUTO_INGEST=${SKILLOGY_AUTO_INGEST:-1}
+      # Hybrid retrieval embeds skills + queries through the same litellm
+      # proxy the agents use (ADR-0011 §"Skillogy↔litellm coupling").
+      # Unset → find_skill falls back to substring search.
+      - DECEPTICON_LLM__PROXY_URL=http://litellm:4000
+      - DECEPTICON_LLM__PROXY_API_KEY=${LITELLM_MASTER_KEY:-sk-decepticon-master}
+      - DECEPTICON_SKILLOGY_EMBED_MODEL=${DECEPTICON_SKILLOGY_EMBED_MODEL:-openai/text-embedding-3-small}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/v1/health')"]
       interval: 10s

--- a/packages/decepticon/decepticon/skillogy/__main__.py
+++ b/packages/decepticon/decepticon/skillogy/__main__.py
@@ -78,6 +78,15 @@ def _maybe_ingest(backend: Neo4jBackend) -> None:
     n = backend.bulk_ingest_cypher(cypher_text)
     log.info("ingested %d Cypher statements from %s", n, cypher_path)
 
+    # Hybrid retrieval (ADR-0011): once the corpus is loaded, create the
+    # vector index and embed each skill through the litellm proxy. The dump
+    # is deliberately embedding-free, so this is what makes semantic
+    # find_skill possible. It degrades to a no-op when the proxy env is
+    # absent — the substring path keeps working either way.
+    from decepticon.skillogy.embed_ingest import ingest_embeddings  # noqa: PLC0415
+
+    ingest_embeddings(backend)
+
 
 def _start_rest(backend: Neo4jBackend, port: int, started_at: float) -> None:
     try:

--- a/packages/decepticon/decepticon/skillogy/embed_ingest.py
+++ b/packages/decepticon/decepticon/skillogy/embed_ingest.py
@@ -38,8 +38,15 @@ def build_embed_text(name: str, description: str, when_to_use: str) -> str:
     return "\n".join(parts)
 
 
-def _input_sha(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+def _input_sha(model: str, text: str) -> str:
+    """SHA of the embedding *input identity* — the model PLUS the text.
+
+    Folding the model in means swapping ``DECEPTICON_SKILLOGY_EMBED_MODEL``
+    (even to one with the same dimension) changes every sha, so the next boot
+    re-embeds the whole corpus instead of silently serving vectors from the
+    old model. Mirrors the disk cache key in ``embeddings._cache_key``.
+    """
+    return hashlib.sha256(f"{model}\n{text}".encode()).hexdigest()
 
 
 def ingest_embeddings(backend: Neo4jBackend) -> dict[str, int]:
@@ -55,6 +62,7 @@ def ingest_embeddings(backend: Neo4jBackend) -> dict[str, int]:
 
     backend.ensure_vector_index(embeddings.embed_dim())
 
+    model = embeddings.embed_model()
     rows = backend.fetch_skills_for_embedding()
     pending: list[tuple[str, str, str]] = []  # (path, text, sha)
     skipped = 0
@@ -63,7 +71,7 @@ def ingest_embeddings(backend: Neo4jBackend) -> dict[str, int]:
         if not text:
             skipped += 1
             continue
-        sha = _input_sha(text)
+        sha = _input_sha(model, text)
         if row.get("embedding_input_sha256") == sha:
             skipped += 1
             continue

--- a/packages/decepticon/decepticon/skillogy/embed_ingest.py
+++ b/packages/decepticon/decepticon/skillogy/embed_ingest.py
@@ -1,0 +1,92 @@
+"""Boot-time embedding backfill for skillogy hybrid retrieval (ADR-0011).
+
+Runs once per container boot, AFTER the ``skills.cypher`` dump has been loaded
+(see ``__main__._maybe_ingest``). It creates the vector index and embeds every
+skill whose embedding-input text changed since the last boot — so the dump
+stays embedding-free (a model swap is a re-embed, not a rebuild) and an
+unchanged corpus is a no-op.
+
+Degrades silently: when the litellm proxy is not configured the whole step is
+skipped and ``find_skill`` keeps using the legacy substring path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from decepticon.skillogy import embeddings
+from decepticon.skillogy.server.neo4j_backend import Neo4jBackend
+
+log = logging.getLogger("skillogy")
+
+# Embed in chunks so a 278-skill corpus is a few proxy round-trips, not one
+# giant request (and a transient failure loses only one chunk).
+_CHUNK_SIZE = 64
+
+
+def build_embed_text(name: str, description: str, when_to_use: str) -> str:
+    """The text a skill is embedded from.
+
+    Per ADR-0011 the embedding signal is ``name`` + ``description`` +
+    ``when_to_use`` — the fields an agent's natural-language query actually
+    rhymes with. The skill ``body`` is deliberately excluded (too long, dilutes
+    the signal) and so is the MoC summary (it lives on a different node and is
+    rendered separately in the system prompt).
+    """
+    parts = [p.strip() for p in (name, description, when_to_use) if p and p.strip()]
+    return "\n".join(parts)
+
+
+def _input_sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def ingest_embeddings(backend: Neo4jBackend) -> dict[str, int]:
+    """Create the vector index and backfill changed/missing skill embeddings.
+
+    Returns a small stats dict (``{"embedded": n, "skipped": m, "failed": k}``)
+    for the boot log. Never raises — a failure leaves the affected skills
+    without an embedding, and ``find_skill`` falls back to substring for them.
+    """
+    if not embeddings.available():
+        log.info("skillogy embeddings unavailable (no litellm proxy env); skipping vector ingest")
+        return {"embedded": 0, "skipped": 0, "failed": 0}
+
+    backend.ensure_vector_index(embeddings.embed_dim())
+
+    rows = backend.fetch_skills_for_embedding()
+    pending: list[tuple[str, str, str]] = []  # (path, text, sha)
+    skipped = 0
+    for row in rows:
+        text = build_embed_text(row["name"], row["description"], row["when_to_use"])
+        if not text:
+            skipped += 1
+            continue
+        sha = _input_sha(text)
+        if row.get("embedding_input_sha256") == sha:
+            skipped += 1
+            continue
+        pending.append((row["path"], text, sha))
+
+    embedded = 0
+    failed = 0
+    for start in range(0, len(pending), _CHUNK_SIZE):
+        chunk = pending[start : start + _CHUNK_SIZE]
+        vectors = embeddings.embed_batch([text for _, text, _ in chunk])
+        writeback: list[dict[str, object]] = []
+        for (path, _text, sha), vec in zip(chunk, vectors, strict=True):
+            if vec is None:
+                failed += 1
+                continue
+            writeback.append({"path": path, "vector": vec, "sha": sha})
+        if writeback:
+            embedded += backend.write_embeddings(writeback)
+
+    log.info(
+        "skillogy embedding ingest: %d embedded, %d unchanged, %d failed",
+        embedded,
+        skipped,
+        failed,
+    )
+    return {"embedded": embedded, "skipped": skipped, "failed": failed}

--- a/packages/decepticon/decepticon/skillogy/embeddings.py
+++ b/packages/decepticon/decepticon/skillogy/embeddings.py
@@ -1,0 +1,167 @@
+"""Embedding helper for skillogy hybrid retrieval (ADR-0011).
+
+Used by BOTH boot-ingest (embed each ``:Skill`` once into Neo4j) and query-time
+``find_skill`` (embed the query for the vector search). Embeddings go through
+the **litellm proxy** the agents already use — the skillogy container must be
+given ``DECEPTICON_LLM__PROXY_URL`` + ``DECEPTICON_LLM__PROXY_API_KEY`` (see
+ADR-0011 §"Skillogy↔litellm coupling").
+
+Degradation contract: this module **never raises** to its callers. When the
+proxy is unconfigured or a request fails, ``embed_text`` returns ``None`` and
+``find_skill`` falls back to the legacy substring path — semantic search is an
+opt-in upgrade, not a hard dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+# OSS default mirrors the KG layer's default (see kg_internal migration V002:
+# "OpenAI text-embedding-3-small (1536) as the OSS default"). Override with
+# DECEPTICON_SKILLOGY_EMBED_MODEL; set the matching dim if the model differs.
+DEFAULT_EMBED_MODEL = "text-embedding-3-small"
+_KNOWN_DIMS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "voyage-3": 1024,
+    "voyage-3-lite": 512,
+}
+_DEFAULT_DIM = 1536
+
+_REQUEST_TIMEOUT = 30.0
+
+
+def embed_model() -> str:
+    return os.environ.get("DECEPTICON_SKILLOGY_EMBED_MODEL", DEFAULT_EMBED_MODEL).strip()
+
+
+def embed_dim() -> int:
+    """Embedding dimension for the configured model (drives the vector index DDL).
+
+    An explicit ``DECEPTICON_SKILLOGY_EMBED_DIM`` wins (for models not in the
+    table); otherwise look the model up, else fall back to 1536.
+    """
+    raw = os.environ.get("DECEPTICON_SKILLOGY_EMBED_DIM", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+    return _KNOWN_DIMS.get(embed_model(), _DEFAULT_DIM)
+
+
+def _proxy() -> tuple[str, str] | None:
+    """``(base_url, api_key)`` for the litellm proxy, or ``None`` if unconfigured."""
+    base = os.environ.get("DECEPTICON_LLM__PROXY_URL", "").strip()
+    key = os.environ.get("DECEPTICON_LLM__PROXY_API_KEY", "").strip()
+    if not base or not key:
+        return None
+    return base.rstrip("/"), key
+
+
+def available() -> bool:
+    """True when an embedding model is reachable (proxy configured)."""
+    return _proxy() is not None
+
+
+def _cache_dir() -> Path:
+    raw = os.environ.get("DECEPTICON_SKILLOGY_EMBED_CACHE", "").strip()
+    path = Path(raw) if raw else Path(tempfile.gettempdir()) / "decepticon-skillogy-embed"
+    return path
+
+
+def _cache_key(model: str, text: str) -> str:
+    return hashlib.sha256(f"{model}\n{text}".encode()).hexdigest()
+
+
+def _cache_get(model: str, text: str) -> list[float] | None:
+    path = _cache_dir() / f"{_cache_key(model, text)}.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _cache_put(model: str, text: str, vector: list[float]) -> None:
+    cache = _cache_dir()
+    try:
+        cache.mkdir(parents=True, exist_ok=True)
+        (cache / f"{_cache_key(model, text)}.json").write_text(json.dumps(vector), encoding="utf-8")
+    except OSError:  # cache is best-effort
+        pass
+
+
+def _request_embeddings(
+    base_url: str, key: str, model: str, inputs: list[str]
+) -> list[list[float]]:
+    """POST to the proxy's OpenAI-compatible ``/v1/embeddings``. May raise."""
+    resp = httpx.post(
+        f"{base_url}/v1/embeddings",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"model": model, "input": inputs},
+        timeout=_REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    # OpenAI shape: {"data": [{"embedding": [...], "index": 0}, ...]}
+    rows = sorted(data["data"], key=lambda d: d.get("index", 0))
+    return [list(r["embedding"]) for r in rows]
+
+
+def embed_batch(texts: list[str]) -> list[list[float] | None]:
+    """Embed many texts. Returns one vector per input, or ``None`` per input
+    when embeddings are unavailable / the request fails. Never raises.
+
+    Cached entries are served without a network call; only the cache misses
+    are sent to the proxy in one batched request.
+    """
+    if not texts:
+        return []
+    model = embed_model()
+    results: list[list[float] | None] = [None] * len(texts)
+
+    # Serve cache hits first.
+    misses: list[int] = []
+    for i, text in enumerate(texts):
+        cached = _cache_get(model, text)
+        if cached is not None:
+            results[i] = cached
+        else:
+            misses.append(i)
+    if not misses:
+        return results
+
+    proxy = _proxy()
+    if proxy is None:
+        log.info("skillogy embeddings unavailable (no litellm proxy env); falling back")
+        return results  # misses stay None → caller falls back
+
+    base_url, key = proxy
+    try:
+        vectors = _request_embeddings(base_url, key, model, [texts[i] for i in misses])
+    except Exception as exc:  # noqa: BLE001 - degrade, never raise to caller
+        log.warning("skillogy embedding request failed (%s); falling back", type(exc).__name__)
+        return results
+    if len(vectors) != len(misses):
+        log.warning("skillogy embedding count mismatch (%d != %d)", len(vectors), len(misses))
+        return results
+    for idx, vec in zip(misses, vectors, strict=True):
+        results[idx] = vec
+        _cache_put(model, texts[idx], vec)
+    return results
+
+
+def embed_text(text: str) -> list[float] | None:
+    """Embed one text. ``None`` when unavailable / on failure (never raises)."""
+    return embed_batch([text])[0]

--- a/packages/decepticon/decepticon/skillogy/embeddings.py
+++ b/packages/decepticon/decepticon/skillogy/embeddings.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import tempfile
+import time
 from pathlib import Path
 
 import httpx
@@ -34,12 +35,37 @@ _KNOWN_DIMS: dict[str, int] = {
     "openai/text-embedding-3-large": 3072,
     "text-embedding-3-small": 1536,
     "text-embedding-3-large": 3072,
+    "voyage/voyage-3": 1024,
+    "voyage/voyage-3-lite": 512,
     "voyage-3": 1024,
     "voyage-3-lite": 512,
+    "gemini/gemini-embedding-001": 3072,
+    "gemini-embedding-001": 3072,
 }
 _DEFAULT_DIM = 1536
 
 _REQUEST_TIMEOUT = 30.0
+# Embedding providers rate-limit aggressively (Voyage's no-payment free tier
+# is 3 RPM / 10K TPM), and boot-ingest fires several chunked requests
+# back-to-back. Providers also mask the 429 as a 500 through litellm, so the
+# retryable set includes 5xx and backoff must be patient enough to ride out a
+# ~60s rate window rather than just a brief blip. The exponential is capped so
+# a single retry can't stall boot indefinitely; once attempts are exhausted
+# the chunk degrades to substring and the next boot re-embeds it (incremental
+# by input-sha). Worst-case added boot latency ≈ sum of the backoffs (~60s).
+_RETRY_STATUS = frozenset({429, 500, 502, 503, 504})
+# Ingest (boot, batched) can afford to be patient — it runs off the request
+# path and a re-embed is cheaper than leaving the corpus unembedded.
+_MAX_ATTEMPTS = 6
+_BACKOFF_BASE = 1.0
+_BACKOFF_CAP = 30.0
+# Query time (a live find_skill) must NOT make the agent wait. litellm already
+# retries the upstream internally, so a single client attempt with a short
+# timeout is enough: if the embedding can't come back in a few seconds we fail
+# fast to None → find_skill returns lexical results immediately instead of
+# blowing the REST client timeout and leaving the agent empty-handed.
+_QUERY_MAX_ATTEMPTS = 1
+_QUERY_REQUEST_TIMEOUT = 5.0
 
 
 def embed_model() -> str:
@@ -105,28 +131,80 @@ def _cache_put(model: str, text: str, vector: list[float]) -> None:
 
 
 def _request_embeddings(
-    base_url: str, key: str, model: str, inputs: list[str]
+    base_url: str,
+    key: str,
+    model: str,
+    inputs: list[str],
+    *,
+    max_attempts: int = _MAX_ATTEMPTS,
+    timeout: float = _REQUEST_TIMEOUT,
 ) -> list[list[float]]:
-    """POST to the proxy's OpenAI-compatible ``/v1/embeddings``. May raise."""
-    resp = httpx.post(
-        f"{base_url}/v1/embeddings",
-        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
-        json={"model": model, "input": inputs},
-        timeout=_REQUEST_TIMEOUT,
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    # OpenAI shape: {"data": [{"embedding": [...], "index": 0}, ...]}
-    rows = sorted(data["data"], key=lambda d: d.get("index", 0))
-    return [list(r["embedding"]) for r in rows]
+    """POST to the proxy's OpenAI-compatible ``/v1/embeddings``.
+
+    Retries transient HTTP failures (429 / 5xx) up to ``max_attempts`` with
+    exponential backoff, honouring a ``Retry-After`` header when the provider
+    sends one. Raises on a non-retryable error or once attempts are exhausted —
+    the caller (``embed_batch``) turns that into a ``None`` fallback. ``ingest``
+    uses the patient default; query time passes a small ``max_attempts`` so a
+    live find_skill never blocks on a slow retry.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(max_attempts):
+        resp = httpx.post(
+            f"{base_url}/v1/embeddings",
+            headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+            json={"model": model, "input": inputs},
+            timeout=timeout,
+        )
+        if resp.status_code in _RETRY_STATUS and attempt < max_attempts - 1:
+            delay = _retry_after(resp) or min(_BACKOFF_BASE * (2**attempt), _BACKOFF_CAP)
+            log.info(
+                "skillogy embedding %d; retry %d/%d in %.1fs",
+                resp.status_code,
+                attempt + 1,
+                max_attempts - 1,
+                delay,
+            )
+            time.sleep(delay)
+            continue
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            last_exc = exc
+            break
+        data = resp.json()
+        # OpenAI shape: {"data": [{"embedding": [...], "index": 0}, ...]}
+        rows = sorted(data["data"], key=lambda d: d.get("index", 0))
+        return [list(r["embedding"]) for r in rows]
+    raise last_exc or httpx.HTTPError("embedding request failed after retries")
 
 
-def embed_batch(texts: list[str]) -> list[list[float] | None]:
+def _retry_after(resp: httpx.Response) -> float | None:
+    """Parse a ``Retry-After`` delay (seconds form) if present and sane."""
+    raw = resp.headers.get("Retry-After", "").strip()
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return None
+    # Clamp so a hostile/huge value can't stall boot-ingest.
+    return min(seconds, 30.0) if seconds > 0 else None
+
+
+def embed_batch(
+    texts: list[str],
+    *,
+    max_attempts: int = _MAX_ATTEMPTS,
+    timeout: float = _REQUEST_TIMEOUT,
+) -> list[list[float] | None]:
     """Embed many texts. Returns one vector per input, or ``None`` per input
     when embeddings are unavailable / the request fails. Never raises.
 
     Cached entries are served without a network call; only the cache misses
-    are sent to the proxy in one batched request.
+    are sent to the proxy in one batched request. ``max_attempts`` / ``timeout``
+    control retry patience and per-request deadline — ingest uses the patient
+    defaults; query time overrides both so a live lookup fails fast to lexical.
     """
     if not texts:
         return []
@@ -151,7 +229,14 @@ def embed_batch(texts: list[str]) -> list[list[float] | None]:
 
     base_url, key = proxy
     try:
-        vectors = _request_embeddings(base_url, key, model, [texts[i] for i in misses])
+        vectors = _request_embeddings(
+            base_url,
+            key,
+            model,
+            [texts[i] for i in misses],
+            max_attempts=max_attempts,
+            timeout=timeout,
+        )
     except Exception as exc:  # noqa: BLE001 - degrade, never raise to caller
         log.warning("skillogy embedding request failed (%s); falling back", type(exc).__name__)
         return results
@@ -165,5 +250,10 @@ def embed_batch(texts: list[str]) -> list[list[float] | None]:
 
 
 def embed_text(text: str) -> list[float] | None:
-    """Embed one text. ``None`` when unavailable / on failure (never raises)."""
-    return embed_batch([text])[0]
+    """Embed one text — the **query-time** entry point (find_skill).
+
+    Uses a small retry budget so a live lookup fails fast to ``None`` (→ lexical
+    fallback) under a sustained rate limit rather than blocking the agent past
+    the REST client timeout. ``None`` when unavailable / on failure; never raises.
+    """
+    return embed_batch([text], max_attempts=_QUERY_MAX_ATTEMPTS, timeout=_QUERY_REQUEST_TIMEOUT)[0]

--- a/packages/decepticon/decepticon/skillogy/embeddings.py
+++ b/packages/decepticon/decepticon/skillogy/embeddings.py
@@ -28,8 +28,10 @@ log = logging.getLogger(__name__)
 # OSS default mirrors the KG layer's default (see kg_internal migration V002:
 # "OpenAI text-embedding-3-small (1536) as the OSS default"). Override with
 # DECEPTICON_SKILLOGY_EMBED_MODEL; set the matching dim if the model differs.
-DEFAULT_EMBED_MODEL = "text-embedding-3-small"
+DEFAULT_EMBED_MODEL = "openai/text-embedding-3-small"
 _KNOWN_DIMS: dict[str, int] = {
+    "openai/text-embedding-3-small": 1536,
+    "openai/text-embedding-3-large": 3072,
     "text-embedding-3-small": 1536,
     "text-embedding-3-large": 3072,
     "voyage-3": 1024,

--- a/packages/decepticon/decepticon/skillogy/server/neo4j_backend.py
+++ b/packages/decepticon/decepticon/skillogy/server/neo4j_backend.py
@@ -140,6 +140,71 @@ class Neo4jBackend:
                 session.run(stmt.rstrip(";").rstrip())
         return len(statements)
 
+    # ---- vector index + embedding backfill (hybrid retrieval, ADR-0011) ----
+
+    # Native Neo4j vector index over the per-skill embedding. Created
+    # idempotently at boot AFTER the cypher dump loads; embeddings are
+    # then backfilled through the litellm proxy (the dump stays embedding-
+    # free so a model swap is a re-embed, not a rebuild). The query side
+    # (find_skill) uses this index for the semantic-local leg of the
+    # hybrid score, and silently skips it when no embeddings exist.
+    VECTOR_INDEX_NAME = "skill_embedding"
+
+    def ensure_vector_index(self, dim: int) -> None:
+        """Create the ``:Skill(embedding)`` vector index if absent (idempotent).
+
+        ``dim`` is inlined as a literal — Neo4j does not accept a query
+        parameter for ``vector.dimensions`` in index DDL. It is coerced to
+        ``int`` first so the f-string cannot carry an injection.
+        """
+        dim_literal = int(dim)
+        cypher = (
+            f"CREATE VECTOR INDEX {self.VECTOR_INDEX_NAME} IF NOT EXISTS "
+            "FOR (s:Skill) ON (s.embedding) "
+            "OPTIONS {indexConfig: {"
+            f"`vector.dimensions`: {dim_literal}, "
+            "`vector.similarity_function`: 'cosine'}}"
+        )
+        with self._driver.session(database=self._database) as session:
+            session.run(cypher)
+
+    def fetch_skills_for_embedding(self) -> list[dict[str, Any]]:
+        """Return the text fields each skill is embedded from, plus the sha of
+        the input that produced its current embedding (``None`` if never
+        embedded). The caller re-embeds only rows whose recomputed input sha
+        differs — so a content edit re-embeds, an unchanged corpus is a no-op.
+        """
+        cypher = (
+            "MATCH (s:Skill) "
+            "RETURN s.path AS path, s.name AS name, "
+            "       coalesce(s.description, '') AS description, "
+            "       coalesce(s.when_to_use, '') AS when_to_use, "
+            "       s.embedding_input_sha256 AS embedding_input_sha256"
+        )
+        with self._driver.session(database=self._database, default_access_mode="READ") as session:
+            return [dict(record) for record in session.run(cypher)]
+
+    def write_embeddings(self, rows: list[dict[str, Any]]) -> int:
+        """Persist embeddings onto their ``:Skill`` nodes.
+
+        Each row is ``{"path": str, "vector": list[float], "sha": str}``.
+        Uses ``db.create.setNodeVectorProperty`` (the supported way to store a
+        vector so the index picks it up) and records the input sha so the next
+        boot can skip unchanged skills. Returns the number of nodes written.
+        """
+        if not rows:
+            return 0
+        cypher = (
+            "UNWIND $rows AS row "
+            "MATCH (s:Skill {path: row.path}) "
+            "CALL db.create.setNodeVectorProperty(s, 'embedding', row.vector) "
+            "SET s.embedding_input_sha256 = row.sha "
+            "RETURN count(s) AS written"
+        )
+        with self._driver.session(database=self._database) as session:
+            result = session.run(cypher, rows=rows).single()
+        return 0 if result is None else int(result["written"])
+
     # ---- skill ops ----
 
     def load_skill(

--- a/packages/decepticon/decepticon/skillogy/server/neo4j_backend.py
+++ b/packages/decepticon/decepticon/skillogy/server/neo4j_backend.py
@@ -273,47 +273,106 @@ class Neo4jBackend:
         limit: int = 20,
         allowed_path_prefixes: list[str] | None = None,
     ) -> list[dict[str, Any]]:
-        """Relationship-aware skill discovery.
+        """Relationship-aware skill discovery — hybrid retrieval (ADR-0011).
 
-        Composable filters combined with AND semantics. Each filter
-        prunes the candidate set via a different edge:
+        The structured filters are hard AND constraints; each prunes the
+        candidate set via a different edge:
 
-        - ``query``: substring match on name / description / when_to_use.
-          Cheap signal for when the agent has a keyword like "kerberoast"
-          but not a path.
         - ``subdomain``: ``(s:Skill)-[:IN_PHASE]->(:Phase {name: $sub})``.
         - ``mitre_id``: ``(s:Skill)-[:IMPLEMENTS]->(:Technique {id: $id})``
           where ``$id`` can be a top-level T1xxx or a sub-T1xxx.yyy.
         - ``tag``: ``(s:Skill)-[:TAGGED]->(:Tag {name: $tag})``.
         - ``tactic_id``: anchors on a Tactic, follows ``HAS_TECHNIQUE`` to
-          its techniques, then back to skills via ``IMPLEMENTS``. Lets
-          the agent ask "show me skills covering Initial Access".
+          its techniques, then back to skills via ``IMPLEMENTS``.
+
+        ``query`` (free text) drives **ranking** via two legs fused with
+        reciprocal-rank fusion:
+
+        - *lexical* — substring match on name / description / when_to_use
+          (the legacy signal; exact for keywords like "kerberoast").
+        - *semantic* — cosine k-NN over the per-skill embedding vector
+          index, so a paraphrase ("steal kerberos tickets") finds the skill
+          even with no shared substring.
+
+        The semantic leg is **opt-in**: when no embeddings exist (the
+        litellm proxy is unconfigured, or the corpus was never embedded),
+        ``find_skill`` returns the pure lexical result, name-ordered —
+        byte-for-byte the pre-ADR-0011 behaviour. The structured-only path
+        (no ``query``) is likewise unchanged.
 
         Returns each match's ``name``, ``path``, ``subdomain``,
         ``description`` and the matched dimensions (``matched_mitre``,
         ``matched_tags``) so the agent can see *why* a skill came back.
         """
-        wheres: list[str] = []
-        params: dict[str, Any] = {"limit": int(min(max(limit, 1), 100))}
-        # Path A: subdomain-anchored
+        from decepticon.skillogy import embeddings  # noqa: PLC0415
+
+        limit = int(min(max(limit, 1), 100))
+        # Over-fetch from each leg so reciprocal-rank fusion has signal to
+        # work with before the final top-``limit`` cut.
+        cand_n = min(max(limit * 3, 30), 100)
+
+        # Structured (edge) filters — shared verbatim by both legs.
+        structured: list[str] = []
+        shared: dict[str, Any] = {}
         if subdomain:
-            wheres.append("(s)-[:IN_PHASE]->(:Phase {name: $subdomain})")
-            params["subdomain"] = subdomain
-        # Path B: tag-anchored
+            structured.append("(s)-[:IN_PHASE]->(:Phase {name: $subdomain})")
+            shared["subdomain"] = subdomain
         if tag:
-            wheres.append("(s)-[:TAGGED]->(:Tag {name: $tag})")
-            params["tag"] = tag
-        # Path C: technique-anchored (direct)
+            structured.append("(s)-[:TAGGED]->(:Tag {name: $tag})")
+            shared["tag"] = tag
         if mitre_id:
-            wheres.append("(s)-[:IMPLEMENTS]->(:Technique {id: $mitre_id})")
-            params["mitre_id"] = mitre_id
-        # Path D: tactic-anchored (one hop via Technique)
+            structured.append("(s)-[:IMPLEMENTS]->(:Technique {id: $mitre_id})")
+            shared["mitre_id"] = mitre_id
         if tactic_id:
-            wheres.append(
+            structured.append(
                 "(s)-[:IMPLEMENTS]->(:Technique)<-[:HAS_TECHNIQUE]-(:Tactic {id: $tactic_id})"
             )
-            params["tactic_id"] = tactic_id
-        # Path E: keyword search across name / description / triggers.
+            shared["tactic_id"] = tactic_id
+        # Per-role path-prefix ACL (ADR-0008) — applied identically to both
+        # legs. Empty/missing leaves both unrestricted (CLI / pytest / lib).
+        acl_clause: str | None = None
+        if allowed_path_prefixes:
+            acl_clause = "ANY(p IN $allowed_path_prefixes WHERE s.path STARTS WITH p)"
+            shared["allowed_path_prefixes"] = list(allowed_path_prefixes)
+
+        if not query and not structured:
+            raise ValueError(
+                "find_skill requires at least one of: query, subdomain, mitre_id, tag, tactic_id"
+            )
+
+        lexical = self._find_lexical(query, structured, acl_clause, shared, cand_n)
+
+        # Semantic leg only when there is free text AND it can be embedded.
+        query_vec = embeddings.embed_text(query) if query else None
+        if query_vec is None:
+            return lexical[:limit]
+
+        semantic = self._find_semantic(query_vec, structured, acl_clause, shared, cand_n)
+        return self._rrf_fuse(lexical, semantic, limit)
+
+    # Shared RETURN tail so the lexical and semantic legs yield identical row
+    # shapes (``score`` is appended by the semantic leg only and stripped at
+    # fusion time).
+    _ENRICH_TAIL = (
+        "OPTIONAL MATCH (s)-[:IMPLEMENTS]->(t:Technique) OPTIONAL MATCH (s)-[:TAGGED]->(tg:Tag) "
+    )
+    _RETURN_FIELDS = (
+        "s.name AS name, s.path AS path, s.subdomain AS subdomain, "
+        "s.description AS description, matched_mitre, matched_tags"
+    )
+
+    def _find_lexical(
+        self,
+        query: str | None,
+        structured: list[str],
+        acl_clause: str | None,
+        shared: dict[str, Any],
+        cand_n: int,
+    ) -> list[dict[str, Any]]:
+        """Substring + structured leg. Name-ordered (stable, legacy order)."""
+        wheres = list(structured)
+        params = dict(shared)
+        params["cand_n"] = cand_n
         if query:
             wheres.append(
                 "(toLower(s.name) CONTAINS toLower($query) "
@@ -321,34 +380,86 @@ class Neo4jBackend:
                 "OR toLower(s.when_to_use) CONTAINS toLower($query))"
             )
             params["query"] = query
-        if not wheres:
-            raise ValueError(
-                "find_skill requires at least one of: query, subdomain, mitre_id, tag, tactic_id"
-            )
-        # Per ADR-0008 — narrow the candidate set to the per-role
-        # path-prefix allowlist when the caller (agent middleware)
-        # supplied one. When the parameter is missing/empty we leave the
-        # query unrestricted so the standalone CLI, pytest, and the
-        # library entrypoint keep their existing behaviour.
-        if allowed_path_prefixes:
-            wheres.append("ANY(p IN $allowed_path_prefixes WHERE s.path STARTS WITH p)")
-            params["allowed_path_prefixes"] = list(allowed_path_prefixes)
-        match_clauses = " AND ".join(wheres)
+        if acl_clause:
+            wheres.append(acl_clause)
         cypher = (
             "MATCH (s:Skill) "
-            f"WHERE {match_clauses} "
-            "OPTIONAL MATCH (s)-[:IMPLEMENTS]->(t:Technique) "
-            "OPTIONAL MATCH (s)-[:TAGGED]->(tag:Tag) "
+            f"WHERE {' AND '.join(wheres)} "
+            f"{self._ENRICH_TAIL}"
             "WITH s, collect(DISTINCT t.id) AS matched_mitre, "
-            "     collect(DISTINCT tag.name) AS matched_tags "
-            "RETURN s.name AS name, s.path AS path, s.subdomain AS subdomain, "
-            "       s.description AS description, "
-            "       matched_mitre, matched_tags "
+            "     collect(DISTINCT tg.name) AS matched_tags "
+            f"RETURN {self._RETURN_FIELDS} "
             "ORDER BY name "
-            "LIMIT $limit"
+            "LIMIT $cand_n"
         )
         with self._driver.session(database=self._database, default_access_mode="READ") as session:
             return [dict(record) for record in session.run(cypher, parameters=params)]
+
+    def _find_semantic(
+        self,
+        query_vec: list[float],
+        structured: list[str],
+        acl_clause: str | None,
+        shared: dict[str, Any],
+        cand_n: int,
+    ) -> list[dict[str, Any]]:
+        """Vector k-NN leg over the ``:Skill(embedding)`` index, score-ordered.
+
+        ``db.index.vector.queryNodes`` cannot pre-apply the structured /
+        ACL predicates, so we over-fetch ``k`` neighbours and filter after —
+        ``k`` is widened when filters are present since many neighbours will
+        be dropped.
+        """
+        post_filters = list(structured)
+        if acl_clause:
+            post_filters.append(acl_clause)
+        k = min(cand_n * 5, 500) if post_filters else cand_n
+        params = dict(shared)
+        params.update(
+            {"index_name": self.VECTOR_INDEX_NAME, "k": k, "qvec": query_vec, "cand_n": cand_n}
+        )
+        where = f"WHERE {' AND '.join(post_filters)} " if post_filters else ""
+        cypher = (
+            "CALL db.index.vector.queryNodes($index_name, $k, $qvec) "
+            "YIELD node AS s, score "
+            f"{where}"
+            f"{self._ENRICH_TAIL}"
+            "WITH s, score, collect(DISTINCT t.id) AS matched_mitre, "
+            "     collect(DISTINCT tg.name) AS matched_tags "
+            f"RETURN {self._RETURN_FIELDS}, score "
+            "ORDER BY score DESC "
+            "LIMIT $cand_n"
+        )
+        with self._driver.session(database=self._database, default_access_mode="READ") as session:
+            return [dict(record) for record in session.run(cypher, parameters=params)]
+
+    @staticmethod
+    def _rrf_fuse(
+        lexical: list[dict[str, Any]],
+        semantic: list[dict[str, Any]],
+        limit: int,
+        *,
+        rrf_k: int = 60,
+    ) -> list[dict[str, Any]]:
+        """Reciprocal-rank fusion of the two ranked legs, keyed by skill path.
+
+        Each leg contributes ``1 / (rrf_k + rank)`` to a skill's score; a
+        skill found by both legs ranks above one found by either alone. Ties
+        break on name for deterministic output. ``rrf_k`` is the standard
+        rank-smoothing constant (60).
+        """
+        scores: dict[str, float] = {}
+        record_by_path: dict[str, dict[str, Any]] = {}
+        for leg in (lexical, semantic):
+            for rank, rec in enumerate(leg):
+                path = rec["path"]
+                record_by_path.setdefault(path, rec)
+                scores[path] = scores.get(path, 0.0) + 1.0 / (rrf_k + rank + 1)
+        ordered = sorted(
+            record_by_path.values(),
+            key=lambda r: (-scores[r["path"]], r.get("name") or ""),
+        )
+        return [{k: v for k, v in r.items() if k != "score"} for r in ordered[:limit]]
 
     # ---- per-phase MoC summary (used by SkillogyMiddleware system prompt) ----
 

--- a/packages/decepticon/tests/unit/skillogy/test_embed_ingest.py
+++ b/packages/decepticon/tests/unit/skillogy/test_embed_ingest.py
@@ -1,0 +1,128 @@
+"""Unit tests for the boot-time embedding backfill (ADR-0011).
+
+Exercises the orchestration in ``embed_ingest.ingest_embeddings`` against a
+fake backend and a faked embeddings module — no Neo4j, no proxy. Pins the
+incremental-by-sha contract (re-embed only changed/missing skills), the
+silent skip when the proxy is unconfigured, and per-row failure handling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from decepticon.skillogy import embed_ingest, embeddings
+
+
+class _FakeBackend:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.index_dim: int | None = None
+        self.written: list[dict[str, Any]] = []
+
+    def ensure_vector_index(self, dim: int) -> None:
+        self.index_dim = dim
+
+    def fetch_skills_for_embedding(self) -> list[dict[str, Any]]:
+        return self._rows
+
+    def write_embeddings(self, rows: list[dict[str, Any]]) -> int:
+        self.written.extend(rows)
+        return len(rows)
+
+
+@pytest.fixture
+def _fake_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings, "available", lambda: True)
+    monkeypatch.setattr(embeddings, "embed_dim", lambda: 8)
+    # Deterministic, non-None vector per input.
+    monkeypatch.setattr(embeddings, "embed_batch", lambda texts: [[float(len(t))] for t in texts])
+
+
+def test_skips_when_proxy_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings, "available", lambda: False)
+    backend = _FakeBackend([{"path": "/p", "name": "n", "description": "d", "when_to_use": "w"}])
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 0, "skipped": 0, "failed": 0}
+    assert backend.index_dim is None  # no index DDL when unavailable
+    assert backend.written == []
+
+
+def test_embeds_all_missing(_fake_embeddings: None) -> None:
+    backend = _FakeBackend(
+        [
+            {"path": "/a", "name": "alpha", "description": "d1", "when_to_use": "w1"},
+            {"path": "/b", "name": "beta", "description": "d2", "when_to_use": "w2"},
+        ]
+    )
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 2, "skipped": 0, "failed": 0}
+    assert backend.index_dim == 8
+    assert {r["path"] for r in backend.written} == {"/a", "/b"}
+    assert all("vector" in r and "sha" in r for r in backend.written)
+
+
+def test_skips_unchanged_by_sha(_fake_embeddings: None) -> None:
+    text = embed_ingest.build_embed_text("alpha", "d1", "w1")
+    sha = embed_ingest._input_sha(text)
+    backend = _FakeBackend(
+        [
+            {
+                "path": "/a",
+                "name": "alpha",
+                "description": "d1",
+                "when_to_use": "w1",
+                "embedding_input_sha256": sha,  # already current
+            },
+            {"path": "/b", "name": "beta", "description": "d2", "when_to_use": "w2"},
+        ]
+    )
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 1, "skipped": 1, "failed": 0}
+    assert [r["path"] for r in backend.written] == ["/b"]
+
+
+def test_changed_content_reembeds(_fake_embeddings: None) -> None:
+    stale_sha = embed_ingest._input_sha("totally different text")
+    backend = _FakeBackend(
+        [
+            {
+                "path": "/a",
+                "name": "alpha",
+                "description": "NEW description",
+                "when_to_use": "w1",
+                "embedding_input_sha256": stale_sha,
+            }
+        ]
+    )
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 1, "skipped": 0, "failed": 0}
+
+
+def test_empty_text_skipped(_fake_embeddings: None) -> None:
+    backend = _FakeBackend([{"path": "/a", "name": "", "description": "", "when_to_use": ""}])
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 0, "skipped": 1, "failed": 0}
+    assert backend.written == []
+
+
+def test_failed_embedding_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings, "available", lambda: True)
+    monkeypatch.setattr(embeddings, "embed_dim", lambda: 8)
+    # First input embeds, second returns None (proxy hiccup).
+    monkeypatch.setattr(embeddings, "embed_batch", lambda texts: [[1.0], None])
+    backend = _FakeBackend(
+        [
+            {"path": "/a", "name": "alpha", "description": "d", "when_to_use": "w"},
+            {"path": "/b", "name": "beta", "description": "d", "when_to_use": "w"},
+        ]
+    )
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 1, "skipped": 0, "failed": 1}
+    assert [r["path"] for r in backend.written] == ["/a"]
+
+
+def test_build_embed_text_excludes_blank_fields() -> None:
+    assert embed_ingest.build_embed_text("name", "", "  ") == "name"
+    assert embed_ingest.build_embed_text("name", "desc", "trigger") == "name\ndesc\ntrigger"

--- a/packages/decepticon/tests/unit/skillogy/test_embed_ingest.py
+++ b/packages/decepticon/tests/unit/skillogy/test_embed_ingest.py
@@ -36,6 +36,7 @@ class _FakeBackend:
 def _fake_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(embeddings, "available", lambda: True)
     monkeypatch.setattr(embeddings, "embed_dim", lambda: 8)
+    monkeypatch.setattr(embeddings, "embed_model", lambda: "test-model")
     # Deterministic, non-None vector per input.
     monkeypatch.setattr(embeddings, "embed_batch", lambda texts: [[float(len(t))] for t in texts])
 
@@ -65,7 +66,7 @@ def test_embeds_all_missing(_fake_embeddings: None) -> None:
 
 def test_skips_unchanged_by_sha(_fake_embeddings: None) -> None:
     text = embed_ingest.build_embed_text("alpha", "d1", "w1")
-    sha = embed_ingest._input_sha(text)
+    sha = embed_ingest._input_sha("test-model", text)
     backend = _FakeBackend(
         [
             {
@@ -84,7 +85,7 @@ def test_skips_unchanged_by_sha(_fake_embeddings: None) -> None:
 
 
 def test_changed_content_reembeds(_fake_embeddings: None) -> None:
-    stale_sha = embed_ingest._input_sha("totally different text")
+    stale_sha = embed_ingest._input_sha("test-model", "totally different text")
     backend = _FakeBackend(
         [
             {
@@ -93,6 +94,26 @@ def test_changed_content_reembeds(_fake_embeddings: None) -> None:
                 "description": "NEW description",
                 "when_to_use": "w1",
                 "embedding_input_sha256": stale_sha,
+            }
+        ]
+    )
+    stats = embed_ingest.ingest_embeddings(backend)  # type: ignore[arg-type]
+    assert stats == {"embedded": 1, "skipped": 0, "failed": 0}
+
+
+def test_model_change_reembeds(_fake_embeddings: None) -> None:
+    # Same text, but the stored sha was produced by a DIFFERENT model →
+    # folding the model into the sha must force a re-embed (no stale vectors).
+    text = embed_ingest.build_embed_text("alpha", "d1", "w1")
+    old_model_sha = embed_ingest._input_sha("some-other-model", text)
+    backend = _FakeBackend(
+        [
+            {
+                "path": "/a",
+                "name": "alpha",
+                "description": "d1",
+                "when_to_use": "w1",
+                "embedding_input_sha256": old_model_sha,
             }
         ]
     )

--- a/packages/decepticon/tests/unit/skillogy/test_embeddings.py
+++ b/packages/decepticon/tests/unit/skillogy/test_embeddings.py
@@ -1,0 +1,173 @@
+"""Unit tests for the skillogy embedding helper (ADR-0011).
+
+The helper underpins hybrid retrieval but must degrade silently: with no
+litellm proxy configured it returns ``None`` so ``find_skill`` falls back to
+the legacy substring path. These tests pin that contract plus the cache and
+batch behaviour, with the HTTP layer faked — no network, no real proxy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from decepticon.skillogy import embeddings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts with no proxy and a private, empty disk cache."""
+    monkeypatch.delenv("DECEPTICON_LLM__PROXY_URL", raising=False)
+    monkeypatch.delenv("DECEPTICON_LLM__PROXY_API_KEY", raising=False)
+    monkeypatch.delenv("DECEPTICON_SKILLOGY_EMBED_MODEL", raising=False)
+    monkeypatch.delenv("DECEPTICON_SKILLOGY_EMBED_DIM", raising=False)
+    monkeypatch.setenv("DECEPTICON_SKILLOGY_EMBED_CACHE", str(tmp_path / "embed-cache"))
+
+
+def _set_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECEPTICON_LLM__PROXY_URL", "http://litellm:4000/")
+    monkeypatch.setenv("DECEPTICON_LLM__PROXY_API_KEY", "sk-test")
+
+
+# --- availability / config -------------------------------------------------
+
+
+def test_unavailable_without_proxy() -> None:
+    assert embeddings.available() is False
+    assert embeddings.embed_text("anything") is None
+
+
+def test_available_with_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+    assert embeddings.available() is True
+
+
+def test_embed_dim_defaults_and_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert embeddings.embed_model() == "text-embedding-3-small"
+    assert embeddings.embed_dim() == 1536
+    monkeypatch.setenv("DECEPTICON_SKILLOGY_EMBED_MODEL", "text-embedding-3-large")
+    assert embeddings.embed_dim() == 3072
+    # explicit dim wins for an unknown model
+    monkeypatch.setenv("DECEPTICON_SKILLOGY_EMBED_MODEL", "some-private-model")
+    monkeypatch.setenv("DECEPTICON_SKILLOGY_EMBED_DIM", "256")
+    assert embeddings.embed_dim() == 256
+    # unknown model, no explicit dim → fallback
+    monkeypatch.delenv("DECEPTICON_SKILLOGY_EMBED_DIM")
+    assert embeddings.embed_dim() == 1536
+
+
+# --- happy path / batching -------------------------------------------------
+
+
+def _fake_response(
+    monkeypatch: pytest.MonkeyPatch, vectors_by_input: dict[str, list[float]]
+) -> list[dict]:
+    """Patch the HTTP call to echo deterministic vectors and record calls."""
+    calls: list[dict] = []
+
+    def fake_request(base_url: str, key: str, model: str, inputs: list[str]) -> list[list[float]]:
+        calls.append({"base_url": base_url, "key": key, "model": model, "inputs": list(inputs)})
+        return [vectors_by_input[text] for text in inputs]
+
+    monkeypatch.setattr(embeddings, "_request_embeddings", fake_request)
+    return calls
+
+
+def test_embed_text_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+    calls = _fake_response(monkeypatch, {"hello": [0.1, 0.2, 0.3]})
+    assert embeddings.embed_text("hello") == [0.1, 0.2, 0.3]
+    assert calls[0]["base_url"] == "http://litellm:4000"  # trailing slash stripped
+    assert calls[0]["inputs"] == ["hello"]
+
+
+def test_embed_batch_preserves_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+    _fake_response(monkeypatch, {"a": [1.0], "b": [2.0], "c": [3.0]})
+    assert embeddings.embed_batch(["a", "b", "c"]) == [[1.0], [2.0], [3.0]]
+
+
+def test_embed_batch_empty() -> None:
+    assert embeddings.embed_batch([]) == []
+
+
+# --- cache -----------------------------------------------------------------
+
+
+def test_cache_avoids_second_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+    calls = _fake_response(monkeypatch, {"x": [9.0]})
+    assert embeddings.embed_text("x") == [9.0]
+    assert embeddings.embed_text("x") == [9.0]
+    assert len(calls) == 1  # second call served from disk cache
+
+
+def test_cache_only_misses_hit_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+    calls = _fake_response(monkeypatch, {"a": [1.0], "b": [2.0]})
+    embeddings.embed_text("a")  # warm cache for "a"
+    calls.clear()
+    assert embeddings.embed_batch(["a", "b"]) == [[1.0], [2.0]]
+    assert calls[0]["inputs"] == ["b"]  # only the miss is requested
+
+
+# --- degradation -----------------------------------------------------------
+
+
+def test_request_failure_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+
+    def boom(*_a: Any, **_k: Any) -> list[list[float]]:
+        raise RuntimeError("proxy down")
+
+    monkeypatch.setattr(embeddings, "_request_embeddings", boom)
+    assert embeddings.embed_text("y") is None
+    assert embeddings.embed_batch(["y", "z"]) == [None, None]
+
+
+def test_count_mismatch_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+
+    def short(base_url: str, key: str, model: str, inputs: list[str]) -> list[list[float]]:
+        return [[1.0]]  # one vector for two inputs
+
+    monkeypatch.setattr(embeddings, "_request_embeddings", short)
+    assert embeddings.embed_batch(["one", "two"]) == [None, None]
+
+
+def test_no_proxy_batch_all_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # proxy intentionally unset by the autouse fixture
+    assert embeddings.embed_batch(["p", "q"]) == [None, None]
+
+
+# --- response parsing ------------------------------------------------------
+
+
+def test_request_parses_openai_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_request_embeddings`` sorts by ``index`` and unwraps embeddings."""
+    captured: dict[str, Any] = {}
+
+    class _Resp:
+        def raise_for_status(self) -> None: ...
+
+        def json(self) -> dict:
+            return {
+                "data": [
+                    {"embedding": [2.0], "index": 1},
+                    {"embedding": [1.0], "index": 0},
+                ]
+            }
+
+    def fake_post(url: str, **kwargs: Any) -> _Resp:
+        captured["url"] = url
+        captured["json"] = kwargs["json"]
+        captured["headers"] = kwargs["headers"]
+        return _Resp()
+
+    monkeypatch.setattr(embeddings.httpx, "post", fake_post)
+    out = embeddings._request_embeddings("http://litellm:4000", "sk-test", "m", ["a", "b"])
+    assert out == [[1.0], [2.0]]  # reordered by index
+    assert captured["url"] == "http://litellm:4000/v1/embeddings"
+    assert captured["json"] == {"model": "m", "input": ["a", "b"]}
+    assert captured["headers"]["Authorization"] == "Bearer sk-test"

--- a/packages/decepticon/tests/unit/skillogy/test_embeddings.py
+++ b/packages/decepticon/tests/unit/skillogy/test_embeddings.py
@@ -44,7 +44,7 @@ def test_available_with_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_embed_dim_defaults_and_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
-    assert embeddings.embed_model() == "text-embedding-3-small"
+    assert embeddings.embed_model() == "openai/text-embedding-3-small"
     assert embeddings.embed_dim() == 1536
     monkeypatch.setenv("DECEPTICON_SKILLOGY_EMBED_MODEL", "text-embedding-3-large")
     assert embeddings.embed_dim() == 3072

--- a/packages/decepticon/tests/unit/skillogy/test_embeddings.py
+++ b/packages/decepticon/tests/unit/skillogy/test_embeddings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import httpx
 import pytest
 
 from decepticon.skillogy import embeddings
@@ -66,8 +67,12 @@ def _fake_response(
     """Patch the HTTP call to echo deterministic vectors and record calls."""
     calls: list[dict] = []
 
-    def fake_request(base_url: str, key: str, model: str, inputs: list[str]) -> list[list[float]]:
-        calls.append({"base_url": base_url, "key": key, "model": model, "inputs": list(inputs)})
+    def fake_request(
+        base_url: str, key: str, model: str, inputs: list[str], **kwargs: Any
+    ) -> list[list[float]]:
+        calls.append(
+            {"base_url": base_url, "key": key, "model": model, "inputs": list(inputs), **kwargs}
+        )
         return [vectors_by_input[text] for text in inputs]
 
     monkeypatch.setattr(embeddings, "_request_embeddings", fake_request)
@@ -129,7 +134,9 @@ def test_request_failure_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_count_mismatch_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_proxy(monkeypatch)
 
-    def short(base_url: str, key: str, model: str, inputs: list[str]) -> list[list[float]]:
+    def short(
+        base_url: str, key: str, model: str, inputs: list[str], **kwargs: Any
+    ) -> list[list[float]]:
         return [[1.0]]  # one vector for two inputs
 
     monkeypatch.setattr(embeddings, "_request_embeddings", short)
@@ -149,6 +156,9 @@ def test_request_parses_openai_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
     class _Resp:
+        status_code = 200
+        headers: dict[str, str] = {}
+
         def raise_for_status(self) -> None: ...
 
         def json(self) -> dict:
@@ -171,3 +181,96 @@ def test_request_parses_openai_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["url"] == "http://litellm:4000/v1/embeddings"
     assert captured["json"] == {"model": "m", "input": ["a", "b"]}
     assert captured["headers"]["Authorization"] == "Bearer sk-test"
+
+
+# --- retry / backoff -------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(
+        self, status_code: int, *, body: dict | None = None, retry_after: str | None = None
+    ):
+        self.status_code = status_code
+        self._body = body or {"data": [{"embedding": [1.0], "index": 0}]}
+        self.headers = {"Retry-After": retry_after} if retry_after else {}
+        self.request = httpx.Request("POST", "http://litellm:4000/v1/embeddings")
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("err", request=self.request, response=self)  # type: ignore[arg-type]
+
+    def json(self) -> dict:
+        return self._body
+
+
+def test_retry_then_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(embeddings.time, "sleep", lambda s: sleeps.append(s))
+    responses = iter([_FakeResp(429), _FakeResp(503), _FakeResp(200)])
+    monkeypatch.setattr(embeddings.httpx, "post", lambda *a, **k: next(responses))
+    out = embeddings._request_embeddings("http://litellm:4000", "sk", "m", ["x"])
+    assert out == [[1.0]]
+    assert sleeps == [1.0, 2.0]  # exponential backoff before each retry
+
+
+def test_retry_honours_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(embeddings.time, "sleep", lambda s: sleeps.append(s))
+    responses = iter([_FakeResp(429, retry_after="5"), _FakeResp(200)])
+    monkeypatch.setattr(embeddings.httpx, "post", lambda *a, **k: next(responses))
+    embeddings._request_embeddings("http://litellm:4000", "sk", "m", ["x"])
+    assert sleeps == [5.0]
+
+
+def test_retry_exhausted_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(embeddings.httpx, "post", lambda *a, **k: _FakeResp(429))
+    with pytest.raises(httpx.HTTPStatusError):
+        embeddings._request_embeddings("http://litellm:4000", "sk", "m", ["x"])
+
+
+def test_backoff_is_capped_and_rides_full_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistent 429s back off exponentially but capped, spanning ~a rate
+    window before giving up — and a 429 masked as 500 is still retried."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(embeddings.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(embeddings.httpx, "post", lambda *a, **k: _FakeResp(500))
+    with pytest.raises(httpx.HTTPStatusError):
+        embeddings._request_embeddings("http://litellm:4000", "sk", "m", ["x"])
+    # _MAX_ATTEMPTS-1 sleeps, exponential then capped at _BACKOFF_CAP
+    assert sleeps == [1.0, 2.0, 4.0, 8.0, 16.0]
+    assert all(s <= embeddings._BACKOFF_CAP for s in sleeps)
+    assert sum(sleeps) >= 30.0  # patient enough for a rate window
+
+
+def test_non_retryable_4xx_raises_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def post(*_a: Any, **_k: Any) -> _FakeResp:
+        calls.append(1)
+        return _FakeResp(401)
+
+    monkeypatch.setattr(embeddings.httpx, "post", post)
+    with pytest.raises(httpx.HTTPStatusError):
+        embeddings._request_embeddings("http://litellm:4000", "sk", "m", ["x"])
+    assert len(calls) == 1  # 401 is not retried
+
+
+def test_batch_degrades_on_retry_exhaustion(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_proxy(monkeypatch)
+    monkeypatch.setattr(embeddings.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(embeddings.httpx, "post", lambda *a, **k: _FakeResp(429))
+    assert embeddings.embed_batch(["a", "b"]) == [None, None]
+
+
+def test_query_embed_text_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Query-time embed_text must NOT use the patient ingest retry budget — a
+    sustained rate limit fails fast (≤ _QUERY_MAX_ATTEMPTS-1 sleeps) → None →
+    find_skill falls back to lexical without blocking the agent."""
+    _set_proxy(monkeypatch)
+    sleeps: list[float] = []
+    monkeypatch.setattr(embeddings.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(embeddings.httpx, "post", lambda *a, **k: _FakeResp(429))
+    assert embeddings.embed_text("a live query") is None
+    assert len(sleeps) == embeddings._QUERY_MAX_ATTEMPTS - 1  # far fewer than ingest
+    assert len(sleeps) < embeddings._MAX_ATTEMPTS - 1

--- a/packages/decepticon/tests/unit/skillogy/test_find_skill_fusion.py
+++ b/packages/decepticon/tests/unit/skillogy/test_find_skill_fusion.py
@@ -1,0 +1,72 @@
+"""Unit tests for the reciprocal-rank fusion in hybrid find_skill (ADR-0011).
+
+``_rrf_fuse`` is the pure-Python core of hybrid retrieval — it merges the
+lexical and semantic ranked legs without touching Neo4j, so we can pin its
+behaviour deterministically. The cypher legs themselves are covered by live
+verification against a running graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from decepticon.skillogy.server.neo4j_backend import Neo4jBackend
+
+
+def _rec(name: str, path: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "name": name,
+        "path": path,
+        "subdomain": "web",
+        "description": f"desc {name}",
+        "matched_mitre": [],
+        "matched_tags": [],
+        **extra,
+    }
+
+
+def test_found_by_both_legs_outranks_single_leg() -> None:
+    # "shared" is rank-2 in lexical and rank-1 in semantic → highest fused.
+    lexical = [_rec("a", "/a"), _rec("shared", "/shared")]
+    semantic = [_rec("shared", "/shared", score=0.9), _rec("b", "/b", score=0.5)]
+    out = Neo4jBackend._rrf_fuse(lexical, semantic, limit=10)
+    assert out[0]["path"] == "/shared"
+    assert {r["path"] for r in out} == {"/a", "/shared", "/b"}
+
+
+def test_score_field_stripped() -> None:
+    semantic = [_rec("s", "/s", score=0.9)]
+    out = Neo4jBackend._rrf_fuse([], semantic, limit=10)
+    assert out == [_rec("s", "/s")]
+    assert "score" not in out[0]
+
+
+def test_respects_limit() -> None:
+    lexical = [_rec(f"n{i}", f"/n{i}") for i in range(5)]
+    out = Neo4jBackend._rrf_fuse(lexical, [], limit=3)
+    assert len(out) == 3
+    # lexical order preserved when there is no semantic leg
+    assert [r["path"] for r in out] == ["/n0", "/n1", "/n2"]
+
+
+def test_deterministic_tiebreak_by_name() -> None:
+    # Two skills each found once at the same rank → equal score, name breaks tie.
+    lexical = [_rec("zebra", "/z")]
+    semantic = [_rec("apple", "/a", score=0.9)]
+    out = Neo4jBackend._rrf_fuse(lexical, semantic, limit=10)
+    assert [r["name"] for r in out] == ["apple", "zebra"]
+
+
+def test_empty_both_legs() -> None:
+    assert Neo4jBackend._rrf_fuse([], [], limit=10) == []
+
+
+def test_dedup_keeps_first_seen_record() -> None:
+    # Same path in both legs: the lexical record (seen first) is kept, so the
+    # output shape is the score-free one.
+    lexical = [_rec("dup", "/dup", description="lexical desc")]
+    semantic = [_rec("dup", "/dup", score=0.9, description="semantic desc")]
+    out = Neo4jBackend._rrf_fuse(lexical, semantic, limit=10)
+    assert len(out) == 1
+    assert out[0]["description"] == "lexical desc"
+    assert "score" not in out[0]


### PR DESCRIPTION
## Summary

Implements **ADR-0011** — `find_skill` now uses **LightRAG-style hybrid retrieval** (lexical substring + semantic vector k-NN, fused with reciprocal-rank fusion) over the existing skillogy graph, so an agent can describe a situation in natural language and get the right domain skills even with zero keyword overlap.

Semantic search is an **opt-in upgrade with graceful degradation**: with no embedding provider configured, `find_skill` returns the byte-for-byte legacy substring result.

## What's included

- **`embeddings.py`** — litellm-proxy-backed embedding client. Disk cache, context-split retry (patient for ingest, fail-fast for query), model-aware input sha. Returns `None` (→ lexical fallback) when unavailable; never raises.
- **`embed_ingest.py` + `neo4j_backend` primitives** — boot-time backfill: `ensure_vector_index` / `fetch_skills_for_embedding` / `write_embeddings`. Incremental by `model+text` sha (re-embed only changed/missing skills). The `skills.cypher` dump stays embedding-free so a model swap is a re-embed, not a corpus rebuild.
- **Hybrid `find_skill`** — lexical leg + vector leg (`db.index.vector.queryNodes`), structured filters + ADR-0008 ACL applied to both, RRF fusion. Legacy behaviour preserved when embeddings absent.
- **Wiring** — `openai/text-embedding-3-small` (default) + `voyage/voyage-3` + `gemini/gemini-embedding-001` litellm routes; skillogy compose service gets the proxy env + `depends_on: litellm (healthy)`; `httpx` added to the skillogy image.

## Live verification (real container + real Voyage + real LLM)

Verified end-to-end against a freshly-built skillogy container, a real Neo4j 5.26, real Voyage embeddings via litellm, and a real `auth/claude-haiku` agent:

- Container boot: corpus ingest (6346 cypher stmts) → vector index ONLINE → **278/278 skills embedded** (incremental recovery across restarts; **0 re-embed when unchanged**).
- REST `find_skill` semantic quality: paraphrases with no keyword overlap return the right skills (e.g. "read internal cloud metadata via a vulnerable URL fetcher" → `ssrf` → `ssrf-to-rce` → `cloud/imds-pivot`).
- **LLM agent end-to-end**: given an SSRF scenario, the model autonomously `find_skill`→`load_skill`'d `exploit/web/ssrf` + `cloud/imds-pivot` and produced situation-specific tradecraft citing the loaded skills.

Two real bugs were caught by the container/agent verification that unit tests missed:
1. skillogy image was missing `httpx` → embeddings silently skipped in-container.
2. ingest-tuned patient retry leaked into the query path → `find_skill` exceeded the REST client timeout → agent got nothing. Fixed by splitting retry policy (fail-fast at query time).

## Infra notes

- Embeddings persist as Neo4j node properties in the **named `neo4j_data` volume** → survive restart/reboot; only the external (Voyage) work is one-time/incremental. The structural cypher MERGE replays each boot (idempotent, local, zero external cost; disable with `SKILLOGY_AUTO_INGEST=0` once seeded).
- The cypher emitter uses per-property `SET` and the Skill node props exclude `embedding`, so re-ingest never wipes vectors (verified: 0 re-embed on a clean restart).

See `docs/adr/0011-skillogy-lightrag-hybrid-retrieval.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
