### PR TITLE
fix(kg): make engagement scope a boundary, not a convention

### DIFF
--- a/packages/decepticon/decepticon/agents/middleware_slots.py
+++ b/packages/decepticon/decepticon/agents/middleware_slots.py
@@ -22,6 +22,7 @@ needs an entry in ``SLOTS_PER_ROLE``.
 
 from __future__ import annotations
 
+import copy
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -281,9 +282,33 @@ class _SafeSummarizationProxy(AgentMiddleware):
     def name(self) -> str:
         return self._inner.name
 
+    def _scoped_inner(self, request: Any) -> AgentMiddleware:
+        """Bind summary generation to this request's already-selected model.
+
+        ProxyKeyOverrideMiddleware is immediately outside this middleware in
+        the canonical stack, so ``request.model`` carries the engagement's
+        LiteLLM virtual key. Deep Agents otherwise calls the process-global
+        model captured at graph construction for summaries. Shallow-copy both
+        middleware layers before rebinding: one shared LangGraph worker can
+        summarize two tenant runs concurrently without either key becoming
+        mutable global state.
+        """
+        # A request without a model (older shapes, and the fallback tests'
+        # stubs) has nothing to rebind — use the inner middleware as-is rather
+        # than raising into the fallback below, which would silently drop
+        # summarization for the turn.
+        model = getattr(request, "model", None)
+        if model is None or model is self._inner.model:
+            return self._inner
+        scoped_inner = copy.copy(self._inner)
+        scoped_helper = copy.copy(self._inner._lc_helper)
+        scoped_helper.model = model
+        scoped_inner._lc_helper = scoped_helper
+        return scoped_inner
+
     def wrap_model_call(self, request: Any, handler: Callable[[Any], Any]) -> Any:
         try:
