### PR TITLE
fix(llm): make invalid model errors actionable

### DIFF
--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -1359,6 +1359,25 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
     # but interpolate the scrubbed copy so an echoed credential never reaches
     # the user-facing message — see _redact_secrets.
     safe_msg = _redact_secrets(msg)
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    status_match = _STATUS_IN_MSG.search(msg)
+    is_bad_request = (
+        "badrequest" in err_type.lower()
+        or status == 400
+        or (status_match is not None and int(status_match.group(1)) == 400)
+    )
+
+    if is_bad_request and "invalid model name" in msg_lower:
+        raise RuntimeError(
+            f"{fatal_prefix}Model '{model_name}' is not available through the LiteLLM "
+            f"proxy. Verify its static route in config/litellm.yaml or dynamic environment "
+            f"configuration (DECEPTICON_MODEL*, DECEPTICON_LITELLM_MODELS, "
+            f"CUSTOM_OPENAI_*, or OLLAMA_MODEL). Restart the proxy, inspect its startup "
+            f"logs, and query /v1/models for the models available to your key.\n"
+            f"Underlying: {safe_msg}"
+        ) from exc
 
     # LiteLLM puts a recognizable prefix in the inner message when the
     # proxy ran out of fallback options for a model_group — issue #107.
@@ -1372,15 +1391,7 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
             f"Underlying: {safe_msg}"
         ) from exc
 
-    if "invalid model name" in msg_lower:
-        raise RuntimeError(
-            f"{fatal_prefix}Model '{model_name}' is not available through the LiteLLM "
-            f"proxy. Verify its route in config/litellm.yaml and query the proxy's "
-            f"/v1/models endpoint for the models available to your key.\n"
-            f"Underlying: {safe_msg}"
-        ) from exc
-
-    if "badrequest" in err_type.lower() or "code: 400" in msg_lower:
+    if is_bad_request:
         raise RuntimeError(
             f"{fatal_prefix}Model '{model_name}' rejected the request (400). "
             f"This usually means a parameter the model no longer supports "

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -1372,6 +1372,14 @@ def _reraise_with_actionable_message(exc: Exception, model_name: str) -> None:
             f"Underlying: {safe_msg}"
         ) from exc
 
+    if "invalid model name" in msg_lower:
+        raise RuntimeError(
+            f"{fatal_prefix}Model '{model_name}' is not available through the LiteLLM "
+            f"proxy. Verify its route in config/litellm.yaml and query the proxy's "
+            f"/v1/models endpoint for the models available to your key.\n"
+            f"Underlying: {safe_msg}"
+        ) from exc
+
     if "badrequest" in err_type.lower() or "code: 400" in msg_lower:
         raise RuntimeError(
             f"{fatal_prefix}Model '{model_name}' rejected the request (400). "

--- a/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
+++ b/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
@@ -100,19 +100,53 @@ class TestActionableMessageFatalLabel:
         # Existing remediation text preserved (regression).
         assert "rejected the request (400)" in msg
 
-    def test_400_invalid_model_names_the_proxy_configuration(self):
+    def test_400_invalid_model_names_static_and_dynamic_proxy_configuration(self):
         exc = _exc_with_status(
             "BadRequestError",
             400,
             "Error code: 400 - Invalid model name passed in model=custom/kimi-k2.7-code. "
-            "Call `/v1/models` to view available models for your key.",
+            "Authorization: Bearer ***. Call `/v1/models` to view "
+            "available models for your key.",
         )
         with pytest.raises(RuntimeError) as info:
             _reraise_with_actionable_message(exc, "custom/kimi-k2.7-code")
 
         msg = str(info.value)
+        assert "non-retryable provider error" in msg
         assert "config/litellm.yaml" in msg
+        assert "dynamic environment" in msg
+        assert "DECEPTICON_MODEL" in msg
+        assert "restart" in msg.lower()
+        assert "startup logs" in msg.lower()
         assert "/v1/models" in msg
+        assert "ROUTELEAKTOKEN12345" not in msg
+        assert "[REDACTED]" in msg
+
+    def test_503_invalid_model_text_is_not_reclassified_as_a_route_error(self):
+        exc = _exc_with_status(
+            "ServiceUnavailableError",
+            503,
+            "Error code: 503 - upstream temporarily returned Invalid model name",
+        )
+        assert _reraise_with_actionable_message(exc, "custom/kimi-k2.7-code") is None
+
+    def test_value_error_invalid_model_text_passes_through(self):
+        exc = ValueError("parser captured provider text: Invalid model name")
+        assert _reraise_with_actionable_message(exc, "custom/kimi-k2.7-code") is None
+
+    def test_composite_400_invalid_model_precedes_no_fallback_guidance(self):
+        exc = _exc_with_status(
+            "BadRequestError",
+            400,
+            "Error code: 400 - Invalid model name passed in model=custom/kimi-k2.7-code. "
+            "No fallback model group found for original model_group=custom/kimi-k2.7-code",
+        )
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "custom/kimi-k2.7-code")
+
+        msg = str(info.value)
+        assert "not available through the LiteLLM proxy" in msg
+        assert "another auth method" not in msg
 
     def test_401_message_labelled_non_retryable(self):
         exc = _exc_with_status("AuthenticationError", 401, "Error code: 401 - invalid_api_key")

