### PR TITLE
fix(tests): allowlist the cli docker.sock mount, run compose tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
               - 'packages/decepticon-sdk/**'
               - 'pyproject.toml'
               - 'uv.lock'
+              # tests/ and docker-compose.yml were missing here, so a
+              # compose edit could break tests/test_compose_network_isolation.py
+              # and no lane would run it. That is how the cli docker.sock
+              # regression from #625 stayed red on main.
+              - 'tests/**'
+              - 'docker-compose.yml'
               - '.github/workflows/ci.yml'
             cli:
               - 'clients/cli/**'

--- a/tests/test_compose_network_isolation.py
+++ b/tests/test_compose_network_isolation.py
@@ -68,12 +68,25 @@ OPERATIONAL_ONLY: frozenset[str] = frozenset(
 )
 
 # The only services permitted on BOTH networks. Adding a third
-# requires an ADR + a deliberate update here. See
-# docs/adr/0002-pr-tiering-and-blast-radius.md.
+# requires an ADR + a deliberate update here.
 DUAL_HOMED_SERVICES: frozenset[str] = frozenset(
     {
         "neo4j",
         "langgraph",
+    }
+)
+
+# The only services permitted to mount the host docker socket. `cli` needs
+# it for the /web slash command, which shells out to
+# `docker compose --profile web up -d web` against the host daemon (#625).
+# It is a client, not an agent: it executes operator keystrokes, never
+# model-directed commands, so it is not the container-escape surface this
+# guard exists for. Multi-tenant deployments drop the mount via a compose
+# overlay. Adding a service that *does* run agent code here is not a
+# deliberate update — it is the regression this test catches.
+DOCKER_SOCKET_SERVICES: frozenset[str] = frozenset(
+    {
+        "cli",
     }
 )
 
@@ -201,27 +214,36 @@ def test_no_service_uses_host_networking():
     )
 
 
-def test_no_service_mounts_docker_socket():
-    """``/var/run/docker.sock`` was removed deliberately.
+def test_only_allowlisted_services_mount_docker_socket():
+    """``/var/run/docker.sock`` is confined to DOCKER_SOCKET_SERVICES.
 
     The HTTP-only sandbox migration replaced ``docker exec`` with a
     FastAPI daemon on port 9999 inside the sandbox container. Mounting
