### PR TITLE
feat(backends): route sandbox endpoint from per-run config (shared-process multi-tenancy)

### DIFF
--- a/packages/decepticon/decepticon/backends/factory.py
+++ b/packages/decepticon/decepticon/backends/factory.py
@@ -28,10 +28,55 @@ import os
 
 from decepticon.backends.http_sandbox import HTTPSandbox
 
+_DEFAULT_SANDBOX_URL = "http://localhost:9999"
 
-@functools.lru_cache(maxsize=8)
+
+# maxsize is sized for the multi-tenant case: a single shared langgraph
+# process can serve many concurrent engagements, each routed to its own
+# per-engagement sandbox (distinct base_url/token). Each must keep its own
+# HTTPSandbox so the SandboxNotificationMiddleware ``_jobs`` view stays
+# consistent within a run; under-sizing this would evict a live run's client
+# mid-flight. 128 covers realistic per-process concurrency with headroom.
+@functools.lru_cache(maxsize=128)
 def _shared_sandbox(base_url: str, token: str | None) -> HTTPSandbox:
     return HTTPSandbox(base_url=base_url, token=token)
+
+
+def _resolve_endpoint() -> tuple[str, str | None]:
+    """Resolve the sandbox ``(base_url, token)``, preferring per-run config.
+
+    A SHARED langgraph process serving many engagements cannot reach a
+    *per-engagement* sandbox through a single process-wide env var. So we first
+    consult the current run's LangGraph config — ``configurable.sandbox_url`` /
+    ``configurable.sandbox_token``, which the caller sets per invocation — and
+    fall back to the ``SAAS_SANDBOX_*`` env vars. The env path still covers the
+    single-tenant / silo / dev deployments (one sandbox per process) and
+    module-import-time construction, where there is no active run context.
+
+    The config keys are deployment-agnostic; nothing here is SaaS-specific.
+    """
+    url: str | None = None
+    token: str | None = None
+    try:
+        # get_config() exposes the current run's RunnableConfig via contextvars
+        # while a graph node executes. It raises RuntimeError outside a runnable
+        # context (e.g. import-time agent construction) — fall back to env then.
+        from langgraph.config import get_config
+
+        configurable = (get_config() or {}).get("configurable") or {}
+        raw_url = configurable.get("sandbox_url")
+        raw_token = configurable.get("sandbox_token")
+        url = raw_url if isinstance(raw_url, str) and raw_url else None
+        token = raw_token if isinstance(raw_token, str) and raw_token else None
+    except Exception:
+        # No active run context, or langgraph config unavailable — use env.
+        pass
+
+    if url is None:
+        url = os.environ.get("SAAS_SANDBOX_URL", _DEFAULT_SANDBOX_URL)
+    if token is None:
+        token = os.environ.get("SAAS_SANDBOX_TOKEN") or None
+    return url, token
 
 
 def build_sandbox_backend() -> HTTPSandbox:
@@ -45,11 +90,17 @@ def build_sandbox_backend() -> HTTPSandbox:
     graph sees a different ``_jobs`` view than the bash tool actually
     registers against — completion notifications never reach the agent.
     Keying by ``(base_url, token)`` keeps tests that monkeypatch the env
-    isolated and supports multi-tenant SaaS deployments where pools
-    target distinct daemons.
+    isolated and supports multi-tenant SaaS deployments where a shared
+    process routes each run to a distinct per-engagement daemon.
+
+    Endpoint resolution (see ``_resolve_endpoint``): the current run's
+    LangGraph ``configurable.sandbox_url`` / ``sandbox_token`` win when
+    present, so a shared process can fan out to per-engagement sandboxes;
+    otherwise the ``SAAS_SANDBOX_*`` env vars apply (single-tenant / silo
+    / dev).
 
     Returns:
-        An ``HTTPSandbox`` instance pointed at the daemon URL.
+        An ``HTTPSandbox`` instance pointed at the resolved daemon URL.
 
     Env:
         SAAS_SANDBOX_URL
