### PR TITLE
fix(skillogy): load_skill returns the body only, not the full props JSON

### DIFF
--- a/packages/decepticon/decepticon/middleware/skillogy.py
+++ b/packages/decepticon/decepticon/middleware/skillogy.py
@@ -187,11 +187,16 @@ def _make_load_skill_tool(backend, allowed_path_prefixes: list[str] | None = Non
 
     @tool
     def load_skill(name_or_path: str) -> str:
-        """Fetch one SKILL.md's body + metadata from the skillogy graph.
+        """Fetch one SKILL.md's body from the skillogy graph.
 
         Accepts either a unique frontmatter ``name`` (e.g. 'kerberoasting')
-        or the canonical ``/skills/.../SKILL.md`` path. Returns the full
-        body + frontmatter fields as JSON.
+        or the canonical ``/skills/.../SKILL.md`` path. Returns the skill
+        BODY with a minimal name/path header — the other node properties
+        (subdomain, when_to_use, tags, MITRE/aatmf, allowed_tools …) exist to
+        FIND the skill via ``find_skill``; once it is loaded the agent only
+        needs the content, so they are omitted to keep the reading context
+        lean. Mirrors the filesystem ``load_skill`` (which strips frontmatter
+        and returns the body) so both backends read identically.
         """
         try:
             if name_or_path.startswith("/skills/"):
@@ -209,7 +214,18 @@ def _make_load_skill_tool(backend, allowed_path_prefixes: list[str] | None = Non
                 props = backend.load_skill(exact[0]["path"], **_acl_kwargs)
             if props is None:
                 return json.dumps({"error": f"no Skill at path {name_or_path!r}"})
-            return json.dumps(props, ensure_ascii=False, default=str)
+            # Body only (+ minimal header). Metadata props are search-side
+            # (find_skill); dumping them into the agent's context on every load
+            # is noise. Header mirrors the filesystem load_skill's format.
+            body = str(props.get("body") or "")
+            path = str(props.get("path") or name_or_path)
+            base_dir = path.rsplit("/", 1)[0] if "/" in path else "/"
+            name = str(props.get("name") or "")
+            description = str(props.get("description") or "").strip()
+            header = f"Base directory for this skill: {base_dir}\nSkill: {name}" + (
+                f" — {description}" if description else ""
+            )
+            return f"{header}\n\n{body.rstrip()}\n"
         except Exception as exc:  # noqa: BLE001 — surface as ToolMessage payload
             return json.dumps({"error": f"load_skill failed: {exc!r}"})
 

--- a/packages/decepticon/decepticon/middleware/skillogy.py
+++ b/packages/decepticon/decepticon/middleware/skillogy.py
@@ -10,8 +10,8 @@ Agent tool surface (Phase 1a, three tools — see Amendment v0.2.2)
   Returns each match's name, path, subdomain, description, plus the
   matched MITRE IDs and tags so the agent sees *why* the skill came
   back.
-- ``load_skill(name_or_path)`` — fetch the full body + frontmatter of
-  one ``:Skill`` node. Accepts either a unique ``name`` or the
+- ``load_skill(name_or_path)`` — fetch the body of one ``:Skill`` node
+  (metadata is search-side, returned by ``find_skill``). Accepts either a unique ``name`` or the
   canonical ``/skills/.../SKILL.md`` path.
 - ``traverse(from_path, edge_types?, depth=2)`` — explicit graph
   walking from a Skill seed along a whitelisted edge set.
@@ -88,8 +88,10 @@ Three tools:
         query     → substring on name / description / when_to_use
       Returns name, path, subdomain, description, matched_mitre, matched_tags.
   • load_skill(name_or_path)
-      Fetch one SKILL.md's body + frontmatter. Accept a unique frontmatter
-      `name` (e.g. 'kerberoasting') or the canonical '/skills/.../SKILL.md' path.
+      Fetch one SKILL.md's body (the content only — metadata like subdomain /
+      tags / when_to_use is search-side, surfaced by find_skill). Accept a
+      unique frontmatter `name` (e.g. 'kerberoasting') or the canonical
+      '/skills/.../SKILL.md' path.
   • traverse(from_path, edge_types?, depth=2)
       BFS from a Skill seed along the edge whitelist
       (IN_PHASE, IMPLEMENTS, TAGGED, BELONGS_TO, RELATED_TO,

--- a/packages/decepticon/tests/unit/middleware/test_skillogy.py
+++ b/packages/decepticon/tests/unit/middleware/test_skillogy.py
@@ -257,23 +257,39 @@ class TestFindSkillTool:
 
 
 class TestLoadSkillTool:
-    def test_path_route_returns_props(self) -> None:
-        backend = _StubBackend(load_response={"name": "x", "body": "..."})
+    def test_path_route_returns_body_only(self) -> None:
+        backend = _StubBackend(
+            load_response={
+                "name": "x",
+                "path": "/skills/x/SKILL.md",
+                "body": "BODY-CONTENT",
+                "subdomain": "web-exploitation",
+            }
+        )
         tool = _make_load_skill_tool(backend)
         out = tool.invoke({"name_or_path": "/skills/x/SKILL.md"})
-        data = json.loads(out)
-        assert data == {"name": "x", "body": "..."}
+        # Body only (+ minimal header) — NOT a JSON props dump, and the
+        # search-side metadata (subdomain) must NOT leak into the reading context.
+        assert not out.strip().startswith("{")
+        assert "BODY-CONTENT" in out
+        assert "Skill: x" in out
+        assert "web-exploitation" not in out
         assert backend.load_calls == ["/skills/x/SKILL.md"]
 
     def test_name_route_resolves_via_find_then_loads(self) -> None:
         # find_skill returns a hit; load_skill is then called with the hit's path.
         backend = _StubBackend(
             find_response=[{"name": "kerberoasting", "path": "/skills/ad/k/SKILL.md"}],
-            load_response={"name": "kerberoasting", "body": "kerb body"},
+            load_response={
+                "name": "kerberoasting",
+                "path": "/skills/ad/k/SKILL.md",
+                "body": "kerb body",
+            },
         )
         tool = _make_load_skill_tool(backend)
-        data = json.loads(tool.invoke({"name_or_path": "kerberoasting"}))
-        assert data["name"] == "kerberoasting"
+        out = tool.invoke({"name_or_path": "kerberoasting"})
+        assert "kerb body" in out
+        assert "Skill: kerberoasting" in out
         # find_skill was hit first (name route), then load_skill with the path.
         assert backend.find_calls and backend.find_calls[0]["query"] == "kerberoasting"
         assert backend.load_calls == ["/skills/ad/k/SKILL.md"]

--- a/packages/decepticon/tests/unit/skillogy/test_acl.py
+++ b/packages/decepticon/tests/unit/skillogy/test_acl.py
@@ -208,12 +208,16 @@ def test_maybe_install_no_role_keeps_acl_unset(monkeypatch):
 # ── tool surface output shape unchanged ──
 
 
-@pytest.mark.parametrize("tool_name", ["find_skill", "load_skill", "traverse"])
+# find_skill / traverse stay JSON (structured search results). load_skill is the
+# exception since the body-only follow-up: it returns the skill BODY as plain
+# markdown (header + content), not a JSON envelope — see
+# test_middleware_load_skill_tool_returns_body. So it is intentionally NOT in
+# this JSON-shape parametrization.
+@pytest.mark.parametrize("tool_name", ["find_skill", "traverse"])
 def test_tool_output_shape_still_json(tool_name):
-    """ADR-0008 changes who-can-see-what but not the wire format. The
-    PR-B markdown follow-up will revisit this; until then, tool results
-    must still parse as JSON so existing agent-side post-processing
-    keeps working."""
+    """ADR-0008 changes who-can-see-what but not the wire format for the
+    search-shaped tools: find_skill / traverse results must still parse as JSON
+    so existing agent-side post-processing keeps working."""
     backend = _RecordingBackend()
     mw = SkillogyMiddleware(
         backend=backend,
@@ -223,8 +227,6 @@ def test_tool_output_shape_still_json(tool_name):
     tools = _tools_by_name(mw)
     if tool_name == "find_skill":
         result = tools[tool_name].invoke({"subdomain": "x"})
-    elif tool_name == "load_skill":
-        result = tools[tool_name].invoke({"name_or_path": "/skills/standard/recon/demo/SKILL.md"})
     else:
         result = tools[tool_name].invoke({"from_path": "/skills/standard/recon/demo/SKILL.md"})
     json.loads(result)  # raises if the closure broke the JSON envelope

--- a/packages/decepticon/tests/unit/skillogy/test_middleware.py
+++ b/packages/decepticon/tests/unit/skillogy/test_middleware.py
@@ -72,8 +72,9 @@ def test_middleware_load_skill_tool_returns_body():
     backend = _FakeBackend()
     mw = SkillogyMiddleware(backend=backend, append_policy_to_system=False)
     result = _tools_by_name(mw)["load_skill"].invoke({"name_or_path": "/skills/ad/k"})
-    payload = json.loads(result)
-    assert "# Body of /skills/ad/k" in payload["body"]
+    # Body-only contract: the result is the skill BODY as plain markdown (with a
+    # minimal name/path header), NOT a JSON envelope — metadata is search-side.
+    assert "# Body of /skills/ad/k" in result
     assert backend.load_calls[0] == "/skills/ad/k"
 
 


### PR DESCRIPTION
## What
The skillogy-backed `load_skill` tool returned `json.dumps(props)` — the entire skill node's properties (`name, path, subdomain, description, when_to_use, body, aatmf_tactic_raw, allowed_tools, …`) — into the agent's context on every load. The filesystem `load_skill` already returns the **body only** (frontmatter stripped). This makes the two backends consistent: `load_skill` now returns the skill **body** with a minimal `name`/`path` header.

## Why
The metadata props are **search-side** — they exist so `find_skill` can locate the right skill (subdomain, when_to_use, tags, MITRE). Once a skill is loaded, the agent only needs the **content**; dumping the metadata JSON on every load is context noise. `find_skill` (search) is unchanged.

## Test
`tests/unit/middleware/test_skillogy.py::TestLoadSkillTool` — updated the two path/name-route tests to assert body-only output (not a JSON props dump; search-side metadata must not leak into the reading context); error-envelope tests unchanged. **5 passed.**

## Deploy note
This is the langgraph-side OSS package (`decepticon.middleware.skillogy`), so it reaches prod via an OSS release → langgraph pin bump (not the SaaS-only plugin path). Safe to batch with the next OSS release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)