### PR TITLE
fix(ci): validate the promote-stable soak_days input before arithmetic

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       soak_days:
-        description: "Soak window in days (release must be at least this old)"
+        description: "Soak window in days — whole number, clamped to a 7-day floor"
         default: "7"
 
 permissions:
@@ -41,10 +41,28 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOAK_DAYS: ${{ github.event.inputs.soak_days || '7' }}
+          SOAK_DAYS_INPUT: ${{ github.event.inputs.soak_days || '7' }}
         run: |
           set -euo pipefail
-          soak_seconds=$(( SOAK_DAYS * 86400 ))
+          # SOAK_DAYS_INPUT is operator-supplied on workflow_dispatch, so it
+          # must be validated before it reaches an arithmetic context.
+          # Command substitution executes inside $(( )) via array-subscript
+          # evaluation — `SOAK_DAYS=$'PATH[$(cmd)]'` runs cmd, and `set -euo
+          # pipefail` does not stop it because the command runs before the
+          # arithmetic error. Digits only, no sign, no expression.
+          if [[ ! "${SOAK_DAYS_INPUT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::soak_days must be a whole number of days."
+            exit 1
+          fi
+          # Floor at 7. Lengthening the soak is a safe direction; shortening
+          # it would let one dispatch hand :stable a release that has not
+          # baked, and :stable is the channel OSS users auto-update from.
+          soak_days="${SOAK_DAYS_INPUT}"
+          if (( soak_days < 7 )); then
+            echo "::notice::soak_days=${soak_days} is below the 7-day floor; using 7."
+            soak_days=7
+          fi
+          soak_seconds=$(( soak_days * 86400 ))
           # Newest FINAL (non-draft, non-prerelease) release whose
           # published_at is at least the soak window in the past, by SemVer.
           version=$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=30" --jq "
@@ -57,7 +75,7 @@ jobs:
             | last // \"\"
           ")
           if [[ -z "${version}" ]]; then
-            echo "No final release has soaked >= ${SOAK_DAYS}d yet — nothing to promote."
+            echo "No final release has soaked >= ${soak_days}d yet — nothing to promote."
             echo "promote=false" >> "$GITHUB_OUTPUT"
           else
             echo "Soaked stable target: ${version}"


### PR DESCRIPTION
## Summary

`promote-stable.yml` took a free-form `workflow_dispatch` string, `soak_days`, and
passed it straight into `soak_seconds=$(( SOAK_DAYS * 86400 ))`. Bash performs
command substitution inside an arithmetic context while evaluating an array
subscript, so that input could execute code on the runner. `set -euo pipefail` does
not prevent it: the substituted command runs *before* the arithmetic error is raised.

## Why it mattered more than the soak window

The job declares `packages: write`, is logged in to `ghcr.io` with `GITHUB_TOKEN`,
and — unlike every job in `release.yml` — **has no environment gate**. So this was a
path from repository write access to pushing images to GHCR while skipping the
`pypi-release` approval that gates the normal release path. Its whole purpose is to
move the `:stable` tag, which is the channel OSS users auto-update from.

Scope of exposure: triggering `workflow_dispatch` requires write access, so this is a
malicious-or-compromised-collaborator issue, not something an outside contributor or
a forked PR can reach. It is not remotely exploitable.

## Changes

`.github/workflows/promote-stable.yml`:

- Rename the env var to `SOAK_DAYS_INPUT` to make it obvious at the use site that the
  value is unvalidated.
- Reject anything that is not digits-only before it reaches any arithmetic context.
- **Floor the value at 7** instead of removing the knob. Lengthening the soak is a
  safe direction; shortening it would let a single dispatch hand `:stable` a release
  that has not baked.
- Record the reason inline, so the guard is not deleted later as noise.

## Intent

- **Issue / ADR this satisfies:** none — found while auditing `.github/` after #779.
- **Anti-goal:** does not add an environment gate. It could not work anyway —
  `pypi-release`'s deployment branch policy is `[{name: "v*", type: "tag"}]`, and this
  workflow runs on `schedule` / `workflow_dispatch` against `main`, so it cannot use
  that environment. Creating a second gated environment would also require approving
  the daily cron run. Validating the input closes the hole at the source instead.

## Root-cause sweep

Checked every other place an untrusted value could reach a shell:

| Location | Verdict |
|---|---|
| `promote-stable.yml:47` `$(( SOAK_DAYS * 86400 ))` | **the sink — fixed here** |
| `release.yml` ×3 `$((30 * attempt))` | safe — `attempt` is an internal loop counter |
| `release-recover.yml` `inputs.version` | safe — passed via `env:`, only used in quoted strings and one `[[ == ]]`, never in arithmetic or `eval` |
| `.github/actions/decepticon-scan/action.yml` | safe — every input goes through `env:`, none reaches arithmetic |
| `ci.yml:328,334` `${{ github.base_ref }}` | safe — the PR's *target* branch, repo-controlled, not contributor-controlled |
| `ci.yml:411` `${{ runner.os }}-${{ runner.arch }}`, `release.yml` `${{ runner.temp }}` | safe — GitHub-controlled |
| `security.yml:182` base SHA | safe — SHA |

No `pull_request_target` anywhere in the repo, and all 98 action references are
SHA-pinned.

## Blast radius

- [x] **Tier-supply-chain** — `.github/workflows/promote-stable.yml`.

**Why this touches a supply-chain surface:** it is the workflow that moves the GHCR
`:stable` tag, and the change is what stops an unvalidated dispatch input from
running on the runner that holds the push token.

## Diff budget

1 file, 1 logical concern, 0 runtime-code lines (`.github/**` excluded).

- [x] My diff fits the budget.

## End-to-end verification

Ran the exact guard snippet from the diff as a standalone script, with the real
payload shapes and the real edge cases. `injected` is whether a side-effect file
appeared, i.e. whether code executed:

```
input='PATH[$(touch m1)]'    -> ::error::soak_days must be a whole number     injected:NO
input='HOME[$(touch m2)]+0'  -> ::error::soak_days must be a whole number     injected:NO
input='0'                    -> OK soak_days=7  soak_seconds=604800           injected:NO
input='3'                    -> OK soak_days=7  soak_seconds=604800           injected:NO
input='7'                    -> OK soak_days=7  soak_seconds=604800           injected:NO
input='30'                   -> OK soak_days=30 soak_seconds=2592000          injected:NO
input='-1'                   -> ::error::soak_days must be a whole number     injected:NO
input='7.5'                  -> ::error::soak_days must be a whole number     injected:NO
input='1e3'                  -> ::error::soak_days must be a whole number     injected:NO
input=''                     -> ::error::soak_days must be a whole number     injected:NO
```

**Confirmed the vulnerability first, against the unpatched snippet**, so this is not a
speculative hardening: with `soak_seconds=$(( SOAK_DAYS * 86400 ))` alone and
`set -euo pipefail` set, both payloads created their side-effect file and *then*
failed with `syntax error: operand expected`. That is the whole bug — the command runs
before the error.

The empty-string row is defence in depth only; `${{ github.event.inputs.soak_days ||
'7' }}` already resolves empty to `7`, which is also why the scheduled path is
unaffected.

YAML re-parses clean: `yaml.safe_load` → `jobs: ['promote-stable']`, dispatch inputs
`['soak_days']`. `actionlint` is not installed locally; the `actionlint` CI job covers it.

## Testing

- [x] Guard logic executed against injection payloads and 8 edge cases (above)
- [x] Vulnerability reproduced on the unpatched snippet before fixing
- [x] Workflow YAML re-parses
- [ ] The workflow itself was not dispatched — doing so would move the real `:stable`
      GHCR tag. The changed step is pure input validation ahead of the existing
      resolve logic, which is unmodified, and the scheduled path resolves to the same
      `soak_days=7` it did before.

## Quality Bar self-check

- [x] No banned pattern in the diff.
- [x] No AI-slop signature survives.
- [x] Every changed line traces to the stated intent.
- [x] I would merge this PR if a stranger opened it.
