### PR TITLE
fix(opplan): don't re-resolve to a live sandbox with no run config (unhangs CI pytest)

### DIFF
--- a/packages/decepticon/decepticon/tools/opplan.py
+++ b/packages/decepticon/decepticon/tools/opplan.py
@@ -125,6 +125,22 @@ def _live_sandbox_backend(fallback: BackendProtocol | None) -> BackendProtocol |
     the captured backend when there is no active run (unit tests) or if
     resolution raises, so behaviour is unchanged off the hosted path.
     """
+    # Only re-resolve when an ACTIVE run actually seeds a per-run sandbox_url
+    # (the multi-tenant orchestrator path this exists for). Off that path — unit
+    # tests, build-time construction, single-tenant/env deploys — there is no
+    # per-run sandbox to reach, and ``build_sandbox_backend()`` does NOT raise:
+    # it returns an HTTPSandbox for the default ``http://localhost:9999``. Writing
+    # OPPLAN through that dead endpoint hangs (the persist test hung the whole
+    # middleware suite → CI 30-min timeout). The captured ``fallback`` already
+    # points at the right backend for those cases, so use it.
+    try:
+        from langgraph.config import get_config
+
+        sandbox_url = ((get_config() or {}).get("configurable") or {}).get("sandbox_url")
+    except Exception:
+        sandbox_url = None
+    if not sandbox_url:
+        return fallback
     try:
         from decepticon.backends import build_sandbox_backend, make_agent_backend
 

--- a/packages/decepticon/tests/unit/middleware/test_filesystem.py
+++ b/packages/decepticon/tests/unit/middleware/test_filesystem.py
@@ -634,7 +634,7 @@ def test_rebind_reresolves_bare_http_sandbox_per_run(monkeypatch) -> None:
     by the per-run resolution of ``build_sandbox_backend()`` — which consults
     ``configurable.sandbox_url`` first, env second."""
     per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
-    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda config=None: per_run)
 
     env = HTTPSandbox("http://shared-sidecar:9999")
     assert _rebind_sandbox_per_run(env) is per_run
@@ -647,7 +647,7 @@ def test_rebind_swaps_composite_default_preserving_routes(monkeypatch) -> None:
     ``/skills/`` route and ``artifacts_root`` are preserved, and the cached
     construction-time composite is left untouched."""
     per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
-    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda config=None: per_run)
 
     skills = RecordingBackend()
     env = HTTPSandbox("http://shared-sidecar:9999")
@@ -667,7 +667,7 @@ def test_rebind_leaves_composite_with_non_sandbox_default_untouched(monkeypatch)
     returned unchanged — we never inject a sandbox where there wasn't one."""
     monkeypatch.setattr(
         "decepticon.backends.build_sandbox_backend",
-        lambda: (_ for _ in ()).throw(AssertionError("must not be called")),
+        lambda config=None: (_ for _ in ()).throw(AssertionError("must not be called")),
     )
     state_like = RecordingBackend()
     composite = CompositeBackend(default=state_like, routes={"/skills/": RecordingBackend()})
@@ -680,7 +680,7 @@ def test_get_backend_reresolves_sandbox_transport_per_run(monkeypatch) -> None:
     the env sidecar) re-resolves each run's filesystem transport to that run's
     own sandbox before scoping it to the engagement workspace."""
     per_run = HTTPSandbox("http://per-run-vm:9999", token="t")
-    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda: per_run)
+    monkeypatch.setattr("decepticon.backends.build_sandbox_backend", lambda config=None: per_run)
 
     env = HTTPSandbox("http://shared-sidecar:9999")
     composite = CompositeBackend(default=env, routes={"/skills/": RecordingBackend()})


### PR DESCRIPTION
## Root cause of the long-standing "CI pytest abnormally slow"

`_live_sandbox_backend` (tools/opplan.py) re-resolves OPPLAN persistence to the run's own sandbox via `build_sandbox_backend()`. The docstring says it "falls back to the captured backend … in unit tests", but the code called `build_sandbox_backend()` **unconditionally** — and it does **not raise** with no run config: it returns an `HTTPSandbox` for the default **`http://localhost:9999`**. Off the hosted path (unit tests, build-time, single-tenant), the persist wrote through that dead endpoint and **hung on the HTTP connect**.

**Chain:** `test_opplan_persistence.py::test_persist_writes_payload_under_workspace_plan` (+ every persist test) hangs → `tests/unit/middleware` (778 tests) never finishes → full suite stalls at ~95% → the `Python (lint + typecheck + test)` job hits its **30-min timeout → CANCELLED**. That's why recent PRs' required check kept showing CANCELLED.

Diagnosis: dir-isolation → `tests/unit/middleware` was the only dir to TIMEOUT (130s); serial `-v` pinpointed the hang at the OPPLAN persist test.

## Fix
Re-resolve **only** when an active run seeds `get_config().configurable.sandbox_url` (the multi-tenant orchestrator path this exists for). Otherwise return the captured `fallback` (already correct for those cases).

## Verify
`tests/unit/middleware`: **130s+ TIMEOUT → 14s, 918 passed** (0 failures). The existing persist tests are the regression guard.

Folds in #753's filesystem-mock config-arg fix so this branch's CI is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)