### PR TITLE
feat(llm): make self-hosted vLLM discoverable, matching the Ollama shortcut

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,41 @@ CLOUDFLARE_AI_GATEWAY_API_KEY=your-cloudflare-ai-gateway-key-here
 # CUSTOM_OPENAI_API_KEY=...
 # CUSTOM_OPENAI_MODEL=gpt-4o-mini
 
+# --- Self-hosted LLM (vLLM) ---
+# For running your own model on your own GPU. Set both and the proxy
+# registers hosted_vllm/<model> at startup — the same shape as OLLAMA_MODEL
+# below, so you don't need to know the LiteLLM provider prefix.
+#
+# VLLM_MODEL must match the server's --served-model-name, NOT the HuggingFace
+# repo. vLLM answers on the served name only, and a mismatch 404s in a way
+# that reads like a routing bug rather than a typo.
+# VLLM_API_BASE=http://host.docker.internal:8000/v1
+# VLLM_MODEL=qwen3-coder-30b
+# VLLM_API_KEY=  # only if you started vLLM with --api-key
+#
+# Serving notes, learned the hard way on a rented Ampere GPU:
+#
+#   --enable-auto-tool-choice --tool-call-parser <parser>  is mandatory.
+#     Without the right parser vLLM returns tool calls as plain text, the
+#     agent calls nothing, and the run fails with no error anywhere. Pick the
+#     parser by reading the model's chat_template: a <tool_call>{"name":...}
+#     JSON body is `hermes`, while <function=name><parameter=k> XML is
+#     `qwen3_coder` / `qwen3_xml`. Guessing costs a full model load to find out.
+#
+#   Prefer a pure-transformer model. vLLM disables automatic prefix caching on
+#     Mamba/linear-attention hybrids, and this agent resends a large prompt
+#     every turn — losing the cache costs far more than the architecture wins.
+#     Check the startup log for `enable_prefix_caching=True`.
+#
+#   MoE beats dense at equal VRAM. A 30B-A3B (3B active) measured ~4x the
+#     generation speed of a 27B dense on the same card, and its smaller weights
+#     leave several times more room for KV cache.
+#
+#   VLLM_USE_FLASHINFER_SAMPLER=0 on hosts with the NVIDIA driver but no CUDA
+#     toolkit. The flashinfer sampler JIT-compiles at startup and dies with
+#     "Could not find nvcc"; attention is unaffected, so disabling just the
+#     sampler is cheaper than installing the toolkit.
+
 # --- Local LLM (Ollama) ---
 # Set both to run Decepticon against a local Ollama model. The
 # launcher's onboard wizard writes these when you pick "Local LLM".

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -401,6 +401,39 @@ def _ollama_model_from_env(source: Mapping[str, str]) -> str | None:
     return f"ollama_chat/{model}"
 
 
