### PR TITLE
feat(telemetry): add client arch/py runtime dims; drop batch engagement_hash

### DIFF
--- a/packages/decepticon/decepticon/telemetry/config.py
+++ b/packages/decepticon/decepticon/telemetry/config.py
@@ -20,6 +20,7 @@ Environment surface (documented in ``TELEMETRY.md``):
 from __future__ import annotations
 
 import os
+import platform
 import uuid
 from dataclasses import dataclass
 from enum import Enum
@@ -151,6 +152,10 @@ class TelemetryConfig:
     install_id: str
     version: str
     os_name: str
+    # Non-identifying runtime dims (the gateway already forwards these). Defaults
+    # keep existing constructors / the disabled no-op sink working unchanged.
+    arch: str = ""
+    py_version: str = ""
 
     @property
     def enabled(self) -> bool:
@@ -160,8 +165,6 @@ class TelemetryConfig:
 
 def resolve_config(env: dict[str, str] | None = None) -> TelemetryConfig:
     """Resolve consent, endpoint, and identity into one config object."""
-    import platform
-
     e = env if env is not None else dict(os.environ)
     # Precedence: DO_NOT_TRACK / opt-out force off; then an env override; then
     # the persisted opt-in choice; else off.
@@ -186,7 +189,22 @@ def resolve_config(env: dict[str, str] | None = None) -> TelemetryConfig:
         install_id=iid,
         version=e.get("DECEPTICON_VERSION") or _detect_version(),
         os_name=sys_map.get(platform.system(), "linux"),
+        arch=_arch(),
+        py_version=platform.python_version(),
     )
+
+
+def _arch() -> str:
+    """CPU architecture as a gateway-safe slug (e.g. ``x86_64``, ``arm64``).
+
+    Returned verbatim only if it matches the gateway's ``arch`` slug pattern;
+    otherwise empty so a surprising ``platform.machine()`` value can never fail
+    the gateway's strict schema and drop the whole batch.
+    """
+    import re
+
+    raw = (platform.machine() or "").lower()
+    return raw if re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", raw) else ""
 
 
 def _detect_version() -> str:

--- a/packages/decepticon/decepticon/telemetry/sink.py
+++ b/packages/decepticon/decepticon/telemetry/sink.py
@@ -47,11 +47,21 @@ class TelemetrySink:
         return self._exporter is not None and self._research
 
     def _envelope(self, events: list[dict[str, Any]]) -> dict[str, Any]:
+        client: dict[str, Any] = {
+            "decepticon_version": self._config.version,
+            "os": self._config.os_name,
+        }
+        # Optional non-identifying runtime dims; omitted when unset so the
+        # gateway's strict schema never sees an empty/invalid value.
+        if self._config.arch:
+            client["arch"] = self._config.arch
+        if self._config.py_version:
+            client["py"] = self._config.py_version
         return {
             "schema_version": SCHEMA_VERSION,
             "tier": "R" if self._research else "A",
             "install_id": self._config.install_id,
-            "client": {"decepticon_version": self._config.version, "os": self._config.os_name},
+            "client": client,
             "events": events,
         }
 

--- a/packages/decepticon/tests/unit/telemetry/test_telemetry_behavioral.py
+++ b/packages/decepticon/tests/unit/telemetry/test_telemetry_behavioral.py
@@ -117,3 +117,55 @@ def test_env_overrides_persisted_mode(tmp_path) -> None:
         resolve_config({**env, "DECEPTICON_TELEMETRY_ENDPOINT": "https://gw"}).mode
         is TelemetryMode.BASIC
     )
