### PR TITLE
fix(telemetry): close the masking gaps #785 left, and gate the corpus before training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ skills/_corpus/
 .ouroboros/
 .gstack/
 .claude/
+.agents/
 
 # Project-specific Claude Code instructions (private)
 CLAUDE.md

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -138,17 +138,40 @@ same placeholder every time that host recurs in the session, but the real target
 / credentials never leave the machine. `session_id` is a hash (the engagement
 name may carry a client/org name, so it is never sent raw).
 
-## What is NEVER collected (Tier C)
+## What is blocked before sending (Tier C)
 
-Raw prompts, target IPs / domains / hosts, credentials, file contents, tool
-output, and client/org names. These are blocked by **three independent layers**:
+Target IPs / domains / hosts, credentials, keys and tokens are blocked by
+**three layers**:
 
-1. **Shape redaction at the source** — `EventLogMiddleware` already records
-   shapes, not contents (`<str:42>`, `***REDACTED***`).
+1. **Shape redaction at the source** — `EventLogMiddleware` records shapes, not
+   contents (`<str:42>`, `***REDACTED***`), for the `basic` tier.
 2. **Client Tier-C scan** — before anything is queued, a fail-closed scanner
-   drops any event that still matches an IP / cred / host pattern.
+   drops any event still matching an IP / cred / host pattern. Drops are
+   reported as a `telemetry.drop` count, never as content.
 3. **Gateway Tier-C reject** — the ingest gateway re-scans and rejects, and
-   drops the client IP (it never reaches the analytics backend).
+   drops your IP (it never reaches the analytics backend).
+
+Layers 2 and 3 are **pattern-based**, which bounds what they can promise: see
+the `research` tier notes above for what survives. They are a floor, not
+anonymization.
+
+## Where it goes, and for how long
+
+- **Recipient:** PurpleAILAB, the Decepticon maintainers. Batches go to a
+  Cloudflare Worker we operate, which forwards to our PostHog project. The
+  Worker never records your IP and disables geo-enrichment.
+- **Purpose:** improving Decepticon, and — for the `research` tier — building a
+  training corpus for future autonomous red-team agents.
+- **Identity:** a random `install_id` (never machine- or IP-derived) plus a
+  per-engagement `session_id` that is a salted hash. Neither is linked to an
+  account; we cannot contact you from telemetry alone.
+- **Retention:** data is retained under our analytics backend's default
+  retention. A specific published retention window and a self-serve deletion
+  path are **not yet in place** — until they are, the reliable control is
+  turning telemetry off (`DECEPTICON_TELEMETRY=off`, `DO_NOT_TRACK=1`, or
+  `decepticon-cli telemetry off`), which takes effect immediately. If you need
+  data already sent to be removed, open an issue with your `install_id`
+  (`decepticon-cli telemetry status` prints it).
 
 ## How it is sent
 

