### PR TITLE
fix(llm): stream tokens instead of faking it (Claude Code + Codex lanes)

### DIFF
--- a/config/claude_code_handler.py
+++ b/config/claude_code_handler.py
@@ -26,13 +26,14 @@ from __future__ import annotations
 import json
 import os
 import time
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Iterable, Iterator
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
 import litellm
+from http_client import async_client, sync_client
 from http_client import post as _http_post
 from litellm import CustomLLM, ModelResponse
 from oauth_token_store import (
@@ -399,29 +400,20 @@ class ClaudeCodeCustomHandler(CustomLLM):
     The part after the ``/`` maps to the actual Anthropic model ID.
     """
 
-    def completion(
+    def _build_anthropic_request(
         self,
         model: str,
         messages: list[dict[str, Any]],
-        api_base: str | None = None,
-        custom_prompt_dict: dict[str, Any] | None = None,
-        model_response: ModelResponse | None = None,
-        print_verbose: Any = None,
-        encoding: Any = None,
-        logging_obj: Any = None,
-        optional_params: dict[str, Any] | None = None,
-        acompletion: bool | None = None,
-        timeout: float | None = None,
-        litellm_params: dict[str, Any] | None = None,
-        logger_fn: Any = None,
-        headers: dict[str, str] | None = None,
-        **kwargs: Any,
-    ) -> ModelResponse:
-        """Route completion directly to Anthropic Messages API with OAuth.
+        optional_params: dict[str, Any] | None,
+        api_base: str | None,
+        *,
+        stream: bool = False,
+    ) -> tuple[str, str, str]:
+        """Build the Anthropic Messages API request.
 
-        Unlike API-key auth (x-api-key header), OAuth uses
-        Authorization: Bearer header + Claude Code spoofing headers.
-        This makes the request indistinguishable from a real Claude Code session.
+        Shared by the buffered (``completion``) and token-streaming
+        (``streaming`` / ``astreaming``) paths so both send the same body.
+        Returns ``(body_str, api_url, actual_model)``.
         """
         # Extract actual Anthropic model ID
         # "auth/claude-sonnet-4-6" -> "claude-sonnet-4-6"
@@ -617,11 +609,46 @@ class ClaudeCodeCustomHandler(CustomLLM):
                     "name": tool_choice["function"]["name"],
                 }
 
+        # Streaming is a per-request flag on the same body — the buffered and
+        # streaming paths must otherwise send byte-identical requests so prompt
+        # caching hits the same prefix.
+        if stream:
+            request_body["stream"] = True
+
         body_str = json.dumps(request_body)
 
         # Direct HTTP call to Anthropic Messages API. Never honor arbitrary
         # api_base values here: this request carries an OAuth bearer token.
         api_url = _resolve_anthropic_api_base(api_base)
+        return body_str, api_url, actual_model
+
+    def completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        api_base: str | None = None,
+        custom_prompt_dict: dict[str, Any] | None = None,
+        model_response: ModelResponse | None = None,
+        print_verbose: Any = None,
+        encoding: Any = None,
+        logging_obj: Any = None,
+        optional_params: dict[str, Any] | None = None,
+        acompletion: bool | None = None,
+        timeout: float | None = None,
+        litellm_params: dict[str, Any] | None = None,
+        logger_fn: Any = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        """Route completion directly to Anthropic Messages API with OAuth.
+
+        Unlike API-key auth (x-api-key header), OAuth uses
+        Authorization: Bearer header + Claude Code spoofing headers.
+        This makes the request indistinguishable from a real Claude Code session.
+        """
+        body_str, api_url, actual_model = self._build_anthropic_request(
+            model, messages, optional_params, api_base, stream=False
+        )
 
         def _send(force_refresh: bool) -> httpx.Response:
             access_token = get_access_token(force_refresh=force_refresh)
@@ -921,16 +948,302 @@ class ClaudeCodeCustomHandler(CustomLLM):
 
         return chunks
 
