### PR TITLE
ci(renovate): enable OSV alerts and digest pinning, record the activation trap

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,10 +13,24 @@
   //     supply-chain story tight (cosign, SBOM, scorecard etc. all run
   //     per PR via the existing security workflow).
   //
-  // Activation: the Renovate GitHub App must be installed on the
-  // PurpleAILAB organization (https://github.com/apps/renovate). Once
-  // installed, Renovate picks up this file from .github/renovate.json5
-  // automatically. No secrets required.
+  // ACTIVATION — this file does nothing on its own.
+  //
+  // Renovate runs as a GitHub App. This config was committed long before
+  // the app was installed, so for months it was inert: no PRs, no
+  // branches, no dependency dashboard, zero Renovate activity in the
+  // repo's history. That is how 83 open advisories (3 critical, 31 high,
+  // 57 runtime-scope) accumulated. The app was installed on the
+  // PurpleAILAB organization on 2026-07-27.
+  //
+  // The trap worth naming, because it is what hid this: OpenSSF Scorecard
+  // awards Dependency-Update-Tool 10/10 for the mere *presence* of this
+  // file. It cannot see whether the app is installed. A green score here
+  // is not evidence that anything runs — verify with actual Renovate PRs
+  // or the dependency dashboard issue, never with the score.
+  //
+  // Installation is a browser OAuth flow with no REST API, so it cannot be
+  // scripted or asserted in CI. If Renovate ever goes quiet, check the
+  // installation before debugging this file. No secrets required.
 
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
@@ -30,6 +44,20 @@
   timezone: "UTC",
   semanticCommitType: "chore",
   semanticCommitScope: "deps",
+  // Advisories from osv.dev on top of GitHub's, plus Renovate's
+  // malicious-package detection. Default is false. GitHub's advisory feed
+  // alone misses ecosystems and lags OSV on some CVEs, which is not a
+  // trade-off an offensive-security tool should be making about its own
+  // dependency graph.
+  osvVulnerabilityAlerts: true,
+  // Pin Docker base images by digest, and keep the digests current.
+  // Default is false, which is why `python:3.13-slim`, `node:24-slim` and
+  // `ghcr.io/berriai/litellm:v1.88.1` are still floating tags — the single
+  // largest deduction in Scorecard's Pinned-Dependencies check for this
+  // repo. Pinning by hand would be worse than not pinning: a frozen digest
+  // nobody bumps stops receiving base-image CVE fixes. Renovate has to own
+  // both halves or neither.
+  pinDigests: true,
   // Keep noise in check: at most 5 PRs/hour, 10 concurrent open.
   prHourlyLimit: 5,
   prConcurrentLimit: 10,
@@ -71,6 +99,12 @@
       labels: ["dependencies", "major-update"],
     },
   ],
+  // Only `labels` is set here on purpose. Renovate merges this over its
+  // own defaults, which already do the right thing for security work:
+  // `schedule: []` (so the weekly schedule above does NOT delay a security
+  // fix), `prCreation: "immediate"`, `rangeStrategy: "update-lockfile"`,
+  // and a `[SECURITY]` commit suffix. Re-stating them here would only
+  // create a second place to keep in sync.
   vulnerabilityAlerts: {
     labels: ["security", "dependencies"],
   },


### PR DESCRIPTION
## Summary

The Renovate GitHub App was installed on the PurpleAILAB org on **2026-07-27**.
`.github/renovate.json5` had been committed long before that, so it had **never run
once** — zero Renovate PRs, branches, or dependency dashboard in the repo's history.
That is how **83 open advisories** (3 critical, 31 high, 57 runtime-scope) accumulated.

Now that it actually runs, two defaults are worth flipping, and one non-obvious trap
is worth writing down.

## Changes

**`osvVulnerabilityAlerts: true`** (default `false`) — adds osv.dev advisories on top
of GitHub's feed, plus Renovate's malicious-package detection. GitHub's advisory feed
alone misses ecosystems and lags OSV on some CVEs. That is not a trade-off an
offensive-security tool should be making about its own dependency graph.

**`pinDigests: true`** (default `false`) — pins Docker base images by digest *and*
keeps the digests current. `python:3.13-slim`, `node:24-slim` and
`ghcr.io/berriai/litellm:v1.88.1` are floating tags today, and they are the single
largest deduction in Scorecard's `Pinned-Dependencies` check for this repo (7/10).

