### PR TITLE
fix(release): restore OSS installation readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,8 +167,9 @@ CLOUDFLARE_AI_GATEWAY_API_KEY=your-cloudflare-ai-gateway-key-here
 # OLLAMA_MODEL=qwen3-coder:30b
 
 # --- LiteLLM Proxy ---
-# WARNING: the values below are dev fallbacks. `decepticon start` refuses
-# to run with them — generate real ones first:
+# WARNING: the values below are dev fallbacks. `decepticon onboard` replaces
+# them with strong random values; `decepticon start` refuses to use them.
+# To generate values manually:
 #   openssl rand -hex 32 | sed 's/^/sk-/'   # LITELLM_MASTER_KEY
 #   openssl rand -hex 24                    # POSTGRES_PASSWORD
 LITELLM_MASTER_KEY=sk-decepticon-master

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,16 @@ WEB_DIR       := clients/web
 DOGFOOD_HOME  := $(CURDIR)/.dogfood
 LAUNCHER_BIN  := clients/launcher/bin/decepticon
 
+# Match the launcher's explicit Compose project without interpolating the
+# environment-controlled stack/project name into Make's shell source.
+define CLEAN_LAUNCHER_STACK
+	@stack="$${DECEPTICON_STACK_NAME:-}"; project="$${DECEPTICON_COMPOSE_PROJECT:-}"; \
+	case "$$stack" in *[!a-z0-9-]* ) echo "invalid DECEPTICON_STACK_NAME: $$stack" >&2; exit 2;; esac; \
+	if [ -z "$$project" ]; then project="decepticon$${stack:+-$$stack}"; fi; \
+	case "$$project" in ""|[!a-z0-9]*|*[!a-z0-9_-]* ) echo "invalid DECEPTICON_COMPOSE_PROJECT: $$project" >&2; exit 2;; esac; \
+	docker compose -p "$$project" $(PROFILES_ALL) down --volumes --remove-orphans 2>/dev/null; true
+endef
+
 # docker compose cannot expand ~ inside compose-file defaults, so resolve it
 # here before any subprocess inherits the env.
 export DECEPTICON_HOME ?= $(HOME)/.decepticon
@@ -89,7 +99,7 @@ help:
 	@echo "Ops:"
 	@echo "  make status       docker compose ps"
 	@echo "  make logs [SVC=]  Follow logs (default: langgraph)"
-	@echo "  make health       KG + Neo4j + Web health checks"
+	@echo "  make health       KG + Neo4j; Web when running"
 	@echo "  make clean        Full teardown (compose volumes + .dogfood/)"
 	@echo ""
 	@echo "Other:"
@@ -103,7 +113,8 @@ help:
 ## launcher version is "dev" so auto-update + config-sync are skipped — the
 ## symlinked .dogfood/ tree is the source of truth.
 dogfood: launcher
-	@echo "[dogfood] Stopping any prior repo-root stack to avoid container-name conflict..."
+	@echo "[dogfood] Stopping any prior launcher and repo-root stacks..."
+	$(CLEAN_LAUNCHER_STACK)
 	@$(COMPOSE) $(PROFILES_ALL) down --remove-orphans 2>/dev/null; true
 	@mkdir -p $(DOGFOOD_HOME)/workspace
 	@ln -sfn $(CURDIR)/docker-compose.yml $(DOGFOOD_HOME)/docker-compose.yml
@@ -136,6 +147,7 @@ smoke:
 	@echo "=== Decepticon pre-release smoke (compose-only, no launcher) ==="
 	@echo ""
 	@echo "[1/4] Clean state (purging containers + volumes)..."
+	$(CLEAN_LAUNCHER_STACK)
 	@$(COMPOSE) $(PROFILES_ALL) down --volumes --remove-orphans 2>/dev/null; true
 	@echo ""
 	@echo "[2/4] Building images from local code..."
@@ -149,7 +161,7 @@ smoke:
 	@$(MAKE) -s health
 	@echo ""
 	@echo "=== smoke OK — stack mirrors OSS user state ==="
-	@echo "  Web:          http://localhost:$${WEB_PORT:-3000}"
+	@echo "  Web:          optional (/web from CLI)"
 	@echo "  LangGraph:    http://localhost:$${LANGGRAPH_PORT:-2024}"
 	@echo "  Run dogfood:  make dogfood"
 	@echo "  Teardown:     make clean"
@@ -322,14 +334,19 @@ health:
 		&& echo "kg:    OK" || (echo "kg:    FAIL" && exit 1)
 	@$(COMPOSE) exec -T neo4j cypher-shell -u neo4j -p "$${NEO4J_PASSWORD:-decepticon-graph}" "RETURN 1 AS ok;" >/dev/null 2>&1 \
 		&& echo "neo4j: OK" || (echo "neo4j: FAIL" && exit 1)