-            return self._inner.wrap_model_call(request, handler)
+            return self._scoped_inner(request).wrap_model_call(request, handler)
         except Exception:
             logger.warning(
                 "Summarization middleware failed; skipping summarization "
@@ -294,7 +319,7 @@ class _SafeSummarizationProxy(AgentMiddleware):
 
     async def awrap_model_call(self, request: Any, handler: Callable[[Any], Awaitable[Any]]) -> Any:
         try:
-            return await self._inner.awrap_model_call(request, handler)
+            return await self._scoped_inner(request).awrap_model_call(request, handler)
         except Exception:
             logger.warning(
                 "Summarization middleware failed; skipping summarization "

--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -52,6 +52,13 @@ class EngagementContextState(AgentState):
     workspace_path: NotRequired[
         Annotated[str, "Sandbox root for this engagement.", _reduce_workspace_path]
     ]
+    kg_engagement: NotRequired[
+        Annotated[
+            str,
+            "Trusted tenant+engagement attack-graph partition.",
+            reduce_converging_value,
+        ]
+    ]
     # Per-run language override. When set via config.configurable.language,
     # the middleware appends a LANGUAGE_POLICY SystemMessage that supersedes
     # the prompt-time DECEPTICON_LANGUAGE env policy. Multi-tenant launchers
@@ -151,9 +158,20 @@ def _hydrate_engagement_state(state: Any) -> dict[str, Any] | None:
         if isinstance(cfg_lang, str) and cfg_lang:
             updates["language"] = cfg_lang
 
-    if engagement_label:
+    # KGMiddleware and the run launcher carry the authoritative composite
+    # tenant+engagement graph partition in ``kg_engagement``. Keep the human /
+    # workspace-facing ``engagement_name`` unchanged, but make every legacy KG
+    # helper's contextvar resolve to the same composite partition as KGStore.
+    cfg_kg_label = configurable.get("kg_engagement")
+    kg_label = (
+        cfg_kg_label if isinstance(cfg_kg_label, str) and cfg_kg_label else get("kg_engagement")
+    )
+    if isinstance(cfg_kg_label, str) and cfg_kg_label and get("kg_engagement") != cfg_kg_label:
+        updates["kg_engagement"] = cfg_kg_label
+    active_graph_label = kg_label if isinstance(kg_label, str) and kg_label else engagement_label
+    if active_graph_label:
         try:
-            set_active_engagement(engagement_label)
+            set_active_engagement(active_graph_label)
         except ValueError:
             # Invalid engagement label format (e.g. contains slashes or
             # control chars). The contextvar stays unset; downstream

--- a/packages/decepticon/decepticon/middleware/kg_internal/store.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/store.py
@@ -178,6 +178,14 @@ class KGStore:
 
     # ── Generic Cypher execution ───────────────────────────────────────
 
+    @staticmethod
+    def _check_scoped_cypher(cypher: str, engagement: str) -> None:
+        # Schema migrations legitimately contain DDL without a row-level scope.
+        # Every runtime graph operation must bind the trusted partition into the
+        # statement itself; merely validating an unused keyword is not isolation.
+        if engagement != "schema" and "$engagement" not in cypher:
+            raise ValueError("Neo4j query rejected: missing $engagement scope")
+
     def execute_read(
         self,
         cypher: str,
@@ -186,12 +194,17 @@ class KGStore:
         engagement: str,
     ) -> list[dict[str, Any]]:
         """Run a read transaction. ``engagement`` must be injected into
-        the Cypher by the caller — this method only enforces that the
-        scope label is set."""
+        the Cypher by the caller — this method enforces that the scope
+        label is set, that the statement actually binds ``$engagement``,
+        and that the caller's params cannot replace that value."""
         self._check_engagement(engagement)
+        self._check_scoped_cypher(cypher, engagement)
+        # The method argument is authoritative. A legacy/raw caller cannot
+        # replace it by smuggling a second value in ``params``.
+        scoped_params = {**(params or {}), "engagement": engagement}
         with self._driver.session(database=self._database) as session:
             return session.execute_read(
-                lambda tx: [dict(record) for record in tx.run(cypher, **(params or {}))]
+                lambda tx: [dict(record) for record in tx.run(cypher, **scoped_params)]
             )
 
     def execute_write(
@@ -203,9 +216,11 @@ class KGStore:
     ) -> list[dict[str, Any]]:
         """Run a write transaction. Driver retries deadlock errors."""
         self._check_engagement(engagement)
+        self._check_scoped_cypher(cypher, engagement)
+        scoped_params = {**(params or {}), "engagement": engagement}
         with self._driver.session(database=self._database) as session:
             return session.execute_write(
-                lambda tx: [dict(record) for record in tx.run(cypher, **(params or {}))]
+                lambda tx: [dict(record) for record in tx.run(cypher, **scoped_params)]
             )
 
     # ── AttackGraphProtocol implementation ─────────────────────────────
@@ -241,6 +256,7 @@ class KGStore:
         edge_cypher = (
             "MATCH (s)-[r]->(d) "
             "WHERE s.engagement = $engagement AND d.engagement = $engagement "
+            "  AND r.engagement = $engagement "
             "RETURN s.key AS src_key, d.key AS dst_key, type(r) AS kind, "
             "       labels(s) AS src_labels, labels(d) AS dst_labels, "
             "       s.label AS src_label, d.label AS dst_label, "

--- a/packages/decepticon/decepticon/middleware/kg_internal/summary.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/summary.py
@@ -63,7 +63,9 @@ def _stats(store: KGStore, *, engagement: str) -> dict[str, int]:
         (
             "MATCH (n) WHERE n.engagement = $engagement "
             "WITH count(n) AS nodes "
-            "OPTIONAL MATCH ()-[r]->() WHERE r.engagement = $engagement "
+            "OPTIONAL MATCH (s)-[r]->(d) "
+            "WHERE s.engagement = $engagement AND r.engagement = $engagement "
+            "  AND d.engagement = $engagement "
             "RETURN nodes, count(r) AS edges"
         ),
         {"engagement": engagement},
@@ -102,7 +104,8 @@ def _open_entrypoints(store: KGStore, *, engagement: str) -> list[dict[str, Any]
     rows = store.execute_read(
         (
             "MATCH (e:Entrypoint) WHERE e.engagement = $engagement "
-            "AND NOT (e)-[:HAS_VULN]->() "
+            "AND NOT (e)-[:HAS_VULN {engagement: $engagement}]->"
+            "(:Vulnerability {engagement: $engagement}) "
             "RETURN e.key AS key, e.label AS label "
             "LIMIT $cap"
         ),
@@ -119,6 +122,8 @@ def _crown_jewels(store: KGStore, *, engagement: str) -> list[dict[str, Any]]:
             "MATCH (c:CrownJewel) WHERE c.engagement = $engagement "
             "OPTIONAL MATCH p=(e:Entrypoint)-[*1..6]->(c) "
             "WHERE e.engagement = $engagement "
+            "  AND all(n IN nodes(p) WHERE n.engagement = $engagement) "
+            "  AND all(r IN relationships(p) WHERE r.engagement = $engagement) "
             "WITH c, count(DISTINCT p) AS paths "
             "RETURN c.key AS key, c.label AS label, paths "
             "LIMIT $cap"

--- a/packages/decepticon/decepticon/tools/ad/adcs_post.py
+++ b/packages/decepticon/decepticon/tools/ad/adcs_post.py
@@ -67,8 +67,8 @@ class PostProcessStats:
 # Same trick the node-write path in ``record_observations`` uses.
 
 _DCSYNC_QUERY = (
-    "MATCH (p)-[gc:GET_CHANGES {engagement: $engagement}]->(d:Domain {engagement: $engagement}) "
-    "MATCH (p)-[gca:GET_CHANGES_ALL {engagement: $engagement}]->(d) "
+    "MATCH (p {engagement: $engagement})-[gc:GET_CHANGES {engagement: $engagement}]->(d:Domain {engagement: $engagement}) "
+    "MATCH (p {engagement: $engagement})-[gca:GET_CHANGES_ALL {engagement: $engagement}]->(d) "
     "MERGE (p)-[r:DCSYNC {engagement: $engagement}]->(d) "
     "ON CREATE SET r.firstseen = $now, "
     "              r.created_by = $created_by, "
@@ -83,7 +83,7 @@ _DCSYNC_QUERY = (
 )
 
 _GOLDEN_CERT_QUERY = (
-    "MATCH (p)-[r:OWNS|WRITE_OWNER|MANAGE_CA {engagement: $engagement}]->"
+    "MATCH (p {engagement: $engagement})-[r:OWNS|WRITE_OWNER|MANAGE_CA {engagement: $engagement}]->"
     "(ca:ADEnterpriseCA {engagement: $engagement}) "
     "WITH DISTINCT p, ca "
     "MERGE (p)-[gc:GOLDEN_CERT {engagement: $engagement}]->(ca) "
@@ -130,7 +130,7 @@ _ADCS_ESC1_QUERY = (
     "  AND ct.enrolleesuppliessubject = true "
     "  AND coalesce(ct.requiresmanagerapproval, false) = false "
     "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
-    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(ct) "
     "WHERE en.bh_right = 'Enroll' "
     "WITH DISTINCT p, eca, ct "
     "MERGE (p)-[r:ADCS_ESC1 {engagement: $engagement}]->(eca) "
@@ -185,7 +185,7 @@ _ADCS_ESC3_QUERY = (
     "WHERE '1.3.6.1.4.1.311.20.2.1' IN agent.applicationpolicies "
     "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(auth) "
     "MATCH (eca)-[:PUBLISHED_TO {engagement: $engagement}]->(agent) "
-    "MATCH (p)-[en {engagement: $engagement}]->(agent) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(agent) "
     "WHERE en.bh_right = 'Enroll' "
     "WITH DISTINCT p, eca, auth, agent "
     "MERGE (p)-[r:ADCS_ESC3 {engagement: $engagement}]->(eca) "
@@ -218,7 +218,7 @@ _ADCS_ESC3_QUERY = (
 # on the edge as ``via_template`` provenance.
 
 _ADCS_ESC4_QUERY = (
-    "MATCH (p)-[r:GENERIC_ALL|GENERIC_WRITE|WRITE_DACL|WRITE_OWNER|OWNS"
+    "MATCH (p {engagement: $engagement})-[r:GENERIC_ALL|GENERIC_WRITE|WRITE_DACL|WRITE_OWNER|OWNS"
     "|OWNS_LIMITED_RIGHTS|WRITE_OWNER_LIMITED_RIGHTS {engagement: $engagement}]->"
     "(ct:ADCertTemplate {engagement: $engagement}) "
     "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
@@ -276,7 +276,7 @@ _ADCS_ESC6A_QUERY = (
     "MATCH (eca)-[:PUBLISHED_TO {engagement: $engagement}]->(ct:ADCertTemplate {engagement: $engagement}) "
     "WHERE ct.authenticationenabled = true "
     "  AND coalesce(ct.requiresmanagerapproval, false) = false "
-    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(ct) "
     "WHERE en.bh_right = 'Enroll' "
     "WITH DISTINCT p, eca, ct "
     "MERGE (p)-[r:ADCS_ESC6A {engagement: $engagement}]->(eca) "
@@ -300,7 +300,7 @@ _ADCS_ESC6B_QUERY = (
     "WHERE ct.authenticationenabled = true "
     "  AND ct.nosecurityextension = true "
     "  AND coalesce(ct.requiresmanagerapproval, false) = false "
-    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(ct) "
     "WHERE en.bh_right = 'Enroll' "
     "WITH DISTINCT p, eca, ct "
     "MERGE (p)-[r:ADCS_ESC6B {engagement: $engagement}]->(eca) "
@@ -325,7 +325,7 @@ _ADCS_ESC9A_QUERY = (
     "  AND ct.subjectaltrequireupn = true "
     "  AND coalesce(ct.requiresmanagerapproval, false) = false "
     "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
-    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(ct) "
     "WHERE en.bh_right = 'Enroll' "
     "WITH DISTINCT p, eca, ct "
     "MERGE (p)-[r:ADCS_ESC9A {engagement: $engagement}]->(eca) "
@@ -368,11 +368,12 @@ _ADCS_ESC13_QUERY = (
     "  AND coalesce(ct.requiresmanagerapproval, false) = false "
     "  AND ct.issuancepolicies IS NOT NULL "
     "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
-    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(ct) "
     "WHERE en.bh_right = 'Enroll' "
     "MATCH (pol:ADIssuancePolicy {engagement: $engagement}) "
     "WHERE pol.certtemplateoid IN ct.issuancepolicies "
-    "MATCH (pol)-[:OID_GROUP_LINK {engagement: $engagement}]->(g) "
+    "MATCH (pol)-[:OID_GROUP_LINK {engagement: $engagement}]->"
+    "(g {engagement: $engagement}) "
     "WITH DISTINCT p, g, ct, pol "
     "MERGE (p)-[r:ADCS_ESC13 {engagement: $engagement}]->(g) "
     "ON CREATE SET r.firstseen = $now, "
@@ -397,7 +398,7 @@ _ADCS_ESC9B_QUERY = (
     "  AND ct.subjectaltrequiredns = true "
     "  AND coalesce(ct.requiresmanagerapproval, false) = false "
     "MATCH (eca:ADEnterpriseCA {engagement: $engagement})-[:PUBLISHED_TO {engagement: $engagement}]->(ct) "
-    "MATCH (p)-[en {engagement: $engagement}]->(ct) "
+    "MATCH (p {engagement: $engagement})-[en {engagement: $engagement}]->(ct) "
     "WHERE en.bh_right = 'Enroll' "
     "WITH DISTINCT p, eca, ct "
     "MERGE (p)-[r:ADCS_ESC9B {engagement: $engagement}]->(eca) "

--- a/packages/decepticon/decepticon/tools/reporting/kg_adapter.py
+++ b/packages/decepticon/decepticon/tools/reporting/kg_adapter.py
@@ -125,7 +125,9 @@ def load_engagement_graph(engagement: str) -> KnowledgeGraph:
 
         edge_rows = store.execute_read(
             (
-                "MATCH (a)-[r]->(b) WHERE r.engagement = $engagement "
+                "MATCH (a)-[r]->(b) "
+                "WHERE a.engagement = $engagement AND r.engagement = $engagement "
+                "  AND b.engagement = $engagement "
                 "RETURN labels(a)[0] AS src_kind, "
                 "       a.key AS src_key, "
                 "       labels(b)[0] AS dst_kind, "

--- a/packages/decepticon/decepticon/tools/research/_state.py
+++ b/packages/decepticon/decepticon/tools/research/_state.py
@@ -100,16 +100,20 @@ class _LegacyStoreShim:
     def query_custom(
         self, query: str, params: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
-        """Raw read-only Cypher passthrough.
+        """Run trusted static Cypher with mandatory engagement scope.
 
-        Engagement scoping is the caller's responsibility — pass
-        ``$engagement`` (auto-injected here as ``_resolve_engagement``)
-        in the query's ``WHERE`` clause if scoping matters. Callers
-        that ignore scoping (e.g. legacy ``chain.py`` Cypher) get the
-        same un-filtered behaviour the old Neo4jStore had.
+        The compatibility layer used to allow an unfiltered query and merely
+        supplied an optional ``engagement`` parameter. Any deployment that
+        serves more than one engagement from one graph — a shared LangGraph
+        plane, a hosted control plane, a team instance — turns that into a
+        cross-engagement read/write primitive. Every raw statement must now
+        reference the trusted ``$engagement`` parameter, and callers cannot
+        override its value.
         """
         engagement = _resolve_engagement()
-        merged: dict[str, Any] = {"engagement": engagement, **(params or {})}
+        if "$engagement" not in query:
+            raise ValueError("raw Neo4j query rejected: missing $engagement scope")
+        merged: dict[str, Any] = {**(params or {}), "engagement": engagement}
         return self._kgstore.execute_read(query, merged, engagement=engagement)
 
     def revision(self) -> float:

--- a/packages/decepticon/decepticon/tools/research/chain.py
+++ b/packages/decepticon/decepticon/tools/research/chain.py
@@ -147,17 +147,17 @@ def plan_chains(
 
     # Build entry/goal filters
     if entrypoint_ids:
-        entry_clause = "WHERE entry.id IN $entry_ids"
+        entry_clause = "WHERE entry.engagement = $engagement AND entry.id IN $entry_ids"
         params: dict[str, Any] = {"entry_ids": entrypoint_ids}
     else:
-        entry_clause = ""
+        entry_clause = "WHERE entry.engagement = $engagement"
         params = {}
 
     if crown_jewel_ids:
-        goal_clause = "WHERE crown.id IN $crown_ids"
+        goal_clause = "WHERE crown.engagement = $engagement AND crown.id IN $crown_ids"
         params["crown_ids"] = crown_jewel_ids
     else:
-        goal_clause = ""
+        goal_clause = "WHERE crown.engagement = $engagement"
 
     params["max_cost"] = max_cost
 
@@ -168,6 +168,8 @@ def plan_chains(
     CALL apoc.algo.dijkstra(entry, crown, '{_ATTACK_REL_TYPES}', 'cost')
     YIELD path, weight
     WHERE weight <= $max_cost AND length(path) <= {max_depth}
+      AND all(n IN nodes(path) WHERE n.engagement = $engagement)
+      AND all(r IN relationships(path) WHERE r.engagement = $engagement)
     RETURN entry.id AS entry_id,
            entry.label AS entry_label,
            crown.id AS crown_id,
@@ -187,6 +189,8 @@ def plan_chains(
     WITH entry, crown, path,
          reduce(c = 0.0, r IN relationships(path) | c + coalesce(r.cost, 1.0)) AS total_cost
     WHERE total_cost <= $max_cost
+      AND all(n IN nodes(path) WHERE n.engagement = $engagement)
+      AND all(r IN relationships(path) WHERE r.engagement = $engagement)
     RETURN entry.id AS entry_id,
            entry.label AS entry_label,
            crown.id AS crown_id,
@@ -259,7 +263,7 @@ def promote_chain(chain: Chain) -> str:
     ]
 
     query = """
-    MERGE (ap:AttackPath {id: $id})
+    MERGE (ap:AttackPath {id: $id, engagement: $engagement})
     SET ap.key = $key,
         ap.label = $label,
         ap.kind = 'AttackPath',
@@ -271,13 +275,13 @@ def promote_chain(chain: Chain) -> str:
 
     WITH ap
 
-    MATCH (entry {id: $entry_id})
-    MERGE (ap)-[:STARTS_AT]->(entry)
+    MATCH (entry {id: $entry_id, engagement: $engagement})
+    MERGE (ap)-[:STARTS_AT {engagement: $engagement}]->(entry)
 
     WITH ap
 
-    MATCH (crown {id: $crown_id})
-    MERGE (ap)-[:REACHES]->(crown)
+    MATCH (crown {id: $crown_id, engagement: $engagement})
+    MERGE (ap)-[:REACHES {engagement: $engagement}]->(crown)
     """
 
     import time
@@ -298,8 +302,9 @@ def promote_chain(chain: Chain) -> str:
     # Add STEP relationships to intermediate nodes
     for i, step in enumerate(chain.steps):
         step_query = """
-        MATCH (ap:AttackPath {id: $ap_id}), (n {id: $node_id})
-        MERGE (ap)-[s:STEP {order: $order}]->(n)
+        MATCH (ap:AttackPath {id: $ap_id, engagement: $engagement}),
+              (n {id: $node_id, engagement: $engagement})
+        MERGE (ap)-[s:STEP {order: $order, engagement: $engagement}]->(n)
         """
         store.query_custom(
             step_query,
@@ -327,7 +332,7 @@ def critical_path_score(chain: Chain) -> float:
     if vuln_ids:
         query = """
         UNWIND $ids AS nid
-        MATCH (v:Vulnerability {id: nid})
+        MATCH (v:Vulnerability {id: nid, engagement: $engagement})
         RETURN coalesce(v.severity, 'info') AS severity
         """
         try:
@@ -357,13 +362,15 @@ def impact_analysis(node_id: str, max_depth: int = 4) -> list[dict[str, Any]]:
     store = get_store()
 
     query = f"""
-    MATCH (start {{id: $node_id}})
+    MATCH (start {{id: $node_id, engagement: $engagement}})
     CALL apoc.path.expandConfig(start, {{
       relationshipFilter: '{_ATTACK_REL_TYPES}',
       maxLevel: {max_depth},
       uniqueness: 'NODE_GLOBAL'
     }})
     YIELD path
+    WHERE all(n IN nodes(path) WHERE n.engagement = $engagement)
+      AND all(r IN relationships(path) WHERE r.engagement = $engagement)
     WITH last(nodes(path)) AS reachable, length(path) AS depth
     RETURN DISTINCT reachable.id AS id,
            labels(reachable)[0] AS type,
@@ -384,8 +391,11 @@ def unexplored_surface() -> list[dict[str, Any]]:
     store = get_store()
 
     query = """
-    MATCH (h:Host)-[:HOSTS]->(s:Service)
-    WHERE NOT (s)-[:HAS_VULN]->()
+    MATCH (h:Host)-[hosts:HOSTS]->(s:Service)
+    WHERE h.engagement = $engagement
+      AND s.engagement = $engagement
+      AND hosts.engagement = $engagement
+      AND NOT (s)-[:HAS_VULN {engagement: $engagement}]->()
       AND h.explored = false
     RETURN h.id AS host_id,
            h.ip AS ip,
@@ -406,9 +416,13 @@ def credential_reachability(credential_id: str) -> list[dict[str, Any]]:
     store = get_store()
 
     query = """
-    MATCH (cred:Credential {id: $cred_id})-[:AUTHENTICATES_TO]->(u:User)
-    OPTIONAL MATCH (u)-[:CAN_ACCESS|ADMIN_TO]->(target)
-    OPTIONAL MATCH (u)-[:HAS_SESSION]->(session_host:Host)
+    MATCH (cred:Credential {id: $cred_id, engagement: $engagement})
+          -[:AUTHENTICATES_TO {engagement: $engagement}]->
+          (u:User {engagement: $engagement})
+    OPTIONAL MATCH (u)-[:CAN_ACCESS|ADMIN_TO {engagement: $engagement}]->
+          (target {engagement: $engagement})
+    OPTIONAL MATCH (u)-[:HAS_SESSION {engagement: $engagement}]->
+          (session_host:Host {engagement: $engagement})
     RETURN cred.id AS cred_id,
            u.username AS identity,
            collect(DISTINCT {type: labels(target)[0], name: coalesce(target.ip, target.label, '')}) AS accessible_targets,

--- a/packages/decepticon/tests/unit/ad/test_adcs_post.py
+++ b/packages/decepticon/tests/unit/ad/test_adcs_post.py
@@ -368,7 +368,10 @@ class TestAdcsEsc3Query:
         q = self._esc3_query(store)
         # Enroll right is required on the **agent** template — that's
         # the one the principal uses to mint enrolment-agent certs.
-        assert "(p)-[en {engagement: $engagement}]->(agent)" in q
+        # The principal node carries the scope too, so assert the shape
+        # rather than one exact rendering of it.
+        assert "-[en {engagement: $engagement}]->(agent)" in q
+        assert "(p {engagement: $engagement})" in q
         assert "bh_right = 'Enroll'" in q
 
     def test_via_template_provenance_attached(self) -> None:

--- a/packages/decepticon/tests/unit/middleware/test_kg_engagement_scope.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_engagement_scope.py
@@ -1,0 +1,105 @@
+"""Engagement scoping is a boundary, not a convention.
+
+One graph can hold several engagements — a shared LangGraph plane, a hosted
+control plane, a team instance. When it does, the ``$engagement`` predicate is
+the only thing separating them, so these tests assert the two ways that
+separation used to be bypassable:
+
+* raw Cypher that simply omits the predicate reads every engagement's nodes, and
+* caller-supplied ``params`` that carry their own ``engagement`` key override
+  the trusted value the store resolved.
+
+Both were reachable from an agent tool (``plan_attack_chains`` issues raw
+Cypher through ``query_custom``), which is why they are guarded at the store
+boundary rather than left to each caller.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from decepticon.middleware.kg_internal.store import KGStore, KGStoreConfig
+
+
+def _fake_driver() -> MagicMock:
+    driver = MagicMock(name="Driver")
+    session = MagicMock(name="Session")
+    driver.session.return_value.__enter__.return_value = session
+    driver.session.return_value.__exit__.return_value = None
+    session.execute_read.return_value = []
+    session.execute_write.return_value = []
+    return driver
+
+
+def _make_store(driver: Any | None = None) -> KGStore:
+    cfg = KGStoreConfig(uri="bolt://x", user="u", password="p", database="neo4j")
+    return KGStore(cfg, driver=driver or _fake_driver())
+
+
+SCOPED = "MATCH (n:Host) WHERE n.engagement = $engagement RETURN n"
+UNSCOPED = "MATCH (n:Host) RETURN n"
+
+
+@pytest.mark.parametrize("method", ["execute_read", "execute_write"])
+def test_cypher_without_the_engagement_predicate_is_rejected(method: str) -> None:
+    """The failure is loud and at the boundary — not a silently wider result set."""
+    store = _make_store()
+    with pytest.raises(ValueError, match="engagement"):
+        getattr(store, method)(UNSCOPED, {}, engagement="eng_a")
+
+
+@pytest.mark.parametrize("method", ["execute_read", "execute_write"])
+def test_scoped_cypher_passes(method: str) -> None:
+    store = _make_store()
+    getattr(store, method)(SCOPED, {}, engagement="eng_a")
+
+
+def test_caller_params_cannot_override_the_trusted_engagement() -> None:
+    """A caller naming someone else's engagement must not win.
+
+    The value the store resolved is authoritative; ``params`` may add to it but
+    never replace it. Asserted on what actually reaches the driver, because the
+    old bug was a dict-merge order — trusted value first, caller's spread over
+    the top of it — which no return-value assertion would have caught.
+    """
+    driver = _fake_driver()
+    store = _make_store(driver)
+    session = driver.session.return_value.__enter__.return_value
+
+    store.execute_read(SCOPED, {"engagement": "eng_victim"}, engagement="eng_caller")
+
+    session.execute_read.assert_called_once()
+    # The store hands the driver a callable; the params it closed over are what
+    # the query will actually run with.
+    sent = _params_sent_to_driver(session.execute_read.call_args)
+    assert sent["engagement"] == "eng_caller"
+
+
+def test_unrelated_caller_params_are_preserved() -> None:
+    """Guarding the engagement key must not throw away the caller's own params."""
+    driver = _fake_driver()
+    store = _make_store(driver)
+    session = driver.session.return_value.__enter__.return_value
+
+    store.execute_read(
+        "MATCH (n:Host) WHERE n.engagement = $engagement AND n.ip = $ip RETURN n",
+        {"ip": "10.0.0.1", "engagement": "eng_victim"},
+        engagement="eng_caller",
+    )
+
+    sent = _params_sent_to_driver(session.execute_read.call_args)
+    assert sent["ip"] == "10.0.0.1"
+    assert sent["engagement"] == "eng_caller"
+
+
+def _params_sent_to_driver(call_args: Any) -> dict[str, Any]:
+    """Run the unit-of-work the store passed to the session and capture its params."""
+    work = call_args.args[0]
+    tx = MagicMock(name="Transaction")
+    tx.run.return_value = []
+    work(tx)
+    tx.run.assert_called_once()
+    return dict(tx.run.call_args.kwargs) or dict(tx.run.call_args.args[1])

--- a/packages/decepticon/tests/unit/middleware/test_kg_summary_unit.py
+++ b/packages/decepticon/tests/unit/middleware/test_kg_summary_unit.py
@@ -140,7 +140,9 @@ class _StubStore:
             return self._responses.get("stats", [{"nodes": 0, "edges": 0}])
         if "(v:Vulnerability)" in cypher:
             return self._responses.get("vulns", [])
-        if "(e:Entrypoint)" in cypher and "NOT (e)-[:HAS_VULN]" in cypher:
+        # Match the relationship type only: the scope predicate inside the
+        # pattern is an implementation detail this stub should not pin.
+        if "(e:Entrypoint)" in cypher and "NOT (e)-[:HAS_VULN" in cypher:
             return self._responses.get("entrypoints", [])
         if "(c:CrownJewel)" in cypher:
             return self._responses.get("crown_jewels", [])


### PR DESCRIPTION
`KGStore` is engagement-scoped, but the legacy attack-graph helpers around it were not, and the scope that did exist could be overridden by the caller. Where one graph holds more than one engagement — a shared LangGraph plane, a hosted control plane, a team instance — those are cross-engagement read/write primitives.

Both are reachable from an agent tool, not just from library code: `plan_attack_chains` (`tools/research/tools.py`) calls `plan_chains()`, which issues raw Cypher through `query_custom()`. With no entry/crown ids supplied, `entry_clause` is empty and the statement is `MATCH (entry:Entrypoint)` — every engagement's nodes.

## Demonstrated, not argued

Two engagements seeded into a real Neo4j, then queried as tenant A. Before:

```
TEST 1  legacy chain query, run AS tenant A
   A-login-portal -> A-customer-database   (engagement=eng_TENANT_A)
   B-login-portal -> B-customer-database   (engagement=eng_TENANT_B)   ← another engagement
   VERDICT: LEAK — tenant B rows returned

TEST 2  caller params carrying their own engagement key
   returned B-login-portal (engagement=eng_TENANT_B)
   VERDICT: LEAK — caller param won
```

After, same script, same database:

```
TEST 1  ValueError: Neo4j query rejected: missing $engagement scope
TEST 2  returned A-login-portal only — trusted value won, isolated
```

The second one is a dict-merge order bug in `_state.query_custom`:

```python
merged = {"engagement": engagement, **(params or {})}   # caller's spread lands last
```

so a caller passing `params={"engagement": ...}` replaced the value the store had resolved.

## What changes

- **`KGStore.execute_read` / `execute_write`** reject a statement that does not bind `$engagement`, and build their params as `{**caller, "engagement": trusted}` so the resolved value always wins. Schema migrations (`engagement="schema"`) are exempt — DDL has no row-level scope to bind.
- **The legacy callers are updated to carry the scope** rather than left to fail: `chain.py`, `summary.py`, `kg_adapter.py`, `adcs_post.py`, and the graph snapshot path in `store.py`.
- **`engagement.py` / `middleware_slots.py`**: the KG state channel carries the active engagement, and summarization binds the model selected for *this* request instead of the deployment-keyed one created at process boot — otherwise concurrent runs summarize through each other's model.

## Breaking

Raw Cypher that omits `$engagement` now raises instead of returning unscoped rows. Every in-repo caller is fixed here; a downstream caller with custom Cypher adds one predicate — `$engagement` is already injected into the params, so it is a `WHERE` clause, not a plumbing change.

That is deliberate. A security boundary that is opt-in is not a boundary, and the previous docstring said as much out loud: *"Callers that ignore scoping … get the same un-filtered behaviour the old Neo4jStore had."*


## Versioning note

The commit is `fix(kg):`, so auto-tag computes a **patch** (`v1.1.40`). Strictly this is a breaking change for an external caller with custom Cypher, which would argue for `fix(kg)!:` and a major. Flagging it rather than deciding it — say the word and I will retitle the commit.

## Tests

Six new cases in `tests/unit/middleware/test_kg_engagement_scope.py`. **Four of them fail against `main`** — verified by reverting `store.py` and re-running — so they hold the fix rather than merely describing it. The parameter-precedence test asserts on what actually reaches the driver, because a return-value assertion cannot see a merge-order bug.

The first full-suite run against this port failed 6 — all of them mine, none pre-existing (verified: the same 6 pass on `main`). Four were a real defect in the port: `_scoped_inner` assumed `request.model` exists, and the `AttributeError` was swallowed by the surrounding fallback, so summarization would have silently degraded on any request shape without it. Now reads `getattr(request, "model", None)`. The other two were tests pinning Cypher text rather than behaviour, updated above. Those four files (72 tests) pass; the full 4900-test re-run is in flight and the number goes here before merge.

`ruff check` / `ruff format` clean, `basedpyright` 0 errors.

## Provenance

These edits have been running in production for a week as a downstream build-time patch (fail-closed, version-locked to the exact wheel). Landing them upstream is what that patch's own docstring names as its endpoint — *"Delete this patch when an equivalent upstream release is pinned"* — and removes a re-audit from every version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
