### PR TITLE
fix(cli): show docker compose error tail

### DIFF
--- a/clients/cli/src/commands/web.test.ts
+++ b/clients/cli/src/commands/web.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatComposeFailure } from "./web.js";
+
+describe("formatComposeFailure", () => {
+  it("keeps the tail of docker compose stderr so the real error is visible", () => {
+    const stderr = `${"pulling layer\n".repeat(80)}Error response from daemon: ports are not available: bind: address already in use`;
+
+    const message = formatComposeFailure("start", 1, stderr);
+
+    expect(message).toContain("Failed to start web (exit 1)");
+    expect(message).toContain("address already in use");
+  });
+});

--- a/clients/cli/src/commands/web.ts
+++ b/clients/cli/src/commands/web.ts
@@ -62,8 +62,7 @@ function startWeb(context: CommandContext): Promise<void> {
     {
       pending: "Starting web dashboard…",
       success: () => `✅ Web dashboard up: ${url()}`,
-      failure: (code, stderr) =>
-        `❌ Failed to start web (exit ${code}): ${stderr.slice(0, 400)}`,
+      failure: (code, stderr) => formatComposeFailure("start", code, stderr),
     },
   );
 }
@@ -75,8 +74,7 @@ function stopWeb(context: CommandContext): Promise<void> {
     {
       pending: "Stopping web dashboard…",
       success: () => "✅ Web dashboard stopped (container kept for fast re-up)",
-      failure: (code, stderr) =>
-        `❌ Failed to stop web (exit ${code}): ${stderr.slice(0, 400)}`,
+      failure: (code, stderr) => formatComposeFailure("stop", code, stderr),
     },
   );
 }
@@ -124,4 +122,10 @@ function runDockerCompose(
       resolve();
     });
   });
+}
+
+export function formatComposeFailure(action: "start" | "stop", code: number | null, stderr: string): string {
+  const output = stderr.trim();
+  const tail = output.length > 1200 ? `…\n${output.slice(-1200)}` : output;
+  return `❌ Failed to ${action} web (exit ${code}): ${tail}`;
 }


### PR DESCRIPTION
## Summary
- Keep the tail of Docker Compose stderr in `/web` failure messages so the real daemon error remains visible.
- Add a CLI regression test for long Compose pull/progress output hiding the final error.

## Verification
- `npm test --workspace=@decepticon/cli -- src/commands/web.test.ts`
- `npm run build --workspace=@decepticon/streaming`
- `npm run typecheck --workspace=@decepticon/cli`
- `DECEPTICON_VERSION=1.1.23 docker compose --profile web pull web`