### PR TITLE
chore(deps): bump langchain to >=1.3.9 (GHSA-gr75-jv2w-4656)

### DIFF
--- a/packages/decepticon/pyproject.toml
+++ b/packages/decepticon/pyproject.toml
@@ -77,8 +77,10 @@ dependencies = [
     # leave on older versions:
     #   cryptography — GHSA-537c-gmf6-5ccf (fixed 48.0.1)
     #   starlette    — CVE-2026-48818 / -48817 / -54283 / -54282 (fixed ≤1.3.1)
+    #   langchain    — GHSA-gr75-jv2w-4656 (fixed 1.3.9)
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
+    "langchain>=1.3.9",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -478,6 +478,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
@@ -526,6 +527,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "langchain", specifier = ">=1.3.9" },
     { name = "langchain-anthropic", specifier = ">=0.3.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3.0" },
@@ -1161,16 +1163,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.7"
+version = "1.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/9e/9354114081622b077e215a3ce66be6231cbe80ee022cdd7b30056749a2c5/langchain-1.3.7.tar.gz", hash = "sha256:49e1dd3a4ec96a09a2d901b5de4cf8cc69cf6bc41be76d9a838ad67a2af7982c", size = 621124, upload-time = "2026-06-10T18:20:35.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7c/651d0dc4913a7a892156c03dd343b99cfe19ee729e6911ab1f4fe7567b8b/langchain-1.3.9.tar.gz", hash = "sha256:9b14ef0db9ef314299ded858b22ca2a40b8f1b05c8c9cb6b82d53a53075fef00", size = 631514, upload-time = "2026-06-12T16:53:27.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/b8/12d4dce378eff231ef6a5db751380607b15d4b1feeb3397fbec043bf5f5e/langchain-1.3.7-py3-none-any.whl", hash = "sha256:7f6e13f6681068e3fb2323f9905c1f41da261c02f55337e23250de3e51d1f325", size = 131429, upload-time = "2026-06-10T18:20:33.069Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/55/3481619d21b9bdfbfda8680fba5cfc6cfe926789b8eaaad95353078cfa20/langchain-1.3.9-py3-none-any.whl", hash = "sha256:4af49ad1095799e4408b489fb79d4b8b49292453618b202d8a697fca59bb6871", size = 132873, upload-time = "2026-06-12T16:53:25.489Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pip-audit (blocking) flags **langchain 1.3.7** (transitive) for **GHSA-gr75-jv2w-4656**, fixed in **1.3.9**. Adds a security floor next to the existing cryptography/starlette pins and regenerates `uv.lock` (1.3.7 → 1.3.9).

This is a **repo-wide CI blocker** — the advisory fails the `CI OK` gate on every open PR (e.g. #695) until langchain is bumped. Merging this unblocks them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)