### PR TITLE
fix(subagent): route sub-agent bash/tools to the per-run sandbox (not the shared sidecar)

### DIFF
--- a/packages/decepticon/decepticon/core/subagent_streaming.py
+++ b/packages/decepticon/decepticon/core/subagent_streaming.py
@@ -30,6 +30,7 @@ Why a RunnableBinding subclass:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import contextvars
 import logging
 import os
@@ -57,6 +58,44 @@ TRANSCRIPT_STATE_KEY = "subagent_transcripts"
 # truncation, or any positive int to change the cap.
 _DEFAULT_TRANSCRIPT_RESULT_CAP = 8000
 _TRANSCRIPT_TRUNCATION_MARKER = "…[truncated]"
+
+
+@contextlib.contextmanager
+def _bind_per_run_sandbox():
+    """Scope bash / web / research tools to THIS run's per-engagement sandbox.
+
+    Sub-agent tool calls resolve their sandbox via ``get_sandbox(config)``, but
+    the ``config`` injected into a SUB-AGENT's tools does not carry the run's
+    ``configurable.sandbox_url`` — only the middleware runtime does (which is why
+    FilesystemMiddleware/``read_file`` reach the per-run VM while ``bash`` fell
+    back to the process-wide ``SANDBOX_URL`` env, i.e. the shared sidecar). This
+    wrapper runs at the PARENT task-node level, where ``get_config()`` IS seeded
+    with the run's config, so resolve the per-engagement sandbox here and set it
+    as the ``_sandbox_var`` contextvar override that ``get_sandbox`` honours
+    before the env default. No-op when there is no per-run ``sandbox_url``
+    (single-tenant / dev) or resolution fails.
+    """
+    token = None
+    var = None
+    try:
+        from langgraph.config import get_config
+
+        cfg = get_config()
+        sandbox_url = ((cfg or {}).get("configurable", {}) or {}).get("sandbox_url")
+        if sandbox_url:
+            from decepticon.backends import build_sandbox_backend
+            from decepticon.tools.bash.bash import _sandbox_var, set_sandbox
+
+            var = _sandbox_var
+            token = set_sandbox(build_sandbox_backend(cfg))
+    except Exception as exc:  # pragma: no cover - defensive
+        log.debug("per-run sandbox bind skipped: %s", exc)
+        token = None
+    try:
+        yield
+    finally:
+        if token is not None and var is not None:
+            var.reset(token)
 
 
 def _transcript_result_cap() -> int:
@@ -439,22 +478,23 @@ class StreamingRunnable(RunnableBinding):
         active_tool_calls: dict[str, ToolCall] = {}
 
         try:
-            for state in self._runnable.stream(
-                input, config=config, stream_mode="values", **kwargs
-            ):
-                last_state = state
-                messages = state.get("messages", [])
-                new_messages = messages[last_count:]
-                last_count = len(messages)
-                self._process_messages(
-                    new_messages,
-                    active_tool_calls,
-                    renderer,
-                    has_renderer,
-                    writer,
-                    session_id,
-                    transcript,
-                )
+            with _bind_per_run_sandbox():
+                for state in self._runnable.stream(
+                    input, config=config, stream_mode="values", **kwargs
+                ):
+                    last_state = state
+                    messages = state.get("messages", [])
+                    new_messages = messages[last_count:]
+                    last_count = len(messages)
+                    self._process_messages(
+                        new_messages,
+                        active_tool_calls,
+                        renderer,
+                        has_renderer,
+                        writer,
+                        session_id,
+                        transcript,
+                    )
 
         except (KeyboardInterrupt, asyncio.CancelledError):
             log.info("[%s] invoke() cancelled", self._name)
@@ -558,29 +598,30 @@ class StreamingRunnable(RunnableBinding):
         active_tool_calls: dict[str, ToolCall] = {}
 
         try:
-            async for state in self._runnable.astream(
-                input, config=config, stream_mode="values", **kwargs
-            ):
-                last_state = state
-                messages = state.get("messages", [])
-                new_messages = messages[last_count:]
-                last_count = len(messages)
-                if new_messages:
-                    log.debug(
-                        "[%s] astream: %d new messages (total %d)",
-                        self._name,
-                        len(new_messages),
-                        len(messages),
+            with _bind_per_run_sandbox():
+                async for state in self._runnable.astream(
+                    input, config=config, stream_mode="values", **kwargs
+                ):
+                    last_state = state
+                    messages = state.get("messages", [])
+                    new_messages = messages[last_count:]
+                    last_count = len(messages)
+                    if new_messages:
+                        log.debug(
+                            "[%s] astream: %d new messages (total %d)",
+                            self._name,
+                            len(new_messages),
+                            len(messages),
+                        )
+                    self._process_messages(
+                        new_messages,
+                        active_tool_calls,
+                        renderer,
+                        has_renderer,
+                        writer,
+                        session_id,
+                        transcript,
                     )
-                self._process_messages(
-                    new_messages,
-                    active_tool_calls,
-                    renderer,
-                    has_renderer,
-                    writer,
-                    session_id,
-                    transcript,
-                )
 
         except (KeyboardInterrupt, asyncio.CancelledError):
             log.info("[%s] ainvoke() cancelled", self._name)

--- a/packages/decepticon/tests/unit/tools/bash/test_sandbox_routing.py
+++ b/packages/decepticon/tests/unit/tools/bash/test_sandbox_routing.py
@@ -59,3 +59,23 @@ def test_token_is_part_of_the_cache_key() -> None:
     t1 = get_sandbox(_cfg("http://eng:9999", "tok-1"))
     t2 = get_sandbox(_cfg("http://eng:9999", "tok-2"))
     assert t1 is not t2
+
+
+def test_subagent_override_wins_when_config_lacks_sandbox_url() -> None:
+    """Sub-agent tools get a config WITHOUT ``sandbox_url`` (langgraph re-seeds
+    its config contextvar per node), so bash fell back to the process default —
+    the shared sidecar. StreamingRunnable._bind_per_run_sandbox sets the run's
+    sandbox as the ``_sandbox_var`` override (which langgraph does NOT touch), so
+    get_sandbox honours it before the default and the sub-agent reaches the VM.
+    """
+    from decepticon.tools.bash.bash import _sandbox_var
+
+    override = MagicMock()
+    token = set_sandbox(override)
+    try:
+        assert get_sandbox({"configurable": {}}) is override
+        assert get_sandbox(None) is override
+        # an explicit per-run config.sandbox_url still wins (orchestrator path)
+        assert get_sandbox(_cfg("http://eng-x:9999")) is not override
+    finally:
+        _sandbox_var.reset(token)


### PR DESCRIPTION
Sub-agent tool calls resolve their sandbox via `get_sandbox(config)`, but langgraph re-seeds its config contextvar **per node**, so a SUB-AGENT's tool config does not carry the run's `configurable.sandbox_url` — only the middleware runtime does. That's why `read_file` (FilesystemMiddleware) reached the per-run VM while `bash` fell back to the process `SANDBOX_URL` env (the shared sidecar). After the SaaS removed that sidecar, the fallback became a hard DNS failure (`Name or service not known`) — recon couldn't run, orchestrator looped re-planning (OPPLAN 'slow'). Confirmed live via LangSmith on a fresh STANDARD-VM engagement.

**Fix:** `StreamingRunnable` wraps every sub-agent dispatch at the PARENT task-node level where `get_config()` IS seeded. `_bind_per_run_sandbox` resolves the per-engagement sandbox there and sets it as the `_sandbox_var` override (which langgraph does NOT reset), so `get_sandbox` honours it before the env default. Fixes bash + web + research in one place. No-op single-tenant/dev. +regression test (5 pass, ruff clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)