### PR TITLE
docs: the README plays the new demo film

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 <br/>
 
 <div align="center">
-  <video src="https://github.com/user-attachments/assets/b3fd40d8-e859-4a39-97f4-bd825694ad96" width="800" controls></video>
+  <video src="https://github.com/user-attachments/assets/2344d6f7-fa44-42bb-9492-1c203e56df3c" width="800" controls></video>
 </div>
 
 <div align="center">

--- a/README_KO.md
+++ b/README_KO.md
@@ -41,7 +41,7 @@
 <br/>
 
 <div align="center">
-  <video src="https://github.com/user-attachments/assets/b3fd40d8-e859-4a39-97f4-bd825694ad96" width="800" controls></video>
+  <video src="https://github.com/user-attachments/assets/2344d6f7-fa44-42bb-9492-1c203e56df3c" width="800" controls></video>
 </div>
 
 <div align="center">


### PR DESCRIPTION
Both READMEs now embed the current product film — the same cut that runs on
[decepticon.red](https://decepticon.red) under the hero.

Two lines, `README.md:44` and `README_KO.md:44`.

### Why the URL looks like that

The embed has to point at a `github.com/user-attachments` asset. GitHub's
markdown sanitizer removes `<video>` entirely for any other host — checked
against the `/markdown` API with both a release-download URL and a
`raw.githubusercontent` URL, and both rendered as empty. `raw.githubusercontent`
also serves `.mp4` as `application/octet-stream` with `nosniff`, so it would
not play even if the tag survived.

That upload only works from a signed-in web session, which is why the film is
not committed to `assets/` — it would be dead weight next to the CDN copy that
actually plays.

### Check

The new URL survives the sanitizer and resolves to a signed
`private-user-images` URL, same as the embed it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)