### PR TITLE
style(ci): ruff-format http_sandbox.py to unblock main CI

### DIFF
--- a/packages/decepticon/decepticon/backends/http_sandbox.py
+++ b/packages/decepticon/decepticon/backends/http_sandbox.py
@@ -108,9 +108,7 @@ class SandboxError(RuntimeError):
     pass
 
 
-def _retry_on_connection_error(
-    fn, max_total_delay=150.0, base_delay=0.5, max_delay=8.0
-):
+def _retry_on_connection_error(fn, max_total_delay=150.0, base_delay=0.5, max_delay=8.0):
     """Retry a function on httpx connection errors with capped exponential backoff.
 
     Only ``ConnectError`` / ``ConnectTimeout`` are retried — both mean the TCP


### PR DESCRIPTION
## What

`make ci-lint` on `main` fails at the `ruff format --check` step — `packages/decepticon/decepticon/backends/http_sandbox.py` was committed unformatted. This fails the **Python (lint + typecheck + test)** required check on `main` itself, which blocks every open PR through branch protection (the failure is unrelated to those PRs' diffs).

## Change

`uv run ruff format` on that one file — the exact formatting ruff produces. **No logic change.**

## Verification (local, on this branch)

- `make ci-lint` → ruff check ✓, ruff format --check ✓, basedpyright **0 errors** ✓
- `make audit-skills-strict` → 310 files, **0 violations** ✓
- `uv run pytest -m 'not slow'` → exit 0 ✓

Unblocks #740, #741 (they just need a rebase/branch-update after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)