### PR TITLE
feat(llm): compose per-role model via PluginBundle.models + env override

### DIFF
--- a/packages/decepticon-core/decepticon_core/plugin_loader.py
+++ b/packages/decepticon-core/decepticon_core/plugin_loader.py
@@ -282,6 +282,13 @@ class PluginBundle:
         ``load_subagents_for_parent``.
     replaced_subagents
         Sub-agent name → SubAgentSpec replacement.
+    models
+        Role name → model id (e.g. ``{"exploit": "auth/claude-sonnet-5"}``).
+        Promotes that model to the role's PRIMARY, demoting the tier
+        default into the fallback chain. Lets a plugin re-tier a single
+        agent by composition, without editing the OSS tier map or an
+        operator env var. ``DECEPTICON_MODEL_<ROLE>`` still wins over a
+        bundle entry (operator override beats plugin default).
     """
 
     items: tuple[Any, ...] = ()
@@ -304,6 +311,9 @@ class PluginBundle:
     # ── Sub-agent overrides ──────────────────────────────────────────
     disabled_subagents: tuple[str, ...] = ()
     replaced_subagents: dict[str, Any] = field(default_factory=dict)
+
+    # ── Model overrides ──────────────────────────────────────────────
+    models: dict[str, str] = field(default_factory=dict)
 
     def matches_role(self, role: str) -> bool:
         """``roles`` filter — empty tuple = unrestricted."""

--- a/packages/decepticon/decepticon/agents/build.py
+++ b/packages/decepticon/decepticon/agents/build.py
@@ -137,6 +137,41 @@ def _iter_override_bundles(role: str) -> Iterator[PluginBundle]:
         yield bundle
 
 
+def resolve_role_model(role: str) -> str | None:
+    """Composed override for a role's PRIMARY model.
+
+    Precedence: ``DECEPTICON_MODEL_<ROLE>`` (operator env) beats a
+    ``PluginBundle.models`` entry (plugin), which beats the tier default
+    (returned as ``None`` here — the factory keeps the default when this
+    yields nothing). This is the model analogue of ``build_middleware`` /
+    ``build_tools``: it lets a plugin re-tier one agent by composition
+    rather than editing the OSS tier map. Returns the winning model id
+    or ``None`` when neither an env nor a bundle override is set.
+    """
+    env = os.environ.get(f"DECEPTICON_MODEL_{role.upper()}", "").strip()
+    if env:
+        return env
+    chosen: str | None = None
+    owner: str | None = None
+    for bundle in _iter_override_bundles(role):
+        model = bundle.models.get(role)
+        if not model:
+            continue
+        this_owner = bundle.bundle or "<unknown>"
+        if chosen is not None and chosen != model:
+            logger.warning(
+                "role %r model set by multiple bundles (%s=%r kept, %s=%r ignored)",
+                role,
+                owner,
+                chosen,
+                this_owner,
+                model,
+            )
+            continue
+        chosen, owner = model, this_owner
+    return chosen
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Override resolution
 # ─────────────────────────────────────────────────────────────────────

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -42,6 +42,7 @@ from decepticon_core.types.llm import (
     AuthMethod,
     Credentials,
     LLMModelMapping,
+    ModelAssignment,
     ModelProfile,
     ProxyConfig,
     Tier,
@@ -1509,6 +1510,29 @@ class LLMFactory:
         self._cache: dict[str, BaseChatModel] = {}
 
     @staticmethod
+    def _compose_assignment(role: str, assignment: ModelAssignment) -> ModelAssignment:
+        """Apply a composed per-role model override to ``assignment``.
+
+        Precedence (env > ``PluginBundle.models`` > tier default) is owned
+        by ``decepticon.agents.build.resolve_role_model``. The displaced
+        tier primary is kept as the head of the fallback chain so a bad
+        override still degrades to the vetted default. Applied per get, so
+        it also re-tiers custom plugin roles that resolve via a fallback
+        role rather than living in ``AGENT_TIERS``. Imported lazily —
+        build → factory is a normal edge; the reverse must stay absent.
+        """
+        from decepticon.agents.build import resolve_role_model
+
+        override = resolve_role_model(role)
+        if not override or override == assignment.primary:
+            return assignment
+        return ModelAssignment(
+            primary=override,
+            fallbacks=[assignment.primary, *(m for m in assignment.fallbacks if m != override)],
+            temperature=assignment.temperature,
+        )
+
+    @staticmethod
     def _resolve_proxy_config() -> ProxyConfig:
         """Resolve proxy config from DecepticonConfig (env vars)."""
         from decepticon_core.utils.config import load_config
@@ -1575,7 +1599,9 @@ class LLMFactory:
             return self._cache[role]
 
         default_role = self._resolve_default_role(role, default_role)
-        assignment = self._router.get_assignment(role, default_role=default_role)
+        assignment = self._compose_assignment(
+            role, self._router.get_assignment(role, default_role=default_role)
+        )
         log.info(
             "Creating LLM for role '%s' → model '%s' via %s",
             role,
@@ -1598,7 +1624,9 @@ class LLMFactory:
         until one succeeds. ``default_role`` works as in ``get_model``.
         """
         default_role = self._resolve_default_role(role, default_role)
