### PR TITLE
feat(launcher): set deployed telemetry gateway as default endpoint

### DIFF
--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -193,7 +193,7 @@ LANGSMITH_PROJECT=decepticon
 # Nothing is sent unless DECEPTICON_TELEMETRY_ENDPOINT is also set (the
 # maintainer's collection gateway URL — left blank in OSS until deployed).
 DECEPTICON_TELEMETRY=off
-DECEPTICON_TELEMETRY_ENDPOINT=
+DECEPTICON_TELEMETRY_ENDPOINT=https://decepticon-telemetry-gateway.purpleailab.workers.dev/v1/telemetry
 
 # --- Ports (optional) ---
 # LANGGRAPH_PORT=2024


### PR DESCRIPTION
## What

The OSS telemetry collection gateway is **deployed** (Cloudflare Worker → PostHog). This sets its URL as the default `DECEPTICON_TELEMETRY_ENDPOINT` so that, **from the next release on**, users who opt into telemetry at onboard (`basic`/`research`) actually reach it.

Endpoint: `https://decepticon-telemetry-gateway.purpleailab.workers.dev/v1/telemetry`

Still **opt-in**: `DECEPTICON_TELEMETRY` defaults to `off`; `DO_NOT_TRACK` / `telemetry off` disable.

## ✅ Live verification (production, end-to-end)

Against the deployed gateway → PostHog (project 479014):

| check | result |
|---|---|
| `GET /` health | **200** |
| clean basic batch | **202** |
| masked trajectory.step | **202** — stored in PostHog as `"login at <DOMAIN_1> on <IP_1> looks injectable; try UNION SQLi"` (tier=R, reasoning intact) |
| trajectory.step with raw `10.0.0.5` in reasoning | **422** rejected, never forwarded |
| PostHog leak check | `10.0.0.5` / `app.corp.internal` **absent** |

The full chain — client masking → gateway Tier-C re-verify + IP drop → PostHog — works in production with the attacker reasoning preserved and zero target leak.

## After merge

Tag a release; opted-in users on that release send identifier-masked telemetry to the gateway. (Gateway is persistent infra — already deployed, no per-release deploy needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)