### PR TITLE
fix(core): preserve subagent failure counter

### DIFF
--- a/packages/decepticon/decepticon/core/subagent_streaming.py
+++ b/packages/decepticon/decepticon/core/subagent_streaming.py
@@ -203,6 +203,15 @@ class StreamingRunnable(RunnableBinding):
         # per-instance state outside the declared field schema.
         object.__setattr__(self, "_consecutive_failures", 0)
 
+    def with_config(self, config: Any = None, **kwargs: Any) -> "StreamingRunnable":
+        rebound = super().with_config(config, **kwargs)
+        object.__setattr__(
+            rebound,
+            "_consecutive_failures",
+            int(getattr(self, "_consecutive_failures", 0)),
+        )
+        return rebound
+
     def _bump_failure_and_format(self, exc: BaseException) -> str:
         """Increment the failure counter; return the message body for the
         returned state. Switches to a distinct TERMINAL marker once the cap

--- a/packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py
+++ b/packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py
@@ -112,6 +112,14 @@ class TestSyncTerminalGuard:
         assert "scanner" in text
         assert str(MAX_SUBAGENT_CONSECUTIVE_FAILURES) in text
 
+    def test_failures_survive_deepagents_with_config_rewrap(self, renderer: None) -> None:
+        wrapper = StreamingRunnable(_ToggleRunnable(), "scanner")
+        out: Any = None
+        for _ in range(MAX_SUBAGENT_CONSECUTIVE_FAILURES):
+            wrapper = wrapper.with_config({"metadata": {"name": "scanner"}, "run_name": "scanner"})
+            out = wrapper.invoke(_hm())
+        assert TERMINAL_MARKER in _last_text(out)
+
     def test_success_resets_counter(self, renderer: None) -> None:
         toggle = _ToggleRunnable(should_fail=True)
         wrapper = StreamingRunnable(toggle, "scanner")


### PR DESCRIPTION
## Summary
- Preserve `StreamingRunnable._consecutive_failures` across `with_config()` rewraps.
- Add regression coverage for deepagents-style per-invocation `with_config()` reconstruction.

Fixes #722

## Verification
- `uv run pytest packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py -q`
- `uv run pytest packages/decepticon/tests/unit/core/test_subagent_streaming.py packages/decepticon/tests/unit/core/test_subagent_streaming_guard.py -q`
- `uv run python -m py_compile packages/decepticon/decepticon/core/subagent_streaming.py`