-	@curl -sf http://localhost:$${WEB_PORT:-3000} >/dev/null 2>&1 \
-		&& echo "web:   OK (http://localhost:$${WEB_PORT:-3000})" \
-		|| (echo "web:   FAIL — not reachable on port $${WEB_PORT:-3000}" && exit 1)
+	@if $(COMPOSE) ps --status running --services | grep -qx web; then \
+		curl -sf http://localhost:$${WEB_PORT:-3000} >/dev/null 2>&1 \
+			&& echo "web:   OK (http://localhost:$${WEB_PORT:-3000})" \
+			|| (echo "web:   FAIL — not reachable on port $${WEB_PORT:-3000}" && exit 1); \
+	else \
+		echo "web:   SKIP (optional profile not running)"; \
+	fi
 
 ## Full teardown: containers + volumes + .dogfood/. Destructive — also
 ## wipes the dogfood .env (API keys) so the next `make dogfood` starts
 ## with a fresh onboard wizard.
 clean:
+	$(CLEAN_LAUNCHER_STACK)
 	$(COMPOSE) $(PROFILES_ALL) down --volumes --remove-orphans
 	@rm -rf $(DOGFOOD_HOME)
 	@echo "OK — compose volumes purged, .dogfood/ removed"

--- a/clients/launcher/cmd/onboard.go
+++ b/clients/launcher/cmd/onboard.go
@@ -196,6 +196,14 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		ui.DimText("Run 'decepticon onboard --reset' to reconfigure")
 		return nil
 	}
+	existingEnv := map[string]string{}
+	if config.EnvExists() {
+		var err error
+		existingEnv, err = config.LoadEnv(config.EnvPath())
+		if err != nil {
+			return fmt.Errorf("read existing .env: %w", err)
+		}
+	}
 
 	// Kick off Ollama discovery in the background so the network
 	// round-trip overlaps with huh's startup work; the OLLAMA_MODEL
@@ -915,6 +923,10 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 			priority = append(priority, m)
 		}
 	}
