### PR TITLE
fix(filesystem): route filesystem tools to the per-run sandbox

### DIFF
--- a/packages/decepticon/decepticon/middleware/filesystem.py
+++ b/packages/decepticon/decepticon/middleware/filesystem.py
@@ -270,6 +270,49 @@ def _workspace_from_runtime(runtime: Any) -> str | None:
     return None
 
 
+def _rebind_sandbox_per_run(backend: BackendProtocol) -> BackendProtocol:
+    """Re-resolve the workspace sandbox transport from THIS run's config.
+
+    The agent backend is composed ONCE at construction
+    (``make_agent_backend(build_sandbox_backend())``) — no run context exists
+    yet, so its ``/workspace`` ``HTTPSandbox`` binds to the process-wide env
+    endpoint (``SANDBOX_URL``). In a SHARED langgraph serving many engagements
+    that single endpoint cannot reach a per-engagement sandbox, so every
+    filesystem op (read / write / ls / glob / grep / edit / download) would land
+    in the shared sidecar instead of the run's OWN sandbox — even though the bash
+    tool already routes per-run via ``configurable.sandbox_url`` (see
+    ``tools/bash/bash.py:get_sandbox``). That left bash and the filesystem
+    pointing at different sandboxes for the same run.
+
+    Re-running ``build_sandbox_backend()`` here resolves the endpoint against the
+    current run's config first (``get_config().configurable.sandbox_url`` /
+    ``sandbox_token``) and the env second — so a multi-tenant run reaches its own
+    per-engagement sandbox while single-tenant / dev runs (no per-run url)
+    resolve to the same env endpoint as before (behaviour unchanged). Only the
+    ``/workspace`` default is swapped; ``/skills/`` and any other routes are
+    preserved. Non-sandbox backends (e.g. a plain ``StateBackend`` in tests) are
+    returned untouched.
+    """
+    # Lazy imports: avoid any import-ordering coupling between the middleware and
+    # the backends package, and keep the env-resolution call out of import time.
+    from deepagents.backends import CompositeBackend
+
+    from decepticon.backends import build_sandbox_backend
+    from decepticon.backends.http_sandbox import HTTPSandbox
+
+    if isinstance(backend, HTTPSandbox):
+        return build_sandbox_backend()
+    if isinstance(backend, CompositeBackend) and isinstance(
+        backend.default, HTTPSandbox
+    ):
+        return CompositeBackend(
+            default=build_sandbox_backend(),
+            routes=backend.routes,
+            artifacts_root=backend.artifacts_root,
+        )
+    return backend
+
+
 class FilesystemMiddleware(BaseFilesystemMiddleware):
     """FilesystemMiddleware with Decepticon's bash tool as the only executor."""
 
@@ -278,6 +321,11 @@ class FilesystemMiddleware(BaseFilesystemMiddleware):
         self.tools = filesystem_tools_without_execute(self.tools)
 
     def _get_backend(self, runtime) -> BackendProtocol:
+        # Resolve the sandbox transport PER-RUN (config.sandbox_url) before
+        # wrapping it in the engagement workspace scoper, so a shared langgraph
+        # routes each engagement's filesystem ops to ITS OWN sandbox — matching
+        # the bash tool. See _rebind_sandbox_per_run.
         return EngagementFilesystemBackend(
-            super()._get_backend(runtime), _workspace_from_runtime(runtime)
+            _rebind_sandbox_per_run(super()._get_backend(runtime)),
+            _workspace_from_runtime(runtime),
         )

