### PR TITLE
feat(desktop): cloud app mode, session cookies, product UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       python: ${{ steps.app.outputs.python }}
       cli: ${{ steps.app.outputs.cli }}
       web: ${{ steps.app.outputs.web }}
+      desktop: ${{ steps.app.outputs.desktop }}
       launcher: ${{ steps.app.outputs.launcher }}
       compose: ${{ steps.app.outputs.compose }}
       docker-images: ${{ steps.docker.outputs.changes }}
@@ -79,6 +80,11 @@ jobs:
             web:
               - 'clients/web/**'
               - 'clients/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+            desktop:
+              - 'clients/desktop/**'
               - 'package.json'
               - 'package-lock.json'
               - '.github/workflows/ci.yml'
@@ -426,6 +432,49 @@ jobs:
         if: needs.changes.outputs.cli == 'true'
         run: cd clients/cli && npm test --if-present
 
+  # Electron desktop shell: pure unit tests (config/platform/ui) exercise
+  # Windows / macOS / Linux path, menu, and Docker-spawn differences. The
+  # ruleset requires a success status, so untouched PRs emit a cheap noop.
+  desktop:
+    name: Desktop (${{ matrix.os }})
+    needs: changes
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - if: needs.changes.outputs.desktop != 'true'
+        run: 'echo "No Desktop-relevant changes — emitting success."'
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: needs.changes.outputs.desktop == 'true'
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: needs.changes.outputs.desktop == 'true'
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - if: needs.changes.outputs.desktop == 'true'
+        run: npm ci
+      # Electron postinstall fetches the platform binary; unit tests import
+      # only Node modules, but installing the package verifies the lockfile
+      # resolves on each OS (optional deps / electron dist).
+      - name: Syntax-check desktop sources
+        if: needs.changes.outputs.desktop == 'true'
+        run: |
+          node --check clients/desktop/src/config.mjs
+          node --check clients/desktop/src/platform.mjs
+          node --check clients/desktop/src/ui.mjs
+          node --check clients/desktop/src/main.mjs
+          node --check clients/desktop/src/preload.cjs
+      - name: Run desktop unit tests
+        if: needs.changes.outputs.desktop == 'true'
+        run: npm run desktop:test
+
   web:
     name: Web (lint + build)
     needs: changes
@@ -663,6 +712,7 @@ jobs:
       - compose-validate
       - python
       - cli
+      - desktop
       - web
       - launcher
       - docker-build

--- a/clients/desktop/package.json
+++ b/clients/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@decepticon/desktop",
   "version": "0.0.0",
   "private": true,
