### PR TITLE
fix(cli): recover after thread creation failure

### DIFF
--- a/clients/cli/src/hooks/useAgent.test.tsx
+++ b/clients/cli/src/hooks/useAgent.test.tsx
@@ -256,6 +256,46 @@ describe("useAgent — engagement handoff lifecycle", () => {
     expect(result.current.assistantId).toBe("soundwave");
   });
 
+  it("recovers after thread creation retries are exhausted", async () => {
+    const mc = mockState.client!;
+    const createThread = mc.threads.create as Mock;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      createThread.mockRejectedValueOnce(new Error("server unavailable"));
+    }
+    createThread.mockResolvedValueOnce({ thread_id: "thread-recovered" });
+    (mc.runs.stream as Mock).mockReturnValueOnce(createMockStream([noopValuesEvent]));
+
+    const { result } = renderHook(() => useAgent());
+
+    act(() => {
+      result.current.submit("first attempt");
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(createThread).toHaveBeenCalledTimes(5);
+    expect(result.current.runState).toBe("idle");
+    expect(result.current.error).toBe("Connection failed: server unavailable");
+    expect(result.current.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "system",
+        content: "Connection failed: server unavailable",
+      }),
+    ]));
+
+    act(() => {
+      result.current.submit("retry");
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(createThread).toHaveBeenCalledTimes(6);
+    expect(mc.runs.stream).toHaveBeenCalledTimes(1);
+    expect(result.current.runState).toBe("idle");
+  });
+
   // ── 5. engagement_ready alone does not clear queuedMessage ───────────────
   it("keeps queuedMessage intact after engagement_ready — only handleStreamComplete handoff branch clears it", async () => {
     const firstStream = createControllableStream();

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -735,10 +735,13 @@ export function useAgent({
               if (attempt === maxRetries) {
                 const msg =
                   err instanceof Error ? err.message : "Failed to create thread";
-                setError(`Connection failed: ${msg}`);
+                const connectionError = `Connection failed: ${msg}`;
+                setError(connectionError);
+                addEvent({ type: "system", content: connectionError });
                 // Clear queued message to prevent infinite retry loop
                 queuedMessageRef.current = null;
                 setQueuedMessage(null);
+                handleStreamComplete(abortController);
                 return;
               }
               // Server may still be loading graphs — wait and retry


### PR DESCRIPTION
## Summary

When LangGraph thread creation exhausts all five retries, the terminal now returns to idle, keeps the failure visible in the transcript, and accepts a later submission instead of remaining permanently blocked behind a stale abort controller.

## Changes

- route terminal thread-creation failure through the normal stream-completion cleanup
- append a system event with the final connection error
- clear stale queued input before cleanup so a failed connection cannot auto-submit it
- add regression coverage for retry exhaustion followed by a successful new submission

## Intent

- **Issue / ADR this satisfies:** release-blocker C1 from the independent gap analysis
- **Anti-goal:** this PR does not add server-side live-run reattachment or change queued-message behavior after an established stream fails.

## Blast radius

- [ ] **Tier-auto** — tests, internal refactors, non-policy docs, lockfile-only dep bumps.
- [x] **Tier-delegate** — agent prompts, skill bodies, middleware internals, web/CLI features.
- [ ] **Tier-owner** — anything CODEOWNERS-gated.

## Diff budget

- [x] My diff fits the budget.
- [ ] **Or** I am requesting `large-diff-approved` from `@PurpleCHOIms`.

## End-to-end verification

Built the CLI with `npm run build`, ran it against a local HTTP server that returned 503 for every LangGraph request, and supplied `DECEPTICON_INITIAL_MESSAGE='first attempt'`. The server observed the five initial `POST /threads` attempts. After exhaustion, I typed `retry after failure` into the running terminal and observed a new sequence of `POST /threads` requests, proving the prompt was reusable rather than wedged. The focused regression first failed with `expected 'connecting' to be 'idle'` on the test-only commit and passed after the implementation commit.

## Testing

- [ ] `make quality` passes (Python + CLI + Web)
- [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks)
- [ ] `pytest tests/` passes
- [x] Every new/changed test was watched to fail without the change and pass with it
- [x] Every new/changed code path was executed on my machine, not just unit-tested in isolation
- [x] Manual testing: built terminal against an HTTP 503 mock; verified a new submission issued fresh thread-create requests after the initial five failures

Commands run:

```text
npm test -- --run src/hooks/useAgent.test.tsx -t 'recovers after thread creation retries are exhausted'
  Test Files  1 passed (1)
  Tests       1 passed | 5 skipped (6)

npm test
  Test Files  4 passed (4)
  Tests       31 passed (31)

npm run typecheck
  tsc --noEmit (exit 0)

npm run build
  tsc (exit 0)
```

## Quality Bar self-check

- [x] No banned pattern from QUALITY_BAR appears in the diff.
- [x] No AI-slop signature from QUALITY_BAR survives.
- [x] Every changed line traces to the stated intent. No drive-by formatting, renaming, or reordering.
- [x] Every public function added or changed has explicit type annotations, and no unnamed exception was introduced.
- [x] I would merge this PR if a stranger opened it.
- [x] If I were tired and reviewing this at the end of a long day, I would still merge it.

## Related Issues

None filed; this is the C1 release-blocker identified by the supplied audit.
