### PR TITLE
test(filesystem): fix sandbox-rebind mocks to accept the config arg

### DIFF
--- a/packages/decepticon/tests/unit/middleware/test_filesystem.py
+++ b/packages/decepticon/tests/unit/middleware/test_filesystem.py
@@ -634,7 +634,7 @@ def test_rebind_reresolves_bare_http_sandbox_per_run(monkeypatch) -> None:
     by the per-run resolution of ``build_sandbox_backend()`` — which consults
     ``configurable.sandbox_url`` first, env second."""
     per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
-    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda config=None: per_run)
 
     env = HTTPSandbox("http://shared-sidecar:9999")
     assert _rebind_sandbox_per_run(env) is per_run
@@ -647,7 +647,7 @@ def test_rebind_swaps_composite_default_preserving_routes(monkeypatch) -> None:
     ``/skills/`` route and ``artifacts_root`` are preserved, and the cached
     construction-time composite is left untouched."""
     per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
-    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda config=None: per_run)
 
     skills = RecordingBackend()
     env = HTTPSandbox("http://shared-sidecar:9999")
@@ -667,7 +667,7 @@ def test_rebind_leaves_composite_with_non_sandbox_default_untouched(monkeypatch)
     returned unchanged — we never inject a sandbox where there wasn't one."""
     monkeypatch.setattr(
         "decepticon.backends.build_sandbox_backend",
-        lambda: (_ for _ in ()).throw(AssertionError("must not be called")),
+        lambda config=None: (_ for _ in ()).throw(AssertionError("must not be called")),
     )
     state_like = RecordingBackend()
     composite = CompositeBackend(default=state_like, routes={"/skills/": RecordingBackend()})
@@ -680,7 +680,7 @@ def test_get_backend_reresolves_sandbox_transport_per_run(monkeypatch) -> None:
     the env sidecar) re-resolves each run's filesystem transport to that run's
     own sandbox before scoping it to the engagement workspace."""
     per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
-    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda config=None: per_run)
 
     env = HTTPSandbox("http://shared-sidecar:9999")
     composite = CompositeBackend(default=env, routes={"/skills/": RecordingBackend()})


### PR DESCRIPTION
## Problem
`main` CI is red — 3 unit tests fail in `tests/unit/middleware/test_filesystem.py`:

```
FAILED test_rebind_reresolves_bare_http_sandbox_per_run
FAILED test_rebind_swaps_composite_default_preserving_routes
FAILED test_get_backend_reresolves_sandbox_transport_per_run
TypeError: <lambda>() takes 0 positional arguments but 1 was given
```

(Coverage is fine — 77.85% ≥ 60%. This is purely the 3 mock failures failing the `ci-test-coverage` gate.)

## Root cause
#749 made the filesystem middleware re-resolve the per-run sandbox by calling `build_sandbox_backend(config)` with a positional `config` argument. The rebind tests still patch it with a **zero-arg** `lambda: per_run`, so the now-1-arg call raises `TypeError`. Stale mock, not a production bug — the tests were never updated alongside #749/#751/#752.

## Fix
Mirror the real signature `build_sandbox_backend(config: Any = None)` in the mocks: `lambda: …` → `lambda config=None: …` (4 occurrences, including the "must not be called" throw-mock for consistency).

## Verify
Target tests: **5 passed** (`-k "rebind or reresolves_sandbox_transport"`). `ruff format --check` + `ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)