@@ -60,6 +111,5 @@ def build_sandbox_backend() -> HTTPSandbox:
             Optional bearer token for daemon auth — recommended even on
             loopback as defence-in-depth.
     """
-    base_url = os.environ.get("SAAS_SANDBOX_URL", "http://localhost:9999")
-    token = os.environ.get("SAAS_SANDBOX_TOKEN") or None
+    base_url, token = _resolve_endpoint()
     return _shared_sandbox(base_url, token)

--- a/packages/decepticon/tests/unit/backends/test_factory.py
+++ b/packages/decepticon/tests/unit/backends/test_factory.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 import pytest
 
 from decepticon.backends import build_sandbox_backend
-from decepticon.backends.factory import _shared_sandbox
+from decepticon.backends.factory import _resolve_endpoint, _shared_sandbox
 
 
 @pytest.fixture(autouse=True)
@@ -71,3 +71,90 @@ def test_build_sandbox_backend_keys_on_token(
     b = build_sandbox_backend()
 
     assert a is not b
+
+
+# ── per-run config routing ────────────────────────────────────────────────
+
+
+def _patch_get_config(
+    monkeypatch: pytest.MonkeyPatch, value: object, *, raises: bool = False
+) -> None:
+    """Patch ``langgraph.config.get_config`` (imported lazily inside factory)."""
+    import langgraph.config as lgc
+
+    def fake() -> object:
+        if raises:
+            raise RuntimeError("Called get_config outside of a runnable context")
+        return value
+
+    monkeypatch.setattr(lgc, "get_config", fake)
+
+
+def test_resolve_endpoint_prefers_run_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shared process routes by the current run's configurable, not env."""
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.setenv("SAAS_SANDBOX_TOKEN", "env-token")
+    _patch_get_config(
+        monkeypatch,
+        {"configurable": {"sandbox_url": "http://eng-42:9999", "sandbox_token": "tok-42"}},
+    )
+
+    assert _resolve_endpoint() == ("http://eng-42:9999", "tok-42")
+
+
+def test_resolve_endpoint_falls_back_to_env_outside_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No runnable context (import-time / silo / dev) → env wins, no crash."""
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.setenv("SAAS_SANDBOX_TOKEN", "env-token")
+    _patch_get_config(monkeypatch, None, raises=True)
+
+    assert _resolve_endpoint() == ("http://env-sandbox:9999", "env-token")
+
+
+def test_resolve_endpoint_env_when_config_lacks_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run config without sandbox_* keys falls back to env per-field."""
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.delenv("SAAS_SANDBOX_TOKEN", raising=False)
+    _patch_get_config(monkeypatch, {"configurable": {"thread_id": "t1"}})
+
+    assert _resolve_endpoint() == ("http://env-sandbox:9999", None)
+
+
+def test_resolve_endpoint_default_url_when_nothing_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No config, no env → loopback default (sidecar / sibling container)."""
+    monkeypatch.delenv("SAAS_SANDBOX_URL", raising=False)
+    monkeypatch.delenv("SAAS_SANDBOX_TOKEN", raising=False)
+    _patch_get_config(monkeypatch, None, raises=True)
+
+    assert _resolve_endpoint() == ("http://localhost:9999", None)
+
+
+def test_build_sandbox_backend_routes_per_run_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two runs with distinct configurable sandboxes get distinct instances."""
+    monkeypatch.delenv("SAAS_SANDBOX_URL", raising=False)
+    monkeypatch.delenv("SAAS_SANDBOX_TOKEN", raising=False)
+
+    _patch_get_config(
+        monkeypatch,
+        {"configurable": {"sandbox_url": "http://eng-a:9999", "sandbox_token": "a"}},
+    )
+    a = build_sandbox_backend()
+
+    _patch_get_config(
+        monkeypatch,
+        {"configurable": {"sandbox_url": "http://eng-b:9999", "sandbox_token": "b"}},
+    )
+    b = build_sandbox_backend()
+
+    assert a is not b
+    assert a._base_url != b._base_url

--- a/packages/decepticon/tests/unit/backends/test_factory.py
+++ b/packages/decepticon/tests/unit/backends/test_factory.py
@@ -158,3 +158,41 @@ def test_build_sandbox_backend_routes_per_run_config(
 
     assert a is not b
     assert a._base_url != b._base_url
+
+
+# ── end-to-end: routing inside a real LangGraph run ───────────────────────
+
+
+def test_build_sandbox_backend_reads_configurable_inside_a_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside an ACTUAL langgraph run, build_sandbox_backend() must pick up the
+    run's configurable.sandbox_url/token via get_config().
+
+    This is the integration link the unit tests stub: it proves a SHARED
+    langgraph process routes each run to its own sandbox purely from the
+    per-invocation config, with env present but overridden.
+    """
+    from langgraph.graph import END, START, StateGraph
+
+    # Env points elsewhere; the run config must win.
+    monkeypatch.setenv("SAAS_SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.setenv("SAAS_SANDBOX_TOKEN", "env-token")
+
+    seen: dict[str, str | None] = {}
+
+    def node(state: dict) -> dict:
+        sb = build_sandbox_backend()
+        seen["url"] = sb._base_url
+        seen["token"] = sb._token
+        return {}
+
+    graph = StateGraph(dict).add_node("n", node).add_edge(START, "n").add_edge("n", END).compile()
+
+    graph.invoke(
+        {},
+        {"configurable": {"sandbox_url": "http://eng-99:9999", "sandbox_token": "tok-99"}},
+    )
+
+    assert seen["url"] == "http://eng-99:9999"
+    assert seen["token"] == "tok-99"


### PR DESCRIPTION
## Why
`build_sandbox_backend()` resolved the daemon `(base_url, token)` from the `SAAS_SANDBOX_*` env vars **only** — a single process-wide target. That hard-wires a 1:1 langgraph-process → sandbox topology: a **shared** langgraph process serving many engagements cannot reach a **per-engagement** sandbox.

This blocks the SaaS multi-tenant target architecture: keep **langgraph/skillogy shared** (they only orchestrate / serve read-only skills) and isolate just the **sandbox** (where offensive tooling actually executes + touches the target) per engagement.

## What
`_resolve_endpoint()` now prefers the **current run's LangGraph config** — `configurable.sandbox_url` / `configurable.sandbox_token`, set by the caller per `invoke`/`stream` — and falls back to `SAAS_SANDBOX_*` env.

`get_config()` raises outside a runnable context (import-time agent construction; dev / silo single-tenant), and the `try/except` treats that as "no per-run override → use env". So **every existing deployment is unchanged** (sidecar pool, GCE silo VM, local-docker, dev all keep env-based resolution).

- `_shared_sandbox` lru_cache `8 → 128`: concurrent per-engagement clients on one process must not evict each other mid-run (that would desync the `SandboxNotificationMiddleware._jobs` view).
- Config keys are deployment-agnostic — no SaaS-specific types cross into core (open-core boundary preserved).

## Tests
8/8 pass. 3 existing env tests unchanged + 5 new: config-wins-over-env, env-fallback-when-outside-run, per-field fallback, loopback default, distinct instances per run config. `ruff check` + `ruff format` clean.

## Consumer (SaaS, separate change)
The SaaS web passes `configurable: { sandbox_url, sandbox_token }` per engagement run, and provisions a per-engagement sandbox-only VM/container instead of a full-stack silo.