-    the docker socket anywhere reintroduces a container-escape path —
-    a compromised process inside the mounted container can spawn or
+    the docker socket into a service that runs agent code reintroduces a
+    container-escape path — a compromised process there can spawn or
     modify peer containers, including the management plane.
     """
     services = _rendered_compose()["services"]
-    violations: list[str] = []
+    actual: set[str] = set()
     for name, svc in services.items():
-        for src in _service_volumes(svc):
-            if "docker.sock" in src:
-                violations.append(f"{name}: {src}")
-    assert not violations, (
-        "services mounting docker.sock (forbidden):\n  "
-        + "\n  ".join(violations)
-        + "\n\nFix: use the sandbox HTTP daemon (port 9999) instead "
-        "of docker exec. See packages/decepticon/decepticon/backends/."
-    )
+        if any("docker.sock" in src for src in _service_volumes(svc)):
+            actual.add(name)
+    unexpected = actual - DOCKER_SOCKET_SERVICES
+    stale = DOCKER_SOCKET_SERVICES - actual
+    msgs: list[str] = []
+    if unexpected:
+        msgs.append(
+            f"services mounting docker.sock without an allowlist entry: {sorted(unexpected)}\n"
+            "Fix: use the sandbox HTTP daemon (port 9999) instead of docker exec "
+            "(see packages/decepticon/decepticon/backends/), or — if the service runs "
+            "no agent code — add it to DOCKER_SOCKET_SERVICES with the reason."
+        )
+    if stale:
+        msgs.append(
+            f"DOCKER_SOCKET_SERVICES lists services that no longer mount it: {sorted(stale)}\n"
+            "Fix: drop the stale entry so the allowlist stays honest."
+        )
+    assert not msgs, "\n\n".join(msgs)
 
 
 def test_published_ports_bind_to_loopback():


### PR DESCRIPTION
## Summary

`tests/test_compose_network_isolation.py::test_no_service_mounts_docker_socket` has
been **failing on `main`** since #625. That PR deliberately added
`/var/run/docker.sock` to the `cli` service — the `/web` slash command shells out to
`docker compose --profile web up -d web` against the host daemon — and did not update
the test that #263 had added to lock the mount out.

It stayed unnoticed because **neither `tests/**` nor `docker-compose.yml` is in
`ci.yml`'s `python` path filter**, so the lane that runs pytest never fires for a
compose or test edit. `CONTRIBUTING_AGENT.md` §2.4 asks contributors to run the
isolation suite by hand after touching compose — that human step was what
compensated for the missing filter, and it did not hold.

## Changes

- `tests/test_compose_network_isolation.py`: convert the test to an allowlist,
  mirroring the existing `DUAL_HOMED_SERVICES` pattern. `DOCKER_SOCKET_SERVICES =
  {"cli"}`, with the reason recorded inline. Renamed to
  `test_only_allowlisted_services_mount_docker_socket` since that is what it now
  asserts. It fails on **both** an un-allowlisted mount *and* a stale allowlist
  entry, so the exception cannot outlive its reason.
- `.github/workflows/ci.yml`: add `tests/**` and `docker-compose.yml` to the `python`
  filter.
- Drop a now-stale reference to ADR-0002 from the `DUAL_HOMED_SERVICES` comment
  (superseded by ADR-0012 in #779).

Why an allowlist and not removing the mount: `cli` is a client, not an agent. It
executes operator keystrokes, never model-directed commands, so it is not the
container-escape surface this guard exists for — and multi-tenant deployments drop
the mount via a compose overlay, which is stated in `docker-compose.yml` at the
mount itself. Removing it would break `/web`.

## Intent

- **Issue / ADR this satisfies:** regression from #625; CI gap that hid it.
- **Anti-goal:** does not touch the `cli` service or `/web`. Does not relax the
  network-isolation tests. Does not attempt to make `tests/**` changes trigger the
  CLI/Web/launcher lanes — only the Python lane, which is the one that runs pytest.

## Blast radius

- [x] **Tier-supply-chain** — `.github/workflows/ci.yml`.

**Why this touches a supply-chain surface:** it widens the `python` path filter, so
the `pytest` lane now fires on more PRs. That makes `CI OK (required status)` stricter,
never weaker. The invariant being changed is the docker-socket rule itself: it goes
from "no service may mount it" (which `main` violates) to "only `cli` may mount it,
and the allowlist must stay accurate."

## Diff budget

2 files, 1 logical concern, 0 runtime-code lines (`tests/**`, `.github/**` excluded).

- [x] My diff fits the budget.

## End-to-end verification

```
$ uv run pytest tests/test_compose_network_isolation.py -q
.....                                                          [100%]
5 passed in 4.16s
```

Before this branch, on `origin/main` at `7c9ba715` with the branch stashed:

```
FAILED tests/test_compose_network_isolation.py::test_no_service_mounts_docker_socket
assert not ['cli: /var/run/docker.sock']
1 failed
```

**Negative cases exercised against the real rendered compose file**, because a guard
that cannot fail is not a guard. Ran the test function with the constant patched:

```
allowlist emptied      -> AssertionError: services mounting docker.sock without an
                          allowlist entry: ['cli']                            PASS
allowlist + langgraph  -> AssertionError: DOCKER_SOCKET_SERVICES lists services that
                          no longer mount it: ['langgraph']                   PASS
```

So it still catches a new un-allowlisted mount, and it now also catches an allowlist
entry that has outlived its mount.

Confirmed the old test name is referenced nowhere else in the repo (`grep -rn`, 0 hits
outside `.git`).

## Testing

- [x] `uv run pytest tests/test_compose_network_isolation.py -q` → 5 passed
- [x] `uv run ruff check` → All checks passed
- [x] `uv run ruff format --check` → 1 file already formatted
- [x] Watched the test fail without the change and pass with it (output above)
- [ ] `make smoke` — not run: no compose service definition, image, or network is
      changed by this diff, only the test that reads compose and one CI path filter.

## Quality Bar self-check

- [x] No banned pattern in the diff.
- [x] No AI-slop signature survives.
- [x] Every changed line traces to the stated intent.
- [x] I would merge this PR if a stranger opened it.
