### PR TITLE
feat(telemetry): per-engagement session_id on every event + purpose-aligned dashboard

### DIFF
--- a/packages/decepticon/decepticon/middleware/event_logging.py
+++ b/packages/decepticon/decepticon/middleware/event_logging.py
@@ -45,7 +45,7 @@ from langchain_core.messages import ToolMessage
 from typing_extensions import override
 
 from decepticon.runtime.event_log import EventLog, EventType
-from decepticon.telemetry.sink import get_sink
+from decepticon.telemetry.sink import get_sink, session_id_for
 
 log = logging.getLogger(__name__)
 
@@ -151,11 +151,10 @@ def _last_human_text(messages: Any) -> str:
 
 
 def _session_id(engagement: str | None) -> str:
-    """A stable per-engagement session id (hashed — the engagement name may carry
-    a client/org name, so it is never sent raw). Groups one engagement's steps."""
-    import hashlib
-
-    return hashlib.sha256((engagement or "").encode("utf-8")).hexdigest()[:16]
+    """A stable per-engagement session id. Delegates to the telemetry canonical
+    :func:`session_id_for` so the middleware, OPPLAN, and finding tools all hash
+    the engagement name identically (the grouping key must agree everywhere)."""
+    return session_id_for(engagement)
 
 
 def _roe_literal_targets(workspace: str) -> list[str]:
@@ -228,13 +227,19 @@ class EventLogMiddleware(AgentMiddleware):
             agent_name = getattr(runtime, "agent_name", "") or ""
         return str(workspace), str(engagement), (agent_name or None)
 
-    def _context(self, request: Any) -> tuple[EventLog | None, str | None]:
-        """Resolve (and lazily build/cache) the EventLog plus the agent name."""
+    def _context(self, request: Any) -> tuple[EventLog | None, str | None, str]:
+        """Resolve the EventLog, agent name, and per-engagement session id.
+
+        ``session_id`` is hashed from the engagement so every telemetry event —
+        not only research trajectory steps — carries the engagement grouping key
+        (enables per-engagement analytics: kill-chain depth, tools/engagement).
+        """
         workspace, engagement, agent = self._resolve_scope(request)
+        sid = _session_id(engagement)
         key = (workspace, engagement)
         cached = self._logs.get(key)
         if cached is not None:
-            return cached, agent
+            return cached, agent, sid
         try:
             event_log = EventLog.for_workspace(workspace, engagement)
         except Exception:  # noqa: BLE001 — never break the agent on a bad path
@@ -245,9 +250,9 @@ class EventLogMiddleware(AgentMiddleware):
                 engagement,
                 exc_info=True,
             )
-            return None, agent
+            return None, agent, sid
         self._logs[key] = event_log
-        return event_log, agent
+        return event_log, agent, sid
 
     def _safe_append(
         self,
@@ -255,6 +260,7 @@ class EventLogMiddleware(AgentMiddleware):
         event_type: EventType,
         payload: dict[str, Any],
         agent: str | None,
+        session_id: str | None = None,
     ) -> None:
         """Append one event, swallowing any I/O failure with a warning."""
         try:
@@ -268,12 +274,14 @@ class EventLogMiddleware(AgentMiddleware):
         # Mirror the same redacted event to the consent-gated telemetry sink.
         # `record` is itself fail-closed and never raises, so disk logging and
         # telemetry stay independent — one failing never affects the other.
-        self._telemetry.record(getattr(event_type, "value", str(event_type)), payload, agent)
+        self._telemetry.record(
+            getattr(event_type, "value", str(event_type)), payload, agent, session_id=session_id
+        )
 
     # ── payload builders ──────────────────────────────────────────────────
 
     def _emit_llm_call(self, request: Any) -> None:
-        event_log, agent = self._context(request)
+        event_log, agent, sid = self._context(request)
         if event_log is None:
             return
         messages = getattr(request, "messages", None) or []
@@ -281,10 +289,10 @@ class EventLogMiddleware(AgentMiddleware):
         payload: dict[str, Any] = {"messages": len(messages)}
         if model_name:
             payload["model"] = model_name
-        self._safe_append(event_log, EventType.LLM_CALL, payload, agent)
+        self._safe_append(event_log, EventType.LLM_CALL, payload, agent, sid)
 
     def _emit_llm_response(self, request: Any, response: Any) -> None:
-        event_log, agent = self._context(request)
+        event_log, agent, sid = self._context(request)
         if event_log is None:
             return
         payload: dict[str, Any] = {}
@@ -296,20 +304,20 @@ class EventLogMiddleware(AgentMiddleware):
             stop = metadata.get("finish_reason") or metadata.get("stop_reason")
             if stop:
                 payload["stop"] = stop
-        self._safe_append(event_log, EventType.LLM_RESPONSE, payload, agent)
+        self._safe_append(event_log, EventType.LLM_RESPONSE, payload, agent, sid)
 
     def _emit_tool_call(self, request: Any) -> None:
-        event_log, agent = self._context(request)
+        event_log, agent, sid = self._context(request)
         if event_log is None:
             return
         tool = getattr(request, "tool", None)
         tool_name = getattr(tool, "name", "") if tool else ""
         args = getattr(request, "tool_call_args", None) or {}
         payload = {"tool": tool_name, "args": _redact_args(args)}
-        self._safe_append(event_log, EventType.TOOL_CALL, payload, agent)
+        self._safe_append(event_log, EventType.TOOL_CALL, payload, agent, sid)
 
     def _emit_tool_result(self, request: Any, response: Any) -> None:
-        event_log, agent = self._context(request)
+        event_log, agent, sid = self._context(request)
         if event_log is None:
             return
         tool = getattr(request, "tool", None)
@@ -321,17 +329,19 @@ class EventLogMiddleware(AgentMiddleware):
                 "status": status,
                 "output_chars": _content_length(getattr(response, "content", "")),
             }
-            self._safe_append(event_log, EventType.TOOL_RESULT, payload, agent)
+            self._safe_append(event_log, EventType.TOOL_RESULT, payload, agent, sid)
             # Emit the finding only after a *successful* finding-tool result, so
             # a failed validate_finding (status='error') never births a phantom
             # finding.created. Order stays tool.call -> tool.result -> finding.
             if status not in {"error"} and _is_finding_tool(tool_name):
-                self._safe_append(event_log, EventType.FINDING_CREATED, {"tool": tool_name}, agent)
+                self._safe_append(
+                    event_log, EventType.FINDING_CREATED, {"tool": tool_name}, agent, sid
+                )
         else:
             # A Command (graph control-flow) carries no tool output to size, and
             # is not a tool *result*, so it never emits a finding.
             payload = {"tool": tool_name, "status": "command"}
-            self._safe_append(event_log, EventType.TOOL_RESULT, payload, agent)
+            self._safe_append(event_log, EventType.TOOL_RESULT, payload, agent, sid)
 
     # ── research trajectory capture (reasoning corpus) ────────────────────
     # Only runs under research consent. Emits the raw prompt / agent reasoning /

--- a/packages/decepticon/decepticon/telemetry/sink.py
+++ b/packages/decepticon/decepticon/telemetry/sink.py
@@ -55,8 +55,22 @@ class TelemetrySink:
             "events": events,
         }
 
-    def record(self, event_type: str, payload: dict[str, Any], agent: str | None = None) -> None:
-        """Sanitize and enqueue one event. No-op when disabled; never raises."""
+    def record(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+        agent: str | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Sanitize and enqueue one event. No-op when disabled; never raises.
+
+        ``session_id`` is the per-engagement hash (from :func:`session_id_for`).
+        Stamping it onto every event — not just trajectory steps — lets the
+        analytics backend group an install's events *by engagement* (kill-chain
+        depth, tools-per-engagement, reach) instead of conflating every
+        engagement that ran on one machine under ``install_id``.
+        """
         if self._exporter is None:
             return
         try:
@@ -65,6 +79,9 @@ class TelemetrySink:
             )
             if ev is None:
                 return
+            # Engagement grouping key — a hash, never the raw engagement name.
+            if session_id:
+                ev["session_id"] = session_id
             # Fail-closed: if anything in the mapped event still looks like Tier-C
             # content, drop it rather than ship it.
             if scan_tier_c(ev) is not None:
@@ -84,6 +101,7 @@ class TelemetrySink:
         confidence: str | None = None,
         detected: bool | None = None,
         agent: str | None = None,
+        session_id: str | None = None,
     ) -> None:
         """Record a validated finding's GROUND-TRUTH classification.
 
@@ -106,14 +124,22 @@ class TelemetrySink:
             payload["confidence"] = confidence
         if detected is not None:
             payload["detected"] = "yes" if detected else "no"
-        self.record("finding.created", payload, agent)
+        self.record("finding.created", payload, agent, session_id=session_id)
 