+
+
+# ── client runtime dims (arch / py) ──────────────────────────────────────────
+
+
+def test_envelope_includes_arch_and_py_when_set() -> None:
+    sent: list[dict[str, Any]] = []
+    cfg = TelemetryConfig(
+        mode=TelemetryMode.BASIC,
+        endpoint="https://gw.example",
+        install_id="1e9a73a6-c8bd-4e1e-be02-78f4b11de4e1",
+        version="1.1.13",
+        os_name="linux",
+        arch="x86_64",
+        py_version="3.13.1",
+    )
+    sink = TelemetrySink(cfg, transport=lambda _u, b: sent.append(json.loads(b)))
+    sink.record_finding(severity="high")
+    sink.close()
+    client = sent[0]["client"]
+    assert client["arch"] == "x86_64"
+    assert client["py"] == "3.13.1"
+
+
+def test_envelope_omits_arch_and_py_when_unset() -> None:
+    # Defaults are empty → keys must be absent so the gateway's strict schema
+    # never sees an empty value.
+    sent: list[dict[str, Any]] = []
+    sink = TelemetrySink(
+        _cfg(TelemetryMode.BASIC), transport=lambda _u, b: sent.append(json.loads(b))
+    )
+    sink.record_finding(severity="high")
+    sink.close()
+    client = sent[0]["client"]
+    assert "arch" not in client
+    assert "py" not in client
+
+
+def test_resolve_config_populates_arch_and_py(tmp_path) -> None:
+    cfg = resolve_config(
+        {
+            "DECEPTICON_HOME": str(tmp_path),
+            "DECEPTICON_TELEMETRY": "basic",
+            "DECEPTICON_TELEMETRY_ENDPOINT": "https://gw",
+        }
+    )
+    # py_version is always the running interpreter's version; arch is the slug or
+    # empty (never a schema-violating value).
+    assert cfg.py_version.count(".") >= 1
+    import re
+
+    assert cfg.arch == "" or re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", cfg.arch)

--- a/telemetry-gateway/schema.json
+++ b/telemetry-gateway/schema.json
@@ -10,7 +10,6 @@
     "schema_version": { "const": "1.0" },
     "tier": { "enum": ["A", "R"] },
     "install_id": { "type": "string", "format": "uuid" },
-    "engagement_hash": { "type": "string", "pattern": "^[a-f0-9]{16,64}$" },
     "client": {
       "type": "object",
       "additionalProperties": false,

--- a/telemetry-gateway/src/posthog.ts
+++ b/telemetry-gateway/src/posthog.ts
@@ -46,7 +46,6 @@ export async function forwardToPostHog(
         arch: batch.client.arch,
         py: batch.client.py,
         tier: batch.tier,
-        engagement_hash: batch.engagement_hash,
         // Privacy hardening — no IP, no geo enrichment.
         $geoip_disable: true,
         $process_person_profile: false,

--- a/telemetry-gateway/src/schema.ts
+++ b/telemetry-gateway/src/schema.ts
@@ -127,18 +127,14 @@ export const ClientInfo = z
 
 /**
  * The batch envelope. `install_id` is a random UUID minted on first run (never
- * machine/IP derived); `engagement_hash` is a non-reversible hash. Neither is
- * personally identifying.
+ * machine/IP derived) — not personally identifying. Per-engagement grouping is
+ * carried by each event's `session_id`, not a batch-level field.
  */
 export const TelemetryBatch = z
   .object({
     schema_version: z.literal("1.0"),
     tier: z.enum(["A", "R"]),
     install_id: z.string().uuid(),
-    engagement_hash: z
-      .string()
-      .regex(/^[a-f0-9]{16,64}$/)
-      .optional(),
     client: ClientInfo,
     events: z.array(TelemetryEvent).min(1).max(500),
   })

--- a/telemetry-gateway/test/schema.test.ts
+++ b/telemetry-gateway/test/schema.test.ts
@@ -5,7 +5,6 @@ const VALID = {
   schema_version: "1.0",
   tier: "A",
   install_id: "1e9a73a6-c8bd-4e1e-be02-78f4b11de4e1",
-  engagement_hash: "a1b2c3d4e5f60718",
   client: { decepticon_version: "1.1.13", os: "linux", arch: "x86_64", py: "3.13" },
   events: [
     { type: "tool.call", ts: 1718880000, tool: "nmap", status: "ok", duration_ms: 1200 },


### PR DESCRIPTION
## What

Two related telemetry refinements.

### Client runtime dims (`arch` / `py`)
- `TelemetryConfig` gains `arch` + `py_version`; `resolve_config` populates them.
- `arch` is produced by a slug-validated `_arch()` that returns `""` for any value the gateway's strict schema would reject, so a surprising `platform.machine()` can never fail validation and drop the whole batch.
- The sink envelope emits `client.arch` / `client.py` **only when set** (omitted otherwise).
- The gateway `ClientInfo` schema and PostHog forwarding **already** accepted `arch`/`py` — this closes the gap where the client never actually sent them.

### Drop redundant `engagement_hash`
- Per-engagement grouping is now carried by each event's `session_id` (see #709), so the batch-level `engagement_hash` is removed from the zod schema, JSON schema, PostHog forwarding, and test fixtures.

## Verification

- python telemetry suite: **66 passed**
- gateway `vitest run` (schema/worker/tierc): **40 passed**
- gateway `tsc --noEmit`: clean
- repo-wide: zero remaining `engagement_hash` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)