### PR TITLE
feat(launcher): clearer 2-step Claude token issuance (link + paste)

### DIFF
--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -34,6 +34,10 @@ func init() {
 	rootCmd.AddCommand(onboardCmd)
 }
 
+// claudeSetupTokenDocsURL is the official Claude Code page covering
+// `claude setup-token` (mint a long-lived 1-year OAuth token for headless use).
+const claudeSetupTokenDocsURL = "https://code.claude.com/docs/en/authentication"
+
 // AuthMethod identifiers — must match decepticon/llm/models.py::AuthMethod.
 const (
 	methodAnthropicOAuth  = "anthropic_oauth"
@@ -339,8 +343,20 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		// credentials from an interactive `claude` login.
 		huh.NewGroup(
 			huh.NewNote().
-				Title("Claude Code Subscription (long-lived token)").
-				Description("Run `claude setup-token` (browser OAuth, needs a\nPro/Max/Team/Enterprise plan) → paste the 1-year\ntoken below. Headless-safe: never refreshed, no live\nClaude Code session needed. Or leave blank to use a\nrotating ~/.claude/.credentials.json from `claude` login."),
+				Title("Claude Code Subscription — 1-year token").
+				Description(
+					"Two steps:\n\n"+
+						"1) Generate a 1-year token — run:\n"+
+						"      claude setup-token\n"+
+						"   (opens browser OAuth; needs a Pro / Max / Team /\n"+
+						"   Enterprise plan). Docs / issue link:\n"+
+						"   "+claudeSetupTokenDocsURL+"\n\n"+
+						"2) Paste the sk-ant-oat01-… token it prints into the\n"+
+						"   field below.\n\n"+
+						"Headless-safe: never refreshed, no live Claude Code\n"+
+						"session. Leave blank to use a rotating\n"+
+						"~/.claude/.credentials.json from a `claude` login.",
+				),
 			huh.NewInput().
 				Title("ANTHROPIC_OAUTH_TOKEN").
 				Placeholder("sk-ant-oat01-...   (leave blank to use credentials file)").


### PR DESCRIPTION
## What
Refines the Claude Code OAuth onboard step (added in #697) into an explicit **two-step** flow, per request:

1. **Generate** a 1-year token — `claude setup-token` (browser OAuth) with the official docs/issue link `https://code.claude.com/docs/en/authentication`.
2. **Paste** the printed `sk-ant-oat01-…` token.

Adds a `claudeSetupTokenDocsURL` constant for the link.

## Why
The previous note only mentioned the command inline. This makes the issuance link + paste step unmistakable in the wizard when "Claude Code OAuth" is selected.

## Notes
- There is no standalone web page that mints a Claude Code OAuth token — `claude setup-token` (CLI) is the documented issuance path; the URL is the docs/help page. The command itself opens the browser OAuth flow.
- Behavior unchanged: blank input still falls back to `~/.claude/.credentials.json`.

## Verification
`go build ./...`, `go vet`, `gofmt -l` clean, `go test ./cmd/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)