### PR TITLE
Harden default credentials, telemetry opt-in, release digest pinning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,10 @@ CLOUDFLARE_AI_GATEWAY_API_KEY=your-cloudflare-ai-gateway-key-here
 # OLLAMA_MODEL=qwen3-coder:30b
 
 # --- LiteLLM Proxy ---
+# WARNING: the values below are dev fallbacks. `decepticon start` refuses
+# to run with them — generate real ones first:
+#   openssl rand -hex 32 | sed 's/^/sk-/'   # LITELLM_MASTER_KEY
+#   openssl rand -hex 24                    # POSTGRES_PASSWORD
 LITELLM_MASTER_KEY=sk-decepticon-master
 LITELLM_SALT_KEY=sk-decepticon-salt-change-me
 
@@ -390,3 +394,9 @@ DECEPTICON_LANGUAGE=en
 # tests or one-off overrides, ``DECEPTICON_LLM_TIMEOUT_SECONDS`` takes
 # precedence over this for the coroutine guard only.
 DECEPTICON_LLM__TIMEOUT=600
+
+# --- Telemetry (opt-in) ---
+# Off by default. Set to `research` (masked reasoning corpus) or `basic`
+# (structural stats only) to share anonymous usage with the maintainers.
+# See TELEMETRY.md for exactly what is collected. DO_NOT_TRACK=1 forces off.
+DECEPTICON_TELEMETRY=off

--- a/.gitattributes
+++ b/.gitattributes
@@ -51,6 +51,11 @@ docker-compose*.yml  text eol=lf
 *.jpeg               binary
 *.gif                binary
 *.ico                binary
+*.mp4                binary
+*.webm               binary
+*.mov                binary
+*.glb                binary
+*.gltf               binary
 *.svg                text eol=lf
 *.pdf                binary
 *.zip                binary

--- a/.github/workflows/pin-digests.yml
+++ b/.github/workflows/pin-digests.yml
@@ -1,0 +1,50 @@
+# Publishes a digest-pinned image manifest as a release asset so operators
+# can pin their compose stack to immutable digests instead of the moving
+# :stable / :latest channel tags.
+#
+# The on-tag release workflow signs + SBOMs every image and moves :latest
+# (and later :stable via promote-stable.yml). This workflow runs after the
+# release is published, resolves each image's manifest-list digest for the
+# released version, and uploads image-digests.txt to the release. Consumers
+# pin with:
+#
+#   ghcr.io/purpleailab/decepticon-litellm@sha256:<digest>
+#
+# or by substituting the tag in docker-compose.yml with the digest form.
+name: Publish digest-pinned manifest
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # upload the manifest to the release
+
+jobs:
+  pin-digests:
+    name: Resolve and publish image digests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Resolve digests for released version
+        id: digests
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          images="decepticon-litellm decepticon-langgraph decepticon-cli decepticon-skillogy decepticon-sandbox decepticon-c2-sliver decepticon-web"
+          : > image-digests.txt
+          for image in ${images}; do
+            ref="ghcr.io/purpleailab/${image}:${version}"
+            digest="$(docker buildx imagetools inspect "${ref}" --format '{{.Manifest.Digest}}')"
+            printf '%s@%s\n' "${ref}" "${digest}" >> image-digests.txt
+          done
+          cat image-digests.txt
+
+      - name: Upload digest manifest to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" image-digests.txt --clobber

--- a/.github/workflows/pin-digests.yml
+++ b/.github/workflows/pin-digests.yml
@@ -29,11 +29,10 @@ jobs:
 
       - name: Resolve digests for released version
         id: digests
