### PR TITLE
fix(sandbox_web): guard Playwright fallback redirects

### DIFF
--- a/packages/decepticon/decepticon/sandbox_web/executor.py
+++ b/packages/decepticon/decepticon/sandbox_web/executor.py
@@ -25,7 +25,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from typing import Optional
+from typing import Callable, Optional
 
 from .fetch_chain import Attempt
 from .validators import Verdict, validate
@@ -134,6 +134,7 @@ def run_playwright_fallback(
     timeout: int = 90,
     profile_dir: Optional[str] = None,
     force_executor: Optional[str] = None,
+    scope_check: Optional[Callable[[str], bool]] = None,
 ) -> tuple[Attempt, str]:
     """Invoke the appropriate Playwright executor.
 
@@ -195,6 +196,7 @@ def run_playwright_fallback(
         # template runs without xvfb; set INSANE_HEADLESS=0 (with xvfb present)
         # to run headful, which evades headless-detecting WAFs (Akamai/DataDome).
         "headless": os.environ.get("INSANE_HEADLESS", "1") not in ("0", "false", "no"),
+        "allowPrivate": False,
     }
     if choice == "playwright_mobile_chrome":
         args["device"] = "iPhone 13 Pro"
@@ -213,13 +215,34 @@ def run_playwright_fallback(
     # Fall back to treating raw stdout as HTML for forward/backward compat.
     html, final_url, status, cookies, user_agent, automation = _parse_envelope(stdout, url)
 
+    from . import safety
+
+    final_url = final_url or url
+    ok, reason = safety.classify_url(final_url, allow_private=safety.allow_private_default())
+    if not ok:
+        att.status = status
+        att.body_size = len(html)
+        att.verdict = Verdict.BLOCKED.value
+        att.reasons = [f"ssrf_blocked:{reason}"]
+        att.error = f"ssrf_blocked:{reason}"
+        att.url = final_url
+        return att, ""
+    if scope_check is not None and not scope_check(final_url):
+        att.status = status
+        att.body_size = len(html)
+        att.verdict = Verdict.BLOCKED.value
+        att.reasons = ["roe_out_of_scope"]
+        att.error = "ROE_REFUSED: final URL not in engagement scope"
+        att.url = final_url
+        return att, ""
+
     resp = _FakeResp(html, status=status, final_url=final_url)
     vr = validate(resp, success_selectors=success_selectors)
     att.status = status
     att.body_size = len(html)
     att.verdict = vr.verdict.value
     att.reasons = list(vr.reasons) + ([f"automation:{automation}"] if automation else [])
-    att.url = final_url or url
+    att.url = final_url
 
     # Cookie bridge: a browser that cleared a JS challenge yields exactly the
     # cookies + UA a plain HTTP client needs. Seed the curl_cffi pool so

--- a/packages/decepticon/decepticon/sandbox_web/fetch_chain.py
+++ b/packages/decepticon/decepticon/sandbox_web/fetch_chain.py
@@ -676,6 +676,12 @@ def _fetch_core(
 
     # If a terminal-nonsuccess (404/auth/429) stopped us, browser won't help.
     skip_browser = stop_reason in _TERMINAL_NONSUCCESS_VALUES
+    # Curl transport already refused a private/internal redirect hop. Do not
+    # re-try the same attacker-controlled URL with the browser tier, which would
+    # otherwise follow that redirect outside the curl SSRF guard.
+    if any((a.error or "").startswith("ssrf_redirect_blocked:") for a in trace):
+        skip_browser = True
+        stop_reason = stop_reason or "ssrf_redirect_blocked"
 
     # -------- Phase 3: Playwright fallback ----------------------------------
     if enable_playwright and not skip_browser:
@@ -697,6 +703,7 @@ def _fetch_core(
                     device_class=device_class,
                     force_executor=fb_name,
                     timeout=timeout if timeout and timeout > 30 else 90,
+                    scope_check=scope_check,
                 )
                 trace.append(pw_attempt)
                 browser_used += 1

--- a/packages/decepticon/decepticon/sandbox_web/templates/package.json
+++ b/packages/decepticon/decepticon/sandbox_web/templates/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Local deps for Playwright real-Chrome templates. npm install && npx playwright install chrome",
   "dependencies": {
+    "ipaddr.js": "^2.2.0",
     "playwright": "^1.58.2",
     "playwright-extra": "^4.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",

--- a/packages/decepticon/decepticon/sandbox_web/templates/playwright_mobile_chrome.js
+++ b/packages/decepticon/decepticon/sandbox_web/templates/playwright_mobile_chrome.js
@@ -11,6 +11,9 @@
  * NO-SITE-NAME RULE: same as playwright_real_chrome.js — no hostname branches.
  */
 
+const dns = require('dns').promises;
+const ipaddr = require('ipaddr.js');
+
 function writeStdoutAsync(payload) {
   return new Promise((resolve, reject) => {
     process.stdout.write(payload, (err) => (err ? reject(err) : resolve()));
@@ -41,6 +44,61 @@ async function readStdinJson() {
   });
 }
 
+function isBlockedIp(host) {
+  try {
+    let ip = ipaddr.process(host); // unwrap IPv4-mapped IPv6 addresses
+    if (ip.kind() === 'ipv6' && ip.match(ipaddr.parse('64:ff9b::'), 96)) {
+      const bytes = ip.toByteArray();
+      ip = ipaddr.fromByteArray(bytes.slice(12)); // NAT64 WKP embeds IPv4 in low 32 bits
+    }
+    const range = ip.range();
+    return !['unicast'].includes(range);
+  } catch (_e) {
+    return false;
+  }
+}
+
+async function classifyUrl(candidate, allowPrivate) {
+  let parsed;
+  try {
+    parsed = new URL(candidate);
+  } catch (e) {
+    return { ok: false, reason: `parse_error:${e.message || e}` };
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return { ok: false, reason: `scheme:${parsed.protocol.replace(':', '') || 'none'}` };
+  }
+  if (allowPrivate) {
+    return { ok: true, reason: 'allow_private' };
+  }
+  const host = parsed.hostname;
+  if (isBlockedIp(host)) {
+    return { ok: false, reason: `ip_blocked:${host}` };
+  }
+  try {
+    const records = await dns.lookup(host, { all: true });
+    for (const record of records) {
+      if (isBlockedIp(record.address)) {
+        return { ok: false, reason: `resolves_internal:${host}->${record.address}` };
+      }
+    }
+  } catch (_e) {
+    return { ok: false, reason: 'resolve_failed_blocked' };
+  }
+  return { ok: true, reason: 'public' };
+}
+
+async function installSafetyGuard(page, allowPrivate) {
+  await page.route('**/*', async (route) => {
+    const check = await classifyUrl(route.request().url(), allowPrivate);
+    if (!check.ok) {
+      await route.abort('blockedbyclient');
+      return;
+    }
+    await route.continue();
+  });
+}
+
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
@@ -51,6 +109,7 @@ async function main() {
   const waitSelector = args.waitSelector || null;
   const timeoutMs = args.timeout || 60000;
   const headless = args.headless ?? false;
+  const allowPrivate = args.allowPrivate === true;
 
   let chromium, devices;
   let automation = 'playwright';
@@ -90,6 +149,7 @@ async function main() {
       ...dev,
     });
     const page = await ctx.newPage();
+    await installSafetyGuard(page, allowPrivate);
     const deadline = Date.now() + timeoutMs;
     const rem = (cap) => Math.max(1000, Math.min(cap || timeoutMs, deadline - Date.now()));
     const mainResp = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: rem(90000) });

--- a/packages/decepticon/decepticon/sandbox_web/templates/playwright_real_chrome.js
+++ b/packages/decepticon/decepticon/sandbox_web/templates/playwright_real_chrome.js
@@ -16,6 +16,8 @@
  */
 
 const fs = require('fs');
+const dns = require('dns').promises;
+const ipaddr = require('ipaddr.js');
 
 // Drain stdout fully before exiting. `process.exit()` can truncate a large
 // HTML payload because it does not wait for pending stdout I/O (Node docs).
@@ -51,6 +53,61 @@ async function readStdinJson() {
   });
 }
 
+function isBlockedIp(host) {
+  try {
+    let ip = ipaddr.process(host); // unwrap IPv4-mapped IPv6 addresses
+    if (ip.kind() === 'ipv6' && ip.match(ipaddr.parse('64:ff9b::'), 96)) {
+      const bytes = ip.toByteArray();
+      ip = ipaddr.fromByteArray(bytes.slice(12)); // NAT64 WKP embeds IPv4 in low 32 bits
+    }
+    const range = ip.range();
+    return !['unicast'].includes(range);
+  } catch (_e) {
+    return false;
+  }
+}
+
+async function classifyUrl(candidate, allowPrivate) {
+  let parsed;
+  try {
+    parsed = new URL(candidate);
+  } catch (e) {
+    return { ok: false, reason: `parse_error:${e.message || e}` };
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return { ok: false, reason: `scheme:${parsed.protocol.replace(':', '') || 'none'}` };
+  }
+  if (allowPrivate) {
+    return { ok: true, reason: 'allow_private' };
+  }
+  const host = parsed.hostname;
+  if (isBlockedIp(host)) {
+    return { ok: false, reason: `ip_blocked:${host}` };
+  }
+  try {
+    const records = await dns.lookup(host, { all: true });
+    for (const record of records) {
+      if (isBlockedIp(record.address)) {
+        return { ok: false, reason: `resolves_internal:${host}->${record.address}` };
+      }
+    }
+  } catch (_e) {
+    return { ok: false, reason: 'resolve_failed_blocked' };
+  }
+  return { ok: true, reason: 'public' };
+}
+
+async function installSafetyGuard(page, allowPrivate) {
+  await page.route('**/*', async (route) => {
+    const check = await classifyUrl(route.request().url(), allowPrivate);
+    if (!check.ok) {
+      await route.abort('blockedbyclient');
+      return;
+    }
+    await route.continue();
+  });
+}
+
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
@@ -61,6 +118,7 @@ async function main() {
   const timeoutMs = args.timeout || 60000;
   const headless = args.headless ?? false;     // Akamai/etc detect headless
   const viewport = args.viewport || { width: 1366, height: 900 };
+  const allowPrivate = args.allowPrivate === true;
 
   let chromium;
   let automation = 'playwright';
@@ -110,6 +168,7 @@ async function main() {
     }
     ctx = await chromium.launchPersistentContext(profileDir, ctxOpts);
     const page = await ctx.newPage();
+    await installSafetyGuard(page, allowPrivate);
     // Single shared deadline across warmup + main + reload navigations so the
     // first nav can't eat the whole budget and starve the rest.
     const deadline = Date.now() + timeoutMs;

--- a/packages/decepticon/tests/unit/sandbox_web/test_executor.py
+++ b/packages/decepticon/tests/unit/sandbox_web/test_executor.py
@@ -16,7 +16,7 @@ from decepticon.sandbox_web.executor import _pick_executor, run_playwright_fallb
 from decepticon.sandbox_web.validators import SMALL_BODY_THRESHOLD, Verdict
 
 
-def _envelope(html: str, final_url: str = "https://example.com/final") -> str:
+def _envelope(html: str, final_url: str = "https://8.8.8.8/final") -> str:
     return json.dumps(
         {
             "html": html,
@@ -69,8 +69,56 @@ def test_mcp_force_remaps_to_local_and_validates(monkeypatch: pytest.MonkeyPatch
     )
     assert att.executor == "playwright_real_chrome"  # remapped, not MCP
     assert att.verdict == Verdict.STRONG_OK.value
-    assert att.url == "https://example.com/final"
+    assert att.url == "https://8.8.8.8/final"
     assert out == html
+
+
+def test_final_private_url_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = "x" * (SMALL_BODY_THRESHOLD + 50) + "<article id='c'>hi</article>"
+    monkeypatch.setattr(executor, "_chrome_channel_available", lambda: True)
+    monkeypatch.setattr(
+        executor,
+        "_run_node_template",
+        lambda template, args, timeout=90: (
+            0,
+            _envelope(html, final_url="http://127.0.0.1:9876/secret"),
+            "",
+        ),
+    )
+    att, out = run_playwright_fallback(
+        "https://example.com/x",
+        profile_id="unknown_challenge",
+        success_selectors=["article#c"],
+        force_executor="playwright_real_chrome",
+    )
+    assert att.verdict == Verdict.BLOCKED.value
+    assert att.error == "ssrf_blocked:ip_blocked:127.0.0.1"
+    assert att.url == "http://127.0.0.1:9876/secret"
+    assert out == ""
+
+
+def test_final_out_of_scope_url_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = "x" * (SMALL_BODY_THRESHOLD + 50) + "<article id='c'>hi</article>"
+    monkeypatch.setattr(executor, "_chrome_channel_available", lambda: True)
+    monkeypatch.setattr(
+        executor,
+        "_run_node_template",
+        lambda template, args, timeout=90: (
+            0,
+            _envelope(html, final_url="https://8.8.4.4/final"),
+            "",
+        ),
+    )
+    att, out = run_playwright_fallback(
+        "https://example.com/x",
+        profile_id="unknown_challenge",
+        success_selectors=["article#c"],
+        force_executor="playwright_real_chrome",
+        scope_check=lambda candidate: "example.com" in candidate,
+    )
+    assert att.verdict == Verdict.BLOCKED.value
+    assert att.error == "ROE_REFUSED: final URL not in engagement scope"
+    assert out == ""
 
 
 def test_rendered_challenge_is_challenge(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- The Playwright/Chromium fallback followed attacker-controlled navigations without the curl transport's SSRF/per-hop RoE checks, allowing final browser URLs (loopback, RFC1918, metadata, etc.) to reach the agent.
- Because the sandbox image now installs Chromium and the Playwright template deps by default, the browser tier became a reachable escalation path that must enforce the same safety checks as the curl grid.
- The change aims to ensure the browser fallback either inherits the same SSRF safety and RoE gating or is suppressed when curl already blocked an unsafe redirect.

### Description
- Threaded a `scope_check` parameter into `run_playwright_fallback` and the fetch chain so per-hop RoE gating can be enforced for fallback runs.
- After the Node template returns, `executor.run_playwright_fallback` now classifies the `finalUrl` via `safety.classify_url` and rejects/block-returns when the final URL is private/blocked or out of RoE scope instead of trusting the browser output.
- `fetch_chain` prevents invoking the browser fallback if the curl transport trace already recorded an `ssrf_redirect_blocked:` error to avoid retrying an attacker-controlled URL with the browser tier.
- Playwright templates (desktop + mobile) now install a request-interception safety guard that resolves and classifies every request (including NAT64/unwrapped IPv4-mapped IPv6 handling via `ipaddr.js`) and aborts requests that resolve to private/loopback/link-local/reserved or fail DNS resolution; `ipaddr.js` was added to the templates' `package.json`.
- Added unit tests covering the new behaviors: blocking a private final URL and blocking an out-of-scope final URL, while preserving successful fallback behavior.

### Testing
- Ran the sandbox_web unit tests with the node subprocess mocked: `DECEPTICON_SKIP_BOOT=1 pytest packages/decepticon/tests/unit/sandbox_web/test_executor.py packages/decepticon/tests/unit/sandbox_web/test_fetch_chain.py packages/decepticon/tests/unit/sandbox_web/test_safety.py` and observed all tests pass (`20 passed, 1 warning`).
- Performed Node syntax checks: `node --check` on both Playwright templates and `python -m py_compile` on modified Python modules, both succeeded with no syntax errors.
- Verified that template dependency changes were limited to adding `ipaddr.js` and that `git diff --check` produced no whitespace or trailing-eol issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c445737808327abaee063618368bc)