### PR TITLE
fix(ops): register ops_* tools only when opscontrol is available

### DIFF
--- a/packages/decepticon/decepticon/agents/standard/decepticon.py
+++ b/packages/decepticon/decepticon/agents/standard/decepticon.py
@@ -160,12 +160,18 @@ def create_decepticon_agent(
         # so a compromised sub-agent cannot spin up unrelated
         # infrastructure). Sub-agents see neither these tools nor the
         # underlying daemon socket.
-        from decepticon.tools.ops import OPS_TOOLS
+        #
+        # Register ``ops_*`` ONLY when the opscontrol daemon socket is
+        # present (``decepticon start`` topology). Daemon-less topologies —
+        # ``make dev`` / ``make smoke``, and hosted deployments that manage
+        # workload teardown externally — have no socket, so offering these
+        # tools would only let the orchestrator call something that returns
+        # ``opscontrol_unreachable``. Gating keeps the toolset honest per
+        # topology instead of relying on the model to avoid an unusable tool.
+        from decepticon.tools.ops import OPS_TOOLS, ops_available
 
-        tools = build_tools(
-            role=_ROLE,
-            standard_tools={t.name: t for t in OPS_TOOLS},
-        )
+        standard_tools = {t.name: t for t in OPS_TOOLS} if ops_available() else {}
+        tools = build_tools(role=_ROLE, standard_tools=standard_tools)
     if middleware is None:
         middleware = build_middleware(
             role=_ROLE,

--- a/packages/decepticon/decepticon/tools/ops/__init__.py
+++ b/packages/decepticon/decepticon/tools/ops/__init__.py
@@ -13,6 +13,8 @@ from decepticon.tools.ops.client import (
     OpsControlClient,
     OpsControlError,
     OpsControlUnreachableError,
+    ops_available,
+    resolve_socket_path,
 )
 from decepticon.tools.ops.tools import (
     OPS_TOOLS,
@@ -27,8 +29,10 @@ __all__ = [
     "OpsControlClient",
     "OpsControlError",
     "OpsControlUnreachableError",
+    "ops_available",
     "ops_cleanup_engagement",
     "ops_start",
     "ops_status",
     "ops_stop",
+    "resolve_socket_path",
 ]

--- a/packages/decepticon/decepticon/tools/ops/client.py
+++ b/packages/decepticon/decepticon/tools/ops/client.py
@@ -21,6 +21,26 @@ DEFAULT_SOCKET_PATH = "/var/run/decepticon-ops.sock"
 SOCKET_PATH_ENV = "DECEPTICON_OPSCONTROL_SOCK"
 
 
+def resolve_socket_path() -> str:
+    """The opscontrol socket path for this process (env override → default)."""
+    return os.environ.get(SOCKET_PATH_ENV, DEFAULT_SOCKET_PATH)
+
+
+def ops_available() -> bool:
+    """True when the opscontrol daemon socket is present.
+
+    The socket file is the ADR-0006 capability grant: it exists only when the
+    stack was brought up via ``decepticon start`` (the daemon bind-mounts it
+    into the langgraph container). Daemon-less topologies — ``make dev`` /
+    ``make smoke``, and hosted deployments that manage workload teardown
+    externally (no opscontrol on the runtime) — have no socket, so the
+    ``ops_*`` tools have nothing to talk to. Registering them there only lets
+    the orchestrator call a tool that can return ``opscontrol_unreachable``;
+    gating registration on this check keeps the toolset honest per topology.
+    """
+    return os.path.exists(resolve_socket_path())
+
+
 class OpsControlError(RuntimeError):
     """Daemon returned a non-2xx HTTP response."""
 

--- a/packages/decepticon/tests/unit/ops/test_client.py
+++ b/packages/decepticon/tests/unit/ops/test_client.py
@@ -15,9 +15,13 @@ import httpx
 import pytest
 
 from decepticon.tools.ops.client import (
+    DEFAULT_SOCKET_PATH,
+    SOCKET_PATH_ENV,
     OpsControlClient,
     OpsControlError,
     OpsControlUnreachableError,
+    ops_available,
+    resolve_socket_path,
 )
 
 
@@ -106,3 +110,24 @@ def test_unreachable_when_socket_missing(tmp_path) -> None:
     client = OpsControlClient(socket_path=str(bogus))
     with pytest.raises(OpsControlUnreachableError):
         client.health()
+
+
+def test_resolve_socket_path_default_and_env(monkeypatch) -> None:
+    monkeypatch.delenv(SOCKET_PATH_ENV, raising=False)
+    assert resolve_socket_path() == DEFAULT_SOCKET_PATH
+    monkeypatch.setenv(SOCKET_PATH_ENV, "/run/custom-ops.sock")
+    assert resolve_socket_path() == "/run/custom-ops.sock"
+
+
+def test_ops_available_false_when_socket_absent(tmp_path, monkeypatch) -> None:
+    # Daemon-less topology (make dev / smoke / hosted) — no socket file.
+    monkeypatch.setenv(SOCKET_PATH_ENV, str(tmp_path / "absent.sock"))
+    assert ops_available() is False
+
+
+def test_ops_available_true_when_socket_present(tmp_path, monkeypatch) -> None:
+    # `decepticon start` topology — the daemon bind-mounted the socket.
+    present = tmp_path / "present.sock"
+    present.write_text("")  # any node at the path counts as the capability grant
+    monkeypatch.setenv(SOCKET_PATH_ENV, str(present))
+    assert ops_available() is True


### PR DESCRIPTION
## Problem

The orchestrator registers the ADR-0006 `ops_*` tools (`ops_start` / `ops_stop` / `ops_cleanup_engagement` / `ops_status`) **unconditionally** (`agents/standard/decepticon.py`). In **daemon-less topologies** — `make dev` / `make smoke`, and hosted deployments that manage workload teardown externally — there is no opscontrol socket, so the orchestrator's `At engagement close, call ops_cleanup_engagement()` step (and any other `ops_*` call) returns:

```
{"error": "opscontrol_unreachable", ...}
```

…wasting a turn on a tool that cannot work in that topology.

## Root-cause fix (not a prompt patch)

Gate **registration** on opscontrol availability rather than telling the model to avoid an unusable tool:

- `tools/ops/client.py`: `resolve_socket_path()` + `ops_available()` (socket-file presence — the ADR-0006 capability grant).
- `tools/ops/__init__.py`: export both.
- `agents/standard/decepticon.py`: `standard_tools = {ops_*} if ops_available() else {}`.

Correct for both topologies: `decepticon start` bind-mounts the socket → tools registered; daemon-less → tools absent, so the model never sees a tool it can't call.

## Tests

`tests/unit/ops/test_client.py`: `ops_available()` True/False by socket presence; `resolve_socket_path()` env override. **4 passed** locally.

## Note

Branches from `main`, so the `ruff format` check is red until #742 lands; I'll rebase once #742 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)