### PR TITLE
feat(llm): native Kimi for Coding support (K3 / K2.7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ TOGETHER_API_KEY=your-together-key-here
 FIREWORKS_API_KEY=your-fireworks-key-here
 COHERE_API_KEY=your-cohere-key-here
 MOONSHOT_API_KEY=your-moonshot-key-here
+# Kimi for Coding (api.kimi.com/coding), K3 / K2.7. Separate platform
+# from the legacy Moonshot API above; keys start with sk-kimi-.
+KIMI_API_KEY=your-kimi-key-here
 ZAI_API_KEY=your-zai-key-here
 DASHSCOPE_API_KEY=your-dashscope-key-here
 

--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -67,6 +67,7 @@ const (
 	methodFireworksAPI    = "fireworks_api"
 	methodCohereAPI       = "cohere_api"
 	methodMoonshotAPI     = "moonshot_api"
+	methodKimiAPI         = "kimi_api"
 	methodZaiAPI          = "zai_api"
 	methodDashscopeAPI    = "dashscope_api"
 	methodGitHubModelsAPI = "github_models_api"
@@ -135,6 +136,7 @@ var methodOrder = []string{
 	methodFireworksAPI,
 	methodCohereAPI,
 	methodMoonshotAPI,
+	methodKimiAPI,
 	methodZaiAPI,
 	methodDashscopeAPI,
 	// Local last so cloud-preferred default still picks remote
@@ -236,6 +238,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		fireworksKey       string
 		cohereKey          string
 		moonshotKey        string
+		kimiKey            string
 		zaiKey             string
 		dashscopeKey       string
 		githubToken        string
@@ -318,6 +321,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 					huh.NewOption("Fireworks AI        — Llama / Mixtral hub (fireworks_ai/*)", methodFireworksAPI),
 					huh.NewOption("Cohere Command      — Command-A / Command-R (cohere/*)", methodCohereAPI),
 					huh.NewOption("Moonshot Kimi K2    — Kimi K2 (moonshot/*)", methodMoonshotAPI),
+					huh.NewOption("Kimi for Coding     — Kimi K3 / K2.7 Coding (kimi/*)", methodKimiAPI),
 					huh.NewOption("Z.ai GLM-4.5        — GLM-4.5 / GLM-4.5-Air (zai/*)", methodZaiAPI),
 					huh.NewOption("Alibaba DashScope   — Qwen Max/Plus/Turbo (dashscope/*)", methodDashscopeAPI),
 					huh.NewOption("LM Studio (local)   — local OpenAI-compatible server (lm_studio/*)", methodLMStudioLocal),
@@ -678,6 +682,18 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		).Title("2 / 5  ·  Moonshot Kimi K2").
 			WithHideFunc(func() bool { return !contains(methods, methodMoonshotAPI) }),
 
+		// Step 2-cloud-ix-b: Kimi for Coding (K3 / K2.7)
+		huh.NewGroup(
+			huh.NewInput().
+				Title("KIMI_API_KEY").
+				Description("Kimi for Coding platform (api.kimi.com/coding) — separate\nfrom the legacy Moonshot API. Keys start with 'sk-kimi-'.").
+				Placeholder("sk-kimi-...").
+				EchoMode(huh.EchoModePassword).
+				Value(&kimiKey).
+				Validate(nonEmpty),
+		).Title("2 / 5  ·  Kimi for Coding").
+			WithHideFunc(func() bool { return !contains(methods, methodKimiAPI) }),
+
 		// Step 2-cloud-x: Z.ai GLM-4.5
 		huh.NewGroup(
 			huh.NewInput().
@@ -1005,6 +1021,9 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	}
 	if moonshotKey != "" {
 		values["MOONSHOT_API_KEY"] = strings.TrimSpace(moonshotKey)
+	}
+	if kimiKey != "" {
+		values["KIMI_API_KEY"] = strings.TrimSpace(kimiKey)
 	}
 	if zaiKey != "" {
 		values["ZAI_API_KEY"] = strings.TrimSpace(zaiKey)

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -180,6 +180,7 @@ var APIKeyNames = []string{
 	"FIREWORKS_API_KEY",
 	"COHERE_API_KEY",
 	"MOONSHOT_API_KEY",
+	"KIMI_API_KEY",
 	"ZAI_API_KEY",
 	"DASHSCOPE_API_KEY",
 	"GITHUB_TOKEN",
@@ -227,6 +228,7 @@ var keyFormatRules = map[string]struct {
 	"FIREWORKS_API_KEY":              {Prefix: "fw_", Hint: "Fireworks keys start with 'fw_'"},
 	"COHERE_API_KEY":                 {Prefix: "", Hint: ""},
 	"MOONSHOT_API_KEY":               {Prefix: "sk-", Hint: "Moonshot keys start with 'sk-'"},
+	"KIMI_API_KEY":                   {Prefix: "sk-kimi-", Hint: "Kimi for Coding keys start with 'sk-kimi-'"},
 	"ZAI_API_KEY":                    {Prefix: "", Hint: ""},
 	"DASHSCOPE_API_KEY":              {Prefix: "sk-", Hint: "DashScope keys start with 'sk-'"},
 	// GitHub fine-grained PATs start with github_pat_; classic PATs

--- a/config/litellm_dynamic_config.py
+++ b/config/litellm_dynamic_config.py
@@ -70,8 +70,9 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     # Cerebras Inference — native LiteLLM ``cerebras/`` provider,
     # OpenAI-compatible at api.cerebras.ai/v1.
     "cerebras": "CEREBRAS_API_KEY",
-    # Kimi is the user-facing name for the same Moonshot account.
-    "kimi": "MOONSHOT_API_KEY",
+    # kimi/ is an OpenAI-compat gateway now (OPENAI_COMPAT_GATEWAYS).
+    # Alias kept so older configs still resolve a key env.
+    "kimi": "KIMI_API_KEY",
     # Xiaomi MiMo Open Platform — OpenAI-compatible (/v1/chat/completions).
     # No native LiteLLM provider yet, so routes are registered under the
     # ``openai/`` provider with an api_base override; this entry lets
@@ -181,6 +182,10 @@ OPENAI_COMPAT_GATEWAYS: dict[str, tuple[str, str]] = {
     "synthetic": ("https://api.synthetic.new/openai/v1", "SYNTHETIC_API_KEY"),
     "zenmux": ("https://zenmux.ai/api/v1", "ZENMUX_API_KEY"),
     "qianfan": ("https://qianfan.baidubce.com/v2", "QIANFAN_API_KEY"),
+    # Kimi for Coding (api.kimi.com/coding). Separate platform from the
+    # legacy Moonshot API: own endpoint, keys and model ids. All models
+    # reject temperature != 1, handled in llm/factory.py.
+    "kimi": ("https://api.kimi.com/coding/v1", "KIMI_API_KEY"),
     # Per-account base URL: the operator sets it to their Cloudflare AI
     # Gateway OpenAI-compat endpoint (``…/compat``). Resolved by LiteLLM at
     # request time, so an unset base only fails the call (with a clear 404),
@@ -632,6 +637,10 @@ def build_model_entry(model_name: str) -> dict[str, Any]:
             "api_key": f"os.environ/{api_key_env}",
             "api_base": api_base,
         }
+        if provider == "kimi":
+            # Kimi for Coding rejects temperature != 1. Same proxy-level
+            # drop as the opus entries in config/litellm.yaml.
+            params["additional_drop_params"] = ["temperature"]
     else:
         params = {"model": model_name}
         if provider == "ollama_chat":

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -285,6 +285,7 @@ OPENAI_API_KEY=sk-proj-...
 | Replicate | `REPLICATE_API_TOKEN` | `r8_...` | [replicate.com](https://replicate.com) |
 | NVIDIA NIM | `NVIDIA_API_KEY` | `nvapi-...` | [build.nvidia.com](https://build.nvidia.com) |
 | Moonshot (Kimi K2) | `MOONSHOT_API_KEY` | `sk-...` | [platform.moonshot.cn](https://platform.moonshot.cn) |
+| Kimi for Coding (K3 / K2.7) | `KIMI_API_KEY` | `sk-kimi-...` | [kimi.com](https://www.kimi.com) (api.kimi.com/coding) |
 | Z.ai (GLM-4.5) | `ZAI_API_KEY` | `...` | [z.ai/manage](https://z.ai/manage) |
 | Alibaba DashScope (Qwen) | `DASHSCOPE_API_KEY` | `sk-...` | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | GitHub Models | `GITHUB_TOKEN` | `github_pat_...` | [github.com/settings/personal-access-tokens](https://github.com/settings/personal-access-tokens) |

--- a/packages/decepticon-core/decepticon_core/types/llm.py
+++ b/packages/decepticon-core/decepticon_core/types/llm.py
@@ -139,7 +139,8 @@ class AuthMethod(StrEnum):
     TOGETHER_API = "together_api"  # Together AI
     FIREWORKS_API = "fireworks_api"  # Fireworks AI
     COHERE_API = "cohere_api"  # Cohere Command
-    MOONSHOT_API = "moonshot_api"  # Moonshot Kimi K2
+    MOONSHOT_API = "moonshot_api"  # legacy Moonshot AI platform (api.moonshot.ai)
+    KIMI_API = "kimi_api"  # Kimi for Coding (api.kimi.com/coding)
     ZAI_API = "zai_api"  # Z.ai GLM-4.5
     DASHSCOPE_API = "dashscope_api"  # Alibaba DashScope (Qwen)
     GITHUB_MODELS_API = "github_models_api"  # GitHub Models (PAT auth)
@@ -357,6 +358,15 @@ METHOD_MODELS: dict[AuthMethod, dict[Tier, str]] = {
         Tier.HIGH: "moonshot/kimi-k2-instruct",
         Tier.MID: "moonshot/moonshot-v1-128k",
         Tier.LOW: "moonshot/moonshot-v1-8k",
+    },
+    # Kimi for Coding is a separate platform from the legacy Moonshot
+    # API above: own endpoint, own keys (KIMI_API_KEY), own model ids.
+    # Routed via the kimi/ gateway in OPENAI_COMPAT_GATEWAYS. HIGH is
+    # K3 (1M context), MID is the coding-tuned K2.7, LOW its fast tier.
+    AuthMethod.KIMI_API: {
+        Tier.HIGH: "kimi/k3",
+        Tier.MID: "kimi/kimi-for-coding",
+        Tier.LOW: "kimi/kimi-for-coding-highspeed",
     },
     # Z.ai GLM family — native ``zai/`` LiteLLM provider (no custom shim
     # needed since LiteLLM 1.55+). LOW = glm-4.5-flash, the free-tier

--- a/packages/decepticon/decepticon/llm/factory.py
+++ b/packages/decepticon/decepticon/llm/factory.py
@@ -237,6 +237,7 @@ _DEFAULT_AUTH_PRIORITY: tuple[AuthMethod, ...] = (
     AuthMethod.FIREWORKS_API,
     AuthMethod.COHERE_API,
     AuthMethod.MOONSHOT_API,
+    AuthMethod.KIMI_API,
     AuthMethod.ZAI_API,
     AuthMethod.DASHSCOPE_API,
     AuthMethod.GITHUB_MODELS_API,
@@ -289,6 +290,7 @@ _API_METHOD_ENV: dict[AuthMethod, str] = {
     AuthMethod.FIREWORKS_API: "FIREWORKS_API_KEY",
     AuthMethod.COHERE_API: "COHERE_API_KEY",
     AuthMethod.MOONSHOT_API: "MOONSHOT_API_KEY",
+    AuthMethod.KIMI_API: "KIMI_API_KEY",
     AuthMethod.ZAI_API: "ZAI_API_KEY",
     AuthMethod.DASHSCOPE_API: "DASHSCOPE_API_KEY",
     AuthMethod.GITHUB_MODELS_API: "GITHUB_TOKEN",
@@ -338,6 +340,8 @@ _KEY_PREFIX_HINTS: dict[AuthMethod, tuple[str, ...]] = {
     AuthMethod.NVIDIA_API: ("nvapi-",),
     AuthMethod.DEEPSEEK_API: ("sk-",),
     AuthMethod.GITHUB_MODELS_API: ("ghp_", "github_pat_", "gho_", "ghs_"),
+    # Kimi for Coding keys ship as sk-kimi-...; accept plain sk- too.
+    AuthMethod.KIMI_API: ("sk-kimi-", "sk-"),
 }
 
 # Substring tokens that mark a value as obviously not a real key.
@@ -748,6 +752,7 @@ _METHOD_LABEL: dict[AuthMethod, str] = {
     AuthMethod.FIREWORKS_API: "Fireworks AI — API key",
     AuthMethod.COHERE_API: "Cohere — API key",
     AuthMethod.MOONSHOT_API: "Moonshot (Kimi) — API key",
+    AuthMethod.KIMI_API: "Kimi for Coding (K3/K2.7) — API key",
     AuthMethod.ZAI_API: "Z.ai (GLM) — API key",
     AuthMethod.DASHSCOPE_API: "Alibaba DashScope (Qwen) — API key",
     AuthMethod.GITHUB_MODELS_API: "GitHub Models — PAT",
@@ -977,7 +982,17 @@ def _model_drops_temperature(model: str) -> bool:
     Opus 4.x build added to METHOD_MODELS.
     """
     slug = model.rsplit("/", 1)[-1].lower()
-    return slug.startswith("claude-opus-4")
+    return slug.startswith("claude-opus-4") or _model_is_kimi_coding(model)
+
+
+def _model_is_kimi_coding(model: str) -> bool:
+    """Kimi for Coding models reject any temperature other than exactly 1.
+
+    Verified against all four ids on api.kimi.com/coding (2026-07).
+    Dropping the param lets the platform default (=1) apply.
+    """
+    slug = model.rsplit("/", 1)[-1].lower()
+    return slug.startswith("kimi-for-coding") or slug in ("k3", "k3-256k")
 
 
 def _model_is_deepseek_thinking(model: str) -> bool:

--- a/packages/decepticon/tests/unit/llm/test_factory.py
+++ b/packages/decepticon/tests/unit/llm/test_factory.py
@@ -700,6 +700,25 @@ class TestTemperatureDrop:
     def test_ollama_keeps_temperature(self):
         assert self._drops("ollama_chat/qwen3-coder:30b") is False
 
+    # Kimi for Coding (api.kimi.com/coding) rejects temperature != 1 on
+    # every model. Verified against all four ids, 2026-07.
+
+    def test_kimi_k3_drops_temperature(self):
+        assert self._drops("kimi/k3") is True
+
+    def test_kimi_k3_256k_drops_temperature(self):
+        assert self._drops("kimi/k3-256k") is True
+
+    def test_kimi_for_coding_drops_temperature(self):
+        assert self._drops("kimi/kimi-for-coding") is True
+
+    def test_kimi_for_coding_highspeed_drops_temperature(self):
+        assert self._drops("kimi/kimi-for-coding-highspeed") is True
+
+    def test_kimi_via_custom_prefix_drops_temperature(self):
+        # Operators routing api.kimi.com through custom/ still get the drop.
+        assert self._drops("custom/kimi-for-coding") is True
+
 
 # ── Actionable error translation (issue #107 + community feedback) ──────
 

--- a/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
+++ b/packages/decepticon/tests/unit/llm/test_litellm_dynamic_config.py
@@ -762,3 +762,31 @@ def test_build_model_entry_vllm_uses_the_key_env_that_is_set(monkeypatch) -> Non
     monkeypatch.setenv("HOSTED_VLLM_API_KEY", "sk-catalog")
     entry = build_model_entry("hosted_vllm/qwen3-coder-30b")
     assert entry["litellm_params"]["api_key"] == "os.environ/HOSTED_VLLM_API_KEY"
+
+
+def test_build_model_entry_routes_kimi_coding_gateway() -> None:
+    entry = build_model_entry("kimi/k3")
+
+    assert entry["litellm_params"] == {
+        "model": "openai/k3",
+        "api_key": "os.environ/KIMI_API_KEY",
+        "api_base": "https://api.kimi.com/coding/v1",
+        # kimi models reject temperature != 1, so the proxy drops it
+        "additional_drop_params": ["temperature"],
+    }
+
+
+def test_validate_model_name_accepts_kimi_coding_models() -> None:
+    for model in (
+        "kimi/k3",
+        "kimi/k3-256k",
+        "kimi/kimi-for-coding",
+        "kimi/kimi-for-coding-highspeed",
+    ):
+        validate_model_name(model)  # must not raise
+
+
+def test_kimi_gateway_registered_in_openai_compat_gateways() -> None:
+    base, key_env = OPENAI_COMPAT_GATEWAYS["kimi"]
+    assert base == "https://api.kimi.com/coding/v1"
+    assert key_env == "KIMI_API_KEY"


### PR DESCRIPTION
## Summary

Adds the Kimi for Coding platform (api.kimi.com/coding) as a first-class provider. It is a separate product from the legacy Moonshot AI API: different endpoint, different keys (sk-kimi-...), different model ids (k3, k3-256k, kimi-for-coding and its highspeed variant). Before this change, routing a Kimi for Coding key through moonshot/ failed with a 400 (invalid model), and routing it through custom/ failed on every agent call because all models on the platform reject temperature != 1.

## Changes

- New AuthMethod.KIMI_API with tier mapping: HIGH kimi/k3, MID kimi/kimi-for-coding, LOW kimi/kimi-for-coding-highspeed.
- kimi/ OpenAI-compat gateway in litellm_dynamic_config (api_base + KIMI_API_KEY), with additional_drop_params ["temperature"] on the route, matching the opus entries in config/litellm.yaml.
- _model_drops_temperature also covers the kimi coding slugs agent-side (belt and suspenders, same as deepseek thinking).
- Onboard wizard: "Kimi for Coding" option writing KIMI_API_KEY, with sk-kimi- format validation.
- Stale "kimi is the same as moonshot" key alias corrected.
- .env.example + setup-guide provider table.

## Blast radius

- [x] **Tier-delegate** — agent prompts, skill bodies, middleware internals, web/CLI features.

## Diff budget

- [x] My diff fits the budget. (9 files, ~60 runtime lines, 1 logical concern)

## End-to-end verification

Ran the full stack locally (docker compose: litellm, langgraph, postgres, neo4j, sandbox) with the patched litellm_dynamic_config.py and KIMI_API_KEY set. Observed: route kimi/kimi-for-coding registered at the proxy; POST /v1/chat/completions with model=kimi/kimi-for-coding and temperature=0 returned 200 from api.kimi.com (the proxy drops the param; without the drop the same request 400s upstream with "invalid temperature: only 1 is allowed for this model"). Verified the tier resolver returns kimi/k3, kimi/kimi-for-coding and kimi/kimi-for-coding-highspeed for HIGH/MID/LOW with Credentials(methods=[KIMI_API]). All four model ids were probed directly against the platform API to confirm the temperature restriction before writing the drop logic. Before writing the native route, the same key completed a full autonomous web pentest engagement through the custom/ workaround path; this PR replaces that workaround.

## Testing

- [ ] `make quality` passes (Python + CLI + Web) — not run; no full dev checkout with Node here. Ran instead, on the exact pushed tree: `ruff check` + `ruff format --check` (clean), `basedpyright` on changed Python files (0 errors, 0 warnings), `go build ./...` + `go vet` on clients/launcher (clean, Go 1.25).
- [ ] `make smoke` succeeds — not run; validated against the real compose stack instead (see End-to-end verification above).
- [x] `pytest` passes — `pytest packages/decepticon/tests/unit packages/decepticon-core/tests -q`: **5025 passed, 7 skipped** (19m51s), on the pushed tree.
- [x] Every new/changed test was watched to fail without the change and pass with it — with only the test commit applied: 7 failed, 370 passed (the 7 new kimi tests). With the implementation commits: all pass. Commit order in the branch shows tests first.
- [x] Every new/changed code path was **executed on my machine**, not just unit-tested in isolation — see End-to-end verification.
- [x] Manual testing (describe): onboard wizard code path reviewed via go vet/build; the huh form group mirrors the adjacent Moonshot group and shares its validation helpers.

## Quality Bar self-check

- [x] No banned pattern from QUALITY_BAR §Banned patterns appears in the diff.
- [x] No AI-slop signature from QUALITY_BAR §AI-slop signatures survives.
- [x] Every changed line traces to the stated intent. No drive-by formatting, renaming, or reordering.
- [x] Every public function I added/changed has explicit type annotations including return type, and every raised exception is a named class.
- [x] I would merge this PR if a stranger opened it.
- [x] If I were tired and reviewing this at the end of a long day, I would still merge it.

## Related Issues

None found open for Kimi for Coding support.