-        env:
-          VERSION: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          version="${VERSION#v}"
+          # GITHUB_REF_NAME is the tag (e.g. v1.1.42) for a release event.
+          version="${GITHUB_REF_NAME#v}"
           images="decepticon-litellm decepticon-langgraph decepticon-cli decepticon-skillogy decepticon-sandbox decepticon-c2-sliver decepticon-web"
           : > image-digests.txt
           for image in ${images}; do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,10 @@ Thank you for your interest in contributing to Decepticon! Whether you're a secu
 ### Development Setup
 
 ```bash
-git clone https://github.com/PurpleAILAB/Decepticon.git
+# The benchmark suite uses git submodules (xbow-validation-benchmarks,
+# MHBench). Clone with --recursive to fetch them; they are optional —
+# the main tool builds and runs without them.
+git clone --recursive https://github.com/PurpleAILAB/Decepticon.git
 cd Decepticon
 
 # Start with hot-reload (builds Docker images + watches for source changes)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,6 +85,20 @@ Every image is signed with Cosign (keyless OIDC) and ships a CycloneDX SBOM.
 The `:latest` tag and the published release appear only *after* every image is
 verified, so a half-finished release never moves the `:latest` tag.
 
+## Digest pinning
+
+`pin-digests.yml` runs on every published release and uploads
+`image-digests.txt` — one line per image, `ghcr.io/purpleailab/<image>:<version>@sha256:<digest>` —
+as a release asset. Operators who want immutable, tamper-evident deploys pin
+their compose stack to the digest form instead of the moving `:stable` /
+`:latest` channel tags:
+
+```yaml
+image: ghcr.io/purpleailab/decepticon-litellm@sha256:<digest>
+```
+
+The digest is the manifest-list digest, so it covers all published platforms.
+
 ## Pre-releases
 
 A tag whose version contains a hyphen (`v1.2.0-rc.1`) is treated as a

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -2,16 +2,18 @@
 
 Decepticon can send **anonymous usage telemetry** to help maintainers see what
 users ask the agents to do and what the agents actually do. Decepticon is
-free/OSS; this sharing helps fund and improve it. It is **opt-out** — the
-onboard wizard asks for consent (default yes) and you can turn it off at any
+free/OSS; this sharing helps fund and improve it. It is **opt-in** — the
+onboard wizard asks for consent (default no) and you can turn it on at any
 time — and designed for a red-team threat model: **raw prompts, targets,
 credentials, and tool output are never transmitted.**
 
 ## TL;DR
 
-- **On by default for consenting users (opt-out).** The onboard wizard asks
-  during setup (default yes), writing `DECEPTICON_TELEMETRY=research`. Existing
+- **Off by default (opt-in).** The onboard wizard asks during setup (default
+  no), writing `DECEPTICON_TELEMETRY=off` unless you choose to share. Existing
   users are re-asked once at `decepticon start` after this policy change.
+- **Turn it on anytime:** set `DECEPTICON_TELEMETRY=research` (or `basic`) in
+  `~/.decepticon/.env`, or run `decepticon-cli telemetry on`.
 - **Turn it off anytime:** set `DECEPTICON_TELEMETRY=off` (or `basic`) in
   `~/.decepticon/.env`, run `decepticon-cli telemetry off`, or `DO_NOT_TRACK=1`.
 - **Nothing is sent** without a `DECEPTICON_TELEMETRY_ENDPOINT` (shipped in the
@@ -22,7 +24,7 @@ credentials, and tool output are never transmitted.**
 
 | Variable / command | Effect |
 |---|---|
-| `DECEPTICON_TELEMETRY=off\|basic\|research` | consent mode (template default `research`; unset ⇒ `off`) |
+| `DECEPTICON_TELEMETRY=off\|basic\|research` | consent mode (template default `off`; unset ⇒ `off`) |
 | `DO_NOT_TRACK=1` | standard kill switch — forces `off` |
 | `BENCHMARK_MODE=1` | forces `off` — benchmark prompts are harness-generated, not user activity |
 | `DECEPTICON_TELEMETRY_ENDPOINT=<url>` | gateway URL; unset ⇒ nothing is sent |

--- a/clients/desktop/README.md
+++ b/clients/desktop/README.md
@@ -1,0 +1,14 @@
+# Decepticon Desktop (deprecated)
+
+> **Deprecated.** The Electron desktop shell is no longer the recommended
+> way to run Decepticon. Use the interactive CLI (`decepticon`) or the web
+> dashboard instead. This package is kept for existing users and will be
+> removed in a future release.
+
+The desktop shell wraps the cloud app and the local web dashboard in an
+Electron window. It adds no functionality over the web dashboard — the
+browser already covers it — and is the highest-maintenance client surface
+in the repo (Electron version churn, platform packaging, code-signing).
+
+**Migration:** run `decepticon start` for the CLI, or open the local web
+dashboard at `http://localhost:3000` after starting the stack.

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -285,6 +285,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 		ui.Warning("set DECEPTICON_OPSCONTROL_SOCK_HOST: " + err.Error())
 	}
 
+	// 4.5. Refuse to start with default credentials. The compose file
+	// ships sk-decepticon-master / decepticon as fallbacks so a bare
+	// `docker compose up` still works for dev, but the launcher is the
+	// supported path — a default-keyed LiteLLM proxy on a reachable host
+	// is a free LLM proxy for anyone who finds it. Fail loud with the fix.
+	if err := checkDefaultCredentials(env); err != nil {
+		return err
+	}
+
 	// 5. Start services
 	c := compose.New()
 