--- a/packages/decepticon/decepticon/telemetry/redact.py
+++ b/packages/decepticon/decepticon/telemetry/redact.py
@@ -98,7 +98,11 @@ _DOMAIN = re.compile(
 
 # Local-regex fallbacks for the LangChain built-ins (used only if the import fails).
 _IP = re.compile(r"\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b")
-_IP6 = re.compile(r"\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b")
+# Four groups minimum. Three colon-separated groups is a wall-clock time —
+# `21:35:00` was being masked as an address, and tool output is full of
+# timestamps. Compressed `::` forms never matched this pattern anyway, so
+# nothing real is lost.
+_IP6 = re.compile(r"\b(?:[A-Fa-f0-9]{1,4}:){3,7}[A-Fa-f0-9]{1,4}\b")
 _MAC = re.compile(r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b")
 _URL = re.compile(r"\bhttps?://[^\s)\]\"'<>]+", re.IGNORECASE)
 _EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")

--- a/packages/decepticon/decepticon/telemetry/redact.py
+++ b/packages/decepticon/decepticon/telemetry/redact.py
@@ -63,6 +63,31 @@ _CRED_SECRET_KV = re.compile(
 # Username pairs, TIGHT form only (`user:bob`). A spaced `user: the attacker` is
 # prose, not a credential, and masking it would corrupt the reasoning.
 _CRED_USER_KV = re.compile(r"(?:login|username|user)[:=]([^\s,;\"']{3,64})", re.IGNORECASE)
+# Credential passed as a COMMAND-LINE FLAG. Observed leaking verbatim in a real
+# engagement: `nxc smb <ip> -u Administrator -p 'Ujmqaz5055'`. Operators paste
+# whole command lines, and no key:value detector sees a flag.
+#
+# `-p` is overloaded — it is nmap's port flag — so a purely numeric/comma/dash
+# value is left alone (`nmap -p 80,443`, `-p 1-65535`, `-p-`). A password is
+# never shaped like a port list.
+_CRED_PW_FLAG = re.compile(
+    r"(?:^|\s)--?(?:p|pw|pass|passwd|password)[=\s]+"
+    r"['\"]?(?![\d,\-]+(?:\s|$|['\"]))([^\s'\"]{3,64})",
+    re.IGNORECASE,
+)
+# `-u` only in its credential form (`curl -u admin:secret`). A bare `-u` is far
+# too overloaded to touch — `sort -u`, `docker -u`, `nxc -u <name>`.
+_CRED_USERPASS_FLAG = re.compile(
+    r"(?:^|\s)--?(?:u|user|username)[=\s]+['\"]?([^\s'\":]{1,64}:[^\s'\"]{1,64})",
+    re.IGNORECASE,
+)
+# IPv4 glued to a label — `ESXI10.10.0.95`. The maintained detector anchors on
+# `\b`, and a letter directly before a digit is not a word boundary, so this
+# leaked a real address verbatim. A leading digit or dot is still excluded so a
+# longer dotted number is never sliced in half.
+_IP_GLUED = re.compile(
+    r"(?<![\d.])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?![\d.])"
+)
 # Bare host/domain — requires a non-numeric TLD so "1.2.3"/"x86_64" never match.
 # The trailing `(?!\()` keeps dotted CODE out: `json.load(...)`, `os.uname()` and
 # friends are not hosts, and masking them destroyed the prompt. Measured: 1,697
@@ -172,6 +197,9 @@ class Redactor:
             ("CRED", _regex_detector(_CRED_SPECIAL)),
             ("CRED", _group_detector(_CRED_SECRET_KV)),
             ("CRED", _group_detector(_CRED_USER_KV)),
+            ("CRED", _group_detector(_CRED_PW_FLAG)),
+            ("CRED", _group_detector(_CRED_USERPASS_FLAG)),
+            ("IP", _regex_detector(_IP_GLUED)),
             ("BLOB", _regex_detector(_BLOB)),
             ("IP6", _regex_detector(_IP6)),
             *_builtin_detectors(),

--- a/packages/decepticon/tests/unit/telemetry/test_telemetry_redact.py
+++ b/packages/decepticon/tests/unit/telemetry/test_telemetry_redact.py
@@ -121,3 +121,45 @@ def test_dotted_code_is_neither_masked_nor_dropped() -> None:
     # A real bare host is still masked, and still caught if it somehow is not.
     assert Redactor().redact("pivot to app.corp.internal") == "pivot to <DOMAIN_1>"
     assert scan_tier_c("pivot to app.corp.internal") is not None
+
+
+def test_credentials_passed_as_command_line_flags_are_masked() -> None:
+    """Operators paste whole command lines; no key:value detector sees a flag.
+
+    Observed leaking verbatim from a real engagement:
+    ``nxc smb <ip> -u Administrator -p 'Ujmqaz5055'``.
+    """
+    from decepticon.telemetry.redact import Redactor
+
+    out = Redactor().redact("nxc smb 10.0.0.5 -p 'Ujmqaz5055' --local-auth")
+    assert "Ujmqaz5055" not in out and "<CRED_" in out
+    assert "sshpass -p <CRED_1>" in Redactor().redact("sshpass -p Hunter2 ssh a@b")
+    # `-u` only in its credential form.
+    assert "s3cret" not in Redactor().redact("curl -u admin:s3cret https://x")
+
+
+def test_port_flags_are_not_mistaken_for_passwords() -> None:
+    """`-p` is nmap's port flag — the most-run tool in the corpus."""
+    from decepticon.telemetry.redact import Redactor
+
+    for cmd in ("nmap -p 80,443 host", "nmap -p- -T4 host", "nmap -p 1-65535 host"):
+        assert Redactor().redact(cmd) == cmd, cmd
+    # `-u` is heavily overloaded and must stay untouched without a colon.
+    assert Redactor().redact("cat f | sort -u") == "cat f | sort -u"
+    assert Redactor().redact("docker run -u 1000 img") == "docker run -u 1000 img"
+
+
+def test_ip_glued_to_a_label_is_masked() -> None:
+    """`\\b` is not a boundary between a letter and a digit.
+
+    ``ESXI10.10.0.95`` reached production unmasked because both the maintained
+    detector and the Tier-C scanner anchor on a word boundary.
+    """
+    from decepticon.telemetry.redact import Redactor
+    from decepticon.telemetry.sanitizer import scan_tier_c
+
+    out = Redactor().redact("ESXI10.10.0.95 and veeam 10.10.0.51")
+    assert "10.10.0.95" not in out and "10.10.0.51" not in out
+    assert scan_tier_c(out) is None
+    # A longer dotted number is never sliced in half.
+    assert Redactor().redact("version 1.2.3 build 4") == "version 1.2.3 build 4"

--- a/packages/decepticon/tests/unit/telemetry/test_telemetry_redact.py
+++ b/packages/decepticon/tests/unit/telemetry/test_telemetry_redact.py
@@ -163,3 +163,21 @@ def test_ip_glued_to_a_label_is_masked() -> None:
     assert scan_tier_c(out) is None
     # A longer dotted number is never sliced in half.
     assert Redactor().redact("version 1.2.3 build 4") == "version 1.2.3 build 4"
+
+
+def test_wall_clock_time_is_not_an_ipv6_address() -> None:
+    """`21:35:00` is three colon-separated groups — so was every timestamp.
+
+    Found in the exported corpus as `"saved_at": "2026-07-21T21:<CRED_1>:00"`.
+    Tool output is full of timestamps, so this corrupted text at scale.
+    """
+    from decepticon.telemetry.redact import Redactor
+    from decepticon.telemetry.sanitizer import scan_tier_c
+
+    for text in ('"saved_at": "2026-07-21T21:35:00"', "completed at 21:35:00 UTC"):
+        assert Redactor().redact(text) == text, text
+        assert scan_tier_c(text) is None, text
+
+    # A real address is still masked.
+    v6 = "2001:db8:85a3:8d3:1319:8a2e:370:7348"
+    assert v6 not in Redactor().redact(f"pivot via {v6}")

--- a/telemetry-gateway/build_dashboard.py
+++ b/telemetry-gateway/build_dashboard.py
@@ -53,6 +53,7 @@ TEST_INSTALLS = (
     "ce9fffea-a87a-4375-a2dd-f6217f743959",
     "2e953b6e-bf01-4140-bc6d-26a6ec2c82f2",
     "6b49be5b-459c-4332-a2f6-30787d8bd479",
+    "28bcd7df-a74e-4489-859d-ed6a8d912add",
 )
 NOT_TEST = (
     "coalesce(toString(properties.decepticon_version),'') NOT IN "

--- a/telemetry-gateway/build_dashboard.py
+++ b/telemetry-gateway/build_dashboard.py
@@ -52,6 +52,7 @@ TEST_INSTALLS = (
     "11111111-1111-4111-8111-111111111111",
     "ce9fffea-a87a-4375-a2dd-f6217f743959",
     "2e953b6e-bf01-4140-bc6d-26a6ec2c82f2",
+    "6b49be5b-459c-4332-a2f6-30787d8bd479",
 )
 NOT_TEST = (
     "coalesce(toString(properties.decepticon_version),'') NOT IN "

--- a/telemetry-gateway/export_corpus.py
+++ b/telemetry-gateway/export_corpus.py
@@ -106,7 +106,8 @@ def _query(host: str, project: str, api_key: str, since_hours: int | None) -> li
         "'11111111-1111-4111-8111-111111111111', "
         "'ce9fffea-a87a-4375-a2dd-f6217f743959', "
         "'2e953b6e-bf01-4140-bc6d-26a6ec2c82f2', "
-        "'6b49be5b-459c-4332-a2f6-30787d8bd479')"
+        "'6b49be5b-459c-4332-a2f6-30787d8bd479', "
+        "'28bcd7df-a74e-4489-859d-ed6a8d912add')"
     )
     if since_hours:
         where += f" AND timestamp > now() - INTERVAL {int(since_hours)} HOUR"

--- a/telemetry-gateway/export_corpus.py
+++ b/telemetry-gateway/export_corpus.py
@@ -101,7 +101,8 @@ def _query(host: str, project: str, api_key: str, since_hours: int | None) -> li
         "AND distinct_id NOT IN ('00000000-0000-4000-8000-000000000001', "
         "'11111111-1111-4111-8111-111111111111', "
         "'ce9fffea-a87a-4375-a2dd-f6217f743959', "
-        "'2e953b6e-bf01-4140-bc6d-26a6ec2c82f2')"
+        "'2e953b6e-bf01-4140-bc6d-26a6ec2c82f2', "
+        "'6b49be5b-459c-4332-a2f6-30787d8bd479')"
     )
     if since_hours:
         where += f" AND timestamp > now() - INTERVAL {int(since_hours)} HOUR"

--- a/telemetry-gateway/export_corpus.py
+++ b/telemetry-gateway/export_corpus.py
@@ -35,6 +35,10 @@ import sys
 import urllib.request
 from typing import Any
 
+# Rows per page. HogQL caps a single query well below the corpus size, so the
+# export pages rather than trusting one request.
+_PAGE = 10_000
+
 # Column order returned by the HogQL query below.
 _COLS = [
     "session_id",
@@ -106,20 +110,61 @@ def _query(host: str, project: str, api_key: str, since_hours: int | None) -> li
     )
     if since_hours:
         where += f" AND timestamp > now() - INTERVAL {int(since_hours)} HOUR"
-    hogql = (
-        "SELECT properties.session_id, properties.step, properties.role, properties.agent, "
-        "properties.tool, properties.text, properties.args_text, properties.observation, distinct_id "
-        f"FROM events WHERE {where} ORDER BY distinct_id, properties.session_id, toInt(properties.step)"
-    )
-    body = json.dumps({"query": {"kind": "HogQLQuery", "query": hogql}}).encode()
-    req = urllib.request.Request(
-        f"{host.rstrip('/')}/api/projects/{project}/query/",
-        data=body,
-        headers={"content-type": "application/json", "authorization": f"Bearer {api_key}"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310 — operator-configured host
-        return json.loads(resp.read()).get("results", [])
+    # Paginate. HogQL applies a default LIMIT of 100 when a query does not state
+    # one, so this exported 100 of 119,774 rows and reported success — a
+    # silently truncated corpus is worse than a failed export. OFFSET is
+    # rejected for personal API keys, so this is keyset pagination on
+    # `timestamp`, as PostHog directs. `timestamp` is selected last so the
+    # `_COLS` zip is unaffected.
+    rows: list[list[Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    cursor = "1970-01-01 00:00:00"
+    while True:
+        hogql = (
+            "SELECT properties.session_id, properties.step, properties.role, properties.agent, "
+            "properties.tool, properties.text, properties.args_text, properties.observation, "
+            "distinct_id, timestamp "
+            f"FROM events WHERE {where} AND timestamp >= toDateTime('{cursor}') "
+            f"ORDER BY timestamp LIMIT {_PAGE}"
+        )
+        body = json.dumps({"query": {"kind": "HogQLQuery", "query": hogql}}).encode()
+        req = urllib.request.Request(
+            f"{host.rstrip('/')}/api/projects/{project}/query/",
+            data=body,
+            headers={"content-type": "application/json", "authorization": f"Bearer {api_key}"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=180) as resp:  # noqa: S310 — operator-configured
+            page = json.loads(resp.read()).get("results", [])
+        if not page:
+            return rows
+        # `>=` re-reads the boundary timestamp, so dedupe rather than risk the
+        # strict-`>` variant skipping rows that share it.
+        fresh = [r for r in page if (key := tuple(map(str, r))) not in seen and not seen.add(key)]
+        rows.extend(fresh)
+        if len(page) < _PAGE:
+            return rows
+        last = str(page[-1][-1])
+        if not fresh:
+            # A whole page at one timestamp: step past it or loop forever.
+            cursor = _bump_ms(last)
+        else:
+            cursor = last
+        print(f"  fetched {len(rows)} rows…", file=sys.stderr)
+
+
+def _bump_ms(ts: str) -> str:
+    """Advance an ISO timestamp by 1ms to break a same-timestamp page."""
+    from datetime import datetime, timedelta
+
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return (datetime.strptime(ts, fmt) + timedelta(milliseconds=1)).strftime(
+                "%Y-%m-%d %H:%M:%S.%f"
+            )
+        except ValueError:
+            continue
+    return ts
 
 
 _SELF_TEST_ROWS = [

--- a/telemetry-gateway/redact_corpus.py
+++ b/telemetry-gateway/redact_corpus.py
@@ -49,6 +49,7 @@ import os
 import re
 import sys
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 # Fields carrying free text. Everything else in a step is a slug or an int.
@@ -90,15 +91,33 @@ Return JSON and nothing else:
 VERIFY_SYSTEM = """\
 You audit de-identified red-team text before it is used to train a model.
 
-Answer one question: could a reader identify a real organization, person, or \
-host from this text? Consider indirect evidence — a product name, a bug-bounty \
-program, a distinctive asset description, or an unusual combination of details \
-— not only explicit identifiers. <TYPE_n> placeholders are already masked and \
-are not identifying.
+Task: NAME the real-world entity that was the TARGET of this engagement — the
+organization, client, person, or host being tested. Put it in "entity".
 
-Be strict. A model memorizes its training data, so a miss is permanent.
+You must produce a name, not a suspicion. "Some organization is masked here" is
+not a name — a <TYPE_n> placeholder is already de-identified and tells you
+nothing. Set "identifying": false with an empty "entity" unless you can write
+down a real entity a reader could look up AND it is the thing under test.
 
-Return JSON: {"identifying": true|false, "reason": "<short reason>"}\
+TARGET (flag these):
+- the client or organization being assessed, however it is referred to
+- a person, handle, or account belonging to the target
+- an unmasked domain, host, or bug-bounty program of the target
+
+NOT the target (never flag, no matter how specific):
+- tools and scanners the operator ran: nmap, semgrep, ffuf, sqlmap, BloodHound
+- software the target happens to run: Redis, nginx, MySQL, ADFS, Active Directory
+- threat actors and adversary profiles being emulated: APT28, Sandworm, FIN7
+- the AI vendor, model, or CLI running the engagement
+- techniques, CVEs, ATT&CK ids, vulnerability detail, generic product categories
+- that a red-team engagement happened, or how it was run
+
+If the only names you can find are tools, platforms, or emulated actors, the
+text is not identifying. Say so.
+
+Return JSON and nothing else. "entity" and "reason" must be single short lines
+with no newlines or quote characters:
+{"identifying": true|false, "entity": "<target name or empty>", "reason": "<how>"}\
 """
 
 
@@ -113,8 +132,25 @@ def _post(url: str, body: dict[str, Any], api_key: str, timeout: int = 120) -> d
         return json.loads(resp.read())
 
 
-def _chat(system: str, user: str, cfg: dict[str, str]) -> dict[str, Any]:
-    """One JSON-returning chat completion through the LiteLLM proxy."""
+_IS_PLACEHOLDER_NAME = re.compile(r"<?[A-Z]+_\d+>?")
+
+
+def _chat(system: str, user: str, cfg: dict[str, str], _retry: bool = True) -> dict[str, Any]:
+    """One JSON-returning chat completion through the LiteLLM proxy.
+
+    Retries once on a malformed reply: models occasionally emit unescaped
+    content inside the JSON, and a fail-closed pipeline turns every such blip
+    into a discarded trajectory.
+    """
+    try:
+        return _chat_once(system, user, cfg)
+    except (json.JSONDecodeError, KeyError, IndexError):
+        if not _retry:
+            raise
+        return _chat_once(system, user + "\n\n(Return strictly valid JSON.)", cfg)
+
+
+def _chat_once(system: str, user: str, cfg: dict[str, str]) -> dict[str, Any]:
     out = _post(
         f"{cfg['url'].rstrip('/')}/v1/chat/completions",
         {
@@ -151,46 +187,32 @@ def _parse_json(content: str) -> dict[str, Any]:
         return json.loads(text[start : end + 1])
 
 
-def steps_to_prompt(steps: list[dict[str, Any]]) -> str:
-    """Render a trajectory as numbered text units for one LLM call.
+def text_windows(steps: list[dict[str, Any]], size: int = 24_000) -> list[str]:
+    """Slice a trajectory's free text into windows that fit one LLM call.
 
-    The whole trajectory goes in one prompt on purpose: whether a token is an
-    identifier is only decidable from surrounding turns.
+    Detection does not need the step structure — it needs text to read, and
+    replacement is applied globally by substring afterwards. So a 6.8M-character
+    trajectory (the largest in the corpus) becomes a few hundred windows rather
+    than one impossible request.
     """
-    lines: list[str] = []
-    for i, step in enumerate(steps):
+    windows: list[str] = []
+    buf: list[str] = []
+    used = 0
+    for step in steps:
         for field in TEXT_FIELDS:
-            value = step.get(field)
-            if value:
-                lines.append(f"[{i}.{field}]\n{value}")
-    return "\n\n".join(lines)
-
-
-def apply_redacted_units(
-    steps: list[dict[str, Any]], units: dict[str, str]
-) -> list[dict[str, Any]]:
-    """Write redacted text back onto a copy of ``steps`` by ``i.field`` key."""
-    out = [dict(s) for s in steps]
-    for key, value in units.items():
-        idx, _, field = key.partition(".")
-        if not idx.isdigit() or field not in TEXT_FIELDS:
-            continue
-        i = int(idx)
-        if 0 <= i < len(out) and out[i].get(field):
-            out[i][field] = value
-    return out
-
-
-def parse_units(text: str) -> dict[str, str]:
-    """Parse the `[i.field]` blocks back out of a model response."""
-    units: dict[str, str] = {}
-    for match in re.finditer(
-        r"^\[(\d+\.(?:text|args_text|observation))\]\n(.*?)(?=^\[\d+\.|\Z)",
-        text,
-        re.DOTALL | re.MULTILINE,
-    ):
-        units[match.group(1)] = match.group(2).rstrip("\n")
-    return units
+            value = str(step.get(field) or "")
+            while value:
+                room = size - used
+                if room <= 0:
+                    windows.append("\n".join(buf))
+                    buf, used = [], 0
+                    room = size
+                head, value = value[:room], value[room:]
+                buf.append(head)
+                used += len(head)
+    if buf:
+        windows.append("\n".join(buf))
+    return windows
 
 
 def apply_identifiers(
@@ -239,27 +261,47 @@ def apply_identifiers(
     return out, applied
 
 
-def redact_trajectory(traj: dict[str, Any], cfg: dict[str, str]) -> tuple[dict[str, Any], str]:
+def _map_windows(system: str, windows: list[str], cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    """Run one prompt over every window concurrently, preserving order."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    workers = max(1, min(int(cfg.get("window_workers", 4)), len(windows)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return list(pool.map(lambda w: _chat(system, w, cfg), windows))
+
+
+def redact_trajectory(traj: dict[str, Any], cfg: dict[str, Any]) -> tuple[dict[str, Any], str]:
     """Return ``(trajectory, verdict)`` where verdict is ``clean`` or a reason.
 
     Never raises: a trajectory that cannot be processed is quarantined, not
     passed through. Fail-closed.
     """
     steps = traj.get("steps") or []
-    prompt = steps_to_prompt(steps)
-    if not prompt.strip():
+    size = int(cfg.get("window", 24_000))
+    windows = text_windows(steps, size)
+    if not windows or not any(w.strip() for w in windows):
         return traj, "empty"
     try:
-        found = _chat(REDACT_SYSTEM, prompt, cfg).get("identifiers") or []
-        if not isinstance(found, list):
-            return traj, "redaction returned a malformed identifier list"
+        found: list[dict[str, str]] = []
+        for reply in _map_windows(REDACT_SYSTEM, windows, cfg):
+            items = reply.get("identifiers")
+            if isinstance(items, list):
+                found.extend(i for i in items if isinstance(i, dict))
         out = dict(traj)
-        out["steps"], _ = apply_identifiers(steps, [i for i in found if isinstance(i, dict)])
-        verdict = _chat(VERIFY_SYSTEM, steps_to_prompt(out["steps"]), cfg)
+        out["steps"], _ = apply_identifiers(steps, found)
+        verdicts = _map_windows(VERIFY_SYSTEM, text_windows(out["steps"], size), cfg)
     except Exception as exc:  # noqa: BLE001 — any failure quarantines, never passes
-        return traj, f"error: {type(exc).__name__}"
-    if verdict.get("identifying"):
-        return out, f"verifier: {str(verdict.get('reason', ''))[:200]}"
+        return traj, f"error: {type(exc).__name__}: {str(exc)[:120]}"
+    for verdict in verdicts:
+        # A flag without a named entity is the verifier restating that masking
+        # happened — measured at 49% of quarantines before it had to name one.
+        entity = str(verdict.get("entity") or "").strip()
+        # A placeholder is not a name. Naming "<ORG_1>" is the verifier restating
+        # that masking happened — the failure mode that was 49% of quarantines.
+        if _IS_PLACEHOLDER_NAME.fullmatch(entity):
+            entity = ""
+        if verdict.get("identifying") and entity:
+            return out, f"verifier[{entity[:60]}]: {str(verdict.get('reason', ''))[:160]}"
     return out, "clean"
 
 
@@ -279,13 +321,12 @@ _SELF_TEST_STEPS = [
 
 
 def _self_test() -> int:
-    prompt = steps_to_prompt(_SELF_TEST_STEPS)
-    assert "[0.text]" in prompt and "[2.args_text]" in prompt and "[2.observation]" in prompt
-    assert "[1.args_text]" not in prompt, "absent fields must not be emitted"
-
-    round_tripped = parse_units(prompt)
-    assert round_tripped["0.text"] == _SELF_TEST_STEPS[0]["text"], round_tripped
-    assert round_tripped["2.observation"] == "12 rows"
+    windows = text_windows(_SELF_TEST_STEPS, size=10_000)
+    assert len(windows) == 1 and "CodeAnt" in windows[0] and "12 rows" in windows[0]
+    # A trajectory far larger than one request splits rather than failing.
+    big = [{"text": "x" * 100_000}]
+    assert len(text_windows(big, size=24_000)) == 5, len(text_windows(big, size=24_000))
+    assert sum(len(w) for w in text_windows(big, size=24_000)) == 100_000, "no text lost"
 
     applied, n = apply_identifiers(_SELF_TEST_STEPS, [{"value": "CodeAnt", "type": "ORG"}])
     assert applied[0]["text"] == "Objective: test the <ORG_1> portal at <IP_1>", applied[0]
@@ -293,8 +334,7 @@ def _self_test() -> int:
     assert _SELF_TEST_STEPS[0]["text"].startswith("Objective: test the CodeAnt"), "must not mutate"
     assert applied[1]["text"] == _SELF_TEST_STEPS[1]["text"], "untouched steps stay identical"
 
-    # Numbering continues past placeholders the client masker already emitted,
-    # so <IP_1> is never reused for a different entity.
+    # Numbering continues past placeholders the client masker already emitted.
     bumped, _ = apply_identifiers(
         [{"text": "<IP_1> and <IP_2> and 10.0.0.9"}], [{"value": "10.0.0.9", "type": "IP"}]
     )
@@ -313,19 +353,11 @@ def _self_test() -> int:
         [{"value": "<ORG_1>", "type": "ORG"}, {"value": "x", "type": "ORG"}],
     )
     assert safe[0]["text"] == "<ORG_1> x", safe
-    assert applied[1]["text"] == _SELF_TEST_STEPS[1]["text"], "untouched steps stay identical"
 
-    # A bogus key must never write outside the trajectory.
-    assert apply_redacted_units(_SELF_TEST_STEPS, {"99.text": "x", "0.bogus": "y"})[0][
-        "text"
-    ].startswith("Objective: test the CodeAnt")
-
-    # Model replies arrive fenced on some proxy paths; a strict json.loads
-    # quarantined every trajectory until this tolerated them.
+    # Model replies arrive fenced on some proxy paths.
     assert _parse_json('```json\n{"text": "ok"}\n```') == {"text": "ok"}
-    assert _parse_json('{"identifying": false}') == {"identifying": False}
     assert _parse_json('here you go: {"text": "ok"} done') == {"text": "ok"}
-    print("self-test OK: units render, round-trip, and apply without mutating the input")
+    print("self-test OK: windows split without loss; replacements apply deterministically")
     return 0
 
 
@@ -337,16 +369,23 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--out", default="-", help="redacted JSONL (training input)")
     ap.add_argument("--quarantine", default=None, help="JSONL for trajectories that failed verify")
     ap.add_argument("--limit", type=int, default=None, help="process at most N trajectories")
+    ap.add_argument("--workers", type=int, default=4, help="trajectories in flight")
+    ap.add_argument(
+        "--window-workers", type=int, default=4, help="windows in flight per trajectory"
+    )
+    ap.add_argument("--window", type=int, default=24_000, help="characters per LLM window")
     ap.add_argument("--self-test", action="store_true", help="run offline checks and exit")
     args = ap.parse_args(argv)
 
     if args.self_test:
         return _self_test()
 
-    cfg = {
+    cfg: dict[str, Any] = {
         "url": os.environ.get("DECEPTICON_LLM__PROXY_URL", ""),
         "key": os.environ.get("DECEPTICON_LLM__PROXY_API_KEY", ""),
         "model": os.environ.get("REDACT_MODEL", "auth/claude-haiku-4-5"),
+        "window": args.window,
+        "window_workers": args.window_workers,
     }
     if not cfg["url"] or not cfg["key"]:
         print(
@@ -356,43 +395,56 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     src = sys.stdin if args.src == "-" else open(args.src, encoding="utf-8")  # noqa: SIM115
+    try:
+        trajectories = [json.loads(line) for line in src if line.strip()]
+    finally:
+        if src is not sys.stdin:
+            src.close()
+    if args.limit is not None:
+        trajectories = trajectories[: args.limit]
+
     out = sys.stdout if args.out == "-" else open(args.out, "w", encoding="utf-8")  # noqa: SIM115
     quarantine = open(args.quarantine, "w", encoding="utf-8") if args.quarantine else None  # noqa: SIM115
 
     kept = dropped = 0
+    reasons: dict[str, int] = {}
     try:
-        for n, line in enumerate(src):
-            if args.limit is not None and n >= args.limit:
-                break
-            line = line.strip()
-            if not line:
-                continue
-            traj = json.loads(line)
-            redacted, verdict = redact_trajectory(traj, cfg)
-            if verdict == "clean":
-                out.write(json.dumps(redacted, ensure_ascii=False) + "\n")
-                kept += 1
-            else:
-                dropped += 1
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            futures = {pool.submit(redact_trajectory, traj, cfg): traj for traj in trajectories}
+            for done, fut in enumerate(as_completed(futures), 1):
+                redacted, verdict = fut.result()
+                if verdict == "clean":
+                    out.write(json.dumps(redacted, ensure_ascii=False) + "\n")
+                    kept += 1
+                else:
+                    dropped += 1
+                    reasons[verdict.split(":")[0]] = reasons.get(verdict.split(":")[0], 0) + 1
+                    if quarantine:
+                        quarantine.write(
+                            json.dumps(
+                                {**redacted, "_quarantine_reason": verdict}, ensure_ascii=False
+                            )
+                            + "\n"
+                        )
+                out.flush()
                 if quarantine:
-                    quarantine.write(
-                        json.dumps({**redacted, "_quarantine_reason": verdict}, ensure_ascii=False)
-                        + "\n"
+                    quarantine.flush()
+                if done % 10 == 0 or done == len(trajectories):
+                    print(
+                        f"  {done}/{len(trajectories)} — {kept} kept / {dropped} quarantined",
+                        file=sys.stderr,
+                        flush=True,
                     )
-            if (kept + dropped) % 25 == 0:
-                print(f"  {kept} kept / {dropped} quarantined", file=sys.stderr)
     finally:
-        for fh in (src, out, quarantine):
-            if fh and fh not in (sys.stdin, sys.stdout):
+        for fh in (out, quarantine):
+            if fh and fh is not sys.stdout:
                 fh.close()
 
     total = kept + dropped
     rate = (100 * dropped / total) if total else 0
     print(f"{kept} kept, {dropped} quarantined ({rate:.1f}%) of {total}", file=sys.stderr)
-    if not args.quarantine and dropped:
-        print(
-            "note: pass --quarantine to keep the rejected trajectories for review.", file=sys.stderr
-        )
+    for reason, n in sorted(reasons.items(), key=lambda kv: -kv[1]):
+        print(f"  {n:>4}  {reason}", file=sys.stderr)
     return 0
 
 

--- a/telemetry-gateway/redact_corpus.py
+++ b/telemetry-gateway/redact_corpus.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Layer 2 — the semantic redaction gate in front of training.
+
+`export_corpus.py` reconstructs trajectories from PostHog. Those trajectories
+have passed the *client* masker, which is pattern-based and therefore bounded:
+it reliably strips structured identifiers (IPs, emails, keys) and whatever the
+engagement declared, and it structurally cannot strip a company name typed into
+free prose, a credential phrased in a language the patterns do not cover, or a
+distinctive description of an asset. Reading 538k live events found all three.
+
+This script is the layer that can. It runs **after** collection and **before**
+the corpus is used for training, where latency stops mattering and correctness
+starts — the placement OpenTelemetry prescribes (redact at the collector, not
+the SDK) and the lifecycle stage ISO/IEC 27559 asks for ("internal reuse").
+
+    export_corpus.py  ->  redact_corpus.py  ->  training set
+                              |
+                              +-> quarantine.jsonl  (never reaches training)
+
+Two passes per trajectory, both LLM:
+
+1. **Redact** — mask any residual target identifier with the same `<TYPE_n>`
+   placeholders, preserving the reasoning verbatim. Technique names, tool names,
+   CVEs and ATT&CK ids are explicitly kept; they are the signal.
+2. **Verify** — an independent prompt, no memory of pass 1, asked only "does
+   anything here still identify a real organization, person, or host?" A
+   trajectory that fails is quarantined rather than shipped. Fail-closed, same
+   posture as the Tier-C scanner.
+
+A model can memorize its training data, so anything that survives this gate is
+effectively permanent. Quarantining a usable trajectory costs one trajectory;
+letting one through costs a target's data, forever.
+
+Usage:
+    set -a; . ~/.decepticon/telemetry-deploy.env; set +a
+    python export_corpus.py --out corpus.jsonl
+    python redact_corpus.py --in corpus.jsonl --out corpus.clean.jsonl \\
+        --quarantine corpus.quarantine.jsonl
+    python redact_corpus.py --self-test        # offline logic check
+
+Env: DECEPTICON_LLM__PROXY_URL, DECEPTICON_LLM__PROXY_API_KEY, REDACT_MODEL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from typing import Any
+
+# Fields carrying free text. Everything else in a step is a slug or an int.
+TEXT_FIELDS = ("text", "args_text", "observation")
+
+# A placeholder the client masker already produced. Pass 1 must reuse this shape
+# so a trajectory stays internally consistent.
+PLACEHOLDER = re.compile(r"<[A-Z]+_\d+>")
+
+REDACT_SYSTEM = """\
+You find identifiers in red-team engagement transcripts destined for a training
+corpus. You do NOT rewrite the text — you only report what must be masked, and
+code applies the replacements.
+
+Report every remaining identifier of a REAL target. Types: ORG, PERSON, HOST, \
+IP, URL, DOMAIN, CRED, EMAIL, PATH.
+
+Report:
+- organization, product, client and bug-bounty program names
+- personal names, usernames, email addresses
+- hostnames, domains, IPs, URLs, and file paths that identify a target
+- credentials, keys and tokens in ANY language or syntax, including command-line
+  flags (-p, --password) and natural phrasings
+
+Keep EXACTLY as written — these are the signal, not identifiers:
+- the reasoning, hypotheses, and rationale
+- technique names, tool names, CVE ids, MITRE ATT&CK ids, CWE ids
+- generic infrastructure words (nginx, mysql, Active Directory, ESXi)
+- existing <TYPE_n> placeholders
+
+Return the exact substrings to replace, copied verbatim from the input so they
+can be matched literally. Report each distinct value once; every occurrence is
+replaced. Report nothing if there is nothing to mask.
+
+Return JSON and nothing else:
+{"identifiers": [{"value": "<exact substring>", "type": "<TYPE>"}]}\
+"""
+
+VERIFY_SYSTEM = """\
+You audit de-identified red-team text before it is used to train a model.
+
+Answer one question: could a reader identify a real organization, person, or \
+host from this text? Consider indirect evidence — a product name, a bug-bounty \
+program, a distinctive asset description, or an unusual combination of details \
+— not only explicit identifiers. <TYPE_n> placeholders are already masked and \
+are not identifying.
+
+Be strict. A model memorizes its training data, so a miss is permanent.
+
+Return JSON: {"identifying": true|false, "reason": "<short reason>"}\
+"""
+
+
+def _post(url: str, body: dict[str, Any], api_key: str, timeout: int = 120) -> dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"content-type": "application/json", "authorization": f"Bearer {api_key}"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — operator-configured
+        return json.loads(resp.read())
+
+
+def _chat(system: str, user: str, cfg: dict[str, str]) -> dict[str, Any]:
+    """One JSON-returning chat completion through the LiteLLM proxy."""
+    out = _post(
+        f"{cfg['url'].rstrip('/')}/v1/chat/completions",
+        {
+            "model": cfg["model"],
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "response_format": {"type": "json_object"},
+            "max_tokens": 8000,
+        },
+        cfg["key"],
+    )
+    return _parse_json(out["choices"][0]["message"]["content"])
+
+
+def _parse_json(content: str) -> dict[str, Any]:
+    """Parse a model's JSON reply, tolerating a markdown fence around it.
+
+    ``response_format={"type": "json_object"}`` is advisory on some proxy paths —
+    the Anthropic-via-OAuth route returns ```` ```json … ``` ```` — so a strict
+    ``json.loads`` quarantined every trajectory.
+    """
+    text = content.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-z]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text.rstrip())
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start, end = text.find("{"), text.rfind("}")
+        if start == -1 or end <= start:
+            raise
+        return json.loads(text[start : end + 1])
+
+
+def steps_to_prompt(steps: list[dict[str, Any]]) -> str:
+    """Render a trajectory as numbered text units for one LLM call.
+
+    The whole trajectory goes in one prompt on purpose: whether a token is an
+    identifier is only decidable from surrounding turns.
+    """
+    lines: list[str] = []
+    for i, step in enumerate(steps):
+        for field in TEXT_FIELDS:
+            value = step.get(field)
+            if value:
+                lines.append(f"[{i}.{field}]\n{value}")
+    return "\n\n".join(lines)
+
+
+def apply_redacted_units(
+    steps: list[dict[str, Any]], units: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Write redacted text back onto a copy of ``steps`` by ``i.field`` key."""
+    out = [dict(s) for s in steps]
+    for key, value in units.items():
+        idx, _, field = key.partition(".")
+        if not idx.isdigit() or field not in TEXT_FIELDS:
+            continue
+        i = int(idx)
+        if 0 <= i < len(out) and out[i].get(field):
+            out[i][field] = value
+    return out
+
+
+def parse_units(text: str) -> dict[str, str]:
+    """Parse the `[i.field]` blocks back out of a model response."""
+    units: dict[str, str] = {}
+    for match in re.finditer(
+        r"^\[(\d+\.(?:text|args_text|observation))\]\n(.*?)(?=^\[\d+\.|\Z)",
+        text,
+        re.DOTALL | re.MULTILINE,
+    ):
+        units[match.group(1)] = match.group(2).rstrip("\n")
+    return units
+
+
+def apply_identifiers(
+    steps: list[dict[str, Any]], identifiers: list[dict[str, str]]
+) -> tuple[list[dict[str, Any]], int]:
+    """Replace reported identifiers across every text field. Pure, deterministic.
+
+    The model reports WHAT to mask; this does the masking. That split matters:
+    asking a model to echo a whole trajectory back risks truncation and silent
+    rewriting of the reasoning, which is the one thing the corpus exists to keep.
+
+    Longest value first so a substring never eats its container. Numbering
+    continues past the placeholders the client masker already emitted.
+    """
+    counters: dict[str, int] = {}
+    for step in steps:
+        for field in TEXT_FIELDS:
+            for m in PLACEHOLDER.finditer(str(step.get(field) or "")):
+                ptype, _, num = m.group(0)[1:-1].rpartition("_")
+                if num.isdigit():
+                    counters[ptype] = max(counters.get(ptype, 0), int(num))
+
+    mapping: dict[str, str] = {}
+    for item in sorted(identifiers, key=lambda i: len(str(i.get("value", ""))), reverse=True):
+        value = str(item.get("value") or "")
+        ptype = re.sub(r"[^A-Z]", "", str(item.get("type") or "").upper()) or "ORG"
+        # Never mask an existing placeholder, and never mask a fragment so short
+        # it would match everywhere.
+        if len(value) < 3 or PLACEHOLDER.fullmatch(value) or value in mapping:
+            continue
+        counters[ptype] = counters.get(ptype, 0) + 1
+        mapping[value] = f"<{ptype}_{counters[ptype]}>"
+
+    out = [dict(s) for s in steps]
+    applied = 0
+    for step in out:
+        for field in TEXT_FIELDS:
+            text = step.get(field)
+            if not text:
+                continue
+            for value, token in mapping.items():
+                if value in text:
+                    text = text.replace(value, token)
+                    applied += 1
+            step[field] = text
+    return out, applied
+
+
+def redact_trajectory(traj: dict[str, Any], cfg: dict[str, str]) -> tuple[dict[str, Any], str]:
+    """Return ``(trajectory, verdict)`` where verdict is ``clean`` or a reason.
+
+    Never raises: a trajectory that cannot be processed is quarantined, not
+    passed through. Fail-closed.
+    """
+    steps = traj.get("steps") or []
+    prompt = steps_to_prompt(steps)
+    if not prompt.strip():
+        return traj, "empty"
+    try:
+        found = _chat(REDACT_SYSTEM, prompt, cfg).get("identifiers") or []
+        if not isinstance(found, list):
+            return traj, "redaction returned a malformed identifier list"
+        out = dict(traj)
+        out["steps"], _ = apply_identifiers(steps, [i for i in found if isinstance(i, dict)])
+        verdict = _chat(VERIFY_SYSTEM, steps_to_prompt(out["steps"]), cfg)
+    except Exception as exc:  # noqa: BLE001 — any failure quarantines, never passes
+        return traj, f"error: {type(exc).__name__}"
+    if verdict.get("identifying"):
+        return out, f"verifier: {str(verdict.get('reason', ''))[:200]}"
+    return out, "clean"
+
+
+# ── offline checks ───────────────────────────────────────────────────────────
+
+_SELF_TEST_STEPS = [
+    {"step": 0, "role": "human", "text": "Objective: test the CodeAnt portal at <IP_1>"},
+    {"step": 1, "role": "agent", "text": "SQLi on the login looks promising"},
+    {
+        "step": 2,
+        "role": "tool",
+        "tool": "bash",
+        "args_text": "sqlmap -u <URL_1>",
+        "observation": "12 rows",
+    },
+]
+
+
+def _self_test() -> int:
+    prompt = steps_to_prompt(_SELF_TEST_STEPS)
+    assert "[0.text]" in prompt and "[2.args_text]" in prompt and "[2.observation]" in prompt
+    assert "[1.args_text]" not in prompt, "absent fields must not be emitted"
+
+    round_tripped = parse_units(prompt)
+    assert round_tripped["0.text"] == _SELF_TEST_STEPS[0]["text"], round_tripped
+    assert round_tripped["2.observation"] == "12 rows"
+
+    applied, n = apply_identifiers(_SELF_TEST_STEPS, [{"value": "CodeAnt", "type": "ORG"}])
+    assert applied[0]["text"] == "Objective: test the <ORG_1> portal at <IP_1>", applied[0]
+    assert n == 1
+    assert _SELF_TEST_STEPS[0]["text"].startswith("Objective: test the CodeAnt"), "must not mutate"
+    assert applied[1]["text"] == _SELF_TEST_STEPS[1]["text"], "untouched steps stay identical"
+
+    # Numbering continues past placeholders the client masker already emitted,
+    # so <IP_1> is never reused for a different entity.
+    bumped, _ = apply_identifiers(
+        [{"text": "<IP_1> and <IP_2> and 10.0.0.9"}], [{"value": "10.0.0.9", "type": "IP"}]
+    )
+    assert bumped[0]["text"] == "<IP_1> and <IP_2> and <IP_3>", bumped
+
+    # Longest first, so a substring never eats its container.
+    nested, _ = apply_identifiers(
+        [{"text": "corp and corp-internal"}],
+        [{"value": "corp", "type": "ORG"}, {"value": "corp-internal", "type": "ORG"}],
+    )
+    assert nested[0]["text"] == "<ORG_2> and <ORG_1>", nested
+
+    # An existing placeholder is never re-masked, and fragments are ignored.
+    safe, _ = apply_identifiers(
+        [{"text": "<ORG_1> x"}],
+        [{"value": "<ORG_1>", "type": "ORG"}, {"value": "x", "type": "ORG"}],
+    )
+    assert safe[0]["text"] == "<ORG_1> x", safe
+    assert applied[1]["text"] == _SELF_TEST_STEPS[1]["text"], "untouched steps stay identical"
+
+    # A bogus key must never write outside the trajectory.
+    assert apply_redacted_units(_SELF_TEST_STEPS, {"99.text": "x", "0.bogus": "y"})[0][
+        "text"
+    ].startswith("Objective: test the CodeAnt")
+
+    # Model replies arrive fenced on some proxy paths; a strict json.loads
+    # quarantined every trajectory until this tolerated them.
+    assert _parse_json('```json\n{"text": "ok"}\n```') == {"text": "ok"}
+    assert _parse_json('{"identifying": false}') == {"identifying": False}
+    assert _parse_json('here you go: {"text": "ok"} done') == {"text": "ok"}
+    print("self-test OK: units render, round-trip, and apply without mutating the input")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--in", dest="src", default="-", help="corpus JSONL from export_corpus.py")
+    ap.add_argument("--out", default="-", help="redacted JSONL (training input)")
+    ap.add_argument("--quarantine", default=None, help="JSONL for trajectories that failed verify")
+    ap.add_argument("--limit", type=int, default=None, help="process at most N trajectories")
+    ap.add_argument("--self-test", action="store_true", help="run offline checks and exit")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    cfg = {
+        "url": os.environ.get("DECEPTICON_LLM__PROXY_URL", ""),
+        "key": os.environ.get("DECEPTICON_LLM__PROXY_API_KEY", ""),
+        "model": os.environ.get("REDACT_MODEL", "auth/claude-haiku-4-5"),
+    }
+    if not cfg["url"] or not cfg["key"]:
+        print(
+            "error: set DECEPTICON_LLM__PROXY_URL and DECEPTICON_LLM__PROXY_API_KEY.",
+            file=sys.stderr,
+        )
+        return 2
+
+    src = sys.stdin if args.src == "-" else open(args.src, encoding="utf-8")  # noqa: SIM115
+    out = sys.stdout if args.out == "-" else open(args.out, "w", encoding="utf-8")  # noqa: SIM115
+    quarantine = open(args.quarantine, "w", encoding="utf-8") if args.quarantine else None  # noqa: SIM115
+
+    kept = dropped = 0
+    try:
+        for n, line in enumerate(src):
+            if args.limit is not None and n >= args.limit:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            traj = json.loads(line)
+            redacted, verdict = redact_trajectory(traj, cfg)
+            if verdict == "clean":
+                out.write(json.dumps(redacted, ensure_ascii=False) + "\n")
+                kept += 1
+            else:
+                dropped += 1
+                if quarantine:
+                    quarantine.write(
+                        json.dumps({**redacted, "_quarantine_reason": verdict}, ensure_ascii=False)
+                        + "\n"
+                    )
+            if (kept + dropped) % 25 == 0:
+                print(f"  {kept} kept / {dropped} quarantined", file=sys.stderr)
+    finally:
+        for fh in (src, out, quarantine):
+            if fh and fh not in (sys.stdin, sys.stdout):
+                fh.close()
+
+    total = kept + dropped
+    rate = (100 * dropped / total) if total else 0
+    print(f"{kept} kept, {dropped} quarantined ({rate:.1f}%) of {total}", file=sys.stderr)
+    if not args.quarantine and dropped:
+        print(
+            "note: pass --quarantine to keep the rejected trajectories for review.", file=sys.stderr
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/telemetry-gateway/src/tierc.ts
+++ b/telemetry-gateway/src/tierc.ts
@@ -30,7 +30,13 @@ const PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
   ["aws_access_key", /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/],
   ["email", /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/],
   ["url", /\bhttps?:\/\/[^\s/$.?#][^\s]*/i],
-  ["ipv4", /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b/],
+  // `(?<![\d.])` rather than `\b`: a letter directly before a digit is not a
+  // word boundary, so `ESXI10.10.0.95` slipped past both this scanner and the
+  // client masker in a real engagement. Mirrors `redact._IP_GLUED`.
+  [
+    "ipv4",
+    /(?<![\d.])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?![\d.])/,
+  ],
   ["ipv6", /\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b|\b(?:[A-Fa-f0-9]{1,4}:){1,7}:\b/],
   ["mac", /\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b/],
   ["user_pass", /\b[\w.-]+:[^\s:@/]{4,}@[\w.-]+/],

--- a/telemetry-gateway/src/tierc.ts
+++ b/telemetry-gateway/src/tierc.ts
@@ -37,7 +37,11 @@ const PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
     "ipv4",
     /(?<![\d.])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?![\d.])/,
   ],
-  ["ipv6", /\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b|\b(?:[A-Fa-f0-9]{1,4}:){1,7}:\b/],
+  // Four groups minimum, mirroring `redact._IP6`: three colon-separated groups
+  // is a wall-clock time, and tool output is full of timestamps. With `{2,7}`
+  // this scanner rejected a batch over `21:35:00` that the masker — correctly —
+  // had left alone.
+  ["ipv6", /\b(?:[A-Fa-f0-9]{1,4}:){3,7}[A-Fa-f0-9]{1,4}\b|\b(?:[A-Fa-f0-9]{1,4}:){1,7}:\b/],
   ["mac", /\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b/],
   ["user_pass", /\b[\w.-]+:[^\s:@/]{4,}@[\w.-]+/],
   // Long opaque blob: base64/hex secret material. 40+ chars with no spaces.

--- a/telemetry-gateway/test/tierc.test.ts
+++ b/telemetry-gateway/test/tierc.test.ts
@@ -72,3 +72,16 @@ describe("dotted code is not a host", () => {
     expect(scanTierC("pivot to app.corp.internal")?.klass).toBe("domain");
   });
 });
+
+describe("IPv4 glued to a label", () => {
+  it("catches an address a word boundary would miss", () => {
+    // Leaked verbatim in a real engagement: `ESXI10.10.0.95`.
+    expect(scanTierC("ESXI10.10.0.95")?.klass).toBe("ipv4");
+    expect(scanTierC("veeam 10.10.0.51")?.klass).toBe("ipv4");
+  });
+
+  it("does not slice a longer dotted number in half", () => {
+    expect(scanTierC("version 1.2.3 build 4")).toBeNull();
+    expect(scanTierC("1.10.10.0.95.7")).toBeNull();
+  });
+});

--- a/telemetry-gateway/test/tierc.test.ts
+++ b/telemetry-gateway/test/tierc.test.ts
@@ -85,3 +85,15 @@ describe("IPv4 glued to a label", () => {
     expect(scanTierC("1.10.10.0.95.7")).toBeNull();
   });
 });
+
+describe("wall-clock time is not IPv6", () => {
+  it("accepts a timestamp the masker correctly leaves alone", () => {
+    // With three groups this rejected whole batches over `21:35:00`.
+    expect(scanTierC('"saved_at": "2026-07-21T21:35:00"')).toBeNull();
+    expect(scanTierC("completed at 21:35:00 UTC")).toBeNull();
+  });
+
+  it("still rejects a real IPv6 address", () => {
+    expect(scanTierC("2001:db8:85a3:8d3:1319:8a2e:370:7348")?.klass).toBe("ipv6");
+  });
+});


### PR DESCRIPTION
Follow-up to #785. Same investigation, the parts that landed after it merged.

## Why

#785 revived the fields that were shipping empty. Reading what then came
through — the real corpus, 715 trajectories / 119,775 steps — turned up
identifiers still leaving machines, and two bugs in the export path itself.

## Leaks found in live data

**Command-line credentials.** Operators paste whole command lines, and no
`key:value` detector sees a flag. Verbatim from a real engagement:

```
nxc smb <ip> -u Administrator -p 'Ujmqaz5055' --smb-timeout 10 --local-auth
```

`-p` is also nmap's port flag — the most-run tool in the corpus — so a purely
numeric/comma/dash value is left alone (`-p 80,443`, `-p-`, `-p 1-65535`), and
`-u` is matched only in its credential form (`curl -u a:b`), leaving `sort -u`
and `docker -u 1000` untouched.

**An IP glued to a label.** `\b` is not a word boundary between a letter and a
digit, so `ESXI10.10.0.95` passed both the maintained IP detector and the
Tier-C scanner. Both scanners get the same lookbehind.

**Every wall-clock time masked as IPv6.** `21:35:00` is three colon-separated
groups. Found in the export as `"saved_at": "2026-07-21T21:<CRED_1>:00"` —
tool output is full of timestamps, so this corrupted text at scale. Four groups
minimum now; compressed `::` forms never matched this pattern anyway.

Each fix lands in **both** the client masker and the Tier-C scanners, keeping
the invariant that anything a scanner rejects is something the masker can mask
— otherwise a step is dropped whole instead of masked, which is strictly worse.

## Bugs in the export path

**`export_corpus` exported 100 of 119,774 rows and reported success.** HogQL
applies a default `LIMIT 100` when a query does not state one. `OFFSET` is
rejected for personal API keys, so this is keyset pagination on `timestamp`
with dedupe across the boundary. A silently truncated corpus is worse than a
failed export.

```
before:   6 trajectories /     100 steps
after : 715 trajectories / 119,775 steps
```

## The L2 gate

Internal-training use is confirmed, so the corpus needs a layer the client
masker structurally cannot be. Pattern matching cannot find a company name in
free prose, a credential phrased in a language the patterns do not cover, or a
distinctive asset description — and the corpus contains all three.

`redact_corpus.py` sits between `export_corpus.py` and any training set: after
collection, before use, where latency stops mattering. Two LLM passes — one
reports identifiers, an independent one audits the result — and anything the
auditor flags is quarantined, never passed. A model memorizes its training
data, so a miss is permanent; quarantining a usable trajectory costs one
trajectory.

The model reports **what** to mask and code applies it. Asking the model to
echo a whole trajectory back truncated and silently rewrote the reasoning — the
one thing the corpus exists to keep.

### Calibrating the auditor was the hard part

| version | quarantined | failure |
|---|---|---|
| judgment-style | 53% | flagged "a red-team engagement happened" as identifying |
| narrowed criteria | 42% | **49% circular** — read the placeholders, concluded something was masked, flagged the text for containing masking |
| ask for evidence | — | flagged the operator's own tools (nmap, semgrep, BloodHound), software the target runs (Redis, ADFS), emulated actors (Sandworm) |
| target vs. tooling | **22.5%** | every remaining flag names a real target |

The turn was asking it to **name the target** rather than judge the text. A
placeholder cannot be named, so the circular path closes. A verdict whose
`entity` is itself a placeholder is rejected in code.

Run against the live corpus, it named targets the pattern masker cannot reach:

```
Telefónica · Telenor · Roblox · Cybersource · Acorns · LDCC-VN · XO Club Dubai
Vietnamese real estate platform · vynex (crypto drainer) · applyfy · vulnbank
```

and masked what reading the data had turned up by hand:
`report_arcgisonline.md` → `report_<PATH_1>`, `"engagement_name": "Project
Shadow"` → `<ORG_1>`, a HackerOne handle → `<PERSON_2>`.

## Gates

```
ruff check / format   pass
basedpyright          0 errors
pytest                100 passed
gateway               typecheck + 48 tests pass
export/redact         self-tests pass
```

Live-verified against the deployed gateway (`3408d471`, already shipped):
masked code 202 · masked credential flags 202 · port lists and version strings
202 · timestamps 202 · bare host **422** · raw IP **422** · glued IP **422** ·
real IPv6 **422**.

## Not in scope

- **The corpus already collected keeps its leaks.** These client fixes apply
  going forward only; the 538k events already in the backend can only be
  cleaned by L2.
- **`roe.json` usually has no `client`.** The schema requires it and the
  roe-template skill interviews for it, but real files on disk omit it — so
  declared-org masking underperforms until the skill and schema agree. Left
  out here because editing a skill triggers the `skills.cypher` rebuild.
- **Retention is still unbounded**, and `TELEMETRY.md` says so rather than
  claiming a window nobody enforces.
- **L3** — sample review of what *passed* — has not been run.