+def _vllm_model_from_env(source: Mapping[str, str]) -> str | None:
+    """Derive ``hosted_vllm/<model>`` from VLLM_API_BASE / VLLM_MODEL.
+
+    The ``hosted_vllm`` provider already works through the generic
+    ``DECEPTICON_MODEL_<ROLE>=hosted_vllm/<model>`` path, but that requires
+    knowing the prefix exists. This mirrors the ``OLLAMA_MODEL`` shortcut so
+    self-hosting a model is symmetric with running one under Ollama: point at
+    the server, name the model, done.
+
+    The model must match the server's ``--served-model-name``, not the
+    HuggingFace repo — vLLM answers on the served name only, and a mismatch
+    surfaces as a 404 that reads like a routing bug rather than a typo.
+
+    ``vllm/`` is passed through untouched so validate_model_name() can reject
+    it with a hint. It is LiteLLM's deprecated local-SDK provider, not the
+    hosted server, and silently rewriting it would leave a ``VLLM_MODEL`` line
+    that disagrees with the route the proxy actually registered.
+    """
+    base = _clean_model(source.get("VLLM_API_BASE")) or _clean_model(
+        source.get("HOSTED_VLLM_API_BASE")
+    )
+    model = _clean_model(source.get("VLLM_MODEL")) or _clean_model(source.get("HOSTED_VLLM_MODEL"))
+    if base is None or model is None:
+        # Unlike Ollama there is no sensible default model: a vLLM server
+        # serves exactly what it was started with. Registering a guess would
+        # produce a route that 404s on every call.
+        return None
+    lower = model.lower()
+    if lower.startswith("hosted_vllm/") or lower.startswith("vllm/"):
+        return model
+    return f"hosted_vllm/{model}"
+
+
 def collect_requested_models(env: Mapping[str, str] | None = None) -> set[str]:
     """Collect model IDs requested through DECEPTICON_MODEL* env vars.
 
@@ -423,6 +456,10 @@ def collect_requested_models(env: Mapping[str, str] | None = None) -> set[str]:
     ollama_model = _ollama_model_from_env(source)
     if ollama_model is not None:
         models.add(ollama_model)
+
+    vllm_model = _vllm_model_from_env(source)
+    if vllm_model is not None:
+        models.add(vllm_model)
 
     return models
 
@@ -662,7 +699,29 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
             # _NO_API_KEY_PROVIDERS. Replaces the former bedrock / vertex_ai /
             # azure / derived-key elif chain.
             params.update(PROVIDER_EXTRA_PARAMS.get(provider, {}))
-            if provider not in _NO_API_KEY_PROVIDERS:
+            if provider == "hosted_vllm":
+                # The table above points at HOSTED_VLLM_API_BASE, but the
+                # VLLM_MODEL shortcut lets an operator name the server with the
+                # shorter VLLM_API_BASE. Emitting the unset one would resolve to
+                # an empty string at request time and 404 with no clue as to
+                # why, so pin whichever the operator actually set. Same failure
+                # mode the ollama_chat branch guards against.
+                if not os.environ.get("HOSTED_VLLM_API_BASE", "").strip():
+                    if os.environ.get("VLLM_API_BASE", "").strip():
+                        params["api_base"] = "os.environ/VLLM_API_BASE"
+                # Same split for the key: the catalog name is
+                # HOSTED_VLLM_API_KEY, but an operator who used the VLLM_MODEL
+                # shortcut will reach for VLLM_API_KEY. Prefer whichever is
+                # actually set; the catalog name stays the default so the
+                # every-provider-uses-a-verified-key-env invariant holds.
+                if not os.environ.get("HOSTED_VLLM_API_KEY", "").strip():
+                    if os.environ.get("VLLM_API_KEY", "").strip():
+                        params["api_key"] = "os.environ/VLLM_API_KEY"
+                    else:
+                        params["api_key"] = f"os.environ/{_resolve_key_env(provider)}"
+                else:
+                    params["api_key"] = f"os.environ/{_resolve_key_env(provider)}"
+            elif provider not in _NO_API_KEY_PROVIDERS:
                 params["api_key"] = f"os.environ/{_resolve_key_env(provider)}"
 
     return {"model_name": model_name, "litellm_params": params}

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,6 @@
 # Models
 
-Decepticon routes every LLM call through a [LiteLLM](https://github.com/BerriAI/litellm) proxy that abstracts Anthropic, OpenAI, Google, MiniMax, DeepSeek, xAI, Mistral, OpenRouter, Nvidia NIM, **local Ollama**, plus six subscription OAuth handlers (Claude Code / ChatGPT / Gemini Advanced / Copilot Pro / SuperGrok / Perplexity Pro) behind a single endpoint. The model assigned to each agent — and the model that takes over when the primary fails — is computed at startup from your **credentials inventory** plus the active **profile**.
+Decepticon routes every LLM call through a [LiteLLM](https://github.com/BerriAI/litellm) proxy that abstracts Anthropic, OpenAI, Google, MiniMax, DeepSeek, xAI, Mistral, OpenRouter, Nvidia NIM, **local Ollama**, **self-hosted vLLM**, plus six subscription OAuth handlers (Claude Code / ChatGPT / Gemini Advanced / Copilot Pro / SuperGrok / Perplexity Pro) behind a single endpoint. The model assigned to each agent — and the model that takes over when the primary fails — is computed at startup from your **credentials inventory** plus the active **profile**.
 
 You don't pick agent-by-agent models manually. You tell Decepticon which credentials you have, in what order of preference; it builds the chain.
 
@@ -41,7 +41,7 @@ For each agent, Decepticon resolves a tier (from the profile) and walks your Aut
 
 `ollama_local` collapses across tiers — local GPUs typically run a single model — and the slug is whatever you pulled (e.g. `qwen3-coder:30b`). When a method has no model at the requested tier (MiniMax LOW, Mistral LOW, ...), the resolver skips it and continues with the next method in your priority list.
 
-The matrix above lists the primary tier-mapped providers. Decepticon resolves the same tier × AuthMethod chain for additional providers not shown above: managed cloud platforms (AWS Bedrock, GCP Vertex AI, Azure OpenAI), further direct APIs (Groq, Together, Fireworks, Cohere, Moonshot, Z.ai, DashScope, Cerebras, Xiaomi MiMo, Baidu Qianfan), multi-vendor gateways (GitHub Models, Hugging Face, OpenCode, Vercel AI Gateway, Cloudflare AI Gateway, Venice, NanoGPT, Synthetic, ZenMux), and local / self-hosted OpenAI-compatible servers (Ollama Cloud, LM Studio, llama.cpp, and custom endpoints). `AuthMethod` and `METHOD_MODELS` in `packages/decepticon-core/decepticon_core/types/llm.py` are the authoritative source for the full provider list and each provider's tier→model mapping.
+The matrix above lists the primary tier-mapped providers. Decepticon resolves the same tier × AuthMethod chain for additional providers not shown above: managed cloud platforms (AWS Bedrock, GCP Vertex AI, Azure OpenAI), further direct APIs (Groq, Together, Fireworks, Cohere, Moonshot, Z.ai, DashScope, Cerebras, Xiaomi MiMo, Baidu Qianfan), multi-vendor gateways (GitHub Models, Hugging Face, OpenCode, Vercel AI Gateway, Cloudflare AI Gateway, Venice, NanoGPT, Synthetic, ZenMux), and local / self-hosted OpenAI-compatible servers (vLLM, Ollama Cloud, LM Studio, llama.cpp, and custom endpoints). `AuthMethod` and `METHOD_MODELS` in `packages/decepticon-core/decepticon_core/types/llm.py` are the authoritative source for the full provider list and each provider's tier→model mapping.
 
 ---
 

--- a/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
@@ -697,3 +697,68 @@ def test_every_catalog_prefix_is_allowed_or_rejected() -> None:
         if prefix in _REJECTED_CATALOG_PREFIXES:
             continue
         assert provider in ALLOWED_DYNAMIC_PROVIDERS, prefix
+
+
+def test_collect_requested_models_picks_up_vllm_shortcut(monkeypatch) -> None:
+    """VLLM_MODEL + VLLM_API_BASE registers a route without knowing the prefix.
+
+    Parity with the OLLAMA_MODEL shortcut: self-hosting a model should not
+    require learning that ``hosted_vllm/`` is the LiteLLM provider name.
+    """
+    env = {"VLLM_API_BASE": "http://gpu:8000/v1", "VLLM_MODEL": "qwen3-coder-30b"}
+    assert "hosted_vllm/qwen3-coder-30b" in collect_requested_models(env)
+
+
+def test_collect_requested_models_vllm_needs_both_vars() -> None:
+    """A base URL alone must not register a route.
+
+    Unlike Ollama there is no defensible default model — a vLLM server serves
+    exactly what it was started with, so a guessed slug would 404 on every call.
+    """
+    assert collect_requested_models({"VLLM_API_BASE": "http://gpu:8000/v1"}) == set()
+    assert collect_requested_models({"VLLM_MODEL": "qwen3-coder-30b"}) == set()
+
+
+def test_collect_requested_models_vllm_passes_through_qualified_id() -> None:
+    """An already-prefixed value is left alone, including the deprecated one.
+
+    ``vllm/`` is LiteLLM's local-SDK provider, not the hosted server. It is
+    passed through so validate_model_name can reject it with a hint; rewriting
+    it silently would leave the operator's env disagreeing with the route.
+    """
+    env = {"VLLM_API_BASE": "http://gpu:8000/v1", "VLLM_MODEL": "hosted_vllm/m"}
+    assert "hosted_vllm/m" in collect_requested_models(env)
+    env["VLLM_MODEL"] = "vllm/m"
+    assert "vllm/m" in collect_requested_models(env)
+
+
+def test_build_model_entry_vllm_uses_the_base_url_that_is_set(monkeypatch) -> None:
+    """The emitted api_base must name whichever env var the operator set.
+
+    Emitting the unset one resolves to an empty string at request time and
+    404s with nothing pointing at the cause.
+    """
+    monkeypatch.delenv("HOSTED_VLLM_API_BASE", raising=False)
+    monkeypatch.setenv("VLLM_API_BASE", "http://gpu:8000/v1")
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    monkeypatch.delenv("HOSTED_VLLM_API_KEY", raising=False)
+    entry = build_model_entry("hosted_vllm/qwen3-coder-30b")
+    assert entry["litellm_params"]["api_base"] == "os.environ/VLLM_API_BASE"
+
+
+def test_build_model_entry_vllm_uses_the_key_env_that_is_set(monkeypatch) -> None:
+    """The key follows the same shortcut split as the base URL.
+
+    An operator who set VLLM_API_BASE will reach for VLLM_API_KEY, not the
+    catalog name. The catalog name stays the default so the
+    every-provider-uses-a-verified-key-env invariant still holds.
+    """
+    monkeypatch.setenv("VLLM_API_BASE", "http://gpu:8000/v1")
+    monkeypatch.delenv("HOSTED_VLLM_API_KEY", raising=False)
+    monkeypatch.setenv("VLLM_API_KEY", "sk-local")
+    entry = build_model_entry("hosted_vllm/qwen3-coder-30b")
+    assert entry["litellm_params"]["api_key"] == "os.environ/VLLM_API_KEY"
+
+    monkeypatch.setenv("HOSTED_VLLM_API_KEY", "sk-catalog")
+    entry = build_model_entry("hosted_vllm/qwen3-coder-30b")
+    assert entry["litellm_params"]["api_key"] == "os.environ/HOSTED_VLLM_API_KEY"


### PR DESCRIPTION
## The routing already worked — nobody could find it

`hosted_vllm` has been in the provider catalog all along (`HOSTED_VLLM_API_BASE`, `HOSTED_VLLM_API_KEY`). What was missing is any way to discover that:

| | Ollama | vLLM (before) |
|---|---|---|
| `.env.example` | labelled block, 20 lines | one word inside a parenthetical |
| shortcut env var | `OLLAMA_MODEL` → auto-registers | none — you had to know the `hosted_vllm/` prefix |
| `docs/models.md` | listed in the matrix | absent |
| elsewhere in `docs/` | — | only as something `llm-redteam` **attacks** |

Someone running their own GPU had to already know the LiteLLM prefix to use the feature.

## Change

`VLLM_MODEL` + `VLLM_API_BASE` register `hosted_vllm/<model>` at startup — the same shape as the Ollama shortcut.

**Both vars are required.** Unlike Ollama there is no defensible default: a vLLM server serves exactly what it was started with, so a guessed slug would 404 on every call. An already-prefixed value passes through untouched, including the deprecated `vllm/` (LiteLLM's local-SDK provider, *not* the hosted server) so `validate_model_name` can reject it with a hint instead of silently rewriting it into disagreement with the operator's `.env`.

The shortcut introduces a second name for the same setting, so the entry builder now emits **whichever env var is actually set**, for both base URL and key. Emitting the unset one resolves to an empty string at request time and 404s or 401s with nothing pointing at the cause — the same trap the `ollama_chat` branch already guards against. The catalog name stays the default, so the existing invariant that every catalog provider references a source-verified key env still holds (that test caught an earlier draft of this and is unmodified).

## The .env.example block records what cost real time

Standing this up on a rented Ampere GPU surfaced four things worth writing down:

- **`--tool-call-parser` is mandatory and unforgiving.** With the wrong parser vLLM returns tool calls as plain text — the agent calls nothing and the run fails with no error anywhere. The parser is readable off the model's `chat_template`: a JSON body inside `<tool_call>` is `hermes`; `<function=name><parameter=k>` XML is `qwen3_coder` / `qwen3_xml`. Guessing costs a full model load per attempt.
- **Prefer a pure-transformer model.** vLLM disables automatic prefix caching on Mamba/linear-attention hybrids, and this agent resends a large prompt every turn. Measured at equal VRAM: caching off with 14,482 KV tokens on a hybrid, versus **on** with 55,520 on a pure-transformer MoE.
- **MoE beats dense at equal VRAM** — ~4x generation speed (140 vs 35 tok/s measured) and far more KV room.
- **`VLLM_USE_FLASHINFER_SAMPLER=0`** where the driver is present but the CUDA toolkit is not. The flashinfer sampler JIT-compiles at startup and dies with `Could not find nvcc`; attention is unaffected, so disabling just the sampler is cheaper than installing the toolkit.

## Verification

Against a live **vLLM 0.26.0** serving **Qwen3-Coder-30B-A3B-AWQ** on an RTX A5000, through the proxy:

| Check | Result |
|---|---|
| streaming tool calls | `{'name':'bash','args':{'cmd':'ls -l /tmp'}}` |
| multi-turn tool results | model read the result and answered |
| prefix caching | 49.4% hit on a repeated prefix |
| `cache_control` passthrough | HTTP 200 |

`pytest` 273 passed · `ruff check` clean · `ruff format` clean · `basedpyright` 0 errors.

## Scope

Docs and one shortcut. No change to how `hosted_vllm` routes for anyone already using the long form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)