### PR TITLE
fix(ops): gate ops_* on daemon reachability, not just socket presence

### DIFF
--- a/packages/decepticon/decepticon/tools/ops/client.py
+++ b/packages/decepticon/decepticon/tools/ops/client.py
@@ -13,6 +13,7 @@ Sandbox SDK) use for UDS-only control planes.
 from __future__ import annotations
 
 import os
+import socket as _socket
 from typing import Any
 
 import httpx
@@ -27,18 +28,33 @@ def resolve_socket_path() -> str:
 
 
 def ops_available() -> bool:
-    """True when the opscontrol daemon socket is present.
+    """True when the opscontrol daemon is actually REACHABLE.
 
-    The socket file is the ADR-0006 capability grant: it exists only when the
-    stack was brought up via ``decepticon start`` (the daemon bind-mounts it
-    into the langgraph container). Daemon-less topologies — ``make dev`` /
-    ``make smoke``, and hosted deployments that manage workload teardown
-    externally (no opscontrol on the runtime) — have no socket, so the
-    ``ops_*`` tools have nothing to talk to. Registering them there only lets
-    the orchestrator call a tool that can return ``opscontrol_unreachable``;
+    The socket is the ADR-0006 capability grant: a live daemon listens on it
+    only when the stack was brought up via ``decepticon start`` (the daemon
+    bind-mounts it into the langgraph container). Daemon-less topologies —
+    ``make dev`` / ``make smoke``, and hosted deployments that manage workload
+    teardown externally (no opscontrol on the runtime) — have no live daemon,
+    so the ``ops_*`` tools have nothing to talk to. Registering them there only
+    lets the orchestrator call a tool that returns ``opscontrol_unreachable``;
     gating registration on this check keeps the toolset honest per topology.
+
+    A bare ``os.path.exists`` is NOT enough: a stale/leftover socket inode (or a
+    path that exists for an unrelated reason in a hosted container) passes the
+    file check while no daemon answers, so the tools get registered and then
+    fail at call time. We require an actual UDS *connect* to succeed — only a
+    live, accepting daemon flips this True.
     """
-    return os.path.exists(resolve_socket_path())
+    path = resolve_socket_path()
+    if not os.path.exists(path):
+        return False
+    try:
+        with _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            sock.connect(path)
+        return True
+    except OSError:
+        return False
 
 
 class OpsControlError(RuntimeError):

--- a/packages/decepticon/tests/unit/ops/test_client.py
+++ b/packages/decepticon/tests/unit/ops/test_client.py
@@ -125,9 +125,29 @@ def test_ops_available_false_when_socket_absent(tmp_path, monkeypatch) -> None:
     assert ops_available() is False
 
 
-def test_ops_available_true_when_socket_present(tmp_path, monkeypatch) -> None:
-    # `decepticon start` topology — the daemon bind-mounted the socket.
+def test_ops_available_false_when_socket_node_but_no_daemon(tmp_path, monkeypatch) -> None:
+    # A stale/leftover node at the path (or an unrelated file in a hosted
+    # container) must NOT count: no daemon is accepting, so a connect fails and
+    # the ops_* tools must stay unregistered. This is the hosted-SaaS case where
+    # a bare os.path.exists wrongly registered the tools and they then failed at
+    # call time with opscontrol_unreachable.
     present = tmp_path / "present.sock"
-    present.write_text("")  # any node at the path counts as the capability grant
+    present.write_text("")  # a plain file — exists, but nothing listens
     monkeypatch.setenv(SOCKET_PATH_ENV, str(present))
-    assert ops_available() is True
+    assert ops_available() is False
+
+
+def test_ops_available_true_when_daemon_accepting(tmp_path, monkeypatch) -> None:
+    # `decepticon start` topology — a live daemon is bound to + accepting on the
+    # socket. Only a successful connect flips this True.
+    import socket as _socket
+
+    sock_path = tmp_path / "live.sock"
+    server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+    try:
+        server.bind(str(sock_path))
+        server.listen(1)
+        monkeypatch.setenv(SOCKET_PATH_ENV, str(sock_path))
+        assert ops_available() is True
+    finally:
+        server.close()


### PR DESCRIPTION
## Problem

`ops_available()` returned `True` whenever the socket path merely **existed** (`os.path.exists`). In a hosted topology (no opscontrol daemon) a stale/leftover socket node — or a path present for an unrelated reason — passed the check, so the `ops_*` tools got **registered with no daemon accepting**. The orchestrator then called e.g. `ops_cleanup_engagement` and hit `opscontrol_unreachable` at call time. (Observed in the hosted SaaS langgraph: a fresh run still called `ops_cleanup_engagement` and failed with `Errno 2`.)

## Fix

Require an actual `AF_UNIX` **connect** to succeed (0.5s timeout) — only a live, accepting daemon flips `ops_available()` `True`. 

- Daemon-less topologies (`make dev` / `make smoke`, hosted deployments) → tools stay unregistered (no more spurious `opscontrol_unreachable`).
- **Forward-compatible**: the moment a real opscontrol daemon is reachable (e.g. deployed on a per-engagement VM for C2 / BloodHound spawning), the connect succeeds and the tools auto-register — no further change.

## Tests
- plain-file socket node (exists, nothing listening) → `False`
- live listening UDS → `True`