### PR TITLE
feat(oauth): register gpt-5.6-terra + gpt-5.6-luna Codex routes

### DIFF
--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -689,12 +689,17 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
 # card (Sonar $1/$1, Sonar Pro $3/$15) — search-call surcharge not
 # modeled.
 _SUBSCRIPTION_SHADOW_PRICING: dict[str, tuple[float, float]] = {
-    # gpt-5.6-sol is the GPT-5.6-family frontier model the Codex subscription
-    # actually serves (verified 2026-07-13 via /backend-api/codex/responses;
-    # plain gpt-5.6 400s with "not supported when using Codex with a ChatGPT
-    # account"). Shadow pricing tracks gpt-5.5 ($5 input parity per the model
-    # card); opportunity-cost only — real spend is the flat subscription.
+    # gpt-5.6-{sol,terra,luna} are the GPT-5.6-family frontier checkpoints the
+    # Codex subscription actually serves (all three verified 2026-07-13 via
+    # /backend-api/codex/responses; plain gpt-5.6 / gpt-5.6-nova / gpt-5.6-codex
+    # 400 with "not supported when using Codex with a ChatGPT account"). They
+    # behave equivalently on verification-reasoning probes — registered so any
+    # agent can be composed onto any of them. Shadow pricing tracks gpt-5.5
+    # ($5 input parity per the model card); opportunity-cost only — real spend
+    # is the flat subscription.
     "auth/gpt-5.6-sol": (0.000005, 0.000030),
+    "auth/gpt-5.6-terra": (0.000005, 0.000030),
+    "auth/gpt-5.6-luna": (0.000005, 0.000030),
     "auth/gpt-5.5": (0.000005, 0.000030),
     "auth/gpt-5.4": (0.0000025, 0.000015),
     "auth/gpt-5.4-mini": (0.00000075, 0.0000045),
@@ -748,13 +753,21 @@ _SUBSCRIPTION_ROUTES: dict[str, list[dict[str, Any]]] = {
         # to api.openai.com regardless of provider. The codex_chatgpt
         # handler strips the ``oauth-`` prefix before sending the model
         # name upstream, so chatgpt.com still receives ``gpt-5.5``.
-        # gpt-5.6-sol — GPT-5.6-family frontier model, served on the ChatGPT
-        # subscription (verified 2026-07-13). Reasoning model; the codex
-        # handler applies the default effort (medium) — no output cap, the
-        # Codex backend rejects max_output_tokens.
+        # gpt-5.6-{sol,terra,luna} — GPT-5.6-family frontier checkpoints served
+        # on the ChatGPT subscription (all three verified 2026-07-13). Reasoning
+        # models; the codex handler applies the default effort (medium) — no
+        # output cap, the Codex backend rejects max_output_tokens.
         {
             "model_name": "auth/gpt-5.6-sol",
             "litellm_params": {"model": "codex-oauth/oauth-gpt-5.6-sol"},
+        },
+        {
+            "model_name": "auth/gpt-5.6-terra",
+            "litellm_params": {"model": "codex-oauth/oauth-gpt-5.6-terra"},
+        },
+        {
+            "model_name": "auth/gpt-5.6-luna",
+            "litellm_params": {"model": "codex-oauth/oauth-gpt-5.6-luna"},
         },
         {
             "model_name": "auth/gpt-5.5",

--- a/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
@@ -241,9 +241,11 @@ def test_merge_dynamic_models_registers_only_supported_chatgpt_oauth_routes() ->
     # provider because the ``gpt-*`` slug collides with OpenAI's aliases.
     entries = {entry["model_name"]: entry["litellm_params"] for entry in merged["model_list"]}
     assert entries == {
-        # GPT-5.6-family frontier model served on the Codex subscription
-        # (verified 2026-07-13; plain gpt-5.6 400s on the Codex account).
+        # GPT-5.6-family frontier checkpoints served on the Codex subscription
+        # (all verified 2026-07-13; plain gpt-5.6 400s on the Codex account).
         "auth/gpt-5.6-sol": {"model": "codex-oauth/oauth-gpt-5.6-sol"},
+        "auth/gpt-5.6-terra": {"model": "codex-oauth/oauth-gpt-5.6-terra"},
+        "auth/gpt-5.6-luna": {"model": "codex-oauth/oauth-gpt-5.6-luna"},
         "auth/gpt-5.5": {"model": "codex-oauth/oauth-gpt-5.5"},
         "auth/gpt-5.4": {"model": "codex-oauth/oauth-gpt-5.4"},
         "auth/gpt-5.4-mini": {"model": "codex-oauth/oauth-gpt-5.4-mini"},


### PR DESCRIPTION
The Codex subscription serves three GPT-5.6-family frontier checkpoints — **sol, terra, luna** — all real-verified 2026-07-13 against `chatgpt.com/backend-api/codex/responses`:
- HTTP 200 + clean `response.completed` at reasoning effort medium / high / xhigh (prod uses xhigh)
- Equivalent, correct verification-reasoning (all three rejected an unproven SQLi/IDOR as NOT-CONFIRMED)
- Plain `gpt-5.6` / `gpt-5.6-nova` / `gpt-5.6-codex` → 400 "not supported when using Codex with a ChatGPT account"

This registers **terra** + **luna** alongside **sol** (already shipped in v1.1.37) in the subscription shadow-pricing + route tables, so any agent can be composed onto any of the three via `PluginBundle.models`. Route-set unit test updated; 268 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)