### PR TITLE
feat(launcher): opt-in usage-telemetry consent in onboard wizard

### DIFF
--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -253,6 +253,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		language            = "en"
 		useLangSmith        bool
 		langSmithKey        string
+		telemetryChoice     = "off"
 	)
 	// Block on the probe (zero-value result on timeout means
 	// "unreachable" — drops through to the remediation Note).
@@ -846,6 +847,31 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 				Validate(nonEmpty),
 		).Title("5 / 5  ·  LangSmith").
 			WithHideFunc(func() bool { return !useLangSmith }),
+
+		// Step 5c: anonymous usage telemetry (opt-in)
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Share anonymous usage telemetry? (optional)").
+				Description(
+					"Help improve Decepticon. Opt-in, and your IP is never stored.\n\n"+
+						"  basic     anonymous stats only (tools used, finding severity/CWE,\n"+
+						"            kill-chain phase) — no prompts, no targets.\n"+
+						"  research  basic + the red-team REASONING (the agent's tactics and\n"+
+						"            rationale), captured to help train future autonomous\n"+
+						"            red-team agents. Target identifiers are MASKED\n"+
+						"            (10.0.0.5 -> <HOST_1>); real targets/creds never leave.\n\n"+
+						"Never sent at any tier: raw prompts, target IPs/hosts, credentials.\n"+
+						"Change anytime: `decepticon-cli telemetry off`, or DO_NOT_TRACK=1.",
+				),
+			huh.NewSelect[string]().
+				Title("Usage telemetry").
+				Options(
+					huh.NewOption("No — share nothing (default)", "off"),
+					huh.NewOption("Basic — anonymous structural stats only", "basic"),
+					huh.NewOption("Research — basic + masked red-team reasoning", "research"),
+				).
+				Value(&telemetryChoice),
+		).Title("5 / 5  ·  Usage telemetry"),
 	).WithTheme(huh.ThemeFunc(ui.DecepticonTheme))
 
 	if err := form.Run(); err != nil {
@@ -1002,6 +1028,11 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		values["LANGSMITH_PROJECT"] = "decepticon"
 	}
 
+	// Anonymous usage telemetry consent. Only sends when a gateway endpoint is
+	// configured (DECEPTICON_TELEMETRY_ENDPOINT, shipped in .env.example); an
+	// unset endpoint keeps it dormant even when the user opted in.
+	values["DECEPTICON_TELEMETRY"] = telemetryChoice
+
 	if err := config.WriteEnvFromEmbed(config.EnvPath(), values); err != nil {
 		return fmt.Errorf("write .env: %w", err)
 	}
@@ -1016,6 +1047,9 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	fmt.Println(ui.Dim.Render("  │") + ui.Cyan.Render("  Language  ") + ui.Dim.Render(language))
 	if useLangSmith {
 		fmt.Println(ui.Dim.Render("  │") + ui.Cyan.Render("  LangSmith ") + ui.Green.Render("enabled"))
+	}
+	if telemetryChoice != "off" {
+		fmt.Println(ui.Dim.Render("  │") + ui.Cyan.Render("  Telemetry ") + ui.Green.Render(telemetryChoice))
 	}
 	fmt.Println(ui.Dim.Render("  │"))
 	fmt.Println(ui.Dim.Render("  │  ") + ui.Dim.Render(config.EnvPath()))

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -391,6 +391,25 @@ DECEPTICON_MODEL_PROFILE=eco
 	}
 }
 
+func TestTelemetryConsentWritesEnv(t *testing.T) {
+	// The onboard wizard writes the telemetry consent choice via the embedded
+	// env.example. Verify the key is in the template and the choice lands.
+	out := filepath.Join(t.TempDir(), ".env")
+	if err := WriteEnvFromEmbed(out, map[string]string{"DECEPTICON_TELEMETRY": "research"}); err != nil {
+		t.Fatalf("WriteEnvFromEmbed() error: %v", err)
+	}
+	env, err := LoadEnv(out)
+	if err != nil {
+		t.Fatalf("LoadEnv() error: %v", err)
+	}
+	if env["DECEPTICON_TELEMETRY"] != "research" {
+		t.Errorf("DECEPTICON_TELEMETRY = %q, want %q", env["DECEPTICON_TELEMETRY"], "research")
+	}
+	if _, ok := env["DECEPTICON_TELEMETRY_ENDPOINT"]; !ok {
+		t.Error("DECEPTICON_TELEMETRY_ENDPOINT missing from embedded template")
+	}
+}
+
 func TestWriteEnv_CommentedOutLines(t *testing.T) {
 	dir := t.TempDir()
 	tmplPath := filepath.Join(dir, ".env.example")

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -185,6 +185,16 @@ LANGSMITH_TRACING=false
 LANGSMITH_API_KEY=your-langsmith-key-here
 LANGSMITH_PROJECT=decepticon
 
+# --- Anonymous usage telemetry (optional, opt-in) ---
+# off | basic | research. The onboard wizard sets this. `basic` shares
+# anonymous structural stats; `research` adds the identifier-masked red-team
+# reasoning corpus. Raw prompts/targets/credentials are never sent; the IP is
+# dropped at the gateway. DO_NOT_TRACK=1 forces off. See TELEMETRY.md.
+# Nothing is sent unless DECEPTICON_TELEMETRY_ENDPOINT is also set (the
+# maintainer's collection gateway URL — left blank in OSS until deployed).
+DECEPTICON_TELEMETRY=off
+DECEPTICON_TELEMETRY_ENDPOINT=
+
 # --- Ports (optional) ---
 # LANGGRAPH_PORT=2024
 # LITELLM_PORT=4000


### PR DESCRIPTION
## What

Adds the **first-run consent step** that makes OSS usage telemetry actually *activatable* — the missing piece between the telemetry client + gateway (#701 / #702) and real collection.

A new **"Usage telemetry"** step in the `decepticon` onboard wizard lets the user choose **off / basic / research**, with a plain-language disclosure:

```
  basic     anonymous stats only (tools used, finding severity/CWE, phase)
            — no prompts, no targets.
  research  basic + the red-team REASONING (tactics + rationale) to help
            train future autonomous red-team agents. Target identifiers are
            MASKED (10.0.0.5 -> <HOST_1>); real targets/creds never leave.
```

## How

- `onboard.go`: a telemetry `Select` group → writes `DECEPTICON_TELEMETRY` to `.env` + a summary line.
- `env.example`: `DECEPTICON_TELEMETRY=off` (opt-in default) + `DECEPTICON_TELEMETRY_ENDPOINT=` (the maintainer's gateway URL — blank in OSS until deployed).

**Opt-in and fail-safe**: default `off`; an opted-in user still sends **nothing** until `DECEPTICON_TELEMETRY_ENDPOINT` is set (i.e. until the maintainer deploys the gateway); `telemetry off` / `DO_NOT_TRACK=1` always disable.

## ✅ Live verification (per repo policy)

The **real `WriteEnvFromEmbed`** (the function `onboard` calls) was driven with a `research` choice and produced a `.env` containing `DECEPTICON_TELEMETRY=research` with the endpoint key present — proving the consent→`.env` path end-to-end (the form itself is interactive TTY; the env-write is the deterministic, verifiable half). Captured as `TestTelemetryConsentWritesEnv`.

`go vet ./...` + `go test ./...` (launcher lane) pass.

## Remaining for activation (maintainer ops)

Deploy the gateway (`wrangler deploy` + PostHog) and set the official `DECEPTICON_TELEMETRY_ENDPOINT` default in `env.example`. Until then this ships safely dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)