### PR TITLE
Add model overrides and Mittwald route

### DIFF
--- a/clients/cli/src/commands/model.ts
+++ b/clients/cli/src/commands/model.ts
@@ -68,6 +68,7 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
     "openrouter/anthropic/claude-opus-4-7",
     "openrouter/anthropic/claude-sonnet-4-6",
     "openrouter/anthropic/claude-haiku-4-5",
+    "openrouter/moonshotai/kimi-k2",
   ],
   "NVIDIA NIM": [
     "nvidia_nim/meta/llama-3.3-70b-instruct",
@@ -115,6 +116,7 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
     "cohere_chat/command-r",
   ],
   "Moonshot Kimi K2": [
+    "openrouter/moonshotai/kimi-k2",
     "moonshot/kimi-k2-instruct",
     "moonshot/moonshot-v1-128k",
     "moonshot/moonshot-v1-8k",
@@ -173,9 +175,10 @@ const SUPPORTED_MODELS: Record<string, string[]> = {
     "cfgateway/anthropic/claude-sonnet-4-6",
     "cfgateway/anthropic/claude-haiku-4-5",
   ],
+  "Mittwald": ["mittwald/Mistral-Medium-3.5-128B"],
   // Local
-  "Ollama (local)": ["ollama_chat/qwen3-coder:30b (or your OLLAMA_MODEL)"],
-  "Ollama Cloud": ["ollama_chat/<your OLLAMA_CLOUD_MODEL>"],
+  "Ollama (local)": ["ollama_chat/qwen2.5-coder:7b", "ollama_chat/qwen3-coder:30b"],
+  "Ollama Cloud": ["ollama_cloud/kimi-k2.6"],
   "LM Studio (local)": ["lm_studio/<your LMSTUDIO_MODEL>"],
   "Custom OpenAI Endpoint": ["custom/<your CUSTOM_OPENAI_MODEL>"],
 };

--- a/clients/cli/src/commands/modelOverride.ts
+++ b/clients/cli/src/commands/modelOverride.ts
@@ -10,7 +10,22 @@
  * Empty string == no override.
  */
 