@@ -339,6 +348,26 @@ func runStart(cmd *cobra.Command, args []string) error {
 // host.docker.internal in /etc/hosts; native-WSL Docker installs need
 // the Windows host IP from /etc/resolv.conf; an Ollama running inside
 // the WSL distro itself sits on 127.0.0.1. Whichever returns 2xx wins.
+// checkDefaultCredentials refuses to start when the compose fallback
+// credentials are still in effect. The compose file defaults to
+// sk-decepticon-master / decepticon so a bare `docker compose up` works
+// for dev; the launcher is the supported path and must not bring up a
+// default-keyed proxy. Returns an error with the one-command fix.
+func checkDefaultCredentials(env map[string]string) error {
+	master := config.Get(env, "LITELLM_MASTER_KEY", "")
+	pgPass := config.Get(env, "POSTGRES_PASSWORD", "")
+	if master != "sk-decepticon-master" && pgPass != "decepticon" {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to start with default credentials (LITELLM_MASTER_KEY=%q, POSTGRES_PASSWORD=%q).\n"+
+			"Generate strong values and set them in %s, then re-run:\n"+
+			"  openssl rand -hex 32 | sed 's/^/sk-/'   # LITELLM_MASTER_KEY\n"+
+			"  openssl rand -hex 24                    # POSTGRES_PASSWORD\n"+
+			"or run `decepticon onboard` to set them interactively.",
+		master, pgPass, config.EnvPath())
+}
+
 func probeOllamaIfSelected(env map[string]string) {
 	priority := strings.ToLower(env["DECEPTICON_AUTH_PRIORITY"])
 	hasOllama := strings.Contains(","+priority+",", ",ollama_local,")

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -185,3 +185,31 @@ func TestApplyAutoUpdate_NoUpdateFlagAlwaysWins(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckDefaultCredentials_RefusesDefaults(t *testing.T) {
+	err := checkDefaultCredentials(map[string]string{
+		"LITELLM_MASTER_KEY": "sk-decepticon-master",
+		"POSTGRES_PASSWORD":  "decepticon",
+	})
+	if err == nil {
+		t.Fatal("default credentials must be refused")
+	}
+}
+
+func TestCheckDefaultCredentials_AllowsCustom(t *testing.T) {
+	err := checkDefaultCredentials(map[string]string{
+		"LITELLM_MASTER_KEY": "sk-9f2c1a7b3d5e",
+		"POSTGRES_PASSWORD":  "x9k2m4p7q1",
+	})
+	if err != nil {
+		t.Fatalf("custom credentials must be allowed, got: %v", err)
+	}
+}
+
+func TestCheckDefaultCredentials_AllowsUnset(t *testing.T) {
+	// Unset keys resolve to "" via config.Get — neither matches a default,
+	// so an empty env must not block startup.
+	if err := checkDefaultCredentials(map[string]string{}); err != nil {
+		t.Fatalf("unset credentials must be allowed, got: %v", err)
+	}
+}

--- a/clients/launcher/internal/migrate/steps.go
+++ b/clients/launcher/internal/migrate/steps.go
@@ -106,9 +106,9 @@ func applyTelemetryReconsent(c *Ctx) (string, error) {
 	consent := confirm(
 		"Share anonymous + masked red-team telemetry?",
 		telemetryConsentBlurb,
-		"Yes, share (recommended)",
-		"No, keep it off",
-		true, // default Yes
+		"Yes, share",
+		"No, keep it off (recommended)",
+		false, // default No — telemetry is opt-in
 	)
 
 	mode := "research"


### PR DESCRIPTION
## What

- **Launcher refuses default credentials** — `decepticon start` now fails loud if `LITELLM_MASTER_KEY` is still `sk-decepticon-master` or `POSTGRES_PASSWORD` is `decepticon`, with the one-command fix printed. A default-keyed LiteLLM proxy on a reachable host is a free LLM proxy for anyone who finds it.
- **Telemetry is now opt-in** — onboard wizard defaults to No, `.env.example` ships `DECEPTICON_TELEMETRY=off`, TELEMETRY.md updated.
- **Digest-pinned release manifest** — `pin-digests.yml` publishes `image-digests.txt` (`image@sha256`) as a release asset so operators can pin compose to immutable digests instead of moving `:stable`/`:latest` tags.
- **Repo hygiene** — `.gitattributes` marks mp4/webm/mov/glb/gltf binary; CONTRIBUTING documents `--recursive` clone for benchmark submodules; desktop client gets a deprecation notice.

## Tests

`go test ./...` in `clients/launcher` passes (3 new tests for the credential check).