### PR TITLE
fix(roe): match recursive domain wildcards

### DIFF
--- a/packages/decepticon-core/decepticon_core/types/roe.py
+++ b/packages/decepticon-core/decepticon_core/types/roe.py
@@ -211,6 +211,8 @@ class Decision:
 
 
 def _glob_match(pattern: str, candidate: str) -> bool:
+    if pattern.startswith("*.") and pattern.count("*") == 1 and "?" not in pattern:
+        return candidate.lower().endswith(pattern[1:].lower())
     regex = "^" + re.escape(pattern).replace(r"\*", "[^.]+").replace(r"\?", ".") + "$"
     return re.match(regex, candidate, re.IGNORECASE) is not None
 

--- a/packages/decepticon-core/tests/test_roe_wildcards.py
+++ b/packages/decepticon-core/tests/test_roe_wildcards.py
@@ -1,0 +1,38 @@
+from decepticon_core.types.roe import MachineEnforcement, evaluate_target
+
+
+def test_bug_bounty_wildcard_allows_nested_subdomains() -> None:
+    rules = MachineEnforcement.from_dict(
+        {"in_scope": [{"target": "*.anduril.dev", "type": "domain-glob"}]}
+    )
+
+    assert evaluate_target("sentry.anduril.dev", rules).allow
+    assert evaluate_target("internal.sentry.anduril.dev", rules).allow
+
+
+def test_bug_bounty_wildcard_does_not_expand_to_apex_or_lookalike() -> None:
+    rules = MachineEnforcement.from_dict(
+        {"in_scope": [{"target": "*.anduril.dev", "type": "domain-glob"}]}
+    )
+
+    assert not evaluate_target("anduril.dev", rules).allow
+    assert not evaluate_target("internal.sentry.anduril.dev.evil.test", rules).allow
+    assert not evaluate_target("evil-anduril.dev", rules).allow
+
+
+def test_explicit_exclusion_overrides_recursive_wildcard() -> None:
+    rules = MachineEnforcement.from_dict(
+        {
+            "in_scope": [
+                {"target": "*.anduril.dev", "type": "domain-glob"},
+            ],
+            "out_of_scope": [
+                {"target": "internal.sentry.anduril.dev", "type": "host"},
+            ],
+        }
+    )
+
+    decision = evaluate_target("internal.sentry.anduril.dev", rules)
+
+    assert not decision.allow
+    assert decision.reason_code == "OUT_OF_SCOPE"


### PR DESCRIPTION
## Summary
- interpret a single leading `*.` scope as every descendant subdomain
- preserve existing behavior for apex hosts and other glob shapes
- preserve explicit out-of-scope precedence

## Verification
- red: nested descendant returned `NOT_IN_SCOPE` before the fix
- green: focused wildcard tests: 3 passed
- core: 101 passed, 1 unrelated heavy-import integration test deselected
- ruff: passed
- basedpyright: 0 errors, 0 warnings
- diff check: passed