### PR TITLE
feat(sandbox): per-engagement sandbox routing in the bash hot path (shared langgraph + isolated sandbox)

### DIFF
--- a/packages/decepticon/decepticon/backends/factory.py
+++ b/packages/decepticon/decepticon/backends/factory.py
@@ -29,7 +29,14 @@ import os
 from decepticon.backends.http_sandbox import HTTPSandbox
 
 
-@functools.lru_cache(maxsize=8)
+# Sized for the multi-tenant case: a single SHARED langgraph process can serve
+# many concurrent engagements, each routed (via the bash tool's per-run
+# ``configurable.sandbox_url`` — see ``tools/bash/bash.py:_sandbox_from_config``)
+# to its OWN per-engagement sandbox. Each must keep its own client so the
+# ``SandboxNotificationMiddleware._jobs`` view stays consistent within a run;
+# under-sizing would evict a live engagement's client mid-flight. 128 covers
+# realistic per-process concurrency with headroom.
+@functools.lru_cache(maxsize=128)
 def _shared_sandbox(base_url: str, token: str | None) -> HTTPSandbox:
     return HTTPSandbox(base_url=base_url, token=token)
 

--- a/packages/decepticon/decepticon/tools/bash/bash.py
+++ b/packages/decepticon/decepticon/tools/bash/bash.py
@@ -254,16 +254,50 @@ def set_sandbox(sandbox: HTTPSandbox) -> contextvars.Token:
     return _sandbox_var.set(sandbox)
 
 
-def get_sandbox() -> HTTPSandbox | None:
-    """Return the current HTTPSandbox instance.
+def _sandbox_from_config(config: RunnableConfig | None) -> HTTPSandbox | None:
+    """Resolve a per-engagement sandbox from the run's injected config.
 
-    Resolution order: the per-context ``_sandbox_var`` (so a
-    request-scoped override takes precedence), then the module-level
-    ``_sandbox_default`` for callers running outside that context —
-    typically tool nodes the LangGraph runtime dispatched in a worker
-    thread, where contextvars from the build-time context are not
-    inherited.
+    In a SHARED langgraph process serving many engagements concurrently, each
+    run carries its own ``configurable.sandbox_url`` / ``sandbox_token`` — the
+    endpoint of *that engagement's* isolated sandbox (VM/container). Resolving
+    the sandbox from the per-call config — exactly how
+    ``_workspace_path_from_config`` already resolves the workspace — routes
+    every command to its OWN engagement sandbox, so one tenant's bash can never
+    execute against another tenant's sandbox. The ``(url, token)``-keyed
+    ``_shared_sandbox`` cache gives each engagement a stable client.
+
+    Returns ``None`` when the config carries no sandbox endpoint (single-tenant
+    / dev / OSS self-host), so the caller falls back to the process default.
     """
+    configurable = (config or {}).get("configurable", {})
+    if not isinstance(configurable, dict):
+        return None
+    url = configurable.get("sandbox_url")
+    if not isinstance(url, str) or not url:
+        return None
+    token = configurable.get("sandbox_token")
+    from decepticon.backends.factory import _shared_sandbox
+
+    return _shared_sandbox(url, token if isinstance(token, str) and token else None)
+
+
+def get_sandbox(config: RunnableConfig | None = None) -> HTTPSandbox | None:
+    """Return the HTTPSandbox for this call.
+
+    Resolution order:
+      1. the run's per-engagement config (``configurable.sandbox_url``) — so a
+         SHARED process fans out to per-engagement sandboxes with no
+         cross-tenant bleed;
+      2. the per-context ``_sandbox_var`` (a request-scoped override);
+      3. the module-level ``_sandbox_default`` for callers running outside that
+         context — typically tool nodes the LangGraph runtime dispatched in a
+         worker thread, where contextvars from the build-time context are not
+         inherited. This is the single-tenant / dev path set by
+         ``set_sandbox`` at agent construction.
+    """
+    from_config = _sandbox_from_config(config)
+    if from_config is not None:
+        return from_config
     sandbox = _sandbox_var.get()
     if sandbox is not None:
         return sandbox
@@ -310,14 +344,19 @@ def bash_workspace(workspace_path: str):
         _current_workspace_path.reset(token)
 
 
-async def _prune_old_scratch(workspace_path: str = "/workspace") -> None:
+async def _prune_old_scratch(
+    workspace_path: str = "/workspace", sandbox: HTTPSandbox | None = None
+) -> None:
     """Drop scratch files older than SCRATCH_TTL_MINUTES.
 
     Throttled to SCRATCH_PRUNE_INTERVAL between attempts so the bash() hot
     path pays for cleanup at most every ~10 minutes per process. Best-effort:
-    a failure here must never block the agent's command.
+    a failure here must never block the agent's command. ``sandbox`` is the
+    already-resolved per-engagement client from the caller, so this never
+    re-resolves to the process default (which would target the wrong tenant).
     """
-    sandbox = get_sandbox()
+    if sandbox is None:
+        sandbox = get_sandbox()
     if sandbox is None or workspace_path == "/workspace":
         return
 
@@ -341,6 +380,7 @@ async def _offload_large_output(
     command: str,
     session: str,
     workspace_path: str = "/workspace",
+    sandbox: HTTPSandbox | None = None,
 ) -> str:
     """Save large output to scratch file in sandbox, return compact reference.
 
@@ -348,8 +388,12 @@ async def _offload_large_output(
     - Write full output to <engagement>/.scratch/ for later retrieval
     - Return preview (head 2K + tail 1K) + file path reference
     - Agent can use read_file or grep to access specific parts later
+
+    ``sandbox`` is the already-resolved per-engagement client from the caller,
+    so the offload writes into the right tenant's sandbox.
     """
-    sandbox = get_sandbox()
+    if sandbox is None:
+        sandbox = get_sandbox()
     if sandbox is None:
         raise RuntimeError("bash tool invoked without a sandbox set in the contextvar")
 
@@ -416,14 +460,14 @@ async def bash(
             session name (not "main"). Check results later with bash_output.
         description: Short label for UI display.
     """
-    _sandbox = get_sandbox()
+    _sandbox = get_sandbox(config)
     if _sandbox is None:
         raise RuntimeError("HTTPSandbox not initialized. Call set_sandbox() first.")
 
     workspace_path = _workspace_path_from_config(config)
     # Best-effort TTL prune of <engagement>/.scratch/ (throttled internally)
 
-    await _prune_old_scratch(workspace_path)
+    await _prune_old_scratch(workspace_path, _sandbox)
 
     # Strip leading/trailing newlines before sending to the sandbox.
     # LLM agents frequently wrap commands in block-form like
@@ -482,7 +526,7 @@ async def bash(
     # Tier 2 (>15K): offload to file, return preview + file reference
     # Tier 3 (>5M): handled by size watchdog in sandbox_kernel/tmux.py (command killed)
     if len(result) > INLINE_LIMIT and not result.startswith(_STATUS_PREFIXES):
-        return await _offload_large_output(result, command, session, workspace_path)
+        return await _offload_large_output(result, command, session, workspace_path, _sandbox)
 
     return result
 
@@ -505,7 +549,7 @@ async def bash_output(session: str = "main", config: RunnableConfig | None = Non
     Args:
         session: Session name passed to bash(..., background=True).
     """
-    _sandbox = get_sandbox()
+    _sandbox = get_sandbox(config)
     if _sandbox is None:
         raise RuntimeError("HTTPSandbox not initialized.")
 
@@ -566,7 +610,7 @@ async def bash_kill(session: str, config: RunnableConfig | None = None) -> str:
     Args:
         session: Session name to terminate.
     """
-    _sandbox = get_sandbox()
+    _sandbox = get_sandbox(config)
     if _sandbox is None:
         raise RuntimeError("HTTPSandbox not initialized.")
 
@@ -592,7 +636,7 @@ async def bash_status(config: RunnableConfig | None = None) -> str:
     Use before launching a new background job to spot conflicts, or to
     detect stale sessions for cleanup.
     """
-    _sandbox = get_sandbox()
+    _sandbox = get_sandbox(config)
     if _sandbox is None:
         raise RuntimeError("HTTPSandbox not initialized.")
 

--- a/packages/decepticon/tests/unit/tools/bash/test_sandbox_routing.py
+++ b/packages/decepticon/tests/unit/tools/bash/test_sandbox_routing.py
@@ -1,0 +1,61 @@
+"""Per-engagement sandbox routing — the isolation property that lets one SHARED
+langgraph process serve many engagements, each on its OWN sandbox.
+
+``get_sandbox(config)`` resolves the sandbox from the run's injected
+``configurable.sandbox_url`` (mirroring how ``_workspace_path_from_config``
+resolves the workspace), so a tenant's bash can never reach another tenant's
+sandbox. Without that key it falls back to the process-default sandbox, so
+single-tenant / dev / OSS self-host behavior is unchanged.
+"""
+
+from unittest.mock import MagicMock
+
+from decepticon.backends import factory
+from decepticon.tools.bash.bash import get_sandbox, set_sandbox
+
+
+def _cfg(url: str, token: str = "tok") -> dict:
+    return {"configurable": {"sandbox_url": url, "sandbox_token": token}}
+
+
+def setup_function() -> None:
+    # Isolate the (url, token)-keyed client cache between tests.
+    factory._shared_sandbox.cache_clear()
+
+
+def test_resolves_distinct_sandbox_per_engagement_config() -> None:
+    a = get_sandbox(_cfg("http://eng-a:9999"))
+    b = get_sandbox(_cfg("http://eng-b:9999"))
+    assert a is not None and b is not None
+    assert a._base_url == "http://eng-a:9999"
+    assert b._base_url == "http://eng-b:9999"
+    assert a is not b  # no cross-tenant sharing
+    # same engagement reuses the cached client (SandboxNotificationMiddleware
+    # _jobs view must stay consistent within a run)
+    assert get_sandbox(_cfg("http://eng-a:9999")) is a
+
+
+def test_config_takes_precedence_over_process_default() -> None:
+    default = MagicMock()
+    set_sandbox(default)
+    resolved = get_sandbox(_cfg("http://eng-x:9999"))
+    assert resolved is not default
+    assert resolved is not None and resolved._base_url == "http://eng-x:9999"
+
+
+def test_falls_back_to_default_without_sandbox_url() -> None:
+    default = MagicMock()
+    set_sandbox(default)
+    assert get_sandbox() is default
+    assert get_sandbox({"configurable": {}}) is default
+    assert get_sandbox({"configurable": {"sandbox_url": ""}}) is default
+    # malformed configurable must not raise — fail safe to the default
+    assert get_sandbox({"configurable": "not-a-dict"}) is default
+
+
+def test_token_is_part_of_the_cache_key() -> None:
+    # Same URL, different token → distinct clients (defence-in-depth: a rotated
+    # per-engagement token must not reuse a stale-auth client).
+    t1 = get_sandbox(_cfg("http://eng:9999", "tok-1"))
+    t2 = get_sandbox(_cfg("http://eng:9999", "tok-2"))
+    assert t1 is not t2


### PR DESCRIPTION
## Why

Target multi-tenant topology: **shared litellm/langgraph, sandbox isolated per engagement** (cost-efficient — don't run a full langgraph per engagement; isolate only the part that touches the target). For that, a shared langgraph process must route each engagement's bash to *its own* sandbox.

Today it can't, and the gap is a **security one**:
- Agent graphs are module-level (`recon.py:graph = create_recon_agent()`), so `build_sandbox_backend()` + `set_sandbox()` run once at **import**, outside any run context.
- The bash hot path read a **process-global** sandbox (`get_sandbox()` → `_sandbox_default`).
- → In a shared langgraph serving many engagements, **every tenant's bash hits the same sandbox** = cross-tenant isolation breach (violates the sandbox network-isolation invariant).

Meanwhile the **workspace** was already resolved per-run from `configurable.workspace_path` (`_workspace_path_from_config`). The sandbox just needed the same treatment — resolve it where it's used, from the run's injected config.

## What

- **`get_sandbox(config)`** resolves the per-engagement sandbox from `configurable.sandbox_url` / `sandbox_token` (cached by `(url, token)`), falling back to the contextvar / process default when absent → **single-tenant / dev / OSS self-host unchanged**.
- All four bash tools (`bash`/`bash_output`/`bash_kill`/`bash_status`) pass their injected `config`; the resolved client is threaded into `_prune_old_scratch` / `_offload_large_output` so they never re-resolve to the global (which would bleed).
- `_shared_sandbox` lru_cache **8 → 128** (one client per concurrent engagement; under-sizing evicts a live engagement's client and desyncs its `SandboxNotificationMiddleware._jobs`).

Resolves routing at the **execution surface**, where the run config is reliably in scope — unlike import-time agent construction (where `get_config()` raises).

## Relationship to #705

**Supersedes #705.** #705 added per-run resolution at the *factory* via `get_config()`, but the bash hot path calls bare `get_sandbox()` and the factory runs at import — so #705 never reached the execution path and would have been inert (and given false "shared is safe" confidence). This routes at the bash tool from the explicitly-injected `config` (the same mechanism that already works for `workspace_path`), so it actually engages and is concurrency-safe. Recommend closing #705 in favor of this.

Still needed to *activate* the shared topology (separate, out of scope here): the SaaS engagement runtime threading `configurable.sandbox_url` per run (today it sets only `workspace_path`/`engagement_id`/…), and flipping `ENGAGEMENT_RUNTIME` to a shared provider. The per-engagement-VM providers (`gce-spot`/`local-docker`) keep working via env regardless.

## Live verification (per CLAUDE.md)

One process, **two concurrent engagements** with distinct `configurable.sandbox_url`, driving the real `bash()` coroutine interleaved:

```
PASS  resolution: A→A, B→B, distinct; no-config→process-default
        engagement A sandbox ran: ['whoami-A-0','whoami-A-1','whoami-A-2','whoami-A-3','whoami-A-4']
        engagement B sandbox ran: ['whoami-B-0','whoami-B-1','whoami-B-2','whoami-B-3','whoami-B-4']
PASS  concurrent bash(): each engagement's commands stayed in its OWN sandbox (zero bleed)
PASS  single-tenant (no per-run config) still uses the process-default sandbox
```

The security assertion (A's command never appears in B's sandbox and vice-versa) holds under interleaved concurrency.

## Tests / gates

- 4 new routing tests (per-engagement resolution, config-over-default precedence, safe-fallback on malformed config, token in cache key).
- bash + backends suite: **178 passed**.
- `ruff check` + `ruff format --check` + `basedpyright --level error`: clean.

Pre-1.0, additive (`get_sandbox` gains an optional `config` arg; new optional configurable keys). No regression to single-tenant.