-    def record_phase(self, phase: str, status: str, agent: str | None = None) -> None:
+    def record_phase(
+        self,
+        phase: str,
+        status: str,
+        agent: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
         """Record an OPPLAN objective phase + status — where the engagement is.
 
         Ground truth from the OPPLAN tracker (``ObjectivePhase`` / status). Tier A.
         """
-        self.record("opplan.update", {"phase": phase, "status": status}, agent)
+        self.record(
+            "opplan.update", {"phase": phase, "status": status}, agent, session_id=session_id
+        )
 
     def add_known_targets(self, targets: list[str]) -> None:
         """Feed the session masker the engagement's known targets (RoE scope).
@@ -178,6 +204,19 @@ def _now() -> float:
     import time
 
     return time.time()
+
+
+def session_id_for(engagement: str | None) -> str:
+    """Stable per-engagement session id (sha256[:16]).
+
+    The engagement name may carry a client/org name, so it is **never** sent
+    raw — this hash is the grouping key shared by every event of one engagement
+    (trajectory steps, tool calls, findings, OPPLAN phases). Canonical home for
+    the hash so the middleware and the OPPLAN/finding tools all agree.
+    """
+    import hashlib
+
+    return hashlib.sha256((engagement or "").encode("utf-8")).hexdigest()[:16]
 
 
 # ── process-wide lazy singleton (what middleware uses) ───────────────────────

--- a/packages/decepticon/decepticon/tools/opplan.py
+++ b/packages/decepticon/decepticon/tools/opplan.py
@@ -393,9 +393,10 @@ def build_opplan_tools(backend: BackendProtocol | None = None) -> list:
         # Ground-truth telemetry: which kill-chain phase the engagement is
         # working — no objective text/target. No-op unless telemetry is on.
         try:
-            from decepticon.telemetry.sink import get_sink
+            from decepticon.telemetry.sink import get_sink, session_id_for
 
-            get_sink().record_phase(getattr(phase, "value", str(phase)), "pending")
+            sid = session_id_for(engagement_name or state.get("engagement_name", ""))
+            get_sink().record_phase(getattr(phase, "value", str(phase)), "pending", session_id=sid)
         except Exception:  # noqa: BLE001 — telemetry must never break the tool
             pass
 

--- a/packages/decepticon/tests/unit/telemetry/test_telemetry_sink.py
+++ b/packages/decepticon/tests/unit/telemetry/test_telemetry_sink.py
@@ -61,6 +61,45 @@ def test_research_sink_tags_tier_r() -> None:
     assert env["events"][0]["tool"] == "nmap"
 
 
+def test_session_id_stamped_on_every_event_type() -> None:
+    """The engagement grouping key lands on ALL events (tool/finding/opplan),
+    not only research trajectory steps — so analytics can group by engagement."""
+    sent: list[dict[str, Any]] = []
+    sink = TelemetrySink(
+        _cfg(TelemetryMode.BASIC, "https://gw.example"),
+        transport=lambda _u, b: sent.append(json.loads(b)),
+    )
+    sid = "319acd0f8933b872"
+    sink.record("tool.call", {"tool": "nmap"}, "recon", session_id=sid)
+    sink.record_finding(severity="high", cwe=["CWE-89"], agent="exploit", session_id=sid)
+    sink.record_phase("recon", "pending", "decepticon", session_id=sid)
+    sink.close()
+
+    events = [e for env in sent for e in env["events"]]
+    assert {e["type"] for e in events} == {"tool.call", "finding.created", "opplan.update"}
+    assert all(e.get("session_id") == sid for e in events), events
+
+
+def test_session_id_omitted_when_not_provided() -> None:
+    sent: list[dict[str, Any]] = []
+    sink = TelemetrySink(
+        _cfg(TelemetryMode.BASIC, "https://gw.example"),
+        transport=lambda _u, b: sent.append(json.loads(b)),
+    )
+    sink.record("tool.call", {"tool": "nmap"}, "recon")  # no session_id
+    sink.close()
+    assert "session_id" not in sent[0]["events"][0]
+
+
+def test_session_id_for_is_stable_non_reversible_hash() -> None:
+    from decepticon.telemetry.sink import session_id_for
+
+    a = session_id_for("acme-corp-pentest")
+    assert a == session_id_for("acme-corp-pentest")  # stable
+    assert len(a) == 16 and a != session_id_for("other-engagement")  # distinct
+    assert "acme" not in a  # never the raw engagement name
+
+
 def test_fail_closed_drops_tier_c_leak() -> None:
     sent: list[bytes] = []
     sink = TelemetrySink(

--- a/telemetry-gateway/build_dashboard.py
+++ b/telemetry-gateway/build_dashboard.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Rebuild the PostHog dashboard into a purpose-aligned view:
+   *How OSS users use the Decepticon red-team harness, and what tactics they run.*
+
+Replaces the generic v1 dashboard with three sections:
+  Usage  — adoption, kill-chain reach, engagement depth, attack surface
+  Tactics— MITRE techniques, tools run, failure hotspots, finding/vuln classes
+  Corpus — the masked reasoning-trajectory training corpus (the gold)
+
+Engagement-level insights rely on `properties.session_id` now being stamped on
+every event (not just trajectory steps) — see feat/telemetry-session-everywhere.
+
+Auth: set -a; . ~/.decepticon/telemetry-deploy.env; set +a
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+HOST = os.environ.get("POSTHOG_HOST", "https://us.posthog.com").rstrip("/")
+PROJECT = os.environ["POSTHOG_CLI_PROJECT_ID"]
+KEY = os.environ["POSTHOG_CLI_API_KEY"]
+# Set OLD_DASHBOARD_ID to retire a previous dashboard (+ its insights) first.
+OLD_DASHBOARD_ID = os.environ.get("OLD_DASHBOARD_ID", "")
+
+
+def api(method: str, path: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{HOST}/api/projects/{PROJECT}{path}",
+        data=data,
+        headers={"content-type": "application/json", "authorization": f"Bearer {KEY}"},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:  # noqa: S310
+        raw = r.read()
+        return json.loads(raw) if raw else {}
+
+
+def hogql(sql: str) -> dict:
+    return {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": sql}}
+
+
+SID = "coalesce(toString(properties.session_id),'') != ''"
+
+INSIGHTS: list[tuple[str, str, str]] = [
+    # ── USAGE ────────────────────────────────────────────────────────────────
+    ("Usage · Engagements & installs per day",
+     "Daily distinct engagements (session_id) and installs — adoption & volume.",
+     f"""SELECT toStartOfDay(timestamp) AS day,
+       count(DISTINCT properties.session_id) AS engagements,
+       count(DISTINCT distinct_id) AS installs
+FROM events WHERE {SID}
+GROUP BY day ORDER BY day"""),
+
+    ("Usage · Kill-chain reach (engagements per phase)",
+     "How far engagements get — count of distinct engagements that reached each "
+     "kill-chain phase. The drop-off recon→exfiltration is the usage funnel.",
+     # Phase ordering lives in an outer query: ordering by multiIf() on the raw
+     # property in the same scope as GROUP BY trips HogQL's not-an-aggregate check.
+     """SELECT phase, engagements_reached FROM (
+  SELECT properties.phase AS phase,
+         count(DISTINCT properties.session_id) AS engagements_reached
+  FROM events WHERE event = 'opplan.update' AND coalesce(toString(properties.phase),'') != ''
+  GROUP BY phase
+) ORDER BY multiIf(phase='recon',1, phase='initial-access',2, phase='post-exploit',3,
+                   phase='c2',4, phase='exfiltration',5, 99)"""),
+
+    ("Usage · Engagement outcome — reached a finding",
+     "Share of engagements that produced at least one validated finding "
+     "(a proxy for end-to-end success).",
+     f"""SELECT
+  count(DISTINCT properties.session_id) AS engagements_total,
+  count(DISTINCT if(event='finding.created', properties.session_id, NULL)) AS engagements_with_finding,
+  round(100 * count(DISTINCT if(event='finding.created', properties.session_id, NULL))
+        / nullIf(count(DISTINCT properties.session_id),0), 1) AS pct_with_finding
+FROM events WHERE {SID}"""),
+
+    ("Usage · Engagement depth (events & tools each)",
+     "Per-engagement activity — total events, distinct tools, max trajectory step. "
+     "Separates quick scans from deep multi-tool engagements.",
+     f"""SELECT properties.session_id AS engagement,
+       count() AS events,
+       count(DISTINCT if(event='tool.call', properties.tool, NULL)) AS distinct_tools,
+       max(toInt(coalesce(toString(properties.step),'0'))) AS max_step
+FROM events WHERE {SID}
+GROUP BY engagement ORDER BY events DESC LIMIT 100"""),
+
+    ("Usage · Power users (engagements per install)",
+     "Engagements per install — one-off trials vs. repeat operators.",
+     f"""SELECT distinct_id AS install,
+       count(DISTINCT properties.session_id) AS engagements,
+       count() AS events
+FROM events WHERE {SID}
+GROUP BY install ORDER BY engagements DESC LIMIT 100"""),
+
+    ("Usage · Agent / attack-surface utilization",
+     "Which of the 16 specialists run (recon/web/AD/cloud/exploit…) — a proxy for "
+     "the attack surfaces users actually target.",
+     """SELECT properties.agent AS agent,
+       count() AS events,
+       count(DISTINCT properties.session_id) AS engagements
+FROM events WHERE coalesce(toString(properties.agent),'') != ''
+GROUP BY agent ORDER BY events DESC"""),
+
+    ("Usage · Model / provider mix",
+     "LLM models powering the agents.",
+     """SELECT properties.model AS model, count() AS llm_calls
+FROM events WHERE event='llm.call' AND coalesce(toString(properties.model),'') != ''
+GROUP BY model ORDER BY llm_calls DESC"""),
+
+    ("Usage · Version & OS adoption",
+     "Installed Decepticon version × OS — upgrade & platform-support signal.",
+     """SELECT properties.decepticon_version AS version, properties.os AS os,
+       count(DISTINCT distinct_id) AS installs
+FROM events GROUP BY version, os ORDER BY installs DESC"""),
+
+    # ── TACTICS ──────────────────────────────────────────────────────────────
+    ("Tactics · MITRE ATT&CK techniques",
+     "Techniques attached to validated findings — what users actually achieve.",
+     """SELECT replaceAll(arrayJoin(JSONExtractArrayRaw(
+         coalesce(toString(properties.mitre_techniques),'[]'))),'"','') AS technique,
+       count() AS findings
+FROM events WHERE event='finding.created'
+GROUP BY technique HAVING technique != '' ORDER BY findings DESC"""),
+
+    ("Tactics · Top tools executed (TTPs)",
+     "Most-run tools — the concrete techniques operators reach for.",
+     """SELECT properties.tool AS tool, count() AS calls,
+       count(DISTINCT properties.session_id) AS engagements
+FROM events WHERE event='tool.call' AND coalesce(toString(properties.tool),'') != ''
+GROUP BY tool ORDER BY calls DESC LIMIT 30"""),
+
+    ("Tactics · Tool failure hotspots (error rate)",
+     "Tools by error rate (≥3 results) — where the harness/tactics break, i.e. "
+     "where users struggle and what to harden.",
+     """SELECT properties.tool AS tool, count() AS results,
+       countIf(properties.status='error') AS errors,
+       round(100*countIf(properties.status='error')/nullIf(count(),0),1) AS error_pct
+FROM events WHERE event='tool.result' AND coalesce(toString(properties.tool),'') != ''
+GROUP BY tool HAVING results >= 3 ORDER BY error_pct DESC, results DESC LIMIT 30"""),
+
+    ("Tactics · Finding severity distribution",
+     "Severity of validated findings.",
+     """SELECT properties.severity AS severity, count() AS findings
+FROM events WHERE event='finding.created' AND coalesce(toString(properties.severity),'') != ''
+GROUP BY severity
+ORDER BY multiIf(severity='critical',1,severity='high',2,severity='medium',3,
+                 severity='low',4,severity='informational',5,99)"""),
+
+    ("Tactics · Vulnerability classes (CWE)",
+     "CWE classes of validated findings — what vuln types users find.",
+     """SELECT replaceAll(arrayJoin(JSONExtractArrayRaw(
+         coalesce(toString(properties.cwe),'[]'))),'"','') AS cwe,
+       count() AS findings
+FROM events WHERE event='finding.created'
+GROUP BY cwe HAVING cwe != '' ORDER BY findings DESC"""),
+
+    ("Tactics · Purple-team detection rate",
+     "Were findings detected by defenses (purple-team flag)?",
+     """SELECT properties.detected AS detected, count() AS findings
+FROM events WHERE event='finding.created' AND coalesce(toString(properties.detected),'') != ''
+GROUP BY detected"""),
+
+    # ── CORPUS (the reasoning gold) ──────────────────────────────────────────
+    ("Corpus · Reasoning steps by role over time",
+     "Masked trajectory steps/day split by role (human/agent/tool) — the training "
+     "corpus accumulating.",
+     """SELECT toStartOfDay(timestamp) AS day, properties.role AS role, count() AS steps
+FROM events WHERE event='trajectory.step' AND coalesce(toString(properties.role),'') != ''
+GROUP BY day, role ORDER BY day, role"""),
+
+    ("Corpus · Reasoning-chain depth per engagement",
+     "Length of the captured reason→act→observe chain per engagement.",
+     f"""SELECT properties.session_id AS engagement,
+       max(toInt(coalesce(toString(properties.step),'0'))) + 1 AS chain_steps,
+       count() AS captured_steps
+FROM events WHERE event='trajectory.step' AND {SID}
+GROUP BY engagement ORDER BY chain_steps DESC LIMIT 100"""),
+
+    ("Corpus · Reasoning volume by agent",
+     "Which specialists generate the most reasoning/tool turns in the corpus.",
+     """SELECT properties.agent AS agent, count() AS steps,
+       countIf(properties.role='agent') AS reasoning_turns,
+       countIf(properties.role='tool') AS tool_turns
+FROM events WHERE event='trajectory.step' AND coalesce(toString(properties.agent),'') != ''
+GROUP BY agent ORDER BY steps DESC"""),
+]
+
+
+def main() -> int:
+    # 1. Retire the generic v1 dashboard + its insights.
+    if OLD_DASHBOARD_ID:
+        try:
+            old = api("GET", f"/dashboards/{OLD_DASHBOARD_ID}/")
+            for tile in old.get("tiles", []):
+                iid = (tile.get("insight") or {}).get("id")
+                if iid:
+                    api("PATCH", f"/insights/{iid}/", {"deleted": True})
+            api("PATCH", f"/dashboards/{OLD_DASHBOARD_ID}/", {"deleted": True})
+            print(f"retired old dashboard {OLD_DASHBOARD_ID} (+{len(old.get('tiles', []))} insights)")
+        except Exception as e:  # noqa: BLE001
+            print(f"(skip old-dashboard cleanup: {e})")
+
+    # 2. New dashboard.
+    dash = api("POST", "/dashboards/", {
+        "name": "Decepticon — OSS Usage & Tactics",
+        "description": "How OSS users use the red-team harness and what tactics they "
+                       "run. Sections: Usage / Tactics / Corpus. Populates as opted-in "
+                       "telemetry arrives from released clients.",
+    })
+    did = dash["id"]
+
+    # 3. Insights linked to it (creation order = tile order).
+    for name, desc, sql in INSIGHTS:
+        ins = api("POST", "/insights/", {
+            "name": name, "description": desc,
+            "query": hogql(sql), "dashboards": [did],
+        })
+        print(f"  + [{ins.get('id')}] {name}")
+
+    # 4. Verify.
+    got = api("GET", f"/dashboards/{did}/")
+    tiles = got.get("tiles", [])
+    print(f"\ndashboard: {got.get('name')}  (id={did})  tiles={len(tiles)}")
+    print(f"URL: {HOST}/project/{PROJECT}/dashboard/{did}")
+    assert len(tiles) == len(INSIGHTS), f"expected {len(INSIGHTS)} tiles, got {len(tiles)}"
+    print("OK — all insights linked.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/telemetry-gateway/build_dashboard.py
+++ b/telemetry-gateway/build_dashboard.py
@@ -12,6 +12,7 @@ every event (not just trajectory steps) — see feat/telemetry-session-everywher
 
 Auth: set -a; . ~/.decepticon/telemetry-deploy.env; set +a
 """
+
 from __future__ import annotations
 
 import json
@@ -46,146 +47,164 @@ SID = "coalesce(toString(properties.session_id),'') != ''"
 
 INSIGHTS: list[tuple[str, str, str]] = [
     # ── USAGE ────────────────────────────────────────────────────────────────
-    ("Usage · Engagements & installs per day",
-     "Daily distinct engagements (session_id) and installs — adoption & volume.",
-     f"""SELECT toStartOfDay(timestamp) AS day,
+    (
+        "Usage · Engagements & installs per day",
+        "Daily distinct engagements (session_id) and installs — adoption & volume.",
+        f"""SELECT toStartOfDay(timestamp) AS day,
        count(DISTINCT properties.session_id) AS engagements,
        count(DISTINCT distinct_id) AS installs
 FROM events WHERE {SID}
-GROUP BY day ORDER BY day"""),
-
-    ("Usage · Kill-chain reach (engagements per phase)",
-     "How far engagements get — count of distinct engagements that reached each "
-     "kill-chain phase. The drop-off recon→exfiltration is the usage funnel.",
-     # Phase ordering lives in an outer query: ordering by multiIf() on the raw
-     # property in the same scope as GROUP BY trips HogQL's not-an-aggregate check.
-     """SELECT phase, engagements_reached FROM (
+GROUP BY day ORDER BY day""",
+    ),
+    (
+        "Usage · Kill-chain reach (engagements per phase)",
+        "How far engagements get — count of distinct engagements that reached each "
+        "kill-chain phase. The drop-off recon→exfiltration is the usage funnel.",
+        # Phase ordering lives in an outer query: ordering by multiIf() on the raw
+        # property in the same scope as GROUP BY trips HogQL's not-an-aggregate check.
+        """SELECT phase, engagements_reached FROM (
   SELECT properties.phase AS phase,
          count(DISTINCT properties.session_id) AS engagements_reached
   FROM events WHERE event = 'opplan.update' AND coalesce(toString(properties.phase),'') != ''
   GROUP BY phase
 ) ORDER BY multiIf(phase='recon',1, phase='initial-access',2, phase='post-exploit',3,
-                   phase='c2',4, phase='exfiltration',5, 99)"""),
-
-    ("Usage · Engagement outcome — reached a finding",
-     "Share of engagements that produced at least one validated finding "
-     "(a proxy for end-to-end success).",
-     f"""SELECT
+                   phase='c2',4, phase='exfiltration',5, 99)""",
+    ),
+    (
+        "Usage · Engagement outcome — reached a finding",
+        "Share of engagements that produced at least one validated finding "
+        "(a proxy for end-to-end success).",
+        f"""SELECT
   count(DISTINCT properties.session_id) AS engagements_total,
   count(DISTINCT if(event='finding.created', properties.session_id, NULL)) AS engagements_with_finding,
   round(100 * count(DISTINCT if(event='finding.created', properties.session_id, NULL))
         / nullIf(count(DISTINCT properties.session_id),0), 1) AS pct_with_finding
-FROM events WHERE {SID}"""),
-
-    ("Usage · Engagement depth (events & tools each)",
-     "Per-engagement activity — total events, distinct tools, max trajectory step. "
-     "Separates quick scans from deep multi-tool engagements.",
-     f"""SELECT properties.session_id AS engagement,
+FROM events WHERE {SID}""",
+    ),
+    (
+        "Usage · Engagement depth (events & tools each)",
+        "Per-engagement activity — total events, distinct tools, max trajectory step. "
+        "Separates quick scans from deep multi-tool engagements.",
+        f"""SELECT properties.session_id AS engagement,
        count() AS events,
        count(DISTINCT if(event='tool.call', properties.tool, NULL)) AS distinct_tools,
        max(toInt(coalesce(toString(properties.step),'0'))) AS max_step
 FROM events WHERE {SID}
-GROUP BY engagement ORDER BY events DESC LIMIT 100"""),
-
-    ("Usage · Power users (engagements per install)",
-     "Engagements per install — one-off trials vs. repeat operators.",
-     f"""SELECT distinct_id AS install,
+GROUP BY engagement ORDER BY events DESC LIMIT 100""",
+    ),
+    (
+        "Usage · Power users (engagements per install)",
+        "Engagements per install — one-off trials vs. repeat operators.",
+        f"""SELECT distinct_id AS install,
        count(DISTINCT properties.session_id) AS engagements,
        count() AS events
 FROM events WHERE {SID}
-GROUP BY install ORDER BY engagements DESC LIMIT 100"""),
-
-    ("Usage · Agent / attack-surface utilization",
-     "Which of the 16 specialists run (recon/web/AD/cloud/exploit…) — a proxy for "
-     "the attack surfaces users actually target.",
-     """SELECT properties.agent AS agent,
+GROUP BY install ORDER BY engagements DESC LIMIT 100""",
+    ),
+    (
+        "Usage · Agent / attack-surface utilization",
+        "Which of the 16 specialists run (recon/web/AD/cloud/exploit…) — a proxy for "
+        "the attack surfaces users actually target.",
+        """SELECT properties.agent AS agent,
        count() AS events,
        count(DISTINCT properties.session_id) AS engagements
 FROM events WHERE coalesce(toString(properties.agent),'') != ''
-GROUP BY agent ORDER BY events DESC"""),
-
-    ("Usage · Model / provider mix",
-     "LLM models powering the agents.",
-     """SELECT properties.model AS model, count() AS llm_calls
+GROUP BY agent ORDER BY events DESC""",
+    ),
+    (
+        "Usage · Model / provider mix",
+        "LLM models powering the agents.",
+        """SELECT properties.model AS model, count() AS llm_calls
 FROM events WHERE event='llm.call' AND coalesce(toString(properties.model),'') != ''
-GROUP BY model ORDER BY llm_calls DESC"""),
-
-    ("Usage · Version & OS adoption",
-     "Installed Decepticon version × OS — upgrade & platform-support signal.",
-     """SELECT properties.decepticon_version AS version, properties.os AS os,
+GROUP BY model ORDER BY llm_calls DESC""",
+    ),
+    (
+        "Usage · Version & OS adoption",
+        "Installed Decepticon version × OS — upgrade & platform-support signal.",
+        """SELECT properties.decepticon_version AS version, properties.os AS os,
        count(DISTINCT distinct_id) AS installs
-FROM events GROUP BY version, os ORDER BY installs DESC"""),
-
+FROM events GROUP BY version, os ORDER BY installs DESC""",
+    ),
     # ── TACTICS ──────────────────────────────────────────────────────────────
-    ("Tactics · MITRE ATT&CK techniques",
-     "Techniques attached to validated findings — what users actually achieve.",
-     """SELECT replaceAll(arrayJoin(JSONExtractArrayRaw(
+    (
+        "Tactics · MITRE ATT&CK techniques",
+        "Techniques attached to validated findings — what users actually achieve.",
+        """SELECT replaceAll(arrayJoin(JSONExtractArrayRaw(
          coalesce(toString(properties.mitre_techniques),'[]'))),'"','') AS technique,
        count() AS findings
 FROM events WHERE event='finding.created'
-GROUP BY technique HAVING technique != '' ORDER BY findings DESC"""),
-
-    ("Tactics · Top tools executed (TTPs)",
-     "Most-run tools — the concrete techniques operators reach for.",
-     """SELECT properties.tool AS tool, count() AS calls,
+GROUP BY technique HAVING technique != '' ORDER BY findings DESC""",
+    ),
+    (
+        "Tactics · Top tools executed (TTPs)",
+        "Most-run tools — the concrete techniques operators reach for.",
+        """SELECT properties.tool AS tool, count() AS calls,
        count(DISTINCT properties.session_id) AS engagements
 FROM events WHERE event='tool.call' AND coalesce(toString(properties.tool),'') != ''
-GROUP BY tool ORDER BY calls DESC LIMIT 30"""),
-
-    ("Tactics · Tool failure hotspots (error rate)",
-     "Tools by error rate (≥3 results) — where the harness/tactics break, i.e. "
-     "where users struggle and what to harden.",
-     """SELECT properties.tool AS tool, count() AS results,
+GROUP BY tool ORDER BY calls DESC LIMIT 30""",
+    ),
+    (
+        "Tactics · Tool failure hotspots (error rate)",
+        "Tools by error rate (≥3 results) — where the harness/tactics break, i.e. "
+        "where users struggle and what to harden.",
+        """SELECT properties.tool AS tool, count() AS results,
        countIf(properties.status='error') AS errors,
        round(100*countIf(properties.status='error')/nullIf(count(),0),1) AS error_pct
 FROM events WHERE event='tool.result' AND coalesce(toString(properties.tool),'') != ''
-GROUP BY tool HAVING results >= 3 ORDER BY error_pct DESC, results DESC LIMIT 30"""),
-
-    ("Tactics · Finding severity distribution",
-     "Severity of validated findings.",
-     """SELECT properties.severity AS severity, count() AS findings
+GROUP BY tool HAVING results >= 3 ORDER BY error_pct DESC, results DESC LIMIT 30""",
+    ),
+    (
+        "Tactics · Finding severity distribution",
+        "Severity of validated findings.",
+        """SELECT properties.severity AS severity, count() AS findings
 FROM events WHERE event='finding.created' AND coalesce(toString(properties.severity),'') != ''
 GROUP BY severity
 ORDER BY multiIf(severity='critical',1,severity='high',2,severity='medium',3,
-                 severity='low',4,severity='informational',5,99)"""),
-
-    ("Tactics · Vulnerability classes (CWE)",
-     "CWE classes of validated findings — what vuln types users find.",
-     """SELECT replaceAll(arrayJoin(JSONExtractArrayRaw(
+                 severity='low',4,severity='informational',5,99)""",
+    ),
+    (
+        "Tactics · Vulnerability classes (CWE)",
+        "CWE classes of validated findings — what vuln types users find.",
+        """SELECT replaceAll(arrayJoin(JSONExtractArrayRaw(
          coalesce(toString(properties.cwe),'[]'))),'"','') AS cwe,
        count() AS findings
 FROM events WHERE event='finding.created'
-GROUP BY cwe HAVING cwe != '' ORDER BY findings DESC"""),
-
-    ("Tactics · Purple-team detection rate",
-     "Were findings detected by defenses (purple-team flag)?",
-     """SELECT properties.detected AS detected, count() AS findings
+GROUP BY cwe HAVING cwe != '' ORDER BY findings DESC""",
+    ),
+    (
+        "Tactics · Purple-team detection rate",
+        "Were findings detected by defenses (purple-team flag)?",
+        """SELECT properties.detected AS detected, count() AS findings
 FROM events WHERE event='finding.created' AND coalesce(toString(properties.detected),'') != ''
-GROUP BY detected"""),
-
+GROUP BY detected""",
+    ),
     # ── CORPUS (the reasoning gold) ──────────────────────────────────────────
-    ("Corpus · Reasoning steps by role over time",
-     "Masked trajectory steps/day split by role (human/agent/tool) — the training "
-     "corpus accumulating.",
-     """SELECT toStartOfDay(timestamp) AS day, properties.role AS role, count() AS steps
+    (
+        "Corpus · Reasoning steps by role over time",
+        "Masked trajectory steps/day split by role (human/agent/tool) — the training "
+        "corpus accumulating.",
+        """SELECT toStartOfDay(timestamp) AS day, properties.role AS role, count() AS steps
 FROM events WHERE event='trajectory.step' AND coalesce(toString(properties.role),'') != ''
-GROUP BY day, role ORDER BY day, role"""),
-
-    ("Corpus · Reasoning-chain depth per engagement",
-     "Length of the captured reason→act→observe chain per engagement.",
-     f"""SELECT properties.session_id AS engagement,
+GROUP BY day, role ORDER BY day, role""",
+    ),
+    (
+        "Corpus · Reasoning-chain depth per engagement",
+        "Length of the captured reason→act→observe chain per engagement.",
+        f"""SELECT properties.session_id AS engagement,
        max(toInt(coalesce(toString(properties.step),'0'))) + 1 AS chain_steps,
        count() AS captured_steps
 FROM events WHERE event='trajectory.step' AND {SID}
-GROUP BY engagement ORDER BY chain_steps DESC LIMIT 100"""),
-
-    ("Corpus · Reasoning volume by agent",
-     "Which specialists generate the most reasoning/tool turns in the corpus.",
-     """SELECT properties.agent AS agent, count() AS steps,
+GROUP BY engagement ORDER BY chain_steps DESC LIMIT 100""",
+    ),
+    (
+        "Corpus · Reasoning volume by agent",
+        "Which specialists generate the most reasoning/tool turns in the corpus.",
+        """SELECT properties.agent AS agent, count() AS steps,
        countIf(properties.role='agent') AS reasoning_turns,
        countIf(properties.role='tool') AS tool_turns
 FROM events WHERE event='trajectory.step' AND coalesce(toString(properties.agent),'') != ''
-GROUP BY agent ORDER BY steps DESC"""),
+GROUP BY agent ORDER BY steps DESC""",
+    ),
 ]
 
 
@@ -199,25 +218,37 @@ def main() -> int:
                 if iid:
                     api("PATCH", f"/insights/{iid}/", {"deleted": True})
             api("PATCH", f"/dashboards/{OLD_DASHBOARD_ID}/", {"deleted": True})
-            print(f"retired old dashboard {OLD_DASHBOARD_ID} (+{len(old.get('tiles', []))} insights)")
+            print(
+                f"retired old dashboard {OLD_DASHBOARD_ID} (+{len(old.get('tiles', []))} insights)"
+            )
         except Exception as e:  # noqa: BLE001
             print(f"(skip old-dashboard cleanup: {e})")
 
     # 2. New dashboard.
-    dash = api("POST", "/dashboards/", {
-        "name": "Decepticon — OSS Usage & Tactics",
-        "description": "How OSS users use the red-team harness and what tactics they "
-                       "run. Sections: Usage / Tactics / Corpus. Populates as opted-in "
-                       "telemetry arrives from released clients.",
-    })
+    dash = api(
+        "POST",
+        "/dashboards/",
+        {
+            "name": "Decepticon — OSS Usage & Tactics",
+            "description": "How OSS users use the red-team harness and what tactics they "
+            "run. Sections: Usage / Tactics / Corpus. Populates as opted-in "
+            "telemetry arrives from released clients.",
+        },
+    )
     did = dash["id"]
 
     # 3. Insights linked to it (creation order = tile order).
     for name, desc, sql in INSIGHTS:
-        ins = api("POST", "/insights/", {
-            "name": name, "description": desc,
-            "query": hogql(sql), "dashboards": [did],
-        })
+        ins = api(
+            "POST",
+            "/insights/",
+            {
+                "name": name,
+                "description": desc,
+                "query": hogql(sql),
+                "dashboards": [did],
+            },
+        )
         print(f"  + [{ins.get('id')}] {name}")
 
     # 4. Verify.


### PR DESCRIPTION
## Why

The strategic purpose of OSS telemetry is to learn **how users use the red-team harness and what tactics they run** (and to grow the masked reasoning corpus). But `session_id` — the per-engagement grouping key — was only stamped on **research trajectory steps**. Basic-tier events (`tool.call`/`tool.result`/`finding.created`/`opplan.update`/`llm.*`) could only be grouped by `install_id`, which conflates *every engagement that ran on one machine*.

That made the core usage questions **unanswerable**: kill-chain depth per engagement, tools/tactics per engagement, reach, and success rate.

## What

Thread `session_id` onto **all** events:

- `sink.record()` — new keyword `session_id`, stamped onto the mapped event (passes the client Tier-C scan; it's a hex hash with no identifier surface).
- `record_finding` / `record_phase` — forward `session_id`.
- `session_id_for()` — canonical `sha256(engagement)[:16]` (the engagement name may carry a client/org name, so it is **never sent raw**); single source of truth shared by the middleware + OPPLAN/finding tools so the grouping key agrees everywhere.
- `EventLogMiddleware._context` returns the sid; the four emit paths forward it.
- OPPLAN `add_objective` passes the engagement's sid to `record_phase`.

**Gateway unchanged** — `session_id` is already an allowed field on every `TelemetryEvent` (schema.ts L94) and is forwarded to PostHog as a property (posthog.ts spreads `...props`).

Also adds **`telemetry-gateway/build_dashboard.py`** — rebuilds the PostHog dashboard into **Usage / Tactics / Corpus** sections (17 insights) whose engagement-level tiles consume this `session_id` (kill-chain reach funnel, engagement depth, success rate, MITRE/TTP/tool-failure, reasoning-chain depth, …). Live dashboard: `project/479014/dashboard/1740993`.

## Live verification (per CLAUDE.md)

Drove the **real** `EventLogMiddleware` model/tool wrap paths + the OPPLAN/finding sink calls through a RESEARCH-mode `TelemetrySink` with a capturing transport:

```
captured 13 events across types: finding.created, llm.call, llm.response,
  opplan.update, tool.call, tool.result, trajectory.step
PASS  every event type carries session_id, all == expected hash (319acd0f8933b872)
PASS  no raw identifier (10.0.0.5 / scanme.example.com) in any forwarded event
  traj human step0: 'Objective: own <DOMAIN_1> at <IP_1>'
  traj agent step1: 'Plan: nmap <IP_1>, then exploit <DOMAIN_1> via the login form.'
```

All 17 dashboard HogQL queries were **executed against PostHog** (200), incl. the array-unnest and the kill-chain funnel (fixed a `not_an_aggregate` ordering error before commit).

## Tests / gates

- 3 new sink tests (session_id on every type, omitted-when-absent, stable non-reversible hash) — pass.
- `pytest -m "not slow"` telemetry+middleware suite: **939 passed**.
- `ruff check` + `ruff format --check` + `basedpyright --level error`: clean.

Pre-1.0, additive contract change (new optional keyword + new allowed field already in the wire schema). No SemVer break.