### PR TITLE
fix(state,opplan): per-run sandbox for OPPLAN + concurrent-write reducer for proxy_api_key

### DIFF
--- a/packages/decepticon/decepticon/middleware/proxy_key_override.py
+++ b/packages/decepticon/decepticon/middleware/proxy_key_override.py
@@ -29,7 +29,7 @@ The key value is never logged here, and ``event_logging`` already redacts
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
@@ -39,6 +39,7 @@ from pydantic import SecretStr
 from typing_extensions import NotRequired, override
 
 from decepticon.llm.factory import LLMFactory, _model_drops_temperature
+from decepticon.middleware.state_reducers import reduce_converging_value
 from decepticon_core.utils.logging import get_logger
 
 log = get_logger("middleware.proxy_key_override")
@@ -52,10 +53,23 @@ class ProxyKeyState(AgentState):
     SaaS caller threading the key via run ``input`` could never reach
     ``request.state`` (the middleware's reachable read path; ``runtime.context``
     needs a top-level ``context`` field, which the Platform forbids alongside
-    ``config.configurable`` that OSS already uses for tenant context). LastValue
-    (overwrite): set once on the kickoff run, persisted to the checkpoint, and
-    read on every model call (incl. resume runs that send no input). Extends
-    ``AgentState`` so the agent's own channels are preserved.
+    ``config.configurable`` that OSS already uses for tenant context). Set once
+    on the kickoff run, persisted to the checkpoint, and read on every model
+    call (incl. resume runs that send no input). Extends ``AgentState`` so the
+    agent's own channels are preserved.
+
+    Reducer — ``reduce_converging_value`` (NOT the default LastValue): the
+    orchestrator can dispatch two sub-agents in the SAME super-step (the model
+    emits multiple ``task()`` tool calls in one turn). deepagents copies parent
+    state into each sub-agent and does NOT exclude ``proxy_api_key``, so each
+    sub-agent's task() Command writes the key back to the parent in that single
+    tick. A LastValue channel rejects >1 write per step with
+    ``InvalidUpdateError`` ("Can receive only one value per step. Use an
+    Annotated key…"), which crashed the whole run and left ``thread.values``
+    without ``objectives`` / ``subagent_transcripts``. Every writer carries the
+    SAME per-run key, so a converging reducer (keep the non-None write) collapses
+    the concurrent writes to one value — the same treatment the launcher-set
+    context channels (``target_url``, ``language`` …) already use.
 
     The value is sensitive (a LiteLLM virtual key). It is never logged here;
     ``event_logging`` redacts ``api_key`` fields; the SaaS stream + state
@@ -64,7 +78,7 @@ class ProxyKeyState(AgentState):
     exposure (NOT run metadata, so it does not regress the metadata-leak fix).
     """
 
-    proxy_api_key: NotRequired[str]
+    proxy_api_key: NotRequired[Annotated[str, reduce_converging_value]]
 
 
 def _read_proxy_key(request: Any) -> str:

--- a/packages/decepticon/decepticon/tools/opplan.py
+++ b/packages/decepticon/decepticon/tools/opplan.py
@@ -103,6 +103,37 @@ def _build_opplan_payload(opplan: OPPLAN) -> dict[str, Any]:
     }
 
 
+def _live_sandbox_backend(fallback: BackendProtocol | None) -> BackendProtocol | None:
+    """Resolve the CURRENT run's sandbox backend, not the graph-build-time one.
+
+    The backend captured when the graph is compiled (``OPPLANMiddleware(backend=)``)
+    resolves its sandbox endpoint from the ``SANDBOX_URL`` env var, because there
+    is no run config at construction time. In a SHARED multi-tenant langgraph that
+    env points at the process-local sidecar, NOT the run's OWN per-engagement
+    sandbox (per-run VM / silo). So OPPLAN persistence wrote ``opplan.json`` to the
+    sidecar's shared workspace (bucket ROOT, unprefixed) while every OTHER doc —
+    written through FilesystemMiddleware, which rebinds per run — landed in the
+    engagement's tenant bucket. ``read_file`` then resolved against the tenant
+    prefix and could never see the OPPLAN.
+
+    Re-resolve per call from the ambient run config, mirroring
+    ``FilesystemMiddleware`` (``build_sandbox_backend`` reads
+    ``config.configurable.sandbox_url`` since the per-run-sandbox fix). OPPLAN
+    runs only in the TOP-LEVEL orchestrator, where langgraph seeds the
+    ``get_config()`` contextvar that ``build_sandbox_backend()`` reads — so no
+    explicit config threading is needed here (unlike a sub-agent). Falls back to
+    the captured backend when there is no active run (unit tests) or if
+    resolution raises, so behaviour is unchanged off the hosted path.
+    """
+    try:
+        from decepticon.backends import build_sandbox_backend, make_agent_backend
+
+        return make_agent_backend(build_sandbox_backend())
+    except Exception as exc:  # pragma: no cover - defensive
+        log.debug("OPPLAN live backend resolution failed, using build-time backend: %s", exc)
+        return fallback
+
+
 def _scoped_opplan_backend(
     backend: BackendProtocol | None,
     workspace_path: str | None,
@@ -113,11 +144,18 @@ def _scoped_opplan_backend(
     if not workspace_path:
         return None
 
+    # Rebind to the run's OWN sandbox before scoping — the captured ``backend``
+    # points at the build-time env sidecar in a shared langgraph (see
+    # ``_live_sandbox_backend``), which routed OPPLAN writes to the wrong bucket.
+    live = _live_sandbox_backend(backend)
+    if live is None:
+        return None
+
     # Local import avoids a module cycle: filesystem.py imports the OPPLAN
     # reducers for its state schema.
     from decepticon.middleware.filesystem import EngagementFilesystemBackend
 
-    return EngagementFilesystemBackend(backend, workspace_path)
+    return EngagementFilesystemBackend(live, workspace_path)
 
 
 def _read_text_from_backend(


### PR DESCRIPTION
## Two prod-confirmed multi-tenant bugs (real-data root-caused via LangSmith + langgraph checkpointer DB)

### 1. `proxy_api_key` `InvalidUpdateError` → run crash → objectives lost
`ProxyKeyState.proxy_api_key` is a reducer-less LastValue channel. When the orchestrator dispatches sub-agents in parallel (multiple `task()` calls in one turn), each sub-agent's `Command` writes `proxy_api_key` back to the parent in the **same super-step**. LastValue rejects >1 write/step:
```
InvalidUpdateError: At key 'proxy_api_key': Can receive only one value per step. Use an Annotated key…
```
The run crashes; the errored `thread.values` then lacks `objectives`/`subagent_transcripts`, so the run-console OPPLAN panel goes blank (checkpoint blob still holds them).
**Fix:** give the channel the existing `reduce_converging_value` reducer — every writer carries the same per-run key, so concurrent writes collapse to one value. Same treatment `target_url`/`language` already use.

### 2. OPPLAN wrote `opplan.json` to the wrong sandbox (shared bucket root)
`build_opplan_tools` captured the graph-**build-time** backend, whose sandbox endpoint resolves from `SANDBOX_URL` env → the process **sidecar**, not the run's own per-engagement sandbox. So `opplan.json` landed in the sidecar's shared workspace (bucket root, unprefixed) while every other doc (written via `FilesystemMiddleware`, which rebinds per run since the per-run-sandbox fix) went to the tenant bucket — and `read_file` (resolving against the tenant prefix) never found it.
**Fix:** `_scoped_opplan_backend` re-resolves the sandbox per call via `build_sandbox_backend()` (reads the ambient run config, seeded at the orchestrator top level), mirroring `FilesystemMiddleware`'s per-run rebind. Falls back to the build-time backend off the hosted path.

## Tests
- `test_proxy_key_override.py` (10) + `test_opplan*.py` (23) pass.
- Added fast checks: reducer attachment on the channel, `_scoped_opplan_backend` rebinds to the live per-run sandbox, and the off-hosted-path fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)