-    def streaming(self, *args: Any, **kwargs: Any) -> Iterator[dict[str, Any]]:
-        """Sync streaming — call completion and yield as chunks."""
-        response = self.completion(*args, **kwargs)
-        yield from self._response_to_chunks(response)
+    def streaming(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        api_base: str | None = None,
+        custom_prompt_dict: dict[str, Any] | None = None,
+        model_response: ModelResponse | None = None,
+        print_verbose: Any = None,
+        encoding: Any = None,
+        logging_obj: Any = None,
+        optional_params: dict[str, Any] | None = None,
+        acompletion: bool | None = None,
+        timeout: float | None = None,
+        litellm_params: dict[str, Any] | None = None,
+        logger_fn: Any = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> Iterator[dict[str, Any]]:
+        """Sync token streaming, straight off the Anthropic SSE response."""
+        body_str, api_url, _ = self._build_anthropic_request(
+            model, messages, optional_params, api_base, stream=True
+        )
+        with sync_client(timeout=timeout or 600) as client:
+            for force_refresh in (False, True):
+                req_headers = _build_headers(get_access_token(force_refresh=force_refresh))
+                with client.stream(
+                    "POST",
+                    f"{api_url}/v1/messages?beta=true",
+                    content=body_str,
+                    headers=req_headers,
+                ) as resp:
+                    if resp.status_code == 401 and not force_refresh:
+                        resp.read()
+                        continue
+                    _raise_for_stream_status(resp, model)
+                    yield from _anthropic_sse_to_chunks(resp.iter_lines())
+                    return
 
-    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:
-        """Async streaming — call acompletion and yield as chunks."""
-        response = await self.acompletion(*args, **kwargs)
-        for chunk in self._response_to_chunks(response):
-            yield chunk
+    async def astreaming(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        api_base: str | None = None,
+        custom_prompt_dict: dict[str, Any] | None = None,
+        model_response: ModelResponse | None = None,
+        print_verbose: Any = None,
+        encoding: Any = None,
+        logging_obj: Any = None,
+        optional_params: dict[str, Any] | None = None,
+        acompletion: bool | None = None,
+        timeout: float | None = None,
+        litellm_params: dict[str, Any] | None = None,
+        logger_fn: Any = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Async token streaming, straight off the Anthropic SSE response."""
+        body_str, api_url, _ = self._build_anthropic_request(
+            model, messages, optional_params, api_base, stream=True
+        )
+        async with async_client(timeout=timeout or 600) as client:
+            for force_refresh in (False, True):
+                req_headers = _build_headers(get_access_token(force_refresh=force_refresh))
+                async with client.stream(
+                    "POST",
+                    f"{api_url}/v1/messages?beta=true",
+                    content=body_str,
+                    headers=req_headers,
+                ) as resp:
+                    if resp.status_code == 401 and not force_refresh:
+                        await resp.aread()
+                        continue
+                    await _araise_for_stream_status(resp, model)
+                    # The SSE parser is a pure sync generator over decoded lines;
+                    # drive it by feeding one line at a time so nothing buffers.
+                    feed = _AnthropicSseAccumulator()
+                    async for line in resp.aiter_lines():
+                        for chunk in feed.push(line):
+                            yield chunk
+                    for chunk in feed.close():
+                        yield chunk
+                    return
+
+
+def _raise_for_stream_status(resp: httpx.Response, model: str) -> None:
+    """Translate a non-200 streaming response into the same typed errors the
+    buffered path raises. Reads the body first — it is still unread here."""
+    if resp.status_code == 200:
+        return
+    resp.read()
+    _raise_stream_error(resp.status_code, resp.text, model)
+
+
+async def _araise_for_stream_status(resp: httpx.Response, model: str) -> None:
+    """Async twin of :func:`_raise_for_stream_status`."""
+    if resp.status_code == 200:
+        return
+    await resp.aread()
+    _raise_stream_error(resp.status_code, resp.text, model)
+
+
+def _raise_stream_error(status_code: int, text: str, model: str) -> None:
+    if status_code == 401:
+        raise litellm.AuthenticationError(
+            message=(
+                "Claude Code authentication was rejected. Run 'claude /login' "
+                f"and retry. Underlying: {text}"
+            ),
+            model=model,
+            llm_provider="auth",
+        )
+    if status_code == 429:
+        raise litellm.RateLimitError(
+            message=f"Rate limit exceeded: {text}",
+            model=model,
+            llm_provider="auth",
+            response=httpx.Response(status_code=429),
+        )
+    raise litellm.APIError(
+        status_code=status_code,
+        message=f"Anthropic API error: {text}",
+        model=model,
+        llm_provider="auth",
+    )
+
+
+class _AnthropicSseAccumulator:
+    """Incremental Anthropic Messages SSE → GenericStreamingChunk translator.
+
+    Pure state machine over decoded SSE lines — no network, no httpx — so the
+    wire format is unit-testable. ``push`` returns the chunks a line produced
+    (usually zero or one); ``close`` flushes the terminating chunk if the
+    stream ended without an explicit ``message_stop``.
+
+    Chunk shape matches :meth:`ClaudeCodeCustomHandler._response_to_chunks` so
+    LiteLLM's stream wrapper sees one contract from both paths.
+    """
+
+    def __init__(self) -> None:
+        self._usage: dict[str, Any] = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+        # index → in-flight tool_use block (Anthropic streams its arguments as
+        # `input_json_delta` fragments that only parse once concatenated).
+        self._tool_blocks: dict[int, dict[str, Any]] = {}
+        self._tool_count = 0
+        self._stop_reason = ""
+        self._finished = False
+
+    def push(self, line: str) -> list[dict[str, Any]]:
+        line = line.strip()
+        if not line.startswith("data:"):
+            return []
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            return []
+        try:
+            event = json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        if not isinstance(event, dict):
+            return []
+        return self._dispatch(event)
+
+    def close(self) -> list[dict[str, Any]]:
+        if self._finished:
+            return []
+        return [self._final_chunk()]
+
+    # ── internals ────────────────────────────────────────────────────
+    def _dispatch(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        kind = event.get("type")
+
+        if kind == "message_start":
+            self._absorb_usage((event.get("message") or {}).get("usage"))
+            return []
+
+        if kind == "content_block_start":
+            block = event.get("content_block") or {}
+            if block.get("type") == "tool_use":
+                self._tool_blocks[int(event.get("index", 0))] = {
+                    "id": block.get("id", ""),
+                    "name": block.get("name", ""),
+                    "json": [],
+                }
+            return []
+
+        if kind == "content_block_delta":
+            return self._on_delta(event)
+
+        if kind == "content_block_stop":
+            return self._on_block_stop(int(event.get("index", 0)))
+
+        if kind == "message_delta":
+            stop = (event.get("delta") or {}).get("stop_reason")
+            if isinstance(stop, str):
+                self._stop_reason = stop
+            self._absorb_usage(event.get("usage"))
+            return []
+
+        if kind == "message_stop":
+            self._finished = True
+            return [self._final_chunk()]
+
+        # ping / error / unknown event types carry no chunk.
+        return []
+
+    def _on_delta(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        delta = event.get("delta") or {}
+        dtype = delta.get("type")
+        if dtype == "text_delta":
+            text = delta.get("text")
+            if not isinstance(text, str) or not text:
+                return []
+            return [
+                {
+                    "text": text,
+                    "is_finished": False,
+                    "finish_reason": "",
+                    "index": 0,
+                    "tool_use": None,
+                    "usage": None,
+                }
+            ]
+        if dtype == "input_json_delta":
+            block = self._tool_blocks.get(int(event.get("index", 0)))
+            fragment = delta.get("partial_json")
+            if block is not None and isinstance(fragment, str):
+                block["json"].append(fragment)
+            return []
+        # thinking_delta / signature_delta are not surfaced as assistant text.
+        return []
+
+    def _on_block_stop(self, index: int) -> list[dict[str, Any]]:
+        block = self._tool_blocks.pop(index, None)
+        if block is None:
+            return []
+        arguments = "".join(block["json"]) or "{}"
+        chunk = {
+            "text": "",
+            "is_finished": False,
+            "finish_reason": "",
+            "index": 0,
+            "tool_use": {
+                "id": block["id"],
+                "type": "function",
+                "function": {"name": block["name"], "arguments": arguments},
+                "index": self._tool_count,
+            },
+            "usage": None,
+        }
+        self._tool_count += 1
+        return [chunk]
+
+    def _absorb_usage(self, usage: Any) -> None:
+        if not isinstance(usage, dict):
+            return
+        # Anthropic reports input tokens on message_start and output tokens on
+        # message_delta, so both are merged in rather than overwritten.
+        if isinstance(usage.get("input_tokens"), int):
+            self._usage["prompt_tokens"] = usage["input_tokens"]
+        if isinstance(usage.get("output_tokens"), int):
+            self._usage["completion_tokens"] = usage["output_tokens"]
+        # Cache buckets ride through untouched — litellm's stream_chunk_builder
+        # reads these keys to price a cached streaming response correctly.
+        for key in ("cache_creation_input_tokens", "cache_read_input_tokens"):
+            if usage.get(key):
+                self._usage[key] = usage[key]
+        self._usage["total_tokens"] = (
+            self._usage["prompt_tokens"] + self._usage["completion_tokens"]
+        )
+
+    def _final_chunk(self) -> dict[str, Any]:
+        self._finished = True
+        if self._tool_count:
+            finish_reason = "tool_calls"
+        else:
+            finish_reason = _map_stop_reason(self._stop_reason) if self._stop_reason else "stop"
+        return {
+            "text": "",
+            "is_finished": True,
+            "finish_reason": finish_reason,
+            "index": 0,
+            "tool_use": None,
+            "usage": self._usage,
+        }
+
+
+def _anthropic_sse_to_chunks(lines: Iterable[str]) -> Iterator[dict[str, Any]]:
+    """Drive :class:`_AnthropicSseAccumulator` over a sync line iterator."""
+    accumulator = _AnthropicSseAccumulator()
+    for line in lines:
+        yield from accumulator.push(line)
+    yield from accumulator.close()
 
 
 def _map_stop_reason(anthropic_reason: str) -> str:

--- a/config/codex_chatgpt_handler.py
+++ b/config/codex_chatgpt_handler.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import httpx
 import litellm
+from http_client import async_client, sync_client
 from http_client import post as _http_post
 from litellm import CustomLLM, ModelResponse
 from oauth_token_store import (
@@ -470,6 +471,214 @@ def _completed_payload(resp: httpx.Response) -> dict[str, Any]:
     )
 
 
+def _raise_for_stream_status(resp: httpx.Response, model: str) -> None:
+    """Mirror the buffered path's typed errors for a streaming response."""
+    if resp.status_code < 400:
+        return
+    resp.read()
+    _raise_stream_error(resp.status_code, resp.text, model)
+
+
+async def _araise_for_stream_status(resp: httpx.Response, model: str) -> None:
+    """Async twin of :func:`_raise_for_stream_status`."""
+    if resp.status_code < 400:
+        return
+    await resp.aread()
+    _raise_stream_error(resp.status_code, resp.text, model)
+
+
+def _raise_stream_error(status_code: int, text: str, model: str) -> None:
+    if status_code == 401:
+        raise litellm.AuthenticationError(
+            message=(
+                "Codex ChatGPT authentication was rejected. Run 'codex logout' "
+                f"and 'codex login'. Underlying: {text}"
+            ),
+            model=model,
+            llm_provider="auth",
+        )
+    raise litellm.APIError(
+        status_code=status_code,
+        message=f"ChatGPT Codex API error: {text}",
+        model=model,
+        llm_provider="auth",
+    )
+
+
+class _CodexSseAccumulator:
+    """Responses-API SSE → GenericStreamingChunk translator.
+
+    The buffered path already walks this same event stream (see
+    :func:`_completed_payload`) but only after ``resp.text`` has pulled the
+    whole body, so the deltas it aggregates have all arrived before the first
+    chunk is emitted. This is the same walk driven incrementally: text deltas
+    are forwarded as they land, and function-call arguments are still
+    reassembled from their fragments before the tool chunk is released.
+
+    Pure state machine over decoded lines — no network — so the wire format is
+    unit-testable. Chunk shape matches
+    :meth:`CodexChatGPTCustomHandler._response_to_chunks`.
+    """
+
+    def __init__(self, model: str) -> None:
+        self._model = model
+        # item_id → in-flight function_call. The Responses API streams a call's
+        # name on `output_item.added` and its arguments as later fragments.
+        self._calls: dict[str, dict[str, Any]] = {}
+        self._emitted = 0
+        self._usage: dict[str, Any] = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+        self._finished = False
+        self._error: str | None = None
+
+    def push(self, line: str) -> list[dict[str, Any]]:
+        line = line.strip()
+        if not line.startswith("data:"):
+            return []
+        data = line.removeprefix("data:").strip()
+        if not data or data == "[DONE]":
+            return []
+        try:
+            event = json.loads(data)
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(event, dict):
+            return []
+        return self._dispatch(event)
+
+    def close(self) -> list[dict[str, Any]]:
+        if self._error is not None:
+            raise litellm.APIError(
+                status_code=500,
+                message=self._error,
+                model=self._model,
+                llm_provider="auth",
+            )
+        if self._finished:
+            return []
+        return [self._final_chunk()]
+
+    # ── internals ────────────────────────────────────────────────────
+    def _dispatch(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        kind = event.get("type")
+
+        if kind == "response.output_text.delta":
+            delta = event.get("delta")
+            if not isinstance(delta, str) or not delta:
+                return []
+            return [
+                {
+                    "text": delta,
+                    "is_finished": False,
+                    "finish_reason": "",
+                    "index": 0,
+                    "tool_use": None,
+                    "usage": None,
+                }
+            ]
+
+        if kind == "response.output_item.added":
+            item = event.get("item") or {}
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                item_id = item.get("id") or item.get("call_id") or "tool_call"
+                self._calls[item_id] = {
+                    "call_id": item.get("call_id") or item_id,
+                    "name": item.get("name") or "",
+                    "arguments": item.get("arguments") or "",
+                }
+            return []
+
+        if kind == "response.function_call_arguments.delta":
+            item_id = event.get("item_id") or event.get("call_id") or "tool_call"
+            entry = self._calls.setdefault(
+                item_id,
+                {"call_id": item_id, "name": event.get("name") or "", "arguments": ""},
+            )
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                entry["arguments"] += delta
+            return []
+
+        if kind == "response.output_item.done":
+            return self._on_item_done(event)
+
+        if kind == "response.completed":
+            payload = event.get("response")
+            if isinstance(payload, dict):
+                self._absorb_usage(payload.get("usage"))
+            self._finished = True
+            return [self._final_chunk()]
+
+        if kind in {"response.failed", "error"}:
+            err = event.get("error") or (event.get("response") or {}).get("error")
+            if isinstance(err, dict):
+                self._error = err.get("message") or json.dumps(err)
+            elif err:
+                self._error = str(err)
+            else:
+                self._error = "ChatGPT Codex stream reported an error"
+            return []
+
+        return []
+
+    def _on_item_done(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        item = event.get("item") or {}
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            return []
+        item_id = item.get("id") or item.get("call_id") or "tool_call"
+        entry = self._calls.pop(
+            item_id,
+            {"call_id": item.get("call_id") or item_id, "name": "", "arguments": ""},
+        )
+        # `done` is authoritative. Its explicit ``call_id`` wins over the entry's:
+        # a `function_call_arguments.delta` that arrives without one seeds the
+        # entry with the ITEM id, and returning that as the tool-call id breaks
+        # tool-result linking (the API matches results on ``call_id``).
+        name = item.get("name") or entry.get("name") or ""
+        call_id = item.get("call_id") or entry.get("call_id") or item_id
+        arguments = entry.get("arguments") or item.get("arguments") or "{}"
+        chunk = {
+            "text": "",
+            "is_finished": False,
+            "finish_reason": "",
+            "index": 0,
+            "tool_use": {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+                "index": self._emitted,
+            },
+            "usage": None,
+        }
+        self._emitted += 1
+        return [chunk]
+
+    def _absorb_usage(self, usage: Any) -> None:
+        if not isinstance(usage, dict):
+            return
+        input_tokens = usage.get("input_tokens") or 0
+        output_tokens = usage.get("output_tokens") or 0
+        self._usage = {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": usage.get("total_tokens") or (input_tokens + output_tokens),
+        }
+
+    def _final_chunk(self) -> dict[str, Any]:
+        self._finished = True
+        return {
+            "text": "",
+            "is_finished": True,
+            "finish_reason": "tool_calls" if self._emitted else "stop",
+            "index": 0,
+            "tool_use": None,
+            "usage": self._usage,
+        }
+
+
 def _model_response(model: str, payload: dict[str, Any]) -> ModelResponse:
     text_parts: list[str] = []
     tool_calls: list[dict[str, Any]] = []
@@ -632,13 +841,87 @@ class CodexChatGPTCustomHandler(CustomLLM):
             }
         ]
 
-    def streaming(self, *args: Any, **kwargs: Any) -> Iterator[dict[str, Any]]:
-        yield from self._response_to_chunks(self.completion(*args, **kwargs))
+    def streaming(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        api_base: str | None = None,
+        custom_prompt_dict: dict[str, Any] | None = None,
+        model_response: ModelResponse | None = None,
+        print_verbose: Any = None,
+        encoding: Any = None,
+        logging_obj: Any = None,
+        optional_params: dict[str, Any] | None = None,
+        acompletion: bool | None = None,
+        timeout: float | None = None,
+        litellm_params: dict[str, Any] | None = None,
+        logger_fn: Any = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> Iterator[dict[str, Any]]:
+        """Sync token streaming off the Responses API SSE."""
+        body = _request_body(model, messages, optional_params)
+        api_root = (api_base or os.environ.get("CHATGPT_API_BASE") or CHATGPT_API_BASE).rstrip("/")
+        with sync_client(timeout=timeout or 600) as client:
+            for force_refresh in (False, True):
+                access_token, account_id = get_codex_access_token(force_refresh=force_refresh)
+                with client.stream(
+                    "POST",
+                    f"{api_root}/responses",
+                    json=body,
+                    headers={**_headers(access_token, account_id), **(headers or {})},
+                ) as resp:
+                    if resp.status_code == 401 and not force_refresh:
+                        resp.read()
+                        continue
+                    _raise_for_stream_status(resp, model)
+                    accumulator = _CodexSseAccumulator(model)
+                    for line in resp.iter_lines():
+                        yield from accumulator.push(line)
+                    yield from accumulator.close()
+                    return
 
-    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:
-        response = await self.acompletion(*args, **kwargs)
-        for chunk in self._response_to_chunks(response):
-            yield chunk
+    async def astreaming(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        api_base: str | None = None,
+        custom_prompt_dict: dict[str, Any] | None = None,
+        model_response: ModelResponse | None = None,
+        print_verbose: Any = None,
+        encoding: Any = None,
+        logging_obj: Any = None,
+        optional_params: dict[str, Any] | None = None,
+        acompletion: bool | None = None,
+        timeout: float | None = None,
+        litellm_params: dict[str, Any] | None = None,
+        logger_fn: Any = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Async token streaming off the Responses API SSE."""
+        body = _request_body(model, messages, optional_params)
+        api_root = (api_base or os.environ.get("CHATGPT_API_BASE") or CHATGPT_API_BASE).rstrip("/")
+        async with async_client(timeout=timeout or 600) as client:
+            for force_refresh in (False, True):
+                access_token, account_id = get_codex_access_token(force_refresh=force_refresh)
+                async with client.stream(
+                    "POST",
+                    f"{api_root}/responses",
+                    json=body,
+                    headers={**_headers(access_token, account_id), **(headers or {})},
+                ) as resp:
+                    if resp.status_code == 401 and not force_refresh:
+                        await resp.aread()
+                        continue
+                    await _araise_for_stream_status(resp, model)
+                    accumulator = _CodexSseAccumulator(model)
+                    async for line in resp.aiter_lines():
+                        for chunk in accumulator.push(line):
+                            yield chunk
+                    for chunk in accumulator.close():
+                        yield chunk
+                    return
 
 
 codex_chatgpt_handler_instance = CodexChatGPTCustomHandler()

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -1685,6 +1685,19 @@ class LLMFactory:
             # Per-model cap so large single-call deliverables (finding reports,
             # recon target models) don't truncate at the proxy's 4096 default.
             "max_tokens": _resolve_max_tokens(model),
+            # Stream the completion even when the agent calls ``invoke()``.
+            # LangChain only emits ``on_llm_new_token`` when the underlying
+            # request streams, and LangGraph's "messages" stream mode is built
+            # on those callbacks — without this, every consumer (CLI renderer,
+            # web run console) receives each agent message as one finished
+            # block instead of token deltas.
+            "streaming": True,
+            # Streaming responses omit usage unless it is explicitly requested,
+            # and the measurement/cost path reads ``usage_metadata`` off the
+            # aggregated message (middleware/event_logging.py). Enabling this
+            # alongside ``streaming`` keeps per-run spend + prompt-cache
+            # accounting intact.
+            "stream_usage": True,
         }
         if _model_drops_temperature(model):
             kwargs["disabled_params"] = {"temperature": None}

--- a/packages/decepticon/tests/unit/llm/test_claude_code_handler_cache_dedup.py
+++ b/packages/decepticon/tests/unit/llm/test_claude_code_handler_cache_dedup.py
@@ -26,6 +26,9 @@ _FAKE_OAUTH.write_json_atomic = lambda *_a, **_kw: None
 _FAKE_HTTP_CLIENT = types.ModuleType("http_client")
 _FAKE_HTTP_CLIENT.post = lambda *_a, **_kw: None
 _FAKE_HTTP_CLIENT.async_post = lambda *_a, **_kw: None
+# The streaming paths build their own keep-alive clients.
+_FAKE_HTTP_CLIENT.sync_client = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.async_client = lambda *_a, **_kw: None
 
 sys.modules.setdefault("litellm", _FAKE_LITELLM)
 sys.modules.setdefault("oauth_token_store", _FAKE_OAUTH)

--- a/packages/decepticon/tests/unit/llm/test_claude_code_handler_streaming.py
+++ b/packages/decepticon/tests/unit/llm/test_claude_code_handler_streaming.py
@@ -26,6 +26,11 @@ _FAKE_LITELLM = types.ModuleType("litellm")
 _FAKE_LITELLM.CustomLLM = object
 _FAKE_LITELLM.ModelResponse = object
 _FAKE_OAUTH = types.ModuleType("oauth_token_store")
+# `sys.modules.setdefault` means whichever handler test imports first installs
+# this stub for the others, so it carries the union of every handler's imports.
+_FAKE_OAUTH.DEFAULT_JWT_SKEW_SECONDS = 60
+_FAKE_OAUTH.decode_jwt_payload = lambda *_a, **_kw: {}
+_FAKE_OAUTH.is_jwt_expired = lambda *_a, **_kw: False
 _FAKE_OAUTH.DEFAULT_REFRESH_BUFFER_SECONDS = 300
 _FAKE_OAUTH.FileBackedCache = lambda *_a, **_kw: None
 _FAKE_OAUTH.is_timestamp_expired = lambda *_a, **_kw: False
@@ -40,10 +45,25 @@ _FAKE_HTTP_CLIENT.async_post = lambda *_a, **_kw: None
 _FAKE_HTTP_CLIENT.sync_client = lambda *_a, **_kw: None
 _FAKE_HTTP_CLIENT.async_client = lambda *_a, **_kw: None
 
-sys.modules.setdefault("litellm", _FAKE_LITELLM)
-sys.modules.setdefault("oauth_token_store", _FAKE_OAUTH)
-sys.modules.setdefault("httpx", types.ModuleType("httpx"))
-sys.modules.setdefault("http_client", _FAKE_HTTP_CLIENT)
+
+def _install(name: str, stub: types.ModuleType) -> None:
+    """Install ``stub``, or top up whatever another handler test installed first.
+
+    These stubs are process-global: the first handler test to import wins, and
+    the others inherit its module. Backfilling missing attributes instead of
+    plain ``setdefault`` keeps collection order from deciding whether a handler
+    with different imports can load at all.
+    """
+    existing = sys.modules.setdefault(name, stub)
+    for attr, value in vars(stub).items():
+        if not attr.startswith("__") and not hasattr(existing, attr):
+            setattr(existing, attr, value)
+
+
+_install("litellm", _FAKE_LITELLM)
+_install("oauth_token_store", _FAKE_OAUTH)
+_install("httpx", types.ModuleType("httpx"))
+_install("http_client", _FAKE_HTTP_CLIENT)
 
 _module = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_module)

--- a/packages/decepticon/tests/unit/llm/test_claude_code_handler_streaming.py
+++ b/packages/decepticon/tests/unit/llm/test_claude_code_handler_streaming.py
@@ -1,0 +1,224 @@
+"""Anthropic SSE → GenericStreamingChunk translation for the OAuth handler.
+
+The handler used to fake streaming: ``astreaming`` awaited the buffered
+``acompletion`` and chopped the finished answer into chunks, so every consumer
+(LangGraph ``messages`` mode, the run console) saw one all-at-once message.
+These tests pin the real behaviour — text arrives as incremental deltas, tool
+arguments are reassembled from ``input_json_delta`` fragments, and usage
+(including the prompt-cache buckets) survives onto the terminating chunk.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+_MODULE_PATH = Path(__file__).resolve().parents[5] / "config" / "claude_code_handler.py"
+_spec = importlib.util.spec_from_file_location("_claude_code_handler_stream_src", _MODULE_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+
+_FAKE_LITELLM = types.ModuleType("litellm")
+_FAKE_LITELLM.CustomLLM = object
+_FAKE_LITELLM.ModelResponse = object
+_FAKE_OAUTH = types.ModuleType("oauth_token_store")
+_FAKE_OAUTH.DEFAULT_REFRESH_BUFFER_SECONDS = 300
+_FAKE_OAUTH.FileBackedCache = lambda *_a, **_kw: None
+_FAKE_OAUTH.is_timestamp_expired = lambda *_a, **_kw: False
+_FAKE_OAUTH.oauth_refresh_request = lambda *_a, **_kw: None
+_FAKE_OAUTH.read_json_file = lambda *_a, **_kw: {}
+_FAKE_OAUTH.with_retry_on_401 = lambda *_a, **_kw: None
+_FAKE_OAUTH.write_json_atomic = lambda *_a, **_kw: None
+
+_FAKE_HTTP_CLIENT = types.ModuleType("http_client")
+_FAKE_HTTP_CLIENT.post = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.async_post = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.sync_client = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.async_client = lambda *_a, **_kw: None
+
+sys.modules.setdefault("litellm", _FAKE_LITELLM)
+sys.modules.setdefault("oauth_token_store", _FAKE_OAUTH)
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+sys.modules.setdefault("http_client", _FAKE_HTTP_CLIENT)
+
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+_to_chunks = _module._anthropic_sse_to_chunks
+
+
+def _sse(*events: dict[str, Any]) -> list[str]:
+    """Render events the way Anthropic's SSE wire does (httpx strips newlines)."""
+    lines: list[str] = []
+    for event in events:
+        lines.append(f"event: {event['type']}")
+        lines.append(f"data: {json.dumps(event)}")
+        lines.append("")
+    return lines
+
+
+def test_text_arrives_as_incremental_deltas() -> None:
+    chunks = list(
+        _to_chunks(
+            _sse(
+                {"type": "message_start", "message": {"usage": {"input_tokens": 11}}},
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}},
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Recon "},
+                },
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "means "},
+                },
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "mapping."},
+                },
+                {"type": "content_block_stop", "index": 0},
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 7},
+                },
+                {"type": "message_stop"},
+            )
+        )
+    )
+
+    # One chunk per delta — NOT one cumulative blob.
+    assert [c["text"] for c in chunks] == ["Recon ", "means ", "mapping.", ""]
+    assert [c["is_finished"] for c in chunks] == [False, False, False, True]
+
+    final = chunks[-1]
+    assert final["finish_reason"] == "stop"
+    assert final["usage"]["prompt_tokens"] == 11
+    assert final["usage"]["completion_tokens"] == 7
+    assert final["usage"]["total_tokens"] == 18
+
+
+def test_tool_arguments_are_reassembled_from_json_fragments() -> None:
+    chunks = list(
+        _to_chunks(
+            _sse(
+                {"type": "message_start", "message": {"usage": {"input_tokens": 3}}},
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "tool_use", "id": "toolu_1", "name": "task"},
+                },
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"agent"'},
+                },
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": ': "recon"}'},
+                },
+                {"type": "content_block_stop", "index": 0},
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "tool_use"},
+                    "usage": {"output_tokens": 5},
+                },
+                {"type": "message_stop"},
+            )
+        )
+    )
+
+    tool_chunks = [c for c in chunks if c["tool_use"]]
+    assert len(tool_chunks) == 1
+    tool = tool_chunks[0]["tool_use"]
+    assert tool["id"] == "toolu_1"
+    assert tool["function"]["name"] == "task"
+    # Fragments only parse once concatenated.
+    assert json.loads(tool["function"]["arguments"]) == {"agent": "recon"}
+    assert chunks[-1]["finish_reason"] == "tool_calls"
+
+
+def test_cache_buckets_survive_onto_the_final_chunk() -> None:
+    chunks = list(
+        _to_chunks(
+            _sse(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "usage": {
+                            "input_tokens": 4,
+                            "cache_creation_input_tokens": 1024,
+                            "cache_read_input_tokens": 2048,
+                        }
+                    },
+                },
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "hi"},
+                },
+                {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+                {"type": "message_stop"},
+            )
+        )
+    )
+
+    usage = chunks[-1]["usage"]
+    assert usage["cache_creation_input_tokens"] == 1024
+    assert usage["cache_read_input_tokens"] == 2048
+
+
+def test_thinking_deltas_and_pings_do_not_leak_into_assistant_text() -> None:
+    chunks = list(
+        _to_chunks(
+            _sse(
+                {"type": "ping"},
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "hmm"},
+                },
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "answer"},
+                },
+                {"type": "message_stop"},
+            )
+        )
+    )
+
+    assert [c["text"] for c in chunks] == ["answer", ""]
+
+
+def test_truncated_stream_still_terminates() -> None:
+    # Upstream cut before message_stop — the wrapper must still see is_finished
+    # once, or LiteLLM's stream wrapper hangs waiting for the terminator.
+    chunks = list(
+        _to_chunks(
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "partial"},
+                },
+            )
+        )
+    )
+
+    assert [c["is_finished"] for c in chunks] == [False, True]
+
+
+def test_malformed_data_lines_are_skipped() -> None:
+    chunks = list(_to_chunks(["data: not-json", "", "data: [DONE]"]))
+
+    # Nothing parsed, but the terminator is still produced.
+    assert len(chunks) == 1
+    assert chunks[0]["is_finished"] is True

