### PR TITLE
fix(release): support Python metadata 2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           uv build --all-packages
 
       - name: Publish to PyPI (all three wheels atomically)
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           # Idempotent re-runs: if a version is already on PyPI (e.g. a
           # partial-failure re-tag after Docker jobs needed to rebuild),


### PR DESCRIPTION
## Summary

Update the SHA-pinned PyPI publish action to its current `release/v1` revision so releases can publish Python artifacts using Core Metadata 2.5.

The `v1.1.42` release job built all three workspace packages successfully, but the older publisher image failed before upload with:

`InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`

The updated immutable action revision includes Twine 7 support for Metadata 2.5. OIDC Trusted Publishing permissions, the `pypi-release` environment, `skip-existing`, and the atomic three-package artifact directory remain unchanged.

## Verification

Exact reviewed commit: `4330208edb2709ed0b181f84b3c9cdb102607dd8`

- action pin provenance: current upstream `release/v1` and tag `v1.14.2`, GitHub-verified commit
- `actionlint` 1.7.7: PASS
- `uv build --all-packages`: PASS, three wheels plus three sdists
- artifact inspection: all six distributions use Core Metadata 2.5
- `twine==7.0.0 check`: PASS for all six distributions
- goal, code-quality, security/supply-chain, context, and manual QA reviews: PASS

## Public API impact

None. Workflow-only dependency pin update.
