### PR TITLE
feat(sandbox): route backend factory from run config

### DIFF
--- a/packages/decepticon/decepticon/backends/factory.py
+++ b/packages/decepticon/decepticon/backends/factory.py
@@ -28,6 +28,8 @@ import os
 
 from decepticon.backends.http_sandbox import HTTPSandbox
 
+_DEFAULT_SANDBOX_URL = "http://localhost:9999"
+
 
 # Sized for the multi-tenant case: a single SHARED langgraph process can serve
 # many concurrent engagements, each routed (via the bash tool's per-run
@@ -41,6 +43,41 @@ def _shared_sandbox(base_url: str, token: str | None) -> HTTPSandbox:
     return HTTPSandbox(base_url=base_url, token=token)
 
 
+def _resolve_endpoint() -> tuple[str, str | None]:
+    """Resolve the sandbox ``(base_url, token)``, preferring per-run config.
+
+    A shared langgraph process serving many engagements cannot reach a
+    per-engagement sandbox through one process-wide env var. So we first consult
+    the current run's LangGraph config — ``configurable.sandbox_url`` /
+    ``configurable.sandbox_token``, set by the caller per invocation — then fall
+    back to ``SANDBOX_URL`` / ``SANDBOX_TOKEN``. The env path still covers
+    single-tenant, sidecar, local-docker, and import-time construction where
+    there is no active run context.
+    """
+    url: str | None = None
+    token: str | None = None
+    try:
+        # get_config() exposes the current run's RunnableConfig via contextvars
+        # while a graph node executes. It raises RuntimeError outside a runnable
+        # context (for example, import-time agent construction), so fall back to
+        # env in that case.
+        from langgraph.config import get_config
+
+        configurable = (get_config() or {}).get("configurable") or {}
+        raw_url = configurable.get("sandbox_url")
+        raw_token = configurable.get("sandbox_token")
+        url = raw_url if isinstance(raw_url, str) and raw_url else None
+        token = raw_token if isinstance(raw_token, str) and raw_token else None
+    except Exception:
+        pass
+
+    if url is None:
+        url = os.environ.get("SANDBOX_URL", _DEFAULT_SANDBOX_URL)
+    if token is None:
+        token = os.environ.get("SANDBOX_TOKEN") or None
+    return url, token
+
+
 def build_sandbox_backend() -> HTTPSandbox:
     """Build the HTTP-transport sandbox backend.
 
@@ -52,8 +89,12 @@ def build_sandbox_backend() -> HTTPSandbox:
     graph sees a different ``_jobs`` view than the bash tool actually
     registers against — completion notifications never reach the agent.
     Keying by ``(base_url, token)`` keeps tests that monkeypatch the env
-    isolated and supports multi-tenant deployments where pools target
-    distinct daemons.
+    isolated and supports multi-tenant deployments where a shared process routes
+    each run to a distinct per-engagement daemon.
+
+    Endpoint resolution (see ``_resolve_endpoint``): the current run's
+    LangGraph ``configurable.sandbox_url`` / ``sandbox_token`` win when
+    present; otherwise ``SANDBOX_URL`` / ``SANDBOX_TOKEN`` apply.
 
     Returns:
         An ``HTTPSandbox`` instance pointed at the daemon URL.
@@ -67,6 +108,5 @@ def build_sandbox_backend() -> HTTPSandbox:
             Optional bearer token for daemon auth — recommended even on
             loopback as defence-in-depth.
     """
-    base_url = os.environ.get("SANDBOX_URL", "http://localhost:9999")
-    token = os.environ.get("SANDBOX_TOKEN") or None
+    base_url, token = _resolve_endpoint()
     return _shared_sandbox(base_url, token)

--- a/packages/decepticon/tests/unit/backends/test_factory.py
+++ b/packages/decepticon/tests/unit/backends/test_factory.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 import pytest
 
 from decepticon.backends import build_sandbox_backend
-from decepticon.backends.factory import _shared_sandbox
+from decepticon.backends.factory import _resolve_endpoint, _shared_sandbox
 
 
 @pytest.fixture(autouse=True)