Pinning them by hand would have been **worse** than leaving them floating: a frozen
digest that nobody bumps silently stops receiving base-image CVE fixes. Renovate has
to own both halves — the pin and the bump — or neither. That is why this lands now,
with the app installed, and not as a manual Dockerfile PR earlier.

**Comment on `vulnerabilityAlerts`** — it is deliberately left at just `labels`. I
checked Renovate's published schema rather than assuming; the defaults already do the
right thing:

```json
{"schedule": [], "prCreation": "immediate", "rangeStrategy": "update-lockfile",
 "commitMessageSuffix": "[SECURITY]", "minimumReleaseAge": null, ...}
```

`schedule: []` means the repo's `schedule:weekly` does **not** delay a security fix —
which was my first assumption and it was wrong. Restating those keys here would only
create a second place to keep in sync, so the comment records why the block is thin.

**Activation comment rewritten** to name the trap that hid this for months: OpenSSF
Scorecard awards `Dependency-Update-Tool: 10/10` for the mere *presence* of this file.
It cannot see whether the app is installed. **A green score there was not evidence
that anything was running.** The comment now says to verify with real Renovate PRs or
the dashboard issue, and to check the installation first if Renovate ever goes quiet.

## Intent

- **Issue / ADR this satisfies:** the `Vulnerabilities: 0` / 83-advisory finding, and
  `Pinned-Dependencies: 7`.
- **Anti-goal:** does not enable auto-merge — the existing "every PR is reviewed
  manually" stance is unchanged. Does not touch any Dockerfile: the digests are
  Renovate's to introduce, so they arrive already under maintenance.

## Blast radius

- [x] **Tier-supply-chain** — this file governs what dependency changes get proposed.

**Why this touches a supply-chain surface:** it widens what Renovate proposes (OSV
advisories) and changes how base images are referenced (digest instead of tag). Both
narrow the trust surface; neither can land anything without a reviewed PR.

## Diff budget

1 file, 1 logical concern, 0 runtime-code lines (`.github/**` excluded).

- [x] My diff fits the budget.

## End-to-end verification

Config validated with Renovate's own validator, before and after the edit:

```
$ npx --package renovate renovate-config-validator .github/renovate.json5
 INFO: Config validated successfully against 1 file(s)
```

Defaults were read from the **published schema**, not from memory —
`docs.renovatebot.com/renovate-schema.json`, which is what produced the
`vulnerabilityAlerts` correction above and confirmed `osvVulnerabilityAlerts` and
`pinDigests` both default to `false`.

Installation confirmed against the live API rather than trusted:

```
$ gh api orgs/PurpleAILAB/installations
  app_slug: renovate   repository_selection: all   created_at: 2026-07-27T09:26:53+09:00
  permissions: contents:write, pull_requests:write, workflows:write,
               checks:write, statuses:write, issues:write, vulnerability_alerts:read
```

`workflows: write` is present, which Renovate needs to bump pinned action SHAs in
`.github/workflows/**`. Those bumps will still satisfy the repo's new
`sha_pinning_required` Actions policy, because Renovate writes full 40-char SHAs with
a version comment — the same format the workflows already use.

Also verified Renovate can maintain `uv.lock` rather than leaving it stale against an
updated `pyproject.toml` — which would have failed CI's `uv --frozen` on every Python
PR. The schema exposes `uv` as an installable Containerbase tool with its own
`constraints.uv` entry, so lockfile regeneration is supported.

Not yet observable at time of writing: no Renovate branch, PR, or dashboard issue
exists yet (`git ls-remote --heads origin | grep -c renovate` → `0`). The app was
installed minutes ago and has not completed its first run. **This PR should be
merged before that first run** so the two flipped defaults apply to it.

## Follow-up, not in this PR

The app was installed with **`repository_selection: all`**. Renovate will therefore
try to onboard *every* org repo, including `bb_Decepticon`, `obsidian-kg`, and the
`xbow-validation-benchmarks` fork of an external upstream — each getting a "Configure
Renovate" onboarding PR. Narrowing the installation to selected repositories is a
UI-only change and worth doing before the noise lands.

## Testing

- [x] `renovate-config-validator` passes
- [x] Option defaults confirmed against the published schema
- [x] App installation and permissions confirmed against the live API
- [ ] Renovate's first run has not happened yet — behaviour of the two flipped
      options will be visible on the first dashboard/PR batch

## Quality Bar self-check

- [x] No banned pattern in the diff.
- [x] No AI-slop signature survives.
- [x] Every changed line traces to the stated intent.
- [x] I would merge this PR if a stranger opened it.
