### PR TITLE
feat(codex): GSM single-reader mode for Cloud Run token rotation

### DIFF
--- a/config/codex_chatgpt_handler.py
+++ b/config/codex_chatgpt_handler.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -51,6 +52,20 @@ CHATGPT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 
 DEFAULT_ORIGINATOR = "codex_cli_rs"
 DEFAULT_USER_AGENT = "codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown"
+
+# ── GSM single-reader mode (Cloud Run) ──────────────────────────────────────
+# On multi-instance / read-only-mount platforms (Cloud Run) a rotating Codex
+# refresh token can't be refreshed in-process without forking the chain across
+# instances (`refresh_token_reused`). When ``CODEX_AUTH_SECRET_RESOURCE`` names
+# a Secret Manager secret (e.g. ``projects/<id>/secrets/codex_auth``) the
+# handler runs READ-ONLY: an external single writer (the SaaS
+# ``refresh-codex-auth`` cron) rotates the token and publishes a new secret
+# version; this handler only ever reads ``versions/latest`` and never refreshes
+# or writes. Unset → classic file-backed behavior (local / single instance).
+CODEX_AUTH_SECRET_RESOURCE = os.environ.get("CODEX_AUTH_SECRET_RESOURCE", "").strip()
+# Re-read GSM once the cached access token is within this window of expiry —
+# the writer should already have published a fresher version by then.
+GSM_REFETCH_SKEW_SECONDS = 5 * 60
 
 
 def _codex_auth_path() -> Path:
@@ -99,7 +114,55 @@ def _load_codex_auth(path: Path) -> dict[str, Any] | None:
 _auth_cache = FileBackedCache(_codex_auth_path(), _load_codex_auth)
 
 
+class _GsmCodexAuth:
+    """Read-only Secret Manager source for Codex credentials (Cloud Run).
+
+    Reads ``<resource>/versions/latest`` and caches the parsed blob. Re-fetches
+    when the cached access token nears expiry — the external writer should have
+    published a fresher version by then. NEVER refreshes or writes, so the
+    rotating refresh-token chain can never fork across instances.
+    """
+
+    def __init__(self, resource: str) -> None:
+        self._resource = resource
+        self._cached: dict[str, Any] | None = None
+        self._lock = threading.Lock()
+        self._client: Any = None
+
+    def _gsm_client(self) -> Any:
+        if self._client is None:
+            # Lazy import so the dependency is only required on platforms that
+            # opt into GSM mode (the litellm Cloud Run image installs it).
+            from google.cloud import secretmanager
+
+            self._client = secretmanager.SecretManagerServiceClient()
+        return self._client
+
+    def _fetch(self) -> dict[str, Any]:
+        resp = self._gsm_client().access_secret_version(
+            request={"name": f"{self._resource}/versions/latest"},
+        )
+        raw = resp.payload.data.decode("utf-8")
+        return _validate_auth(json.loads(raw), Path(self._resource))
+
+    @staticmethod
+    def _needs_refetch(auth: dict[str, Any]) -> bool:
+        token = auth.get("tokens", {}).get("access_token")
+        return not token or is_jwt_expired(token, skew_seconds=GSM_REFETCH_SKEW_SECONDS)
+
+    def get(self, *, force: bool = False) -> dict[str, Any]:
+        with self._lock:
+            if force or self._cached is None or self._needs_refetch(self._cached):
+                self._cached = self._fetch()
+            return self._cached
+
+
+_gsm_auth = _GsmCodexAuth(CODEX_AUTH_SECRET_RESOURCE) if CODEX_AUTH_SECRET_RESOURCE else None
+
+
 def _read_auth() -> dict[str, Any]:
+    if _gsm_auth is not None:
+        return _gsm_auth.get()
     auth = _auth_cache.get()
     if auth is None:
         path = _codex_auth_path()
@@ -113,6 +176,11 @@ def _read_auth() -> dict[str, Any]:
 
 def _write_auth(auth: dict[str, Any]) -> None:
     """Persist auth back to the Codex CLI store and refresh the cache key."""
+    # GSM single-reader mode never refreshes, so this is normally unreachable;
+    # guard defensively so a stray write can't fork the externally-managed
+    # rotating chain or touch a read-only mount.
+    if _gsm_auth is not None:
+        return
     path = _codex_auth_path()
     write_json_atomic(path, auth)
     # Even if the on-disk write failed (read-only mount), keep the
