### PR TITLE
fix(release): skip oversized sandbox BuildKit SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.platform }}
           provenance: mode=max
-          sbom: true
+          sbom: ${{ matrix.image != 'decepticon-sandbox' }}
           outputs: type=image,name=ghcr.io/purpleailab/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.platform }}


### PR DESCRIPTION
## Summary

- disable the duplicate per-platform BuildKit SBOM only for `decepticon-sandbox`
- retain `provenance: mode=max` for every heavy image digest
- retain the canonical merged-manifest CycloneDX SBOM, Cosign signature, and Cosign SBOM attestation

## Why

The `v1.1.43` release's native arm64 sandbox build completed the Dockerfile but failed while exporting BuildKit's generated SPDX predicate:

```
/tmp/buildkit-mount.../sbom.spdx.json exceeds 41943040 bytes
```

The workflow already generates and attests a separate CycloneDX SBOM after assembling the multi-architecture sandbox manifest, so the oversized per-platform BuildKit predicate is redundant.

## Verification

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- actual sandbox image export on amd64 with `--provenance=mode=max --sbom=false --load`: pass
- native arm64 Dockerfile build in release run reached image export successfully before failing only on the oversized generated SPDX
- exact-SHA goal, code-quality, context/integration, and security/supply-chain reviews: pass at `ae9bf4b7abae6d0bbc5cb0c64a7dfce27affd990`

The final merged-manifest CycloneDX generation and Cosign attachment path is unchanged.