+	installationSecrets, err := onboardingInstallationSecrets(existingEnv)
+	if err != nil {
+		return fmt.Errorf("generate installation credentials: %w", err)
+	}
 
 	values := map[string]string{
 		"DECEPTICON_MODEL_PROFILE":    profile,
@@ -926,6 +938,10 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		"DECEPTICON_AUTH_GROK":        boolStr(contains(methods, methodGrokOAuth)),
 		"DECEPTICON_AUTH_COPILOT":     boolStr(contains(methods, methodCopilotOAuth)),
 		"DECEPTICON_AUTH_PERPLEXITY":  boolStr(contains(methods, methodPerplexityOAuth)),
+		"LITELLM_MASTER_KEY":          installationSecrets.LiteLLMMasterKey,
+		"LITELLM_SALT_KEY":            installationSecrets.LiteLLMSaltKey,
+		"POSTGRES_PASSWORD":           installationSecrets.PostgresPassword,
+		"NEO4J_PASSWORD":              installationSecrets.Neo4jPassword,
 	}
 
 	if anthropicKey != "" {
@@ -1107,6 +1123,26 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 
 	ui.DimText("  Run 'decepticon' to start the platform")
 	return nil
+}
+
+func onboardingInstallationSecrets(existing map[string]string) (config.InstallationSecrets, error) {
+	secrets, err := config.NewInstallationSecrets()
+	if err != nil {
+		return config.InstallationSecrets{}, err
+	}
+	if value := strings.TrimSpace(existing["LITELLM_MASTER_KEY"]); value != "" {
+		secrets.LiteLLMMasterKey = value
+	}
+	if value := strings.TrimSpace(existing["LITELLM_SALT_KEY"]); value != "" {
+		secrets.LiteLLMSaltKey = value
+	}
+	if value := strings.TrimSpace(existing["POSTGRES_PASSWORD"]); value != "" {
+		secrets.PostgresPassword = value
+	}
+	if value := strings.TrimSpace(existing["NEO4J_PASSWORD"]); value != "" {
+		secrets.Neo4jPassword = value
+	}
+	return secrets, nil
 }
 
 func contains(haystack []string, needle string) bool {

--- a/clients/launcher/cmd/onboard_secrets_test.go
+++ b/clients/launcher/cmd/onboard_secrets_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import "testing"
+
+func TestOnboardingInstallationSecretsPreservesExistingValues(t *testing.T) {
+	existing := map[string]string{
+		"LITELLM_MASTER_KEY": "existing-master",
+		"LITELLM_SALT_KEY":   "existing-salt",
+		"POSTGRES_PASSWORD":  "existing-postgres",
+		"NEO4J_PASSWORD":     "existing-neo4j",
+	}
+
+	// Given credentials already bound to persistent database volumes, when the
+	// wizard is reset, then every installation credential remains unchanged.
+	secrets, err := onboardingInstallationSecrets(existing)
+	if err != nil {
+		t.Fatalf("onboardingInstallationSecrets() error: %v", err)
+	}
+	if secrets.LiteLLMMasterKey != existing["LITELLM_MASTER_KEY"] ||
+		secrets.LiteLLMSaltKey != existing["LITELLM_SALT_KEY"] ||
+		secrets.PostgresPassword != existing["POSTGRES_PASSWORD"] ||
+		secrets.Neo4jPassword != existing["NEO4J_PASSWORD"] {
+		t.Fatalf("reset rotated credentials: %#v", secrets)
+	}
+}
+
+func TestOnboardingInstallationSecretsFillsMissingValues(t *testing.T) {
+	// Given a partial configuration, when installation secrets are resolved,
+	// then the existing value is preserved and every missing value is generated.
+	secrets, err := onboardingInstallationSecrets(map[string]string{
+		"POSTGRES_PASSWORD": "existing-postgres",
+	})
+	if err != nil {
+		t.Fatalf("onboardingInstallationSecrets() error: %v", err)
+	}
+	if secrets.PostgresPassword != "existing-postgres" {
+		t.Fatalf("PostgresPassword = %q, want preserved value", secrets.PostgresPassword)
+	}
+	if secrets.LiteLLMMasterKey == "" || secrets.LiteLLMSaltKey == "" || secrets.Neo4jPassword == "" {
+		t.Fatal("missing installation credentials were not generated")
+	}
+}

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -353,16 +353,16 @@ func runStart(cmd *cobra.Command, args []string) error {
 // are still in effect. A bare docker compose up remains available for dev,
 // while the supported launcher path cannot expose a default-keyed service.
 func checkDefaultCredentials(env map[string]string) error {
-	defaults := map[string]string{
-		"LITELLM_MASTER_KEY": "sk-decepticon-master",
-		"LITELLM_SALT_KEY":   "sk-decepticon-salt-change-me",
-		"POSTGRES_PASSWORD":  "decepticon",
-		"NEO4J_PASSWORD":     "decepticon-graph",
+	defaults := map[string][]string{
+		"LITELLM_MASTER_KEY": {"sk-decepticon-master"},
+		"LITELLM_SALT_KEY":   {"sk-decepticon-salt-change-me", "sk-decepticon-salt"},
+		"POSTGRES_PASSWORD":  {"decepticon"},
+		"NEO4J_PASSWORD":     {"decepticon-graph"},
 	}
 	insecure := make([]string, 0, len(defaults))
-	for name, fallback := range defaults {
+	for name, fallbacks := range defaults {
 		value := strings.TrimSpace(config.Get(env, name, ""))
-		if value == "" || value == fallback {
+		if value == "" || slices.Contains(fallbacks, value) {
 			insecure = append(insecure, name)
 		}
 	}

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -361,7 +361,8 @@ func checkDefaultCredentials(env map[string]string) error {
 	}
 	insecure := make([]string, 0, len(defaults))
 	for name, fallback := range defaults {
-		if config.Get(env, name, "") == fallback {
+		value := strings.TrimSpace(config.Get(env, name, ""))
+		if value == "" || value == fallback {
 			insecure = append(insecure, name)
 		}
 	}
@@ -370,7 +371,7 @@ func checkDefaultCredentials(env map[string]string) error {
 	}
 	slices.Sort(insecure)
 	return fmt.Errorf(
-		"refusing to start with default credentials in %s: %s.\n"+
+		"refusing to start with missing or default credentials in %s: %s.\n"+
 			"For a new install, delete %s and run `decepticon onboard`.\n"+
 			"For an initialized install, do not change database passwords in .env alone; "+
 			"back up the engagement, run `decepticon remove`, then onboard again so credentials and volumes are recreated together.",

--- a/clients/launcher/cmd/start.go
+++ b/clients/launcher/cmd/start.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -348,24 +349,32 @@ func runStart(cmd *cobra.Command, args []string) error {
 // host.docker.internal in /etc/hosts; native-WSL Docker installs need
 // the Windows host IP from /etc/resolv.conf; an Ollama running inside
 // the WSL distro itself sits on 127.0.0.1. Whichever returns 2xx wins.
-// checkDefaultCredentials refuses to start when the compose fallback
-// credentials are still in effect. The compose file defaults to
-// sk-decepticon-master / decepticon so a bare `docker compose up` works
-// for dev; the launcher is the supported path and must not bring up a
-// default-keyed proxy. Returns an error with the one-command fix.
+// checkDefaultCredentials refuses to start when compose fallback credentials
+// are still in effect. A bare docker compose up remains available for dev,
+// while the supported launcher path cannot expose a default-keyed service.
 func checkDefaultCredentials(env map[string]string) error {
-	master := config.Get(env, "LITELLM_MASTER_KEY", "")
-	pgPass := config.Get(env, "POSTGRES_PASSWORD", "")
-	if master != "sk-decepticon-master" && pgPass != "decepticon" {
+	defaults := map[string]string{
+		"LITELLM_MASTER_KEY": "sk-decepticon-master",
+		"LITELLM_SALT_KEY":   "sk-decepticon-salt-change-me",
+		"POSTGRES_PASSWORD":  "decepticon",
+		"NEO4J_PASSWORD":     "decepticon-graph",
+	}
+	insecure := make([]string, 0, len(defaults))
+	for name, fallback := range defaults {
+		if config.Get(env, name, "") == fallback {
+			insecure = append(insecure, name)
+		}
+	}
+	if len(insecure) == 0 {
 		return nil
 	}
+	slices.Sort(insecure)
 	return fmt.Errorf(
-		"refusing to start with default credentials (LITELLM_MASTER_KEY=%q, POSTGRES_PASSWORD=%q).\n"+
-			"Generate strong values and set them in %s, then re-run:\n"+
-			"  openssl rand -hex 32 | sed 's/^/sk-/'   # LITELLM_MASTER_KEY\n"+
-			"  openssl rand -hex 24                    # POSTGRES_PASSWORD\n"+
-			"or run `decepticon onboard` to set them interactively.",
-		master, pgPass, config.EnvPath())
+		"refusing to start with default credentials in %s: %s.\n"+
+			"For a new install, delete %s and run `decepticon onboard`.\n"+
+			"For an initialized install, do not change database passwords in .env alone; "+
+			"back up the engagement, run `decepticon remove`, then onboard again so credentials and volumes are recreated together.",
+		config.EnvPath(), strings.Join(insecure, ", "), config.EnvPath())
 }
 
 func probeOllamaIfSelected(env map[string]string) {

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -187,12 +187,18 @@ func TestApplyAutoUpdate_NoUpdateFlagAlwaysWins(t *testing.T) {
 }
 
 func TestCheckDefaultCredentials_RefusesDefaults(t *testing.T) {
-	err := checkDefaultCredentials(map[string]string{
+	defaults := map[string]string{
 		"LITELLM_MASTER_KEY": "sk-decepticon-master",
+		"LITELLM_SALT_KEY":   "sk-decepticon-salt-change-me",
 		"POSTGRES_PASSWORD":  "decepticon",
-	})
-	if err == nil {
-		t.Fatal("default credentials must be refused")
+		"NEO4J_PASSWORD":     "decepticon-graph",
+	}
+	for name, value := range defaults {
+		// Given any single public fallback, when startup validates the env, then
+		// that credential independently blocks the launcher path.
+		if err := checkDefaultCredentials(map[string]string{name: value}); err == nil {
+			t.Fatalf("default %s must be refused", name)
+		}
 	}
 }
 

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -188,11 +188,11 @@ func TestApplyAutoUpdate_NoUpdateFlagAlwaysWins(t *testing.T) {
 }
 
 func TestCheckDefaultCredentials_RefusesDefaults(t *testing.T) {
-	defaults := map[string]string{
-		"LITELLM_MASTER_KEY": "sk-decepticon-master",
-		"LITELLM_SALT_KEY":   "sk-decepticon-salt-change-me",
-		"POSTGRES_PASSWORD":  "decepticon",
-		"NEO4J_PASSWORD":     "decepticon-graph",
+	defaults := map[string][]string{
+		"LITELLM_MASTER_KEY": {"sk-decepticon-master"},
+		"LITELLM_SALT_KEY":   {"sk-decepticon-salt-change-me", "sk-decepticon-salt"},
+		"POSTGRES_PASSWORD":  {"decepticon"},
+		"NEO4J_PASSWORD":     {"decepticon-graph"},
 	}
 	custom := map[string]string{
 		"LITELLM_MASTER_KEY": "sk-9f2c1a7b3d5e",
@@ -200,13 +200,15 @@ func TestCheckDefaultCredentials_RefusesDefaults(t *testing.T) {
 		"POSTGRES_PASSWORD":  "x9k2m4p7q1",
 		"NEO4J_PASSWORD":     "n8v7c6x5z4",
 	}
-	for name, value := range defaults {
+	for name, values := range defaults {
 		// Given any single public fallback, when startup validates the env, then
 		// that credential independently blocks the launcher path.
-		env := maps.Clone(custom)
-		env[name] = value
-		if err := checkDefaultCredentials(env); err == nil {
-			t.Fatalf("default %s must be refused", name)
+		for _, value := range values {
+			env := maps.Clone(custom)
+			env[name] = value
+			if err := checkDefaultCredentials(env); err == nil {
+				t.Fatalf("default %s=%q must be refused", name, value)
+			}
 		}
 	}
 }

--- a/clients/launcher/cmd/start_test.go
+++ b/clients/launcher/cmd/start_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"maps"
 	"reflect"
 	"testing"
 
@@ -193,10 +194,18 @@ func TestCheckDefaultCredentials_RefusesDefaults(t *testing.T) {
 		"POSTGRES_PASSWORD":  "decepticon",
 		"NEO4J_PASSWORD":     "decepticon-graph",
 	}
+	custom := map[string]string{
+		"LITELLM_MASTER_KEY": "sk-9f2c1a7b3d5e",
+		"LITELLM_SALT_KEY":   "sk-salt-7c6b5a4d3e2f",
+		"POSTGRES_PASSWORD":  "x9k2m4p7q1",
+		"NEO4J_PASSWORD":     "n8v7c6x5z4",
+	}
 	for name, value := range defaults {
 		// Given any single public fallback, when startup validates the env, then
 		// that credential independently blocks the launcher path.
-		if err := checkDefaultCredentials(map[string]string{name: value}); err == nil {
+		env := maps.Clone(custom)
+		env[name] = value
+		if err := checkDefaultCredentials(env); err == nil {
 			t.Fatalf("default %s must be refused", name)
 		}
 	}
@@ -205,17 +214,34 @@ func TestCheckDefaultCredentials_RefusesDefaults(t *testing.T) {
 func TestCheckDefaultCredentials_AllowsCustom(t *testing.T) {
 	err := checkDefaultCredentials(map[string]string{
 		"LITELLM_MASTER_KEY": "sk-9f2c1a7b3d5e",
+		"LITELLM_SALT_KEY":   "sk-salt-7c6b5a4d3e2f",
 		"POSTGRES_PASSWORD":  "x9k2m4p7q1",
+		"NEO4J_PASSWORD":     "n8v7c6x5z4",
 	})
 	if err != nil {
 		t.Fatalf("custom credentials must be allowed, got: %v", err)
 	}
 }
 
-func TestCheckDefaultCredentials_AllowsUnset(t *testing.T) {
-	// Unset keys resolve to "" via config.Get — neither matches a default,
-	// so an empty env must not block startup.
-	if err := checkDefaultCredentials(map[string]string{}); err != nil {
-		t.Fatalf("unset credentials must be allowed, got: %v", err)
+func TestCheckDefaultCredentials_RefusesMissingOrEmpty(t *testing.T) {
+	custom := map[string]string{
+		"LITELLM_MASTER_KEY": "sk-9f2c1a7b3d5e",
+		"LITELLM_SALT_KEY":   "sk-salt-7c6b5a4d3e2f",
+		"POSTGRES_PASSWORD":  "x9k2m4p7q1",
+		"NEO4J_PASSWORD":     "n8v7c6x5z4",
+	}
+	for name := range custom {
+		// Given one missing credential, when startup validates the env, then
+		// the Compose public fallback cannot enter the supported launcher path.
+		env := maps.Clone(custom)
+		delete(env, name)
+		if err := checkDefaultCredentials(env); err == nil {
+			t.Fatalf("missing %s must be refused", name)
+		}
+
+		env[name] = "   "
+		if err := checkDefaultCredentials(env); err == nil {
+			t.Fatalf("empty %s must be refused", name)
+		}
 	}
 }

--- a/clients/launcher/internal/config/config.go
+++ b/clients/launcher/internal/config/config.go
@@ -152,12 +152,41 @@ func writeEnvFromString(tmpl string, outputPath string, values map[string]string
 			out = append(out, key+"="+val)
 		}
 	}
-
-
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return fmt.Errorf("create directory: %w", err)
 	}
-	return os.WriteFile(outputPath, []byte(strings.Join(out, "\n")), 0o600)
+	return writePrivateFile(outputPath, []byte(strings.Join(out, "\n")))
+}
+
+// writePrivateFile atomically replaces path with a file that is private from
+// its first byte. os.WriteFile's mode is ignored when path already exists,
+// which could leave credentials world-readable after onboard --reset.
+func writePrivateFile(path string, data []byte) (retErr error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".env.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary env: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		if retErr != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return fmt.Errorf("secure temporary env: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write temporary env: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary env: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace env: %w", err)
+	}
+	return nil
 }
 
 // APIKeyNames lists the API key environment variable names to check.

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -427,7 +428,7 @@ func TestWriteEnvFromEmbedReplacesPermissiveFilePrivately(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat .env: %v", err)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
+	if got := info.Mode().Perm(); runtime.GOOS != "windows" && got != 0o600 {
 		t.Fatalf(".env permissions = %04o, want 0600", got)
 	}
 }

--- a/clients/launcher/internal/config/config_test.go
+++ b/clients/launcher/internal/config/config_test.go
@@ -410,6 +410,28 @@ func TestTelemetryConsentWritesEnv(t *testing.T) {
 	}
 }
 
+func TestWriteEnvFromEmbedReplacesPermissiveFilePrivately(t *testing.T) {
+	out := filepath.Join(t.TempDir(), ".env")
+	// Given an existing configuration created with unsafe legacy permissions.
+	if err := os.WriteFile(out, []byte("POSTGRES_PASSWORD=old\n"), 0o644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	// When onboarding replaces it with generated credentials.
+	if err := WriteEnvFromEmbed(out, map[string]string{"POSTGRES_PASSWORD": "generated-secret"}); err != nil {
+		t.Fatalf("WriteEnvFromEmbed() error: %v", err)
+	}
+
+	// Then the replacement is private even though the old inode was not.
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("stat .env: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf(".env permissions = %04o, want 0600", got)
+	}
+}
+
 func TestBackfillEnvFromEmbed(t *testing.T) {
 	out := filepath.Join(t.TempDir(), ".env")
 	// Simulate a pre-#706 .env: has telemetry mode but NOT the endpoint,

--- a/clients/launcher/internal/config/secrets.go
+++ b/clients/launcher/internal/config/secrets.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// InstallationSecrets contains the service credentials generated for a new
+// launcher-managed installation.
+type InstallationSecrets struct {
+	LiteLLMMasterKey string
+	LiteLLMSaltKey   string
+	PostgresPassword string
+	Neo4jPassword    string
+}
+
+// NewInstallationSecrets generates independent credentials for every service
+// that otherwise inherits a public development default from .env.example.
+func NewInstallationSecrets() (InstallationSecrets, error) {
+	masterKey, err := randomHex(32)
+	if err != nil {
+		return InstallationSecrets{}, fmt.Errorf("generate LiteLLM master key: %w", err)
+	}
+	saltKey, err := randomHex(32)
+	if err != nil {
+		return InstallationSecrets{}, fmt.Errorf("generate LiteLLM salt key: %w", err)
+	}
+	postgresPassword, err := randomHex(24)
+	if err != nil {
+		return InstallationSecrets{}, fmt.Errorf("generate Postgres password: %w", err)
+	}
+	neo4jPassword, err := randomHex(32)
+	if err != nil {
+		return InstallationSecrets{}, fmt.Errorf("generate Neo4j password: %w", err)
+	}
+
+	return InstallationSecrets{
+		LiteLLMMasterKey: "sk-" + masterKey,
+		LiteLLMSaltKey:   "sk-" + saltKey,
+		PostgresPassword: postgresPassword,
+		Neo4jPassword:    neo4jPassword,
+	}, nil
+}
+
+func randomHex(byteLength int) (string, error) {
+	value := make([]byte, byteLength)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("read operating-system randomness: %w", err)
+	}
+	return hex.EncodeToString(value), nil
+}

--- a/clients/launcher/internal/config/secrets_test.go
+++ b/clients/launcher/internal/config/secrets_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewInstallationSecrets_generates_nondefault_credentials(t *testing.T) {
+	// Given
+	const defaultMasterKey = "sk-decepticon-master"
+	const defaultDatabasePassword = "decepticon"
+
+	// When
+	secrets, err := NewInstallationSecrets()
+
+	// Then
+	if err != nil {
+		t.Fatalf("NewInstallationSecrets() error = %v", err)
+	}
+	if secrets.LiteLLMMasterKey == defaultMasterKey {
+		t.Fatal("LiteLLM master key must not use the public default")
+	}
+	if secrets.PostgresPassword == defaultDatabasePassword {
+		t.Fatal("Postgres password must not use the public default")
+	}
+	if !strings.HasPrefix(secrets.LiteLLMMasterKey, "sk-") {
+		t.Fatalf("LiteLLM master key = %q, want sk- prefix", secrets.LiteLLMMasterKey)
+	}
+	wantLengths := map[string]int{
+		secrets.LiteLLMMasterKey: 67,
+		secrets.LiteLLMSaltKey:   67,
+		secrets.PostgresPassword: 48,
+		secrets.Neo4jPassword:    64,
+	}
+	for value, want := range wantLengths {
+		if len(value) != want {
+			t.Fatalf("generated credential length = %d, want %d", len(value), want)
+		}
+	}
+}
+
+func TestNewInstallationSecrets_generates_independent_values(t *testing.T) {
+	// Given
+	const generatedSecretCount = 4
+
+	// When
+	secrets, err := NewInstallationSecrets()
+
+	// Then
+	if err != nil {
+		t.Fatalf("NewInstallationSecrets() error = %v", err)
+	}
+	values := map[string]struct{}{
+		secrets.LiteLLMMasterKey: {},
+		secrets.LiteLLMSaltKey:   {},
+		secrets.PostgresPassword: {},
+		secrets.Neo4jPassword:    {},
+	}
+	if len(values) != generatedSecretCount {
+		t.Fatalf("generated %d unique values, want %d", len(values), generatedSecretCount)
+	}
+}

--- a/containers/langgraph.Dockerfile
+++ b/containers/langgraph.Dockerfile
@@ -45,7 +45,8 @@ RUN uv sync --no-dev --frozen --extra neo4j
 # uv sync creates /app/.venv but does NOT modify PATH. Prepend
 # the venv's bin/ so ``langgraph`` and any other workspace-installed
 # console-scripts resolve without a venv activation step.
-ENV PATH=/app/.venv/bin:$PATH
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PATH=/app/.venv/bin:$PATH
 
 EXPOSE 2024
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,9 @@ services:
   # Neo4j — Attack Chain Graph (the agent's persistent working memory)
   # On sandbox-net so cypher-shell from inside sandbox reaches bolt://neo4j:7687
   neo4j:
-    image: neo4j:5.26-community
+    # Pin the patch release: the mutable 5.26 tag currently resolves to
+    # 5.26.29, whose JVM exits with SIGBUS during startup on WSL2.
+    image: neo4j:5.26.28-community
     container_name: decepticon${DECEPTICON_STACK_NAME:+-${DECEPTICON_STACK_NAME}}-neo4j
     # heap_max 256m + pagecache 64m + JVM/APOC off-heap ≈ <1g nominal.
     # 2g caps the JVM so a large attack-graph scan can't swap-thrash the host.
@@ -421,14 +423,14 @@ services:
     # python urllib — same pattern as the litellm healthcheck. Runs entirely
     # inside the container so host OS (Linux / macOS / Windows) is irrelevant;
     # avoids relying on curl/wget being present in the langgraph base image.
-    # start_period covers FastAPI + graph-server boot after litellm flips
-    # healthy; retries is post-cushion grace.
+    # start_period covers a cold FastAPI + all-graph import on slower hosts
+    # after litellm flips healthy; retries is post-cushion grace.
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:2024/ok')"]
       interval: 5s
       timeout: 3s
       retries: 12
-      start_period: 90s
+      start_period: 180s
     networks:
       # decepticon-net: reach litellm, postgres, neo4j (infra plane).
       # sandbox-net: reach the sandbox container's HTTP daemon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     env_file: .env
     environment:
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-sk-decepticon-master}
-      - LITELLM_SALT_KEY=${LITELLM_SALT_KEY:-sk-decepticon-salt}
+      - LITELLM_SALT_KEY=${LITELLM_SALT_KEY:-sk-decepticon-salt-change-me}
       - CODEX_AUTH_PATH=/root/.codex/auth.json
       - DATABASE_URL=postgresql://decepticon:${POSTGRES_PASSWORD:-decepticon}@postgres:5432/litellm
     depends_on:

--- a/docs/adr/0006-agent-driven-container-lifecycle.md
+++ b/docs/adr/0006-agent-driven-container-lifecycle.md
@@ -129,7 +129,7 @@ service activation through it.  Four sub-decisions:
    `profiles: [c2-sliver]` but the **default value of
    `COMPOSE_PROFILES` is removed from `.env.example`** so a vanilla
    `make dev` brings up only the core plane (litellm + postgres +
-   neo4j-KGStore + langgraph + web + sandbox + skillogy +
+   neo4j-KGStore + langgraph + sandbox + skillogy +
    `ops-control`).  Domain services are inert until something
    `ops_start`s them.
 

--- a/docs/adr/0011-skillogy-lightrag-hybrid-retrieval.md
+++ b/docs/adr/0011-skillogy-lightrag-hybrid-retrieval.md
@@ -96,7 +96,7 @@ is what we want.
   free). The git dump stays embedding-free and reproducible without any
   embedding creds.
 - Create a Neo4j **native vector index** on `:Skill(embedding)` after the embed
-  pass. Deployed Neo4j is **`neo4j:5.26-community`** (`docker-compose.yml:117`),
+  pass. Deployed Neo4j is **`neo4j:5.26.28-community`** (`docker-compose.yml:117`),
   which supports native vector indexes.
 - Embeddings via the **litellm gateway** (a cloud embedding model, e.g.
   `voyage-3` / `text-embedding-3-large` — same endpoint used at query time so
@@ -201,7 +201,7 @@ Touch points, in dependency order. Each step is independently testable.
 - In the same boot path (a sibling `_ensure_indexes`): after the embed pass, run
   `CREATE VECTOR INDEX skill_embedding IF NOT EXISTS FOR (s:Skill) ON s.embedding
    OPTIONS {indexConfig: {`vector.dimensions`: EMBED_DIM, `vector.similarity_function`: 'cosine'}}`.
-  Idempotent; the deployed `neo4j:5.26-community` supports native vector indexes.
+  Idempotent; the deployed `neo4j:5.26.28-community` supports native vector indexes.
 
 ### Step 4 — find_skill hybrid retrieval (backend)
 `server/neo4j_backend.py::find_skill` — replace ONLY the keyword Path E

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@
 
 | Command | Description |
 |---------|-------------|
-| `decepticon` | Start all services, open the terminal UI, and print the web dashboard URL |
+| `decepticon` | Start the core services and open the terminal UI |
 | `decepticon onboard` | Interactive setup wizard (provider, API key, model profile, LangSmith) |
 | `decepticon onboard --reset` | Reconfigure even if `.env` already exists |
 | `decepticon stop` | Stop all services |

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -6,7 +6,7 @@ Manual testing procedures for verifying the LLM gateway features.
 
 - Docker and Docker Compose installed
 - At least one LLM provider API key or an authorized local/OpenAI-compatible model endpoint
-- `make dev` successfully starts all services
+- `make dev` successfully starts the core services
 
 ## Scenario 1: API Key Provider Routing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,17 +50,17 @@ Configuration is saved to `~/.decepticon/.env`. Run `decepticon onboard --reset`
 decepticon
 ```
 
-Starts all services (PostgreSQL, LiteLLM, LangGraph, Neo4j, sandbox, C2 server, web dashboard) and opens the interactive terminal UI.
+Starts the core management and sandbox services, then opens the interactive terminal UI. Specialist services such as the C2 server and web dashboard start on demand.
 
-**Web Dashboard** (browser):
+**Web Dashboard** (browser, optional):
 
-The web dashboard starts as part of the default stack — it's reachable at `http://localhost:3000` once `decepticon` (or `make dev` for contributors) is running.
+From the terminal UI, run `/web` (or `/web up`) to start the dashboard. It is then reachable at `http://localhost:3000`.
 
 ---
 
 ## First Real Engagement
 
-1. Launch Decepticon (`decepticon`) and open <http://localhost:3000>
+1. Launch Decepticon (`decepticon`). To use the browser UI, run `/web` and open <http://localhost:3000>.
 2. The **Soundwave** agent interviews you to define the engagement:
    - Target scope (IP range, URL, Git repo, file upload, or local path)
    - Threat actor profile

--- a/docs/makefile-reference.md
+++ b/docs/makefile-reference.md
@@ -42,7 +42,7 @@ make smoke      # fast check
 make dogfood    # full OSS UX
 ```
 
-The Web dashboard is part of the default Compose stack; after `make dev` it's reachable at <http://localhost:3000>.
+The Web dashboard is optional. Start it from the CLI with `/web`; it is then reachable at <http://localhost:3000>.
 
 ---
 
@@ -87,7 +87,7 @@ To regenerate just the Prisma client (without a full build): `cd clients/web && 
 |--------|-------------|
 | `make status` | Show running service status (`docker compose ps`) |
 | `make logs [SVC=service]` | Follow logs (default: `langgraph`). Override: `make logs SVC=litellm` |
-| `make health` | KG backend + Neo4j + Web health checks (broader than `decepticon kg-health`, which only checks the KG) |
+| `make health` | KG backend + Neo4j health checks, plus Web when it is running (broader than `decepticon kg-health`, which only checks the KG) |
 | `make clean` | Full teardown: stop services, remove volumes, **and remove `.dogfood/`**. Use this when you want the next `make dogfood` to start from a fresh onboard wizard. |
 
 ---

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -703,7 +703,7 @@ See [Models](models.md) for the full role-to-model mapping.
 
 ## Web Dashboard
 
-The web dashboard starts automatically with `decepticon` and is accessible at:
+The web dashboard is optional. Start it from the interactive CLI with `/web`, then open:
 
 ```
 http://localhost:3000
@@ -733,7 +733,7 @@ See [Web Dashboard](web-dashboard.md) for the full feature reference.
 ### Core Commands
 
 ```bash
-decepticon                  # Launch platform (all services + interactive CLI)
+decepticon                  # Launch the core stack + interactive CLI
 decepticon onboard          # Setup wizard (auth, provider, profile)
 decepticon onboard --reset  # Re-run setup from scratch
 decepticon stop             # Stop all services, keep data


### PR DESCRIPTION
## Summary

Restores the OSS install/release path after v1.1.40 by fixing the release blockers found while dogfooding the launcher and Compose stack.

- pin Neo4j to `5.26.28-community` to avoid the WSL2 SIGBUS regression observed with the newer patch image
- make Web health optional, extend LangGraph startup allowance, and prevent Python bytecode writes in the runtime image
- scope cleanup to the launcher-selected Compose project and reject unsafe stack names before invoking Docker
- generate independent installation credentials with `crypto/rand`, preserve initialized database credentials on reset, and atomically replace `.env` with mode `0600`
- fail closed when any required credential is missing, blank, or equal to a current or legacy public default
- align the Compose salt fallback, templates, launcher validation, tests, and user documentation

## Public API impact

No `decepticon-core` or `decepticon-sdk` contract changes. This PR is limited to launcher, local Compose/release behavior, container configuration, tests, and documentation.

## Verification

Exact reviewed commit: `b7cdc3cdae93312ad3150be09117053ceabee605`

- `make quality-strict`: PASS
  - 5,104 Python tests passed, 46 skipped, 78% coverage
  - basedpyright: 0 errors
  - CLI: 31 tests passed; typecheck and build passed
  - Web: lint and production build passed
- `make smoke`: PASS
  - core services healthy, KG and Neo4j OK, optional Web correctly skipped
- `make dogfood`: PASS
  - fresh isolated launcher onboarding created an engagement and reached the real interactive CLI
  - LangGraph `/ok` returned true, health was healthy, and restart count was zero
  - generated `.env` mode was `0600`; secret lengths were `67/67/48/64` without recording secret values
  - Ctrl-C exited the CLI cleanly
- reset live audit: existing installation credential hashes were preserved and `.env` remained mode `0600`
- stack-name injection negative case: rejected before command execution

## Review gates

- Goal verification: PASS
- Code quality: PASS
- Security: PASS
- Documentation/context consistency: PASS
- Manual QA: PASS — 24 isolated P0/P1 scenarios, including fail-closed credentials, optional Web health, Neo4j runtime/Cypher, unsafe stack names, project-scoped cleanup, and unrelated-stack isolation