-        assignment = self._router.get_assignment(role, default_role=default_role)
+        assignment = self._compose_assignment(
+            role, self._router.get_assignment(role, default_role=default_role)
+        )
         if not assignment.fallbacks:
             return []
 

--- a/packages/decepticon/tests/unit/llm/test_role_model_override.py
+++ b/packages/decepticon/tests/unit/llm/test_role_model_override.py
@@ -1,0 +1,82 @@
+"""Composed per-role model override — ``PluginBundle.models`` + the
+``DECEPTICON_MODEL_<ROLE>`` operator env, applied by ``LLMFactory``.
+
+This is the model analogue of the middleware/tool/prompt composition a
+plugin already gets: a SaaS bundle can re-tier a single agent onto a
+different model without editing the OSS tier map or a global env var.
+"""
+
+from decepticon.agents.build import resolve_role_model
+from decepticon.llm.factory import LLMFactory
+from decepticon_core.plugin_loader import PluginBundle
+from decepticon_core.types.llm import ModelAssignment
+
+_ITER = "decepticon.agents.build._iter_override_bundles"
+
+
+class TestResolveRoleModel:
+    def test_none_when_neither_env_nor_bundle(self, monkeypatch):
+        monkeypatch.delenv("DECEPTICON_MODEL_EXPLOIT", raising=False)
+        monkeypatch.setattr(_ITER, lambda role: iter(()))
+        assert resolve_role_model("exploit") is None
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("DECEPTICON_MODEL_EXPLOIT", "auth/claude-sonnet-5")
+        assert resolve_role_model("exploit") == "auth/claude-sonnet-5"
+
+    def test_bundle_override(self, monkeypatch):
+        monkeypatch.delenv("DECEPTICON_MODEL_EXPLOIT", raising=False)
+        bundle = PluginBundle(bundle="rt", models={"exploit": "auth/claude-sonnet-5"})
+        monkeypatch.setattr(_ITER, lambda role: iter((bundle,)))
+        assert resolve_role_model("exploit") == "auth/claude-sonnet-5"
+
+    def test_env_beats_bundle(self, monkeypatch):
+        monkeypatch.setenv("DECEPTICON_MODEL_EXPLOIT", "auth/claude-opus-4-8")
+        bundle = PluginBundle(bundle="rt", models={"exploit": "auth/claude-sonnet-5"})
+        monkeypatch.setattr(_ITER, lambda role: iter((bundle,)))
+        assert resolve_role_model("exploit") == "auth/claude-opus-4-8"
+
+    def test_conflicting_bundles_keep_first(self, monkeypatch):
+        monkeypatch.delenv("DECEPTICON_MODEL_EXPLOIT", raising=False)
+        a = PluginBundle(bundle="a", models={"exploit": "auth/claude-sonnet-5"})
+        b = PluginBundle(bundle="b", models={"exploit": "openai/gpt-5.5"})
+        monkeypatch.setattr(_ITER, lambda role: iter((a, b)))
+        assert resolve_role_model("exploit") == "auth/claude-sonnet-5"
+
+
+class TestComposeAssignment:
+    """``LLMFactory._compose_assignment`` re-tiers a role at get time —
+    so it also covers custom plugin roles resolved via a fallback role,
+    not just those hardcoded in ``AGENT_TIERS``."""
+
+    def _base(self):
+        return ModelAssignment(
+            primary="anthropic/claude-opus-4-8",
+            fallbacks=["openai/gpt-5.5"],
+            temperature=0.3,
+        )
+
+    def test_override_promoted_to_primary(self, monkeypatch):
+        monkeypatch.setenv("DECEPTICON_MODEL_EXPLOIT", "auth/claude-sonnet-5")
+        a = LLMFactory._compose_assignment("exploit", self._base())
+        assert a.primary == "auth/claude-sonnet-5"
+        assert a.fallbacks[0] == "anthropic/claude-opus-4-8"  # default demoted, not dropped
+        assert a.temperature == 0.3
+
+    def test_no_override_returns_input_unchanged(self, monkeypatch):
+        monkeypatch.delenv("DECEPTICON_MODEL_EXPLOIT", raising=False)
+        monkeypatch.setattr(_ITER, lambda role: iter(()))
+        base = self._base()
+        assert LLMFactory._compose_assignment("exploit", base) is base
+
+    def test_override_equal_to_primary_is_noop(self, monkeypatch):
+        monkeypatch.setenv("DECEPTICON_MODEL_EXPLOIT", "anthropic/claude-opus-4-8")
+        base = self._base()
+        assert LLMFactory._compose_assignment("exploit", base) is base
+
+    def test_override_deduped_from_fallbacks(self, monkeypatch):
+        # Promoting a model already in the fallback chain must not double it.
+        monkeypatch.setenv("DECEPTICON_MODEL_EXPLOIT", "openai/gpt-5.5")
+        a = LLMFactory._compose_assignment("exploit", self._base())
+        assert a.primary == "openai/gpt-5.5"
+        assert a.fallbacks == ["anthropic/claude-opus-4-8"]