@@ -173,8 +241,26 @@ def get_codex_access_token(force_refresh: bool = False) -> tuple[str, str | None
     auth = _read_auth()
     token = auth["tokens"]["access_token"]
     if force_refresh or is_jwt_expired(token, skew_seconds=DEFAULT_JWT_SKEW_SECONDS):
-        auth = _refresh_tokens(auth)
-        token = auth["tokens"]["access_token"]
+        if _gsm_auth is not None:
+            # GSM single-reader mode: never self-refresh (that forks the
+            # rotating chain). Re-read the latest secret version — the external
+            # writer should have rotated it. If it's STILL expired the writer is
+            # behind/down: fail loudly rather than mint a forked token.
+            auth = _gsm_auth.get(force=True)
+            token = auth["tokens"]["access_token"]
+            if is_jwt_expired(token, skew_seconds=0):
+                raise litellm.AuthenticationError(
+                    message=(
+                        "Codex access token from Secret Manager is expired and no "
+                        "fresher version is available — the refresh-codex-auth "
+                        "writer may be down."
+                    ),
+                    model="auth",
+                    llm_provider="auth",
+                )
+        else:
+            auth = _refresh_tokens(auth)
+            token = auth["tokens"]["access_token"]
     tokens = auth["tokens"]
     account_id = tokens.get("account_id") or _extract_account_id(tokens.get("id_token"), token)
     return token, account_id

--- a/containers/litellm.Dockerfile
+++ b/containers/litellm.Dockerfile
@@ -1,11 +1,15 @@
 FROM ghcr.io/berriai/litellm:v1.88.1
 
 # xxhash is required for CCH (Claude Code Hash) request signing.
+# google-cloud-secret-manager backs the Codex GSM single-reader mode
+# (CODEX_AUTH_SECRET_RESOURCE) — the handler reads the rotating codex_auth
+# token from Secret Manager instead of a pinned read-only mount on Cloud Run.
 # The v1.88.x base ships a uv-managed venv at /app/.venv (first on PATH)
 # with no pip and no uv on PATH, so a bare `pip install` fails (exit 127).
 # Bootstrap pip into that venv via ensurepip, then install with the venv's
-# python so xxhash lands where the litellm process imports from.
-RUN python -m ensurepip --upgrade && python -m pip install --no-cache-dir xxhash
+# python so the packages land where the litellm process imports from.
+RUN python -m ensurepip --upgrade && \
+    python -m pip install --no-cache-dir xxhash google-cloud-secret-manager
 
 COPY config/http_client.py /app/http_client.py
 COPY config/oauth_token_store.py /app/oauth_token_store.py

--- a/packages/decepticon/tests/unit/llm/test_oauth_handlers.py
+++ b/packages/decepticon/tests/unit/llm/test_oauth_handlers.py
@@ -155,6 +155,101 @@ class TestCodexRefreshNoSecretLeak:
         assert "SECRET" not in message
 
 
+# ── Codex GSM single-reader mode (Cloud Run) ────────────────────────────
+
+
+def _jwt_with_exp(exp: float) -> str:
+    """Mint a fake JWT whose payload carries only an ``exp`` claim."""
+    import base64
+    import json as _json
+
+    payload = base64.urlsafe_b64encode(_json.dumps({"exp": exp}).encode()).decode().rstrip("=")
+    return f"eyJhbGciOiJub25lIn0.{payload}.sig"
+
+
+def _codex_blob(exp: float) -> dict[str, Any]:
+    return {
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": _jwt_with_exp(exp),
+            "id_token": "x.y.z",
+            "refresh_token": "r",
+        },
+    }
+
+
+class TestCodexGsmReaderMode:
+    def test_get_caches_while_token_fresh(self, monkeypatch) -> None:
+        import time
+
+        src = codex._GsmCodexAuth("projects/p/secrets/codex_auth")
+        calls = {"n": 0}
+        fresh = _codex_blob(time.time() + 3600)
+
+        def fake_fetch() -> dict[str, Any]:
+            calls["n"] += 1
+            return fresh
+
+        monkeypatch.setattr(src, "_fetch", fake_fetch)
+        assert src.get() is src.get()
+        assert calls["n"] == 1  # cached — no second GSM read while fresh
+
+    def test_get_refetches_when_cached_token_near_expiry(self, monkeypatch) -> None:
+        import time
+
+        src = codex._GsmCodexAuth("projects/p/secrets/codex_auth")
+        near = _codex_blob(time.time() + 60)  # inside the 5-min refetch skew
+        fresh = _codex_blob(time.time() + 3600)
+        seq = [near, fresh]
+        monkeypatch.setattr(src, "_fetch", lambda: seq.pop(0))
+        assert src.get() is near
+        assert src.get() is fresh  # cached blob near expiry → re-read latest
+        assert not seq
+
+    def test_token_expiry_refetches_gsm_and_never_self_refreshes(self, monkeypatch) -> None:
+        import time
+
+        expired = _codex_blob(time.time() - 10)
+        fresh = _codex_blob(time.time() + 3600)
+
+        def fake_get(*, force: bool = False) -> dict[str, Any]:
+            return fresh if force else expired
+
+        monkeypatch.setattr(codex, "_gsm_auth", SimpleNamespace(get=fake_get))
+
+        def _no_refresh(*a, **k):
+            raise AssertionError("GSM mode must not self-refresh (forks the chain)")
+
+        monkeypatch.setattr(codex, "_refresh_tokens", _no_refresh)
+        token, _ = codex.get_codex_access_token()
+        assert token == fresh["tokens"]["access_token"]
+
+    def test_writer_behind_raises_instead_of_self_refresh(self, monkeypatch) -> None:
+        import time
+
+        expired = _codex_blob(time.time() - 10)
+        monkeypatch.setattr(
+            codex, "_gsm_auth", SimpleNamespace(get=lambda *, force=False: expired)
+        )
+
+        def _no_refresh(*a, **k):
+            raise AssertionError("must not self-refresh")
+
+        monkeypatch.setattr(codex, "_refresh_tokens", _no_refresh)
+        with pytest.raises(codex.litellm.AuthenticationError):
+            codex.get_codex_access_token()
+
+    def test_write_auth_is_noop_in_gsm_mode(self, monkeypatch) -> None:
+        # A stray write must not touch disk or fork the externally-managed chain.
+        monkeypatch.setattr(codex, "_gsm_auth", SimpleNamespace(get=lambda **k: {}))
+        wrote = {"called": False}
+        monkeypatch.setattr(
+            codex, "write_json_atomic", lambda *a, **k: wrote.__setitem__("called", True)
+        )
+        codex._write_auth({"tokens": {}})
+        assert wrote["called"] is False
+
+
 # ── B10 / B11: streaming must preserve tool calls + finish_reason ───────
 
 


