### PR TITLE
docs: release v1.1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ follows [Semantic Versioning](https://semver.org/) from `1.0.0`
 onward (the `0.x` cycle is pre-stable per the core/framework/sdk split
 design spec, §13.4).
 
+## [1.1.39] — 2026-07-27
+
+Released as a patch by maintainer decision: the one `feat:` in the range
+(#773, a benchmark-provider addition) changes no runtime behaviour for
+existing users, so the SemVer minor bump the auto-tag rules would have
+computed was overridden.
+
+> **Note on the sections below.** The `[1.1.8] — Unreleased` heading that
+> follows has not been rotated since 2026-06-01, so releases 1.1.9 through
+> 1.1.38 are absent from this file. That backlog is untouched here rather
+> than reconstructed from git; this section covers only 1.1.38 → 1.1.39.
+
+### Fixed
+
+- **LLM responses stream again — they never actually did.** Two independent
+  causes, either sufficient on its own. The Claude Code OAuth handler's
+  `streaming`/`astreaming` awaited the *buffered* completion and chopped the
+  finished answer into chunks, never sending `"stream": true` upstream; and
+  `_create_chat_model` built `ChatOpenAI` without `streaming`, so `.invoke()`
+  issued a non-streaming request and LangChain never fired
+  `on_llm_new_token` — which is what LangGraph's `messages` stream mode is
+  built on. Both handlers now translate their upstream SSE directly, and
+  `stream_usage=True` accompanies `streaming=True` so the measurement path
+  still sees `usage_metadata`. The Codex ChatGPT lane had the same symptom
+  from a third angle (it asked to stream, then read `resp.text` before
+  walking the events) and is fixed alongside. (#786)
+- **Telemetry fields that shipped empty or constant.** `wrap_model_call`
+  returns a `ModelResponse` wrapper, not an `AIMessage`, so reasoning,
+  tokens and stop reason were read off attributes that do not exist; and
+  `_slug(None)` returned the literal `"none"`, poisoning four columns with a
+  real-looking value. Redaction also gains credential-KV and opaque-blob
+  detectors, and stops mangling dotted code as domains. (#785)
+- **`bash` prompt steers to `curl_cffi` over raw `curl`** for web fetches —
+  raw `curl`'s TLS/JA3 fingerprint is blocked by WAFs on the first request,
+  and retrying never clears it. (#777)
+- **Windows launcher self-update** moves the running image aside instead of
+  renaming over it (an executable cannot be overwritten while in use), with
+  rollback on failure and best-effort cleanup on the next launch. (#775)
+- **CLI recovers after thread-creation retries are exhausted** instead of
+  leaving the run state stuck. (#774)
+
+### Documentation
+
+- Model catalog, tier table and CLI slash-command reference synced with the
+  code — MID is `claude-sonnet-5`, HIGH is `claude-opus-4-8`, and the web
+  dashboard is dynamic-spawn (`/web`), not part of the default stack. (#778)
+
+[1.1.39]: https://github.com/PurpleAILAB/Decepticon/compare/v1.1.38...v1.1.39
+
 ## [1.1.8] — Unreleased
 
 The agent-driven dynamic infrastructure release. Specialist workloads


### PR DESCRIPTION
Changelog entry for the 1.1.38 → 1.1.39 range, ahead of tagging.

Released as a **patch** by maintainer decision: the one `feat:` in the range (#773, a benchmark-provider addition) changes no runtime behaviour for existing users, so the minor bump the auto-tag rules would compute is overridden.

Covers #774, #775, #777, #778, #785, #786.

**Pre-existing drift, deliberately left alone:** the `[1.1.8] — Unreleased` heading below has not been rotated since 2026-06-01, so 1.1.9 → 1.1.38 are missing from this file. Reconstructing 30 releases from git is a separate decision, so this PR adds only the 1.1.39 section and says so inline rather than silently re-labelling the stale block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)