### PR TITLE
feat(llm): modular per-role model override + MID→Sonnet 5

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/llm.py
+++ b/packages/decepticon-core/decepticon_core/types/llm.py
@@ -174,12 +174,12 @@ class AuthMethod(StrEnum):
 METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
     AuthMethod.ANTHROPIC_API: {
         Tier.HIGH: "anthropic/claude-opus-4-8",
-        Tier.MID: "anthropic/claude-sonnet-4-6",
+        Tier.MID: "anthropic/claude-sonnet-5",
         Tier.LOW: "anthropic/claude-haiku-4-5",
     },
     AuthMethod.ANTHROPIC_OAUTH: {
         Tier.HIGH: "auth/claude-opus-4-8",
-        Tier.MID: "auth/claude-sonnet-4-6",
+        Tier.MID: "auth/claude-sonnet-5",
         Tier.LOW: "auth/claude-haiku-4-5",
     },
     AuthMethod.OPENAI_API: {

--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -234,8 +234,8 @@ def _make_opscontrol_notification(**_: Any):
     return OpsControlNotificationMiddleware()
 
 
-def _make_model_override(**_: Any):
-    return ModelOverrideMiddleware()
+def _make_model_override(*, role: str | None = None, **_: Any):
+    return ModelOverrideMiddleware(role=role)
 
 
 def _make_proxy_key_override(**_: Any):

--- a/packages/decepticon/decepticon/middleware/model_override.py
+++ b/packages/decepticon/decepticon/middleware/model_override.py
@@ -32,35 +32,69 @@ from __future__ import annotations
 
 from typing import Any
 
+from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
 from langchain_openai import ChatOpenAI
 from pydantic import SecretStr
-from typing_extensions import override
+from typing_extensions import Annotated, NotRequired, override
 
 from decepticon.llm.factory import LLMFactory, _model_drops_temperature
+from decepticon.middleware.state_reducers import reduce_converging_value
 from decepticon_core.utils.logging import get_logger
 
 log = get_logger("middleware.model_override")
 
 
-def _read_override(request: Any) -> str:
+def _read_override(request: Any, role: str | None = None) -> str:
     """Pull the override id out of runtime context or input state.
+
+    Two shapes are honoured, in priority order:
+
+      1. ``model_overrides`` — a ``{role: model_id}`` MAP. When ``role`` is
+         present in the map, that per-agent model wins. This is the
+         PER-AGENT policy surface — a multi-tenant host (e.g. the SaaS)
+         threads one map per run so ``soundwave`` and ``exploit`` can run
+         a different model than the rest WITHOUT an OSS release. Set once
+         on the run (Runtime context or the ``model_overrides`` state
+         channel, which propagates to sub-agents like ``proxy_api_key``).
+      2. ``model_override`` — a single model id applied to EVERY agent
+         (the CLI ``/model`` command). Fallback when the map has no entry
+         for this role.
 
     Returns the empty string when nothing is set so the caller can
     short-circuit with a single truthiness check.
     """
+
+    def _pick(container: Any) -> str:
+        if not isinstance(container, dict):
+            return ""
+        if role:
+            overrides = container.get("model_overrides")
+            if isinstance(overrides, dict):
+                value = overrides.get(role, "")
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        value = container.get("model_override", "")
+        return value.strip() if isinstance(value, str) and value.strip() else ""
+
     runtime = getattr(request, "runtime", None)
     if runtime is not None:
         ctx = getattr(runtime, "context", None) or {}
-        if isinstance(ctx, dict):
-            value = ctx.get("model_override", "")
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+        picked = _pick(ctx if isinstance(ctx, dict) else {})
+        if picked:
+            return picked
     state = getattr(request, "state", None) or {}
-    get = state.get if hasattr(state, "get") else (lambda _k, _d=None: None)
-    value = get("model_override", "") or ""
-    return value.strip() if isinstance(value, str) else ""
+    if hasattr(state, "get"):
+        picked = _pick(
+            {
+                "model_overrides": state.get("model_overrides"),
+                "model_override": state.get("model_override", ""),
+            }
+        )
+        if picked:
+            return picked
+    return ""
 
 
 def _build_proxied_llm(model_id: str, original: BaseChatModel) -> BaseChatModel:
@@ -98,17 +132,51 @@ def _build_proxied_llm(model_id: str, original: BaseChatModel) -> BaseChatModel:
     return ChatOpenAI(**kwargs)
 
 
+class ModelOverridesState(AgentState):
+    """Declares a ``model_overrides`` channel on the orchestrator graph.
+
+    Mirrors ``ProxyKeyState`` (see ``proxy_key_override``). The Platform
+    DROPS an undeclared key from run ``input``, so without this channel a
+    SaaS caller threading a per-role model map via run ``input`` could
+    never reach ``request.state`` (the middleware's reachable read path;
+    ``runtime.context`` needs a top-level ``context`` field the Platform
+    forbids alongside ``config.configurable``). Set once on the kickoff
+    run, persisted to the checkpoint, read on every model call.
+
+    Reducer — ``reduce_converging_value`` (NOT the default LastValue):
+    the orchestrator dispatches sub-agents in the SAME super-step and
+    deepagents copies parent state (incl. ``model_overrides``) into each,
+    so every sub-agent writes the map back to the parent in one tick. A
+    LastValue channel rejects >1 write per step; a converging reducer
+    keeps the (identical) non-None write. Same treatment ``proxy_api_key``
+    and the launcher-set context channels already use.
+    """
+
+    model_overrides: NotRequired[Annotated[dict, reduce_converging_value]]
+
+
 class ModelOverrideMiddleware(AgentMiddleware):
     """Per-invocation model swap driven by Runtime context / input state.
 
     Wired into every agent's middleware stack ahead of
     ``ModelFallbackMiddleware`` so the override picks the new primary
     and the existing fallback chain still applies on its failure.
+
+    ``role`` is the agent this instance is attached to (the slot factory
+    passes it). It lets a per-role ``model_overrides`` map target this
+    agent specifically; without it only the global ``model_override``
+    (CLI ``/model``) applies.
     """
+
+    state_schema = ModelOverridesState
+
+    def __init__(self, role: str | None = None) -> None:
+        super().__init__()
+        self._role = role
 
     @override
     def wrap_model_call(self, request, handler):
-        override_id = _read_override(request)
+        override_id = _read_override(request, self._role)
         if not override_id:
             return handler(request)
         try:
@@ -121,7 +189,7 @@ class ModelOverrideMiddleware(AgentMiddleware):
 
     @override
     async def awrap_model_call(self, request, handler):
-        override_id = _read_override(request)
+        override_id = _read_override(request, self._role)
         if not override_id:
             return await handler(request)
         try:

--- a/packages/decepticon/tests/unit/middleware/test_model_override.py
+++ b/packages/decepticon/tests/unit/middleware/test_model_override.py
@@ -234,6 +234,42 @@ class TestReadOverride:
 
         assert _read_override(_Req()) == "openai/gpt-5.4"
 
+    def test_per_role_map_targets_the_matching_role(self) -> None:
+        class _Runtime:
+            context = {"model_overrides": {"soundwave": "auth/claude-sonnet-5"}}
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        assert _read_override(_Req(), "soundwave") == "auth/claude-sonnet-5"
+        # a role NOT in the map (and no global) → no override
+        assert _read_override(_Req(), "recon") == ""
+        # no role passed → the per-role map is ignored
+        assert _read_override(_Req()) == ""
+
+    def test_per_role_map_beats_the_global_override(self) -> None:
+        class _Runtime:
+            context = {
+                "model_overrides": {"exploit": "auth/claude-sonnet-5"},
+                "model_override": "openai/gpt-5.5",
+            }
+
+        class _Req:
+            runtime = _Runtime()
+            state: dict[str, Any] = {}
+
+        # exploit → its per-role model; other roles → the global override
+        assert _read_override(_Req(), "exploit") == "auth/claude-sonnet-5"
+        assert _read_override(_Req(), "recon") == "openai/gpt-5.5"
+
+    def test_per_role_map_from_state_channel(self) -> None:
+        class _Req:
+            runtime = None
+            state = {"model_overrides": {"soundwave": "auth/claude-sonnet-5"}}
+
+        assert _read_override(_Req(), "soundwave") == "auth/claude-sonnet-5"
+
     def test_empty_string_means_no_override(self) -> None:
         class _Runtime:
             context = {"model_override": ""}


### PR DESCRIPTION
## What

Make the model overridable **per agent role** without an OSS release — the same modular escape hatch prompts/tools already have.

- `_read_override` now honours a `model_overrides` {role: model_id} MAP (runtime context OR a declared state channel) ahead of the global single `model_override` (CLI /model). The slot factory passes each agent's role into the middleware.
- Declares a `model_overrides` state channel (`ModelOverridesState`, mirroring `ProxyKeyState`): the Platform drops undeclared keys from run input, so a host threading the map via run input needs this channel to reach `request.state`; the converging reducer collapses concurrent sub-agent writes and propagates the map to sub-agents.
- Moves the ANTHROPIC MID tier default to Sonnet 5 (was Sonnet 4.6) for version currency; the per-role map is what pins Soundwave/exploit downstream.

## Why

A multi-tenant host (the SaaS) can now pin Soundwave + exploit to a specific model per run without waiting on an OSS release — future model policy is a host-only change.

## Test

`tests/unit/middleware/test_model_override.py` — added per-role map cases (targets matching role, beats global override, reads from the state channel). Full file passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)