### PR DESCRIPTION
## Why
The Codex/ChatGPT subscription uses a **rotating** refresh token — each refresh invalidates the previous one. On Cloud Run the `codex_auth` secret is mounted **read-only** and instances don't share state, so when multiple litellm instances each refresh in-process they fork the chain → `refresh_token_reused` → auth death.

## What
Adds a **read-only Secret Manager source**, active only when `CODEX_AUTH_SECRET_RESOURCE` names the secret (e.g. `projects/<id>/secrets/codex_auth`):

- `_read_auth()` reads `<resource>/versions/latest`, caches it, re-fetches only when the cached access token nears expiry (5-min skew).
- `get_codex_access_token()` in GSM mode **never self-refreshes** — on expiry it re-reads the latest version (an external single writer rotates the token + publishes a new version). If the latest is *still* expired (writer behind/down) it raises `AuthenticationError` rather than minting a forked token.
- `_write_auth()` is a defensive no-op in GSM mode.

Unset env → **unchanged** file-backed behavior (local / single-instance). `google-cloud-secret-manager` is added to the litellm image and **lazy-imported** (only loaded when the mode is on).

The single writer is the SaaS `refresh-codex-auth` cron (separate repo) — readers here never write, so the rotating chain can't fork.

## Test
`packages/decepticon/tests/unit/llm/test_oauth_handlers.py::TestCodexGsmReaderMode` — caches while fresh, re-fetches near expiry, never self-refreshes, raises when writer is behind, `_write_auth` no-op. 11 passed (5 new + 6 existing codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)