@@ -71,3 +71,118 @@ def test_build_sandbox_backend_keys_on_token(
     b = build_sandbox_backend()
 
     assert a is not b
+
+
+# ── per-run config routing ────────────────────────────────────────────────
+
+
+def _patch_get_config(
+    monkeypatch: pytest.MonkeyPatch, value: object, *, raises: bool = False
+) -> None:
+    """Patch ``langgraph.config.get_config`` (imported lazily inside factory)."""
+    import langgraph.config as lgc
+
+    def fake() -> object:
+        if raises:
+            raise RuntimeError("Called get_config outside of a runnable context")
+        return value
+
+    monkeypatch.setattr(lgc, "get_config", fake)
+
+
+def test_resolve_endpoint_prefers_run_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shared process routes by the current run's configurable, not env."""
+    monkeypatch.setenv("SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.setenv("SANDBOX_TOKEN", "env-token")
+    _patch_get_config(
+        monkeypatch,
+        {"configurable": {"sandbox_url": "http://eng-42:9999", "sandbox_token": "tok-42"}},
+    )
+
+    assert _resolve_endpoint() == ("http://eng-42:9999", "tok-42")
+
+
+def test_resolve_endpoint_falls_back_to_env_outside_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No runnable context (import-time / sidecar / dev) means env wins."""
+    monkeypatch.setenv("SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.setenv("SANDBOX_TOKEN", "env-token")
+    _patch_get_config(monkeypatch, None, raises=True)
+
+    assert _resolve_endpoint() == ("http://env-sandbox:9999", "env-token")
+
+
+def test_resolve_endpoint_env_when_config_lacks_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run config without sandbox_* keys falls back to env per-field."""
+    monkeypatch.setenv("SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.delenv("SANDBOX_TOKEN", raising=False)
+    _patch_get_config(monkeypatch, {"configurable": {"thread_id": "t1"}})
+
+    assert _resolve_endpoint() == ("http://env-sandbox:9999", None)
+
+
+def test_resolve_endpoint_default_url_when_nothing_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No config, no env means loopback default."""
+    monkeypatch.delenv("SANDBOX_URL", raising=False)
+    monkeypatch.delenv("SANDBOX_TOKEN", raising=False)
+    _patch_get_config(monkeypatch, None, raises=True)
+
+    assert _resolve_endpoint() == ("http://localhost:9999", None)
+
+
+def test_build_sandbox_backend_routes_per_run_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two runs with distinct configurable sandboxes get distinct instances."""
+    monkeypatch.delenv("SANDBOX_URL", raising=False)
+    monkeypatch.delenv("SANDBOX_TOKEN", raising=False)
+
+    _patch_get_config(
+        monkeypatch,
+        {"configurable": {"sandbox_url": "http://eng-a:9999", "sandbox_token": "a"}},
+    )
+    a = build_sandbox_backend()
+
+    _patch_get_config(
+        monkeypatch,
+        {"configurable": {"sandbox_url": "http://eng-b:9999", "sandbox_token": "b"}},
+    )
+    b = build_sandbox_backend()
+
+    assert a is not b
+    assert a._base_url != b._base_url
+
+
+def test_build_sandbox_backend_reads_configurable_inside_a_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real LangGraph run should route the factory from run config."""
+    from langgraph.graph import END, START, StateGraph
+
+    monkeypatch.setenv("SANDBOX_URL", "http://env-sandbox:9999")
+    monkeypatch.setenv("SANDBOX_TOKEN", "env-token")
+
+    seen: dict[str, str | None] = {}
+
+    def node(state: dict) -> dict:
+        sb = build_sandbox_backend()
+        seen["url"] = sb._base_url
+        seen["token"] = sb._token
+        return {}
+
+    graph = StateGraph(dict).add_node("n", node).add_edge(START, "n").add_edge("n", END).compile()
+
+    graph.invoke(
+        {},
+        {"configurable": {"sandbox_url": "http://eng-99:9999", "sandbox_token": "tok-99"}},
+    )
+
+    assert seen["url"] == "http://eng-99:9999"
+    assert seen["token"] == "tok-99"


### PR DESCRIPTION
## Summary

Build on PR #712 neutral sandbox env contract and make build_sandbox_backend resolve the current LangGraph run config before falling back to process env.

Changes:
- Resolve configurable.sandbox_url and configurable.sandbox_token from langgraph.config.get_config inside the backend factory.
- Keep SANDBOX_URL and SANDBOX_TOKEN as the neutral fallback for local, sidecar, single-tenant, and import-time construction.
- Preserve the base_url plus token shared client cache so background-job notification state remains stable per sandbox endpoint.
- Add unit coverage for config precedence, env fallback, default loopback fallback, distinct per-run clients, and an actual LangGraph run.

## Why

PR #710 routes bash hot-path calls from per-run config. This closes the matching backend-factory path so graph construction and factory-time backend users resolve the same per-engagement sandbox endpoint in shared LangGraph deployments.

This is the OSS-neutral substrate only. It does not add GCE or Cloud Run provisioning. Downstream control planes should create and manage their own sandbox runtimes, then pass endpoints through config.configurable.

## Verification

- uv run ruff check packages/decepticon/decepticon/backends/factory.py packages/decepticon/tests/unit/backends/test_factory.py
- uv run ruff format --check packages/decepticon/decepticon/backends/factory.py packages/decepticon/tests/unit/backends/test_factory.py
- DECEPTICON_USE_SKILLOGY=0 uv run pytest packages/decepticon/tests/unit/backends/test_factory.py

## Codex alignment note

This implements the routing layer that a Codex-like bash and sandbox architecture needs: command execution can target a per-run sandbox without relying on process-wide env. Full Codex-style permission profiles, approval policy, and subprocess env allowlisting are not part of this PR and should be separate follow-up work.