-let _override = "";
+let _override = (process.env.DECEPTICON_MODEL_OVERRIDE ?? "").trim();
+let _roleOverrides: Record<string, string> = {};
+
+try {
+  const raw = (process.env.DECEPTICON_MODEL_OVERRIDES ?? "").trim();
+  const parsed = raw ? JSON.parse(raw) : {};
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    _roleOverrides = Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>)
+        .filter(([, model]) => typeof model === "string" && model.trim())
+        .map(([role, model]) => [role, (model as string).trim()]),
+    );
+  }
+} catch {
+  _roleOverrides = {};
+}
 
 export function setModelOverride(id: string): void {
   _override = id.trim();
@@ -18,4 +33,8 @@ export function setModelOverride(id: string): void {
 
 export function getModelOverride(): string {
   return _override;
+}
+
+export function getModelOverrides(): Record<string, string> {
+  return { ..._roleOverrides };
 }

--- a/clients/cli/src/components/Banner.tsx
+++ b/clients/cli/src/components/Banner.tsx
@@ -47,6 +47,8 @@ const BANNER_LOGO = extractLogo(BANNER_FULL);
 const BANNER_LOGO_WIDTH = Math.max(
   ...BANNER_LOGO.split("\n").map((l) => l.length),
 );
+const COMPACT_FULL_WIDTH = Math.max(BANNER_FULL_WIDTH, 220);
+const COMPACT_LOGO_WIDTH = Math.max(BANNER_LOGO_WIDTH, 110);
 
 // ── Responsive banner component ──────────────────────────────────────
 
@@ -55,12 +57,12 @@ export const Banner = React.memo(function Banner() {
   const cols = stdout?.columns ?? 80;
 
   // Wide terminal — full banner with logo + text art
-  if (cols >= BANNER_FULL_WIDTH) {
+  if (cols >= COMPACT_FULL_WIDTH) {
     return <Text color="red">{BANNER_FULL}</Text>;
   }
 
   // Medium terminal — braille logo + text name below
-  if (cols >= BANNER_LOGO_WIDTH) {
+  if (cols >= COMPACT_LOGO_WIDTH) {
     return (
       <Box flexDirection="column">
         <Text color="red">{BANNER_LOGO}</Text>

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -24,7 +24,7 @@ import {
   extractText,
   stripResultTags,
 } from "@decepticon/streaming";
-import { getModelOverride } from "../commands/modelOverride.js";
+import { getModelOverride, getModelOverrides } from "../commands/modelOverride.js";
 import { getAssistantOverride } from "../commands/assistantOverride.js";
 
 interface LangChainMessage {
@@ -56,6 +56,25 @@ interface UseAgentOptions {
 interface PendingTool {
   name: string;
   args: Record<string, unknown>;
+}
+
+function buildRunConfig(): { config?: { configurable: Record<string, unknown> } } {
+  const configurable: Record<string, unknown> = {};
+  const slug = process.env.DECEPTICON_ENGAGEMENT;
+  if (slug) {
+    configurable.engagement_name = slug;
+    configurable.workspace_path =
+      process.env.DECEPTICON_WORKSPACE_PATH ?? "/workspace";
+  }
+  const modelOverride = getModelOverride();
+  if (modelOverride) {
+    configurable.model_override = modelOverride;
+  }
+  const modelOverrides = getModelOverrides();
+  if (Object.keys(modelOverrides).length > 0) {
+    configurable.model_overrides = modelOverrides;
+  }
+  return Object.keys(configurable).length > 0 ? { config: { configurable } } : {};
 }
 
 export interface StreamStats {
@@ -765,28 +784,13 @@ export function useAgent({
           messages: [{ role: "user", content: message }],
         };
 
-        const configurable: Record<string, unknown> = {};
-        const slug = process.env.DECEPTICON_ENGAGEMENT;
-        if (slug) {
-          configurable.engagement_name = slug;
-          configurable.workspace_path =
-            process.env.DECEPTICON_WORKSPACE_PATH ?? "/workspace";
-        }
-        const modelOverride = getModelOverride();
-        if (modelOverride) {
-          configurable.model_override = modelOverride;
-        }
-
-        const hasConfigurable = Object.keys(configurable).length > 0;
-        const streamConfig = hasConfigurable ? { configurable } : undefined;
-
         try {
           const stream = client.runs.stream(
             threadIdRef.current!,
             getAssistantOverride() || assistantIdRef.current,
             {
               input,
-              ...(streamConfig ? { config: streamConfig } : {}),
+              ...buildRunConfig(),
               ...STREAM_OPTIONS,
               onDisconnect: "continue",
               signal: abortController.signal,
@@ -872,6 +876,7 @@ export function useAgent({
             getAssistantOverride() || assistantIdRef.current,
             {
               command: { resume: value },
+              ...buildRunConfig(),
               ...STREAM_OPTIONS,
               onDisconnect: "continue",
               signal: abortController.signal,
@@ -934,6 +939,7 @@ export function useAgent({
               getAssistantOverride() || assistantIdRef.current,
               {
                 command: { resume: value ?? true },
+                ...buildRunConfig(),
                 ...STREAM_OPTIONS,
                 onDisconnect: "continue",
                 signal: abortController.signal,

--- a/clients/launcher/internal/ui/theme.go
+++ b/clients/launcher/internal/ui/theme.go
@@ -76,8 +76,8 @@ const bannerLogo = "" +
 	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⢷⡿⡯⠃\n" +
 	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠁"
 
-const bannerFullWidth = 165
-const bannerLogoWidth = 60
+const bannerFullWidth = 220
+const bannerLogoWidth = 110
 
 // RenderBanner returns a responsive banner based on terminal width.
 func RenderBanner() string {

--- a/clients/web/prisma/migrations/20260708120000_add_engagement_model_override/migration.sql
+++ b/clients/web/prisma/migrations/20260708120000_add_engagement_model_override/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Engagement" ADD COLUMN "modelOverride" TEXT;

--- a/clients/web/prisma/migrations/20260708153000_add_engagement_model_overrides/migration.sql
+++ b/clients/web/prisma/migrations/20260708153000_add_engagement_model_overrides/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Engagement" ADD COLUMN "modelOverrides" JSONB;

--- a/clients/web/prisma/schema.prisma
+++ b/clients/web/prisma/schema.prisma
@@ -36,7 +36,9 @@ model Engagement {
   userId      String           @default("local")
 
   // LangGraph thread tracking
-  threadId      String?
+  threadId       String?
+  modelOverride  String?
+  modelOverrides Json?
   workspacePath String?
 
   createdAt   DateTime         @default(now())

--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -29,7 +29,8 @@
 
 import { WebSocketServer, WebSocket } from "ws";
 import * as pty from "node-pty";
-import { resolve, dirname } from "path";
+import * as fs from "fs";
+import { resolve, dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -41,6 +42,7 @@ const CLI_PATH = resolve(__dirname, "../../cli/src/index.tsx");
 const LANGGRAPH_API_URL = process.env.LANGGRAPH_API_URL ?? "http://localhost:2024";
 const ORPHAN_TTL = 60_000; // Kill orphaned PTYs after 60s with no WS
 const SCROLLBACK_LIMIT = 50_000; // chars of recent output to buffer for reattach
+const DEFAULT_BLOCKED_MODEL_PATTERNS = ["wormgpt", "uncensored", "abliterate"];
 
 const ALLOWED_ORIGINS = new Set(
   (process.env.TERMINAL_ALLOWED_ORIGINS ?? `http://localhost:${WEB_PORT},http://127.0.0.1:${WEB_PORT}`)
@@ -63,6 +65,8 @@ interface Session {
   orphanTimer: ReturnType<typeof setTimeout> | null;
   dead: boolean;                // PTY exited
   exitCode: number | null;
+  modelOverride: string;
+  modelOverridesJson: string;
 }
 
 const sessions = new Map<string, Session>();
@@ -130,6 +134,59 @@ function persistThreadId(engagementId: string, threadId: string): void {
   }).catch(() => {});
 }
 
+function isBlockedModelId(value: string): boolean {
+  const blockedPatterns = readBlockedModelPatterns();
+  const lower = value.toLowerCase();
+  return blockedPatterns.some((part) => lower.includes(part.toLowerCase()));
+}
+
+function modelPolicyPath(): string {
+  return (
+    process.env.MODEL_POLICY_PATH ??
+    join(process.env.WORKSPACE_PATH ?? "/workspace", ".decepticon", "model-policy.json")
+  );
+}
+
+function readBlockedModelPatterns(): string[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(modelPolicyPath(), "utf8")) as {
+      blockedPatterns?: unknown;
+    };
+    const values = Array.isArray(parsed.blockedPatterns) ? parsed.blockedPatterns : [];
+    const seen = new Set<string>();
+    return values
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .filter((pattern) => {
+        const key = pattern.toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+  } catch {
+    return [...DEFAULT_BLOCKED_MODEL_PATTERNS];
+  }
+}
+
+function normalizeModelOverridesJson(raw: string): string {
+  if (!raw.trim()) return "";
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "";
+    const clean: Record<string, string> = {};
+    for (const [role, model] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!/^[a-z][a-z0-9_-]{1,63}$/.test(role)) continue;
+      if (typeof model !== "string") continue;
+      const trimmed = model.trim();
+      if (trimmed && trimmed.length <= 200 && !isBlockedModelId(trimmed)) clean[role] = trimmed;
+    }
+    return Object.keys(clean).length > 0 ? JSON.stringify(clean) : "";
+  } catch {
+    return "";
+  }
+}
+
 // ── Connection Handler ───────────────────────────────────────────
 
 wss.on("connection", async (ws: WebSocket, req) => {
@@ -142,6 +199,9 @@ wss.on("connection", async (ws: WebSocket, req) => {
   const engagementId = url.searchParams.get("engagementId") ?? "";
   const engagementSlug = url.searchParams.get("engagementSlug") ?? "";
   const agentId = url.searchParams.get("agentId") ?? "soundwave";
+  const requestedModelOverride = (url.searchParams.get("modelOverride") ?? "").trim();
+  const modelOverride = isBlockedModelId(requestedModelOverride) ? "" : requestedModelOverride;
+  const modelOverridesJson = normalizeModelOverridesJson(url.searchParams.get("modelOverrides") ?? "");
 
   if (!engagementSlug) {
     ws.close(1008, "Missing engagementSlug");
@@ -153,32 +213,41 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
   // ── Reattach to existing session ──
   if (session && !session.dead) {
-    console.log(`[terminal-server] Reattaching WS to existing session: ${key} (pid=${session.term.pid})`);
+    if (
+      session.modelOverride !== modelOverride ||
+      session.modelOverridesJson !== modelOverridesJson
+    ) {
+      console.log(`[terminal-server] Model config changed for ${key}; respawning PTY`);
+      destroySession(key);
+      session = undefined;
+    } else {
+      console.log(`[terminal-server] Reattaching WS to existing session: ${key} (pid=${session.term.pid})`);
 
-    // Cancel orphan timer
-    if (session.orphanTimer) {
-      clearTimeout(session.orphanTimer);
-      session.orphanTimer = null;
+      // Cancel orphan timer
+      if (session.orphanTimer) {
+        clearTimeout(session.orphanTimer);
+        session.orphanTimer = null;
+      }
+
+      // Detach old WS if any. 4001 (app range) distinguishes "another connection
+      // took over" from the genuine PTY-exit 1000 the client treats as session end.
+      if (session.ws && session.ws !== ws && session.ws.readyState === WebSocket.OPEN) {
+        session.ws.close(4001, "Replaced by new connection");
+      }
+      session.ws = ws;
+
+      // Send threadId
+      if (session.threadId) sendJson(ws, { type: "threadId", threadId: session.threadId });
+
+      // Send scrollback so the client sees recent output without a full re-render
+      if (session.scrollback) {
+        sendJson(ws, { type: "reattached" });
+        ws.send(session.scrollback);
+      }
+
+      wireWsToSession(ws, session);
+      return;
     }
-
-    // Detach old WS if any. 4001 (app range) distinguishes "another connection
-    // took over" from the genuine PTY-exit 1000 the client treats as session end.
-    if (session.ws && session.ws !== ws && session.ws.readyState === WebSocket.OPEN) {
-      session.ws.close(4001, "Replaced by new connection");
-    }
-    session.ws = ws;
-
-    // Send threadId
-    if (session.threadId) sendJson(ws, { type: "threadId", threadId: session.threadId });
-
-    // Send scrollback so the client sees recent output without a full re-render
-    if (session.scrollback) {
-      sendJson(ws, { type: "reattached" });
-      ws.send(session.scrollback);
-    }
-
-    wireWsToSession(ws, session);
-    return;
   }
 
   // ── Clean up dead session ──
@@ -214,12 +283,14 @@ wss.on("connection", async (ws: WebSocket, req) => {
     DECEPTICON_API_URL: LANGGRAPH_API_URL,
   };
   if (threadId) env.DECEPTICON_THREAD_ID = threadId;
+  if (modelOverride) env.DECEPTICON_MODEL_OVERRIDE = modelOverride;
+  if (modelOverridesJson) env.DECEPTICON_MODEL_OVERRIDES = modelOverridesJson;
 
   let term: pty.IPty;
   try {
     term = pty.spawn("node", ["--import", "tsx/esm", CLI_PATH], {
       name: "xterm-256color",
-      cols: 120,
+      cols: 80,
       rows: 30,
       cwd: resolve(__dirname, "../.."),
       env,
@@ -244,6 +315,8 @@ wss.on("connection", async (ws: WebSocket, req) => {
     orphanTimer: null,
     dead: false,
     exitCode: null,
+    modelOverride,
+    modelOverridesJson,
   };
   sessions.set(key, newSession);
 

--- a/clients/web/server/web-proxy.ts
+++ b/clients/web/server/web-proxy.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Runtime proxy for the containerized web app.
+ *
+ * It keeps the dashboard and the embedded terminal on one public origin:
+ * regular HTTP goes to Next.js, while /terminal WebSocket upgrades go to the
+ * terminal bridge process.
+ */
+
+import http, { type IncomingMessage } from "http";
+import net from "net";
+
+const PORT = parseInt(process.env.WEB_PROXY_PORT ?? "3000", 10);
+const NEXT_PORT = parseInt(process.env.NEXT_INTERNAL_PORT ?? "3001", 10);
+const TERMINAL_PORT = parseInt(process.env.TERMINAL_PORT ?? "3003", 10);
+const HOST = process.env.HOSTNAME ?? "0.0.0.0";
+
+function requestPath(req: IncomingMessage): string {
+  return req.url ?? "/";
+}
+
+function isTerminalRequest(req: IncomingMessage): boolean {
+  return requestPath(req).startsWith("/terminal");
+}
+
+function proxyHttp(req: IncomingMessage, res: http.ServerResponse): void {
+  if (isTerminalRequest(req)) {
+    res.writeHead(426, { "content-type": "text/plain; charset=utf-8" });
+    res.end("WebSocket upgrade required");
+    return;
+  }
+
+  const headers = { ...req.headers };
+  headers.host = req.headers.host;
+  headers["x-forwarded-host"] = req.headers.host ?? "";
+  headers["x-forwarded-proto"] = req.headers["x-forwarded-proto"] ?? "http";
+
+  const upstream = http.request(
+    {
+      host: "127.0.0.1",
+      port: NEXT_PORT,
+      method: req.method,
+      path: requestPath(req),
+      headers,
+    },
+    (upstreamRes) => {
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      upstreamRes.pipe(res);
+    },
+  );
+
+  upstream.on("error", (err) => {
+    if (!res.headersSent) {
+      res.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    }
+    res.end(`Next.js upstream unavailable: ${err.message}`);
+  });
+
+  req.pipe(upstream);
+}
+
+function proxyUpgrade(req: IncomingMessage, socket: net.Socket, head: Buffer): void {
+  const targetPort = isTerminalRequest(req) ? TERMINAL_PORT : NEXT_PORT;
+  const upstream = net.connect(targetPort, "127.0.0.1");
+
+  upstream.on("connect", () => {
+    upstream.write(`${req.method} ${requestPath(req)} HTTP/${req.httpVersion}\r\n`);
+    for (const [name, value] of Object.entries(req.headers)) {
+      if (Array.isArray(value)) {
+        for (const item of value) upstream.write(`${name}: ${item}\r\n`);
+      } else if (value !== undefined) {
+        upstream.write(`${name}: ${value}\r\n`);
+      }
+    }
+    upstream.write("\r\n");
+    if (head.length > 0) upstream.write(head);
+    upstream.pipe(socket);
+    socket.pipe(upstream);
+  });
+
+  upstream.on("error", () => {
+    if (!socket.destroyed) {
+      socket.write("HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+      socket.destroy();
+    }
+  });
+
+  socket.on("error", () => upstream.destroy());
+}
+
+const server = http.createServer(proxyHttp);
+
+server.on("upgrade", proxyUpgrade);
+server.on("clientError", (_err, socket) => {
+  socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(
+    `[web-proxy] Listening on http://${HOST}:${PORT} ` +
+    `(next=127.0.0.1:${NEXT_PORT}, terminal=127.0.0.1:${TERMINAL_PORT})`,
+  );
+});

--- a/clients/web/src/app/(dashboard)/engagements/[id]/documents/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/documents/page.tsx
@@ -173,9 +173,9 @@ export default function DocumentsPage() {
   const totalFiles = folders.reduce((sum, g) => sum + g.files.length, 0);
 
   return (
-    <div className="flex h-full gap-4 overflow-hidden">
+    <div className="flex h-full min-w-0 flex-col gap-4 overflow-visible md:flex-row md:overflow-hidden">
       {/* Left: Folder tree */}
-      <div className="w-64 shrink-0 overflow-hidden flex flex-col">
+      <div className="flex max-h-72 w-full shrink-0 flex-col overflow-hidden md:max-h-none md:w-64">
         <div className="mb-3">
           <h1 className="text-lg font-bold tracking-tight">Documents</h1>
           <p className="text-xs text-muted-foreground">
@@ -247,22 +247,22 @@ export default function DocumentsPage() {
       </div>
 
       {/* Right: File content viewer */}
-      <Card className="flex-1 overflow-hidden">
+      <Card className="min-w-0 flex-1 overflow-hidden">
         <CardHeader className="border-b border-border/50 pb-3">
-          <CardTitle className="flex items-center gap-2 text-sm font-mono">
+          <CardTitle className="flex min-w-0 flex-wrap items-center gap-2 text-xs font-mono sm:text-sm">
             <FileText className="h-4 w-4" />
-            {selectedFile?.path ?? "Select a file"}
+            <span className="min-w-0 break-all">{selectedFile?.path ?? "Select a file"}</span>
           </CardTitle>
         </CardHeader>
         <CardContent className="p-0">
-          <ScrollArea className="h-[calc(100vh-14rem)]">
-            <div className="p-6">
+          <ScrollArea className="h-[calc(100dvh-18rem)] md:h-[calc(100dvh-14rem)]">
+            <div className="p-3 sm:p-6">
               {fileLoading ? (
                 <div className="flex items-center justify-center py-16">
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 </div>
               ) : selectedFile ? (
-                <pre className="whitespace-pre-wrap text-sm text-muted-foreground font-mono">
+                <pre className="whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground sm:text-sm">
                   {selectedFile.content}
                 </pre>
               ) : (

--- a/clients/web/src/app/(dashboard)/engagements/[id]/findings/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/findings/page.tsx
@@ -214,7 +214,7 @@ export default function FindingsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Findings</h1>
           <p className="text-sm text-muted-foreground">
@@ -222,7 +222,7 @@ export default function FindingsPage() {
           </p>
         </div>
         <Select value={filterSeverity} onValueChange={(v) => setFilterSeverity(v ?? "all")}>
-          <SelectTrigger className="w-40">
+          <SelectTrigger className="w-full sm:w-40">
             <SelectValue placeholder="Filter severity" />
           </SelectTrigger>
           <SelectContent>
@@ -252,7 +252,8 @@ export default function FindingsPage() {
               </div>
             </div>
           ) : (
-            <Table>
+            <div className="overflow-x-auto">
+            <Table className="min-w-[44rem]">
               <TableHeader>
                 <TableRow>
                   <TableHead>ID</TableHead>
@@ -272,7 +273,7 @@ export default function FindingsPage() {
                     <TableCell className="font-mono text-xs text-muted-foreground">
                       {finding.id}
                     </TableCell>
-                    <TableCell className="font-medium">
+                    <TableCell className="max-w-72 whitespace-normal break-words font-medium">
                       {finding.title}
                     </TableCell>
                     <TableCell>
@@ -286,7 +287,7 @@ export default function FindingsPage() {
                     <TableCell className="font-mono text-xs text-muted-foreground">
                       {finding.cvssScore != null ? finding.cvssScore.toFixed(1) : "—"}
                     </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
+                    <TableCell className="max-w-72 whitespace-normal break-words text-sm text-muted-foreground">
                       {finding.affectedAssets.length > 0
                         ? finding.affectedAssets.join(", ")
                         : "—"}
@@ -295,6 +296,7 @@ export default function FindingsPage() {
                 ))}
               </TableBody>
             </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/clients/web/src/app/(dashboard)/engagements/[id]/layout.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/layout.tsx
@@ -5,6 +5,7 @@ import { useParams, usePathname } from "next/navigation";
 import { EngagementProvider } from "@/lib/engagement-context";
 import { useRunObserver } from "@/hooks/useRunObserver";
 import { WebTerminal } from "@/components/terminal/web-terminal";
+import type { ModelOverrides } from "@/components/engagement/engagement-model-picker";
 import { cn } from "@/lib/utils";
 
 const REQUIRED_PLAN_DOCS = ["roe", "conops", "deconfliction"] as const;
@@ -25,7 +26,11 @@ export default function EngagementLayout({
   const pathname = usePathname();
   const engagementId = params.id as string;
 
-  const [engagement, setEngagement] = useState<{ name: string } | null>(null);
+  const [engagement, setEngagement] = useState<{
+    name: string;
+    modelOverride?: string | null;
+    modelOverrides?: ModelOverrides | null;
+  } | null>(null);
   const [agentId, setAgentId] = useState<"soundwave" | "decepticon" | null>(null);
   const [threadId, setThreadId] = useState<string | null>(null);
 
@@ -39,7 +44,12 @@ export default function EngagementLayout({
           fetch(`/api/engagements/${engagementId}/plan-docs`),
         ]);
         if (!engRes.ok) return;
-        const eng = (await engRes.json()) as { name: string; threadId?: string | null };
+        const eng = (await engRes.json()) as {
+          name: string;
+          threadId?: string | null;
+          modelOverride?: string | null;
+          modelOverrides?: ModelOverrides | null;
+        };
         const planDocs = planRes.ok ? ((await planRes.json()) as Record<string, unknown>) : {};
         if (cancelled) return;
         setEngagement(eng);
@@ -53,6 +63,29 @@ export default function EngagementLayout({
     };
     load();
     return () => { cancelled = true; };
+  }, [engagementId]);
+
+  useEffect(() => {
+    function handleModelsUpdated(event: Event) {
+      const detail = (event as CustomEvent<{
+        engagementId?: string;
+        modelOverride?: string | null;
+        modelOverrides?: ModelOverrides | null;
+      }>).detail;
+      if (detail?.engagementId !== engagementId) return;
+      setEngagement((current) =>
+        current
+          ? {
+              ...current,
+              modelOverride: detail.modelOverride || null,
+              modelOverrides: detail.modelOverrides ?? null,
+            }
+          : current,
+      );
+    }
+
+    window.addEventListener("decepticon:engagement-models-updated", handleModelsUpdated);
+    return () => window.removeEventListener("decepticon:engagement-models-updated", handleModelsUpdated);
   }, [engagementId]);
 
   // Persistent observer — survives tab navigation
@@ -74,27 +107,38 @@ export default function EngagementLayout({
       isRunning={isRunning}
       activeRunId={activeRunId}
     >
-      <div className="flex h-full overflow-hidden">
-        <div className="flex-1 min-w-0 overflow-auto">
-          {children}
-        </div>
-        {/* Terminal: always mounted, visibility controlled by route */}
+      <div className="flex h-full min-w-0 flex-col overflow-hidden">
         <div
           className={cn(
-            "shrink-0 overflow-hidden border-l border-white/[0.08] transition-[width] duration-200",
-            isLivePath ? "w-[35%] min-w-[350px]" : "w-0 min-w-0",
+            "min-h-0 min-w-0 flex-1",
+            isLivePath ? "flex flex-col overflow-hidden xl:flex-row" : "overflow-auto",
           )}
         >
-          {terminalReady && (
-            <WebTerminal
-              engagementId={engagementId}
-              engagementSlug={engagement!.name}
-              agentId={agentId!}
-              threadId={threadId ?? undefined}
-              className="h-full"
-              onThreadId={setThreadId}
-            />
-          )}
+          <div className={cn("min-h-0 min-w-0 flex-1", isLivePath ? "overflow-hidden" : "")}>
+            {children}
+          </div>
+          {/* Terminal: always mounted, visibility controlled by route */}
+          <div
+            className={cn(
+              "overflow-hidden transition-[height,width] duration-200",
+              isLivePath
+                ? "h-[42dvh] min-h-64 shrink-0 border-t border-white/[0.08] xl:h-auto xl:w-[clamp(460px,32vw,620px)] xl:border-l xl:border-t-0"
+                : "h-0 min-h-0",
+            )}
+          >
+            {terminalReady && (
+              <WebTerminal
+                engagementId={engagementId}
+                engagementSlug={engagement!.name}
+                agentId={agentId!}
+                modelOverride={engagement.modelOverride || ""}
+                modelOverrides={engagement.modelOverrides ?? undefined}
+                threadId={threadId ?? undefined}
+                className="h-full"
+                onThreadId={setThreadId}
+              />
+            )}
+          </div>
         </div>
       </div>
     </EngagementProvider>

--- a/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/live/page.tsx
@@ -29,9 +29,9 @@ export default function LivePage() {
   }
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="grid h-full min-h-0 min-w-0 grid-rows-[minmax(420px,1fr)_240px] overflow-hidden xl:grid-cols-[320px_minmax(520px,1fr)] xl:grid-rows-1">
       {/* Left: Activity Feed */}
-      <div className="relative w-1/4 min-w-[280px] overflow-hidden border-r border-white/[0.08]">
+      <div className="relative order-2 min-h-0 overflow-hidden border-t border-white/[0.08] xl:order-none xl:border-r xl:border-t-0">
         <LiveActivityFeed events={events} engagementId={engagementId} />
         {selectedAgent && (
           <div className="absolute inset-0 z-20">
@@ -45,18 +45,18 @@ export default function LivePage() {
       </div>
 
       {/* Center: Agent Execution Graph + OPPLAN overlay */}
-      <div className="relative flex-1 min-w-[400px] overflow-hidden">
+      <div className="relative order-1 min-h-0 min-w-0 overflow-hidden xl:order-none">
         <AgentGraphCanvas
           agents={agents}
           events={events}
           selectedAgent={selectedAgent}
           onAgentClick={handleAgentClick}
         />
-        <div className="absolute right-4 top-4 z-10">
+        <div className="absolute inset-x-3 bottom-3 z-10 md:inset-auto md:right-4 md:top-4">
           <OpplanLiveOverlay engagementId={engagementId} />
         </div>
         {/* HITL approval gates — surface prominently during a run */}
-        <div className="absolute left-4 top-4 z-30 w-[360px] max-w-[calc(100%-2rem)]">
+        <div className="absolute left-3 top-3 z-30 w-[min(360px,calc(100%-1.5rem))] sm:left-4 sm:top-4 sm:max-w-[calc(100%-2rem)]">
           <ApprovalGate engagementId={engagementId} />
         </div>
       </div>

--- a/clients/web/src/app/(dashboard)/engagements/[id]/plan/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/plan/page.tsx
@@ -52,7 +52,7 @@ function SafeText({ value, className }: { value: unknown; className?: string }) 
   if (typeof value === "string") return <p className={className}>{value}</p>;
   if (typeof value === "boolean" || typeof value === "number") return <p className={className}>{String(value)}</p>;
   return (
-    <pre className="whitespace-pre-wrap text-xs text-foreground/80 rounded bg-muted/50 p-2 font-mono">
+    <pre className="whitespace-pre-wrap break-words rounded bg-muted/50 p-2 font-mono text-xs text-foreground/80">
       {JSON.stringify(value, null, 2)}
     </pre>
   );
@@ -74,12 +74,12 @@ function Field({ label, value }: { label: string; value: unknown }) {
   const display = typeof value === "object" ? JSON.stringify(value, null, 2) : String(value);
   const isBlock = display.includes("\n");
   return (
-    <div className={isBlock ? "space-y-1 text-sm" : "flex gap-3 text-sm"}>
-      <span className="w-40 shrink-0 text-muted-foreground">{label}</span>
+    <div className={isBlock ? "space-y-1 text-sm" : "space-y-1 text-sm sm:flex sm:gap-3 sm:space-y-0"}>
+      <span className="w-auto shrink-0 text-muted-foreground sm:w-40">{label}</span>
       {isBlock ? (
-        <pre className="whitespace-pre-wrap text-xs text-foreground/80 rounded bg-muted/50 p-2 font-mono">{display}</pre>
+        <pre className="whitespace-pre-wrap break-words rounded bg-muted/50 p-2 font-mono text-xs text-foreground/80">{display}</pre>
       ) : (
-        <span className="text-foreground">{display}</span>
+        <span className="min-w-0 break-words text-foreground">{display}</span>
       )}
     </div>
   );
@@ -642,9 +642,9 @@ export default function PlanPage() {
   const selectedMeta = DOC_META.find((d) => d.key === selected);
 
   return (
-    <div className="flex h-full gap-4 overflow-hidden">
+    <div className="flex h-full min-w-0 flex-col gap-4 overflow-visible md:flex-row md:overflow-hidden">
       {/* Left: Document list */}
-      <div className="w-64 shrink-0 space-y-1.5">
+      <div className="w-full shrink-0 space-y-1.5 md:w-64">
         <div className="mb-3">
           <h1 className="text-lg font-bold tracking-tight">Plan</h1>
           <p className="text-xs text-muted-foreground">Engagement documents</p>
@@ -685,21 +685,21 @@ export default function PlanPage() {
       </div>
 
       {/* Right: Document content */}
-      <Card className="flex-1 overflow-hidden">
+      <Card className="min-w-0 flex-1 overflow-hidden">
         <CardHeader className="border-b border-border/50 pb-3">
-          <CardTitle className="flex items-center gap-2 text-base">
+          <CardTitle className="flex min-w-0 flex-wrap items-center gap-2 text-sm sm:text-base">
             {selectedMeta && (
               <selectedMeta.icon className={cn("h-4 w-4", selectedMeta.color)} />
             )}
             {selectedMeta?.label ?? "Select a document"}
-            <span className="text-xs font-normal text-muted-foreground">
+            <span className="min-w-0 text-xs font-normal text-muted-foreground">
               {selectedMeta?.desc}
             </span>
           </CardTitle>
         </CardHeader>
         <CardContent className="p-0">
-          <ScrollArea className="h-[calc(100vh-14rem)]">
-            <div className="p-6">
+          <ScrollArea className="h-[calc(100dvh-18rem)] md:h-[calc(100dvh-14rem)]">
+            <div className="p-3 sm:p-6">
               {selectedData && Renderer ? (
                 <Renderer data={selectedData} />
               ) : (

--- a/clients/web/src/app/(dashboard)/engagements/[id]/timeline/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/timeline/page.tsx
@@ -76,7 +76,7 @@ export default function TimelinePage() {
 
       <Card>
         <CardContent className="p-0">
-          <ScrollArea className="h-[calc(100vh-14rem)]">
+          <ScrollArea className="h-[calc(100dvh-14rem)]">
             <div className="divide-y divide-border/50">
               {events.length === 0 ? (
                 <div className="flex items-center justify-center py-16 text-sm text-muted-foreground">
@@ -87,20 +87,20 @@ export default function TimelinePage() {
                   const cfg = typeConfig[event.type] ?? typeConfig.file_created;
                   const Icon = cfg.icon;
                   return (
-                    <div key={i} className="flex items-start gap-4 px-6 py-4">
+                    <div key={i} className="flex flex-col gap-2 px-3 py-4 sm:flex-row sm:items-start sm:gap-4 sm:px-6">
                       <div className={cn("flex h-8 w-8 shrink-0 items-center justify-center rounded-lg", cfg.bg)}>
                         <Icon className={cn("h-4 w-4", cfg.color)} />
                       </div>
                       <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium">{event.title}</span>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="min-w-0 break-words text-sm font-medium">{event.title}</span>
                           {event.severity && (
                             <Badge className={cn("text-[10px]", sevColor[event.severity])}>
                               {event.severity}
                             </Badge>
                           )}
                         </div>
-                        <p className="mt-0.5 text-xs text-muted-foreground">{event.detail}</p>
+                        <p className="mt-0.5 break-words text-xs text-muted-foreground">{event.detail}</p>
                       </div>
                       <time className="shrink-0 text-xs text-muted-foreground">
                         {new Date(event.timestamp).toLocaleString()}

--- a/clients/web/src/app/(dashboard)/engagements/new/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/new/page.tsx
@@ -1,22 +1,107 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import { Globe, Server, Loader2 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { BUILTIN_MODEL_GROUPS, DEFAULT_MODEL_OPTION } from "@/lib/model-options";
+import { Bot, Globe, Server, Loader2, RefreshCw } from "lucide-react";
 import { isValidEngagementSlug } from "@/lib/engagement-slug";
+
+type LocalModel = {
+  id: string;
+  label: string;
+  provider: "ollama" | "llamacpp" | "lmstudio" | "custom";
+};
+
+type ModelPolicy = {
+  blockedPatterns: string[];
+};
+
+const LOCAL_PROVIDER_LABELS: Record<LocalModel["provider"], string> = {
+  ollama: "Ollama",
+  llamacpp: "llama.cpp",
+  lmstudio: "LM Studio",
+  custom: "Custom OpenAI",
+};
+
+function isBlockedModel(id: string, patterns: string[]): boolean {
+  const lower = id.toLowerCase();
+  return patterns.some((pattern) => lower.includes(pattern.toLowerCase()));
+}
 
 export default function NewEngagementPage() {
   const router = useRouter();
   const [targetType, setTargetType] = useState("web_url");
   const [name, setName] = useState("");
   const [targetValue, setTargetValue] = useState("");
+  const [modelChoice, setModelChoice] = useState("default");
+  const [localModels, setLocalModels] = useState<LocalModel[]>([]);
+  const [modelPolicy, setModelPolicy] = useState<ModelPolicy>({
+    blockedPatterns: ["wormgpt", "uncensored", "abliterate"],
+  });
+  const [localModelsLoading, setLocalModelsLoading] = useState(false);
+  const [customModel, setCustomModel] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const loadLocalModels = useCallback(async () => {
+    setLocalModelsLoading(true);
+    try {
+      const res = await fetch("/api/local-models", { cache: "no-store" });
+      if (!res.ok) throw new Error("Failed to load local models");
+      const data = (await res.json()) as { models?: LocalModel[] };
+      setLocalModels(data.models ?? []);
+    } catch {
+      setLocalModels([]);
+    } finally {
+      setLocalModelsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadLocalModels();
+  }, [loadLocalModels]);
+
+  const loadModelPolicy = useCallback(async () => {
+    try {
+      const res = await fetch("/api/model-policy", { cache: "no-store" });
+      if (!res.ok) throw new Error("Failed to load model policy");
+      setModelPolicy((await res.json()) as ModelPolicy);
+    } catch {
+      setModelPolicy({ blockedPatterns: ["wormgpt", "uncensored", "abliterate"] });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadModelPolicy();
+  }, [loadModelPolicy]);
+
+  const localModelsByProvider = useMemo(
+    () =>
+      localModels.reduce(
+        (groups, model) => {
+          const group = groups[model.provider] ?? [];
+          group.push(model);
+          groups[model.provider] = group;
+          return groups;
+        },
+        {} as Partial<Record<LocalModel["provider"], LocalModel[]>>,
+      ),
+    [localModels],
+  );
 
   const nameValid = isValidEngagementSlug(name);
   const nameError =
@@ -24,9 +109,20 @@ export default function NewEngagementPage() {
       ? "Name must be 3-64 chars, lowercase letters / digits with internal hyphens only"
       : null;
 
+  const modelOverride =
+    modelChoice === "default"
+      ? ""
+      : modelChoice === "custom"
+        ? customModel.trim()
+        : modelChoice;
+
   async function handleSubmit() {
     if (!nameValid || !targetValue.trim()) {
       setError("Please fill in all required fields");
+      return;
+    }
+    if (modelChoice === "custom" && !modelOverride) {
+      setError("Please provide a model id");
       return;
     }
 
@@ -37,7 +133,7 @@ export default function NewEngagementPage() {
       const res = await fetch("/api/engagements", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, targetType, targetValue }),
+        body: JSON.stringify({ name, targetType, targetValue, modelOverride: modelOverride || null }),
       });
 
       if (!res.ok) {
@@ -46,7 +142,8 @@ export default function NewEngagementPage() {
       }
 
       const engagement = await res.json();
-      router.push(`/engagements/${engagement.id}/live?new=true`);
+      const params = new URLSearchParams({ new: "true" });
+      router.push(`/engagements/${engagement.id}/live?${params.toString()}`);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
@@ -55,7 +152,7 @@ export default function NewEngagementPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    <div className="mx-auto max-w-2xl space-y-4 sm:space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">New Engagement</h1>
         <p className="text-sm text-muted-foreground">
@@ -92,6 +189,89 @@ export default function NewEngagementPage() {
               </p>
             )}
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bot className="h-4 w-4" />
+            Model
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <Label htmlFor="model">Primary Model</Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => void loadLocalModels()}
+                disabled={localModelsLoading}
+                title="Refresh local models"
+              >
+                <RefreshCw className={`h-4 w-4 ${localModelsLoading ? "animate-spin" : ""}`} />
+              </Button>
+            </div>
+            <Select value={modelChoice} onValueChange={(v) => setModelChoice(v ?? "default")}>
+              <SelectTrigger id="model" className="w-full">
+                <SelectValue placeholder="Select model" />
+              </SelectTrigger>
+              <SelectContent align="start" className="max-h-96">
+                <SelectGroup>
+                  <SelectLabel>Default</SelectLabel>
+                  <SelectItem value={DEFAULT_MODEL_OPTION.value}>{DEFAULT_MODEL_OPTION.label}</SelectItem>
+                </SelectGroup>
+                {BUILTIN_MODEL_GROUPS.map((group) => (
+                  <SelectGroup key={group.label}>
+                    <SelectLabel>{group.label}</SelectLabel>
+                    {group.models.map((model) => {
+                      const blocked = isBlockedModel(model.value, modelPolicy.blockedPatterns);
+                      return (
+                        <SelectItem key={model.value} value={model.value} disabled={blocked}>
+                          {blocked ? `${model.label} (gesperrt)` : model.label}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectGroup>
+                ))}
+                {(Object.keys(LOCAL_PROVIDER_LABELS) as LocalModel["provider"][]).map((provider) => {
+                  const models = localModelsByProvider[provider] ?? [];
+                  if (models.length === 0) return null;
+                  return (
+                    <SelectGroup key={provider}>
+                      <SelectLabel>{LOCAL_PROVIDER_LABELS[provider]}</SelectLabel>
+                      {models.map((model) => {
+                        const blocked = isBlockedModel(model.id, modelPolicy.blockedPatterns);
+                        return (
+                          <SelectItem key={model.id} value={model.id} disabled={blocked}>
+                            {blocked ? `${model.label} (gesperrt)` : model.label}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectGroup>
+                  );
+                })}
+                <SelectGroup>
+                  <SelectLabel>Manual</SelectLabel>
+                  <SelectItem value="custom">Custom model ID</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {modelChoice === "custom" && (
+            <div className="space-y-2">
+              <Label htmlFor="custom-model">Model ID</Label>
+              <Input
+                id="custom-model"
+                placeholder="provider/model"
+                value={customModel}
+                onChange={(e) => setCustomModel(e.target.value)}
+              />
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -152,11 +332,11 @@ export default function NewEngagementPage() {
         </CardContent>
       </Card>
 
-      <div className="flex justify-end gap-3">
-        <Button variant="outline" onClick={() => router.back()}>
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-3">
+        <Button variant="outline" className="w-full sm:w-auto" onClick={() => router.back()}>
           Cancel
         </Button>
-        <Button onClick={handleSubmit} disabled={submitting || !nameValid}>
+        <Button className="w-full sm:w-auto" onClick={handleSubmit} disabled={submitting || !nameValid}>
           {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Create Engagement
         </Button>

--- a/clients/web/src/app/(dashboard)/engagements/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/page.tsx
@@ -73,15 +73,15 @@ export default function EngagementsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Engagements</h1>
           <p className="text-sm text-muted-foreground">
             Manage your red team testing operations
           </p>
         </div>
-        <Link href="/engagements/new">
-          <Button>
+        <Link href="/engagements/new" className="w-full sm:w-auto">
+          <Button className="w-full sm:w-auto">
             <Plus className="mr-2 h-4 w-4" />
             New Engagement
           </Button>
@@ -108,7 +108,8 @@ export default function EngagementsPage() {
               one.
             </div>
           ) : (
-            <Table>
+            <div className="overflow-x-auto">
+            <Table className="min-w-[44rem]">
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
@@ -122,7 +123,7 @@ export default function EngagementsPage() {
                   const Icon = targetIcons[eng.targetType] ?? Globe;
                   return (
                     <TableRow key={eng.id}>
-                      <TableCell>
+                      <TableCell className="max-w-56 whitespace-normal break-words">
                         <Link
                           href={`/engagements/${eng.id}`}
                           className="font-medium text-foreground hover:underline"
@@ -133,7 +134,7 @@ export default function EngagementsPage() {
                       <TableCell>
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
                           <Icon className="h-3.5 w-3.5" />
-                          <span className="truncate max-w-[200px]">
+                          <span className="max-w-[220px] truncate">
                             {eng.targetValue}
                           </span>
                         </div>
@@ -154,6 +155,7 @@ export default function EngagementsPage() {
                 })}
               </TableBody>
             </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/clients/web/src/app/(dashboard)/layout.tsx
+++ b/clients/web/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,4 @@
 import { Sidebar } from "@/components/layout/sidebar";
-import { Header } from "@/components/layout/header";
 import { CommandPalette } from "@/components/layout/command-palette";
 
 export default function DashboardLayout({
@@ -8,11 +7,10 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex h-screen overflow-hidden">
+    <div className="flex h-dvh overflow-hidden pb-16 md:pb-0">
       <Sidebar />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Header />
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <main className="min-w-0 flex-1 overflow-auto p-0">{children}</main>
       </div>
       <CommandPalette />
     </div>

--- a/clients/web/src/app/api/engagements/[id]/route.ts
+++ b/clients/web/src/app/api/engagements/[id]/route.ts
@@ -1,4 +1,5 @@
 import { requireAuth, AuthError } from "@/lib/auth-bridge";
+import { assertModelAllowed } from "@/lib/model-policy";
 import { prisma } from "@/lib/prisma";
 import { SLUG_RE, VALID_TARGET_TYPES, VALID_STATUSES } from "@/lib/workspace";
 import { NextRequest, NextResponse } from "next/server";
@@ -48,7 +49,15 @@ export async function PATCH(
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    const ALLOWED_FIELDS = ["name", "status", "targetType", "targetValue", "threadId"] as const;
+    const ALLOWED_FIELDS = [
+      "name",
+      "status",
+      "targetType",
+      "targetValue",
+      "threadId",
+      "modelOverride",
+      "modelOverrides",
+    ] as const;
     const data: Record<string, unknown> = {};
     for (const field of ALLOWED_FIELDS) {
       if (field in body) data[field] = body[field];
@@ -85,6 +94,68 @@ export async function PATCH(
         { error: `Invalid targetType. Must be one of: ${VALID_TARGET_TYPES.join(", ")}` },
         { status: 400 }
       );
+    }
+
+    if ("modelOverride" in data) {
+      if (data.modelOverride == null || data.modelOverride === "") {
+        data.modelOverride = null;
+      } else if (typeof data.modelOverride !== "string" || data.modelOverride.length > 200) {
+        return NextResponse.json(
+          { error: "Invalid modelOverride. Must be a model id up to 200 chars" },
+          { status: 400 }
+        );
+      } else {
+        try {
+          await assertModelAllowed(data.modelOverride);
+        } catch (e) {
+          return NextResponse.json(
+            { error: e instanceof Error ? e.message : "Blocked model id is not allowed" },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
+    if ("modelOverrides" in data) {
+      if (data.modelOverrides == null || data.modelOverrides === "") {
+        data.modelOverrides = null;
+      } else if (
+        typeof data.modelOverrides !== "object" ||
+        Array.isArray(data.modelOverrides)
+      ) {
+        return NextResponse.json(
+          { error: "Invalid modelOverrides. Must be an object of role to model id" },
+          { status: 400 },
+        );
+      } else {
+        const clean: Record<string, string> = {};
+        for (const [role, model] of Object.entries(data.modelOverrides as Record<string, unknown>)) {
+          if (!/^[a-z][a-z0-9_-]{1,63}$/.test(role)) {
+            return NextResponse.json(
+              { error: "Invalid modelOverrides role key" },
+              { status: 400 },
+            );
+          }
+          if (model == null || model === "") continue;
+          if (typeof model !== "string" || model.length > 200) {
+            return NextResponse.json(
+              { error: "Invalid modelOverrides model id. Must be up to 200 chars" },
+              { status: 400 },
+            );
+          }
+          const trimmed = model.trim();
+          try {
+            await assertModelAllowed(trimmed);
+          } catch (e) {
+            return NextResponse.json(
+              { error: e instanceof Error ? e.message : "Blocked model id is not allowed" },
+              { status: 400 },
+            );
+          }
+          if (trimmed) clean[role] = trimmed;
+        }
+        data.modelOverrides = Object.keys(clean).length > 0 ? clean : null;
+      }
     }
 
     const engagement = await prisma.engagement.update({

--- a/clients/web/src/app/api/engagements/route.ts
+++ b/clients/web/src/app/api/engagements/route.ts
@@ -1,4 +1,5 @@
 import { requireAuth, AuthError } from "@/lib/auth-bridge";
+import { assertModelAllowed } from "@/lib/model-policy";
 import { prisma } from "@/lib/prisma";
 import { SLUG_RE, VALID_TARGET_TYPES } from "@/lib/workspace";
 import { NextRequest, NextResponse } from "next/server";
@@ -8,6 +9,27 @@ import * as path from "path";
 const WORKSPACE = process.env.WORKSPACE_PATH ?? path.join(process.env.HOME ?? "", ".decepticon", "workspace");
 
 const WORKSPACE_SUBDIRS = ["plan"];
+
+async function normalizeModelOverrides(value: unknown): Promise<Record<string, string> | null> {
+  if (value == null || value === "") return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid modelOverrides. Must be an object of role to model id");
+  }
+
+  const clean: Record<string, string> = {};
+  for (const [role, model] of Object.entries(value as Record<string, unknown>)) {
+    if (!/^[a-z][a-z0-9_-]{1,63}$/.test(role)) {
+      throw new Error("Invalid modelOverrides role key");
+    }
+    if (typeof model !== "string" || model.length > 200) {
+      throw new Error("Invalid modelOverrides model id. Must be up to 200 chars");
+    }
+    const trimmed = model.trim();
+    await assertModelAllowed(trimmed);
+    if (trimmed) clean[role] = trimmed;
+  }
+  return Object.keys(clean).length > 0 ? clean : null;
+}
 
 function isEngagementWorkspaceDir(name: string) {
   return SLUG_RE.test(name) && !name.startsWith(".");
@@ -69,6 +91,19 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
     const { name, targetType, targetValue } = body;
+    const modelOverride =
+      typeof body.modelOverride === "string" && body.modelOverride.trim()
+        ? body.modelOverride.trim()
+        : null;
+    let modelOverrides: Record<string, string> | null = null;
+    try {
+      modelOverrides = await normalizeModelOverrides(body.modelOverrides);
+    } catch (e) {
+      return NextResponse.json(
+        { error: e instanceof Error ? e.message : "Invalid modelOverrides" },
+        { status: 400 }
+      );
+    }
 
     if (!name || !targetType || !targetValue) {
       return NextResponse.json(
@@ -80,6 +115,21 @@ export async function POST(req: NextRequest) {
     if (!VALID_TARGET_TYPES.includes(targetType)) {
       return NextResponse.json(
         { error: `Invalid targetType. Must be one of: ${VALID_TARGET_TYPES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    if (modelOverride && modelOverride.length > 200) {
+      return NextResponse.json(
+        { error: "Invalid modelOverride. Must be a model id up to 200 chars" },
+        { status: 400 }
+      );
+    }
+    try {
+      await assertModelAllowed(modelOverride ?? "");
+    } catch (e) {
+      return NextResponse.json(
+        { error: e instanceof Error ? e.message : "Blocked model id is not allowed" },
         { status: 400 }
       );
     }
@@ -112,6 +162,8 @@ export async function POST(req: NextRequest) {
         name,
         targetType,
         targetValue,
+        modelOverride,
+        ...(modelOverrides ? { modelOverrides } : {}),
         userId,
         workspacePath: wsPath,
       },

--- a/clients/web/src/app/api/local-models/route.ts
+++ b/clients/web/src/app/api/local-models/route.ts
@@ -1,0 +1,205 @@
+import { NextResponse } from "next/server";
+
+type LocalModel = {
+  id: string;
+  label: string;
+  provider: "ollama" | "llamacpp" | "lmstudio" | "custom";
+};
+
+type ProbeResult = {
+  provider: LocalModel["provider"];
+  status: "ok" | "error" | "skipped";
+  detail?: string;
+};
+
+const ROUTE_PREFIX: Record<LocalModel["provider"], string> = {
+  ollama: "ollama_chat",
+  llamacpp: "llamacpp",
+  lmstudio: "lm_studio",
+  custom: "custom",
+};
+
+const LITELLM_URL = trimBaseUrl(process.env.LITELLM_URL) || "http://litellm:4000";
+const LITELLM_KEY = process.env.LITELLM_API_KEY ?? process.env.LITELLM_MASTER_KEY ?? "";
+
+function trimBaseUrl(value: string | undefined): string {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function ollamaNativeBase(value: string | undefined): string {
+  const base = trimBaseUrl(value);
+  return base.replace(/\/v1$/i, "");
+}
+
+function uniqueModels(models: LocalModel[]): LocalModel[] {
+  const seen = new Set<string>();
+  return models.filter((model) => {
+    if (seen.has(model.id)) return false;
+    seen.add(model.id);
+    return true;
+  });
+}
+
+async function fetchJson(url: string, headers?: HeadersInit): Promise<unknown> {
+  const res = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+async function registeredLiteLLMModels(): Promise<Set<string>> {
+  if (!LITELLM_KEY) return new Set();
+  try {
+    const data = (await fetchJson(`${LITELLM_URL}/v1/models`, {
+      Authorization: `Bearer ${LITELLM_KEY}`,
+    })) as { data?: Array<{ id?: string }> };
+    return new Set(data.data?.map((model) => model.id).filter((id): id is string => Boolean(id)) ?? []);
+  } catch {
+    return new Set();
+  }
+}
+
+function litellmParamsFor(model: LocalModel): Record<string, string> {
+  if (model.provider === "ollama") {
+    const base = ollamaNativeBase(process.env.OLLAMA_API_BASE) || "http://host.docker.internal:11434";
+    return {
+      model: model.id,
+      api_base: base,
+    };
+  }
+  if (model.provider === "llamacpp") {
+    return {
+      model: `openai/${model.id.split("/", 2)[1]}`,
+      api_base: trimBaseUrl(process.env.LLAMACPP_API_BASE),
+      api_key: process.env.LLAMACPP_API_KEY ? "os.environ/LLAMACPP_API_KEY" : "llama-cpp",
+    };
+  }
+  if (model.provider === "lmstudio") {
+    return {
+      model: `openai/${model.id.split("/", 2)[1]}`,
+      api_base: trimBaseUrl(process.env.LMSTUDIO_API_BASE),
+      api_key: process.env.LMSTUDIO_API_KEY ? "os.environ/LMSTUDIO_API_KEY" : "lm-studio",
+    };
+  }
+  return {
+    model: `openai/${model.id.split("/", 2)[1]}`,
+    api_base: trimBaseUrl(process.env.CUSTOM_OPENAI_API_BASE),
+    api_key: "os.environ/CUSTOM_OPENAI_API_KEY",
+  };
+}
+
+async function ensureLiteLLMModels(models: LocalModel[]): Promise<ProbeResult> {
+  if (!LITELLM_KEY) return { provider: "ollama", status: "skipped", detail: "LiteLLM key not configured" };
+  const registered = await registeredLiteLLMModels();
+  const missing = models.filter((model) => !registered.has(model.id));
+  if (missing.length === 0) return { provider: "ollama", status: "ok", detail: "all local models registered" };
+
+  let added = 0;
+  for (const model of missing) {
+    try {
+      const res = await fetch(`${LITELLM_URL}/model/new`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${LITELLM_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model_name: model.id,
+          litellm_params: litellmParamsFor(model),
+          model_info: { source: model.provider, display_name: model.label },
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      if (res.ok) added += 1;
+    } catch {
+      // Keep discovery usable even if a route could not be registered.
+    }
+  }
+  return {
+    provider: "ollama",
+    status: added === missing.length ? "ok" : "error",
+    detail: `registered ${added}/${missing.length} missing local models`,
+  };
+}
+
+async function listOllama(): Promise<{ models: LocalModel[]; result: ProbeResult }> {
+  const base = ollamaNativeBase(process.env.OLLAMA_API_BASE) || "http://host.docker.internal:11434";
+  try {
+    const data = (await fetchJson(`${base}/api/tags`)) as {
+      models?: Array<{ name?: string; model?: string }>;
+    };
+    const models =
+      data.models
+        ?.map((item) => (item.name ?? item.model ?? "").trim())
+        .filter(Boolean)
+        .map((name) => ({
+          id: `ollama_chat/${name}`,
+          label: name,
+          provider: "ollama" as const,
+        })) ?? [];
+    return { models, result: { provider: "ollama", status: "ok", detail: `${models.length} models` } };
+  } catch (err) {
+    return {
+      models: [],
+      result: {
+        provider: "ollama",
+        status: "error",
+        detail: err instanceof Error ? err.message : "unreachable",
+      },
+    };
+  }
+}
+
+async function listOpenAICompatible(
+  provider: "llamacpp" | "lmstudio" | "custom",
+  baseUrl: string | undefined,
+  apiKey: string | undefined,
+): Promise<{ models: LocalModel[]; result: ProbeResult }> {
+  const base = trimBaseUrl(baseUrl);
+  if (!base) return { models: [], result: { provider, status: "skipped", detail: "base URL not configured" } };
+
+  const headers: HeadersInit = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+  try {
+    const data = (await fetchJson(`${base}/models`, headers)) as {
+      data?: Array<{ id?: string }>;
+    };
+    const models =
+      data.data
+        ?.map((item) => (item.id ?? "").trim())
+        .filter(Boolean)
+        .map((name) => ({
+          id: `${ROUTE_PREFIX[provider]}/${name}`,
+          label: name,
+          provider,
+        })) ?? [];
+    return { models, result: { provider, status: "ok", detail: `${models.length} models` } };
+  } catch (err) {
+    return {
+      models: [],
+      result: {
+        provider,
+        status: "error",
+        detail: err instanceof Error ? err.message : "unreachable",
+      },
+    };
+  }
+}
+
+export async function GET() {
+  const [ollama, llamacpp, lmstudio, custom] = await Promise.all([
+    listOllama(),
+    listOpenAICompatible("llamacpp", process.env.LLAMACPP_API_BASE, process.env.LLAMACPP_API_KEY),
+    listOpenAICompatible("lmstudio", process.env.LMSTUDIO_API_BASE, process.env.LMSTUDIO_API_KEY),
+    listOpenAICompatible("custom", process.env.CUSTOM_OPENAI_API_BASE, process.env.CUSTOM_OPENAI_API_KEY),
+  ]);
+
+  const models = uniqueModels([...ollama.models, ...llamacpp.models, ...lmstudio.models, ...custom.models]);
+  const registration = await ensureLiteLLMModels(models);
+
+  return NextResponse.json({
+    models,
+    sources: [ollama.result, llamacpp.result, lmstudio.result, custom.result, registration],
+  });
+}

--- a/clients/web/src/app/api/model-policy/route.ts
+++ b/clients/web/src/app/api/model-policy/route.ts
@@ -1,0 +1,42 @@
+import { requireAuth, AuthError } from "@/lib/auth-bridge";
+import { readModelPolicy, writeModelPolicy } from "@/lib/model-policy";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    await requireAuth();
+    return NextResponse.json(await readModelPolicy());
+  } catch (e) {
+    if (e instanceof AuthError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("GET /api/model-policy error:", e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  try {
+    await requireAuth();
+    const body = await req.json();
+    if (!Array.isArray(body.blockedPatterns)) {
+      return NextResponse.json(
+        { error: "blockedPatterns must be an array" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(await writeModelPolicy(body.blockedPatterns));
+  } catch (e) {
+    if (e instanceof AuthError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("PATCH /api/model-policy error:", e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/clients/web/src/components/engagement/engagement-model-picker.tsx
+++ b/clients/web/src/components/engagement/engagement-model-picker.tsx
@@ -1,0 +1,563 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { BUILTIN_MODEL_GROUPS, BUILTIN_MODELS, DEFAULT_MODEL_OPTION } from "@/lib/model-options";
+import { cn } from "@/lib/utils";
+import { Ban, Check, RefreshCw, Save, Shield, SlidersHorizontal, X } from "lucide-react";
+
+type LocalModel = {
+  id: string;
+  label: string;
+  provider: "ollama" | "llamacpp" | "lmstudio" | "custom";
+};
+
+export type ModelOverrides = Record<string, string>;
+
+type ModelPolicy = {
+  blockedPatterns: string[];
+};
+
+const AGENT_ROLES = [
+  { value: "soundwave", label: "Soundwave", hint: "planning" },
+  { value: "decepticon", label: "Decepticon", hint: "orchestration" },
+  { value: "recon", label: "Recon", hint: "discovery" },
+  { value: "exploit", label: "Exploit", hint: "validation" },
+  { value: "postexploit", label: "Post-Exploit", hint: "follow-up" },
+  { value: "analyst", label: "Analyst", hint: "reasoning" },
+  { value: "blue_cell", label: "Blue Cell", hint: "defense" },
+  { value: "cloud_hunter", label: "Cloud Hunter", hint: "cloud" },
+  { value: "ad_operator", label: "AD Operator", hint: "identity" },
+  { value: "reverser", label: "Reverser", hint: "binaries" },
+  { value: "forensicator", label: "Forensicator", hint: "evidence" },
+  { value: "osint_operator", label: "OSINT Operator", hint: "passive" },
+  { value: "mobile_operator", label: "Mobile Operator", hint: "mobile" },
+  { value: "wireless_operator", label: "Wireless Operator", hint: "wireless" },
+  { value: "iot_operator", label: "IoT Operator", hint: "devices" },
+  { value: "ics_operator", label: "ICS Operator", hint: "safety" },
+  { value: "contract_auditor", label: "Contract Auditor", hint: "contracts" },
+  { value: "phisher", label: "Phisher", hint: "only if RoE allows" },
+  { value: "supply_chain_operator", label: "Supply Chain", hint: "deps" },
+] as const;
+
+const LOCAL_PROVIDER_LABELS: Record<LocalModel["provider"], string> = {
+  ollama: "Ollama",
+  llamacpp: "llama.cpp",
+  lmstudio: "LM Studio",
+  custom: "Custom OpenAI",
+};
+
+function choiceFromOverride(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "default";
+  if (BUILTIN_MODELS.some((model) => model.value === trimmed)) return trimmed;
+  return "custom";
+}
+
+function normalizeOverrides(value: ModelOverrides | null | undefined): ModelOverrides {
+  if (!value) return {};
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([role, model]) => [role, model.trim()])
+      .filter(([, model]) => Boolean(model)),
+  );
+}
+
+function isBlockedModel(id: string, patterns: string[]): boolean {
+  const lower = id.toLowerCase();
+  return patterns.some((pattern) => lower.includes(pattern.toLowerCase()));
+}
+
+function uniquePatterns(patterns: string[]): string[] {
+  const seen = new Set<string>();
+  const clean: string[] = [];
+  for (const pattern of patterns) {
+    const trimmed = pattern.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    clean.push(trimmed);
+  }
+  return clean;
+}
+
+function isKnownModelChoice(
+  value: string,
+  localModelsByProvider: Partial<Record<LocalModel["provider"], LocalModel[]>>,
+): boolean {
+  if (BUILTIN_MODELS.some((model) => model.value === value)) return true;
+  return Object.values(localModelsByProvider).some((models) =>
+    (models ?? []).some((model) => model.id === value),
+  );
+}
+
+function RoleModelSelect({
+  value,
+  blockedPatterns,
+  localModelsByProvider,
+  compact = false,
+  onChange,
+}: {
+  value: string;
+  blockedPatterns: string[];
+  localModelsByProvider: Partial<Record<LocalModel["provider"], LocalModel[]>>;
+  compact?: boolean;
+  onChange: (value: string) => void;
+}) {
+  const [forceCustom, setForceCustom] = useState(false);
+  const trimmedValue = value.trim();
+  const knownChoice = isKnownModelChoice(trimmedValue, localModelsByProvider);
+  const choice = forceCustom || (trimmedValue && !knownChoice) ? "custom" : trimmedValue || "default";
+  const customValue = choice === "custom" && trimmedValue !== "default" ? trimmedValue : "";
+
+  useEffect(() => {
+    if (trimmedValue && knownChoice) setForceCustom(false);
+  }, [knownChoice, trimmedValue]);
+
+  return (
+    <div className={compact ? "flex min-w-0 flex-1 flex-col gap-2" : "flex min-w-0 flex-1 flex-col gap-2 sm:flex-row"}>
+      <Select
+        value={choice}
+        onValueChange={(next) => {
+          if (next === "custom") {
+            setForceCustom(true);
+            return;
+          }
+          setForceCustom(false);
+          onChange(next === "default" ? "" : next ?? "");
+        }}
+      >
+        <SelectTrigger className={compact ? "h-8 w-full min-w-0" : "h-8 min-w-0 sm:w-72"}>
+          <SelectValue placeholder="Default chain" />
+        </SelectTrigger>
+        <SelectContent align="start">
+          <SelectGroup>
+            <SelectLabel>Default</SelectLabel>
+            <SelectItem value={DEFAULT_MODEL_OPTION.value}>{DEFAULT_MODEL_OPTION.label}</SelectItem>
+          </SelectGroup>
+          {BUILTIN_MODEL_GROUPS.map((group) => (
+            <SelectGroup key={group.label}>
+              <SelectLabel>{group.label}</SelectLabel>
+              {group.models.map((model) => {
+                const blocked = isBlockedModel(model.value, blockedPatterns);
+                return (
+                  <SelectItem key={model.value} value={model.value} disabled={blocked}>
+                    {blocked ? `${model.label} (gesperrt)` : model.label}
+                  </SelectItem>
+                );
+              })}
+            </SelectGroup>
+          ))}
+          {(Object.keys(LOCAL_PROVIDER_LABELS) as LocalModel["provider"][]).map((provider) => {
+            const models = localModelsByProvider[provider] ?? [];
+            if (models.length === 0) return null;
+            return (
+              <SelectGroup key={provider}>
+                <SelectLabel>{LOCAL_PROVIDER_LABELS[provider]}</SelectLabel>
+                {models.map((model) => {
+                  const blocked = isBlockedModel(model.id, blockedPatterns);
+                  return (
+                    <SelectItem key={model.id} value={model.id} disabled={blocked}>
+                      {blocked ? `${model.label} (gesperrt)` : model.label}
+                    </SelectItem>
+                  );
+                })}
+              </SelectGroup>
+            );
+          })}
+          <SelectGroup>
+            <SelectLabel>Manual</SelectLabel>
+            <SelectItem value="custom">Custom model ID</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      {choice === "custom" && (
+        <Input
+          className={compact ? "h-8 w-full min-w-0" : "h-8 min-w-0 sm:w-72"}
+          placeholder="provider/model"
+          value={customValue}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      )}
+    </div>
+  );
+}
+
+export function EngagementModelPicker({
+  engagementId,
+  value,
+  overrides,
+  variant = "bar",
+  onChange,
+}: {
+  engagementId: string;
+  value: string;
+  overrides?: ModelOverrides | null;
+  variant?: "bar" | "sidebar";
+  onChange: (value: string, overrides: ModelOverrides) => void;
+}) {
+  const [choice, setChoice] = useState(choiceFromOverride(value));
+  const [customModel, setCustomModel] = useState(choiceFromOverride(value) === "custom" ? value.trim() : "");
+  const [roleOverrides, setRoleOverrides] = useState<ModelOverrides>(() => normalizeOverrides(overrides));
+  const [showRoles, setShowRoles] = useState(false);
+  const [showPolicy, setShowPolicy] = useState(false);
+  const [localModels, setLocalModels] = useState<LocalModel[]>([]);
+  const [modelPolicy, setModelPolicy] = useState<ModelPolicy>({
+    blockedPatterns: ["wormgpt", "uncensored", "abliterate"],
+  });
+  const [policyDraft, setPolicyDraft] = useState("");
+  const [savingPolicy, setSavingPolicy] = useState(false);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+
+  useEffect(() => {
+    const trimmed = (value ?? "").trim();
+    const localMatch = localModels.some((model) => model.id === trimmed);
+    const next = localMatch ? trimmed : choiceFromOverride(trimmed);
+    setChoice(next);
+    if (next === "custom") setCustomModel(trimmed);
+  }, [localModels, value]);
+
+  useEffect(() => {
+    setRoleOverrides(normalizeOverrides(overrides));
+  }, [overrides]);
+
+  const loadLocalModels = useCallback(async () => {
+    setLoadingModels(true);
+    try {
+      const res = await fetch("/api/local-models", { cache: "no-store" });
+      if (!res.ok) throw new Error("failed");
+      const data = (await res.json()) as { models?: LocalModel[] };
+      setLocalModels(data.models ?? []);
+    } catch {
+      setLocalModels([]);
+    } finally {
+      setLoadingModels(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadLocalModels();
+  }, [loadLocalModels]);
+
+  const loadModelPolicy = useCallback(async () => {
+    try {
+      const res = await fetch("/api/model-policy", { cache: "no-store" });
+      if (!res.ok) throw new Error("failed");
+      setModelPolicy((await res.json()) as ModelPolicy);
+    } catch {
+      setModelPolicy({
+        blockedPatterns: ["wormgpt", "uncensored", "abliterate"],
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadModelPolicy();
+  }, [loadModelPolicy]);
+
+  const localModelsByProvider = useMemo(
+    () =>
+      localModels.reduce(
+        (groups, model) => {
+          const group = groups[model.provider] ?? [];
+          group.push(model);
+          groups[model.provider] = group;
+          return groups;
+        },
+        {} as Partial<Record<LocalModel["provider"], LocalModel[]>>,
+      ),
+    [localModels],
+  );
+
+  const selectedModel = choice === "custom" ? customModel.trim() : choice === "default" ? "" : choice;
+  const cleanOverrides = normalizeOverrides(roleOverrides);
+  const blockedPatterns = modelPolicy.blockedPatterns;
+  const dirty =
+    selectedModel !== (value ?? "").trim() ||
+    JSON.stringify(cleanOverrides) !== JSON.stringify(normalizeOverrides(overrides));
+
+  const selectableModels = useMemo(
+    () => [
+      ...BUILTIN_MODELS.filter((model) => model.value !== "default").map((model) => ({
+        id: model.value,
+        label: model.label,
+        provider: "cloud",
+      })),
+      ...localModels.map((model) => ({
+        id: model.id,
+        label: model.label,
+        provider: LOCAL_PROVIDER_LABELS[model.provider],
+      })),
+    ],
+    [localModels],
+  );
+
+  async function savePolicy(nextPatterns: string[]) {
+    setSavingPolicy(true);
+    setStatus("idle");
+    try {
+      const res = await fetch("/api/model-policy", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ blockedPatterns: uniquePatterns(nextPatterns) }),
+      });
+      if (!res.ok) throw new Error("save failed");
+      setModelPolicy((await res.json()) as ModelPolicy);
+    } catch {
+      setStatus("error");
+    } finally {
+      setSavingPolicy(false);
+    }
+  }
+
+  function blockModel(id: string) {
+    void savePolicy([...blockedPatterns, id]);
+  }
+
+  function freeModel(id: string) {
+    const lower = id.toLowerCase();
+    void savePolicy(blockedPatterns.filter((pattern) => !lower.includes(pattern.toLowerCase())));
+  }
+
+  function addPattern() {
+    if (!policyDraft.trim()) return;
+    void savePolicy([...blockedPatterns, policyDraft]);
+    setPolicyDraft("");
+  }
+
+  function updateRole(role: string, model: string) {
+    setStatus("idle");
+    setRoleOverrides((current) => {
+      const next = { ...current };
+      const trimmed = model.trim();
+      if (trimmed) next[role] = trimmed;
+      else delete next[role];
+      return next;
+    });
+  }
+
+  async function save() {
+    if (choice === "custom" && !customModel.trim()) return;
+    if ([selectedModel, ...Object.values(cleanOverrides)].some((model) => isBlockedModel(model, blockedPatterns))) {
+      setStatus("error");
+      return;
+    }
+    setSaving(true);
+    setStatus("idle");
+    try {
+      const res = await fetch(`/api/engagements/${engagementId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          modelOverride: selectedModel || null,
+          modelOverrides: Object.keys(cleanOverrides).length ? cleanOverrides : null,
+        }),
+      });
+      if (!res.ok) throw new Error("save failed");
+      const engagement = (await res.json()) as {
+        modelOverride?: string | null;
+        modelOverrides?: ModelOverrides | null;
+      };
+      const nextModel = engagement.modelOverride ?? "";
+      const nextOverrides = normalizeOverrides(engagement.modelOverrides);
+      onChange(nextModel, nextOverrides);
+      window.dispatchEvent(
+        new CustomEvent("decepticon:engagement-models-updated", {
+          detail: {
+            engagementId,
+            modelOverride: nextModel,
+            modelOverrides: nextOverrides,
+          },
+        }),
+      );
+      setStatus("saved");
+    } catch {
+      setStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const compact = variant === "sidebar";
+
+  return (
+    <div
+      className={cn(
+        compact
+          ? "rounded-lg border border-border/60 bg-sidebar-accent/20 p-2"
+          : "border-b border-border/60 px-3 py-2 sm:px-4",
+      )}
+    >
+      <div className={cn("flex gap-2", compact ? "flex-col" : "flex-wrap items-center")}>
+        <span className="text-xs font-medium uppercase text-muted-foreground sm:shrink-0">Model</span>
+        <RoleModelSelect
+          value={selectedModel}
+          blockedPatterns={blockedPatterns}
+          localModelsByProvider={localModelsByProvider}
+          compact={compact}
+          onChange={(next) => {
+            const nextChoice =
+              next && isKnownModelChoice(next, localModelsByProvider)
+                ? next
+                : choiceFromOverride(next);
+            setChoice(nextChoice);
+            setCustomModel(nextChoice === "custom" ? next : "");
+            setStatus("idle");
+          }}
+        />
+        <div className={cn("flex flex-wrap items-center gap-2", compact && "grid grid-cols-2")}>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className={compact ? "w-full" : "w-10"}
+            onClick={() => void loadLocalModels()}
+            disabled={loadingModels}
+            title="Refresh models"
+          >
+            <RefreshCw className={loadingModels ? "animate-spin" : ""} />
+          </Button>
+          <Button
+            type="button"
+            variant={showRoles ? "secondary" : "outline"}
+            size="sm"
+            className={cn("w-auto", compact && "w-full px-2")}
+            onClick={() => setShowRoles((open) => !open)}
+          >
+            <SlidersHorizontal />
+            Agents
+          </Button>
+          <Button
+            type="button"
+            variant={showPolicy ? "secondary" : "outline"}
+            size="sm"
+            className={cn("w-auto", compact && "w-full px-2")}
+            onClick={() => setShowPolicy((open) => !open)}
+          >
+            <Shield />
+            Policy
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className={cn("w-auto", compact && "w-full px-2")}
+            onClick={() => void save()}
+            disabled={saving || !dirty || (choice === "custom" && !customModel.trim())}
+          >
+            {saving ? <RefreshCw className="animate-spin" /> : <Save />}
+            Save
+          </Button>
+        </div>
+        {status === "saved" && <span className="text-xs text-emerald-400">Saved</span>}
+        {status === "error" && <span className="text-xs text-destructive">Error</span>}
+      </div>
+
+      {showPolicy && (
+        <div className={cn("mt-3 space-y-3 overflow-auto rounded-md border border-border/60 bg-background/40 p-2", compact ? "max-h-72" : "max-h-96")}>
+          <div className={cn("flex flex-col gap-2", !compact && "sm:flex-row sm:items-center")}>
+            <Input
+              className={compact ? "h-8 min-w-0" : "h-8 min-w-0 sm:w-80"}
+              placeholder="Modell-ID oder Muster"
+              value={policyDraft}
+              onChange={(event) => setPolicyDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") addPattern();
+              }}
+            />
+            <Button
+              type="button"
+              size="sm"
+              className="w-auto"
+              disabled={savingPolicy || !policyDraft.trim()}
+              onClick={addPattern}
+            >
+              <Ban />
+              Sperren
+            </Button>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {blockedPatterns.map((pattern) => (
+              <button
+                key={`blocked-${pattern}`}
+                type="button"
+                className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-muted px-2 text-xs hover:bg-muted/80"
+                disabled={savingPolicy}
+                onClick={() => void savePolicy(blockedPatterns.filter((item) => item !== pattern))}
+                title="Sperre entfernen"
+              >
+                {pattern}
+                <X className="size-3" />
+              </button>
+            ))}
+          </div>
+
+          <div className="space-y-1">
+            {selectableModels.map((model) => {
+              const blocked = isBlockedModel(model.id, blockedPatterns);
+              return (
+                <div
+                  key={model.id}
+                  className={cn("flex flex-col gap-2 border-b border-border/40 py-2 last:border-b-0", !compact && "sm:flex-row sm:items-center")}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">{model.label}</div>
+                    <div className="truncate text-xs text-muted-foreground">{model.provider} · {model.id}</div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant={blocked ? "destructive" : "outline"}
+                    size="sm"
+                    className="w-auto"
+                    disabled={savingPolicy}
+                    onClick={() => (blocked ? freeModel(model.id) : blockModel(model.id))}
+                    title={blocked ? "Modell freigeben" : "Modell sperren"}
+                  >
+                    {blocked ? <Ban /> : <Check />}
+                    {blocked ? "Gesperrt" : "Frei"}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {showRoles && (
+        <div className={cn("mt-3 space-y-2 overflow-auto rounded-md border border-border/60 bg-background/40 p-2", compact ? "max-h-72" : "max-h-96")}>
+          {AGENT_ROLES.map((role) => (
+            <div
+              key={role.value}
+              className={cn("flex flex-col gap-2 border-b border-border/40 py-2 last:border-b-0", !compact && "sm:flex-row sm:items-center")}
+            >
+              <div className={compact ? "min-w-0" : "min-w-40"}>
+                <div className="text-sm font-medium">{role.label}</div>
+                <div className="text-xs text-muted-foreground">{role.hint}</div>
+              </div>
+              <RoleModelSelect
+                value={roleOverrides[role.value] ?? ""}
+                blockedPatterns={blockedPatterns}
+                localModelsByProvider={localModelsByProvider}
+                compact={compact}
+                onChange={(next) => updateRole(role.value, next)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/components/layout/command-palette.tsx
+++ b/clients/web/src/components/layout/command-palette.tsx
@@ -116,7 +116,7 @@ export function CommandPalette() {
       <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={() => { setOpen(false); setQuery(""); }} />
 
       {/* Palette */}
-      <div className="fixed left-1/2 top-[20%] z-50 w-[520px] -translate-x-1/2 overflow-hidden rounded-xl border border-white/[0.1] bg-zinc-900 shadow-2xl">
+      <div className="fixed left-1/2 top-16 z-50 w-[calc(100vw-1rem)] max-w-[520px] -translate-x-1/2 overflow-hidden rounded-xl border border-white/[0.1] bg-zinc-900 shadow-2xl sm:top-[20%]">
         {/* Search input */}
         <div className="flex items-center gap-2 border-b border-white/[0.08] px-4 py-3">
           <Search className="h-4 w-4 text-zinc-500" />
@@ -132,7 +132,7 @@ export function CommandPalette() {
         </div>
 
         {/* Results */}
-        <div className="max-h-[340px] overflow-auto p-2">
+        <div className="max-h-[min(60dvh,340px)] overflow-auto p-2">
           {filtered.length === 0 ? (
             <p className="py-8 text-center text-sm text-zinc-500">No commands found</p>
           ) : (
@@ -151,14 +151,14 @@ export function CommandPalette() {
                       onClick={() => execute(cmd)}
                       onMouseEnter={() => setSelectedIndex(globalIdx)}
                       className={cn(
-                        "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors",
+                        "flex w-full min-w-0 items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors sm:gap-3 sm:px-3",
                         isSelected ? "bg-white/[0.08] text-white" : "text-zinc-400 hover:bg-white/[0.04]",
                       )}
                     >
                       <cmd.icon className="h-4 w-4 shrink-0 text-zinc-500" />
-                      <span className="flex-1">{cmd.label}</span>
+                      <span className="min-w-0 flex-1 truncate">{cmd.label}</span>
                       {cmd.shortcut && (
-                        <kbd className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-600">
+                        <kbd className="hidden shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-600 sm:inline">
                           {cmd.shortcut}
                         </kbd>
                       )}

--- a/clients/web/src/components/layout/header.tsx
+++ b/clients/web/src/components/layout/header.tsx
@@ -6,22 +6,27 @@ import { Separator } from "@/components/ui/separator";
 
 export function Header() {
   return (
-    <header className="flex h-14 items-center justify-between border-b border-border/50 bg-background/80 px-6 backdrop-blur-sm">
-      <div className="flex items-center gap-3">
-        <h2 className="text-sm font-medium text-muted-foreground">
+    <header className="flex h-12 items-center justify-between gap-2 border-b border-border/50 bg-background/80 px-3 backdrop-blur-sm md:h-14 md:px-6">
+      <div className="flex min-w-0 flex-1 items-center gap-2 md:gap-3">
+        <h2 className="truncate text-xs font-medium text-muted-foreground sm:text-sm">
           Autonomous Red Team Platform
         </h2>
-        <Separator orientation="vertical" className="h-4" />
-        <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+        <Separator orientation="vertical" className="hidden h-4 sm:block" />
+        <span className="hidden rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400 sm:inline-flex">
           Online
         </span>
       </div>
 
-      <div className="flex items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1">
         <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground">
           <Bell className="h-4 w-4" />
         </Button>
-        <span className="text-xs text-muted-foreground">Local Mode</span>
+        <span
+          className="hidden text-xs text-muted-foreground sm:inline"
+          title="Self-hosted Docker instance running on this Windows host"
+        >
+          Self-hosted
+        </span>
       </div>
     </header>
   );

--- a/clients/web/src/components/layout/sidebar.tsx
+++ b/clients/web/src/components/layout/sidebar.tsx
@@ -17,9 +17,11 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronDown,
+  Bell,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { EngagementModelPicker, type ModelOverrides } from "@/components/engagement/engagement-model-picker";
 import {
   Tooltip,
   TooltipContent,
@@ -56,6 +58,8 @@ const bottomNav: NavItem[] = [
 interface Engagement {
   id: string;
   name: string;
+  modelOverride?: string | null;
+  modelOverrides?: ModelOverrides | null;
 }
 
 export function Sidebar() {
@@ -63,6 +67,7 @@ export function Sidebar() {
   const [collapsed, setCollapsed] = useState(false);
   const [engDropdownOpen, setEngDropdownOpen] = useState(false);
   const [engagements, setEngagements] = useState<Engagement[]>([]);
+  const [activeEngagement, setActiveEngagement] = useState<Engagement | null>(null);
 
   // Derive engagement ID from pathname — only refetch when engagement context changes
   const engMatch = pathname.match(/^\/engagements\/([^/]+)/);
@@ -84,8 +89,29 @@ export function Sidebar() {
     return () => { cancelled = true; };
   }, [activeEngId]);
 
+  useEffect(() => {
+    if (!activeEngId) {
+      setActiveEngagement(null);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/engagements/${activeEngId}`, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error("fetch failed");
+        return res.json();
+      })
+      .then((data: Engagement) => {
+        if (!cancelled) setActiveEngagement(data);
+      })
+      .catch(() => {
+        if (!cancelled) setActiveEngagement(null);
+      });
+    return () => { cancelled = true; };
+  }, [activeEngId]);
+
   const activeEng = activeEngId
-    ? engagements.find((e) => e.id === activeEngId) ?? null
+    ? activeEngagement ?? engagements.find((e) => e.id === activeEngId) ?? null
     : null;
 
   function resolveHref(item: NavItem) {
@@ -142,25 +168,62 @@ export function Sidebar() {
     return link;
   }
 
+  function renderMobileNavItem(item: NavItem) {
+    const href = resolveHref(item);
+    const active = isActive(item);
+    const disabled = item.engagementScoped && !activeEngId;
+
+    return (
+      <Link
+        key={href}
+        href={disabled ? "#" : href}
+        aria-label={item.label}
+        className={cn(
+          "flex min-w-14 flex-col items-center justify-center gap-0.5 rounded-lg px-2 py-1.5 text-[10px] font-medium transition-colors",
+          active
+            ? "bg-primary/10 text-primary"
+            : disabled
+              ? "cursor-not-allowed text-muted-foreground/25"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground"
+        )}
+        onClick={(e) => disabled && e.preventDefault()}
+      >
+        <item.icon className="h-4 w-4 shrink-0" />
+        <span className="max-w-14 truncate">{item.label}</span>
+      </Link>
+    );
+  }
+
   return (
+    <>
     <aside
       className={cn(
-        "flex h-full flex-col border-r border-border/50 bg-sidebar transition-all duration-200",
-        collapsed ? "w-16" : "w-60"
+        "hidden h-full flex-col border-r border-border/50 bg-sidebar transition-all duration-200 md:flex",
+        collapsed ? "w-16" : "w-72"
       )}
     >
       {/* Logo */}
-      <div className="flex h-14 items-center gap-2.5 border-b border-border/50 px-4">
+      <div className="flex min-h-14 items-center gap-2.5 border-b border-border/50 px-4 py-3">
         <img src="/logo.png" alt="PurpleAILab" width={26} height={26} className="shrink-0" />
         {!collapsed && (
-          <span className="text-sm font-bold tracking-tight">
-            <span className="text-purple-400">Purple</span>
-            <span className="text-foreground">AILab</span>
-          </span>
+          <div className="min-w-0 flex-1">
+            <span className="block truncate text-sm font-bold tracking-tight">
+              <span className="text-purple-400">Purple</span>
+              <span className="text-foreground">AILab</span>
+            </span>
+            <div className="mt-0.5 flex min-w-0 items-center gap-2 text-[10px] text-muted-foreground">
+              <span className="truncate">Autonomous Red Team Platform</span>
+              <span className="rounded-full bg-emerald-500/10 px-1.5 py-0.5 font-medium text-emerald-400">Online</span>
+            </div>
+            <div className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground" title="Self-hosted Docker instance running on this Windows host">
+              <Bell className="size-3" />
+              <span>Self-hosted</span>
+            </div>
+          </div>
         )}
       </div>
 
-      <nav className="flex flex-1 flex-col overflow-hidden">
+      <nav className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
         {/* Global nav */}
         <div className="space-y-0.5 p-2">
           {globalNav.map(renderNavItem)}
@@ -229,9 +292,31 @@ export function Sidebar() {
           <div className="space-y-0.5">
             {engagementNav.map(renderNavItem)}
           </div>
+
+          {!collapsed && activeEngagement && (
+            <div className="mt-3">
+              <EngagementModelPicker
+                engagementId={activeEngagement.id}
+                value={activeEngagement.modelOverride ?? ""}
+                overrides={activeEngagement.modelOverrides ?? null}
+                variant="sidebar"
+                onChange={(modelOverride, modelOverrides) => {
+                  setActiveEngagement((current) =>
+                    current
+                      ? {
+                          ...current,
+                          modelOverride: modelOverride || null,
+                          modelOverrides,
+                        }
+                      : current,
+                  );
+                }}
+              />
+            </div>
+          )}
         </div>
 
-        <div className="flex-1" />
+        <div className="min-h-4 flex-1" />
 
         {/* Bottom nav */}
         <div className="space-y-0.5 p-2">
@@ -251,5 +336,11 @@ export function Sidebar() {
         </Button>
       </div>
     </aside>
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/60 bg-sidebar/95 px-2 py-1.5 backdrop-blur md:hidden">
+      <div className="flex gap-1 overflow-x-auto">
+        {[...globalNav, ...engagementNav, ...bottomNav].map(renderMobileNavItem)}
+      </div>
+    </nav>
+    </>
   );
 }

--- a/clients/web/src/components/streaming/agent-detail-panel.tsx
+++ b/clients/web/src/components/streaming/agent-detail-panel.tsx
@@ -143,7 +143,7 @@ export function AgentDetailPanel({
   return (
     <div
       className={cn(
-        "flex h-full w-[360px] shrink-0 flex-col bg-zinc-950 border-l border-white/[0.08]",
+        "flex h-full w-full shrink-0 flex-col bg-zinc-950 border-l border-white/[0.08] sm:w-[360px]",
         className,
       )}
     >

--- a/clients/web/src/components/streaming/approval-gate.tsx
+++ b/clients/web/src/components/streaming/approval-gate.tsx
@@ -191,13 +191,13 @@ function ApprovalCard({ request, engagementId, onDecided }: ApprovalCardProps) {
 
         {error && <p className="text-destructive">{error}</p>}
 
-        <div className="flex gap-2">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
           <Button
             type="button"
             size="sm"
             onClick={() => decide("allow")}
             disabled={submitting !== null}
-            className="flex-1 bg-emerald-600 text-white hover:bg-emerald-500"
+            className="bg-emerald-600 text-white hover:bg-emerald-500"
           >
             {submitting === "allow" ? (
               <Loader2 className="animate-spin" />
@@ -212,7 +212,7 @@ function ApprovalCard({ request, engagementId, onDecided }: ApprovalCardProps) {
             variant="destructive"
             onClick={() => decide("deny")}
             disabled={submitting !== null}
-            className="flex-1"
+            className="w-full"
           >
             {submitting === "deny" ? <Loader2 className="animate-spin" /> : <X />}
             Deny
@@ -223,7 +223,7 @@ function ApprovalCard({ request, engagementId, onDecided }: ApprovalCardProps) {
             variant="outline"
             onClick={() => decide("redirect")}
             disabled={submitting !== null}
-            className="flex-1"
+            className="w-full"
           >
             {submitting === "redirect" ? (
               <Loader2 className="animate-spin" />

--- a/clients/web/src/components/streaming/live-activity-feed.tsx
+++ b/clients/web/src/components/streaming/live-activity-feed.tsx
@@ -425,7 +425,7 @@ export function LiveActivityFeed({ events, engagementId, className }: LiveActivi
   }
 
   return (
-    <div className={cn("flex flex-col overflow-hidden rounded-lg border border-white/[0.08] bg-zinc-900", className)}>
+    <div className={cn("flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-white/[0.08] bg-zinc-900", className)}>
       {/* Header */}
       <div className="flex items-center justify-between border-b border-white/[0.08] px-3 py-1.5">
         <span className="text-[11px] font-medium text-zinc-400">Activity Feed</span>

--- a/clients/web/src/components/streaming/opplan-live-overlay.tsx
+++ b/clients/web/src/components/streaming/opplan-live-overlay.tsx
@@ -303,7 +303,7 @@ export function OpplanLiveOverlay({
       >
         <div className="overflow-hidden">
           <div className="border-t border-white/[0.06]">
-            <ScrollArea className="max-h-[300px]">
+            <ScrollArea className="max-h-[min(300px,45dvh)]">
               <div className="divide-y divide-white/[0.04]">
                 {objectives.map((obj) => (
                   <ObjectiveRow key={obj.id} obj={obj} expandedObjectiveId={expandedObjectiveId} onToggleExpand={setExpandedObjectiveId} />

--- a/clients/web/src/components/terminal/web-terminal.tsx
+++ b/clients/web/src/components/terminal/web-terminal.tsx
@@ -17,7 +17,6 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { cn } from "@/lib/utils";
 
-const TERMINAL_WS_URL = process.env.NEXT_PUBLIC_TERMINAL_WS_URL ?? "ws://localhost:3003";
 const MAX_RECONNECT_DELAY = 4000;
 const INITIAL_RECONNECT_DELAY = 1000;
 const MAX_RECONNECT_ATTEMPTS = 15;
@@ -39,10 +38,22 @@ function sanitizeTermBytes(s: string): string {
   return s.replace(/[\x00\x7f]/g, "");
 }
 
+function defaultTerminalWsUrl(): string {
+  if (typeof window === "undefined") return "ws://localhost:3003";
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}/terminal`;
+}
+
+function terminalWsUrl(): string {
+  return process.env.NEXT_PUBLIC_TERMINAL_WS_URL?.trim() || defaultTerminalWsUrl();
+}
+
 interface WebTerminalProps {
   engagementId: string;
   engagementSlug: string;
   agentId?: string;
+  modelOverride?: string;
+  modelOverrides?: Record<string, string>;
   threadId?: string;
   className?: string;
   onThreadId?: (threadId: string) => void;
@@ -52,6 +63,8 @@ export function WebTerminal({
   engagementId,
   engagementSlug,
   agentId = "soundwave",
+  modelOverride,
+  modelOverrides,
   threadId,
   className,
   onThreadId,
@@ -65,6 +78,12 @@ export function WebTerminal({
   engagementSlugRef.current = engagementSlug;
   const agentIdRef = useRef(agentId);
   agentIdRef.current = agentId;
+  const modelOverrideRef = useRef(modelOverride ?? "");
+  const modelOverridesRef = useRef(modelOverrides ?? {});
+  const lastConnectedModelOverrideRef = useRef(modelOverride ?? "");
+  const lastConnectedModelOverridesRef = useRef(JSON.stringify(modelOverrides ?? {}));
+  modelOverrideRef.current = modelOverride ?? "";
+  modelOverridesRef.current = modelOverrides ?? {};
   const threadIdRef = useRef(threadId);
   threadIdRef.current = threadId;
   const onThreadIdRef = useRef(onThreadId);
@@ -80,6 +99,7 @@ export function WebTerminal({
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track whether we've shown the reconnecting message (to avoid spam)
   const reconnectMsgShownRef = useRef(false);
+  const modelChangeReconnectRef = useRef(false);
   // True between sending a ping and receiving the next inbound frame; the
   // pong-timeout only force-closes the socket while this is still set.
   const awaitingPongRef = useRef(false);
@@ -121,12 +141,21 @@ export function WebTerminal({
     const eid = engagementIdRef.current;
     const slug = engagementSlugRef.current;
     const aid = agentIdRef.current;
+    const model = modelOverrideRef.current.trim();
+    const roleModels = modelOverridesRef.current;
+    const roleModelsJson = JSON.stringify(roleModels);
+    lastConnectedModelOverrideRef.current = model;
+    lastConnectedModelOverridesRef.current = roleModelsJson;
     const tid = threadIdRef.current;
 
     let wsUrl =
-      `${TERMINAL_WS_URL}?engagementId=${encodeURIComponent(eid)}` +
+      `${terminalWsUrl()}?engagementId=${encodeURIComponent(eid)}` +
       `&engagementSlug=${encodeURIComponent(slug)}` +
       `&agentId=${encodeURIComponent(aid)}`;
+    if (model) wsUrl += `&modelOverride=${encodeURIComponent(model)}`;
+    if (Object.keys(roleModels).length > 0) {
+      wsUrl += `&modelOverrides=${encodeURIComponent(roleModelsJson)}`;
+    }
     if (tid) wsUrl += `&threadId=${encodeURIComponent(tid)}`;
 
     const ws = new WebSocket(wsUrl);
@@ -172,6 +201,13 @@ export function WebTerminal({
 
     ws.onclose = (ev) => {
       if (disposedRef.current) return;
+
+      if (modelChangeReconnectRef.current) {
+        modelChangeReconnectRef.current = false;
+        setConnState("reconnecting");
+        connectWs();
+        return;
+      }
 
       if (ev.code === 4001) {
         // Server handed this session to another connection (e.g. a second tab).
@@ -272,7 +308,7 @@ export function WebTerminal({
       const term = new Terminal({
         cursorBlink: true,
         cursorStyle: "bar",
-        fontSize: 13,
+        fontSize: 12,
         fontFamily: "'JetBrains Mono', 'IBM Plex Mono', 'Fira Code', monospace",
         theme: {
           background: "#0a0e14",
@@ -342,6 +378,26 @@ export function WebTerminal({
     init();
     return cleanup;
   }, [init, cleanup]);
+
+  useEffect(() => {
+    const next = (modelOverride ?? "").trim();
+    const nextRoles = JSON.stringify(modelOverrides ?? {});
+    if (
+      next === lastConnectedModelOverrideRef.current.trim() &&
+      nextRoles === lastConnectedModelOverridesRef.current
+    ) {
+      return;
+    }
+    reconnectAttemptRef.current = 0;
+    reconnectMsgShownRef.current = false;
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      modelChangeReconnectRef.current = true;
+      ws.close(1000, "model override changed");
+    } else if (termRef.current) {
+      connectWs();
+    }
+  }, [modelOverride, modelOverrides, connectWs]);
 
   // ── Heartbeat: detect silently-dead sockets ──────────────────────
   // Ping every 15s. A live socket answers with a pong (or is already
@@ -426,11 +482,10 @@ export function WebTerminal({
   return (
     <div className={cn("relative flex flex-col", className)}>
       {/* Status bar */}
-      <div className="flex items-center gap-2 border-b border-white/[0.06] bg-[#0a0e14] px-3 py-1.5">
+      <div className="flex min-w-0 items-center gap-2 border-b border-white/[0.06] bg-[#0a0e14] px-3 py-1.5">
         <div className={cn("h-2 w-2 rounded-full", statusColor[connState])} />
-        <span className="text-[11px] text-zinc-500">{statusLabel[connState]}</span>
-        <span className="flex-1" />
-        <span className="text-[10px] font-mono text-zinc-600">{engagementSlug}</span>
+        <span className="shrink-0 text-[11px] text-zinc-500">{statusLabel[connState]}</span>
+        <span className="min-w-0 flex-1 truncate text-right font-mono text-[10px] text-zinc-600">{engagementSlug}</span>
       </div>
       {/* Terminal container */}
       <div

--- a/clients/web/src/lib/model-options.ts
+++ b/clients/web/src/lib/model-options.ts
@@ -1,0 +1,52 @@
+export type BuiltinModelGroup = "default" | "gpt" | "mittwald" | "cloud";
+
+export type BuiltinModelOption = {
+  value: string;
+  label: string;
+  group: BuiltinModelGroup;
+};
+
+export const DEFAULT_MODEL_OPTION: BuiltinModelOption = {
+  value: "default",
+  label: "Default chain",
+  group: "default",
+};
+
+export const GPT_MODELS: BuiltinModelOption[] = [
+  { value: "auth/gpt-5.5", label: "GPT OAuth 5.5", group: "gpt" },
+  { value: "auth/gpt-5.4", label: "GPT OAuth 5.4", group: "gpt" },
+  { value: "auth/gpt-5.4-mini", label: "GPT OAuth 5.4 Mini", group: "gpt" },
+  { value: "auth/gpt-5.3-codex", label: "GPT OAuth 5.3 Codex", group: "gpt" },
+  { value: "auth/gpt-5.3-codex-spark", label: "GPT OAuth 5.3 Codex Spark", group: "gpt" },
+];
+
+export const MITTWALD_MODELS: BuiltinModelOption[] = [
+  { value: "mittwald/gpt-oss-120b", label: "gpt-oss-120b", group: "mittwald" },
+  { value: "mittwald/Ministral-3-14B-Instruct-2512", label: "Ministral-3-14B-Instruct-2512", group: "mittwald" },
+  { value: "mittwald/whisper-large-v3-turbo", label: "whisper-large-v3-turbo", group: "mittwald" },
+  { value: "mittwald/Qwen3.5-122B-A10B-FP8", label: "Qwen3.5-122B-A10B-FP8", group: "mittwald" },
+  { value: "mittwald/Qwen3.6-35B-A3B-FP8", label: "Qwen3.6-35B-A3B-FP8", group: "mittwald" },
+  { value: "mittwald/Qwen3.5-0.8B", label: "Qwen3.5-0.8B", group: "mittwald" },
+  { value: "mittwald/Qwen3-VL-Reranker-2B", label: "Qwen3-VL-Reranker-2B", group: "mittwald" },
+  { value: "mittwald/GLM-OCR", label: "GLM-OCR", group: "mittwald" },
+  { value: "mittwald/Mistral-Medium-3.5-128B", label: "Mistral-Medium-3.5-128B", group: "mittwald" },
+  { value: "mittwald/Qwen3-Embedding-8B", label: "Qwen3-Embedding-8B", group: "mittwald" },
+];
+
+export const CLOUD_MODELS: BuiltinModelOption[] = [
+  { value: "openrouter/moonshotai/kimi-k2", label: "Kimi K2 via OpenRouter", group: "cloud" },
+  { value: "groq/llama-3.1-8b-instant", label: "Groq Free", group: "cloud" },
+];
+
+export const BUILTIN_MODEL_GROUPS = [
+  { label: "GPT", models: GPT_MODELS },
+  { label: "Mittwald", models: MITTWALD_MODELS },
+  { label: "Cloud", models: CLOUD_MODELS },
+] as const;
+
+export const BUILTIN_MODELS: BuiltinModelOption[] = [
+  DEFAULT_MODEL_OPTION,
+  ...GPT_MODELS,
+  ...MITTWALD_MODELS,
+  ...CLOUD_MODELS,
+];

--- a/clients/web/src/lib/model-policy.ts
+++ b/clients/web/src/lib/model-policy.ts
@@ -1,0 +1,85 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+export const DEFAULT_BLOCKED_MODEL_PATTERNS = ["wormgpt", "uncensored", "abliterate"] as const;
+
+export type ModelPolicy = {
+  blockedPatterns: string[];
+};
+
+const MAX_PATTERN_LENGTH = 200;
+
+function policyPath(): string {
+  return (
+    process.env.MODEL_POLICY_PATH ??
+    path.join(process.env.WORKSPACE_PATH ?? "/workspace", ".decepticon", "model-policy.json")
+  );
+}
+
+function normalizePattern(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_PATTERN_LENGTH) return null;
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function uniquePatterns(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const patterns: string[] = [];
+  for (const value of values) {
+    const pattern = normalizePattern(value);
+    if (!pattern) continue;
+    const key = pattern.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    patterns.push(pattern);
+  }
+  return patterns;
+}
+
+export function modelIdMatchesPattern(modelId: string, pattern: string): boolean {
+  return modelId.toLowerCase().includes(pattern.toLowerCase());
+}
+
+export function isBlockedModelId(modelId: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => modelIdMatchesPattern(modelId, pattern));
+}
+
+export async function readModelPolicy(): Promise<ModelPolicy> {
+  try {
+    const raw = await fs.readFile(policyPath(), "utf8");
+    const parsed = JSON.parse(raw) as { blockedPatterns?: unknown };
+    const values = Array.isArray(parsed.blockedPatterns) ? parsed.blockedPatterns : [];
+    return {
+      blockedPatterns: uniquePatterns(values),
+    };
+  } catch {
+    return {
+      blockedPatterns: [...DEFAULT_BLOCKED_MODEL_PATTERNS],
+    };
+  }
+}
+
+export async function writeModelPolicy(blockedPatterns: unknown[]): Promise<ModelPolicy> {
+  const clean = uniquePatterns(blockedPatterns);
+  const target = policyPath();
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(
+    target,
+    `${JSON.stringify({ blockedPatterns: clean }, null, 2)}\n`,
+    "utf8",
+  );
+  return {
+    blockedPatterns: clean,
+  };
+}
+
+export async function assertModelAllowed(modelId: string): Promise<void> {
+  const trimmed = modelId.trim();
+  if (!trimmed) return;
+  const policy = await readModelPolicy();
+  if (isBlockedModelId(trimmed, policy.blockedPatterns)) {
+    throw new Error("Blocked model id is not allowed for this application");
+  }
+}

--- a/containers/web-entrypoint.sh
+++ b/containers/web-entrypoint.sh
@@ -18,6 +18,9 @@ cd /app/clients/web
 
 NEXT_PID=""
 TERM_PID=""
+PROXY_PID=""
+WEB_PROXY_PORT="${WEB_PROXY_PORT:-3000}"
+NEXT_INTERNAL_PORT="${NEXT_INTERNAL_PORT:-3001}"
 
 # ── Handlers ──────────────────────────────────────────────────────
 
@@ -27,14 +30,15 @@ restart_next() {
     kill "$NEXT_PID" 2>/dev/null
     wait "$NEXT_PID" 2>/dev/null || true
   fi
-  echo "[entrypoint] Starting Next.js..."
-  node server.js &
+  echo "[entrypoint] Starting Next.js on internal port ${NEXT_INTERNAL_PORT}..."
+  PORT="$NEXT_INTERNAL_PORT" node server.js &
   NEXT_PID=$!
   echo "[entrypoint] Next.js restarted (PID $NEXT_PID)"
 }
 
 shutdown() {
   echo "[entrypoint] SIGTERM received — shutting down..."
+  [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null
   [ -n "$NEXT_PID" ] && kill "$NEXT_PID" 2>/dev/null
   [ -n "$TERM_PID" ] && kill "$TERM_PID" 2>/dev/null
   wait 2>/dev/null
@@ -53,11 +57,15 @@ echo "[entrypoint] Starting terminal server (ws://0.0.0.0:${TERMINAL_PORT:-3003}
 npx --yes tsx server/terminal-server.ts &
 TERM_PID=$!
 
-echo "[entrypoint] Starting Next.js (standalone)..."
-node server.js &
+echo "[entrypoint] Starting Next.js (standalone on internal port ${NEXT_INTERNAL_PORT})..."
+PORT="$NEXT_INTERNAL_PORT" node server.js &
 NEXT_PID=$!
 
-echo "[entrypoint] Ready (terminal=$TERM_PID, next=$NEXT_PID)"
+echo "[entrypoint] Starting web proxy (http://0.0.0.0:${WEB_PROXY_PORT})..."
+WEB_PROXY_PORT="$WEB_PROXY_PORT" NEXT_INTERNAL_PORT="$NEXT_INTERNAL_PORT" npx --yes tsx server/web-proxy.ts &
+PROXY_PID=$!
+
+echo "[entrypoint] Ready (terminal=$TERM_PID, next=$NEXT_PID, proxy=$PROXY_PID)"
 
 # Wait for either child to exit. If Next.js crashes, restart it.
 # If the terminal server crashes, exit (Docker will restart the container).
@@ -66,15 +74,22 @@ while true; do
   # so we poll instead.
   if ! kill -0 "$TERM_PID" 2>/dev/null; then
     echo "[entrypoint] Terminal server died — exiting"
+    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null
     [ -n "$NEXT_PID" ] && kill "$NEXT_PID" 2>/dev/null
     exit 1
   fi
   if ! kill -0 "$NEXT_PID" 2>/dev/null; then
     echo "[entrypoint] Next.js died — restarting..."
     sleep 1
-    node server.js &
+    PORT="$NEXT_INTERNAL_PORT" node server.js &
     NEXT_PID=$!
     echo "[entrypoint] Next.js restarted (PID $NEXT_PID)"
+  fi
+  if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+    echo "[entrypoint] Web proxy died - exiting"
+    [ -n "$NEXT_PID" ] && kill "$NEXT_PID" 2>/dev/null
+    [ -n "$TERM_PID" ] && kill "$TERM_PID" 2>/dev/null
+    exit 1
   fi
   sleep 2
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-sk-decepticon-master}
       - LITELLM_SALT_KEY=${LITELLM_SALT_KEY:-sk-decepticon-salt}
+      - STORE_MODEL_IN_DB=True
       - CODEX_AUTH_PATH=/root/.codex/auth.json
       - DATABASE_URL=postgresql://decepticon:${POSTGRES_PASSWORD:-decepticon}@postgres:5432/litellm
     depends_on:

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -234,8 +234,8 @@ def _make_opscontrol_notification(**_: Any):
     return OpsControlNotificationMiddleware()
 
 
-def _make_model_override(**_: Any):
-    return ModelOverrideMiddleware()
+def _make_model_override(*, role: str, **_: Any):
+    return ModelOverrideMiddleware(role=role)
 
 
 def _make_proxy_key_override(**_: Any):

--- a/packages/decepticon/decepticon/middleware/model_override.py
+++ b/packages/decepticon/decepticon/middleware/model_override.py
@@ -30,6 +30,8 @@ Failure modes:
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
@@ -44,7 +46,51 @@ from decepticon_core.utils.logging import get_logger
 log = get_logger("middleware.model_override")
 
 
-def _read_override(request: Any) -> str:
+def _normalize_role(role: str | None) -> str:
+    """Normalize role names to the env/UI spelling used for overrides."""
+    return (role or "").strip().lower().replace("-", "_")
+
+
+def _read_model_overrides_value(value: Any) -> dict[str, str]:
+    """Parse a role -> model map from runtime context or state."""
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return {}
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    if not isinstance(value, Mapping):
+        return {}
+
+    overrides: dict[str, str] = {}
+    for role, model_id in value.items():
+        if not isinstance(role, str) or not isinstance(model_id, str):
+            continue
+        normalized_role = _normalize_role(role)
+        cleaned_model_id = model_id.strip()
+        if normalized_role and cleaned_model_id:
+            overrides[normalized_role] = cleaned_model_id
+    return overrides
+
+
+def _read_model_overrides(request: Any) -> dict[str, str]:
+    """Pull the role override map out of runtime context or input state."""
+    runtime = getattr(request, "runtime", None)
+    if runtime is not None:
+        ctx = getattr(runtime, "context", None) or {}
+        if isinstance(ctx, dict):
+            overrides = _read_model_overrides_value(ctx.get("model_overrides", {}))
+            if overrides:
+                return overrides
+
+    state = getattr(request, "state", None) or {}
+    get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
+    return _read_model_overrides_value(get("model_overrides", {}))
+
+
+def _read_global_override(request: Any) -> str:
     """Pull the override id out of runtime context or input state.
 
     Returns the empty string when nothing is set so the caller can
@@ -61,6 +107,21 @@ def _read_override(request: Any) -> str:
     get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
     value = get("model_override", "") or ""
     return value.strip() if isinstance(value, str) else ""
+
+
+def _read_override(request: Any, role: str | None = None) -> str:
+    """Resolve the effective override id for one agent role.
+
+    Role-specific overrides win over the engagement-wide/global override.
+    A ``default`` entry in the role map can act as a map-local fallback.
+    """
+    normalized_role = _normalize_role(role)
+    overrides = _read_model_overrides(request)
+    if normalized_role and normalized_role in overrides:
+        return overrides[normalized_role]
+    if "default" in overrides:
+        return overrides["default"]
+    return _read_global_override(request)
 
 
 def _build_proxied_llm(model_id: str, original: BaseChatModel) -> BaseChatModel:
@@ -106,9 +167,13 @@ class ModelOverrideMiddleware(AgentMiddleware):
     and the existing fallback chain still applies on its failure.
     """
 
+    def __init__(self, role: str | None = None) -> None:
+        super().__init__()
+        self.role = _normalize_role(role)
+
     @override
     def wrap_model_call(self, request, handler):
-        override_id = _read_override(request)
+        override_id = _read_override(request, self.role)
         if not override_id:
             return handler(request)
         try:
@@ -116,12 +181,12 @@ class ModelOverrideMiddleware(AgentMiddleware):
         except Exception as exc:
             log.warning("model_override %s failed to bind: %s", override_id, exc)
             return handler(request)
-        log.info("model_override active: %s", override_id)
+        log.info("model_override active%s: %s", f" for {self.role}" if self.role else "", override_id)
         return handler(request.override(model=new_llm))
 
     @override
     async def awrap_model_call(self, request, handler):
-        override_id = _read_override(request)
+        override_id = _read_override(request, self.role)
         if not override_id:
             return await handler(request)
         try:
@@ -129,7 +194,7 @@ class ModelOverrideMiddleware(AgentMiddleware):
         except Exception as exc:
             log.warning("model_override %s failed to bind: %s", override_id, exc)
             return await handler(request)
-        log.info("model_override active: %s", override_id)
+        log.info("model_override active%s: %s", f" for {self.role}" if self.role else "", override_id)
         return await handler(request.override(model=new_llm))
 
 

--- a/packages/decepticon/tests/unit/middleware/test_model_override.py
+++ b/packages/decepticon/tests/unit/middleware/test_model_override.py
@@ -227,6 +227,62 @@ class TestReadOverride:
 
         assert _read_override(_Req()) == "openai/gpt-5.5"
 
+    def test_role_override_takes_priority_over_global(self) -> None:
+        class _Runtime:
+            context = {
+                "model_override": "openai/gpt-5.5",
+                "model_overrides": {"recon": "ollama_chat/qwen2.5-coder:7b"},
+            }
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        assert _read_override(_Req(), "recon") == "ollama_chat/qwen2.5-coder:7b"
+
+    def test_role_override_normalizes_hyphenated_role_names(self) -> None:
+        class _Runtime:
+            context = {"model_overrides": {"blue_cell": "mittwald/Mistral-Medium-3.5-128B"}}
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        assert _read_override(_Req(), "blue-cell") == "mittwald/Mistral-Medium-3.5-128B"
+
+    def test_default_role_override_falls_back_before_global(self) -> None:
+        class _Runtime:
+            context = {
+                "model_override": "openai/gpt-5.5",
+                "model_overrides": {"default": "groq/llama-3.1-8b-instant"},
+            }
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        assert _read_override(_Req(), "recon") == "groq/llama-3.1-8b-instant"
+
+    def test_state_role_override_used_when_runtime_absent(self) -> None:
+        class _Req:
+            runtime = None
+            state = {
+                "model_override": "openai/gpt-5.4",
+                "model_overrides": {"exploit": "openrouter/moonshotai/kimi-k2"},
+            }
+
+        assert _read_override(_Req(), "exploit") == "openrouter/moonshotai/kimi-k2"
+
+    def test_json_encoded_role_overrides_are_supported(self) -> None:
+        class _Runtime:
+            context = {"model_overrides": '{"analyst":"auth/gpt-5.4-mini"}'}
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        assert _read_override(_Req(), "analyst") == "auth/gpt-5.4-mini"
+
     def test_state_used_when_runtime_absent(self) -> None:
         class _Req:
             runtime = None


### PR DESCRIPTION
Adds engagement-level model overrides, exposes model selection in the web UI, wires overrides through the terminal/CLI LangGraph run config, and adds dynamic LiteLLM support for Mittwald AI Hosting via MITTWALD_AI_BASE_URL / MITTWALD_AI_MODEL.\n\nRuntime verified locally with Docker: web/langgraph/litellm healthy and mittwald/Mistral-Medium-3.5-128B returns OK through LiteLLM.