### PR TITLE
docs(readme): add live hosted app (app.decepticon.red) link + callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@
 <a href="https://docs.decepticon.red">
   <img src="https://img.shields.io/badge/Docs-docs.decepticon.red-8B5CF6?logo=bookstack&logoColor=white&style=for-the-badge" alt="Documentation">
 </a>
+<a href="https://app.decepticon.red">
+  <img src="https://img.shields.io/badge/Live%20App-app.decepticon.red-FF2D55?logo=rocket&logoColor=white&style=for-the-badge" alt="Live hosted app">
+</a>
 
 </div>
 
@@ -39,6 +42,18 @@
 
 <div align="center">
   <video src="https://github.com/user-attachments/assets/b3fd40d8-e859-4a39-97f4-bd825694ad96" width="800" controls></video>
+</div>
+
+<div align="center">
+
+### ☁️ Don't want to self-host? **Decepticon is live in the cloud.**
+
+Skip the Docker setup — run autonomous red-team engagements right from your browser.
+
+<a href="https://app.decepticon.red">
+  <img src="https://img.shields.io/badge/Launch%20the%20Live%20App-app.decepticon.red-FF2D55?logo=rocket&logoColor=white&style=for-the-badge" alt="Launch the live app at app.decepticon.red">
+</a>
+
 </div>
 
 ---

--- a/README_KO.md
+++ b/README_KO.md
@@ -32,6 +32,9 @@
 <a href="https://docs.decepticon.red">
   <img src="https://img.shields.io/badge/문서-docs.decepticon.red-8B5CF6?logo=bookstack&logoColor=white&style=for-the-badge" alt="Docs">
 </a>
+<a href="https://app.decepticon.red">
+  <img src="https://img.shields.io/badge/라이브%20앱-app.decepticon.red-FF2D55?logo=rocket&logoColor=white&style=for-the-badge" alt="라이브 호스팅 앱">
+</a>
 
 </div>
 
@@ -39,6 +42,18 @@
 
 <div align="center">
   <video src="https://github.com/user-attachments/assets/b3fd40d8-e859-4a39-97f4-bd825694ad96" width="800" controls></video>
+</div>
+
+<div align="center">
+
+### ☁️ 직접 설치하기 번거롭다면? **Decepticon이 클라우드에서 라이브로 돌아갑니다.**
+
+Docker 설치 없이 — 브라우저에서 바로 자율 레드팀 엔게이지먼트를 실행하세요.
+
+<a href="https://app.decepticon.red">
+  <img src="https://img.shields.io/badge/라이브%20앱%20실행하기-app.decepticon.red-FF2D55?logo=rocket&logoColor=white&style=for-the-badge" alt="app.decepticon.red 라이브 앱 실행">
+</a>
+
 </div>
 
 ---


### PR DESCRIPTION
## What

Drive README visitors to the hosted commercial product at **https://app.decepticon.red**.

- **Badge row**: new `Live App — app.decepticon.red` badge alongside Discord / Website / Docs.
- **Below the demo video** (just above Install): a cloud callout banner labeling the product as live, with a `Launch the Live App` button.
- Mirrored in both `README.md` (EN) and `README_KO.md` (KO) to keep the language toggle in sync.

## Why

The hosted product is live; the OSS README is the highest-traffic entry point, so a prominent above-the-fold link lets self-host-averse users go straight to the managed app.

## Notes

- Docs-only change — no code, no CI-gated logic touched.
- `app.decepticon.red` had no prior reference in the repo; this is the first link to it.