-  "description": "Decepticon desktop shell for the local web dashboard",
+  "description": "Decepticon desktop shell for the cloud app and local web dashboard",
   "type": "module",
   "main": "src/main.mjs",
   "scripts": {

--- a/clients/desktop/src/config.mjs
+++ b/clients/desktop/src/config.mjs
@@ -318,7 +318,7 @@ function normalizeCookieEntry(entry, dashboard) {
   const details = {
     url,
     name: String(entry.name),
-    value: decodeCookieValue(String(entry.value)),
+    value: String(entry.value),
     path: cookiePath,
     secure,
     httpOnly: Boolean(entry.httpOnly),
@@ -347,13 +347,6 @@ function normalizeCookieEntry(entry, dashboard) {
   return details;
 }
 
-function decodeCookieValue(value) {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
 
 function normalizeSameSite(value) {
   const v = String(value || "lax").toLowerCase();

--- a/clients/desktop/src/config.mjs
+++ b/clients/desktop/src/config.mjs
@@ -5,6 +5,24 @@ import path from "node:path";
 export const DASHBOARD_READY_ATTEMPTS = 100;
 export const DASHBOARD_READY_DELAY_MS = 1500;
 
+/** Hosted product app (same UI as https://app.decepticon.red). */
+export const CLOUD_APP_URL = "https://app.decepticon.red";
+export const SESSION_PARTITION = "persist:decepticon-desktop";
+
+/** OAuth / IdP hosts that must stay in-app so session cookies land in Electron. */
+export const AUTH_HOST_SUFFIXES = [
+  "accounts.google.com",
+  "google.com",
+  "gstatic.com",
+  "googleapis.com",
+  "github.com",
+  "githubusercontent.com",
+  "login.microsoftonline.com",
+  "microsoftonline.com",
+  "live.com",
+  "appleid.apple.com",
+];
+
 function readInstalledWebPort(envFile, readFile) {
   try {
     for (const line of readFile(envFile, "utf8").split(/\r?\n/)) {
@@ -17,7 +35,42 @@ function readInstalledWebPort(envFile, readFile) {
   return "";
 }
 
-export function resolveDesktopConfig(env = process.env, host = os, readFile = fs.readFileSync) {
+export function isLocalHost(hostname) {
+  const host = String(hostname || "").toLowerCase();
+  return host === "localhost"
+    || host === "127.0.0.1"
+    || host === "[::1]"
+    || host === "::1"
+    || host.endsWith(".localhost");
+}
+
+export function isLocalDashboardUrl(url) {
+  try {
+    return isLocalHost(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function isDecepticonHost(hostname) {
+  const host = String(hostname || "").toLowerCase();
+  return host === "decepticon.red" || host.endsWith(".decepticon.red");
+}
+
+export function isAuthHost(hostname) {
+  const host = String(hostname || "").toLowerCase();
+  return AUTH_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+}
+
+/**
+ * Resolve desktop target.
+ *
+ * Modes (DECEPTICON_DESKTOP_MODE):
+ * - cloud — always https://app.decepticon.red (or DECEPTICON_DESKTOP_URL)
+ * - local — always the installed local dashboard
+ * - auto  — local when install config exists, otherwise cloud (default)
+ */
+export function resolveDesktopConfig(env = process.env, host = os, readFile = fs.readFileSync, exists = fs.existsSync) {
   const decepticonHome = env.DECEPTICON_HOME || path.join(host.homedir(), ".decepticon");
   const envFile = env.DECEPTICON_COMPOSE_ENV_FILE || path.join(decepticonHome, ".env");
   const webPort = env.WEB_PORT?.trim() || readInstalledWebPort(envFile, readFile) || "3000";
@@ -25,14 +78,48 @@ export function resolveDesktopConfig(env = process.env, host = os, readFile = fs
   const project = env.DECEPTICON_COMPOSE_PROJECT?.trim()
     || (stackName ? `decepticon-${stackName}` : "decepticon");
   const versionFile = env.DECEPTICON_VERSION_FILE || path.join(decepticonHome, ".version");
-  return {
-    dashboardUrl: env.DECEPTICON_DESKTOP_URL || `http://localhost:${webPort}`,
+  const localDashboardUrl = `http://localhost:${webPort}`;
+  const explicitUrl = env.DECEPTICON_DESKTOP_URL?.trim() || "";
+  const modeRaw = (env.DECEPTICON_DESKTOP_MODE || "auto").trim().toLowerCase();
+  const mode = ["cloud", "local", "auto"].includes(modeRaw) ? modeRaw : "auto";
+
+  const provisional = {
     decepticonHome,
     composeFile: env.DECEPTICON_COMPOSE_FILE || path.join(decepticonHome, "docker-compose.yml"),
     envFile,
     versionFile,
     project,
     webContainer: stackName ? `decepticon-${stackName}-web` : "decepticon-web",
+  };
+
+  let dashboardUrl = explicitUrl;
+  let resolvedMode = mode;
+  if (!dashboardUrl) {
+    if (mode === "cloud") {
+      dashboardUrl = CLOUD_APP_URL;
+    } else if (mode === "local") {
+      dashboardUrl = localDashboardUrl;
+    } else {
+      const hasLocalInstall = missingConfigFiles(provisional, exists).length === 0;
+      resolvedMode = hasLocalInstall ? "local" : "cloud";
+      dashboardUrl = hasLocalInstall ? localDashboardUrl : CLOUD_APP_URL;
+    }
+  } else {
+    resolvedMode = isLocalDashboardUrl(dashboardUrl) ? "local" : "cloud";
+  }
+
+  const cookiesPath = env.DECEPTICON_DESKTOP_COOKIES?.trim()
+    || path.join(decepticonHome, "desktop-cookies.txt");
+
+  return {
+    ...provisional,
+    dashboardUrl,
+    localDashboardUrl,
+    cloudAppUrl: CLOUD_APP_URL,
+    mode: resolvedMode,
+    isCloud: !isLocalDashboardUrl(dashboardUrl),
+    cookiesPath,
+    partition: SESSION_PARTITION,
   };
 }
 
@@ -73,6 +160,8 @@ export function setupGuide(platform = os.platform()) {
     apiKeyCommand: "decepticon onboard --reset",
     downloadUrl: "https://github.com/PurpleAILAB/Decepticon/releases/latest",
     docsUrl: "https://docs.decepticon.red",
+    cloudAppUrl: CLOUD_APP_URL,
+    marketingUrl: "https://decepticon.red",
   };
 }
 
@@ -102,6 +191,25 @@ export function canNavigateInApp(targetUrl, dashboardUrl) {
   }
 }
 
+/**
+ * Navigation allowed inside the shell window.
+ * Local mode: same-origin only.
+ * Cloud mode: app origin, other decepticon.red hosts, and known OAuth/IdP hosts
+ * so Google/GitHub login cookies land in the persistent Electron session.
+ */
+export function canNavigateInShell(targetUrl, dashboardUrl, { cloud = false } = {}) {
+  if (canNavigateInApp(targetUrl, dashboardUrl)) return true;
+  const treatAsCloud = cloud || !isLocalDashboardUrl(dashboardUrl);
+  if (!treatAsCloud) return false;
+  try {
+    const { protocol, hostname } = new URL(targetUrl);
+    if (protocol !== "http:" && protocol !== "https:") return false;
+    return isDecepticonHost(hostname) || isAuthHost(hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function dashboardResponseReady(response, dashboardUrl) {
   return response.status < 500 && canNavigateInApp(response.url, dashboardUrl);
 }
@@ -118,4 +226,153 @@ export function isTrustedIpcSender(event, webContents) {
   return event.sender === webContents
     && event.senderFrame === webContents?.mainFrame
     && event.senderFrame.url?.startsWith("data:text/html;charset=utf-8,") === true;
+}
+
+/**
+ * Parse Cookie-Editor JSON export or Netscape cookie file into Electron cookie set options.
+ * Only cookies whose domain matches the dashboard host (or parent) are returned.
+ */
+export function parseCookieImport(raw, dashboardUrl) {
+  const text = String(raw || "").trim();
+  if (!text) return [];
+
+  let dashboard;
+  try {
+    dashboard = new URL(dashboardUrl);
+  } catch {
+    return [];
+  }
+
+  const entries = text.startsWith("[") || text.startsWith("{")
+    ? parseJsonCookies(text)
+    : parseNetscapeCookies(text);
+
+  return entries
+    .map((entry) => normalizeCookieEntry(entry, dashboard))
+    .filter(Boolean);
+}
+
+function parseJsonCookies(text) {
+  const data = JSON.parse(text);
+  const list = Array.isArray(data) ? data : [data];
+  return list.map((item) => ({
+    name: item.name,
+    value: item.value,
+    domain: item.domain,
+    path: item.path || "/",
+    secure: Boolean(item.secure),
+    httpOnly: Boolean(item.httpOnly),
+    hostOnly: Boolean(item.hostOnly),
+    expirationDate: item.expirationDate,
+    sameSite: item.sameSite,
+  }));
+}
+
+function parseNetscapeCookies(text) {
+  const out = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      // #HttpOnly_ prefix is Netscape extension for HttpOnly
+      if (!trimmed.startsWith("#HttpOnly_")) continue;
+    }
+    let httpOnly = false;
+    let row = trimmed;
+    if (row.startsWith("#HttpOnly_")) {
+      httpOnly = true;
+      row = row.slice("#HttpOnly_".length);
+    } else if (row.startsWith("#")) {
+      continue;
+    }
+    const parts = row.split(/\t/);
+    if (parts.length < 7) continue;
+    const [domain, includeSubdomains, pathPart, secure, expires, name, value] = parts;
+    const hostOnly = String(includeSubdomains).toUpperCase() === "FALSE" && !String(domain).startsWith(".");
+    out.push({
+      name,
+      value,
+      domain,
+      path: pathPart || "/",
+      secure: String(secure).toUpperCase() === "TRUE",
+      httpOnly,
+      hostOnly,
+      expirationDate: Number(expires) > 0 ? Number(expires) : undefined,
+      sameSite: "lax",
+    });
+  }
+  return out;
+}
+
+function normalizeCookieEntry(entry, dashboard) {
+  if (!entry?.name || entry.value == null) return null;
+  const domain = String(entry.domain || dashboard.hostname).replace(/^\./, "");
+  if (!cookieDomainMatches(domain, dashboard.hostname)) return null;
+
+  const secure = Boolean(entry.secure) || dashboard.protocol === "https:";
+  const cookiePath = entry.path || "/";
+  const host = domain.replace(/^\./, "");
+  const sameSite = normalizeSameSite(entry.sameSite);
+  const url = `${secure ? "https" : "http"}://${host}${cookiePath}`;
+
+  /** @type {{ url: string, name: string, value: string, path: string, secure: boolean, httpOnly: boolean, sameSite: string, domain?: string, expirationDate?: number }} */
+  const details = {
+    url,
+    name: String(entry.name),
+    value: decodeCookieValue(String(entry.value)),
+    path: cookiePath,
+    secure,
+    httpOnly: Boolean(entry.httpOnly),
+    sameSite,
+  };
+
+  // hostOnly / __Host- cookies must not set Domain
+  const hostOnly = entry.hostOnly === true || details.name.startsWith("__Host-");
+  if (!hostOnly) {
+    details.domain = domain.startsWith(".") ? domain : `.${domain}`;
+  }
+
+  if (details.name.startsWith("__Secure-") || details.name.startsWith("__Host-")) {
+    details.secure = true;
+    details.url = `https://${host}${details.path}`;
+  }
+  if (details.name.startsWith("__Host-")) {
+    details.path = "/";
+    delete details.domain;
+  }
+
+  if (typeof entry.expirationDate === "number" && Number.isFinite(entry.expirationDate)) {
+    details.expirationDate = entry.expirationDate;
+  }
+
+  return details;
+}
+
+function decodeCookieValue(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeSameSite(value) {
+  const v = String(value || "lax").toLowerCase();
+  if (v === "no_restriction" || v === "none") return "no_restriction";
+  if (v === "strict") return "strict";
+  return "lax";
+}
+
+function cookieDomainMatches(cookieDomain, host) {
+  const domain = cookieDomain.replace(/^\./, "").toLowerCase();
+  const hostname = host.toLowerCase();
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+export function readCookieImportFile(filePath, readFile = fs.readFileSync, exists = fs.existsSync) {
+  if (!filePath || !exists(filePath)) return null;
+  try {
+    return readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
 }

--- a/clients/desktop/src/config.test.mjs
+++ b/clients/desktop/src/config.test.mjs
@@ -286,7 +286,7 @@ test("parseCookieImport accepts Cookie-Editor JSON for the app host", () => {
   const cookies = parseCookieImport(raw, CLOUD_APP_URL);
   assert.equal(cookies.length, 1);
   assert.equal(cookies[0].name, "__Secure-better-auth.session_token");
-  assert.equal(cookies[0].value, "example.token+value");
+  assert.equal(cookies[0].value, "example.token%2Bvalue");
   assert.equal(cookies[0].secure, true);
   assert.equal(cookies[0].httpOnly, true);
   assert.equal(cookies[0].sameSite, "lax");

--- a/clients/desktop/src/config.test.mjs
+++ b/clients/desktop/src/config.test.mjs
@@ -5,22 +5,25 @@ import path from "node:path";
 import {
   canOpenExternal,
   canNavigateInApp,
+  canNavigateInShell,
   composeUpArgs,
   composeProcessEnv,
+  CLOUD_APP_URL,
   DASHBOARD_READY_ATTEMPTS,
   DASHBOARD_READY_DELAY_MS,
   dashboardResponseReady,
   isTrustedIpcSender,
   missingConfigFiles,
+  parseCookieImport,
   readInstalledVersion,
   resolveDesktopConfig,
   setupGuide,
 } from "./config.mjs";
 import { statusHtml } from "./ui.mjs";
 
-test("resolveDesktopConfig defaults to the installed Decepticon home and WEB_PORT", () => {
+test("resolveDesktopConfig defaults to the installed Decepticon home and WEB_PORT in local mode", () => {
   const cfg = resolveDesktopConfig(
-    { WEB_PORT: "3999" },
+    { WEB_PORT: "3999", DECEPTICON_DESKTOP_MODE: "local" },
     { homedir: () => "/home/alice", platform: "linux" },
   );
 
@@ -30,11 +33,55 @@ test("resolveDesktopConfig defaults to the installed Decepticon home and WEB_POR
   assert.equal(cfg.envFile, path.join("/home/alice", ".decepticon", ".env"));
   assert.equal(cfg.webContainer, "decepticon-web");
   assert.equal(cfg.project, "decepticon");
+  assert.equal(cfg.isCloud, false);
+  assert.equal(cfg.mode, "local");
+});
+
+test("resolveDesktopConfig auto mode uses cloud when local install is missing", () => {
+  const cfg = resolveDesktopConfig(
+    { DECEPTICON_HOME: "/tmp/decepticon-missing-install" },
+    { homedir: () => "/unused", platform: "linux" },
+    () => {
+      throw new Error("no env");
+    },
+    () => false,
+  );
+
+  assert.equal(cfg.dashboardUrl, CLOUD_APP_URL);
+  assert.equal(cfg.isCloud, true);
+  assert.equal(cfg.mode, "cloud");
+});
+
+test("resolveDesktopConfig auto mode uses local when install config exists", () => {
+  const home = "/opt/decepticon";
+  const existing = new Set([
+    path.join(home, "docker-compose.yml"),
+    path.join(home, ".env"),
+  ]);
+  const cfg = resolveDesktopConfig(
+    { DECEPTICON_HOME: home, WEB_PORT: "4310" },
+    { homedir: () => "/unused", platform: "linux" },
+    () => "WEB_PORT=4310\n",
+    (file) => existing.has(file),
+  );
+
+  assert.equal(cfg.dashboardUrl, "http://localhost:4310");
+  assert.equal(cfg.isCloud, false);
+  assert.equal(cfg.mode, "local");
+});
+
+test("resolveDesktopConfig cloud mode always targets the hosted app", () => {
+  const cfg = resolveDesktopConfig(
+    { DECEPTICON_DESKTOP_MODE: "cloud", WEB_PORT: "3000" },
+    { homedir: () => "/home/alice", platform: "linux" },
+  );
+  assert.equal(cfg.dashboardUrl, CLOUD_APP_URL);
+  assert.equal(cfg.isCloud, true);
 });
 
 test("resolveDesktopConfig reads WEB_PORT from the installed env file", () => {
   const cfg = resolveDesktopConfig(
-    { DECEPTICON_HOME: "/opt/decepticon" },
+    { DECEPTICON_HOME: "/opt/decepticon", DECEPTICON_DESKTOP_MODE: "local" },
     { homedir: () => "/unused", platform: "linux" },
     () => "POSTGRES_PASSWORD=secret\nWEB_PORT=4310\n",
   );
@@ -46,6 +93,7 @@ test("resolveDesktopConfig prefers explicit Compose project", () => {
   const cfg = resolveDesktopConfig({
     DECEPTICON_COMPOSE_PROJECT: "vendor-dev",
     DECEPTICON_STACK_NAME: "lab",
+    DECEPTICON_DESKTOP_MODE: "local",
   });
 
   assert.equal(cfg.project, "vendor-dev");
@@ -53,19 +101,22 @@ test("resolveDesktopConfig prefers explicit Compose project", () => {
 
 test("readInstalledVersion pins Compose to the installed CLI version", () => {
   const cfg = resolveDesktopConfig(
-    { DECEPTICON_HOME: "/opt/decepticon" },
+    { DECEPTICON_HOME: "/opt/decepticon", DECEPTICON_DESKTOP_MODE: "local" },
     { homedir: () => "/unused", platform: "linux" },
   );
 
   assert.equal(cfg.versionFile, path.join("/opt/decepticon", ".version"));
   assert.equal(readInstalledVersion(cfg, () => "v1.1.23\n"), "1.1.23");
   assert.equal(readInstalledVersion(cfg, () => ""), "");
-  assert.equal(resolveDesktopConfig({ DECEPTICON_STACK_NAME: "lab" }).webContainer, "decepticon-lab-web");
+  assert.equal(
+    resolveDesktopConfig({ DECEPTICON_STACK_NAME: "lab", DECEPTICON_DESKTOP_MODE: "local" }).webContainer,
+    "decepticon-lab-web",
+  );
 });
 
 test("composeUpArgs starts only the dynamic web profile", () => {
   const cfg = resolveDesktopConfig(
-    { DECEPTICON_HOME: "/opt/decepticon", DECEPTICON_STACK_NAME: "lab" },
+    { DECEPTICON_HOME: "/opt/decepticon", DECEPTICON_STACK_NAME: "lab", DECEPTICON_DESKTOP_MODE: "local" },
     { homedir: () => "/unused", platform: "linux" },
   );
 
@@ -108,7 +159,7 @@ test("composeProcessEnv preserves explicit stack ownership", () => {
 
 test("missingConfigFiles catches incomplete desktop setup before Compose runs", () => {
   const cfg = resolveDesktopConfig(
-    { DECEPTICON_HOME: "/tmp/decepticon-desktop-smoke" },
+    { DECEPTICON_HOME: "/tmp/decepticon-desktop-smoke", DECEPTICON_DESKTOP_MODE: "local" },
     { homedir: () => "/unused", platform: "linux" },
   );
   const existing = new Set([path.join("/tmp/decepticon-desktop-smoke", "docker-compose.yml")]);
@@ -122,6 +173,29 @@ test("canNavigateInApp only allows same-origin dashboard navigation", () => {
   assert.equal(canNavigateInApp("http://localhost:3000/engagements", "http://localhost:3000"), true);
   assert.equal(canNavigateInApp("https://docs.decepticon.red", "http://localhost:3000"), false);
   assert.equal(canNavigateInApp("not a url", "http://localhost:3000"), false);
+});
+
+test("canNavigateInShell allows OAuth hosts in cloud mode", () => {
+  assert.equal(
+    canNavigateInShell("https://accounts.google.com/o/oauth2", CLOUD_APP_URL, { cloud: true }),
+    true,
+  );
+  assert.equal(
+    canNavigateInShell("https://github.com/login/oauth/authorize", CLOUD_APP_URL, { cloud: true }),
+    true,
+  );
+  assert.equal(
+    canNavigateInShell("https://decepticon.red/", CLOUD_APP_URL, { cloud: true }),
+    true,
+  );
+  assert.equal(
+    canNavigateInShell("https://evil.example/phish", CLOUD_APP_URL, { cloud: true }),
+    false,
+  );
+  assert.equal(
+    canNavigateInShell("https://accounts.google.com/o/oauth2", "http://localhost:3000", { cloud: false }),
+    false,
+  );
 });
 
 test("dashboardResponseReady rejects external redirects", () => {
@@ -184,34 +258,85 @@ test("setupGuide gives OS-specific install and onboarding commands", () => {
   assert.match(setupGuide("win32").installCommand, /install\.ps1/);
   assert.equal(setupGuide("linux").onboardCommand, "decepticon onboard");
   assert.equal(setupGuide("linux").apiKeyCommand, "decepticon onboard --reset");
+  assert.equal(setupGuide("linux").cloudAppUrl, CLOUD_APP_URL);
 });
 
-test("statusHtml renders CLI-style branding and no start button dependency", () => {
+test("parseCookieImport accepts Cookie-Editor JSON for the app host", () => {
+  const raw = JSON.stringify([
+    {
+      domain: "app.decepticon.red",
+      expirationDate: 1788504699.6696,
+      hostOnly: true,
+      httpOnly: true,
+      name: "__Secure-better-auth.session_token",
+      path: "/",
+      sameSite: "lax",
+      secure: true,
+      value: "example.token%2Bvalue",
+    },
+    {
+      domain: "evil.example",
+      name: "skip-me",
+      value: "nope",
+      path: "/",
+      secure: true,
+    },
+  ]);
+
+  const cookies = parseCookieImport(raw, CLOUD_APP_URL);
+  assert.equal(cookies.length, 1);
+  assert.equal(cookies[0].name, "__Secure-better-auth.session_token");
+  assert.equal(cookies[0].value, "example.token+value");
+  assert.equal(cookies[0].secure, true);
+  assert.equal(cookies[0].httpOnly, true);
+  assert.equal(cookies[0].sameSite, "lax");
+  assert.equal(cookies[0].url, "https://app.decepticon.red/");
+  assert.equal(cookies[0].domain, undefined);
+});
+
+test("parseCookieImport accepts Netscape format", () => {
+  const raw = [
+    "# Netscape HTTP Cookie File",
+    "#HttpOnly_app.decepticon.red\tFALSE\t/\tTRUE\t1788504699\t__Secure-better-auth.session_token\texample.token",
+  ].join("\n");
+
+  const cookies = parseCookieImport(raw, CLOUD_APP_URL);
+  assert.equal(cookies.length, 1);
+  assert.equal(cookies[0].name, "__Secure-better-auth.session_token");
+  assert.equal(cookies[0].httpOnly, true);
+  assert.equal(cookies[0].secure, true);
+  assert.equal(cookies[0].expirationDate, 1788504699);
+  assert.equal(cookies[0].domain, undefined);
+});
+
+test("statusHtml renders product branding and cloud actions", () => {
   const html = statusHtml(
     {
-      dashboardUrl: "http://localhost:3000",
+      dashboardUrl: CLOUD_APP_URL,
+      cloudAppUrl: CLOUD_APP_URL,
       decepticonHome: "/home/alice/.decepticon",
       iconDataUrl: "data:image/png;base64,chameleon",
       installedVersion: "1.1.23",
+      isCloud: true,
       setup: setupGuide("linux"),
     },
-    "offline",
+    "connecting to Decepticon cloud…",
   );
 
   assert.match(html, /alt="Decepticon chameleon"/);
-  assert.ok(html.includes("PurpleAILAB / Decepticon local runtime"));
-  assert.ok(html.includes("root@decepticon:/workspace"));
-  assert.ok(html.includes("docker compose --profile web up -d web"));
+  assert.ok(html.includes("PurpleAILAB"));
+  assert.ok(html.includes("An AI red team under your command."));
+  assert.ok(html.includes("app.decepticon.red"));
   assert.ok(html.includes("v1.1.23"));
-  assert.ok(html.includes("auto-update via CLI"));
-  assert.ok(html.includes("telemetry via .env"));
+  assert.ok(html.includes("session persisted"));
+  assert.ok(html.includes("Open cloud app"));
   assert.ok(html.includes("Copy install"));
   assert.ok(html.includes("Copy onboarding"));
   assert.ok(html.includes("Copy API key setup"));
   assert.ok(html.includes("Download"));
   assert.ok(html.includes("Setup docs"));
-  assert.ok(html.includes("Set API keys"));
   assert.match(html, /data-desktop-action="retry"/);
+  assert.match(html, /data-desktop-action="openCloud"/);
   assert.match(html, /data-desktop-action="openInBrowser"/);
   assert.doesNotMatch(html, /data-desktop-action="startDashboard"/);
   assert.doesNotMatch(html, /onclick=/);

--- a/clients/desktop/src/main.mjs
+++ b/clients/desktop/src/main.mjs
@@ -20,6 +20,13 @@ import {
   resolveDesktopConfig,
   setupGuide,
 } from "./config.mjs";
+import {
+  applicationMenuTemplate,
+  browserWindowChrome,
+  dockerComposeSpawn,
+  dockerInspectSpawn,
+  envAssignHint,
+} from "./platform.mjs";
 import { statusHtml } from "./ui.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -35,7 +42,16 @@ let starting = false;
 let cookiesImported = false;
 
 app.setName("Decepticon");
-if (process.platform === "win32") app.setAppUserModelId("red.decepticon.desktop");
+if (process.platform === "win32") {
+  app.setAppUserModelId("red.decepticon.desktop");
+}
+if (process.platform === "darwin" && app.dock) {
+  try {
+    app.dock.setIcon(iconPath);
+  } catch {
+    // Dock icon is best-effort; PNG may be rejected on some macOS builds.
+  }
+}
 
 async function dashboardReady() {
   const controller = new AbortController();
@@ -59,19 +75,17 @@ async function dashboardReady() {
 
 async function runningWebImageCurrent() {
   if (!installedVersion) return true;
+  const { command, args, options } = dockerInspectSpawn(config.webContainer, {
+    env: composeEnv(),
+  });
   return new Promise((resolve) => {
-    execFile(
-      "docker",
-      ["inspect", "--format", "{{.Config.Image}}", config.webContainer],
-      { env: composeEnv(), timeout: 2000 },
-      (err, stdout) => {
-        if (err) {
-          resolve(true);
-          return;
-        }
-        resolve(stdout.trim().endsWith(`:${installedVersion}`));
-      },
-    );
+    execFile(command, args, options, (err, stdout) => {
+      if (err) {
+        resolve(true);
+        return;
+      }
+      resolve(String(stdout).trim().endsWith(`:${installedVersion}`));
+    });
   });
 }
 
@@ -146,8 +160,8 @@ async function bootstrapDashboard() {
         `Could not reach ${config.dashboardUrl}.`,
         "Check your network, then retry — or switch to a local dashboard:",
         "",
-        "  set DECEPTICON_DESKTOP_MODE=local",
-        "  npm run desktop",
+        envAssignHint("DECEPTICON_DESKTOP_MODE", "local"),
+        "npm run desktop",
       ].join("\n"),
     );
     return;
@@ -186,9 +200,10 @@ function startWebProfile() {
   }
 
   starting = true;
-  const args = composeUpArgs(config);
-  const child = spawn("docker", args, { env: composeEnv(), stdio: ["ignore", "pipe", "pipe"] });
-  let output = `$ docker ${args.join(" ")}\n`;
+  const composeArgs = composeUpArgs(config);
+  const { command, args, options } = dockerComposeSpawn(composeArgs, { env: composeEnv() });
+  const child = spawn(command, args, options);
+  let output = `$ ${command} ${args.join(" ")}\n`;
   const append = (chunk) => {
     output = (output + chunk.toString()).slice(-8000);
   };
@@ -196,7 +211,12 @@ function startWebProfile() {
   child.stderr.on("data", append);
   child.on("error", async (err) => {
     starting = false;
-    await loadStatus("docker compose launch failed", err.message);
+    const hint = process.platform === "win32"
+      ? "Is Docker Desktop running and `docker` on PATH?"
+      : process.platform === "darwin"
+        ? "Is Docker Desktop running? Try: open -a Docker"
+        : "Is the Docker daemon running? Try: sudo systemctl start docker";
+    await loadStatus("docker compose launch failed", `${err.message}\n${hint}`);
   });
   child.on("close", async (code) => {
     starting = false;
@@ -242,17 +262,20 @@ function registerIpcHandlers() {
   onStatusAction("desktop:copy-api-key", () => clipboard.writeText(setup.apiKeyCommand));
 }
 
+function installApplicationMenu() {
+  const template = applicationMenuTemplate(process.platform, app.name);
+  // Wire Help → docs on Windows/Linux (macOS uses system Help less often for this).
+  const help = template.find((item) => item.label === "Help");
+  if (help && Array.isArray(help.submenu) && help.submenu[0]) {
+    help.submenu[0].click = () => openWebUrl(setup.docsUrl);
+  }
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 1440,
-    height: 960,
-    minWidth: 1000,
-    minHeight: 700,
-    show: false,
-    title: "Decepticon",
+    ...browserWindowChrome(process.platform),
     icon: iconPath,
-    backgroundColor: "#050609",
-    autoHideMenuBar: true,
     webPreferences: {
       partition: config.partition,
       contextIsolation: true,
@@ -264,6 +287,7 @@ function createWindow() {
 
   mainWindow.once("ready-to-show", () => {
     mainWindow?.show();
+    if (process.platform === "darwin") mainWindow?.focus();
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -274,7 +298,7 @@ function createWindow() {
         overrideBrowserWindowOptions: {
           width: 520,
           height: 720,
-          autoHideMenuBar: true,
+          autoHideMenuBar: process.platform !== "darwin",
           backgroundColor: "#050609",
           webPreferences: {
             partition: config.partition,
@@ -316,7 +340,7 @@ if (!hasSingleInstanceLock) {
   });
 
   app.whenReady().then(() => {
-    Menu.setApplicationMenu(null);
+    installApplicationMenu();
     const ses = appSession();
     ses.setPermissionCheckHandler(() => false);
     ses.setPermissionRequestHandler((_webContents, _permission, callback) => {
@@ -324,11 +348,14 @@ if (!hasSingleInstanceLock) {
     });
     createWindow();
     app.on("activate", () => {
+      // macOS: re-open window when dock icon is clicked and none remain.
       if (BrowserWindow.getAllWindows().length === 0) createWindow();
+      else mainWindow?.show();
     });
   });
 }
 
 app.on("window-all-closed", () => {
+  // macOS apps stay alive until explicit Cmd+Q.
   if (process.platform !== "darwin") app.quit();
 });

--- a/clients/desktop/src/main.mjs
+++ b/clients/desktop/src/main.mjs
@@ -272,26 +272,8 @@ function installApplicationMenu() {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
-function createWindow() {
-  mainWindow = new BrowserWindow({
-    ...browserWindowChrome(process.platform),
-    icon: iconPath,
-    webPreferences: {
-      partition: config.partition,
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-      preload: path.join(__dirname, "preload.cjs"),
-    },
-  });
-
-  mainWindow.once("ready-to-show", () => {
-    mainWindow?.show();
-    if (process.platform === "darwin") mainWindow?.focus();
-  });
-
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    // Keep OAuth / product popups inside the shell when allowed; else system browser.
+function secureWebContents(webContents) {
+  webContents.setWindowOpenHandler(({ url }) => {
     if (canNavigateInShell(url, config.dashboardUrl, { cloud: config.isCloud })) {
       return {
         action: "allow",
@@ -313,21 +295,44 @@ function createWindow() {
     return { action: "deny" };
   });
 
-  mainWindow.webContents.on("will-navigate", (event, url) => {
+  webContents.on("will-navigate", (event, url) => {
     if (!canNavigateInShell(url, config.dashboardUrl, { cloud: config.isCloud })) {
       event.preventDefault();
       openWebUrl(url);
     }
   });
-
-  mainWindow.webContents.on("will-redirect", (event, url) => {
+  webContents.on("will-redirect", (event, url) => {
     if (!canNavigateInShell(url, config.dashboardUrl, { cloud: config.isCloud })) {
       event.preventDefault();
     }
   });
+}
+
+app.on("web-contents-created", (_event, webContents) => {
+  secureWebContents(webContents);
+});
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    ...browserWindowChrome(process.platform),
+    icon: iconPath,
+    webPreferences: {
+      partition: config.partition,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      preload: path.join(__dirname, "preload.cjs"),
+    },
+  });
+
+  mainWindow.once("ready-to-show", () => {
+    mainWindow?.show();
+    if (process.platform === "darwin") mainWindow?.focus();
+  });
 
   registerIpcHandlers();
   bootstrapDashboard();
+
 }
 
 if (!hasSingleInstanceLock) {

--- a/clients/desktop/src/main.mjs
+++ b/clients/desktop/src/main.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  canNavigateInApp,
+  canNavigateInShell,
   canOpenExternal,
   composeProcessEnv,
   composeUpArgs,
@@ -14,6 +14,8 @@ import {
   dashboardResponseReady,
   isTrustedIpcSender,
   missingConfigFiles,
+  parseCookieImport,
+  readCookieImportFile,
   readInstalledVersion,
   resolveDesktopConfig,
   setupGuide,
@@ -27,17 +29,26 @@ const config = resolveDesktopConfig();
 const installedVersion = readInstalledVersion(config);
 const setup = setupGuide();
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
+const appSession = () => session.fromPartition(config.partition);
 let mainWindow;
 let starting = false;
+let cookiesImported = false;
 
-app.setName("Decepticon Desktop");
+app.setName("Decepticon");
 if (process.platform === "win32") app.setAppUserModelId("red.decepticon.desktop");
 
 async function dashboardReady() {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 1500);
   try {
-    const res = await fetch(config.dashboardUrl, { signal: controller.signal });
+    const res = await fetch(config.dashboardUrl, {
+      signal: controller.signal,
+      redirect: "manual",
+    });
+    // Cloud login pages often 302 to /login — still "ready" for the shell.
+    if (config.isCloud) {
+      return res.status > 0 && res.status < 500;
+    }
     return dashboardResponseReady(res, config.dashboardUrl);
   } catch {
     return false;
@@ -77,13 +88,74 @@ async function waitForDashboardReady(
 
 async function loadStatus(message, detail) {
   if (!mainWindow) return;
-  await mainWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(statusHtml({ ...config, iconDataUrl, installedVersion, setup }, message, detail))}`);
+  await mainWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(statusHtml({
+    ...config,
+    iconDataUrl,
+    installedVersion,
+    setup,
+  }, message, detail))}`);
+}
+
+async function importSessionCookies() {
+  if (cookiesImported) return { imported: 0, skipped: true };
+  cookiesImported = true;
+  const raw = readCookieImportFile(config.cookiesPath);
+  if (!raw) return { imported: 0, skipped: true };
+
+  let cookies;
+  try {
+    cookies = parseCookieImport(raw, config.dashboardUrl);
+  } catch (err) {
+    return { imported: 0, error: err instanceof Error ? err.message : String(err) };
+  }
+  if (cookies.length === 0) return { imported: 0, skipped: true };
+
+  const ses = appSession();
+  let imported = 0;
+  for (const cookie of cookies) {
+    try {
+      await ses.cookies.set(cookie);
+      imported += 1;
+    } catch {
+      // Skip malformed or rejected cookies; login can still proceed interactively.
+    }
+  }
+  await ses.cookies.flushStore();
+  return { imported };
+}
+
+async function loadDashboard() {
+  if (!mainWindow) return;
+  const result = await importSessionCookies();
+  if (result.error) {
+    await loadStatus("cookie import failed", result.error);
+  }
+  await mainWindow.loadURL(config.dashboardUrl);
 }
 
 async function bootstrapDashboard() {
+  if (config.isCloud) {
+    await loadStatus("connecting to Decepticon cloud…");
+    if (await dashboardReady()) {
+      await loadDashboard();
+      return;
+    }
+    await loadStatus(
+      "cloud app unreachable",
+      [
+        `Could not reach ${config.dashboardUrl}.`,
+        "Check your network, then retry — or switch to a local dashboard:",
+        "",
+        "  set DECEPTICON_DESKTOP_MODE=local",
+        "  npm run desktop",
+      ].join("\n"),
+    );
+    return;
+  }
+
   if (await dashboardReady()) {
     if (await runningWebImageCurrent()) {
-      await mainWindow?.loadURL(config.dashboardUrl);
+      await loadDashboard();
       return;
     }
     await loadStatus(`dashboard is running on an older image; updating to v${installedVersion}…`);
@@ -106,7 +178,7 @@ function startWebProfile() {
       "Missing required Decepticon config file(s):",
       ...missing.map(([label, file]) => `- ${label}: ${file}`),
       "",
-      "Use the buttons below to copy the installer, run onboarding, or open docs.",
+      "Use the buttons below to open the cloud app, copy the installer, or run onboarding.",
       "Onboarding handles API keys, telemetry consent, auto-update settings, Docker checks, and model/provider setup.",
     ].join("\n");
     loadStatus("desktop setup incomplete; bootstrap blocked", detail);
@@ -131,7 +203,7 @@ function startWebProfile() {
     if (code === 0) {
       await loadStatus("web profile started; waiting for dashboard readiness…", output);
       if (await waitForDashboardReady()) {
-        await mainWindow?.loadURL(config.dashboardUrl);
+        await loadDashboard();
         return;
       }
       await loadStatus("web profile started, but dashboard did not become ready", output);
@@ -150,6 +222,7 @@ function registerIpcHandlers() {
   ipcMain.removeAllListeners("desktop:open-in-browser");
   ipcMain.removeAllListeners("desktop:open-download");
   ipcMain.removeAllListeners("desktop:open-docs");
+  ipcMain.removeAllListeners("desktop:open-cloud");
   ipcMain.removeAllListeners("desktop:copy-install");
   ipcMain.removeAllListeners("desktop:copy-onboard");
   ipcMain.removeAllListeners("desktop:copy-api-key");
@@ -161,6 +234,7 @@ function registerIpcHandlers() {
   };
   onStatusAction("desktop:retry", bootstrapDashboard);
   onStatusAction("desktop:open-in-browser", () => openWebUrl(config.dashboardUrl));
+  onStatusAction("desktop:open-cloud", () => openWebUrl(config.cloudAppUrl || setup.cloudAppUrl));
   onStatusAction("desktop:open-download", () => openWebUrl(setup.downloadUrl));
   onStatusAction("desktop:open-docs", () => openWebUrl(setup.docsUrl));
   onStatusAction("desktop:copy-install", () => clipboard.writeText(setup.installCommand));
@@ -175,10 +249,12 @@ function createWindow() {
     minWidth: 1000,
     minHeight: 700,
     show: false,
-    title: "Decepticon Desktop",
+    title: "Decepticon",
     icon: iconPath,
     backgroundColor: "#050609",
+    autoHideMenuBar: true,
     webPreferences: {
+      partition: config.partition,
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
@@ -191,19 +267,39 @@ function createWindow() {
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    // Keep OAuth / product popups inside the shell when allowed; else system browser.
+    if (canNavigateInShell(url, config.dashboardUrl, { cloud: config.isCloud })) {
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: {
+          width: 520,
+          height: 720,
+          autoHideMenuBar: true,
+          backgroundColor: "#050609",
+          webPreferences: {
+            partition: config.partition,
+            contextIsolation: true,
+            nodeIntegration: false,
+            sandbox: true,
+          },
+        },
+      };
+    }
     openWebUrl(url);
     return { action: "deny" };
   });
 
   mainWindow.webContents.on("will-navigate", (event, url) => {
-    if (!canNavigateInApp(url, config.dashboardUrl)) {
+    if (!canNavigateInShell(url, config.dashboardUrl, { cloud: config.isCloud })) {
       event.preventDefault();
       openWebUrl(url);
     }
   });
 
   mainWindow.webContents.on("will-redirect", (event, url) => {
-    if (!canNavigateInApp(url, config.dashboardUrl)) event.preventDefault();
+    if (!canNavigateInShell(url, config.dashboardUrl, { cloud: config.isCloud })) {
+      event.preventDefault();
+    }
   });
 
   registerIpcHandlers();
@@ -221,8 +317,9 @@ if (!hasSingleInstanceLock) {
 
   app.whenReady().then(() => {
     Menu.setApplicationMenu(null);
-    session.defaultSession.setPermissionCheckHandler(() => false);
-    session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    const ses = appSession();
+    ses.setPermissionCheckHandler(() => false);
+    ses.setPermissionRequestHandler((_webContents, _permission, callback) => {
       callback(false);
     });
     createWindow();

--- a/clients/desktop/src/platform.mjs
+++ b/clients/desktop/src/platform.mjs
@@ -1,0 +1,156 @@
+/**
+ * Pure platform helpers — no Electron import so unit tests run on every OS.
+ */
+
+/** Shell one-liner to set an env var for the current platform. */
+export function envAssignHint(name, value, platform = process.platform) {
+  if (platform === "win32") {
+    return [
+      `PowerShell:  $env:${name}="${value}"`,
+      `cmd.exe:     set ${name}=${value}`,
+    ].join("\n");
+  }
+  return `export ${name}=${value}`;
+}
+
+/** How to launch Docker Compose on this host (array form; no shell interpolation). */
+export function dockerComposeSpawn(args, { platform = process.platform, env = process.env } = {}) {
+  // Docker Desktop ships `docker.exe` / `docker` with the compose plugin on all
+  // three platforms. Passing the argv array avoids Windows path-quoting bugs.
+  return {
+    command: "docker",
+    args: [...args],
+    options: {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      // Hide the brief console flash when spawning from a GUI app on Windows.
+      windowsHide: platform === "win32",
+      // Never shell:true — args must not be re-parsed by cmd.exe / sh.
+      shell: false,
+    },
+  };
+}
+
+export function dockerInspectSpawn(webContainer, { platform = process.platform, env = process.env } = {}) {
+  return {
+    command: "docker",
+    args: ["inspect", "--format", "{{.Config.Image}}", webContainer],
+    options: {
+      env,
+      timeout: 2000,
+      windowsHide: platform === "win32",
+      shell: false,
+    },
+  };
+}
+
+/**
+ * Application menu template with platform roles.
+ * macOS needs Edit roles or Cmd+C/V fail inside login forms.
+ * Windows/Linux get the same Edit menu so Ctrl+C/V work consistently.
+ */
+export function applicationMenuTemplate(platform = process.platform, appName = "Decepticon") {
+  /** @type {Array<Record<string, unknown>>} */
+  const template = [];
+
+  if (platform === "darwin") {
+    template.push({
+      label: appName,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    });
+  }
+
+  template.push({
+    label: "Edit",
+    submenu: [
+      { role: "undo" },
+      { role: "redo" },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { role: "selectAll" },
+    ],
+  });
+
+  template.push({
+    label: "View",
+    submenu: [
+      { role: "reload" },
+      { role: "forceReload" },
+      { role: "toggleDevTools" },
+      { type: "separator" },
+      { role: "resetZoom" },
+      { role: "zoomIn" },
+      { role: "zoomOut" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+    ],
+  });
+
+  template.push({
+    label: "Window",
+    submenu: platform === "darwin"
+      ? [
+          { role: "minimize" },
+          { role: "zoom" },
+          { type: "separator" },
+          { role: "front" },
+          { type: "separator" },
+          { role: "window" },
+        ]
+      : [
+          { role: "minimize" },
+          { role: "close" },
+        ],
+  });
+
+  if (platform !== "darwin") {
+    template.push({
+      label: "Help",
+      submenu: [
+        {
+          label: "Decepticon Docs",
+          // main process wires click → shell.openExternal; role-less label only.
+        },
+      ],
+    });
+  }
+
+  return template;
+}
+
+/** BrowserWindow construction options that differ by OS. */
+export function browserWindowChrome(platform = process.platform) {
+  const common = {
+    width: 1440,
+    height: 960,
+    minWidth: 1000,
+    minHeight: 700,
+    show: false,
+    title: "Decepticon",
+    backgroundColor: "#050609",
+    autoHideMenuBar: platform !== "darwin",
+  };
+
+  if (platform === "darwin") {
+    return {
+      ...common,
+      // Traffic lights + title; keeps the product feel without a custom titlebar.
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 14, y: 14 },
+    };
+  }
+
+  return common;
+}

--- a/clients/desktop/src/platform.test.mjs
+++ b/clients/desktop/src/platform.test.mjs
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import {
+  applicationMenuTemplate,
+  browserWindowChrome,
+  dockerComposeSpawn,
+  dockerInspectSpawn,
+  envAssignHint,
+} from "./platform.mjs";
+import { resolveDesktopConfig, setupGuide } from "./config.mjs";
+
+test("envAssignHint is shell-correct on Windows, macOS, and Linux", () => {
+  const win = envAssignHint("DECEPTICON_DESKTOP_MODE", "local", "win32");
+  assert.match(win, /\$env:DECEPTICON_DESKTOP_MODE="local"/);
+  assert.match(win, /set DECEPTICON_DESKTOP_MODE=local/);
+
+  const unix = envAssignHint("DECEPTICON_DESKTOP_MODE", "local", "linux");
+  assert.equal(unix, "export DECEPTICON_DESKTOP_MODE=local");
+
+  const mac = envAssignHint("DECEPTICON_DESKTOP_MODE", "cloud", "darwin");
+  assert.equal(mac, "export DECEPTICON_DESKTOP_MODE=cloud");
+});
+
+test("dockerComposeSpawn never enables shell and hides the console on Windows", () => {
+  const win = dockerComposeSpawn(["compose", "ps"], {
+    platform: "win32",
+    env: { PATH: "C:\\Program Files\\Docker\\Docker\\resources\\bin" },
+  });
+  assert.equal(win.command, "docker");
+  assert.deepEqual(win.args, ["compose", "ps"]);
+  assert.equal(win.options.shell, false);
+  assert.equal(win.options.windowsHide, true);
+  assert.equal(win.options.env.PATH.includes("Docker"), true);
+
+  const linux = dockerComposeSpawn(["compose", "ps"], { platform: "linux", env: {} });
+  assert.equal(linux.options.windowsHide, false);
+  assert.equal(linux.options.shell, false);
+});
+
+test("dockerInspectSpawn uses the Go template format string on every OS", () => {
+  for (const platform of ["win32", "darwin", "linux"]) {
+    const spawn = dockerInspectSpawn("decepticon-web", { platform, env: {} });
+    assert.equal(spawn.command, "docker");
+    assert.deepEqual(spawn.args, ["inspect", "--format", "{{.Config.Image}}", "decepticon-web"]);
+    assert.equal(spawn.options.shell, false);
+    assert.equal(spawn.options.windowsHide, platform === "win32");
+  }
+});
+
+test("applicationMenuTemplate includes Edit roles required for login forms", () => {
+  for (const platform of ["win32", "darwin", "linux"]) {
+    const template = applicationMenuTemplate(platform, "Decepticon");
+    const labels = template.map((item) => item.label);
+    assert.ok(labels.includes("Edit"), `Edit menu missing on ${platform}`);
+    assert.ok(labels.includes("View"), `View menu missing on ${platform}`);
+    assert.ok(labels.includes("Window"), `Window menu missing on ${platform}`);
+
+    const edit = template.find((item) => item.label === "Edit");
+    const roles = edit.submenu.map((item) => item.role).filter(Boolean);
+    assert.ok(roles.includes("copy"), `copy role missing on ${platform}`);
+    assert.ok(roles.includes("paste"), `paste role missing on ${platform}`);
+    assert.ok(roles.includes("selectAll"), `selectAll role missing on ${platform}`);
+  }
+
+  const mac = applicationMenuTemplate("darwin", "Decepticon");
+  assert.equal(mac[0].label, "Decepticon");
+  assert.ok(mac[0].submenu.some((item) => item.role === "quit"));
+
+  const win = applicationMenuTemplate("win32", "Decepticon");
+  assert.ok(win.some((item) => item.label === "Help"));
+  assert.equal(win[0].label, "Edit");
+});
+
+test("browserWindowChrome uses hiddenInset title bar only on macOS", () => {
+  const mac = browserWindowChrome("darwin");
+  assert.equal(mac.titleBarStyle, "hiddenInset");
+  assert.deepEqual(mac.trafficLightPosition, { x: 14, y: 14 });
+  assert.equal(mac.autoHideMenuBar, false);
+
+  const win = browserWindowChrome("win32");
+  assert.equal(win.titleBarStyle, undefined);
+  assert.equal(win.autoHideMenuBar, true);
+
+  const linux = browserWindowChrome("linux");
+  assert.equal(linux.titleBarStyle, undefined);
+  assert.equal(linux.autoHideMenuBar, true);
+});
+
+test("setupGuide install commands match each OS family", () => {
+  assert.match(setupGuide("win32").installCommand, /install\.ps1/);
+  assert.match(setupGuide("win32").installCommand, /winget|Docker\.DockerDesktop/);
+  assert.match(setupGuide("darwin").installCommand, /install\.sh/);
+  assert.match(setupGuide("linux").installCommand, /install\.sh/);
+  assert.doesNotMatch(setupGuide("darwin").installCommand, /install\.ps1/);
+  assert.doesNotMatch(setupGuide("linux").installCommand, /install\.ps1/);
+});
+
+test("resolveDesktopConfig joins cookie and home paths with the host path module", () => {
+  const host = {
+    homedir: () => "/home/alice",
+  };
+  const cfg = resolveDesktopConfig(
+    { DECEPTICON_DESKTOP_MODE: "cloud" },
+    host,
+    () => {
+      throw new Error("no env");
+    },
+    () => false,
+  );
+  // path.join is the Node path for the runner OS (correct for desktop runtime).
+  assert.equal(cfg.decepticonHome, path.join("/home/alice", ".decepticon"));
+  assert.equal(cfg.cookiesPath, path.join("/home/alice", ".decepticon", "desktop-cookies.txt"));
+  assert.equal(cfg.dashboardUrl, "https://app.decepticon.red");
+});
+
+test("resolveDesktopConfig uses path.join so Windows home paths stay native", () => {
+  const home = process.platform === "win32"
+    ? "C:\\Users\\Alice"
+    : "/home/alice";
+  const cfg = resolveDesktopConfig(
+    { DECEPTICON_HOME: home, DECEPTICON_DESKTOP_MODE: "cloud" },
+    { homedir: () => home, platform: process.platform },
+    () => {
+      throw new Error("no env");
+    },
+    () => false,
+  );
+  assert.equal(cfg.decepticonHome, home);
+  assert.equal(cfg.cookiesPath, path.join(home, "desktop-cookies.txt"));
+  // Path separators must match the host OS.
+  if (process.platform === "win32") {
+    assert.match(cfg.cookiesPath, /\\/);
+  } else {
+    assert.doesNotMatch(cfg.cookiesPath, /\\/);
+  }
+});

--- a/clients/desktop/src/preload.cjs
+++ b/clients/desktop/src/preload.cjs
@@ -3,6 +3,7 @@ const { ipcRenderer } = require("electron");
 const channels = {
   retry: "desktop:retry",
   openInBrowser: "desktop:open-in-browser",
+  openCloud: "desktop:open-cloud",
   openDownload: "desktop:open-download",
   openDocs: "desktop:open-docs",
   copyInstall: "desktop:copy-install",

--- a/clients/desktop/src/ui.mjs
+++ b/clients/desktop/src/ui.mjs
@@ -1,11 +1,14 @@
-export function statusHtml(config, message = "checking local dashboard…", detail = "") {
+export function statusHtml(config, message = "checking dashboard…", detail = "") {
   const escapedMessage = escapeHtml(message);
   const escapedDetail = escapeHtml(detail);
-  const escapedVersion = escapeHtml(config.installedVersion ? `v${config.installedVersion}` : "setup required");
+  const escapedVersion = escapeHtml(config.installedVersion ? `v${config.installedVersion}` : "cloud");
   const setup = config.setup || {};
   const installCommand = escapeHtml(setup.installCommand || "curl -fsSL https://decepticon.red/install.sh | bash");
   const onboardCommand = escapeHtml(setup.onboardCommand || "decepticon onboard");
   const apiKeyCommand = escapeHtml(setup.apiKeyCommand || "decepticon onboard --reset");
+  const cloudUrl = escapeHtml(config.cloudAppUrl || setup.cloudAppUrl || "https://app.decepticon.red");
+  const dashboardUrl = escapeHtml(config.dashboardUrl || cloudUrl);
+  const modeLabel = config.isCloud ? "cloud" : "local";
   const icon = config.iconDataUrl
     ? `<img class="mark" src="${escapeHtml(config.iconDataUrl)}" alt="Decepticon chameleon" />`
     : `<div class="mark mark-fallback" aria-hidden="true">D</div>`;
@@ -16,31 +19,33 @@ export function statusHtml(config, message = "checking local dashboard…", deta
   <meta charset="utf-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Decepticon Desktop</title>
+  <title>Decepticon</title>
   <style>
     :root {
       color-scheme: dark;
       --bg: #050609;
-      --panel: #090b10;
-      --line: rgb(255 255 255 / .09);
-      --muted: #7c8798;
-      --text: #e7eaf0;
-      --red: #d71925;
+      --panel: #0a0c12;
+      --line: rgb(255 255 255 / .08);
+      --muted: #8b95a8;
+      --text: #eef1f6;
+      --red: #e11d2e;
       --purple: #7c3aed;
+      --purple-soft: #a78bfa;
       --green: #22c55e;
-      --blue: #60a5fa;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      --font: "Geist", "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+      --mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
 
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      font-family: var(--font);
       background:
-        radial-gradient(circle at 18% 8%, rgb(124 58 237 / .18), transparent 28rem),
-        linear-gradient(180deg, #080a0f 0%, var(--bg) 100%);
+        radial-gradient(ellipse 80% 50% at 50% -20%, rgb(124 58 237 / .28), transparent 55%),
+        radial-gradient(circle at 90% 80%, rgb(225 29 46 / .08), transparent 28rem),
+        linear-gradient(180deg, #07080d 0%, var(--bg) 55%, #030407 100%);
       color: var(--text);
-      overflow: hidden;
     }
 
     body::before {
@@ -48,169 +53,261 @@ export function statusHtml(config, message = "checking local dashboard…", deta
       position: fixed;
       inset: 0;
       pointer-events: none;
-      background: repeating-linear-gradient(0deg, rgb(255 255 255 / .035) 0 1px, transparent 1px 4px);
-      opacity: .18;
-      mix-blend-mode: screen;
+      opacity: .35;
+      background-image:
+        linear-gradient(rgb(255 255 255 / .03) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(255 255 255 / .03) 1px, transparent 1px);
+      background-size: 48px 48px;
+      mask-image: radial-gradient(ellipse at center, black 20%, transparent 75%);
     }
 
     .screen {
       position: relative;
       min-height: 100vh;
-      padding: clamp(1rem, 2vw, 1.4rem);
       display: grid;
-      grid-template-rows: auto 1fr;
-      gap: 1rem;
+      place-items: center;
+      padding: clamp(1.25rem, 4vw, 2.5rem);
     }
 
-    .header {
+    .card {
+      width: min(720px, 100%);
+      border: 1px solid var(--line);
+      border-radius: 1.15rem;
+      background: rgb(10 12 18 / .88);
+      box-shadow:
+        0 0 0 1px rgb(124 58 237 / .08),
+        0 2rem 5rem rgb(0 0 0 / .55);
+      overflow: hidden;
+      backdrop-filter: blur(12px);
+    }
+
+    .card-head {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 1rem;
-      border: 1px solid var(--line);
-      border-radius: .55rem;
-      background: rgb(8 10 16 / .92);
-      padding: .8rem 1rem;
-      box-shadow: 0 1.5rem 4rem rgb(0 0 0 / .35);
+      padding: 1.25rem 1.4rem 1rem;
+      border-bottom: 1px solid var(--line);
     }
 
-    .brand { display: flex; align-items: center; gap: .95rem; min-width: 0; }
+    .brand { display: flex; align-items: center; gap: .9rem; min-width: 0; }
     .mark {
-      width: 4.35rem;
-      height: 4.35rem;
+      width: 3.1rem;
+      height: 3.1rem;
       object-fit: cover;
-      border-radius: .65rem;
+      border-radius: .8rem;
       background: #0d1018;
-      box-shadow: 0 0 0 1px rgb(124 58 237 / .65), 0 0 32px rgb(124 58 237 / .42);
+      box-shadow: 0 0 0 1px rgb(124 58 237 / .55), 0 0 28px rgb(124 58 237 / .35);
       flex: 0 0 auto;
     }
-    .mark-fallback { display: grid; place-items: center; color: #c4b5fd; font-weight: 900; }
-    .brand-kicker { color: #9ca3af; font-size: .72rem; letter-spacing: .16em; text-transform: uppercase; }
-    .brand-title { margin: .1rem 0 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: clamp(1.9rem, 3.4vw, 3.35rem); line-height: .9; letter-spacing: -.06em; font-weight: 900; }
-    .brand-title .red { color: var(--red); text-shadow: 0 0 22px rgb(215 25 37 / .32); }
+    .mark-fallback { display: grid; place-items: center; color: var(--purple-soft); font-weight: 900; }
+    .kicker {
+      color: #9aa3b5;
+      font-size: .72rem;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      font-weight: 600;
+    }
+    .title {
+      margin: .15rem 0 0;
+      font-size: clamp(1.55rem, 3vw, 2rem);
+      line-height: 1;
+      letter-spacing: -.05em;
+      font-weight: 800;
+    }
+    .title .red { color: var(--red); }
 
-    .status { display: flex; flex-wrap: wrap; justify-content: end; gap: .45rem; color: #cbd5e1; }
-    .status span { border: 1px solid var(--line); border-radius: 999px; padding: .42rem .62rem; background: rgb(255 255 255 / .045); font-size: .75rem; font-weight: 700; }
-    .status .live::before { content: "● "; color: var(--green); text-shadow: 0 0 10px var(--green); }
-
-    .terminal {
-      min-height: 0;
+    .badges { display: flex; flex-wrap: wrap; justify-content: end; gap: .4rem; }
+    .badge {
       border: 1px solid var(--line);
-      border-radius: .55rem;
-      background: rgb(4 6 10 / .94);
-      box-shadow: 0 2rem 6rem rgb(0 0 0 / .42);
-      overflow: hidden;
-      display: grid;
-      grid-template-rows: auto 1fr auto;
+      border-radius: 999px;
+      padding: .35rem .65rem;
+      background: rgb(255 255 255 / .04);
+      color: #cbd5e1;
+      font-size: .72rem;
+      font-weight: 650;
+    }
+    .badge.live::before {
+      content: "";
+      display: inline-block;
+      width: .45rem;
+      height: .45rem;
+      border-radius: 999px;
+      margin-right: .35rem;
+      background: var(--green);
+      box-shadow: 0 0 10px var(--green);
+      vertical-align: middle;
     }
 
-    .chrome { display: flex; align-items: center; gap: .55rem; padding: .72rem .9rem; border-bottom: 1px solid var(--line); background: rgb(255 255 255 / .035); color: #b7c0ce; font-size: .82rem; }
-    .lights { display: flex; gap: .35rem; }
-    .lights i { width: .68rem; height: .68rem; border-radius: 999px; display: block; }
-    .lights i:nth-child(1) { background: #ef4444; }
-    .lights i:nth-child(2) { background: #f59e0b; }
-    .lights i:nth-child(3) { background: #22c55e; }
+    .card-body { padding: 1.35rem 1.4rem 1.2rem; }
+    .headline {
+      margin: 0 0 .55rem;
+      font-size: 1.15rem;
+      font-weight: 700;
+      letter-spacing: -.02em;
+    }
+    .lede {
+      margin: 0;
+      color: var(--muted);
+      font-size: .95rem;
+      line-height: 1.55;
+    }
+    .status-line {
+      margin-top: 1.1rem;
+      padding: .85rem 1rem;
+      border-radius: .75rem;
+      border: 1px solid var(--line);
+      background: rgb(0 0 0 / .28);
+      font-family: var(--mono);
+      font-size: .82rem;
+      line-height: 1.55;
+    }
+    .status-line strong { color: #f8fafc; font-weight: 650; }
+    .status-line .muted { color: var(--muted); }
+    .status-line .target { color: #c4b5fd; word-break: break-all; }
+    .detail {
+      margin: .85rem 0 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      color: #a8b3c7;
+      font-family: var(--mono);
+      font-size: .78rem;
+      line-height: 1.55;
+    }
 
-    .body { padding: clamp(1rem, 2vw, 1.55rem); font-size: clamp(.92rem, 1.25vw, 1.05rem); line-height: 1.72; overflow: auto; }
-    .green { color: var(--green); }
-    .blue { color: var(--blue); }
-    .purple { color: #a78bfa; }
-    .muted { color: var(--muted); }
-    .red { color: #f87171; }
-    .cmd { color: #f8fafc; }
-    .target { color: #bae6fd; word-break: break-all; }
-    .output { white-space: pre-wrap; word-break: break-word; margin-top: 1rem; color: #a8b3c7; }
-    .setup-grid {
+    .steps {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: .75rem;
-      margin-top: 1.1rem;
+      gap: .7rem;
+      margin-top: 1.15rem;
     }
-    .setup-card {
+    .step {
       border: 1px solid var(--line);
-      border-radius: .55rem;
+      border-radius: .8rem;
       padding: .85rem;
-      background: rgb(255 255 255 / .035);
+      background: rgb(255 255 255 / .03);
     }
-    .setup-card strong { display: block; color: #f8fafc; margin-bottom: .35rem; }
-    .setup-card code { display: block; color: #c4b5fd; white-space: pre-wrap; word-break: break-word; margin-top: .45rem; }
-
+    .step strong {
+      display: block;
+      font-size: .82rem;
+      margin-bottom: .3rem;
+      color: #f8fafc;
+    }
+    .step p {
+      margin: 0;
+      color: var(--muted);
+      font-size: .78rem;
+      line-height: 1.45;
+    }
+    .step code {
+      display: block;
+      margin-top: .55rem;
+      color: var(--purple-soft);
+      font-family: var(--mono);
+      font-size: .7rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
 
     .actions {
       display: flex;
       flex-wrap: wrap;
-      gap: .65rem;
-      border-top: 1px solid var(--line);
-      padding: .85rem .9rem;
-      background: rgb(255 255 255 / .025);
+      gap: .55rem;
+      padding: 0 1.4rem 1.35rem;
     }
     button {
       border: 1px solid var(--line);
-      border-radius: .45rem;
-      background: rgb(255 255 255 / .055);
-      color: #e5e7eb;
-      padding: .65rem .85rem;
+      border-radius: .65rem;
+      background: rgb(255 255 255 / .04);
+      color: #e8edf5;
+      padding: .7rem .95rem;
       font: inherit;
-      font-weight: 800;
+      font-size: .86rem;
+      font-weight: 650;
       cursor: pointer;
+      transition: border-color .15s ease, background .15s ease, color .15s ease;
     }
-    button:hover { border-color: rgb(124 58 237 / .65); color: white; background: rgb(124 58 237 / .18); }
-    button:focus-visible { outline: 2px solid #a78bfa; outline-offset: 2px; }
+    button.primary {
+      background: linear-gradient(180deg, #8b5cf6 0%, #6d28d9 100%);
+      border-color: rgb(167 139 250 / .45);
+      color: white;
+      box-shadow: 0 .4rem 1.4rem rgb(109 40 217 / .35);
+    }
+    button.primary:hover {
+      background: linear-gradient(180deg, #9b6dff 0%, #7c3aed 100%);
+    }
+    button:hover {
+      border-color: rgb(124 58 237 / .55);
+      background: rgb(124 58 237 / .14);
+      color: white;
+    }
+    button:focus-visible { outline: 2px solid var(--purple-soft); outline-offset: 2px; }
 
     @media (max-width: 760px) {
-      body { overflow: auto; }
-      .screen { min-height: auto; }
-      .header { align-items: flex-start; flex-direction: column; }
-      .status { justify-content: start; }
-      .setup-grid { grid-template-columns: 1fr; }
-      .mark { width: 3.5rem; height: 3.5rem; }
+      .steps { grid-template-columns: 1fr; }
+      .card-head { flex-direction: column; align-items: flex-start; }
+      .badges { justify-content: start; }
     }
   </style>
 </head>
 <body>
   <main class="screen">
-    <header class="header">
-      <div class="brand">
-        ${icon}
-        <div>
-          <div class="brand-kicker">PurpleAILAB / Decepticon local runtime</div>
-          <h1 class="brand-title">Decepti<span class="red">con</span></h1>
+    <section class="card" aria-label="Decepticon desktop">
+      <header class="card-head">
+        <div class="brand">
+          ${icon}
+          <div>
+            <div class="kicker">PurpleAILAB</div>
+            <h1 class="title">Decepti<span class="red">con</span></h1>
+          </div>
         </div>
-      </div>
-      <div class="status" aria-label="Runtime status">
-        <span class="live">desktop online</span>
-        <span>${escapedVersion}</span>
-        <span>auto-update via CLI</span>
-        <span>telemetry via .env</span>
-      </div>
-    </header>
+        <div class="badges" aria-label="Runtime status">
+          <span class="badge live">${escapeHtml(modeLabel)}</span>
+          <span class="badge">${escapedVersion}</span>
+          <span class="badge">session persisted</span>
+        </div>
+      </header>
 
-    <section class="terminal" aria-label="Desktop bootstrap terminal">
-      <div class="chrome"><span class="lights"><i></i><i></i><i></i></span> root@decepticon:/workspace — desktop bootstrap</div>
-      <div class="body">
-        <div><span class="green">●</span> Skill<span class="purple">(engagement-startup)</span></div>
-        <div class="muted">└─ loaded desktop shell, chameleon icon, local web bridge</div>
-        <br />
-        <div><span class="green">┌─(desktop㉿host)-[</span><span class="blue">${escapeHtml(config.decepticonHome || "~/.decepticon")}</span><span class="green">]</span></div>
-        <div><span class="green">└─#</span> <span class="cmd">docker compose --profile web up -d web</span></div>
-        <br />
-        <div><span class="green">●</span> dashboard target <span class="target">${escapeHtml(config.dashboardUrl)}</span></div>
-        <div><span class="green">●</span> status <span class="cmd">${escapedMessage}</span></div>
-        <div class="output ${escapedDetail ? "" : "muted"}">${escapedDetail || "# auto-starting dashboard when config is present\n# first run: install Decepticon, then run decepticon onboard"}</div>
-        <div class="setup-grid" aria-label="Onboarding steps">
-          <div class="setup-card"><strong>1. Download</strong><span class="muted">Install the CLI + config for this OS.</span><code>${installCommand}</code></div>
-          <div class="setup-card"><strong>2. Onboard</strong><span class="muted">Set API keys, telemetry, updates, Docker, and model provider.</span><code>${onboardCommand}</code></div>
-          <div class="setup-card"><strong>3. Change API key</strong><span class="muted">Re-run setup anytime without editing files by hand.</span><code>${apiKeyCommand}</code></div>
+      <div class="card-body">
+        <h2 class="headline">An AI red team under your command.</h2>
+        <p class="lede">
+          Same control plane as the website — scope, RoE, and OPPLAN enforced at runtime.
+          Sign in on the cloud app, or bootstrap the local dashboard when Docker is installed.
+        </p>
+        <div class="status-line">
+          <div><strong>target</strong> <span class="target">${dashboardUrl}</span></div>
+          <div><strong>status</strong> <span class="muted">${escapedMessage}</span></div>
+        </div>
+        <pre class="detail">${escapedDetail || "Tip: export cookies from app.decepticon.red into ~/.decepticon/desktop-cookies.txt (JSON or Netscape) to restore a browser session. Prefer signing in interactively — do not commit session tokens."}</pre>
+        <div class="steps" aria-label="Setup paths">
+          <div class="step">
+            <strong>1. Cloud app</strong>
+            <p>Open the hosted product UI (Google / GitHub / email login).</p>
+            <code>${cloudUrl}</code>
+          </div>
+          <div class="step">
+            <strong>2. Local install</strong>
+            <p>Install CLI + Docker stack for offline / self-hosted use.</p>
+            <code>${installCommand}</code>
+          </div>
+          <div class="step">
+            <strong>3. Onboard</strong>
+            <p>API keys, telemetry, updates, and model provider.</p>
+            <code>${onboardCommand}</code>
+            <code>${apiKeyCommand}</code>
+          </div>
         </div>
       </div>
+
       <div class="actions">
-        <button type="button" data-desktop-action="retry">Retry bootstrap</button>
+        <button type="button" class="primary" data-desktop-action="retry">Continue</button>
+        <button type="button" data-desktop-action="openCloud">Open cloud app</button>
+        <button type="button" data-desktop-action="openInBrowser">Open in browser</button>
         <button type="button" data-desktop-action="copyInstall">Copy install</button>
         <button type="button" data-desktop-action="copyOnboard">Copy onboarding</button>
         <button type="button" data-desktop-action="copyApiKey">Copy API key setup</button>
         <button type="button" data-desktop-action="openDownload">Download</button>
         <button type="button" data-desktop-action="openDocs">Setup docs</button>
-        <button type="button" data-desktop-action="openInBrowser">Open dashboard in browser</button>
       </div>
     </section>
   </main>

--- a/clients/desktop/src/ui.mjs
+++ b/clients/desktop/src/ui.mjs
@@ -9,6 +9,10 @@ export function statusHtml(config, message = "checking dashboard…", detail = "
   const cloudUrl = escapeHtml(config.cloudAppUrl || setup.cloudAppUrl || "https://app.decepticon.red");
   const dashboardUrl = escapeHtml(config.dashboardUrl || cloudUrl);
   const modeLabel = config.isCloud ? "cloud" : "local";
+  const cookiesPathHint = escapeHtml(
+    config.cookiesPath
+    || (config.decepticonHome ? `${config.decepticonHome}/desktop-cookies.txt` : "~/.decepticon/desktop-cookies.txt"),
+  );
   const icon = config.iconDataUrl
     ? `<img class="mark" src="${escapeHtml(config.iconDataUrl)}" alt="Decepticon chameleon" />`
     : `<div class="mark mark-fallback" aria-hidden="true">D</div>`;
@@ -278,7 +282,7 @@ export function statusHtml(config, message = "checking dashboard…", detail = "
           <div><strong>target</strong> <span class="target">${dashboardUrl}</span></div>
           <div><strong>status</strong> <span class="muted">${escapedMessage}</span></div>
         </div>
-        <pre class="detail">${escapedDetail || "Tip: export cookies from app.decepticon.red into ~/.decepticon/desktop-cookies.txt (JSON or Netscape) to restore a browser session. Prefer signing in interactively — do not commit session tokens."}</pre>
+        <pre class="detail">${escapedDetail || `Tip: export cookies from app.decepticon.red into ${cookiesPathHint} (JSON or Netscape) to restore a browser session. Prefer signing in interactively — do not commit session tokens.`}</pre>
         <div class="steps" aria-label="Setup paths">
           <div class="step">
             <strong>1. Cloud app</strong>

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -27,7 +27,15 @@ The dashboard is **dynamic-spawn** (v1.1.8+): it does NOT come up on `decepticon
 npm run desktop
 ```
 
-The desktop app is an Electron shell for the same local dashboard. It loads `http://localhost:${WEB_PORT:-3000}`, auto-starts the existing `web` Docker Compose profile from `~/.decepticon` when the dashboard is offline, keeps external links in the system browser, and shows a CLI-style status console if setup is incomplete.
+The desktop app is an Electron shell for the product UI:
+
+| Mode | When | Target |
+|---|---|---|
+| `auto` (default) | Local install present → local; otherwise cloud | `http://localhost:${WEB_PORT:-3000}` or `https://app.decepticon.red` |
+| `cloud` | `DECEPTICON_DESKTOP_MODE=cloud` | Hosted app (website login, Google/GitHub OAuth in-window) |
+| `local` | `DECEPTICON_DESKTOP_MODE=local` | Local dashboard; auto-starts the `web` Docker Compose profile from `~/.decepticon` when offline |
+
+Sessions use a persistent Electron partition (`persist:decepticon-desktop`). Optional one-shot cookie import: drop a Cookie-Editor JSON or Netscape export at `~/.decepticon/desktop-cookies.txt` (or set `DECEPTICON_DESKTOP_COOKIES`). Prefer interactive sign-in; never commit session tokens. External links stay in the system browser; status UI matches the product branding when bootstrap is blocked.
 
 Headless operators (no CLI, e.g. CI) can drive the same lifecycle from the host shell:
 ```bash

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -35,7 +35,19 @@ The desktop app is an Electron shell for the product UI:
 | `cloud` | `DECEPTICON_DESKTOP_MODE=cloud` | Hosted app (website login, Google/GitHub OAuth in-window) |
 | `local` | `DECEPTICON_DESKTOP_MODE=local` | Local dashboard; auto-starts the `web` Docker Compose profile from `~/.decepticon` when offline |
 
-Sessions use a persistent Electron partition (`persist:decepticon-desktop`). Optional one-shot cookie import: drop a Cookie-Editor JSON or Netscape export at `~/.decepticon/desktop-cookies.txt` (or set `DECEPTICON_DESKTOP_COOKIES`). Prefer interactive sign-in; never commit session tokens. External links stay in the system browser; status UI matches the product branding when bootstrap is blocked.
+Sessions use a persistent Electron partition (`persist:decepticon-desktop`). Optional one-shot cookie import: drop a Cookie-Editor JSON or Netscape export at `~/.decepticon/desktop-cookies.txt` (Windows: `%USERPROFILE%\.decepticon\desktop-cookies.txt`) or set `DECEPTICON_DESKTOP_COOKIES`. Prefer interactive sign-in; never commit session tokens.
+
+Cross-platform notes (Linux / macOS / Windows):
+
+| Concern | Behavior |
+|---|---|
+| Install copy-button | `install.sh` on Unix; `install.ps1` + winget Docker hint on Windows |
+| Local stack start | `docker compose …` via argv spawn (`shell: false`); `windowsHide` on Windows |
+| Login form edit keys | Application **Edit** menu roles (required for Cmd/Ctrl+C/V on all three) |
+| Window lifecycle | macOS stays running after last window close (dock re-activate); others quit |
+| CI | `Desktop (ubuntu/macOS/windows)` runs unit + syntax checks on every desktop change |
+
+External links stay in the system browser; status UI matches the product branding when bootstrap is blocked.
 
 Headless operators (no CLI, e.g. CI) can drive the same lifecycle from the host shell:
 ```bash


### PR DESCRIPTION
## Summary

Align the Electron desktop shell with the hosted product (`https://app.decepticon.red`): cloud-first auto mode, persistent login sessions, optional cookie import, OAuth in-window, and product-style status UI.

## Changes

- `DECEPTICON_DESKTOP_MODE=auto|cloud|local` (default auto: cloud when local install missing)
- Persistent partition `persist:decepticon-desktop`
- Cookie import from `~/.decepticon/desktop-cookies.txt` (Cookie-Editor JSON or Netscape); Decepticon app-domain only
- Cloud navigation allowlist for `*.decepticon.red` + Google/GitHub OAuth hosts; applies to every Electron web contents instance
- Status page restyled toward marketing/product look; primary Continue / Open cloud app actions
- Docs update in `docs/web-dashboard.md`

## Intent

- Make the desktop app feel like the website control plane
- **Anti-goal:** does not package installers, auto-updaters, or a second backend

## Blast radius

- [x] Tier-delegate (desktop shell + docs)
- Supply-chain: no new dependencies

## Verification

- `npm run desktop:test` — 30/30 passed
- `node --check clients/desktop/src/config.mjs && node --check clients/desktop/src/main.mjs`
- GitHub Actions Security and CI completed successfully, including Desktop on Ubuntu, macOS, and Windows

## Security note

Do not commit session tokens. Prefer interactive login; cookie import is local restore only and preserves cookie values exactly.