### PR TITLE
feat(launcher): opt-out telemetry + general .env migration for existing users

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,22 +1,28 @@
 # Decepticon Telemetry
 
 Decepticon can send **anonymous usage telemetry** to help maintainers see what
-users ask the agents to do and what the agents actually do. It is **opt-in** and
-designed for a red-team threat model: **raw prompts, targets, credentials, and
-tool output are never transmitted.**
+users ask the agents to do and what the agents actually do. Decepticon is
+free/OSS; this sharing helps fund and improve it. It is **opt-out** — the
+onboard wizard asks for consent (default yes) and you can turn it off at any
+time — and designed for a red-team threat model: **raw prompts, targets,
+credentials, and tool output are never transmitted.**
 
 ## TL;DR
 
-- **Off by default.** Nothing is sent unless you set `DECEPTICON_TELEMETRY=basic`
-  (or `research`) **and** a `DECEPTICON_TELEMETRY_ENDPOINT`.
-- **`DO_NOT_TRACK=1`** (or `decepticon-cli telemetry off`) forces it off forever.
+- **On by default for consenting users (opt-out).** The onboard wizard asks
+  during setup (default yes), writing `DECEPTICON_TELEMETRY=research`. Existing
+  users are re-asked once at `decepticon start` after this policy change.
+- **Turn it off anytime:** set `DECEPTICON_TELEMETRY=off` (or `basic`) in
+  `~/.decepticon/.env`, run `decepticon-cli telemetry off`, or `DO_NOT_TRACK=1`.
+- **Nothing is sent** without a `DECEPTICON_TELEMETRY_ENDPOINT` (shipped in the
+  `.env` template; backfilled into existing installs on update).
 - **See exactly what would be sent:** `decepticon-cli telemetry preview`.
 
 ## Controls
 
 | Variable / command | Effect |
 |---|---|
-| `DECEPTICON_TELEMETRY=off\|basic\|research` | consent mode (default `off`) |
+| `DECEPTICON_TELEMETRY=off\|basic\|research` | consent mode (template default `research`; unset ⇒ `off`) |
 | `DO_NOT_TRACK=1` | standard kill switch — forces `off` |
 | `DECEPTICON_TELEMETRY_ENDPOINT=<url>` | gateway URL; unset ⇒ nothing is sent |
 | `decepticon-cli telemetry status` | show resolved mode / endpoint / anonymous id |

--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/huh/v2"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/cmd/opscontrol"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/migrate"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/platform"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/starprompt"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
@@ -253,7 +254,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		language            = "en"
 		useLangSmith        bool
 		langSmithKey        string
-		telemetryChoice     = "off"
+		telemetryConsent    = true // opt-out: default to sharing (masked)
 	)
 	// Block on the probe (zero-value result on timeout means
 	// "unreachable" — drops through to the remediation Note).
@@ -848,34 +849,37 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		).Title("5 / 5  ·  LangSmith").
 			WithHideFunc(func() bool { return !useLangSmith }),
 
-		// Step 5c: anonymous usage telemetry (opt-in)
+		// Step 5c: usage telemetry consent (opt-out — default yes)
 		huh.NewGroup(
-			huh.NewNote().
-				Title("Share anonymous usage telemetry? (optional)").
+			huh.NewConfirm().
+				Title("Share anonymous + masked red-team telemetry?").
 				Description(
-					"Help improve Decepticon. Opt-in, and your IP is never stored.\n\n"+
-						"  basic     anonymous stats only (tools used, finding severity/CWE,\n"+
-						"            kill-chain phase) — no prompts, no targets.\n"+
-						"  research  basic + the red-team REASONING (the agent's tactics and\n"+
-						"            rationale), captured to help train future autonomous\n"+
-						"            red-team agents. Target identifiers are MASKED\n"+
-						"            (10.0.0.5 -> <HOST_1>); real targets/creds never leave.\n\n"+
-						"Never sent at any tier: raw prompts, target IPs/hosts, credentials.\n"+
-						"Change anytime: `decepticon-cli telemetry off`, or DO_NOT_TRACK=1.",
-				),
-			huh.NewSelect[string]().
-				Title("Usage telemetry").
-				Options(
-					huh.NewOption("No — share nothing (default)", "off"),
-					huh.NewOption("Basic — anonymous structural stats only", "basic"),
-					huh.NewOption("Research — basic + masked red-team reasoning", "research"),
+					"Decepticon is free/OSS — sharing usage helps fund and improve it,\n"+
+						"and contributes masked red-team reasoning to train future open\n"+
+						"offensive-security agents.\n\n"+
+						"  • anonymous structural stats (tools used, finding severity/CWE,\n"+
+						"    kill-chain phase)\n"+
+						"  • the agent's red-team REASONING, with target identifiers MASKED\n"+
+						"    (10.0.0.5 -> <HOST_1>, acme.com -> <DOMAIN_1>)\n\n"+
+						"Never sent: raw prompts, real target IPs/hosts, credentials. Your\n"+
+						"IP is dropped at the gateway. Change anytime: DECEPTICON_TELEMETRY=off\n"+
+						"(or basic) in .env, `decepticon-cli telemetry off`, or DO_NOT_TRACK=1.",
 				).
-				Value(&telemetryChoice),
+				Affirmative("Yes, share (recommended)").
+				Negative("No, keep it off").
+				Value(&telemetryConsent),
 		).Title("5 / 5  ·  Usage telemetry"),
 	).WithTheme(huh.ThemeFunc(ui.DecepticonTheme))
 
 	if err := form.Run(); err != nil {
 		return fmt.Errorf("setup cancelled: %w", err)
+	}
+
+	// Opt-out telemetry: consent maps to the research tier (masked
+	// reasoning corpus); declining writes an explicit off.
+	telemetryChoice := "research"
+	if !telemetryConsent {
+		telemetryChoice = "off"
 	}
 
 	// Strict-mode gate: refuse to write .env when the user picked
