### PR TITLE
fix(sandbox): widen connection retry to cover per-engagement sandbox boot

### DIFF
--- a/packages/decepticon/decepticon/backends/http_sandbox.py
+++ b/packages/decepticon/decepticon/backends/http_sandbox.py
@@ -108,26 +108,52 @@ class SandboxError(RuntimeError):
     pass
 
 
-def _retry_on_connection_error(fn, max_retries=3, base_delay=0.5):
-    """Retry a function on httpx connection errors with exponential backoff."""
+def _retry_on_connection_error(
+    fn, max_total_delay=150.0, base_delay=0.5, max_delay=8.0
+):
+    """Retry a function on httpx connection errors with capped exponential backoff.
+
+    Only ``ConnectError`` / ``ConnectTimeout`` are retried — both mean the TCP
+    connection was never established, so the request never reached the daemon
+    and re-sending it is side-effect-free (unlike a ``ReadTimeout``, where the
+    command may already be running). That safety is what lets us retry even
+    ``execute`` (bash) here.
+
+    The retry budget is time-based (``max_total_delay`` seconds of cumulative
+    sleep) rather than a fixed attempt count, because a per-engagement sandbox
+    can take 1-2 minutes to become reachable: VM provision -> COS boot ->
+    sandbox image pull -> container start before the daemon listens on :9999.
+    During that window connections are refused; retrying for ~``max_total_delay``
+    lets the agent's first tool call ride out the boot instead of failing the
+    run. A genuinely dead/unroutable sandbox still surfaces the error within
+    roughly ``max_total_delay`` (delays are capped at ``max_delay`` so the loop
+    keeps probing rather than backing off unboundedly).
+    """
     last_exc = None
-    for attempt in range(max_retries):
+    slept = 0.0
+    attempt = 0
+    while True:
         try:
             return fn()
         except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
             last_exc = exc
-            if attempt < max_retries - 1:
-                delay = base_delay * (2**attempt)
-                log.warning(
-                    "Sandbox connection failed (attempt %d/%d), retrying in %.1fs: %s",
-                    attempt + 1,
-                    max_retries,
-                    delay,
-                    exc,
-                )
-                time.sleep(delay)
-    if last_exc is None:  # max_retries <= 0 — never attempted
-        raise SandboxError("retry loop made no attempts (max_retries <= 0)")
+            delay = min(base_delay * (2**attempt), max_delay)
+            if slept + delay > max_total_delay:
+                break
+            log.warning(
+                "Sandbox connection failed (attempt %d, %.1fs/%.0fs elapsed), "
+                "retrying in %.1fs: %s",
+                attempt + 1,
+                slept,
+                max_total_delay,
+                delay,
+                exc,
+            )
+            time.sleep(delay)
+            slept += delay
+            attempt += 1
+    if last_exc is None:  # max_total_delay <= 0 — never able to retry
+        raise SandboxError("retry loop made no attempts (max_total_delay <= 0)")
     raise last_exc
 
 

--- a/packages/decepticon/tests/unit/backends/test_http_sandbox.py
+++ b/packages/decepticon/tests/unit/backends/test_http_sandbox.py
@@ -118,6 +118,48 @@ def test_retry_exhausts_reraises_connect_timeout(monkeypatch: pytest.MonkeyPatch
         _retry_on_connection_error(always_fail)
 
 
+def test_retry_rides_out_sandbox_boot_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A per-engagement sandbox can refuse connections for 1-2 min while it
+    boots. The retry budget must outlast that window — far more than the old
+    3-attempt cap — so the agent's first tool call survives the boot."""
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "decepticon.backends.http_sandbox.time.sleep", lambda d: sleep_calls.append(d)
+    )
+    sentinel = object()
+    attempts: list[int] = []
+
+    def booting() -> object:
+        attempts.append(1)
+        # Refuse for the first 15 attempts (would blow the old max_retries=3).
+        if len(attempts) <= 15:
+            raise httpx.ConnectError("[Errno 111] Connection refused")
+        return sentinel
+
+    result = _retry_on_connection_error(booting)
+    assert result is sentinel
+    assert len(attempts) == 16
+    # Backoff is capped (no unbounded growth) so the loop keeps probing.
+    assert max(sleep_calls) <= 8.0
+
+
+def test_retry_budget_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A genuinely dead sandbox must still surface within the time budget —
+    the cumulative (intended) backoff stays within max_total_delay."""
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "decepticon.backends.http_sandbox.time.sleep", lambda d: sleep_calls.append(d)
+    )
+
+    def always_fail() -> None:
+        raise httpx.ConnectError("refused")
+
+    with pytest.raises(httpx.ConnectError):
+        _retry_on_connection_error(always_fail, max_total_delay=30.0, max_delay=8.0)
+    assert sum(sleep_calls) <= 30.0
+    assert max(sleep_calls) <= 8.0
+
+
 def test_request_wraps_http_status_error_as_sandbox_error() -> None:
     sb = HTTPSandbox(base_url="http://localhost:9999")
     _inject_client(sb, _make_handler(500, None))


### PR DESCRIPTION
## Problem

`HTTPSandbox._retry_on_connection_error` retried `httpx.ConnectError`/`ConnectTimeout` only **3 times at 0.5s base backoff (~3.5s total)**. A per-engagement sandbox VM takes **1-2 minutes** to become reachable: VM provision → COS boot → sandbox image pull → container start before the daemon listens on `:9999`.

When a run's first sandbox tool call (e.g. `write_file` during engagement planning) routes to a freshly-provisioned per-engagement sandbox that is still booting, it hits `ConnectError('[Errno 111] Connection refused')` and the whole run fails. Observed live: VM created `02:00:01`, sandbox container started `02:02:16`, but the run's `write_file` fired at `02:01:05` → refused → run errored.

## Fix

Switch `_retry_on_connection_error` to a **time-budgeted, capped-backoff** retry:
- `max_total_delay=150.0` seconds of cumulative backoff (covers the boot window)
- `max_delay=8.0` cap per attempt (keeps probing rather than backing off unboundedly)
- still retries **only** `ConnectError`/`ConnectTimeout` — the TCP connection was never established, so the request never reached the daemon and re-sending is side-effect-free (this is what makes retrying even `execute`/bash safe; `ReadTimeout`, where a command may already be running, is *not* retried)

A genuinely dead/unroutable sandbox still surfaces the error within ~`max_total_delay`.

## Tests

- Existing retry tests unchanged-pass (first-try-no-sleep; recover-after-2 still sees `[0.5, 1.0]`; exhaust re-raises).
- New: `test_retry_rides_out_sandbox_boot_window` (recovers after 15 refusals — far past the old 3-cap; backoff capped ≤8s) and `test_retry_budget_is_bounded` (cumulative sleep ≤ budget).
- `ruff` clean, `basedpyright` 0 errors, `tests/unit/backends/` 122 passed.