### PR TITLE
ci: scope workflow write permissions to the jobs that use them

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -16,9 +16,13 @@ on:
         description: "Soak window in days — whole number, clamped to a 7-day floor"
         default: "7"
 
+# Default the workflow to read-only and grant the write scope on the one job
+# that needs it. This workflow has a single job, so the effect is identical —
+# but a top-level `packages: write` would be inherited by any job added later
+# without anyone having to ask for it, and that is what Scorecard's
+# Token-Permissions check flags.
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: promote-stable
@@ -28,6 +32,9 @@ jobs:
   promote-stable:
     name: Promote :stable to the newest soaked final
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # gh api reads the release list; no checkout in this job
+      packages: write # retag :stable in GHCR
     steps:
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -13,15 +13,20 @@ on:
         default: true
         type: boolean
 
+# Read-only by default; the write scopes live on the job that uses them. Single
+# job today, so behaviour is unchanged — the point is that a job added later
+# does not silently inherit `contents: write` + `packages: write`.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   finalize:
     name: Verify images & promote release
     runs-on: ubuntu-latest
     environment: pypi-release
+    permissions:
+      contents: write # gh release edit --draft=false / --prerelease
+      packages: write # retag GHCR images to :latest
     steps:
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:


### PR DESCRIPTION
## Summary

`promote-stable.yml` and `release-recover.yml` declared their write scopes at
**workflow** level. Both files have exactly one job, so the effective permissions are
identical either way — but a top-level write scope is inherited by any job added
later without anyone having to ask for it. That is what OpenSSF Scorecard's
`Token-Permissions` check flags, and it names both files explicitly:

```
Warn: topLevel 'packages' permission set to 'write': .github/workflows/promote-stable.yml:21
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-recover.yml:17
Warn: topLevel 'packages' permission set to 'write': .github/workflows/release-recover.yml:18
```

Default both to `contents: read` and move the write scopes onto the job, each with a
comment naming what it is for.

## Changes

| File | Before (workflow level) | After (workflow level) | After (job level) |
|---|---|---|---|
| `promote-stable.yml` | `contents: read`, `packages: write` | `contents: read` | `contents: read`, `packages: write` |
| `release-recover.yml` | `contents: write`, `packages: write` | `contents: read` | `contents: write`, `packages: write` |

## Intent

- **Issue / ADR this satisfies:** OpenSSF Scorecard `Token-Permissions: 0` on
  `PurpleAILAB/Decepticon` (measured 2026-07-26 at `a7567c57`).
- **Anti-goal:** **`release.yml` is deliberately untouched.** It has eight jobs, a
  job-level `permissions:` block *replaces* rather than extends the workflow default,
  and getting one scope wrong there breaks a release at tag-push time — which cannot
  be verified without cutting a real release. The cost/benefit does not justify it:
  `Token-Permissions: 0` is what nodejs, curl, sigstore/cosign, langchain and nuclei
  all score, so this is not an outlier finding. Revisit alongside the next release,
  when the change can actually be observed.

## Blast radius

- [x] **Tier-supply-chain** — two release-path workflows.

**Why this touches a supply-chain surface:** both workflows push to GHCR. The change
narrows what their `GITHUB_TOKEN` can do; it cannot widen it. The invariant being
changed is *where* the write scope is declared, not what it grants today.

## Diff budget

2 files, 1 logical concern, 0 runtime-code lines (`.github/**` excluded).

- [x] My diff fits the budget.

## End-to-end verification

Not a dry run — `promote-stable` was **dispatched from this branch** and completed
successfully, exercising the exact path the changed permission governs. It was a
genuine no-op: `:stable` was already at `1.1.38` (the daily cron promoted it on
2026-07-19 once v1.1.38 passed the 7-day soak), so the run re-pointed the tag to the
same digest.

```
run 30227158382  headBranch=ci/scope-workflow-token-permissions  event=workflow_dispatch
  ✓ Set up job
  ✓ docker/login-action
  ✓ docker/setup-buildx-action
  ✓ Resolve newest soaked final release
  ✓ Promote :<version> → :stable
```

Log excerpts — the GHCR **write** is the thing being proven, and it happened under the
new job-level `packages: write` with no 403:

```
Soaked stable target: 1.1.38
Promoting ghcr.io/purpleailab/decepticon-litellm:1.1.38 → ghcr.io/purpleailab/decepticon-litellm:stable
  #1 0.320 pushing sha256:9b1be04f… to ghcr.io/purpleailab/decepticon-litellm:stable
Promoting ghcr.io/purpleailab/decepticon-langgraph:1.1.38 → ghcr.io/purpleailab/decepticon-langgraph:stable
  #1 0.306 pushing sha256:3c7907ed… to ghcr.io/purpleailab/decepticon-langgraph:stable
```

That run also confirms #781's input guard behaves correctly in production —
`soak_days` resolved through the digits-only check and the 7-day floor to select
`1.1.38`.

`release-recover.yml` was **not** dispatched: it retags images to `:latest` and undrafts
a GitHub Release, so running it to prove a permissions refactor would have real side
effects. Its change is structurally identical to `promote-stable`'s (single job, same
two scopes, one of which is the same `packages: write` just proven), and
`yaml.safe_load` confirms the resulting structure:

```
promote-stable.yml   top={'contents': 'read'}  job[promote-stable]={'contents': 'read', 'packages': 'write'}
release-recover.yml  top={'contents': 'read'}  job[finalize]={'contents': 'write', 'packages': 'write'}
```

## Unrelated observation from the run history (not fixed here)

The scheduled `promote-stable` run on 2026-07-26 **failed**, on
`docker/setup-buildx-action`:

```
ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

A Docker Hub timeout pulling `moby/buildkit`, not a code fault — 07-19 through 07-25
all succeeded and the job is idempotent, so the next day's cron self-heals. Worth a
separate PR to wrap that step in the same retry-with-backoff loop `release.yml`
already uses (`delay=$((30 * attempt))`), rather than bundling it here.

## Testing

- [x] `promote-stable` dispatched from this branch → success, GHCR write observed
- [x] Both files re-parse; effective permissions confirmed unchanged
- [ ] `release-recover` not dispatched — see above

## Quality Bar self-check

- [x] No banned pattern in the diff.
- [x] No AI-slop signature survives.
- [x] Every changed line traces to the stated intent.
- [x] I would merge this PR if a stranger opened it.
