### PR TITLE
feat: port Strix v1.5.0 capabilities

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -53,3 +53,4 @@ B2|2026-08-09|dependency-evidence test skipped helper call|invoke `_dependency_c
 B3|2026-08-09|test expected raw CVSS, not KEV-adjusted score|assert existing composite score
 B4|2026-08-09|async cleanup test asserted before unrelated start completed|wait for seeded workload starts
 B5|2026-08-09|new imports violated repository ordering|apply ruff import ordering
+B6|2026-08-09|new Python files missed repository formatter|apply ruff format before CI

--- a/SPEC.md
+++ b/SPEC.md
@@ -52,3 +52,4 @@ B1|2026-08-09|`uv run pytest` timeout before collection|retry direct venv pytest
 B2|2026-08-09|dependency-evidence test skipped helper call|invoke `_dependency_chains` before assertion
 B3|2026-08-09|test expected raw CVSS, not KEV-adjusted score|assert existing composite score
 B4|2026-08-09|async cleanup test asserted before unrelated start completed|wait for seeded workload starts
+B5|2026-08-09|new imports violated repository ordering|apply ruff import ordering

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,54 @@
+# SPEC
+
+## §G GOAL
+Port selected Strix v1.5.0 capabilities into Decepticon without parallel architecture.
+
+## §C CONSTRAINTS
+- Reuse Decepticon plugin, role, KG, reporting, LLM, sandbox contracts.
+- ∀ API operation, dependency finding, container → engagement-scoped + provenance-tagged.
+- API import ! parse-only; network actions remain RoE + egress-gated.
+- No second plugin manager, skill store, graph schema, UI server, or agent loop.
+- Preserve public tool/API contracts unless additive.
+- Both source projects Apache-2.0; retain notices for copied code, prefer native implementation.
+
+## §I INTERFACES
+- tool: API spec/collection import → compact JSON inventory + KG observations.
+- tool: `cve_enrich_dependencies` → repo-relative manifest path, chain, reachability evidence.
+- report: finding severity → demonstrated-impact ceiling + evidence level.
+- env: `DECEPTICON_LLM_EXTRA_HEADERS` → JSON object, optional OpenAI-compatible request headers.
+- env: `DECEPTICON_LLM_DISABLE_STREAMING` → opt-in non-streaming OpenAI-compatible calls.
+- runtime: dynamic container → engagement/run identity label; teardown selects matching label.
+
+## §R RESEARCH
+id|topic|finding|src
+R1|Strix v1.5.0|Adds API spec/Postman targets, dependency reachability evidence, impact-calibrated severity, LLM compatibility controls, run labels|https://github.com/usestrix/strix/releases/tag/v1.5.0
+R2|SCA baseline|`cve_enrich_dependencies` parses 4 manifest forms, ranks OSV/NVD/EPSS/KEV results, but lacks manifest provenance + reachability ladder|https://github.com/PurpleAILAB/Decepticon/blob/main/packages/decepticon/decepticon/tools/research/tools.py#L558-L684
+R3|extension contracts|Plugins, roles, skills, middleware, KG ingesters already first-class; new features ! extend nearest contract|https://github.com/PurpleAILAB/Decepticon/tree/main/packages/decepticon-core/decepticon_core
+R4|license|Strix + Decepticon Apache-2.0|https://github.com/usestrix/strix/blob/v1.5.0/LICENSE
+
+## §V INVARIANTS
+V1: ∀ imported API op → engagement + source provenance; import sends no network request.
+V2: ∀ imported API op → request execution still passes RoE + egress gates.
+V3: ∀ dependency finding → engagement-workspace-relative manifest path + evidence level; outside path emits no provenance path.
+V4: reported severity ≤ evidence ceiling: declared≤low, resolved≤medium, symbol/call-path≤high, runtime-observed≤critical; raw CVSS/EPSS/KEV remains retained.
+V5: header config ! JSON string map; reject `Authorization`, `Host`, `Content-Length`; non-streaming preserves usage + error handling.
+V6: ∀ dynamic container → engagement/run label; teardown filters both labels.
+V7: all new data survives existing serialisation, reporting, and engagement isolation paths.
+V8: API import accepts local OpenAPI/Postman JSON/YAML only; external `$ref` ⊥ resolves.
+V9: workload profile owned by one engagement; generated run ID labels every created dynamic container.
+
+## §T TASKS
+id|status|task|cites
+T1|x|add OpenAPI/Postman import tool + KG adapter|V1,V2,V7,V8,I.tool
+T2|x|add dependency chain + reachability evidence|V3,V7,I.tool
+T3|x|cap report severity by impact evidence|V4,V7,I.report
+T4|x|add LLM header + non-streaming controls|V5,I.env
+T5|x|label dynamic containers by run|V6,I.runtime
+T6|x|test imported capabilities + regression paths|V1,V2,V3,V4,V5,V6,V7
+
+## §B BUGS
+id|date|cause|fix
+B1|2026-08-09|`uv run pytest` timeout before collection|retry direct venv pytest; no code invariant
+B2|2026-08-09|dependency-evidence test skipped helper call|invoke `_dependency_chains` before assertion
+B3|2026-08-09|test expected raw CVSS, not KEV-adjusted score|assert existing composite score
+B4|2026-08-09|async cleanup test asserted before unrelated start completed|wait for seeded workload starts

--- a/clients/launcher/internal/opscontrol/docker_compose_backend.go
+++ b/clients/launcher/internal/opscontrol/docker_compose_backend.go
@@ -2,10 +2,15 @@ package opscontrol
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/PurpleAILAB/Decepticon/clients/launcher/internal/config"
 )
@@ -26,6 +31,7 @@ type DockerComposeBackend struct {
 	// notes BHCE cold-start is ~30s; we default to 180s to absorb
 	// goose migrations and dawgs index build.
 	WaitTimeoutSeconds int
+	runs sync.Map
 }
 
 // NewDockerComposeBackend constructs a backend with the launcher's
@@ -61,6 +67,51 @@ func (b *DockerComposeBackend) baseArgs() []string {
 	return args
 }
 
+
+
+type workloadRun struct {
+	engagement string
+	runID      string
+}
+
+func newRunID() (string, error) {
+	var bytes [12]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", fmt.Errorf("generate workload run id: %w", err)
+	}
+	return hex.EncodeToString(bytes[:]), nil
+}
+
+func labeledComposeOverride(services []string, workload, engagement, runID string) (string, error) {
+	override := map[string]map[string]map[string]map[string]string{"services": {}}
+	for _, service := range services {
+		override["services"][service] = map[string]map[string]string{
+			"labels": {
+				"decepticon.engagement": engagement,
+				"decepticon.run":        runID,
+				"decepticon.workload":   workload,
+			},
+		}
+	}
+	contents, err := json.Marshal(override)
+	if err != nil {
+		return "", fmt.Errorf("encode workload labels: %w", err)
+	}
+	file, err := os.CreateTemp("", "decepticon-ops-labels-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create workload label override: %w", err)
+	}
+	if _, err := file.Write(contents); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return "", fmt.Errorf("write workload label override: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(file.Name())
+		return "", fmt.Errorf("close workload label override: %w", err)
+	}
+	return file.Name(), nil
+}
 // Start runs `docker compose --profile <workload> up -d --wait`. The
 // caller (server.go) has already taken the per-workload mutex, so
 // concurrent calls on the same workload are serialized.
@@ -75,8 +126,25 @@ func (b *DockerComposeBackend) baseArgs() []string {
 // ops_start; they must keep running AFTER). `--no-recreate` tells
 // compose to skip the hash diff and only create services the
 // requested profile activates that are not already running.
-func (b *DockerComposeBackend) Start(ctx context.Context, workload string, _ string) (Handle, error) {
-	args := append(b.baseArgs(),
+func (b *DockerComposeBackend) Start(ctx context.Context, workload, engagementID string) (Handle, error) {
+	if engagementID == "" {
+		return Handle{}, fmt.Errorf("workload %s requires an engagement id", workload)
+	}
+	services, err := b.profileExclusiveServices(ctx, workload)
+	if err != nil {
+		return Handle{}, err
+	}
+	runID, err := newRunID()
+	if err != nil {
+		return Handle{}, err
+	}
+	override, err := labeledComposeOverride(services, workload, engagementID, runID)
+	if err != nil {
+		return Handle{}, err
+	}
+	defer os.Remove(override)
+	args := append(b.baseArgs(), "-f", override)
+	args = append(args,
 		"--profile", workload,
 		"up", "-d", "--no-build", "--no-recreate", "--wait",
 		"--wait-timeout", fmt.Sprintf("%d", b.WaitTimeoutSeconds),
@@ -87,7 +155,8 @@ func (b *DockerComposeBackend) Start(ctx context.Context, workload string, _ str
 	if err != nil {
 		return Handle{}, fmt.Errorf("compose up --profile %s: %w: %s", workload, err, strings.TrimSpace(string(out)))
 	}
-	return Handle{Workload: workload, State: StateRunning}, nil
+	b.runs.Store(workload, workloadRun{engagement: engagementID, runID: runID})
+	return Handle{Workload: workload, State: StateRunning, EngagementID: engagementID}, nil
 }
 
 // Stop terminates and removes only the services exclusive to the
@@ -116,48 +185,38 @@ func (b *DockerComposeBackend) Start(ctx context.Context, workload string, _ str
 // the whole project regardless of `--profile`, so a single
 // `ops_stop("ad")` would nuke the entire stack.
 func (b *DockerComposeBackend) Stop(ctx context.Context, workload string) error {
-	services, err := b.profileExclusiveServices(ctx, workload)
-	if err != nil {
-		return err
+	value, ok := b.runs.Load(workload)
+	if !ok {
+		return fmt.Errorf("workload %s has no run label; refusing unscoped teardown", workload)
 	}
-	if len(services) == 0 {
-		// Nothing profile-exclusive to stop — the workload was never
-		// materialized via compose (e.g. registry had a stale entry
-		// from a daemon-side bug). Treat as a no-op.
+	run := value.(workloadRun)
+	filterArgs := []string{
+		"ps", "-aq",
+		"--filter", "label=decepticon.engagement=" + run.engagement,
+		"--filter", "label=decepticon.run=" + run.runID,
+		"--filter", "label=decepticon.workload=" + workload,
+	}
+	psCmd := exec.CommandContext(ctx, "docker", filterArgs...)
+	out, err := psCmd.Output()
+	if err != nil {
+		return fmt.Errorf("list workload containers: %w", err)
+	}
+	containers := strings.Fields(string(out))
+	if len(containers) == 0 {
+		b.runs.Delete(workload)
 		return nil
 	}
-
-	stopArgs := append(b.baseArgs(), append([]string{"stop"}, services...)...)
-	stopCmd := exec.CommandContext(ctx, "docker", stopArgs...)
-	stopCmd.Env = ComposeCommandEnv()
+	stopCmd := exec.CommandContext(ctx, "docker", append([]string{"stop"}, containers...)...)
 	if out, err := stopCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("compose stop %v: %w: %s", services, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("stop workload containers: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-
-	// `rm -f` skips the confirmation prompt; `-s` is "also remove
-	// stopped containers" (without it the command would no-op right
-	// after `stop`). `-v` is intentionally omitted so named volumes
-	// — and the BHCE engagement state inside them — survive the
-	// stop/start cycle.
-	rmArgs := append(b.baseArgs(), append([]string{"rm", "-fs"}, services...)...)
-	rmCmd := exec.CommandContext(ctx, "docker", rmArgs...)
-	rmCmd.Env = ComposeCommandEnv()
+	rmCmd := exec.CommandContext(ctx, "docker", append([]string{"rm", "-f"}, containers...)...)
 	if out, err := rmCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("compose rm %v: %w: %s", services, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("remove workload containers: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	b.runs.Delete(workload)
 	return nil
 }
-
-// profileExclusiveServices returns the list of compose service names
-// that belong to `workload`'s profile and to NO default (profile-less)
-// service. It is the set-difference of:
-//
-//	(`compose config --services --profile workload`)  // default + workload
-//	  minus
-//	(`compose config --services`)                     // default only
-//
-// Used by Stop so cleanup never targets the always-on management
-// plane.
 func (b *DockerComposeBackend) profileExclusiveServices(ctx context.Context, workload string) ([]string, error) {
 	withProfile, err := b.listServices(ctx, workload)
 	if err != nil {

--- a/clients/launcher/internal/opscontrol/docker_compose_labels_test.go
+++ b/clients/launcher/internal/opscontrol/docker_compose_labels_test.go
@@ -1,0 +1,30 @@
+package opscontrol
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestLabeledComposeOverrideScopesEveryService(t *testing.T) {
+	path, err := labeledComposeOverride([]string{"bhce", "bhce-neo4j"}, "ad", "eng-1", "run-1")
+	if err != nil {
+		t.Fatalf("labeledComposeOverride: %v", err)
+	}
+	defer os.Remove(path)
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read override: %v", err)
+	}
+	var document map[string]map[string]map[string]map[string]string
+	if err := json.Unmarshal(contents, &document); err != nil {
+		t.Fatalf("decode override: %v", err)
+	}
+	for _, service := range []string{"bhce", "bhce-neo4j"} {
+		labels := document["services"][service]["labels"]
+		if labels["decepticon.engagement"] != "eng-1" || labels["decepticon.run"] != "run-1" || labels["decepticon.workload"] != "ad" {
+			t.Fatalf("%s labels = %#v", service, labels)
+		}
+	}
+}

--- a/clients/launcher/internal/opscontrol/server_test.go
+++ b/clients/launcher/internal/opscontrol/server_test.go
@@ -206,6 +206,16 @@ func TestServer_CleanupEngagementStopsTaggedWorkloads(t *testing.T) {
 		}
 	}
 
+	// Start is asynchronous; the cleanup assertion needs all seed workloads
+	// materialized before it can distinguish engagement-scoped teardown.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && be.startCount.Load() != 3 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if be.startCount.Load() != 3 {
+		t.Fatal("seed workload starts did not complete")
+	}
+
 	// Cleanup eng-1.
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/engagements/eng-1/cleanup", nil)

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -80,6 +80,9 @@ LLM_TIMEOUT_ENV = "DECEPTICON_LLM_TIMEOUT_SECONDS"
 # ``DECEPTICON_LLM_TIMEOUT_SECONDS`` (explicit, whole-coroutine) >
 # ``DECEPTICON_LLM__TIMEOUT`` (the published env knob) > default.
 LLM_TIMEOUT_ENV_ALIAS = "DECEPTICON_LLM__TIMEOUT"
+LLM_EXTRA_HEADERS_ENV = "DECEPTICON_LLM_EXTRA_HEADERS"
+LLM_DISABLE_STREAMING_ENV = "DECEPTICON_LLM_DISABLE_STREAMING"
+_PROTECTED_EXTRA_HEADERS = frozenset({"authorization", "host", "content-length"})
 
 
 def _model_max_output_tokens(model: str) -> int:
@@ -159,6 +162,33 @@ def _resolve_llm_timeout_seconds() -> float:
     if value <= 0:
         raise ValueError(f"{source} must be greater than 0")
     return value
+
+
+def _resolve_extra_headers() -> dict[str, str] | None:
+    raw = os.getenv(LLM_EXTRA_HEADERS_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{LLM_EXTRA_HEADERS_ENV} must be a JSON object") from exc
+    if not isinstance(parsed, dict) or not all(
+        isinstance(name, str) and isinstance(value, str) for name, value in parsed.items()
+    ):
+        raise ValueError(f"{LLM_EXTRA_HEADERS_ENV} must be a JSON object of string headers")
+    protected = sorted(name for name in parsed if name.lower() in _PROTECTED_EXTRA_HEADERS)
+    if protected:
+        raise ValueError(f"{LLM_EXTRA_HEADERS_ENV} cannot override {', '.join(protected)}")
+    return parsed
+
+
+def _resolve_disable_streaming() -> bool:
+    raw = os.getenv(LLM_DISABLE_STREAMING_ENV, "").strip().lower()
+    if not raw or raw in {"0", "false", "no", "off"}:
+        return False
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    raise ValueError(f"{LLM_DISABLE_STREAMING_ENV} must be a boolean")
 
 
 async def call_with_timeout(coro: Awaitable[Any], timeout: float) -> Any:
@@ -1679,6 +1709,8 @@ class LLMFactory:
         belt-and-suspenders for any future client that bypasses this
         factory.
         """
+        disable_streaming = _resolve_disable_streaming()
+        extra_headers = _resolve_extra_headers()
         kwargs: dict[str, Any] = {
             "model": model,
             "base_url": self._proxy.url,
@@ -1694,14 +1726,16 @@ class LLMFactory:
             # on those callbacks — without this, every consumer (CLI renderer,
             # web run console) receives each agent message as one finished
             # block instead of token deltas.
-            "streaming": True,
+            "streaming": not disable_streaming,
             # Streaming responses omit usage unless it is explicitly requested,
             # and the measurement/cost path reads ``usage_metadata`` off the
             # aggregated message (middleware/event_logging.py). Enabling this
             # alongside ``streaming`` keeps per-run spend + prompt-cache
             # accounting intact.
-            "stream_usage": True,
+            "stream_usage": not disable_streaming,
         }
+        if extra_headers is not None:
+            kwargs["default_headers"] = extra_headers
         if _model_drops_temperature(model):
             kwargs["disabled_params"] = {"temperature": None}
         elif _model_is_deepseek_thinking(model):

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -20,15 +20,15 @@ the same adapter signature.
 
 from __future__ import annotations
 
-import json
 import hashlib
-import yaml
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 import defusedxml.ElementTree as ET
+import yaml
 
 from decepticon.middleware.kg_internal.ai_surface import (
     technology_for_banner,

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -21,6 +21,8 @@ the same adapter signature.
 from __future__ import annotations
 
 import json
+import hashlib
+import yaml
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -569,6 +571,162 @@ def _adapt_sarif(
 
 # ── Register built-ins at import time ──────────────────────────────────
 
+
+_HTTP_METHODS = frozenset({"delete", "get", "head", "options", "patch", "post", "put", "trace"})
+
+
+def _has_external_ref(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "$ref" and isinstance(nested, str):
+                parsed = urlparse(nested)
+                if parsed.scheme or parsed.netloc:
+                    return True
+            if _has_external_ref(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_has_external_ref(nested) for nested in value)
+    return False
+
+
+def _load_api_document(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    parsed: Any
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        parsed = yaml.safe_load(text)
+    else:
+        parsed = json.loads(text)
+    if not isinstance(parsed, dict):
+        raise ValueError("API document must be an object")
+    if _has_external_ref(parsed):
+        raise ValueError("external $ref is not supported")
+    return parsed
+
+
+def _postman_url(request: dict[str, Any]) -> str:
+    url = request.get("url")
+    if isinstance(url, str):
+        return url
+    if not isinstance(url, dict):
+        return ""
+    raw = url.get("raw")
+    if isinstance(raw, str):
+        return raw
+    host = url.get("host", [])
+    path = url.get("path", [])
+    host_text = ".".join(str(part) for part in host) if isinstance(host, list) else str(host)
+    path_text = "/".join(str(part) for part in path) if isinstance(path, list) else str(path)
+    protocol = str(url.get("protocol") or "https")
+    return f"{protocol}://{host_text}/{path_text}" if host_text else f"/{path_text}"
+
+
+def _iter_postman_items(items: Any) -> list[tuple[str, str, str]]:
+    operations: list[tuple[str, str, str]] = []
+    if not isinstance(items, list):
+        return operations
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        operations.extend(_iter_postman_items(item.get("item")))
+        request = item.get("request")
+        if not isinstance(request, dict):
+            continue
+        raw_url = _postman_url(request)
+        if not raw_url:
+            continue
+        parsed = urlparse(raw_url)
+        method = str(request.get("method") or "GET").upper()
+        operations.append((method, parsed.path or "/", raw_url))
+    return operations
+
+
+def _adapt_api_spec(
+    path: Path,
+    store: KGStore,
+    engagement: str,
+    created_by: str,
+    source_episode_id: str,
+) -> dict[str, Any]:
+    """Import a local OpenAPI or Postman document without contacting its target."""
+    try:
+        document = _load_api_document(path)
+    except (OSError, ValueError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        return {"error": f"API document parse failed: {exc}", "operations": 0}
+
+    source_hash = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    source_key = f"api-spec::{source_hash}"
+    operations: list[tuple[str, str, str, dict[str, Any]]] = []
+    source_kind = ""
+
+    paths = document.get("paths")
+    if isinstance(paths, dict) and ("openapi" in document or "swagger" in document):
+        source_kind = "openapi"
+        servers = document.get("servers")
+        base_url = ""
+        if isinstance(servers, list) and servers and isinstance(servers[0], dict):
+            candidate = servers[0].get("url")
+            if isinstance(candidate, str):
+                base_url = candidate
+        for route, item in paths.items():
+            if not isinstance(route, str) or not isinstance(item, dict):
+                continue
+            for method, operation in item.items():
+                if method.lower() not in _HTTP_METHODS or not isinstance(operation, dict):
+                    continue
+                operations.append((method.upper(), route, base_url, operation))
+    elif isinstance(document.get("info"), dict) and "item" in document:
+        source_kind = "postman"
+        for method, route, raw_url in _iter_postman_items(document.get("item")):
+            operations.append((method, route, raw_url, {}))
+    else:
+        return {"error": "unsupported API document: expected OpenAPI or Postman collection", "operations": 0}
+
+    observations: list[dict[str, Any]] = []
+    operation_keys: list[str] = []
+    for method, route, base_url, operation in operations:
+        operation_id = operation.get("operationId") if isinstance(operation.get("operationId"), str) else ""
+        key = f"{source_key}::{method}::{route}"
+        operation_keys.append(key)
+        parameters = operation.get("parameters")
+        observations.append(
+            {
+                "kind": "Entrypoint",
+                "key": key,
+                "label": f"{method} {route}",
+                "props": {
+                    "api_operation": True,
+                    "method": method,
+                    "path": route,
+                    "base_url": base_url,
+                    "operation_id": operation_id,
+                    "parameter_count": len(parameters) if isinstance(parameters, list) else 0,
+                    "source": source_kind,
+                    "execution_state": "imported",
+                    "requires_roe": True,
+                },
+            }
+        )
+    if not observations:
+        return {"source": source_kind, "operations": 0, "records": {"created": 0, "merged": 0, "edges": 0}}
+    observations.append(
+        {
+            "kind": "SourceFile",
+            "key": source_key,
+            "label": path.name,
+            "props": {"source": source_kind, "sha256": source_hash},
+            "edges_out": [{"to_key": key, "kind": "CONTAINS", "weight": 1.0} for key in operation_keys],
+        }
+    )
+    records = store.record_observations(
+        observations,
+        engagement=engagement,
+        created_by=created_by,
+        source_episode_id=source_episode_id,
+    )
+    return {"source": source_kind, "operations": len(operation_keys), "records": records}
+
+
+register_adapter("api_spec", _adapt_api_spec)
 
 register_adapter("nmap_xml", _adapt_nmap_xml)
 register_adapter("nuclei_jsonl", _adapt_nuclei_jsonl)

--- a/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
+++ b/packages/decepticon/decepticon/middleware/kg_internal/ingest.py
@@ -679,12 +679,17 @@ def _adapt_api_spec(
         for method, route, raw_url in _iter_postman_items(document.get("item")):
             operations.append((method, route, raw_url, {}))
     else:
-        return {"error": "unsupported API document: expected OpenAPI or Postman collection", "operations": 0}
+        return {
+            "error": "unsupported API document: expected OpenAPI or Postman collection",
+            "operations": 0,
+        }
 
     observations: list[dict[str, Any]] = []
     operation_keys: list[str] = []
     for method, route, base_url, operation in operations:
-        operation_id = operation.get("operationId") if isinstance(operation.get("operationId"), str) else ""
+        operation_id = (
+            operation.get("operationId") if isinstance(operation.get("operationId"), str) else ""
+        )
         key = f"{source_key}::{method}::{route}"
         operation_keys.append(key)
         parameters = operation.get("parameters")
@@ -707,14 +712,20 @@ def _adapt_api_spec(
             }
         )
     if not observations:
-        return {"source": source_kind, "operations": 0, "records": {"created": 0, "merged": 0, "edges": 0}}
+        return {
+            "source": source_kind,
+            "operations": 0,
+            "records": {"created": 0, "merged": 0, "edges": 0},
+        }
     observations.append(
         {
             "kind": "SourceFile",
             "key": source_key,
             "label": path.name,
             "props": {"source": source_kind, "sha256": source_hash},
-            "edges_out": [{"to_key": key, "kind": "CONTAINS", "weight": 1.0} for key in operation_keys],
+            "edges_out": [
+                {"to_key": key, "kind": "CONTAINS", "weight": 1.0} for key in operation_keys
+            ],
         }
     )
     records = store.record_observations(

--- a/packages/decepticon/decepticon/tools/research/tools.py
+++ b/packages/decepticon/decepticon/tools/research/tools.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -309,6 +310,66 @@ def _parse_dependencies(path: Path) -> list[tuple[str, str, str]]:
     return []
 
 
+def _dependency_provenance(
+    dep: tuple[str, str, str],
+    *,
+    manifest_path: str | None,
+    chains: dict[tuple[str, str, str], list[str]],
+) -> dict[str, Any]:
+    name, version, ecosystem = dep
+    level = "declared" if ecosystem == "PyPI" else "resolved"
+    props: dict[str, Any] = {
+        "reachability_level": level,
+        "dependency_chain": chains.get(dep, [f"{name}@{version}"]),
+    }
+    if manifest_path is not None:
+        props["manifest_path"] = manifest_path
+    return props
+
+
+_EVIDENCE_SEVERITY_CEILING = {
+    "declared": Severity.LOW,
+    "resolved": Severity.MEDIUM,
+    "symbol-matched": Severity.HIGH,
+    "call-path": Severity.HIGH,
+    "runtime-observed": Severity.CRITICAL,
+}
+
+
+def _reported_severity(score: float, evidence_level: str) -> tuple[Severity, Severity]:
+    raw = _severity_from_score(score)
+    ceiling = _EVIDENCE_SEVERITY_CEILING[evidence_level]
+    return raw, raw if SEVERITY_SCORE[raw] <= SEVERITY_SCORE[ceiling] else ceiling
+
+
+def _dependency_chains(path: Path) -> dict[tuple[str, str, str], list[str]]:
+    if path.name.lower() != "package-lock.json":
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    packages = payload.get("packages")
+    if not isinstance(packages, dict):
+        return {}
+    chains: dict[tuple[str, str, str], list[str]] = {}
+    for package_path, meta in packages.items():
+        if not package_path.startswith("node_modules/") or not isinstance(meta, dict):
+            continue
+        name = meta.get("name") or package_path.rsplit("node_modules/", 1)[-1]
+        version = meta.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            continue
+        chain = [part.strip("/") for part in package_path.split("node_modules/")[1:] if part]
+        chains[(name, version, "npm")] = chain or [f"{name}@{version}"]
+    return chains
+
+
+def _manifest_path(path: Path) -> str | None:
+    workspace = Path(os.getenv("DECEPTICON_WORKSPACE_PATH", Path.cwd())).resolve()
+    try:
+        return path.resolve().relative_to(workspace).as_posix()
+    except ValueError:
+        return None
+
+
 # ── Knowledge graph tools ───────────────────────────────────────────────
 
 
@@ -572,6 +633,8 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
         deps = _parse_dependencies(dep_path)
     except (OSError, ValueError, json.JSONDecodeError) as e:
         return _json({"error": f"dependency parse failed: {e}"})
+    manifest_path = _manifest_path(dep_path)
+    chains = _dependency_chains(dep_path)
 
     # Deduplicate and cap work for bounded runtime.
     dedup: dict[tuple[str, str, str], None] = {}
@@ -605,6 +668,11 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
     with graph_transaction() as graph:
         for dep, records in results:
             name, version, ecosystem = dep
+            provenance = _dependency_provenance(
+                dep,
+                manifest_path=manifest_path,
+                chains=chains,
+            )
             dep_node = graph.upsert_node(
                 Node.make(
                     NodeKind.SERVICE,
@@ -615,6 +683,7 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
                     version=version,
                     ecosystem=ecosystem,
                     source="dependency-enricher",
+                    **provenance,
                 )
             )
 
@@ -623,7 +692,9 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
                 if not cve_id.startswith("CVE-"):
                     continue
                 score = float(rec.get("score") or 0.0)
-                severity = _severity_from_score(score)
+                raw_severity, severity = _reported_severity(
+                    score, str(provenance["reachability_level"])
+                )
                 cve_node = graph.upsert_node(
                     Node.make(
                         NodeKind.CVE,
@@ -646,6 +717,7 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
                         ecosystem=ecosystem,
                         cve_id=cve_id,
                         severity=severity.value,
+                        raw_severity=raw_severity.value,
                         cvss=rec.get("cvss"),
                         cvss_vector=rec.get("cvss_vector"),
                         epss=rec.get("epss"),
@@ -655,6 +727,7 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
                         summary=rec.get("summary", ""),
                         references=rec.get("references", []),
                         source="dependency-enricher",
+                        **provenance,
                     )
                 )
                 graph.upsert_edge(Edge.make(dep_node.id, cve_node.id, EdgeKind.AFFECTS, weight=0.5))
@@ -667,21 +740,24 @@ async def cve_enrich_dependencies(path: str, limit: int = 100, min_score: float 
                         "cve": cve_id,
                         "score": score,
                         "severity": severity.value,
+                        "raw_severity": raw_severity.value,
                         "kev": bool(rec.get("kev")),
+                        "dependency_chain": provenance["dependency_chain"],
+                        "reachability_level": provenance["reachability_level"],
                     }
                 )
                 added += 1
 
     kept.sort(key=lambda x: x["score"], reverse=True)
-    return _json(
-        {
-            "dependency_file": str(dep_path),
-            "dependencies_scanned": len(planned),
-            "high_signal_records": added,
-            "results": kept[:100],
-            "stats": graph.stats(),
-        }
-    )
+    response: dict[str, Any] = {
+        "dependencies_scanned": len(planned),
+        "high_signal_records": added,
+        "results": kept[:100],
+        "stats": graph.stats(),
+    }
+    if manifest_path is not None:
+        response["manifest_path"] = manifest_path
+    return _json(response)
 
 
 # ── Static analysis ingestion ───────────────────────────────────────────

--- a/packages/decepticon/tests/unit/llm/test_provider_controls.py
+++ b/packages/decepticon/tests/unit/llm/test_provider_controls.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from decepticon.llm.factory import _resolve_disable_streaming, _resolve_extra_headers
+
+
+def test_extra_headers_accepts_string_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECEPTICON_LLM_EXTRA_HEADERS", '{"HTTP-Referer":"https://example.test"}')
+
+    assert _resolve_extra_headers() == {"HTTP-Referer": "https://example.test"}
+
+
+def test_extra_headers_rejects_malformed_or_protected_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECEPTICON_LLM_EXTRA_HEADERS", "[]")
+    with pytest.raises(ValueError, match="JSON object"):
+        _resolve_extra_headers()
+
+    monkeypatch.setenv("DECEPTICON_LLM_EXTRA_HEADERS", '{"Authorization":"secret"}')
+    with pytest.raises(ValueError, match="cannot override Authorization"):
+        _resolve_extra_headers()
+
+
+def test_disable_streaming_requires_boolean(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECEPTICON_LLM_DISABLE_STREAMING", "true")
+    assert _resolve_disable_streaming() is True
+
+    monkeypatch.setenv("DECEPTICON_LLM_DISABLE_STREAMING", "maybe")
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _resolve_disable_streaming()

--- a/packages/decepticon/tests/unit/llm/test_provider_controls.py
+++ b/packages/decepticon/tests/unit/llm/test_provider_controls.py
@@ -11,7 +11,9 @@ def test_extra_headers_accepts_string_map(monkeypatch: pytest.MonkeyPatch) -> No
     assert _resolve_extra_headers() == {"HTTP-Referer": "https://example.test"}
 
 
-def test_extra_headers_rejects_malformed_or_protected_values(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_extra_headers_rejects_malformed_or_protected_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("DECEPTICON_LLM_EXTRA_HEADERS", "[]")
     with pytest.raises(ValueError, match="JSON object"):
         _resolve_extra_headers()

--- a/packages/decepticon/tests/unit/middleware/test_api_spec_ingest.py
+++ b/packages/decepticon/tests/unit/middleware/test_api_spec_ingest.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from decepticon.middleware.kg_internal.ingest import _adapt_api_spec, available_scanners
+
+
+class _StubStore:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def record_observations(
+        self,
+        observations: list[dict[str, Any]],
+        *,
+        engagement: str,
+        created_by: str,
+        source_episode_id: str,
+    ) -> dict[str, int]:
+        self.calls.append(
+            {
+                "observations": observations,
+                "engagement": engagement,
+                "created_by": created_by,
+                "source_episode_id": source_episode_id,
+            }
+        )
+        return {"created": len(observations), "merged": 0, "edges": len(observations) - 1}
+
+
+def test_api_spec_adapter_imports_openapi_without_requesting_target(tmp_path: Path) -> None:
+    spec = tmp_path / "openapi.yaml"
+    spec.write_text(
+        """openapi: 3.0.0
+servers:
+  - url: https://api.example.test/v1
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      parameters:
+        - name: limit
+          in: query
+    post:
+      operationId: createUser
+""",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+
+    result = _adapt_api_spec(spec, store, "eng-1", "recon", "episode-1")  # type: ignore[arg-type]
+
+    assert "api_spec" in available_scanners()
+    assert result["source"] == "openapi"
+    assert result["operations"] == 2
+    assert len(store.calls) == 1
+    call = store.calls[0]
+    assert call["engagement"] == "eng-1"
+    endpoints = [item for item in call["observations"] if item["kind"] == "Entrypoint"]
+    assert {item["label"] for item in endpoints} == {"GET /users", "POST /users"}
+    assert all(item["props"]["execution_state"] == "imported" for item in endpoints)
+    assert all(item["props"]["requires_roe"] is True for item in endpoints)
+
+
+def test_api_spec_adapter_imports_postman_collection(tmp_path: Path) -> None:
+    collection = tmp_path / "collection.json"
+    collection.write_text(
+        """{
+  "info": {"name": "test", "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"},
+  "item": [{"name": "health", "request": {"method": "GET", "url": "https://api.example.test/health"}}]
+}""",
+        encoding="utf-8",
+    )
+    store = _StubStore()
+
+    result = _adapt_api_spec(collection, store, "eng-1", "recon", "episode-1")  # type: ignore[arg-type]
+
+    assert result["source"] == "postman"
+    assert result["operations"] == 1
+    endpoint = next(item for item in store.calls[0]["observations"] if item["kind"] == "Entrypoint")
+    assert endpoint["label"] == "GET /health"
+    assert endpoint["props"]["base_url"] == "https://api.example.test/health"
+
+
+def test_api_spec_adapter_rejects_external_references(tmp_path: Path) -> None:
+    spec = tmp_path / "openapi.json"
+    spec.write_text(
+        '{"openapi":"3.0.0","paths":{"/users":{"$ref":"https://example.test/paths.json"}}}',
+        encoding="utf-8",
+    )
+    store = _StubStore()
+
+    result = _adapt_api_spec(spec, store, "eng-1", "recon", "episode-1")  # type: ignore[arg-type]
+
+    assert "external $ref" in result["error"]
+    assert store.calls == []

--- a/packages/decepticon/tests/unit/research/test_dependency_enrichment_evidence.py
+++ b/packages/decepticon/tests/unit/research/test_dependency_enrichment_evidence.py
@@ -35,7 +35,9 @@ async def test_cve_enrichment_records_workspace_evidence(tmp_path: Path, monkeyp
     monkeypatch.setattr(research_tools.cve_mod, "lookup_cves", fake_lookup_cves)
 
     payload = json.loads(
-        await research_tools.cve_enrich_dependencies.ainvoke({"path": str(manifest), "min_score": 7.0})
+        await research_tools.cve_enrich_dependencies.ainvoke(
+            {"path": str(manifest), "min_score": 7.0}
+        )
     )
 
     assert payload["manifest_path"] == "requirements.txt"

--- a/packages/decepticon/tests/unit/research/test_dependency_enrichment_evidence.py
+++ b/packages/decepticon/tests/unit/research/test_dependency_enrichment_evidence.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from decepticon.tools.research import tools as research_tools
+from decepticon.tools.research.cve import Exploitability
+from decepticon_core.types.kg import KnowledgeGraph, NodeKind
+
+
+@pytest.mark.asyncio
+async def test_cve_enrichment_records_workspace_evidence(tmp_path: Path, monkeypatch) -> None:
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("flask==2.0.0\n", encoding="utf-8")
+    monkeypatch.setenv("DECEPTICON_WORKSPACE_PATH", str(tmp_path))
+    graph = KnowledgeGraph()
+
+    @contextmanager
+    def fake_transaction():
+        yield graph
+
+    async def fake_lookup_package(package: str, version: str, ecosystem: str) -> list[str]:
+        assert (package, version, ecosystem) == ("flask", "2.0.0", "PyPI")
+        return ["CVE-2024-1111"]
+
+    async def fake_lookup_cves(cve_ids: list[str], concurrency: int = 6) -> list[Exploitability]:
+        assert cve_ids == ["CVE-2024-1111"]
+        return [Exploitability(cve_id="CVE-2024-1111", cvss=9.8, epss=0.8, kev=True)]
+
+    monkeypatch.setattr(research_tools, "graph_transaction", fake_transaction)
+    monkeypatch.setattr(research_tools.cve_mod, "lookup_package", fake_lookup_package)
+    monkeypatch.setattr(research_tools.cve_mod, "lookup_cves", fake_lookup_cves)
+
+    payload = json.loads(
+        await research_tools.cve_enrich_dependencies.ainvoke({"path": str(manifest), "min_score": 7.0})
+    )
+
+    assert payload["manifest_path"] == "requirements.txt"
+    assert payload["results"] == [
+        {
+            "dependency": "flask@2.0.0",
+            "ecosystem": "PyPI",
+            "cve": "CVE-2024-1111",
+            "score": 10.0,
+            "severity": "low",
+            "raw_severity": "critical",
+            "kev": True,
+            "dependency_chain": ["flask@2.0.0"],
+            "reachability_level": "declared",
+        }
+    ]
+    vulnerability = graph.by_kind(NodeKind.VULNERABILITY)[0]
+    assert vulnerability.props["manifest_path"] == "requirements.txt"
+    assert vulnerability.props["reachability_level"] == "declared"
+    assert vulnerability.props["severity"] == "low"
+    assert vulnerability.props["raw_severity"] == "critical"

--- a/packages/decepticon/tests/unit/research/test_dependency_evidence.py
+++ b/packages/decepticon/tests/unit/research/test_dependency_evidence.py
@@ -49,4 +49,3 @@ def test_dependency_evidence_preserves_nested_npm_chain(tmp_path: Path) -> None:
     chains = _dependency_chains(lock)
 
     assert chains[("child", "2.0.0", "npm")] == ["parent", "child"]
-

--- a/packages/decepticon/tests/unit/research/test_dependency_evidence.py
+++ b/packages/decepticon/tests/unit/research/test_dependency_evidence.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from decepticon.tools.research.tools import _dependency_chains, _dependency_provenance, _manifest_path
+
+
+def test_dependency_evidence_uses_workspace_relative_manifest_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manifest = workspace / "requirements.txt"
+    manifest.write_text("flask==2.0.0\n", encoding="utf-8")
+    monkeypatch.setenv("DECEPTICON_WORKSPACE_PATH", str(workspace))
+
+    assert _manifest_path(manifest) == "requirements.txt"
+    assert _manifest_path(tmp_path / "outside.txt") is None
+    assert _dependency_provenance(
+        ("flask", "2.0.0", "PyPI"), manifest_path="requirements.txt", chains={}
+    ) == {
+        "reachability_level": "declared",
+        "dependency_chain": ["flask@2.0.0"],
+        "manifest_path": "requirements.txt",
+    }
+
+
+def test_dependency_evidence_preserves_nested_npm_chain(tmp_path: Path) -> None:
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/parent": {"name": "parent", "version": "1.0.0"},
+                    "node_modules/parent/node_modules/child": {
+                        "name": "child",
+                        "version": "2.0.0",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    chains = _dependency_chains(lock)
+
+    assert chains[("child", "2.0.0", "npm")] == ["parent", "child"]
+

--- a/packages/decepticon/tests/unit/research/test_dependency_evidence.py
+++ b/packages/decepticon/tests/unit/research/test_dependency_evidence.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from decepticon.tools.research.tools import _dependency_chains, _dependency_provenance, _manifest_path
+from decepticon.tools.research.tools import (
+    _dependency_chains,
+    _dependency_provenance,
+    _manifest_path,
+)
 
 
 def test_dependency_evidence_uses_workspace_relative_manifest_path(


### PR DESCRIPTION
## Summary
- import local OpenAPI/Postman specifications into the engagement KG
- retain dependency-chain and reachability evidence while capping reported severity by demonstrated impact
- add OpenAI-compatible provider controls and run-scoped dynamic workload teardown

## Verification
- `python -m pytest -p pytest_asyncio.plugin packages/decepticon/tests/unit/middleware/test_api_spec_ingest.py packages/decepticon/tests/unit/research/test_dependency_evidence.py packages/decepticon/tests/unit/research/test_dependency_enrichment_evidence.py packages/decepticon/tests/unit/llm/test_provider_controls.py -q`
- `go test ./internal/opscontrol`