### PR TITLE
fix(agents): restore cve_lookup on exploit/exploiter/cloud/mobile/detector

### DIFF
--- a/packages/decepticon/decepticon/agents/plugins/detector.py
+++ b/packages/decepticon/decepticon/agents/plugins/detector.py
@@ -58,14 +58,21 @@ from decepticon.agents.build import build_middleware, build_tools
 from decepticon.agents.prompts import load_prompt
 from decepticon.backends import build_sandbox_backend, make_agent_backend
 from decepticon.llm import LLMFactory
+
+# cve_lookup / cve_by_package are self-contained NVD/EPSS/KEV + OSV lookups (no
+# KG/Neo4j dependency) — exactly the dependency-correlation surface this agent
+# needs per its docstring. Only the kg_* tools in tools/research stay deferred
+# pending the Neo4j middleware redesign.
+from decepticon.tools.research.tools import cve_by_package, cve_lookup
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
-# KG tools and cve_* were removed pending the Neo4j middleware redesign
-# (see docs/design/neo4j-research-notes.md). KG surface is currently
-# limited to the analyst agent. cve_lookup / cve_by_package also live
-# in the broken tools/research module; reintroduce from a clean source
-# after the refactor lands.
-_STANDARD_TOOLS: dict[str, Any] = {}
+_STANDARD_TOOLS: dict[str, Any] = {
+    t.name: t
+    for t in [
+        cve_lookup,
+        cve_by_package,
+    ]
+}
 
 _SKILL_SOURCES: list[str] = [
     "/skills/plugins/detector/",

--- a/packages/decepticon/decepticon/agents/plugins/exploiter.py
+++ b/packages/decepticon/decepticon/agents/plugins/exploiter.py
@@ -60,18 +60,21 @@ from decepticon.llm import LLMFactory
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import cve_poc_lookup, payload_search
+
+# cve_lookup / cve_by_package are self-contained NVD/EPSS/KEV + OSV lookups (no
+# KG/Neo4j dependency). The exploiter's docstring promises "cve_* are all
+# available" and its CVE skills mandate them, so restore them here. Only the
+# kg_* / fuzz_* tools in tools/research stay deferred pending the Neo4j redesign.
+from decepticon.tools.research.tools import cve_by_package, cve_lookup
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
-# KG / CVE / chain-planning / fuzz tools were removed pending the Neo4j
-# middleware redesign (see docs/design/neo4j-research-notes.md). KG
-# surface is currently limited to the analyst agent. cve_lookup / fuzz_*
-# also live in the broken tools/research module; reintroduce from a
-# clean source after the refactor lands.
 _STANDARD_TOOLS: dict[str, Any] = {
     t.name: t
     for t in [
-        # References
+        # References + CVE intel
         cve_poc_lookup,
+        cve_lookup,
+        cve_by_package,
         payload_search,
         # Execution
         *BASH_TOOLS,

--- a/packages/decepticon/decepticon/agents/standard/cloud_hunter.py
+++ b/packages/decepticon/decepticon/agents/standard/cloud_hunter.py
@@ -45,17 +45,22 @@ from decepticon.llm import LLMFactory
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.cloud.tools import CLOUD_TOOLS
+
+# cve_lookup is a self-contained NVD/EPSS/CISA-KEV scorer (no KG/Neo4j
+# dependency). The container-cve skill (skills/standard/cloud/container/
+# container-cve) calls it on the runtime version, so it MUST be on this agent's
+# surface. Only the kg_* tools in tools/research stay deferred pending the Neo4j
+# middleware redesign — cve_lookup is not.
+from decepticon.tools.research.tools import cve_lookup
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
-# KG tools were removed pending the Neo4j middleware redesign (see
-# docs/design/neo4j-research-notes.md). KG surface is currently limited
-# to the analyst agent. cve_lookup also lives in the broken tools/research
-# module; reintroduce from a clean source after the refactor lands.
 _STANDARD_TOOLS: dict[str, Any] = {
     t.name: t
     for t in [
         # Cloud tools
         *CLOUD_TOOLS,
+        # CVE intel
+        cve_lookup,
         # Execution
         *BASH_TOOLS,
     ]

--- a/packages/decepticon/decepticon/agents/standard/exploit.py
+++ b/packages/decepticon/decepticon/agents/standard/exploit.py
@@ -65,17 +65,21 @@ from decepticon.tools.references.tools import (
     methodology_lookup,
     payload_search,
 )
+
+# cve_lookup is a self-contained NVD/EPSS/CISA-KEV scorer with NO KG/Neo4j
+# dependency. The CVE exploitation skill (skills/standard/exploit/web/cve) has a
+# hard rule to call it before the first exploit attempt, so it MUST be on this
+# agent's surface. Only the kg_* tools in tools/research are deferred pending the
+# Neo4j middleware redesign — cve_lookup is not.
+from decepticon.tools.research.tools import cve_lookup
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
-# KG tools were removed pending the Neo4j middleware redesign (see
-# docs/design/neo4j-research-notes.md). KG surface is currently limited
-# to the analyst agent. cve_lookup also lives in the broken tools/research
-# module; reintroduce from a clean source after the refactor lands.
 _STANDARD_TOOLS: dict[str, Any] = {
     t.name: t
     for t in [
-        # References
+        # References + CVE intel
         cve_poc_lookup,
+        cve_lookup,
         payload_search,
         methodology_lookup,
         # Execution

--- a/packages/decepticon/decepticon/agents/standard/mobile_operator.py
+++ b/packages/decepticon/decepticon/agents/standard/mobile_operator.py
@@ -35,17 +35,20 @@ from decepticon.llm import LLMFactory
 from decepticon.tools.bash import BASH_TOOLS
 from decepticon.tools.bash.bash import set_sandbox
 from decepticon.tools.references.tools import methodology_lookup, payload_search
+
+# cve_lookup is a self-contained NVD/EPSS/CISA-KEV scorer (no KG/Neo4j
+# dependency) — mobile targets ship native libs with version-specific CVEs, so
+# keep it on the surface. Only the kg_* tools in tools/research stay deferred
+# pending the Neo4j middleware redesign.
+from decepticon.tools.research.tools import cve_lookup
 from decepticon_core.plugin_loader import SubAgentSpec, is_bundle_enabled, load_plugin_callbacks
 
-# KG tools were removed pending the Neo4j middleware redesign (see
-# docs/design/neo4j-research-notes.md). KG surface is currently limited
-# to the analyst agent. cve_lookup also lives in the broken tools/research
-# module; reintroduce from a clean source after the refactor lands.
 _STANDARD_TOOLS: dict[str, Any] = {
     t.name: t
     for t in [
         payload_search,
         methodology_lookup,
+        cve_lookup,
         *BASH_TOOLS,
     ]
 }


### PR DESCRIPTION
## Symptom
An exploit-path agent calls `cve_lookup` (mandated by the CVE skill) and errors:
```
Error: cve_lookup is not a valid tool, try one of [..., cve_poc_lookup, payload_search, methodology_lookup, ...]
```
It then falls back to slow free-form web search instead of the NVD/EPSS/KEV lookup.

## Root cause
Five agents load skills that hard-require `cve_lookup` but had dropped it from their toolset: **exploit, exploiter, cloud_hunter, mobile_operator, detector**. They excluded the whole `tools/research` bundle to avoid the `kg_*` tools that are deferred pending the Neo4j middleware redesign — and lost `cve_lookup` (+ `cve_by_package`) as collateral.

But `cve_lookup` / `cve_by_package` are **self-contained** NVD/EPSS/CISA-KEV + OSV lookups with **no KG/Neo4j dependency** — the identical import is already used successfully by `osint_operator`, `ics_operator`, `iot_operator`, `forensicator`, `supply_chain_operator`. The exploiter/detector docstrings even still promise "cve_* are all available".

## Fix
Re-import `cve_lookup` (and `cve_by_package` for exploiter/detector, which do dependency correlation) from `tools/research` directly — **not** the `kg_*` tools, which stay deferred. `detector`'s surface becomes exactly `{cve_lookup, cve_by_package}` per its docstring.

## Verification
`py_compile` + `ruff check` clean on all five. Import mirrors the already-working agents (full module import isn't runnable locally — it reaches external services at import — so relying on the proven-identical import + CI).