--- a/packages/decepticon/tests/unit/llm/test_codex_chatgpt_handler_streaming.py
+++ b/packages/decepticon/tests/unit/llm/test_codex_chatgpt_handler_streaming.py
@@ -194,7 +194,14 @@ def test_truncated_stream_still_terminates() -> None:
 
 def test_malformed_and_done_lines_are_skipped() -> None:
     accumulator = _Accumulator("auth/gpt-5.4-mini")
-    assert accumulator.push("data: not-json") == []
-    assert accumulator.push("data: [DONE]") == []
-    assert accumulator.push("event: response.completed") == []
-    assert accumulator.close()[0]["is_finished"] is True
+    # Both push and close mutate the accumulator, so they run outside the
+    # asserts — `python -O` strips assert statements along with their calls.
+    malformed = accumulator.push("data: not-json")
+    done_marker = accumulator.push("data: [DONE]")
+    event_line = accumulator.push("event: response.completed")
+    final = accumulator.close()
+
+    assert malformed == []
+    assert done_marker == []
+    assert event_line == []
+    assert final[0]["is_finished"] is True

--- a/packages/decepticon/tests/unit/llm/test_codex_chatgpt_handler_streaming.py
+++ b/packages/decepticon/tests/unit/llm/test_codex_chatgpt_handler_streaming.py
@@ -1,0 +1,200 @@
+"""Responses-API SSE → GenericStreamingChunk translation for the Codex handler.
+
+The handler already asked the Codex backend to stream, but ``_completed_payload``
+read ``resp.text`` — the whole body — before walking the events, so every delta
+had landed before the first chunk was yielded. These tests pin the incremental
+walk: text is forwarded as it arrives, function-call arguments are still
+reassembled from their fragments, and a ``response.failed`` event still raises.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[5] / "config" / "codex_chatgpt_handler.py"
+_spec = importlib.util.spec_from_file_location("_codex_chatgpt_handler_stream_src", _MODULE_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+
+
+class _FakeAPIError(Exception):
+    def __init__(self, *_a: Any, **kw: Any) -> None:
+        super().__init__(kw.get("message", ""))
+        self.message = kw.get("message", "")
+
+
+_FAKE_LITELLM = types.ModuleType("litellm")
+_FAKE_LITELLM.CustomLLM = object
+_FAKE_LITELLM.ModelResponse = object
+_FAKE_LITELLM.APIError = _FakeAPIError
+_FAKE_LITELLM.AuthenticationError = _FakeAPIError
+_FAKE_LITELLM.BadRequestError = _FakeAPIError
+
+_FAKE_OAUTH = types.ModuleType("oauth_token_store")
+# `sys.modules.setdefault` means whichever handler test imports first installs
+# this stub for the others, so it carries the union of every handler's imports.
+_FAKE_OAUTH.DEFAULT_REFRESH_BUFFER_SECONDS = 300
+_FAKE_OAUTH.is_timestamp_expired = lambda *_a, **_kw: False
+_FAKE_OAUTH.DEFAULT_JWT_SKEW_SECONDS = 60
+_FAKE_OAUTH.FileBackedCache = lambda *_a, **_kw: None
+_FAKE_OAUTH.decode_jwt_payload = lambda *_a, **_kw: {}
+_FAKE_OAUTH.is_jwt_expired = lambda *_a, **_kw: False
+_FAKE_OAUTH.oauth_refresh_request = lambda *_a, **_kw: None
+_FAKE_OAUTH.read_json_file = lambda *_a, **_kw: {}
+_FAKE_OAUTH.with_retry_on_401 = lambda *_a, **_kw: None
+_FAKE_OAUTH.write_json_atomic = lambda *_a, **_kw: None
+
+_FAKE_HTTP_CLIENT = types.ModuleType("http_client")
+_FAKE_HTTP_CLIENT.post = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.async_post = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.sync_client = lambda *_a, **_kw: None
+_FAKE_HTTP_CLIENT.async_client = lambda *_a, **_kw: None
+
+
+def _install(name: str, stub: types.ModuleType) -> None:
+    """Install ``stub``, or top up whatever another handler test installed first.
+
+    These stubs are process-global: the first handler test to import wins, and
+    the others inherit its module. Backfilling missing attributes instead of
+    plain ``setdefault`` keeps collection order from deciding whether a handler
+    with different imports can load at all.
+    """
+    existing = sys.modules.setdefault(name, stub)
+    for attr, value in vars(stub).items():
+        if not attr.startswith("__") and not hasattr(existing, attr):
+            setattr(existing, attr, value)
+
+
+_install("litellm", _FAKE_LITELLM)
+_install("oauth_token_store", _FAKE_OAUTH)
+_install("httpx", types.ModuleType("httpx"))
+_install("http_client", _FAKE_HTTP_CLIENT)
+
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+_Accumulator = _module._CodexSseAccumulator
+
+
+def _drive(*events: dict[str, Any]) -> list[dict[str, Any]]:
+    """Feed events through the accumulator the way httpx delivers SSE lines."""
+    accumulator = _Accumulator("auth/gpt-5.4-mini")
+    chunks: list[dict[str, Any]] = []
+    for event in events:
+        chunks.extend(accumulator.push(f"data: {json.dumps(event)}"))
+        chunks.extend(accumulator.push(""))
+    chunks.extend(accumulator.close())
+    return chunks
+
+
+def test_text_arrives_as_incremental_deltas() -> None:
+    chunks = _drive(
+        {"type": "response.output_text.delta", "delta": "one"},
+        {"type": "response.output_text.delta", "delta": "\n"},
+        {"type": "response.output_text.delta", "delta": "two"},
+        {
+            "type": "response.completed",
+            "response": {"usage": {"input_tokens": 35, "output_tokens": 108}},
+        },
+    )
+
+    assert [c["text"] for c in chunks] == ["one", "\n", "two", ""]
+    assert [c["is_finished"] for c in chunks] == [False, False, False, True]
+    final = chunks[-1]
+    assert final["finish_reason"] == "stop"
+    assert final["usage"] == {
+        "prompt_tokens": 35,
+        "completion_tokens": 108,
+        "total_tokens": 143,
+    }
+
+
+def test_function_call_arguments_are_reassembled_before_release() -> None:
+    chunks = _drive(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_1",
+                "call_id": "call_abc",
+                "name": "get_weather",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": '{"city"',
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": ': "Seoul"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {"type": "function_call", "id": "item_1", "call_id": "call_abc"},
+        },
+        {"type": "response.completed", "response": {"usage": {}}},
+    )
+
+    tools = [c["tool_use"] for c in chunks if c["tool_use"]]
+    assert len(tools) == 1
+    assert tools[0]["id"] == "call_abc"
+    assert tools[0]["function"]["name"] == "get_weather"
+    assert json.loads(tools[0]["function"]["arguments"]) == {"city": "Seoul"}
+    assert chunks[-1]["finish_reason"] == "tool_calls"
+
+
+def test_name_is_backfilled_when_only_the_done_event_carries_it() -> None:
+    # Some upstream variants skip `output_item.added`; `done` is authoritative.
+    chunks = _drive(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_9",
+            "delta": "{}",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "id": "item_9",
+                "call_id": "call_z",
+                "name": "task",
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    )
+
+    tools = [c["tool_use"] for c in chunks if c["tool_use"]]
+    assert tools[0]["function"]["name"] == "task"
+    assert tools[0]["id"] == "call_z"
+
+
+def test_failed_response_raises_on_close() -> None:
+    accumulator = _Accumulator("auth/gpt-5.4-mini")
+    accumulator.push('data: {"type": "response.failed", "error": {"message": "upstream exploded"}}')
+    # Assert against whichever litellm stub ended up installed (see _install) —
+    # binding to the local class would depend on which handler test ran first.
+    with pytest.raises(_module.litellm.APIError):
+        accumulator.close()
+
+
+def test_truncated_stream_still_terminates() -> None:
+    chunks = _drive({"type": "response.output_text.delta", "delta": "partial"})
+
+    assert [c["is_finished"] for c in chunks] == [False, True]
+
+
+def test_malformed_and_done_lines_are_skipped() -> None:
+    accumulator = _Accumulator("auth/gpt-5.4-mini")
+    assert accumulator.push("data: not-json") == []
+    assert accumulator.push("data: [DONE]") == []
+    assert accumulator.push("event: response.completed") == []
+    assert accumulator.close()[0]["is_finished"] is True


### PR DESCRIPTION
## Problem

Agent messages appear all at once — in the CLI renderer and in any web client consuming LangGraph's `messages` stream mode. Nothing in the chain actually streamed.

Two independent causes, **either one sufficient** to break it:

**1. The OAuth handler faked streaming.** `ClaudeCodeCustomHandler.streaming` / `astreaming` awaited the buffered `completion` / `acompletion`, then chopped the finished answer into chunks. The request never carried `"stream": true`, so the entire answer landed before the first chunk was yielded.

**2. The model was built non-streaming.** `_create_chat_model` constructed `ChatOpenAI` without `streaming`, so `.invoke()` issued a non-streaming request. LangChain only fires `on_llm_new_token` when the underlying request streams, and LangGraph's `messages` mode is built on those callbacks — so even a genuinely streaming proxy would have been buffered here.

## Change

The handler now sends `"stream": true` and translates Anthropic's Messages SSE directly:

- text arrives as incremental `text_delta` chunks
- tool arguments are reassembled from `input_json_delta` fragments (they only parse once concatenated)
- usage — including the `cache_creation_input_tokens` / `cache_read_input_tokens` buckets `stream_chunk_builder` prices — rides the terminating chunk, same contract as `_response_to_chunks`
- 401-refresh-retry, 429, and non-200 handling match the buffered path
- a truncated upstream still emits exactly one `is_finished` chunk, so LiteLLM's stream wrapper can't hang waiting for a terminator

The request body is now built once in `_build_anthropic_request` and shared by both paths, so buffered and streaming requests are byte-identical and prompt caching still hits the same prefix.

`stream_usage=True` accompanies `streaming=True` — streamed responses omit usage unless explicitly requested, and the measurement path reads `usage_metadata` off the aggregated message (`middleware/event_logging.py`).

## Verification

The SSE translator is a pure state machine over decoded lines, so the wire format is unit-tested without network: 6 new tests covering incremental text, tool-argument reassembly, cache-bucket passthrough, `thinking_delta`/`ping` suppression, truncated streams, and malformed `data:` lines.

- `pytest packages/decepticon/tests/unit/llm/` — **630 passed**
- `ruff check .` / `ruff format --check .` — clean (685 files)

Verified end to end against a real run on a local stack (LiteLLM + langgraph + a `task()` sub-agent dispatch). Per-frame content length of LangGraph `messages/partial`:

| | before | after |
|---|---|---|
| sub-agent | `[1471, 1471, 1471]` | `[1, 72, 160, 240, 315, 379, 450, 514]` |
| supervisor | `[55, 55, 55, 55]` | `[3, 103, 244]` |

Flat sequences mean the first frame already carried the whole message. Usage still reports on the streaming path (`prompt_tokens: 28, completion_tokens: 17` on a live `stream_options.include_usage` call).

## Codex ChatGPT (second commit)

The Codex handler had the same symptom from a different angle: it already asked the backend to stream, but `_completed_payload` read `resp.text` before walking the events, so the deltas had all arrived before the first chunk was yielded. Same treatment — the Responses-API SSE is now walked incrementally, with function-call arguments still reassembled from their fragments before the tool chunk is released.

It also fixes a latent tool-call bug: when a `function_call_arguments.delta` arrives before `output_item.added`, the entry is seeded with the ITEM id, and the old precedence kept that over the authoritative `call_id` on `output_item.done`. Returning an item id as the tool-call id breaks tool-result linking. The buffered `_completed_payload` shares that precedence and is left alone here.

Verified live against the ChatGPT Codex backend (`auth/gpt-5.4-mini`):

| | before | after |
|---|---|---|
| text | 3 chunks (whole answer in the first) | 55 chunks, token by token |
| tool calls | — | `finish_reason=tool_calls`, name preserved, args parse clean |
| usage | — | `prompt_tokens=35 completion_tokens=108` |

## Not included

The remaining four OAuth handlers — `gemini`, `grok`, `copilot`, `perplexity` — share the same buffered-then-chopped shape and each needs its own upstream SSE translation. Left untouched rather than half-done; worth a follow-up per provider.

The prompt-cache bucket passthrough is covered by unit test but not demonstrated on a live cache hit — the verification prompt stayed under the cache minimum, so both buckets read 0 on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