### PR DESCRIPTION
## Why

Per-agent **model** selection was the one agent-shaping dimension a downstream plugin could **not** compose. Tools, middleware, prompts and subagents are all overridable via `PluginBundle` / entry-points, but the model was pinned by the OSS `AGENT_TIERS` map. `DECEPTICON_MODEL_<ROLE>` was *documented* as a per-role override but only reached the LiteLLM **dynamic-config** generator — a deployment on a **static** LiteLLM config silently ignored it (verified against prod: `exploit` stayed on Opus and `DECEPTICON_MODEL_SOUNDWAVE` was inert).

## What

Add a model override channel symmetric with the existing ones:

- `PluginBundle.models: dict[str, str]` — role → model id (plugin composition)
- `build.resolve_role_model(role)` — precedence `DECEPTICON_MODEL_<ROLE>` (operator env) > bundle > tier default
- `LLMFactory._compose_assignment` applies it at `get_model` / `get_fallback_models` time (per-get, so custom plugin roles that resolve via a `llm_role_fallback` are covered too), demoting the displaced tier default to the head of the fallback chain so a bad override still degrades to the vetted default.

Lets a downstream package re-tier a single agent onto a different model **by composition alone**, with no edit to the OSS tier map.

## Tests

`packages/decepticon/tests/unit/llm/test_role_model_override.py` — env/bundle/precedence/conflict + `_compose_assignment` promotion, dedup, no-op cases. Full `llm/` + `plugin`/`bundle` suites green (112 + 32). ruff + basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)