### PR TITLE
test(llm): MID tier asserts Sonnet 5 (re-green main CI)

### DIFF
--- a/packages/decepticon/tests/unit/llm/test_models.py
+++ b/packages/decepticon/tests/unit/llm/test_models.py
@@ -55,13 +55,13 @@ class TestMethodModels:
     def test_anthropic_api_full_tier_coverage(self):
         m = METHOD_MODELS[AuthMethod.ANTHROPIC_API]
         assert m[Tier.HIGH] == "anthropic/claude-opus-4-8"
-        assert m[Tier.MID] == "anthropic/claude-sonnet-4-6"
+        assert m[Tier.MID] == "anthropic/claude-sonnet-5"
         assert m[Tier.LOW] == "anthropic/claude-haiku-4-5"
 
     def test_anthropic_oauth_routes_to_auth_prefix(self):
         m = METHOD_MODELS[AuthMethod.ANTHROPIC_OAUTH]
         assert m[Tier.HIGH] == "auth/claude-opus-4-8"
-        assert m[Tier.MID] == "auth/claude-sonnet-4-6"
+        assert m[Tier.MID] == "auth/claude-sonnet-5"
         assert m[Tier.LOW] == "auth/claude-haiku-4-5"
 
     def test_openai_full_tier_coverage(self):


### PR DESCRIPTION
#762 bumped anthropic MID tier → `claude-sonnet-5` but left `test_models.py` asserting `sonnet-4-6`, so main CI is red (2 failed / 4979 passed, coverage 78% fine). Updates the two MID assertions to match the shipped map. Test-only; no behavior change (1.1.35 already ships the correct map).

Local: `test_models.py` 61 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)