### PR TITLE
feat(llm): per-run LiteLLM virtual-key override for multi-tenant cost attribution

### DIFF
--- a/packages/decepticon-core/decepticon_core/contracts/slots.py
+++ b/packages/decepticon-core/decepticon_core/contracts/slots.py
@@ -47,6 +47,11 @@ class MiddlewareSlot(StrEnum):
     BUDGET = "budget"
     MODEL_OVERRIDE = "model-override"
     MODEL_FALLBACK = "model-fallback"
+    # Per-run LiteLLM virtual-key swap (multi-tenant cost attribution). Placed
+    # AFTER MODEL_FALLBACK so it is inner-most relative to model selection and
+    # re-keys whatever model is actually called (primary, /model override, or a
+    # fallback model). No-op when no per-run key is threaded (OSS default).
+    PROXY_KEY_OVERRIDE = "proxy-key-override"
     SUMMARIZATION = "summarization"
     PROMPT_CACHING = "prompt-caching"
     PATCH_TOOL_CALLS = "patch-tool-calls"
@@ -126,9 +131,13 @@ plugin can't silently subvert the safety story.
 
 
 # Common slots every agent uses (the "tail" of the middleware stack).
+# PROXY_KEY_OVERRIDE is in the tail so EVERY LLM-calling agent re-keys to the
+# per-run virtual key when one is threaded (multi-tenant cost attribution); it
+# is a no-op otherwise, so OSS / single-tenant runs are unaffected.
 _TAIL_SLOTS: frozenset[MiddlewareSlot] = frozenset(
     {
         MiddlewareSlot.MODEL_FALLBACK,
+        MiddlewareSlot.PROXY_KEY_OVERRIDE,
         MiddlewareSlot.SUMMARIZATION,
         MiddlewareSlot.PROMPT_CACHING,
         MiddlewareSlot.PATCH_TOOL_CALLS,

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -53,6 +53,7 @@ from decepticon.middleware.hitl import (
     HITLApprovalMiddleware,
 )
 from decepticon.middleware.model_override import ModelOverrideMiddleware
+from decepticon.middleware.proxy_key_override import ProxyKeyOverrideMiddleware
 from decepticon.middleware.notifications import SandboxNotificationMiddleware
 from decepticon.middleware.opscontrol_notifications import (
     OpsControlNotificationMiddleware,
@@ -225,6 +226,10 @@ def _make_model_override(**_: Any):
     return ModelOverrideMiddleware()
 
 
+def _make_proxy_key_override(**_: Any):
+    return ProxyKeyOverrideMiddleware()
+
+
 def _make_model_fallback(*, fallback_models: list | None = None, **_: Any):
     """Conditional slot — returns None when no fallback chain exists.
 
@@ -365,6 +370,7 @@ DEFAULT_SLOT_FACTORIES: dict[MiddlewareSlot, SlotFactory] = {
     MiddlewareSlot.BUDGET: _make_budget,
     MiddlewareSlot.MODEL_OVERRIDE: _make_model_override,
     MiddlewareSlot.MODEL_FALLBACK: _make_model_fallback,
+    MiddlewareSlot.PROXY_KEY_OVERRIDE: _make_proxy_key_override,
     MiddlewareSlot.SUMMARIZATION: _make_summarization,
     MiddlewareSlot.PROMPT_CACHING: _make_prompt_caching,
     MiddlewareSlot.PATCH_TOOL_CALLS: _make_patch_tool_calls,

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -53,12 +53,12 @@ from decepticon.middleware.hitl import (
     HITLApprovalMiddleware,
 )
 from decepticon.middleware.model_override import ModelOverrideMiddleware
-from decepticon.middleware.proxy_key_override import ProxyKeyOverrideMiddleware
 from decepticon.middleware.notifications import SandboxNotificationMiddleware
 from decepticon.middleware.opscontrol_notifications import (
     OpsControlNotificationMiddleware,
 )
 from decepticon.middleware.prompt_injection_shield import PromptInjectionShieldMiddleware
+from decepticon.middleware.proxy_key_override import ProxyKeyOverrideMiddleware
 from decepticon.middleware.roe import build_default_sink
 
 # Slot enum + per-role applicability mapping + safety-critical set

--- a/packages/decepticon/decepticon/middleware/proxy_key_override.py
+++ b/packages/decepticon/decepticon/middleware/proxy_key_override.py
@@ -1,0 +1,128 @@
+"""Per-run LiteLLM virtual-key override — multi-tenant cost attribution.
+
+In a SHARED langgraph serving many orgs, the baked-in model authenticates to
+the LiteLLM proxy with the env master key (``DECEPTICON_LLM__PROXY_API_KEY``),
+so ALL spend lands on the master key and can't be split per customer. The SaaS
+launch flow mints a virtual key per engagement (the key's ``team_id`` is the
+org) and threads it in as ``config.configurable.proxy_api_key``. This middleware
+reads that key and rebinds the model for the wrapped call to authenticate with
+it, so LiteLLM attributes the spend to that key's team (= the org) — the basis
+for per-customer billing + budget enforcement (``/team/info`` spend per org).
+
+Slot placement: ``PROXY_KEY_OVERRIDE`` sits AFTER ``MODEL_FALLBACK`` in the
+canonical slot order, i.e. inner-most relative to model selection. So it
+re-keys whatever model is actually about to be called — including a fallback
+model the fallback middleware swapped in, and any model the model-override
+middleware selected. Keep that ordering or fallbacks mis-attribute.
+
+Resolution order (mirrors ``model_override``):
+
+  1. ``request.runtime.context.proxy_api_key`` (Runtime context)
+  2. ``request.state["proxy_api_key"]`` (input state)
+
+When neither is set the wrapped handler runs with the original env-keyed model
+untouched — so single-tenant / OSS deployments (no per-run key) are unaffected.
+
+The key value is never logged here, and ``event_logging`` already redacts
+``api_key`` fields, so the virtual key does not leak into event streams.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.language_models import BaseChatModel
+from langchain_openai import ChatOpenAI
+from pydantic import SecretStr
+from typing_extensions import override
+
+from decepticon.llm.factory import LLMFactory, _model_drops_temperature
+from decepticon_core.utils.logging import get_logger
+
+log = get_logger("middleware.proxy_key_override")
+
+
+def _read_proxy_key(request: Any) -> str:
+    """Pull the per-run virtual key out of runtime context or input state.
+
+    Returns the empty string when nothing is set so the caller can
+    short-circuit with a single truthiness check.
+    """
+    runtime = getattr(request, "runtime", None)
+    if runtime is not None:
+        ctx = getattr(runtime, "context", None) or {}
+        if isinstance(ctx, dict):
+            value = ctx.get("proxy_api_key", "")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    state = getattr(request, "state", None) or {}
+    get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+    value = get("proxy_api_key", "") or ""
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _rekey_model(original: BaseChatModel, api_key: str) -> BaseChatModel:
+    """Rebuild ``original`` against the LiteLLM proxy, authenticating with
+    ``api_key`` instead of the env master key.
+
+    Rebuild rather than ``model_copy`` because the OpenAI client binds the API
+    key at ``__init__`` — a shallow copy would keep the old client (old key).
+    Model id, base url, timeout, retries, and the temperature gate mirror the
+    baked-in primary (same as ``model_override._build_proxied_llm``) so
+    streaming / tool calling / fallback semantics are unchanged; only the
+    Authorization key differs.
+    """
+    proxy = LLMFactory._resolve_proxy_config()
+    model_id = getattr(original, "model_name", None) or getattr(original, "model", None)
+    if not model_id:
+        raise ValueError("cannot resolve model id from current model for re-key")
+    kwargs: dict[str, Any] = {
+        "model": model_id,
+        "base_url": proxy.url,
+        "api_key": SecretStr(api_key),
+        "timeout": proxy.timeout,
+        "max_retries": proxy.max_retries,
+    }
+    if not _model_drops_temperature(str(model_id)):
+        temperature = getattr(original, "temperature", None)
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+    return ChatOpenAI(**kwargs)
+
+
+class ProxyKeyOverrideMiddleware(AgentMiddleware):
+    """Per-invocation LiteLLM key swap driven by Runtime context / input state.
+
+    No-op when no per-run key is present, so OSS / single-tenant deployments
+    behave exactly as before.
+    """
+
+    @override
+    def wrap_model_call(self, request, handler):
+        key = _read_proxy_key(request)
+        if not key:
+            return handler(request)
+        try:
+            new_llm = _rekey_model(request.model, key)
+        except Exception as exc:
+            log.warning("proxy_key_override failed to bind: %s", exc)
+            return handler(request)
+        log.info("proxy_key_override active (per-run virtual key)")
+        return handler(request.override(model=new_llm))
+
+    @override
+    async def awrap_model_call(self, request, handler):
+        key = _read_proxy_key(request)
+        if not key:
+            return await handler(request)
+        try:
+            new_llm = _rekey_model(request.model, key)
+        except Exception as exc:
+            log.warning("proxy_key_override failed to bind: %s", exc)
+            return await handler(request)
+        log.info("proxy_key_override active (per-run virtual key)")
+        return await handler(request.override(model=new_llm))
+
+
+__all__ = ["ProxyKeyOverrideMiddleware"]

--- a/packages/decepticon/tests/unit/agents/test_build.py
+++ b/packages/decepticon/tests/unit/agents/test_build.py
@@ -600,6 +600,7 @@ def test_middleware_slot_enum_order_is_assembly_order():
         "budget",
         "model-override",
         "model-fallback",
+        "proxy-key-override",
         "summarization",
         "prompt-caching",
         "patch-tool-calls",

--- a/packages/decepticon/tests/unit/middleware/test_proxy_key_override.py
+++ b/packages/decepticon/tests/unit/middleware/test_proxy_key_override.py
@@ -1,0 +1,153 @@
+"""Tests for ProxyKeyOverrideMiddleware.
+
+The middleware re-binds the agent's LLM to a per-run LiteLLM virtual key
+(threaded by the SaaS launch flow as ``config.configurable.proxy_api_key``) so
+that, in a shared multi-tenant langgraph, each engagement's spend authenticates
+with — and is therefore attributed to — that org's key/team instead of the env
+master key. No key threaded ⇒ no-op (OSS / single-tenant unaffected).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_openai import ChatOpenAI
+
+from decepticon.middleware.proxy_key_override import (
+    ProxyKeyOverrideMiddleware,
+    _read_proxy_key,
+    _rekey_model,
+)
+
+
+@pytest.fixture
+def proxy_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    env = {
+        "DECEPTICON_LLM__PROXY_URL": "http://litellm:4000",
+        "DECEPTICON_LLM__PROXY_API_KEY": "sk-decepticon-master",
+        "DECEPTICON_LLM__TIMEOUT": "120",
+        "DECEPTICON_LLM__MAX_RETRIES": "2",
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return env
+
+
+def _original_chat_model(
+    model: str = "openai/gpt-5.5", temperature: float | None = 0.4
+) -> ChatOpenAI:
+    return ChatOpenAI(
+        model=model,
+        temperature=temperature,
+        api_key="sk-decepticon-master",
+        base_url="http://litellm:4000",
+    )
+
+
+# ── _read_proxy_key ─────────────────────────────────────────────────────
+
+
+class TestReadProxyKey:
+    def test_runtime_context_takes_priority(self) -> None:
+        class _Runtime:
+            context = {"proxy_api_key": "sk-org-A"}
+
+        class _Req:
+            runtime = _Runtime()
+            state = {"proxy_api_key": "sk-org-B"}
+
+        assert _read_proxy_key(_Req()) == "sk-org-A"
+
+    def test_state_used_when_runtime_absent(self) -> None:
+        class _Req:
+            runtime = None
+            state = {"proxy_api_key": "sk-org-B"}
+
+        assert _read_proxy_key(_Req()) == "sk-org-B"
+
+    def test_empty_means_no_key(self) -> None:
+        class _Runtime:
+            context = {"proxy_api_key": "   "}
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        assert _read_proxy_key(_Req()) == ""
+
+
+# ── _rekey_model ────────────────────────────────────────────────────────
+
+
+class TestRekeyModel:
+    def test_swaps_api_key_to_per_run_key(self, proxy_env: dict[str, str]) -> None:
+        bound = _rekey_model(_original_chat_model(), "sk-engagement-xyz")
+        # The whole point: authenticate with the per-run key, NOT the master.
+        assert bound.openai_api_key.get_secret_value() == "sk-engagement-xyz"
+        assert bound.openai_api_key.get_secret_value() != proxy_env[
+            "DECEPTICON_LLM__PROXY_API_KEY"
+        ]
+
+    def test_preserves_model_id_and_proxy_url(self, proxy_env: dict[str, str]) -> None:
+        bound = _rekey_model(
+            _original_chat_model(model="anthropic/claude-sonnet-4-6"), "sk-k"
+        )
+        assert bound.model_name == "anthropic/claude-sonnet-4-6"
+        assert bound.openai_api_base == proxy_env["DECEPTICON_LLM__PROXY_URL"]
+
+    def test_drops_temperature_for_opus_4x(self, proxy_env: dict[str, str]) -> None:
+        bound = _rekey_model(
+            _original_chat_model(model="auth/claude-opus-4-8", temperature=0.4),
+            "sk-k",
+        )
+        assert bound.temperature is None
+
+    def test_preserves_temperature_for_other_models(
+        self, proxy_env: dict[str, str]
+    ) -> None:
+        bound = _rekey_model(_original_chat_model(temperature=0.4), "sk-k")
+        assert bound.temperature == 0.4
+
+
+# ── Middleware wiring ───────────────────────────────────────────────────
+
+
+class TestProxyKeyOverrideMiddlewareWiring:
+    def test_no_key_passes_through_untouched(self) -> None:
+        mw = ProxyKeyOverrideMiddleware()
+        seen: list[Any] = []
+
+        def handler(request: Any) -> str:
+            seen.append(request)
+            return "passthrough"
+
+        class _Req:
+            runtime = None
+            state: dict[str, Any] = {}
+
+        assert mw.wrap_model_call(_Req(), handler) == "passthrough"
+        assert seen[0].__class__.__name__ == "_Req"  # original request, no override
+
+    def test_key_present_rekeys_model(self, proxy_env: dict[str, str]) -> None:
+        mw = ProxyKeyOverrideMiddleware()
+        captured: dict[str, Any] = {}
+
+        class _Req:
+            def __init__(self) -> None:
+                self.runtime = None
+                self.state = {"proxy_api_key": "sk-engagement-xyz"}
+                self.model = _original_chat_model()
+
+            def override(self, *, model: Any) -> "_Req":
+                new = _Req()
+                new.state = self.state
+                new.model = model
+                return new
+
+        def handler(request: Any) -> str:
+            captured["key"] = request.model.openai_api_key.get_secret_value()
+            return "ok"
+
+        assert mw.wrap_model_call(_Req(), handler) == "ok"
+        assert captured["key"] == "sk-engagement-xyz"

--- a/packages/decepticon/tests/unit/middleware/test_proxy_key_override.py
+++ b/packages/decepticon/tests/unit/middleware/test_proxy_key_override.py
@@ -85,14 +85,10 @@ class TestRekeyModel:
         bound = _rekey_model(_original_chat_model(), "sk-engagement-xyz")
         # The whole point: authenticate with the per-run key, NOT the master.
         assert bound.openai_api_key.get_secret_value() == "sk-engagement-xyz"
-        assert bound.openai_api_key.get_secret_value() != proxy_env[
-            "DECEPTICON_LLM__PROXY_API_KEY"
-        ]
+        assert bound.openai_api_key.get_secret_value() != proxy_env["DECEPTICON_LLM__PROXY_API_KEY"]
 
     def test_preserves_model_id_and_proxy_url(self, proxy_env: dict[str, str]) -> None:
-        bound = _rekey_model(
-            _original_chat_model(model="anthropic/claude-sonnet-4-6"), "sk-k"
-        )
+        bound = _rekey_model(_original_chat_model(model="anthropic/claude-sonnet-4-6"), "sk-k")
         assert bound.model_name == "anthropic/claude-sonnet-4-6"
         assert bound.openai_api_base == proxy_env["DECEPTICON_LLM__PROXY_URL"]
 
@@ -103,9 +99,7 @@ class TestRekeyModel:
         )
         assert bound.temperature is None
 
-    def test_preserves_temperature_for_other_models(
-        self, proxy_env: dict[str, str]
-    ) -> None:
+    def test_preserves_temperature_for_other_models(self, proxy_env: dict[str, str]) -> None:
         bound = _rekey_model(_original_chat_model(temperature=0.4), "sk-k")
         assert bound.temperature == 0.4
 


### PR DESCRIPTION
## Why
A shared langgraph plane serving many tenants authenticates **every** org's LLM calls with the env master key (`DECEPTICON_LLM__PROXY_API_KEY`), so all proxy spend lands on one key and can't be split per customer (verified downstream: 9 per-org LiteLLM teams exist but show $0 — all spend sits on the master key). Hosts that already mint a virtual key per run (key `team_id` = tenant) have no way to make the engine use it.

## What
New `PROXY_KEY_OVERRIDE` middleware slot. When `config.configurable.proxy_api_key` is threaded, the middleware rebinds the model to authenticate with that key, so LiteLLM attributes spend to the key's team → per-tenant `/team/info` billing + budget enforcement.

- **`PROXY_KEY_OVERRIDE` slot** placed **after `MODEL_FALLBACK`** (inner-most relative to model selection) and added to `_TAIL_SLOTS`, so every LLM-calling role re-keys whatever model is actually called — primary, `/model` override, **or a fallback model** (fallbacks are pre-built with the env key; inner placement re-keys them too).
- **`ProxyKeyOverrideMiddleware`** mirrors `ModelOverrideMiddleware`: reads the key from `runtime.context` then input `state`; rebuilds the model via the resolved proxy config swapping only `api_key` (rebuild, **not** `model_copy` — the OpenAI client binds the key at `__init__`); **no-op when no key is threaded**, so OSS / single-tenant deployments are unchanged.
- Key is never logged; `event_logging` already redacts `api_key`.

## Tests
`uv run pytest` green: 30 middleware (read-resolution, rekey: api_key swap + model-id/url preserved + Opus temp drop, middleware passthrough/rekey wiring) + 41 `test_build` (slot-order assertion updated for the new slot).

## Compatibility
Additive + no-op without a threaded key. Single-tenant/OSS behaviour is identical. The downstream SaaS consumer threads `config.configurable.proxy_api_key = engagement.litellmKey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)