@@ -1035,6 +1039,13 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 
 	if err := config.WriteEnvFromEmbed(config.EnvPath(), values); err != nil {
 		return fmt.Errorf("write .env: %w", err)
+	}
+
+	// Record the telemetry policy as acknowledged: this fresh install just
+	// answered the same consent question the start-time re-consent migration
+	// would ask, so it must never be re-prompted.
+	if err := migrate.MarkAcked(config.DecepticonHome(), migrate.TelemetryPolicyID); err != nil {
+		ui.Warning("Could not record telemetry consent ack: " + err.Error())
 	}
 
 	// Summary

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -17,6 +17,7 @@ import (
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/engagement"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/health"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/migrate"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/platform"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/starprompt"
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
@@ -134,6 +135,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	// 2.1. Apply idempotent config/policy migrations for already-onboarded
+	// users. They never re-run the onboard wizard (step 1 only fires when
+	// .env is absent), so this is how a new release's env keys and policy
+	// changes reach them: env-key backfill (every start) + one-time
+	// interactive re-consent prompts (deferred on non-TTY). New steps plug
+	// into internal/migrate.Registry — no wiring needed here.
+	migrate.RunAll(env)
+
 	if err := config.ValidateAuth(env); err != nil {
 		return err
 	}

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -623,6 +623,116 @@ func AppendEnvLine(path, key, value string) error {
 	return err
 }
 
+// BackfillEnvFromEmbed appends any ACTIVE key present in the embedded
+// env.example template but missing from the user's .env, using the
+// template's default value. It is the general "a new release added a
+// config key, get it to already-onboarded users" primitive: those users
+// never re-run the onboard wizard (cmd/start.go only runs it when .env is
+// absent), so without this a key added to the template after their
+// install would never reach their container (telemetry vars, for one,
+// flow into langgraph purely via env_file:.env).
+//
+// Guarantees:
+//   - Existing keys and their values are NEVER modified (only additions).
+//   - Commented / optional template lines (e.g. "# LANGGRAPH_PORT=2024")
+//     are ignored — only active defaults are backfilled.
+//   - A one-time ".env.bak" snapshot is written before the first append.
+//   - Idempotent: a second call with no new template keys is a no-op.
+//
+// Returns the list of keys added (nil when nothing changed).
+func BackfillEnvFromEmbed(envPath string) ([]string, error) {
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	present := make(map[string]bool)
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if k, _, ok := parseEnvLine(trimmed); ok {
+			present[k] = true
+		}
+	}
+
+	var added []string
+	var toAppend []string
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(EnvTemplate, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		k, _, ok := parseEnvLine(trimmed)
+		if !ok || present[k] || seen[k] {
+			continue
+		}
+		seen[k] = true
+		added = append(added, k)
+		toAppend = append(toAppend, trimmed)
+	}
+	if len(toAppend) == 0 {
+		return nil, nil
+	}
+
+	backupPath := envPath + ".bak"
+	if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
+		if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+			return nil, fmt.Errorf("write backup %s: %w", backupPath, err)
+		}
+	}
+
+	var b strings.Builder
+	b.Write(data)
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("\n# --- Backfilled by `decepticon start` (new keys from this release) ---\n")
+	for _, line := range toAppend {
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(envPath, []byte(b.String()), 0o600); err != nil {
+		return nil, err
+	}
+	return added, nil
+}
+
+// SetEnvKey sets KEY=value in the .env at path, replacing the first active
+// occurrence in place (preserving surrounding lines and comments) or
+// appending the line when the key is absent. Unlike AppendEnvLine it
+// overwrites an existing value, so it is the right primitive for a
+// migration that must change a setting (e.g. flipping DECEPTICON_TELEMETRY
+// after a re-consent prompt).
+func SetEnvKey(path, key, value string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	replaced := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if k, _, ok := parseEnvLine(trimmed); ok && k == key {
+			lines[i] = key + "=" + value
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		lines = append(lines, key+"="+value)
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600)
+}
+
 // Get returns a config value with a fallback default.
 func Get(env map[string]string, key, fallback string) string {
 	if val, ok := env[key]; ok && val != "" {

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -410,6 +410,81 @@ func TestTelemetryConsentWritesEnv(t *testing.T) {
 	}
 }
 
+func TestBackfillEnvFromEmbed(t *testing.T) {
+	out := filepath.Join(t.TempDir(), ".env")
+	// Simulate a pre-#706 .env: has telemetry mode but NOT the endpoint,
+	// plus a real user value that must be preserved untouched.
+	seed := "DECEPTICON_TELEMETRY=off\nANTHROPIC_API_KEY=sk-real-user-key\n"
+	if err := os.WriteFile(out, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	added, err := BackfillEnvFromEmbed(out)
+	if err != nil {
+		t.Fatalf("BackfillEnvFromEmbed() error: %v", err)
+	}
+	if !strings.Contains(strings.Join(added, ","), "DECEPTICON_TELEMETRY_ENDPOINT") {
+		t.Errorf("expected DECEPTICON_TELEMETRY_ENDPOINT in added keys, got %v", added)
+	}
+
+	env, err := LoadEnv(out)
+	if err != nil {
+		t.Fatalf("LoadEnv() error: %v", err)
+	}
+	// New key backfilled from the template default.
+	if env["DECEPTICON_TELEMETRY_ENDPOINT"] == "" {
+		t.Error("DECEPTICON_TELEMETRY_ENDPOINT not backfilled")
+	}
+	// Existing values preserved exactly (never overwritten).
+	if env["DECEPTICON_TELEMETRY"] != "off" {
+		t.Errorf("DECEPTICON_TELEMETRY = %q, want preserved %q", env["DECEPTICON_TELEMETRY"], "off")
+	}
+	if env["ANTHROPIC_API_KEY"] != "sk-real-user-key" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want preserved real key", env["ANTHROPIC_API_KEY"])
+	}
+	// .bak snapshot of the pre-migration file.
+	if _, err := os.Stat(out + ".bak"); err != nil {
+		t.Errorf("expected .env.bak backup: %v", err)
+	}
+
+	// Idempotent: a second run adds nothing.
+	added2, err := BackfillEnvFromEmbed(out)
+	if err != nil {
+		t.Fatalf("second BackfillEnvFromEmbed() error: %v", err)
+	}
+	if len(added2) != 0 {
+		t.Errorf("second backfill should be a no-op, added %v", added2)
+	}
+}
+
+func TestSetEnvKey(t *testing.T) {
+	out := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(out, []byte("DECEPTICON_TELEMETRY=off\n# a comment\nFOO=bar\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Replace an existing key.
+	if err := SetEnvKey(out, "DECEPTICON_TELEMETRY", "research"); err != nil {
+		t.Fatalf("SetEnvKey replace: %v", err)
+	}
+	// Append a missing key.
+	if err := SetEnvKey(out, "NEW_KEY", "val"); err != nil {
+		t.Fatalf("SetEnvKey append: %v", err)
+	}
+	env, err := LoadEnv(out)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if env["DECEPTICON_TELEMETRY"] != "research" {
+		t.Errorf("DECEPTICON_TELEMETRY = %q, want research", env["DECEPTICON_TELEMETRY"])
+	}
+	if env["NEW_KEY"] != "val" {
+		t.Errorf("NEW_KEY = %q, want val", env["NEW_KEY"])
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want preserved bar", env["FOO"])
+	}
+}
+
 func TestWriteEnv_CommentedOutLines(t *testing.T) {
 	dir := t.TempDir()
 	tmplPath := filepath.Join(dir, ".env.example")

--- a/clients/launcher/internal/config/env.example
+++ b/clients/launcher/internal/config/env.example
@@ -185,14 +185,18 @@ LANGSMITH_TRACING=false
 LANGSMITH_API_KEY=your-langsmith-key-here
 LANGSMITH_PROJECT=decepticon
 
-# --- Anonymous usage telemetry (optional, opt-in) ---
-# off | basic | research. The onboard wizard sets this. `basic` shares
-# anonymous structural stats; `research` adds the identifier-masked red-team
-# reasoning corpus. Raw prompts/targets/credentials are never sent; the IP is
-# dropped at the gateway. DO_NOT_TRACK=1 forces off. See TELEMETRY.md.
-# Nothing is sent unless DECEPTICON_TELEMETRY_ENDPOINT is also set (the
-# maintainer's collection gateway URL — left blank in OSS until deployed).
-DECEPTICON_TELEMETRY=off
+# --- Usage telemetry (opt-out) ---
+# off | basic | research. Decepticon is free/OSS; sharing usage helps fund
+# and improve it. The onboard wizard asks for consent (default: yes); the
+# default below applies to non-interactive installs.
+#   research = anonymous structural stats + the agent's red-team REASONING
+#              with target identifiers MASKED (10.0.0.5 -> <HOST_1>).
+#   basic    = anonymous structural stats only (tools/severity/CWE/phase).
+# Raw prompts, real target IPs/hosts, and credentials are NEVER sent; your
+# IP is dropped at the gateway. Opt out anytime: set this to `off`, run
+# `decepticon-cli telemetry off`, or DO_NOT_TRACK=1. See TELEMETRY.md.
+# Nothing is sent unless DECEPTICON_TELEMETRY_ENDPOINT is also set.
+DECEPTICON_TELEMETRY=research
 DECEPTICON_TELEMETRY_ENDPOINT=https://decepticon-telemetry-gateway.purpleailab.workers.dev/v1/telemetry
 
 # --- Ports (optional) ---

--- a/clients/launcher/internal/migrate/migrate.go
+++ b/clients/launcher/internal/migrate/migrate.go
@@ -1,0 +1,152 @@
+// Package migrate runs idempotent, ordered upgrade steps at
+// `decepticon start` so that already-onboarded users — who never re-run
+// the onboard wizard (cmd/start.go only invokes it when .env is absent) —
+// still pick up config keys and policy changes introduced by later
+// releases.
+//
+// There are two kinds of step:
+//
+//   - Non-interactive (Interactive=false): a pure, self-idempotent config
+//     migration. Runs on EVERY start regardless of TTY and is never
+//     ack-recorded (so it keeps catching newly-added keys after each
+//     update). Example: backfilling new env.example keys into an existing
+//     .env.
+//
+//   - Interactive (Interactive=true): a one-time prompt, e.g. a consent
+//     re-ask after a policy change. It is recorded in the ack store so it
+//     runs at most once, and is SILENTLY SKIPPED (deferred) when stdin is
+//     not a TTY — so CI / piped starts are never blocked and the next
+//     interactive start reconsiders.
+//
+// Adding a future migration is one line: append a Step to Registry().
+// That is the whole mechanism; no new wiring in start.go.
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/term"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
+)
+
+// ackFileName is the JSON record of interactive migrations the user has
+// already been through, stored inside DECEPTICON_HOME.
+const ackFileName = ".migrations.json"
+
+// Ctx is the shared state threaded through every step.
+type Ctx struct {
+	EnvPath string
+	Env     map[string]string // current .env, mutated as steps write
+	Home    string
+	IsTTY   bool
+
+	ackPath string
+	acks    map[string]string
+}
+
+// Step is one upgrade applied at start. See the package doc for the
+// interactive vs non-interactive contract.
+type Step struct {
+	ID          string
+	Description string
+	Interactive bool
+	// Apply performs the migration and returns a human note to surface
+	// (empty for "nothing happened"). For interactive steps a nil error
+	// records the ack so the step never runs again.
+	Apply func(c *Ctx) (note string, err error)
+}
+
+// Indirections so tests can drive the framework without a real TTY or
+// Huh prompt.
+var (
+	isInteractive = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+)
+
+// RunAll builds a real Ctx from the launcher environment and applies the
+// registered steps. env is the already-loaded .env map; steps may mutate
+// it so the rest of `start` sees post-migration values.
+func RunAll(env map[string]string) {
+	home := config.DecepticonHome()
+	c := &Ctx{
+		EnvPath: config.EnvPath(),
+		Env:     env,
+		Home:    home,
+		IsTTY:   isInteractive(),
+		ackPath: filepath.Join(home, ackFileName),
+	}
+	c.loadAcks()
+	Run(c, Registry())
+}
+
+// Run applies steps in order against c. Errors are surfaced as warnings
+// and never abort the start flow.
+func Run(c *Ctx, steps []Step) {
+	for _, s := range steps {
+		if s.Interactive {
+			if c.Acked(s.ID) {
+				continue
+			}
+			if !c.IsTTY {
+				continue // defer to the next interactive start
+			}
+		}
+		note, err := s.Apply(c)
+		if err != nil {
+			ui.Warning(fmt.Sprintf("migration %q: %v", s.ID, err))
+			continue
+		}
+		if note != "" {
+			ui.Info(note)
+		}
+		if s.Interactive {
+			if ackErr := c.ack(s.ID); ackErr != nil {
+				ui.Warning(fmt.Sprintf("could not record migration %q: %v", s.ID, ackErr))
+			}
+		}
+	}
+}
+
+// MarkAcked records an interactive migration as already handled. The
+// onboard wizard calls this for the telemetry policy so a fresh install —
+// which just made the same choice in the wizard — never gets re-prompted
+// at first start.
+func MarkAcked(home, id string) error {
+	c := &Ctx{ackPath: filepath.Join(home, ackFileName)}
+	c.loadAcks()
+	return c.ack(id)
+}
+
+// Acked reports whether the interactive migration id has been recorded.
+func (c *Ctx) Acked(id string) bool {
+	_, ok := c.acks[id]
+	return ok
+}
+
+func (c *Ctx) loadAcks() {
+	c.acks = map[string]string{}
+	data, err := os.ReadFile(c.ackPath)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(data, &c.acks)
+}
+
+func (c *Ctx) ack(id string) error {
+	if c.acks == nil {
+		c.acks = map[string]string{}
+	}
+	c.acks[id] = "acked"
+	if err := os.MkdirAll(filepath.Dir(c.ackPath), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c.acks, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(c.ackPath, data, 0o600)
+}

--- a/clients/launcher/internal/migrate/migrate_test.go
+++ b/clients/launcher/internal/migrate/migrate_test.go
@@ -1,0 +1,228 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+)
+
+func newTestCtx(t *testing.T, env map[string]string, tty bool) *Ctx {
+	t.Helper()
+	home := t.TempDir()
+	envPath := filepath.Join(home, ".env")
+	// A minimal .env so file-writing steps have something to edit.
+	if _, ok := env["DECEPTICON_TELEMETRY"]; ok {
+		_ = os.WriteFile(envPath, []byte("DECEPTICON_TELEMETRY="+env["DECEPTICON_TELEMETRY"]+"\n"), 0o600)
+	} else {
+		_ = os.WriteFile(envPath, []byte("FOO=bar\n"), 0o600)
+	}
+	c := &Ctx{
+		EnvPath: envPath,
+		Env:     env,
+		Home:    home,
+		IsTTY:   tty,
+		ackPath: filepath.Join(home, ackFileName),
+	}
+	c.loadAcks()
+	return c
+}
+
+func TestRun_NonInteractiveStepAlwaysRuns(t *testing.T) {
+	c := newTestCtx(t, map[string]string{}, false)
+	ran := 0
+	Run(c, []Step{{
+		ID:          "noninteractive",
+		Interactive: false,
+		Apply:       func(_ *Ctx) (string, error) { ran++; return "", nil },
+	}})
+	if ran != 1 {
+		t.Fatalf("non-interactive step ran %d times, want 1", ran)
+	}
+	// Non-interactive steps are never ack-recorded (they re-run each start).
+	if c.Acked("noninteractive") {
+		t.Error("non-interactive step should not be ack-recorded")
+	}
+}
+
+func TestRun_InteractiveDeferredOnNonTTY(t *testing.T) {
+	c := newTestCtx(t, map[string]string{}, false)
+	ran := 0
+	step := Step{
+		ID:          "consent",
+		Interactive: true,
+		Apply:       func(_ *Ctx) (string, error) { ran++; return "", nil },
+	}
+	Run(c, []Step{step})
+	if ran != 0 {
+		t.Fatalf("interactive step ran on non-TTY (%d), want deferred", ran)
+	}
+	if c.Acked("consent") {
+		t.Error("deferred step must not be acked")
+	}
+}
+
+func TestRun_InteractiveRunsOnceThenAcked(t *testing.T) {
+	c := newTestCtx(t, map[string]string{}, true)
+	ran := 0
+	step := Step{
+		ID:          "consent",
+		Interactive: true,
+		Apply:       func(_ *Ctx) (string, error) { ran++; return "ok", nil },
+	}
+	Run(c, []Step{step})
+	Run(c, []Step{step}) // second start: already acked
+	if ran != 1 {
+		t.Fatalf("interactive step ran %d times, want exactly 1", ran)
+	}
+	if !c.Acked("consent") {
+		t.Error("interactive step should be acked after running")
+	}
+	// Ack persists across a fresh Ctx (simulating a new process).
+	c2 := &Ctx{ackPath: c.ackPath}
+	c2.loadAcks()
+	if !c2.Acked("consent") {
+		t.Error("ack did not persist to disk")
+	}
+}
+
+func TestTelemetryReconsent_Yes(t *testing.T) {
+	defer swapConfirm(true)()
+	c := newTestCtx(t, map[string]string{"DECEPTICON_TELEMETRY": "off"}, true)
+	if _, err := applyTelemetryReconsent(c); err != nil {
+		t.Fatalf("applyTelemetryReconsent: %v", err)
+	}
+	assertEnvKey(t, c.EnvPath, "DECEPTICON_TELEMETRY", "research")
+	if c.Env["DECEPTICON_TELEMETRY"] != "research" {
+		t.Errorf("in-memory env not updated: %q", c.Env["DECEPTICON_TELEMETRY"])
+	}
+}
+
+func TestTelemetryReconsent_No(t *testing.T) {
+	defer swapConfirm(false)()
+	c := newTestCtx(t, map[string]string{"DECEPTICON_TELEMETRY": "off"}, true)
+	if _, err := applyTelemetryReconsent(c); err != nil {
+		t.Fatalf("applyTelemetryReconsent: %v", err)
+	}
+	assertEnvKey(t, c.EnvPath, "DECEPTICON_TELEMETRY", "off")
+}
+
+func TestTelemetryReconsent_HardOptOutDoNotTrack(t *testing.T) {
+	// DO_NOT_TRACK must skip the prompt entirely and leave the value alone.
+	called := false
+	restore := confirm
+	confirm = func(_, _, _, _ string, _ bool) bool { called = true; return true }
+	defer func() { confirm = restore }()
+
+	c := newTestCtx(t, map[string]string{"DECEPTICON_TELEMETRY": "off", "DO_NOT_TRACK": "1"}, true)
+	if _, err := applyTelemetryReconsent(c); err != nil {
+		t.Fatalf("applyTelemetryReconsent: %v", err)
+	}
+	if called {
+		t.Error("prompt shown despite DO_NOT_TRACK")
+	}
+	assertEnvKey(t, c.EnvPath, "DECEPTICON_TELEMETRY", "off")
+}
+
+func TestTelemetryReconsent_HardOptOutMarker(t *testing.T) {
+	called := false
+	restore := confirm
+	confirm = func(_, _, _, _ string, _ bool) bool { called = true; return true }
+	defer func() { confirm = restore }()
+
+	c := newTestCtx(t, map[string]string{"DECEPTICON_TELEMETRY": "off"}, true)
+	markerDir := filepath.Join(c.Home, "telemetry")
+	if err := os.MkdirAll(markerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(markerDir, "opt_out"), []byte("opted out\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applyTelemetryReconsent(c); err != nil {
+		t.Fatalf("applyTelemetryReconsent: %v", err)
+	}
+	if called {
+		t.Error("prompt shown despite opt-out marker")
+	}
+	assertEnvKey(t, c.EnvPath, "DECEPTICON_TELEMETRY", "off")
+}
+
+func TestEnvBackfillStepReflectsIntoEnv(t *testing.T) {
+	c := newTestCtx(t, map[string]string{"DECEPTICON_TELEMETRY": "off"}, false)
+	if _, err := applyEnvBackfill(c); err != nil {
+		t.Fatalf("applyEnvBackfill: %v", err)
+	}
+	// The endpoint (a template default missing from the seed) should now be
+	// both on disk and reflected into the in-memory env map.
+	if c.Env["DECEPTICON_TELEMETRY_ENDPOINT"] == "" {
+		t.Error("backfilled key not reflected into in-memory env")
+	}
+}
+
+// TestRunAll_ExistingUserUpgrade exercises the fully wired path an existing
+// (pre-endpoint) user hits at `decepticon start`: env-backfill adds the
+// telemetry endpoint their .env never had, and the one-time re-consent
+// prompt flips them to research — then never fires again.
+func TestRunAll_ExistingUserUpgrade(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("DECEPTICON_HOME", home)
+	envPath := filepath.Join(home, ".env")
+	// A pre-#706 .env: telemetry off, NO endpoint key at all.
+	if err := os.WriteFile(envPath, []byte("DECEPTICON_TELEMETRY=off\nANTHROPIC_API_KEY=sk-real\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	defer swapConfirm(true)()
+	restoreTTY := isInteractive
+	isInteractive = func() bool { return true }
+	defer func() { isInteractive = restoreTTY }()
+
+	env, err := config.LoadEnv(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	RunAll(env)
+
+	got, err := config.LoadEnv(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["DECEPTICON_TELEMETRY_ENDPOINT"] == "" {
+		t.Error("endpoint not backfilled for existing user")
+	}
+	if got["DECEPTICON_TELEMETRY"] != "research" {
+		t.Errorf("DECEPTICON_TELEMETRY = %q, want research after consent", got["DECEPTICON_TELEMETRY"])
+	}
+	if got["ANTHROPIC_API_KEY"] != "sk-real" {
+		t.Errorf("real key not preserved: %q", got["ANTHROPIC_API_KEY"])
+	}
+
+	// Second start: consent must NOT be asked again.
+	asked := false
+	confirm = func(_, _, _, _ string, _ bool) bool { asked = true; return true }
+	env2, _ := config.LoadEnv(envPath)
+	RunAll(env2)
+	if asked {
+		t.Error("re-consent prompt fired a second time (ack not honored)")
+	}
+}
+
+// --- helpers ---
+
+func swapConfirm(answer bool) func() {
+	restore := confirm
+	confirm = func(_, _, _, _ string, _ bool) bool { return answer }
+	return func() { confirm = restore }
+}
+
+func assertEnvKey(t *testing.T, path, key, want string) {
+	t.Helper()
+	env, err := config.LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if env[key] != want {
+		t.Errorf("%s = %q, want %q", key, env[key], want)
+	}
+}

--- a/clients/launcher/internal/migrate/steps.go
+++ b/clients/launcher/internal/migrate/steps.go
@@ -1,0 +1,143 @@
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"charm.land/huh/v2"
+
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
+)
+
+// TelemetryPolicyID identifies the one-time telemetry re-consent prompt.
+// Bumping the date suffix (a new step ID) re-asks every user again after a
+// future policy change.
+const TelemetryPolicyID = "telemetry-policy-2026-06"
+
+// confirm is indirected so tests can answer the prompt without a TTY.
+var confirm = func(title, description, affirmative, negative string, defaultYes bool) bool {
+	v := defaultYes
+	if err := huh.NewConfirm().
+		Title(title).
+		Description(description).
+		Affirmative(affirmative).
+		Negative(negative).
+		Value(&v).
+		Run(); err != nil {
+		// A prompt error (e.g. aborted) must not silently enable a
+		// data-collection setting — fail to the conservative answer.
+		return false
+	}
+	return v
+}
+
+// Registry is the ordered list of migrations applied at every start.
+// Append a Step here to ship a future config/policy migration.
+func Registry() []Step {
+	return []Step{
+		{
+			ID:          "env-backfill",
+			Description: "Backfill newly-added env.example keys into an existing .env",
+			Interactive: false,
+			Apply:       applyEnvBackfill,
+		},
+		{
+			ID:          TelemetryPolicyID,
+			Description: "Re-ask telemetry consent after the opt-out policy change",
+			Interactive: true,
+			Apply:       applyTelemetryReconsent,
+		},
+	}
+}
+
+func applyEnvBackfill(c *Ctx) (string, error) {
+	added, err := config.BackfillEnvFromEmbed(c.EnvPath)
+	if err != nil {
+		return "", err
+	}
+	if len(added) == 0 {
+		return "", nil
+	}
+	// Reflect the new keys into the in-memory env so the rest of `start`
+	// sees them this run (without clobbering anything already loaded).
+	if reloaded, lerr := config.LoadEnv(c.EnvPath); lerr == nil {
+		for k, v := range reloaded {
+			if _, ok := c.Env[k]; !ok {
+				c.Env[k] = v
+			}
+		}
+	}
+	shown := added
+	const cap = 8
+	suffix := ""
+	if len(added) > cap {
+		shown = added[:cap]
+		suffix = fmt.Sprintf(", +%d more", len(added)-cap)
+	}
+	return fmt.Sprintf(
+		"Added %d new config key(s) to .env: %s%s (backup at %s.bak)",
+		len(added), strings.Join(shown, ", "), suffix, c.EnvPath,
+	), nil
+}
+
+const telemetryConsentBlurb = "" +
+	"Decepticon is free and open source. Sharing anonymous usage helps fund\n" +
+	"and improve it, and — with your consent — contributes masked red-team\n" +
+	"reasoning to train future open offensive-security agents.\n\n" +
+	"What is shared (research tier):\n" +
+	"  • anonymous structural stats (tools used, finding severity/CWE, phase)\n" +
+	"  • the agent's red-team REASONING, with target identifiers MASKED\n" +
+	"    (10.0.0.5 -> <HOST_1>, acme.com -> <DOMAIN_1>)\n\n" +
+	"Never sent at any tier: raw prompts, real target IPs/hosts, credentials.\n" +
+	"Your IP is dropped at the gateway.\n\n" +
+	"You can change this anytime: set DECEPTICON_TELEMETRY=off (or basic) in\n" +
+	"~/.decepticon/.env, run `decepticon-cli telemetry off`, or DO_NOT_TRACK=1."
+
+func applyTelemetryReconsent(c *Ctx) (string, error) {
+	// Honor hard opt-outs without prompting (and record the ack so we
+	// never re-ask): DO_NOT_TRACK, or the persistent opt-out marker
+	// written by `decepticon-cli telemetry off`.
+	if truthy(os.Getenv("DO_NOT_TRACK")) || truthy(c.Env["DO_NOT_TRACK"]) || hasOptOutMarker(c.Home) {
+		return "", nil
+	}
+
+	consent := confirm(
+		"Share anonymous + masked red-team telemetry?",
+		telemetryConsentBlurb,
+		"Yes, share (recommended)",
+		"No, keep it off",
+		true, // default Yes
+	)
+
+	mode := "research"
+	if !consent {
+		mode = "off"
+	}
+	if err := config.SetEnvKey(c.EnvPath, "DECEPTICON_TELEMETRY", mode); err != nil {
+		return "", err
+	}
+	c.Env["DECEPTICON_TELEMETRY"] = mode
+
+	if consent {
+		return "Telemetry: research tier enabled (identifiers masked). " +
+			"Disable anytime with DECEPTICON_TELEMETRY=off or DO_NOT_TRACK=1.", nil
+	}
+	return "Telemetry: kept off.", nil
+}
+
+// hasOptOutMarker mirrors the Python config's persistent opt-out marker at
+// $DECEPTICON_HOME/telemetry/opt_out (decepticon_core/.../telemetry).
+func hasOptOutMarker(home string) bool {
+	_, err := os.Stat(filepath.Join(home, "telemetry", "opt_out"))
+	return err == nil
+}
+
+func truthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/packages/decepticon/decepticon/telemetry/config.py
+++ b/packages/decepticon/decepticon/telemetry/config.py
@@ -1,13 +1,18 @@
 """Telemetry consent + configuration resolution.
 
-Opt-in by design (decision §0.4): telemetry is OFF unless the user explicitly
-enables it, and ``DO_NOT_TRACK`` always forces it off. Resolution is pure and
-side-effect-free *except* :func:`install_id`, which lazily mints a random UUID
-the first time telemetry is actually enabled.
+The PRODUCT default is opt-out: the launcher's onboard wizard asks for consent
+(default yes) and the shipped ``.env`` template defaults ``DECEPTICON_TELEMETRY``
+to ``research``, so consenting users collect by default while ``DO_NOT_TRACK`` and
+``decepticon-cli telemetry off`` always force it off. This module is the
+fail-SAFE floor: when ``DECEPTICON_TELEMETRY`` is unset (e.g. standalone library
+use, never onboarded), it resolves to ``off`` — the value, not the absence,
+turns telemetry on. Resolution is pure and side-effect-free *except*
+:func:`install_id`, which lazily mints a random UUID the first time telemetry is
+actually enabled.
 
 Environment surface (documented in ``TELEMETRY.md``):
 
-* ``DECEPTICON_TELEMETRY``          ``off`` | ``basic`` | ``extended``  (default ``off``)
+* ``DECEPTICON_TELEMETRY``          ``off`` | ``basic`` | ``research`` (template default ``research``; unset → ``off``)
 * ``DO_NOT_TRACK``                  truthy → forces ``off`` (standard)
 * ``DECEPTICON_TELEMETRY_ENDPOINT`` gateway URL; unset → effectively ``off``
 """


### PR DESCRIPTION
## What & why

Already-onboarded users never re-run the onboard wizard (it only runs when
`.env` is absent) and `decepticon update` never touches `.env`. So any key
added to `env.example` after a user's install never reaches them — including
the `#706` telemetry endpoint, which flows into langgraph **only** via
`env_file:.env` (it is not in the compose `environment:` block). Net effect:
existing users' telemetry is permanently dormant, and there is no general path
for config/policy changes to reach them on update.

This PR fixes the class of problem and ships the telemetry opt-out policy on top
of it.

## 1. General `.env` migration framework (`internal/migrate`)

Ordered, idempotent steps run at `decepticon start` (right after `LoadEnv`):

- **non-interactive** steps run every start, self-idempotent, never ack'd —
  e.g. `env-backfill` (`config.BackfillEnvFromEmbed`: appends only ACTIVE
  template keys missing from `.env`, never overwrites existing values, ignores
  commented/optional lines, writes a one-time `.env.bak`).
- **interactive** steps prompt once, record an ack in
  `$DECEPTICON_HOME/.migrations.json`, and are **silently deferred on non-TTY**
  so CI/headless starts never block (the next interactive start reconsiders).

Future config/policy migrations = append one `Step` to `Registry()`; no new
`start.go` wiring. Also adds `config.SetEnvKey` (replace-or-append).

## 2. Telemetry opt-in → opt-out (default `research`)

- `env.example` default `off` → `research`.
- onboard wizard: 3-option select → **Yes/No confirm (default Yes)**, and it
  acks the policy so fresh installs are never re-prompted.
- existing users: `env-backfill` adds the endpoint, then a one-time re-consent
  step (default Yes) flips `DECEPTICON_TELEMETRY` once — **parity with new
  installs without a silent flip**.
- hard opt-outs honored without prompting: `DO_NOT_TRACK` or the
  `decepticon-cli telemetry off` marker.
- Python `config.py` is behaviorally unchanged — it remains the fail-safe floor
  (`off` when `DECEPTICON_TELEMETRY` is unset); only the docstring + `TELEMETRY.md`
  were updated to the opt-out framing.

## Verification

- **CI mirror:** Go `build`/`vet`/`test` green (incl. a wired
  `TestRunAll_ExistingUserUpgrade` integration test); Python `406 passed`,
  `ruff` clean.
- **Live (built binary, simulated pre-#706 `.env`, 4 scenarios):**
  | scenario | observed |
  |---|---|
  | non-TTY start | endpoint backfilled, `.env.bak`=original, `off` preserved (deferred), no ack |
  | TTY start, default-Yes | `off` → `research`, ack written |
  | second start | `research` kept, backfill no-op, no re-prompt |
  | `DO_NOT_TRACK=1` on a TTY | never flips (stays `off`), still ack'd |