--- a/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
+++ b/packages/decepticon/tests/unit/llm/test_factory_classify_errors.py
@@ -100,6 +100,20 @@ class TestActionableMessageFatalLabel:
         # Existing remediation text preserved (regression).
         assert "rejected the request (400)" in msg
 
+    def test_400_invalid_model_names_the_proxy_configuration(self):
+        exc = _exc_with_status(
+            "BadRequestError",
+            400,
+            "Error code: 400 - Invalid model name passed in model=custom/kimi-k2.7-code. "
+            "Call `/v1/models` to view available models for your key.",
+        )
+        with pytest.raises(RuntimeError) as info:
+            _reraise_with_actionable_message(exc, "custom/kimi-k2.7-code")
+
+        msg = str(info.value)
+        assert "config/litellm.yaml" in msg
+        assert "/v1/models" in msg
+
     def test_401_message_labelled_non_retryable(self):
         exc = _exc_with_status("AuthenticationError", 401, "Error code: 401 - invalid_api_key")
         with pytest.raises(RuntimeError) as info:


### PR DESCRIPTION
## What changed
- distinguish confirmed LiteLLM HTTP 400 invalid-model responses from generic parameter errors
- prioritize missing-route remediation when LiteLLM appends `No fallback model group found`
- direct operators to static `config/litellm.yaml` routes or dynamic environment routes, proxy restart/startup logs, and `/v1/models`
- preserve unrelated and retryable errors instead of overmatching message text
- preserve non-retryable classification and redact upstream credentials
- add regression coverage with visible RED/GREEN commit pairs

## Why
Closes #747. The previous message suggested removing unsupported model parameters even when the configured model route itself was invalid.

## Impact
Error-classification/message change only; no model routing, authentication, or provider configuration changes. Missing-route guidance now requires a confirmed 400/`BadRequestError`; 503 and unrelated `ValueError` paths retain their prior behavior.

## Testing
- `unset PYTHONPATH && uv run ruff check packages/decepticon/decepticon/llm/factory.py packages/decepticon/tests/unit/llm/test_factory_classify_errors.py`
- `unset PYTHONPATH && uv run ruff format --check packages/decepticon/decepticon/llm/factory.py packages/decepticon/tests/unit/llm/test_factory_classify_errors.py`
- `unset PYTHONPATH && uv run basedpyright packages/decepticon/decepticon/llm/factory.py packages/decepticon/tests/unit/llm/test_factory_classify_errors.py` — 0 errors
- `unset PYTHONPATH && uv run pytest packages/decepticon/tests/unit/llm/test_factory_classify_errors.py -q` — 26 passed
- `unset PYTHONPATH && uv run pytest packages/decepticon/tests/unit/llm -q` — 621 passed, 3 Windows-specific skips
- `git diff --check`

## End-to-end verification statement
Ran `_ProxiedChatOpenAI.invoke()` through the real LangChain/OpenAI HTTP client against a local HTTP server that returned provider-shaped responses. A 400 body containing `Invalid model name` plus an echoed bearer value produced the non-retryable static/dynamic LiteLLM route guidance, included `/v1/models`, and emitted `[REDACTED]` without the credential. Repeating the same invocation with HTTP 503 and identical invalid-model text did not produce missing-route guidance, confirming the retryable path is not overmatched. No live paid provider was called; the local server was the controlled stand-in for the provider response.

## Independent review follow-up
The first independent review found two blockers: unguarded text overmatching and wrong precedence for composite no-fallback errors. Both are covered by failing-before-fix tests and resolved in commits `6bbd3128` and `94f09948`. It also requested dynamic-route guidance, explicit fatal/redaction assertions, and end-to-end evidence; all are included.

## Ponytail Full
Reuses the existing error-classification, HTTP-status extraction, and redaction path; adds no dependency, helper, config flag, or public API. The confirmed-400 missing-route check precedes both fallback and generic 400 guidance.

## Anti-goals
- no model routing changes
- no LiteLLM configuration changes
- no credential handling changes
- no changes to retry policy