--- a/packages/decepticon/tests/unit/middleware/test_filesystem.py
+++ b/packages/decepticon/tests/unit/middleware/test_filesystem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from deepagents.backends import CompositeBackend
 from deepagents.backends.protocol import (
     EditResult,
     FileDownloadResponse,
@@ -12,9 +13,11 @@ from deepagents.backends.protocol import (
 )
 from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesystemMiddleware
 
+from decepticon.backends.http_sandbox import HTTPSandbox
 from decepticon.middleware.filesystem import (
     EngagementFilesystemBackend,
     FilesystemMiddleware,
+    _rebind_sandbox_per_run,
     _workspace_from_runtime,
 )
 
@@ -616,4 +619,82 @@ def test_filesystem_middleware_get_backend_wraps_in_engagement_backend() -> None
     result = mw._get_backend(_FakeRuntime())
 
     assert isinstance(result, EngagementFilesystemBackend)
+    assert result._root == "/workspace/eng"
+
+
+def test_rebind_passes_through_non_sandbox_backend() -> None:
+    """A plain (non-sandbox) backend is returned untouched — single-tenant /
+    dev / test setups that don't use ``HTTPSandbox`` are never rebound."""
+    backend = RecordingBackend()
+    assert _rebind_sandbox_per_run(backend) is backend
+
+
+def test_rebind_reresolves_bare_http_sandbox_per_run(monkeypatch) -> None:
+    """A bare ``HTTPSandbox`` (the construction-time env endpoint) is replaced
+    by the per-run resolution of ``build_sandbox_backend()`` — which consults
+    ``configurable.sandbox_url`` first, env second."""
+    per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+
+    env = HTTPSandbox("http://shared-sidecar:9999")
+    assert _rebind_sandbox_per_run(env) is per_run
+
+
+def test_rebind_swaps_composite_default_preserving_routes(monkeypatch) -> None:
+    """For the real agent backend — a ``CompositeBackend`` whose ``/workspace``
+    default is the env ``HTTPSandbox`` and whose ``/skills/`` route reads the
+    local tree — only the workspace default is re-resolved per-run. The
+    ``/skills/`` route and ``artifacts_root`` are preserved, and the cached
+    construction-time composite is left untouched."""
+    per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+
+    skills = RecordingBackend()
+    env = HTTPSandbox("http://shared-sidecar:9999")
+    composite = CompositeBackend(
+        default=env, routes={"/skills/": skills}, artifacts_root="/art"
+    )
+
+    rebound = _rebind_sandbox_per_run(composite)
+
+    assert isinstance(rebound, CompositeBackend)
+    assert rebound.default is per_run  # workspace transport re-resolved per-run
+    assert rebound.routes == {"/skills/": skills}  # /skills route preserved
+    assert rebound.artifacts_root == "/art"  # artifacts_root preserved
+    assert composite.default is env  # original (cached) composite untouched
+
+
+def test_rebind_leaves_composite_with_non_sandbox_default_untouched(monkeypatch) -> None:
+    """A composite whose default is NOT a sandbox (e.g. a dev StateBackend) is
+    returned unchanged — we never inject a sandbox where there wasn't one."""
+    monkeypatch.setattr(
+        "decepticon.backends.build_sandbox_backend",
+        lambda: (_ for _ in ()).throw(AssertionError("must not be called")),
+    )
+    state_like = RecordingBackend()
+    composite = CompositeBackend(default=state_like, routes={"/skills/": RecordingBackend()})
+
+    assert _rebind_sandbox_per_run(composite) is composite
+
+
+def test_get_backend_reresolves_sandbox_transport_per_run(monkeypatch) -> None:
+    """End-to-end: a shared langgraph (one construction-time composite bound to
+    the env sidecar) re-resolves each run's filesystem transport to that run's
+    own sandbox before scoping it to the engagement workspace."""
+    per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+
+    env = HTTPSandbox("http://shared-sidecar:9999")
+    composite = CompositeBackend(default=env, routes={"/skills/": RecordingBackend()})
+
+    class _FakeRuntime:
+        state = {}
+        config = {"configurable": {"workspace_path": "/workspace/eng"}}
+
+    mw = FilesystemMiddleware(backend=composite)
+    result = mw._get_backend(_FakeRuntime())
+
+    assert isinstance(result, EngagementFilesystemBackend)
+    assert isinstance(result._backend, CompositeBackend)
+    assert result._backend.default is per_run  # routed to THIS run's sandbox
     assert result._root == "/workspace/eng"


### PR DESCRIPTION
## Problem

`FilesystemMiddleware._get_backend` returned the backend captured at **agent construction** — `make_agent_backend(build_sandbox_backend())`, whose `/workspace` `HTTPSandbox` is bound to the process-wide `SANDBOX_URL`. In a **shared langgraph** serving many runs, every filesystem op (`read`/`write`/`ls`/`glob`/`grep`/`edit`/`download`) therefore hit that single env endpoint, even when the run supplied its own `configurable.sandbox_url`.

The **bash tool already resolves the sandbox per-run** (`tools/bash/bash.py:get_sandbox`). So for the same run, bash and the filesystem could point at **different sandboxes** — bash at the run's sandbox, the filesystem at the env one. Files an agent wrote via bash were invisible to `read_file`/`ls`, and files written via `write_file` never reached the run's own sandbox.

## Fix

Re-resolve the workspace transport **per-run** in `_get_backend`, via `build_sandbox_backend()` (which consults `get_config().configurable.sandbox_url` / `sandbox_token` first, env second) — mirroring `get_sandbox(config)` in the bash tool.

- Swaps **only** the `/workspace` default; the `/skills/` route and `artifacts_root` are preserved (works whether the backend is a bare `HTTPSandbox` or the `CompositeBackend` from `make_agent_backend`).
- **Single-tenant / dev** runs (no per-run url) resolve to the same env endpoint as before → behaviour unchanged.
- **Non-sandbox** backends (e.g. a plain `StateBackend` in tests) are returned untouched.

This makes the filesystem honour the same per-run sandbox routing the bash tool already does, so both halves of a run see one consistent filesystem.

## Tests

- 5 new unit tests in `tests/unit/middleware/test_filesystem.py`: non-sandbox pass-through, bare `HTTPSandbox` re-resolution, composite default-swap (routes + `artifacts_root` preserved, original untouched), composite with non-sandbox default left untouched, and end-to-end `_get_backend` per-run routing.
- `test_filesystem.py` 48 passed; broader `tests/unit/middleware/` + `tests/unit/backends/` slice 1037 passed.
- `ruff` clean, `basedpyright` 0 errors on the changed module.