### PR TITLE
fix(launcher): replace running binary safely on Windows

### DIFF
--- a/clients/launcher/cmd/root.go
+++ b/clients/launcher/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/ui"
+	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/updater"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	updater.CleanupOldBinary()
 	if err := rootCmd.Execute(); err != nil {
 		ui.Error(err.Error())
 		os.Exit(1)

--- a/clients/launcher/internal/updater/updater.go
+++ b/clients/launcher/internal/updater/updater.go
@@ -515,9 +515,44 @@ func downloadFile(client *http.Client, url, dst string) error {
 	return os.WriteFile(dst, data, 0o600)
 }
 
+// CleanupOldBinary removes the backup left by a successful Windows update.
+// It is best-effort because the old parent process may still hold the file
+// open during the immediate post-update re-exec; the next launch retries it.
+func CleanupOldBinary() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	execPath, err := executableFn()
+	if err != nil {
+		return
+	}
+	_ = os.Remove(execPath + ".old")
+}
+
+func replaceExecutable(tmpPath, execPath string) error {
+	if runtime.GOOS != "windows" {
+		return os.Rename(tmpPath, execPath)
+	}
+
+	oldPath := execPath + ".old"
+	if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove previous backup: %w", err)
+	}
+	if err := os.Rename(execPath, oldPath); err != nil {
+		return fmt.Errorf("backup running binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, execPath); err != nil {
+		if rollbackErr := os.Rename(oldPath, execPath); rollbackErr != nil {
+			return fmt.Errorf("install new binary: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	return nil
+}
+
 // SelfUpdate downloads and replaces the current binary. The download is
 // verified against “checksums.txt“ (GoReleaser-produced) before the
-// atomic rename — a tampered binary on the GitHub CDN never reaches
+// executable swap — a tampered binary on the GitHub CDN never reaches
 // disk in the executable path. Releases that predate checksum
 // verification (no “checksums.txt“ asset) emit a warning and fall
 // back to the legacy unverified replace.
@@ -585,8 +620,9 @@ func SelfUpdate(release *Release) error {
 		return fmt.Errorf("chmod temp file: %w", err)
 	}
 
-	// Atomic replace
-	if err := os.Rename(tmpPath, execPath); err != nil {
+	// Atomic replace on POSIX. Windows first moves the running image aside
+	// because an executable cannot be overwritten while it is in use.
+	if err := replaceExecutable(tmpPath, execPath); err != nil {
 		os.Remove(tmpPath)
 		return fmt.Errorf("replace binary: %w", err)
 	}

--- a/clients/launcher/internal/updater/updater_test.go
+++ b/clients/launcher/internal/updater/updater_test.go
@@ -435,6 +435,58 @@ func TestSelfUpdate_WritesAndRenames(t *testing.T) {
 	}
 }
 
+func TestReplaceExecutable_WindowsRollsBackFailedInstall(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows executable replacement only")
+	}
+
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "decepticon.exe")
+	previousContent := []byte("previous binary content")
+	if err := os.WriteFile(execPath, previousContent, 0o755); err != nil {
+		t.Fatalf("seed current binary: %v", err)
+	}
+
+	err := replaceExecutable(filepath.Join(dir, "missing.tmp"), execPath)
+	if err == nil {
+		t.Fatal("replaceExecutable with missing temp file: expected error, got nil")
+	}
+
+	current, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatalf("read current binary after rollback: %v", readErr)
+	}
+	if string(current) != string(previousContent) {
+		t.Errorf("current binary after rollback = %q, want %q", current, previousContent)
+	}
+	if _, statErr := os.Stat(execPath + ".old"); !os.IsNotExist(statErr) {
+		t.Errorf("backup should be restored after a failed install; stat error = %v", statErr)
+	}
+}
+
+func TestCleanupOldBinary_WindowsRemovesStaleBackup(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows executable cleanup only")
+	}
+
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "decepticon.exe")
+	oldPath := fakeBin + ".old"
+	if err := os.WriteFile(oldPath, []byte("stale binary"), 0o755); err != nil {
+		t.Fatalf("seed stale backup: %v", err)
+	}
+
+	orig := executableFn
+	executableFn = func() (string, error) { return fakeBin, nil }
+	t.Cleanup(func() { executableFn = orig })
+
+	CleanupOldBinary()
+
+	if _, statErr := os.Stat(oldPath); !os.IsNotExist(statErr) {
+		t.Errorf("stale backup should be removed; stat error = %v", statErr)
+	}
+}
+
 // ---- WriteVersion ----
 
 func TestWriteVersion_StripsVPrefix(t *testing.T) {

--- a/clients/launcher/internal/updater/updater_test.go
+++ b/clients/launcher/internal/updater/updater_test.go
@@ -393,6 +393,10 @@ func TestSelfUpdate_WritesAndRenames(t *testing.T) {
 
 	dir := t.TempDir()
 	fakeBin := filepath.Join(dir, "decepticon")
+	previousContent := []byte("previous binary content")
+	if err := os.WriteFile(fakeBin, previousContent, 0o755); err != nil {
+		t.Fatalf("seed current binary: %v", err)
+	}
 
 	// Redirect executableFn so SelfUpdate writes into our temp dir instead
 	// of clobbering the running test binary. Matches the isWSLFn pattern.
@@ -419,6 +423,15 @@ func TestSelfUpdate_WritesAndRenames(t *testing.T) {
 	// The temp file must be cleaned up by the rename.
 	if _, statErr := os.Stat(fakeBin + ".tmp"); !os.IsNotExist(statErr) {
 		t.Error(".tmp file should not exist after a successful rename")
+	}
+	if runtime.GOOS == "windows" {
+		previous, readErr := os.ReadFile(fakeBin + ".old")
+		if readErr != nil {
+			t.Fatalf("read Windows backup: %v", readErr)
+		}
+		if string(previous) != string(previousContent) {
+			t.Errorf("Windows backup content = %q, want %q", previous, previousContent)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Native Windows self-update now moves the running launcher to `.old` before installing the verified temporary binary, rolls back if installation fails, and removes the stale backup on a later invocation. Non-Windows replacement behavior is unchanged.

## Changes

- use a Windows-specific `current -> .old -> current` executable swap
- restore `.old` when moving the downloaded executable into place fails
- clean stale `.old` backups best-effort at launcher startup
- add regression coverage for replacement, rollback, and deferred cleanup

## Intent

- **Issue / ADR this satisfies:** release-blocker C2 from the independent gap analysis
- **Anti-goal:** this PR does not change release discovery, checksum policy, update channels, or launcher signing.

## Blast radius

- [ ] **Tier-auto** — tests, internal refactors, non-policy docs, lockfile-only dep bumps.
- [ ] **Tier-delegate** — agent prompts, skill bodies, middleware internals, web/CLI features.
- [x] **Tier-owner** — release/bootstrap behavior that replaces the launcher executable.

**Why this needs an owner change:** The updater replaces the host launcher binary and therefore sits on the installation and supply-chain boundary. The change is intentionally small and checksum verification remains upstream of replacement, but failure semantics and rollback deserve owner review.

## Diff budget

- [x] My diff fits the budget.
- [ ] **Or** I am requesting `large-diff-approved` from `@PurpleCHOIms`.

## End-to-end verification

On Windows 10, I built and launched a native Go probe from a temporary path, copied the executable to the updater's `.tmp` path, and invoked the production `replaceExecutable` path while the original image was still running. The old process stayed alive as `.old`, the replacement path launched successfully as a second process, cleanup left `.old` in place while the old process held the image, and a later `CleanupOldBinary` call removed it after that process exited. The committed regression first failed with `read Windows backup ... The system cannot find the file specified` on the test-only commit and passed after the implementation commit. I did not contact GitHub or replace the installed Decepticon launcher; HTTP download behavior remains covered by the existing `httptest`-backed `SelfUpdate` test.

## Testing

- [ ] `make quality` passes (Python + CLI + Web)
- [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks)
- [ ] `pytest tests/` passes
- [x] Every new/changed test was watched to fail without the change and pass with it
- [x] Every new/changed code path was executed on my machine, not just unit-tested in isolation
- [x] Manual testing: replaced and re-launched a copied, currently running native Windows executable; verified deferred `.old` cleanup

Commands run:

```text
go test ./internal/updater -count=1
  ok github.com/PurpleAILAB/Decepticon/clients/launcher/internal/updater

go test ./...
  all launcher packages passed

go vet ./...
  exit 0

go build ./...
GOOS=linux GOARCH=amd64 go build ./...
GOOS=darwin GOARCH=amd64 go build ./...
  all exited 0

test -z "$(gofmt -l cmd/root.go internal/updater/updater.go internal/updater/updater_test.go)"
  exit 0
```

An independent read-only review reported no security concerns or logic errors and confirmed Windows rollback/cleanup and cross-platform behavior.

## Quality Bar self-check

- [x] No banned pattern from QUALITY_BAR appears in the diff.
- [x] No AI-slop signature from QUALITY_BAR survives.
- [x] Every changed line traces to the stated intent. No drive-by formatting, renaming, or reordering.
- [x] Every public function added or changed has explicit type annotations, and no unnamed exception was introduced.
- [x] I would merge this PR if a stranger opened it.
- [x] If I were tired and reviewing this at the end of a long day, I would still merge it.

## Related Issues

None filed; this is the C2 release-blocker identified by the supplied audit.
