### PR TITLE
style(factory): ruff format _resolve_endpoint (fix CI)

### DIFF
--- a/packages/decepticon/decepticon/backends/factory.py
+++ b/packages/decepticon/decepticon/backends/factory.py
@@ -85,9 +85,7 @@ def _resolve_endpoint(config: Any = None) -> tuple[str, str | None]:
         try:
             from langgraph.config import get_config
 
-            cv_url, cv_token = _endpoint_from_configurable(
-                (get_config() or {}).get("configurable")
-            )
+            cv_url, cv_token = _endpoint_from_configurable((get_config() or {}).get("configurable"))
             url = cv_url
             if token is None:
                 token = cv_token


### PR DESCRIPTION
Pure ruff-format fix for `backends/factory.py` — the v1.1.30 change wrapped a call across 3 lines but ruff wants it on one (within line length). No logic change. Unblocks `make ci-lint` (`ruff format --check`) which went red on v1.1.30.