### PR TITLE
feat(telemetry): wire RoE in-scope targets into the research masker

### DIFF
--- a/packages/decepticon/decepticon/middleware/event_logging.py
+++ b/packages/decepticon/decepticon/middleware/event_logging.py
@@ -150,6 +150,28 @@ def _last_human_text(messages: Any) -> str:
     return ""
 
 
+def _roe_literal_targets(workspace: str) -> list[str]:
+    """Literal in-scope hosts/IPs from ``<workspace>/plan/roe.json``.
+
+    These are the engagement's actual authorized targets — ground truth that the
+    research masker masks with certainty, covering identifiers the generic PII
+    detectors miss (bare hostnames, NetBIOS names). CIDRs and domain globs are
+    skipped (the detectors handle the concrete hosts under them).
+    """
+    import json
+    from pathlib import Path
+
+    from decepticon_core.types.roe import MachineEnforcement
+
+    try:
+        data = json.loads((Path(workspace) / "plan" / "roe.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    block = data.get("machine_enforcement") if isinstance(data, dict) else None
+    rules = MachineEnforcement.from_dict(block)
+    return [r.pattern for r in rules.in_scope if r.resolved_kind() in ("ip", "host")]
+
+
 class EventLogMiddleware(AgentMiddleware):
     """Emit compact engagement events to ``events.jsonl`` as the agent runs.
 
@@ -168,6 +190,8 @@ class EventLogMiddleware(AgentMiddleware):
         # Consent-gated maintainer telemetry. Shared no-op sink when disabled
         # (the default), so this adds zero behavior unless the user opts in.
         self._telemetry = get_sink()
+        # Workspaces whose RoE targets have already been fed to the masker.
+        self._roe_seen: set[str] = set()
 
     # ── scope + log resolution ────────────────────────────────────────────
 
@@ -302,11 +326,24 @@ class EventLogMiddleware(AgentMiddleware):
     # action / observation to the telemetry sink, which MASKS target identifiers
     # before anything leaves the machine. No-op (and no extraction cost) otherwise.
 
+    def _ensure_roe_known(self, workspace: str) -> None:
+        """Once per workspace, feed the masker the RoE in-scope literal targets."""
+        if workspace in self._roe_seen:
+            return
+        self._roe_seen.add(workspace)
+        try:
+            targets = _roe_literal_targets(workspace)
+        except Exception:  # noqa: BLE001 — never break the run on a bad RoE file
+            targets = []
+        if targets:
+            self._telemetry.add_known_targets(targets)
+
     def _emit_trajectory_model(self, request: Any, response: Any) -> None:
         if not self._telemetry.research:
             return
         try:
-            _workspace, _engagement, agent = self._resolve_scope(request)
+            workspace, _engagement, agent = self._resolve_scope(request)
+            self._ensure_roe_known(workspace)
             prompt = _msg_text(_last_human_text(getattr(request, "messages", None)))[
                 :_TRAJ_TEXT_CAP
             ]
@@ -325,7 +362,8 @@ class EventLogMiddleware(AgentMiddleware):
         try:
             import json
 
-            _workspace, _engagement, agent = self._resolve_scope(request)
+            workspace, _engagement, agent = self._resolve_scope(request)
+            self._ensure_roe_known(workspace)
             tool = getattr(getattr(request, "tool", None), "name", "") or ""
             args = getattr(request, "tool_call_args", None) or {}
             try:

--- a/packages/decepticon/decepticon/telemetry/redact.py
+++ b/packages/decepticon/decepticon/telemetry/redact.py
@@ -130,6 +130,18 @@ class Redactor:
             ("DOMAIN", _regex_detector(_DOMAIN)),
         ]
 
+    def add_known(self, targets: list[str]) -> None:
+        """Add engagement-known targets (RoE scope / discovered hosts).
+
+        These are masked with certainty by exact match — covering identifiers no
+        detector catches (bare Windows hostnames like ``dc01``, NetBIOS names,
+        internal codenames). Re-sorted longest-first so a subdomain is replaced
+        before its parent.
+        """
+        merged = set(self._known)
+        merged.update(t for t in targets if t)
+        self._known = sorted(merged, key=len, reverse=True)
+
     def _placeholder(self, value: str, ptype: str) -> str:
         existing = self._map.get(value)
         if existing is not None:

--- a/packages/decepticon/decepticon/telemetry/sink.py
+++ b/packages/decepticon/decepticon/telemetry/sink.py
@@ -118,6 +118,16 @@ class TelemetrySink:
     # text fields a trajectory step may carry — masked in place, never bucketed.
     _STEP_TEXT_FIELDS = ("prompt", "reasoning", "observation", "args_text")
 
+    def add_known_targets(self, targets: list[str]) -> None:
+        """Feed the session masker the engagement's known targets (RoE scope).
+
+        Lets the redactor mask the *actual* targets with certainty — covering
+        identifiers the generic detectors miss. No-op unless research is active.
+        """
+        if self._exporter is None or not self._research or not targets:
+            return
+        self._redactor.add_known(targets)
+
     def record_step(self, step: dict[str, Any], agent: str | None = None) -> None:
         """Record an identifier-MASKED reasoning/trajectory step (RESEARCH only).
 

--- a/packages/decepticon/tests/unit/telemetry/test_telemetry_redact.py
+++ b/packages/decepticon/tests/unit/telemetry/test_telemetry_redact.py
@@ -48,6 +48,18 @@ def test_known_targets_masked_with_certainty() -> None:
     assert "dc01" not in out and "fileserver" not in out
 
 
+def test_add_known_closes_the_detector_gap() -> None:
+    # Without a known list, a bare NetBIOS-style host LEAKS (no detector catches it).
+    leaky = Redactor()
+    assert "WIN-A8F3K2" in leaky.redact("pivot to WIN-A8F3K2")
+    # Feeding the RoE target masks it with certainty.
+    r = Redactor()
+    r.add_known(["WIN-A8F3K2", "dc01"])
+    out = r.redact("pivot to WIN-A8F3K2, then dc01")
+    assert "WIN-A8F3K2" not in out and "dc01" not in out
+    assert "<HOST_1>" in out and "<HOST_2>" in out
+
+
 def test_does_not_over_mask_harmless_text() -> None:
     r = Redactor()
     keep = "connect web:8080 set mode:fast decepticon v1.2.3 x86_64 ran T1190 CWE-89 step 7"

--- a/packages/decepticon/tests/unit/telemetry/test_telemetry_sink.py
+++ b/packages/decepticon/tests/unit/telemetry/test_telemetry_sink.py
@@ -118,6 +118,28 @@ def test_record_step_stable_across_steps() -> None:
     assert "<IP_1>" in evs[0]["reasoning"] and "<IP_1>" in evs[1]["observation"]
 
 
+def test_add_known_targets_masks_bare_host_in_step() -> None:
+    sent: list[dict[str, Any]] = []
+    sink = TelemetrySink(
+        _cfg(TelemetryMode.RESEARCH, "https://gw.example"),
+        transport=lambda _u, b: sent.append(json.loads(b)),
+    )
+    sink.add_known_targets(["dc01"])  # an RoE target no detector would catch
+    sink.record_step({"kind": "model", "reasoning": "kerberoast dc01 for the hash"}, "ad")
+    sink.close()
+    ev = sent[0]["events"][0]
+    blob = json.dumps(sent)
+    assert "dc01" not in blob  # masked with certainty
+    assert "<HOST_1>" in ev["reasoning"] and "kerberoast" in ev["reasoning"]  # tactic kept
+
+
+def test_add_known_targets_is_research_only() -> None:
+    sink = TelemetrySink(
+        _cfg(TelemetryMode.BASIC, "https://gw.example"), transport=lambda _u, _b: None
+    )
+    sink.add_known_targets(["dc01"])  # no-op under basic; must not raise
+
+
 def test_preview_returns_exact_payload() -> None:
     sink = TelemetrySink(
         _cfg(TelemetryMode.BASIC, "https://gw.example"), transport=lambda _u, _b: None


### PR DESCRIPTION
## What

Feeds the engagement's **own authorized targets** (RoE `in_scope` literal hosts from `<workspace>/plan/roe.json`) into the research-tier identifier masker, so they are masked with **certainty** — closing the gap where a generic PII detector can't catch a target.

This is the highest-confidence masking layer and the one no PII library ships (Presidio/LangChain/regex all miss it): it's the engagement's **domain ground truth** — *what is actually being attacked* — which only Decepticon knows.

## The gap it closes

| target | detectors (regex/NER) | + RoE known |
|---|---|---|
| `10.0.0.5` | ✅ IP | ✅ |
| `app.corp.internal` | ✅ domain | ✅ |
| **`dc01`** (bare Windows hostname, no TLD) | ❌ **leaks** | ✅ masked |
| **`WIN-A8F3K2`** (NetBIOS) | ❌ **leaks** | ✅ masked |
| internal codename | ❌ **leaks** | ✅ masked |

## How

- `Redactor.add_known(targets)` — extend the stable known-set (longest-first).
- `TelemetrySink.add_known_targets()` — research-only; feeds the session masker.
- `EventLogMiddleware` extracts RoE `in_scope` literal ip/host rules once per workspace (reusing `decepticon_core` `MachineEnforcement`) and feeds them before capturing a trajectory step. CIDRs/globs are left to the detectors (the concrete hosts under them get caught).

## ✅ Live verification (per repo policy)

A workspace whose `roe.json` lists `dc01` as `in_scope` drove a **real `EventLogMiddleware` (research)** → running gateway → PostHog:

```json
{ "event": "trajectory.step",
  "prompt": "Objective: own the domain controller <HOST_1>",
  "reasoning": "Kerberoast <HOST_1> to get the service hash, then exploit <IP_1> and pivot back to <HOST_1>." }
```

`dc01` → `<HOST_1>` (stable across prompt + reasoning), tactics intact (Kerberoast, service hash, pivot), and `dc01` **ABSENT** from the forwarded payload — even though no PII detector would ever flag a bare hostname. `_roe_literal_targets` correctly extracted `['dc01']` from the RoE.

## Tests

`telemetry` + `event_logging` **70 passed** · `ruff` + `basedpyright` (0 errors) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)